### PR TITLE
chore(flags): Add management commands and schedule for flags HyperCache 

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -85,9 +85,6 @@ class PostHogConfig(AppConfig):
 
         file_system_registrations.register_core_file_system_types()
 
-        # Import signal handlers to register them
-        from posthog.models.feature_flag import flags_cache  # noqa: F401
-
     def _setup_lazy_admin(self):
         """Set up lazy loading of admin classes to avoid importing all at startup."""
         import sys

--- a/posthog/management/commands/_base_hypercache_command.py
+++ b/posthog/management/commands/_base_hypercache_command.py
@@ -1,0 +1,803 @@
+"""
+Base class for HyperCache management commands.
+
+Provides common utilities for HyperCache management commands.
+This is specific to HyperCache instances (feature flags, team metadata, etc.).
+For other cache types, create a different base class.
+"""
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandParser
+from django.db import connection
+
+from posthog.caching.flags_redis_cache import FLAGS_DEDICATED_CACHE_ALIAS
+from posthog.models.team.team import Team
+from posthog.storage.hypercache_manager import HyperCacheManagementConfig, warm_caches
+
+
+class BaseHyperCacheCommand(BaseCommand):
+    """
+    Utility base class for HyperCache management commands.
+
+    Provides common helpers for:
+    - Argument parsing (team IDs, batch sizes, TTL ranges)
+    - Output formatting (headers, progress, statistics)
+    - Verification framework (compare cache vs database)
+    - Warming framework (batch loading, TTL staggering)
+    - Progress reporting and metrics
+
+    This base class is specifically designed for HyperCache implementations.
+    Commands for feature flags cache, team metadata cache, etc. inherit from this
+    and implement the required abstract methods.
+
+    Commands keep their own implementation logic while this class reduces boilerplate.
+    """
+
+    # Argument parsing helpers - commands can call these in add_arguments()
+
+    def add_common_team_arguments(self, parser: CommandParser):
+        """Add --team-ids argument common to all cache commands."""
+        parser.add_argument(
+            "--team-ids",
+            nargs="+",
+            type=int,
+            help="Specific team IDs to process (if not provided, processes all teams)",
+        )
+
+    def add_warm_arguments(self, parser: CommandParser):
+        """
+        Add arguments specific to warming commands.
+
+        Includes: --batch-size, --invalidate-first, --no-stagger, --min-ttl-days, --max-ttl-days
+        """
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=100,
+            help="Number of teams to process at a time (default: 100)",
+        )
+        parser.add_argument(
+            "--invalidate-first",
+            action="store_true",
+            help="Invalidate all existing caches before warming (use when schema changes)",
+        )
+        parser.add_argument(
+            "--no-stagger",
+            action="store_true",
+            help="Disable TTL staggering (all caches get same TTL)",
+        )
+        parser.add_argument(
+            "--min-ttl-days",
+            type=int,
+            default=5,
+            help="Minimum TTL in days when staggering (default: 5)",
+        )
+        parser.add_argument(
+            "--max-ttl-days",
+            type=int,
+            default=7,
+            help="Maximum TTL in days when staggering (default: 7)",
+        )
+
+    def add_verify_arguments(self, parser: CommandParser):
+        """
+        Add arguments specific to verification commands.
+
+        Includes: --sample, --verbose, --fix
+        """
+        parser.add_argument(
+            "--sample",
+            type=int,
+            help="Verify a random sample of N teams instead of all teams",
+        )
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            help="Show detailed information about mismatches",
+        )
+        parser.add_argument(
+            "--fix",
+            action="store_true",
+            help="Automatically update mismatched or missing caches from database",
+        )
+
+    def add_analyze_arguments(self, parser: CommandParser):
+        """
+        Add arguments specific to analysis commands.
+
+        Includes: --sample-size, --detailed
+        """
+        parser.add_argument(
+            "--sample-size",
+            type=int,
+            default=100,
+            help="Number of teams to sample for size analysis (default: 100)",
+        )
+        parser.add_argument(
+            "--detailed",
+            action="store_true",
+            help="Show detailed field-by-field size breakdown",
+        )
+
+    # Output formatting helpers
+
+    def print_header(self, title: str, width: int = 70):
+        """Print a formatted section header with borders."""
+        self.stdout.write("\n" + "=" * width)
+        self.stdout.write(self.style.SUCCESS(title))
+        self.stdout.write("=" * width)
+
+    def print_separator(self, width: int = 70):
+        """Print a separator line."""
+        self.stdout.write("=" * width)
+
+    def format_percentage(self, part: int, total: int) -> str:
+        """
+        Format part/total as percentage string with 1 decimal place.
+
+        Args:
+            part: The partial count
+            total: The total count
+
+        Returns:
+            Formatted percentage string (e.g., "75.0%")
+        """
+        if total == 0:
+            return "0.0%"
+        return f"{(part / total * 100):.1f}%"
+
+    def format_bytes(self, bytes_val: float) -> str:
+        """
+        Format bytes in human-readable format.
+
+        Args:
+            bytes_val: Number of bytes to format
+
+        Returns:
+            Formatted string with appropriate unit (B, KB, MB, GB, TB)
+
+        Example:
+            >>> format_bytes(1536)
+            "1.5 KB"
+        """
+        for unit in ["B", "KB", "MB", "GB"]:
+            if bytes_val < 1024.0:
+                return f"{bytes_val:.1f} {unit}"
+            bytes_val /= 1024.0
+        return f"{bytes_val:.1f} TB"
+
+    def calculate_percentile(self, data: list[float] | list[int], percentile: int) -> float:
+        """
+        Calculate percentile of numeric data.
+
+        Args:
+            data: List of numeric values
+            percentile: Percentile to calculate (0-100)
+
+        Returns:
+            Calculated percentile value (0 if data is empty)
+
+        Example:
+            >>> calculate_percentile([1, 2, 3, 4, 5], 50)
+            3.0
+        """
+        if not data:
+            return 0
+        data_sorted = sorted(data)
+        index = (percentile / 100) * (len(data_sorted) - 1)
+        lower = data_sorted[int(index)]
+        upper = data_sorted[min(int(index) + 1, len(data_sorted) - 1)]
+        return lower + (upper - lower) * (index % 1)
+
+    def process_teams_in_chunks(
+        self,
+        queryset,
+        chunk_size: int,
+        process_chunk_fn,
+        progress_interval: int = 1000,
+    ) -> int:
+        """
+        Process teams in chunks using the seek method to avoid memory exhaustion.
+
+        This method implements an efficient chunking pattern that maintains constant memory
+        usage regardless of total team count. It uses the seek method (WHERE id > last_id)
+        rather than OFFSET-based pagination to avoid performance degradation with large datasets.
+
+        Args:
+            queryset: Django QuerySet of teams to process (must be orderable by id)
+            chunk_size: Number of teams to load into memory at once
+            process_chunk_fn: Callback function that takes a list of teams and processes them
+            progress_interval: Show progress message every N teams (0 to disable)
+
+        Returns:
+            Total number of teams processed
+
+        Example:
+            def process_chunk(teams):
+                for team in teams:
+                    # Do something with team
+                    pass
+
+            total = self.process_teams_in_chunks(
+                Team.objects.select_related("organization", "project"),
+                chunk_size=1000,
+                process_chunk_fn=process_chunk
+            )
+        """
+        total_processed = 0
+        last_id = 0
+
+        while True:
+            chunk = list(queryset.filter(id__gt=last_id).order_by("id")[:chunk_size])
+            if not chunk:
+                break
+
+            # Process this chunk
+            process_chunk_fn(chunk)
+
+            # Track progress
+            total_processed += len(chunk)
+            last_id = chunk[-1].id
+
+            # Show progress if configured
+            if progress_interval > 0 and total_processed % progress_interval == 0:
+                self.stdout.write(f"Progress: {total_processed} teams processed...")
+
+        return total_processed
+
+    # Verification framework
+
+    def run_verification(
+        self,
+        team_ids: list[int] | None,
+        sample_size: int | None,
+        verbose: bool,
+        fix: bool,
+    ):
+        """
+        Generic verification flow for cache commands.
+
+        This method implements the complete verification workflow that is common across
+        all verify commands. Subclasses only need to implement cache-specific logic.
+
+        Args:
+            team_ids: Specific team IDs to verify, or None for all/sample
+            sample_size: Number of random teams to sample, or None
+            verbose: Show detailed diff information
+            fix: Automatically fix cache issues
+
+        Subclasses must implement:
+            - get_hypercache_config() -> HyperCacheManagementConfig
+            - verify_team(team, verbose, batch_data) -> dict
+
+        Subclasses may optionally implement:
+            - format_verbose_diff(diff) -> None (for custom verbose output)
+        """
+        # Establish persistent database connection (disabled in tests to avoid connection leaks)
+        if not settings.TEST:
+            connection.ensure_connection()
+
+        try:
+            stats: dict[str, int] = {
+                "total": 0,
+                "cache_miss": 0,
+                "cache_match": 0,
+                "cache_mismatch": 0,
+                "fixed": 0,
+                "fix_failed": 0,
+            }
+
+            mismatches: list[dict] = []
+
+            # Process teams in chunks to avoid loading all teams into memory at once
+            if team_ids:
+                teams_queryset = Team.objects.filter(id__in=team_ids).select_related("organization", "project")
+                self.stdout.write(f"Verifying {teams_queryset.count()} specific teams...\n")
+                self._verify_teams_batch(list(teams_queryset), stats, mismatches, verbose, fix)
+            elif sample_size:
+                teams_queryset = Team.objects.select_related("organization", "project").order_by("?")[:sample_size]
+                self.stdout.write(f"Verifying random sample of {teams_queryset.count()} teams...\n")
+                self._verify_teams_batch(list(teams_queryset), stats, mismatches, verbose, fix)
+            else:
+                # For all teams, use chunked iteration to avoid memory exhaustion
+                teams_queryset = Team.objects.select_related("organization", "project")
+                total = teams_queryset.count()
+                self.stdout.write(f"Verifying all {total} teams...\n")
+
+                # Process teams in chunks using the helper method
+                def process_chunk(chunk):
+                    self._verify_teams_batch(chunk, stats, mismatches, verbose, fix)
+
+                self.process_teams_in_chunks(
+                    teams_queryset,
+                    chunk_size=1000,
+                    process_chunk_fn=process_chunk,
+                    progress_interval=1000,
+                )
+
+            self._print_verification_results(stats, mismatches, verbose, fix)
+        finally:
+            if not settings.TEST:
+                connection.close()
+
+    def _verify_teams_batch(
+        self,
+        teams: list,
+        stats: dict[str, int],
+        mismatches: list[dict],
+        verbose: bool,
+        fix: bool,
+    ):
+        """
+        Verify a batch of teams against their cached data.
+
+        This method handles batch loading (if available) and delegates verification
+        to the subclass's verify_team() method.
+        """
+        # Batch-load data if the HyperCache supports it
+        config = self.get_hypercache_config()
+        batch_data = None
+        if config.hypercache.batch_load_fn:
+            try:
+                batch_data = config.hypercache.batch_load_fn(teams)
+            except Exception as e:
+                self.stdout.write(self.style.WARNING(f"Batch load failed, falling back to individual loads: {e}"))
+
+        for team in teams:
+            stats["total"] += 1
+
+            # Delegate to subclass for actual verification
+            result = self.verify_team(team, verbose, batch_data)
+
+            # Handle result
+            if result["status"] == "match":
+                stats["cache_match"] += 1
+            elif result["status"] == "miss":
+                stats["cache_miss"] += 1
+                self._handle_cache_issue(team, result, stats, mismatches, fix)
+            elif result["status"] == "mismatch":
+                stats["cache_mismatch"] += 1
+                self._handle_cache_issue(team, result, stats, mismatches, fix)
+
+    def _handle_cache_issue(
+        self,
+        team,
+        result: dict,
+        stats: dict[str, int],
+        mismatches: list[dict],
+        fix: bool,
+    ):
+        """Handle a cache issue (miss or mismatch)."""
+        issue_detail = {
+            "team_id": team.id,
+            "team_name": team.name,
+            "issue": result["issue"],
+            "details": result["details"],
+        }
+
+        if "diffs" in result:
+            issue_detail["diffs"] = result["diffs"]
+
+        if fix:
+            if self._fix_cache(team, stats):
+                issue_detail["fixed"] = True
+            else:
+                issue_detail["fixed"] = False
+
+        mismatches.append(issue_detail)
+
+    def _fix_cache(self, team, stats: dict[str, int]) -> bool:
+        """Fix cache for a team by updating from database."""
+        try:
+            config = self.get_hypercache_config()
+            success = config.update_fn(team)
+            if success:
+                stats["fixed"] += 1
+                self.stdout.write(self.style.SUCCESS(f"  ✓ Fixed cache for team {team.id} ({team.name})"))
+            else:
+                stats["fix_failed"] += 1
+                self.stdout.write(self.style.ERROR(f"  ✗ Failed to fix cache for team {team.id} ({team.name})"))
+            return success
+        except Exception as e:
+            stats["fix_failed"] += 1
+            self.stdout.write(self.style.ERROR(f"  ✗ Error fixing cache for team {team.id} ({team.name}): {e}"))
+            return False
+
+    def _print_verification_results(self, stats: dict, mismatches: list[dict], verbose: bool, fix: bool):
+        """Print verification results."""
+        config = self.get_hypercache_config()
+        cache_name = config.cache_display_name
+
+        self.stdout.write("\n" + "=" * 70)
+        self.stdout.write(self.style.SUCCESS("\nVerification Results:"))
+        self.stdout.write("=" * 70 + "\n")
+
+        self.stdout.write(f"Total teams verified: {stats['total']}")
+        self.stdout.write(
+            f"Cache matches:        {stats['cache_match']} ({self.format_percentage(stats['cache_match'], stats['total'])})"
+        )
+        self.stdout.write(
+            f"Cache mismatches:     {stats['cache_mismatch']} ({self.format_percentage(stats['cache_mismatch'], stats['total'])})"
+        )
+        self.stdout.write(
+            f"Cache misses:         {stats['cache_miss']} ({self.format_percentage(stats['cache_miss'], stats['total'])})"
+        )
+
+        if fix:
+            self.stdout.write(
+                f"Cache fixes applied:  {stats['fixed']} ({self.format_percentage(stats['fixed'], stats['total'])})"
+            )
+            if stats["fix_failed"] > 0:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Cache fixes failed:   {stats['fix_failed']} ({self.format_percentage(stats['fix_failed'], stats['total'])})"
+                    )
+                )
+
+        if mismatches:
+            self.stdout.write("\n" + "=" * 70)
+            self.stdout.write(self.style.WARNING(f"\nFound {len(mismatches)} issue(s):"))
+            self.stdout.write("=" * 70 + "\n")
+
+            for mismatch in mismatches:
+                issue_prefix = f"[{mismatch['issue']}] Team {mismatch['team_id']} ({mismatch['team_name']})"
+
+                if fix and "fixed" in mismatch:
+                    if mismatch["fixed"]:
+                        self.stdout.write(self.style.SUCCESS(f"\n{issue_prefix} - FIXED"))
+                    else:
+                        self.stdout.write(self.style.ERROR(f"\n{issue_prefix} - FIX FAILED"))
+                else:
+                    self.stdout.write(self.style.ERROR(f"\n{issue_prefix}"))
+
+                if verbose and mismatch.get("diffs"):
+                    # Use subclass's format_verbose_diff (or base implementation)
+                    for diff in mismatch["diffs"]:
+                        self.format_verbose_diff(diff)
+                else:
+                    self.stdout.write(f"  {mismatch['details']}")
+
+        self.stdout.write("\n" + "=" * 70)
+
+        if stats["cache_match"] == stats["total"]:
+            self.stdout.write(self.style.SUCCESS(f"\n✓ All {cache_name} caches verified successfully!\n"))
+        else:
+            if fix:
+                if stats["fixed"] > 0 and stats["fix_failed"] == 0:
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f"\n✓ Found and fixed {stats['fixed']} issue(s) with {len(mismatches)} team(s)\n"
+                        )
+                    )
+                elif stats["fix_failed"] > 0:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"\n⚠ Fixed {stats['fixed']} issue(s), but {stats['fix_failed']} fixes failed\n"
+                        )
+                    )
+            else:
+                self.stdout.write(self.style.WARNING(f"\n⚠ Found issues with {len(mismatches)} team(s)\n"))
+
+    # Methods that subclasses must implement
+
+    def get_hypercache_config(self) -> HyperCacheManagementConfig:
+        """
+        Return the HyperCache management configuration for this cache type.
+
+        Required properties:
+        - hypercache: HyperCache instance (with batch_load_fn)
+        - update_fn: Function to update cache for a team
+        - cache_name: Canonical cache name (e.g., "flags", "team_metadata")
+
+        All other properties (display name, Redis patterns, expiry tracking, etc.) are
+        derived from cache_name and other required properties.
+
+        Example:
+            return FLAGS_HYPERCACHE_MANAGEMENT_CONFIG
+        """
+        raise NotImplementedError("Subclasses must implement get_hypercache_config()")
+
+    def verify_team(self, team, verbose: bool, batch_data: dict | None = None) -> dict:
+        """
+        Verify a single team's cache against the database.
+
+        Args:
+            team: Team object to verify
+            verbose: Whether to include detailed diff information
+            batch_data: Pre-loaded batch data (if batch loading is supported)
+
+        Returns:
+            dict with keys:
+                - status: "match", "miss", or "mismatch"
+                - issue: Issue type (e.g., "CACHE_MISS", "DATA_MISMATCH")
+                - details: Human-readable description
+                - diffs: (optional) List of differences for verbose output
+        """
+        raise NotImplementedError("Subclasses must implement verify_team()")
+
+    # Warming framework
+
+    def _display_warm_results(self, cache_name: str, successful: int, failed: int):
+        """Display warming results summary."""
+        total = successful + failed
+        success_rate = self.format_percentage(successful, total)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\n{cache_name.capitalize()} cache warm completed:\n"
+                f"  Total teams: {total}\n"
+                f"  Successful: {successful}\n"
+                f"  Failed: {failed}\n"
+                f"  Success rate: {success_rate}\n"
+            )
+        )
+
+    def _validate_teams(self, team_ids: list[int], cache_name: str) -> list[Team] | None:
+        """
+        Validate team IDs exist and warn about missing ones.
+
+        Returns:
+            List of Team objects, or None if no teams found
+        """
+        self.stdout.write(f"\nWarming {cache_name} cache for {len(team_ids)} specific team(s)...\n")
+
+        teams = list(Team.objects.filter(id__in=team_ids).select_related("organization", "project"))
+        found_ids = {team.id for team in teams}
+        missing_ids = set(team_ids) - found_ids
+
+        if missing_ids:
+            self.stdout.write(self.style.WARNING(f"Warning: Could not find teams with IDs: {sorted(missing_ids)}\n"))
+
+        return teams if teams else None
+
+    def _confirm_invalidate(self, cache_name: str) -> bool:
+        """
+        Get user confirmation for invalidating all caches.
+
+        Returns:
+            True if user confirmed, False otherwise
+        """
+        self.stdout.write(
+            self.style.WARNING(
+                f"WARNING: This will invalidate ALL existing {cache_name} caches before warming.\n"
+                "This should only be used when the cache schema has changed.\n"
+            )
+        )
+        confirm = input("Are you sure? Type 'yes' to continue: ")
+        if confirm.lower() != "yes":
+            self.stdout.write(self.style.ERROR("Aborted."))
+            return False
+        return True
+
+    def run_warm(
+        self,
+        team_ids: list[int] | None,
+        batch_size: int,
+        invalidate_first: bool,
+        stagger_ttl: bool,
+        min_ttl_days: int,
+        max_ttl_days: int,
+    ):
+        """
+        Generic warming flow for cache commands.
+
+        This method implements the complete warming workflow that is common across
+        all warm commands. Subclasses only need to implement cache-specific logic.
+
+        Args:
+            team_ids: Specific team IDs to warm, or None for all teams
+            batch_size: Number of teams to process at a time
+            invalidate_first: Whether to invalidate all caches before warming
+            stagger_ttl: Whether to randomize TTLs
+            min_ttl_days: Minimum TTL in days (when staggering)
+            max_ttl_days: Maximum TTL in days (when staggering)
+
+        Subclasses must implement:
+            - get_hypercache_config() -> HyperCacheManagementConfig
+        """
+        config = self.get_hypercache_config()
+        cache_name = config.cache_display_name
+
+        # Handle specific teams
+        if team_ids:
+            teams = self._validate_teams(team_ids, cache_name)
+            if not teams:
+                return
+
+            # Process all specific teams at once (small batch)
+            actual_batch_size = len(teams)
+            actual_invalidate_first = False  # Never invalidate for specific teams
+        else:
+            # Handle all teams - show configuration and get confirmation if needed
+            self.stdout.write(
+                self.style.WARNING(
+                    f"\nStarting {cache_name} cache warm:\n"
+                    f"  Batch size: {batch_size}\n"
+                    f"  Invalidate first: {invalidate_first}\n"
+                    f"  Stagger TTL: {stagger_ttl}\n"
+                    f"  TTL range: {min_ttl_days}-{max_ttl_days} days\n"
+                )
+            )
+
+            if invalidate_first and not self._confirm_invalidate(cache_name):
+                return
+
+            actual_batch_size = batch_size
+            actual_invalidate_first = invalidate_first
+
+        # Warm the caches
+        successful, failed = warm_caches(
+            config,
+            batch_size=actual_batch_size,
+            invalidate_first=actual_invalidate_first,
+            stagger_ttl=stagger_ttl,
+            min_ttl_days=min_ttl_days,
+            max_ttl_days=max_ttl_days,
+            team_ids=team_ids,
+        )
+
+        # Display results
+        self._display_warm_results(cache_name, successful, failed)
+
+        # Warn about failures (only for all teams workflow)
+        if not team_ids and failed > 0:
+            self.stdout.write(self.style.WARNING(f"Warning: {failed} teams failed to cache. Check logs for details."))
+
+    # Optional methods that subclasses can override for enhanced functionality
+
+    def format_verbose_diff(self, diff: dict):
+        """
+        Format and print a single diff for verbose verification output.
+
+        Override this in subclasses to provide custom formatting for cache diffs.
+        The base implementation provides generic field-based diff formatting.
+
+        Args:
+            diff: Dict containing diff information (structure varies by subclass)
+        """
+        # Default formatting for generic diffs
+        if "field" in diff:
+            self.stdout.write(f"  Field: {diff['field']}")
+            self.stdout.write(f"    DB:    {diff.get('db_value')}")
+            self.stdout.write(f"    Cache: {diff.get('cached_value')}")
+
+    # Configuration and validation helpers
+
+    def check_dedicated_cache_configured(self) -> bool:
+        """
+        Check if the dedicated cache is configured and display status.
+
+        Auto-generates the operation description based on the command name and config.
+
+        Returns:
+            True if dedicated cache is configured, False otherwise
+
+        Example:
+            if not self.check_dedicated_cache_configured():
+                return
+        """
+        has_dedicated_cache = FLAGS_DEDICATED_CACHE_ALIAS in settings.CACHES
+        has_flags_redis_url = bool(settings.FLAGS_REDIS_URL)
+
+        # Display cache configuration status
+        self.stdout.write("\n" + "=" * 70)
+        self.stdout.write(self.style.SUCCESS("Cache Configuration:"))
+        self.stdout.write("=" * 70)
+        self.stdout.write(f"FLAGS_REDIS_URL configured: {has_flags_redis_url}")
+        self.stdout.write(f"Dedicated cache available: {has_dedicated_cache}")
+        self.stdout.write("=" * 70 + "\n")
+
+        # Error if dedicated cache is not available
+        if not has_dedicated_cache:
+            # Auto-generate operation description from config and command name
+            operation_description = self._get_operation_description()
+
+            self.stdout.write(
+                self.style.ERROR(
+                    f"\nERROR: Dedicated cache (FLAGS_REDIS_URL) is NOT configured.\n"
+                    "\n"
+                    f"This command {operation_description}.\n"
+                    "Without FLAGS_REDIS_URL set, the system falls back to the default Redis cache,\n"
+                    "which would cause incorrect behavior.\n"
+                    "\n"
+                    "To fix this:\n"
+                    "  1. Set the FLAGS_REDIS_URL environment variable to your dedicated Redis instance\n"
+                    "  2. Re-run this command\n"
+                    "\n"
+                    "Example: FLAGS_REDIS_URL=redis://your-redis:6379/0\n"
+                )
+            )
+            return False
+
+        return True
+
+    def _get_operation_description(self) -> str:
+        """
+        Generate operation description for error messages based on command and config.
+
+        Returns a description like:
+        - "warms the dedicated flags cache"
+        - "verifies the dedicated team metadata cache"
+        """
+        config = self.get_hypercache_config()
+
+        # Derive operation verb from module name
+        module_name = self.__class__.__module__
+        if "warm" in module_name:
+            operation = "warms"
+        elif "verify" in module_name:
+            operation = "verifies"
+        elif "analyze" in module_name:
+            operation = "analyzes"
+        else:
+            operation = "operates on"
+
+        return f"{operation} the dedicated {config.cache_display_name} cache"
+
+    def validate_batch_size(self, batch_size: int) -> bool:
+        """
+        Validate batch size is within safe limits.
+
+        Args:
+            batch_size: The batch size to validate
+
+        Returns:
+            True if valid, False otherwise
+        """
+        if batch_size < 1:
+            self.stdout.write(self.style.ERROR("--batch-size must be at least 1"))
+            return False
+        if batch_size > 5000:
+            self.stdout.write(self.style.ERROR("--batch-size cannot be greater than 5000 (too many teams at once)"))
+            return False
+        return True
+
+    def validate_sample_size(self, sample_size: int) -> bool:
+        """
+        Validate sample size is within safe limits.
+
+        Args:
+            sample_size: The sample size to validate
+
+        Returns:
+            True if valid, False otherwise
+        """
+        if sample_size < 1:
+            self.stdout.write(self.style.ERROR("--sample must be at least 1"))
+            return False
+        if sample_size > 10000:
+            self.stdout.write(self.style.ERROR("--sample cannot exceed 10000 (use smaller sample for verification)"))
+            return False
+        return True
+
+    def validate_ttl_range(self, min_ttl_days: int, max_ttl_days: int) -> bool:
+        """
+        Validate TTL day range is within safe limits.
+
+        Args:
+            min_ttl_days: Minimum TTL in days
+            max_ttl_days: Maximum TTL in days
+
+        Returns:
+            True if valid, False otherwise
+        """
+        if min_ttl_days < 1:
+            self.stdout.write(self.style.ERROR("--min-ttl-days must be at least 1"))
+            return False
+        if min_ttl_days > 30:
+            self.stdout.write(self.style.ERROR("--min-ttl-days cannot be greater than 30 days"))
+            return False
+        if max_ttl_days < 1:
+            self.stdout.write(self.style.ERROR("--max-ttl-days must be at least 1"))
+            return False
+        if max_ttl_days > 30:
+            self.stdout.write(self.style.ERROR("--max-ttl-days cannot be greater than 30 days"))
+            return False
+        if min_ttl_days > max_ttl_days:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"--min-ttl-days ({min_ttl_days}) cannot be greater than --max-ttl-days ({max_ttl_days})"
+                )
+            )
+            return False
+        return True

--- a/posthog/management/commands/verify_flags_cache.py
+++ b/posthog/management/commands/verify_flags_cache.py
@@ -1,0 +1,227 @@
+"""
+Management command to verify flags cache consistency.
+
+Compares cached flags data against database to detect discrepancies.
+
+IMPORTANT: This command requires FLAGS_REDIS_URL to be set. It will error if the
+dedicated flags cache is not configured to prevent misleading results.
+
+Usage:
+    # Verify all teams
+    python manage.py verify_flags_cache
+
+    # Verify specific teams
+    python manage.py verify_flags_cache --team-ids 123 456 789
+
+    # Sample random teams
+    python manage.py verify_flags_cache --sample 100
+
+    # Verbose output (show full diffs)
+    python manage.py verify_flags_cache --verbose
+
+    # Automatically fix cache issues
+    python manage.py verify_flags_cache --fix
+
+    # Fix specific teams
+    python manage.py verify_flags_cache --team-ids 123 456 --fix
+"""
+
+from posthog.management.commands._base_hypercache_command import BaseHyperCacheCommand
+from posthog.models.feature_flag.flags_cache import (
+    FLAGS_HYPERCACHE_MANAGEMENT_CONFIG,
+    _get_feature_flags_for_service,
+    flags_hypercache,
+)
+
+
+class Command(BaseHyperCacheCommand):
+    help = "Verify flags cache consistency against database"
+
+    def add_arguments(self, parser):
+        self.add_common_team_arguments(parser)
+        self.add_verify_arguments(parser)
+
+    def handle(self, *args, **options):
+        # Check if dedicated flags cache is configured (fail fast)
+        if not self.check_dedicated_cache_configured():
+            return
+
+        team_ids = options.get("team_ids")
+        sample_size = options.get("sample")
+        verbose = options.get("verbose", False)
+        fix = options.get("fix", False)
+
+        # Validate input arguments to prevent resource exhaustion
+        if sample_size is not None:
+            if not self.validate_sample_size(sample_size):
+                return
+
+        # Use the generic verification framework
+        self.run_verification(
+            team_ids=team_ids,
+            sample_size=sample_size,
+            verbose=verbose,
+            fix=fix,
+        )
+
+    # Implement required methods for verification framework
+
+    def get_hypercache_config(self):
+        """Return the HyperCache management configuration."""
+        return FLAGS_HYPERCACHE_MANAGEMENT_CONFIG
+
+    def verify_team(self, team, verbose: bool, batch_data: dict | None = None) -> dict:
+        """Verify a single team's flags cache against the database."""
+        # Use get_from_cache_with_source to detect cache misses vs. hits
+        # get_from_cache has cache-through behavior that auto-loads on miss, hiding true misses
+        cached_data, source = flags_hypercache.get_from_cache_with_source(team)
+
+        # Get flags from database (use pre-loaded data if available)
+        if batch_data and team.id in batch_data:
+            db_data = batch_data[team.id]
+        else:
+            db_data = _get_feature_flags_for_service(team)
+
+        db_flags = db_data.get("flags", []) if isinstance(db_data, dict) else []
+
+        # Handle cache miss (source="db" means cache miss, data was loaded from database)
+        # ANY cache miss is a problem - we want ALL teams cached (even empty ones)
+        # This ensures Rust service never has to fall back to database
+        if source == "db":
+            return {
+                "status": "miss",
+                "issue": "CACHE_MISS",
+                "details": f"No cache entry found (team has {len(db_flags)} flags in DB)",
+            }
+
+        # Extract flags from cache (guaranteed to be a dict since source != "db")
+        cached_flags = cached_data.get("flags", []) if cached_data else []
+
+        # Compare flags
+        match, diffs = self._compare_flags(db_flags, cached_flags)
+
+        if match:
+            return {"status": "match", "issue": "", "details": ""}
+
+        # Cache mismatch
+        details = diffs if verbose else self._summarize_diffs(diffs)
+        return {
+            "status": "mismatch",
+            "issue": "DATA_MISMATCH",
+            "details": details,
+            "diffs": diffs,
+        }
+
+    def format_verbose_diff(self, diff):
+        """Format a single diff for verbose output (flags-specific formatting)."""
+        diff_type = diff.get("type")
+        if diff_type == "MISSING_IN_CACHE":
+            self.stdout.write(f"  Missing flag: {diff.get('flag_key')} (ID: {diff.get('flag_id')})")
+        elif diff_type == "STALE_IN_CACHE":
+            self.stdout.write(f"  Stale flag: {diff.get('flag_key')} (ID: {diff.get('flag_id')})")
+        elif diff_type == "FIELD_MISMATCH":
+            self.stdout.write(f"  Mismatched flag: {diff.get('flag_key')} (ID: {diff.get('flag_id')})")
+            for field_diff in diff.get("field_diffs", []):
+                self.stdout.write(f"    Field: {field_diff['field']}")
+                self.stdout.write(f"      DB:    {field_diff['db_value']}")
+                self.stdout.write(f"      Cache: {field_diff['cached_value']}")
+
+    # Private helper methods for flag comparison
+
+    def _find_missing_flags(self, db_flags_by_id: dict, cached_flags_by_id: dict) -> list[dict]:
+        """Find flags that exist in DB but are missing from cache."""
+        missing = []
+        for flag_id in db_flags_by_id:
+            if flag_id not in cached_flags_by_id:
+                missing.append(
+                    {
+                        "type": "MISSING_IN_CACHE",
+                        "flag_id": flag_id,
+                        "flag_key": db_flags_by_id[flag_id].get("key"),
+                    }
+                )
+        return missing
+
+    def _find_stale_flags(self, db_flags_by_id: dict, cached_flags_by_id: dict) -> list[dict]:
+        """Find flags that exist in cache but have been deleted from DB."""
+        stale = []
+        for flag_id in cached_flags_by_id:
+            if flag_id not in db_flags_by_id:
+                stale.append(
+                    {
+                        "type": "STALE_IN_CACHE",
+                        "flag_id": flag_id,
+                        "flag_key": cached_flags_by_id[flag_id].get("key"),
+                    }
+                )
+        return stale
+
+    def _compare_flag_fields(self, db_flag: dict, cached_flag: dict) -> list[dict]:
+        """Compare field values between DB and cached versions of a flag."""
+        field_diffs = []
+        all_keys = set(db_flag.keys()) | set(cached_flag.keys())
+
+        for key in all_keys:
+            db_val = db_flag.get(key)
+            cached_val = cached_flag.get(key)
+
+            if db_val != cached_val:
+                field_diffs.append(
+                    {
+                        "field": key,
+                        "db_value": db_val,
+                        "cached_value": cached_val,
+                    }
+                )
+
+        return field_diffs
+
+    def _compare_flags(self, db_flags: list, cached_flags: list) -> tuple[bool, list[dict]]:
+        """Compare DB and cached flags, return (match, diffs)."""
+        # Create ID-indexed dicts for comparison
+        db_flags_by_id = {flag["id"]: flag for flag in db_flags}
+        cached_flags_by_id = {flag["id"]: flag for flag in cached_flags}
+
+        diffs = []
+
+        # Find missing flags
+        diffs.extend(self._find_missing_flags(db_flags_by_id, cached_flags_by_id))
+
+        # Find stale flags
+        diffs.extend(self._find_stale_flags(db_flags_by_id, cached_flags_by_id))
+
+        # Compare field values for flags that exist in both
+        for flag_id in db_flags_by_id:
+            if flag_id in cached_flags_by_id:
+                db_flag = db_flags_by_id[flag_id]
+                cached_flag = cached_flags_by_id[flag_id]
+
+                field_diffs = self._compare_flag_fields(db_flag, cached_flag)
+
+                if field_diffs:
+                    diffs.append(
+                        {
+                            "type": "FIELD_MISMATCH",
+                            "flag_id": flag_id,
+                            "flag_key": db_flag.get("key"),
+                            "field_diffs": field_diffs,
+                        }
+                    )
+
+        return len(diffs) == 0, diffs
+
+    def _summarize_diffs(self, diffs: list[dict]) -> str:
+        """Summarize diffs into a readable string."""
+        missing_count = sum(1 for d in diffs if d.get("type") == "MISSING_IN_CACHE")
+        stale_count = sum(1 for d in diffs if d.get("type") == "STALE_IN_CACHE")
+        mismatch_count = sum(1 for d in diffs if d.get("type") == "FIELD_MISMATCH")
+
+        summary_parts = []
+        if missing_count > 0:
+            summary_parts.append(f"{missing_count} missing")
+        if stale_count > 0:
+            summary_parts.append(f"{stale_count} stale")
+        if mismatch_count > 0:
+            summary_parts.append(f"{mismatch_count} mismatched")
+
+        return f"{', '.join(summary_parts)} flags" if summary_parts else "unknown differences"

--- a/posthog/management/commands/verify_team_metadata_cache.py
+++ b/posthog/management/commands/verify_team_metadata_cache.py
@@ -3,6 +3,9 @@ Management command to verify team metadata cache consistency.
 
 Compares cached data against database to detect discrepancies.
 
+IMPORTANT: This command requires FLAGS_REDIS_URL to be set. It will error if the
+dedicated flags cache is not configured to prevent misleading results.
+
 Usage:
     # Verify all teams
     python manage.py verify_team_metadata_cache
@@ -12,9 +15,6 @@ Usage:
 
     # Sample random teams
     python manage.py verify_team_metadata_cache --sample 100
-
-    # Check dedicated flags cache too
-    python manage.py verify_team_metadata_cache --check-dedicated-cache
 
     # Verbose output (show full diffs)
     python manage.py verify_team_metadata_cache --verbose
@@ -26,181 +26,75 @@ Usage:
     python manage.py verify_team_metadata_cache --team-ids 123 456 --fix
 """
 
-from django.conf import settings
-from django.core.cache import caches
-from django.core.management.base import BaseCommand
-
-from posthog.caching.flags_redis_cache import FLAGS_DEDICATED_CACHE_ALIAS
-from posthog.models.team.team import Team
+from posthog.management.commands._base_hypercache_command import BaseHyperCacheCommand
 from posthog.storage.team_metadata_cache import (
+    TEAM_HYPERCACHE_MANAGEMENT_CONFIG,
     TEAM_METADATA_FIELDS,
     _serialize_team_field,
     get_team_metadata,
-    team_metadata_hypercache,
-    update_team_metadata_cache,
 )
 
 
-class Command(BaseCommand):
+class Command(BaseHyperCacheCommand):
     help = "Verify team metadata cache consistency against database"
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--team-ids",
-            nargs="+",
-            type=int,
-            help="Specific team IDs to verify",
-        )
-        parser.add_argument(
-            "--sample",
-            type=int,
-            help="Randomly sample N teams to verify",
-        )
-        parser.add_argument(
-            "--verbose",
-            action="store_true",
-            help="Show detailed diffs for mismatches",
-        )
-        parser.add_argument(
-            "--check-dedicated-cache",
-            action="store_true",
-            help="Also verify data exists in dedicated flags Redis cache",
-        )
-        parser.add_argument(
-            "--fix",
-            action="store_true",
-            help="Automatically fix cache mismatches by updating cache from database",
-        )
+        self.add_common_team_arguments(parser)
+        self.add_verify_arguments(parser)
 
     def handle(self, *args, **options):
+        # Check if dedicated cache is configured (fail fast)
+        if not self.check_dedicated_cache_configured():
+            return
+
         team_ids = options.get("team_ids")
         sample_size = options.get("sample")
         verbose = options.get("verbose", False)
-        check_dedicated = options.get("check_dedicated_cache", False)
         fix = options.get("fix", False)
 
-        has_dedicated_cache = FLAGS_DEDICATED_CACHE_ALIAS in settings.CACHES
+        # Use the generic verification framework
+        self.run_verification(
+            team_ids=team_ids,
+            sample_size=sample_size,
+            verbose=verbose,
+            fix=fix,
+        )
 
-        if check_dedicated and not has_dedicated_cache:
-            self.stdout.write(
-                self.style.WARNING("Dedicated flags cache not configured, skipping dedicated cache check\n")
-            )
-            check_dedicated = False
+    # Implement required methods for verification framework
 
-        if team_ids:
-            teams = Team.objects.filter(id__in=team_ids).select_related("organization", "project")
-            self.stdout.write(f"Verifying {len(teams)} specific teams...\n")
-        elif sample_size:
-            teams = Team.objects.select_related("organization", "project").order_by("?")[:sample_size]
-            self.stdout.write(f"Verifying random sample of {len(teams)} teams...\n")
-        else:
-            teams = Team.objects.select_related("organization", "project")
-            total = teams.count()
-            self.stdout.write(f"Verifying all {total} teams...\n")
+    def get_hypercache_config(self):
+        """Return the HyperCache management configuration."""
+        return TEAM_HYPERCACHE_MANAGEMENT_CONFIG
 
-        stats: dict[str, int] = {
-            "total": 0,
-            "cache_miss": 0,
-            "cache_match": 0,
-            "cache_mismatch": 0,
-            "dedicated_miss": 0,
-            "fixed": 0,
-            "fix_failed": 0,
+    def verify_team(self, team, verbose: bool, batch_data: dict | None = None) -> dict:
+        """Verify a single team's metadata cache against the database."""
+        cached_data = get_team_metadata(team)
+
+        # Handle cache miss
+        if not cached_data:
+            return {
+                "status": "miss",
+                "issue": "CACHE_MISS",
+                "details": "No cached data found",
+            }
+
+        # Get DB data and compare
+        db_data = self._get_db_data(team)
+        match, diffs = self._compare_data(db_data, cached_data)
+
+        if match:
+            return {"status": "match", "issue": "", "details": ""}
+
+        # Cache mismatch
+        details = diffs if verbose else f"{len(diffs)} field(s) differ"
+        return {
+            "status": "mismatch",
+            "issue": "DATA_MISMATCH",
+            "details": details,
+            "diffs": diffs,
         }
 
-        mismatches = []
-
-        for team in teams:
-            stats["total"] += 1
-
-            cached_data = get_team_metadata(team)
-
-            if not cached_data:
-                stats["cache_miss"] += 1
-                issue_detail = {
-                    "team_id": team.id,
-                    "team_name": team.name,
-                    "issue": "CACHE_MISS",
-                    "details": "No cached data found",
-                }
-
-                if fix:
-                    if self._fix_cache(team, stats):
-                        issue_detail["fixed"] = True
-                    else:
-                        issue_detail["fixed"] = False
-
-                mismatches.append(issue_detail)
-                continue
-
-            db_data = self._get_db_data(team)
-
-            match, diffs = self._compare_data(db_data, cached_data)
-
-            if match:
-                stats["cache_match"] += 1
-            else:
-                stats["cache_mismatch"] += 1
-                issue_detail = {
-                    "team_id": team.id,
-                    "team_name": team.name,
-                    "issue": "DATA_MISMATCH",
-                    "details": diffs if verbose else f"{len(diffs)} field(s) differ",
-                    "diffs": diffs,
-                }
-
-                if fix:
-                    if self._fix_cache(team, stats):
-                        issue_detail["fixed"] = True
-                    else:
-                        issue_detail["fixed"] = False
-
-                mismatches.append(issue_detail)
-
-            if check_dedicated:
-                cache_key = team_metadata_hypercache.get_cache_key(team)
-                dedicated_cache = caches[FLAGS_DEDICATED_CACHE_ALIAS]
-                dedicated_data = dedicated_cache.get(cache_key)
-
-                if not dedicated_data:
-                    stats["dedicated_miss"] += 1
-                    issue_detail = {
-                        "team_id": team.id,
-                        "team_name": team.name,
-                        "issue": "DEDICATED_CACHE_MISS",
-                        "details": "Data not found in dedicated flags cache",
-                    }
-
-                    if fix:
-                        if self._fix_cache(team, stats):
-                            issue_detail["fixed"] = True
-                        else:
-                            issue_detail["fixed"] = False
-
-                    mismatches.append(issue_detail)
-
-            if stats["total"] % 100 == 0:
-                self.stdout.write(f"Progress: {stats['total']} teams verified...")
-
-        self._print_results(stats, mismatches, verbose, check_dedicated, fix)
-
-    def _fix_cache(self, team: Team, stats: dict[str, int]) -> bool:
-        """Fix cache for a team by updating from database."""
-        try:
-            success = update_team_metadata_cache(team)
-            if success:
-                stats["fixed"] += 1
-                self.stdout.write(self.style.SUCCESS(f"  ✓ Fixed cache for team {team.id} ({team.name})"))
-            else:
-                stats["fix_failed"] += 1
-                self.stdout.write(self.style.ERROR(f"  ✗ Failed to fix cache for team {team.id} ({team.name})"))
-            return success
-        except Exception as e:
-            stats["fix_failed"] += 1
-            self.stdout.write(self.style.ERROR(f"  ✗ Error fixing cache for team {team.id} ({team.name}): {e}"))
-            return False
-
-    def _get_db_data(self, team: Team) -> dict:
+    def _get_db_data(self, team) -> dict:
         """Get team data from database in same format as cache."""
         data = {}
         for field in TEAM_METADATA_FIELDS:
@@ -234,87 +128,3 @@ class Command(BaseCommand):
                 )
 
         return len(diffs) == 0, diffs
-
-    def _print_results(self, stats: dict, mismatches: list[dict], verbose: bool, check_dedicated: bool, fix: bool):
-        """Print verification results."""
-        self.stdout.write("\n" + "=" * 70)
-        self.stdout.write(self.style.SUCCESS("\nVerification Results:"))
-        self.stdout.write("=" * 70 + "\n")
-
-        self.stdout.write(f"Total teams verified: {stats['total']}")
-        self.stdout.write(
-            f"Cache matches:        {stats['cache_match']} ({self._percent(stats['cache_match'], stats['total'])})"
-        )
-        self.stdout.write(
-            f"Cache mismatches:     {stats['cache_mismatch']} ({self._percent(stats['cache_mismatch'], stats['total'])})"
-        )
-        self.stdout.write(
-            f"Cache misses:         {stats['cache_miss']} ({self._percent(stats['cache_miss'], stats['total'])})"
-        )
-
-        if check_dedicated:
-            self.stdout.write(
-                f"Dedicated cache miss: {stats['dedicated_miss']} ({self._percent(stats['dedicated_miss'], stats['total'])})"
-            )
-
-        if fix:
-            self.stdout.write(
-                f"Cache fixes applied:  {stats['fixed']} ({self._percent(stats['fixed'], stats['total'])})"
-            )
-            if stats["fix_failed"] > 0:
-                self.stdout.write(
-                    self.style.ERROR(
-                        f"Cache fixes failed:   {stats['fix_failed']} ({self._percent(stats['fix_failed'], stats['total'])})"
-                    )
-                )
-
-        if mismatches:
-            self.stdout.write("\n" + "=" * 70)
-            self.stdout.write(self.style.WARNING(f"\nFound {len(mismatches)} issue(s):"))
-            self.stdout.write("=" * 70 + "\n")
-
-            for mismatch in mismatches:
-                issue_prefix = f"[{mismatch['issue']}] Team {mismatch['team_id']} ({mismatch['team_name']})"
-
-                if fix and "fixed" in mismatch:
-                    if mismatch["fixed"]:
-                        self.stdout.write(self.style.SUCCESS(f"\n{issue_prefix} - FIXED"))
-                    else:
-                        self.stdout.write(self.style.ERROR(f"\n{issue_prefix} - FIX FAILED"))
-                else:
-                    self.stdout.write(self.style.ERROR(f"\n{issue_prefix}"))
-
-                if verbose and mismatch.get("diffs"):
-                    for diff in mismatch["diffs"]:
-                        self.stdout.write(f"  Field: {diff['field']}")
-                        self.stdout.write(f"    DB:    {diff['db_value']}")
-                        self.stdout.write(f"    Cache: {diff['cached_value']}")
-                else:
-                    self.stdout.write(f"  {mismatch['details']}")
-
-        self.stdout.write("\n" + "=" * 70)
-
-        if stats["cache_match"] == stats["total"]:
-            self.stdout.write(self.style.SUCCESS("\n✓ All caches verified successfully!\n"))
-        else:
-            if fix:
-                if stats["fixed"] > 0 and stats["fix_failed"] == 0:
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f"\n✓ Found and fixed {stats['fixed']} issue(s) with {len(mismatches)} team(s)\n"
-                        )
-                    )
-                elif stats["fix_failed"] > 0:
-                    self.stdout.write(
-                        self.style.WARNING(
-                            f"\n⚠ Fixed {stats['fixed']} issue(s), but {stats['fix_failed']} fix(es) failed\n"
-                        )
-                    )
-            else:
-                self.stdout.write(self.style.WARNING(f"\n⚠ Found issues with {len(mismatches)} team(s)\n"))
-
-    def _percent(self, part: int, total: int) -> str:
-        """Calculate percentage."""
-        if total == 0:
-            return "0.0%"
-        return f"{(part / total * 100):.1f}%"

--- a/posthog/management/commands/warm_flags_cache.py
+++ b/posthog/management/commands/warm_flags_cache.py
@@ -1,36 +1,36 @@
 """
-Management command to warm the team metadata cache.
+Management command to warm the flags cache.
 
 IMPORTANT: This command requires FLAGS_REDIS_URL to be set. It will error if the
 dedicated flags cache is not configured to prevent warming the wrong cache.
 
 Usage:
     # Initial cache warm (preserves existing caches)
-    python manage.py warm_team_metadata_cache
+    python manage.py warm_flags_cache
 
     # Warm specific teams
-    python manage.py warm_team_metadata_cache --team-ids 12345 67890
+    python manage.py warm_flags_cache --team-ids 12345 67890
 
     # Schema changes (invalidates all caches first)
-    python manage.py warm_team_metadata_cache --invalidate-first
+    python manage.py warm_flags_cache --invalidate-first
 
     # Custom batch size and TTL range
-    python manage.py warm_team_metadata_cache --batch-size 200 --min-ttl-days 6 --max-ttl-days 8
+    python manage.py warm_flags_cache --batch-size 200 --min-ttl-days 6 --max-ttl-days 8
 """
 
 from posthog.management.commands._base_hypercache_command import BaseHyperCacheCommand
-from posthog.storage.team_metadata_cache import TEAM_HYPERCACHE_MANAGEMENT_CONFIG
+from posthog.models.feature_flag.flags_cache import FLAGS_HYPERCACHE_MANAGEMENT_CONFIG
 
 
 class Command(BaseHyperCacheCommand):
-    help = "Warm team metadata cache for all teams (initial build or schema migration)"
+    help = "Warm flags cache for all teams (initial build or schema migration)"
 
     def add_arguments(self, parser):
         self.add_common_team_arguments(parser)
         self.add_warm_arguments(parser)
 
     def handle(self, *args, **options):
-        # Check if dedicated cache is configured (fail fast)
+        # Check if dedicated flags cache is configured (fail fast)
         if not self.check_dedicated_cache_configured():
             return
 
@@ -61,4 +61,4 @@ class Command(BaseHyperCacheCommand):
 
     def get_hypercache_config(self):
         """Return the HyperCache management configuration."""
-        return TEAM_HYPERCACHE_MANAGEMENT_CONFIG
+        return FLAGS_HYPERCACHE_MANAGEMENT_CONFIG

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -30,6 +30,12 @@ KLUDGES_COUNTER = Counter(
     labelnames=["kludge"],
 )
 
+TOMBSTONE_COUNTER = Counter(
+    "posthog_tombstone_total",
+    "Rare anomalous events that should almost never occur. Used to track edge cases, cleanup operations finding stale data, and other scenarios that indicate potential bugs or race conditions.",
+    labelnames=["namespace", "operation", "component"],
+)
+
 
 def _push(settings, job, registry):
     push_to_gateway(settings, job, registry)

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -284,6 +284,10 @@ def refresh_expiring_flags_caches(ttl_threshold_hours: int = 24, limit: int = 50
     Args:
         ttl_threshold_hours: Refresh caches expiring within this many hours
         limit: Maximum number of teams to refresh per run (default 5000)
+               5000 chosen as starting point to balance:
+               - Memory efficiency: Doesn't load too many teams into memory at once
+               - Throughput: With ~200K teams total, hourly runs can process 120K/day (5000 * 24)
+               - Responsiveness: Completes quickly enough to not block other operations
 
     Returns:
         Tuple of (successful_refreshes, failed_refreshes)

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -8,6 +8,7 @@ and group type mappings), this cache provides just the raw flag data.
 The cache is automatically invalidated when:
 - FeatureFlag models are created, updated, or deleted
 - Team models are created or deleted (to ensure flag caches are cleaned up)
+- Hourly refresh job detects expiring entries (TTL < 24h)
 
 Cache Key Pattern:
 - Uses team_id as the key
@@ -16,25 +17,44 @@ Cache Key Pattern:
 Configuration:
 - Redis TTL: 7 days (configurable via FLAGS_CACHE_TTL env var)
 - Miss TTL: 1 day (configurable via FLAGS_CACHE_MISS_TTL env var)
+
+Manual operations:
+    from posthog.models.feature_flag.flags_cache import clear_flags_cache
+    clear_flags_cache(team_id)
 """
 
+import time
+from collections import defaultdict
 from typing import Any
 
 from django.conf import settings
+from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.cache import cache, caches
 from django.db import transaction
+from django.db.models import Q
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 import structlog
 
 from posthog.caching.flags_redis_cache import FLAGS_DEDICATED_CACHE_ALIAS
+from posthog.metrics import TOMBSTONE_COUNTER
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.feature_flag.feature_flag import get_feature_flags, serialize_feature_flags
 from posthog.models.team import Team
+from posthog.redis import get_client
+from posthog.storage.cache_expiry_manager import (
+    cleanup_stale_expiry_tracking as cleanup_generic,
+    get_teams_with_expiring_caches,
+    refresh_expiring_caches,
+)
 from posthog.storage.hypercache import HyperCache
+from posthog.storage.hypercache_manager import HyperCacheManagementConfig, get_cache_stats
 
 logger = structlog.get_logger(__name__)
+
+# Sorted set key for tracking cache expirations
+FLAGS_CACHE_EXPIRY_SORTED_SET = "flags_cache_expiry"
 
 
 def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
@@ -62,6 +82,82 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     return {"flags": flags_data}
 
 
+def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str, Any]]:
+    """
+    Batch load feature flags for multiple teams in one query.
+
+    This avoids N+1 queries by loading all flags for all teams at once,
+    then grouping them by team_id.
+
+    Args:
+        teams: List of Team objects to load flags for
+
+    Returns:
+        Dict mapping team_id to {"flags": [...]} for each team
+    """
+    if not teams:
+        return {}
+
+    # Load all flags for all teams in one query with evaluation tags pre-loaded
+    all_flags = list(
+        FeatureFlag.objects.filter(team__in=teams, active=True, deleted=False)
+        .select_related("team")
+        .annotate(
+            evaluation_tag_names_agg=ArrayAgg(
+                "evaluation_tags__tag__name",
+                filter=Q(evaluation_tags__isnull=False),
+                distinct=True,
+            )
+        )
+    )
+
+    # Transfer aggregated tag names to model instances
+    for flag in all_flags:
+        flag._evaluation_tag_names = flag.evaluation_tag_names_agg or []
+
+    # Group flags by team_id
+    flags_by_team_id: dict[int, list[FeatureFlag]] = defaultdict(list)
+    for flag in all_flags:
+        flags_by_team_id[flag.team_id].append(flag)
+
+    # Serialize flags for each team
+    result: dict[int, dict[str, Any]] = {}
+    for team in teams:
+        team_flags = flags_by_team_id.get(team.id, [])
+        flags_data = serialize_feature_flags(team_flags)
+
+        logger.info(
+            "Loaded feature flags for service cache (batch)",
+            team_id=team.id,
+            project_id=team.project_id,
+            flag_count=len(flags_data),
+        )
+
+        result[team.id] = {"flags": flags_data}
+
+    return result
+
+
+def _track_cache_expiry(team: Team | int, ttl_seconds: int) -> None:
+    """
+    Track cache expiration in Redis sorted set for efficient expiry queries.
+
+    Args:
+        team: Team object or team ID
+        ttl_seconds: TTL in seconds from now
+    """
+    try:
+        redis_client = get_client()
+
+        # Get team ID for tracking
+        team_id = team.id if isinstance(team, Team) else team
+
+        expiration_timestamp = time.time() + ttl_seconds
+        redis_client.zadd(FLAGS_CACHE_EXPIRY_SORTED_SET, {str(team_id): expiration_timestamp})
+    except Exception as e:
+        logger.warning("Failed to track cache expiry in sorted set", error=str(e), error_type=type(e).__name__)
+
+
 # Use dedicated flags cache if available, otherwise fall back to default cache
 if FLAGS_DEDICATED_CACHE_ALIAS in settings.CACHES:
     _flags_cache_client = caches[FLAGS_DEDICATED_CACHE_ALIAS]
@@ -76,10 +172,11 @@ flags_hypercache = HyperCache(
     cache_ttl=settings.FLAGS_CACHE_TTL,
     cache_miss_ttl=settings.FLAGS_CACHE_MISS_TTL,
     cache_client=_flags_cache_client,
+    batch_load_fn=_get_feature_flags_for_teams_batch,
 )
 
 
-def get_flags_from_cache(team: Team) -> list[dict[str, Any]]:
+def get_flags_from_cache(team: Team) -> list[dict[str, Any]] | None:
     """
     Get feature flags from the cache for a team.
 
@@ -89,47 +186,155 @@ def get_flags_from_cache(team: Team) -> list[dict[str, Any]]:
         team: The team to get flags for
 
     Returns:
-        List of flag dictionaries (empty list if not found or FLAGS_REDIS_URL not configured)
+        list: Flag dictionaries (empty list if team has zero flags)
+        None: Cache miss or FLAGS_REDIS_URL not configured
     """
     if not settings.FLAGS_REDIS_URL:
-        return []
+        return None
 
     result = flags_hypercache.get_from_cache(team)
     if result is None:
-        return []
+        return None
     return result.get("flags", [])
 
 
-def update_flags_cache(team: Team) -> None:
+def update_flags_cache(team: Team | int, ttl: int | None = None) -> bool:
     """
     Update the flags cache for a team.
 
     This explicitly updates both Redis and S3 with the latest flag data.
     Only operates when FLAGS_REDIS_URL is configured to avoid writing to shared cache.
 
+    Note: Update duration is tracked by CACHE_SYNC_DURATION_HISTOGRAM in hypercache.py
+
     Args:
-        team: The team to update cache for
+        team: Team object or team ID
+        ttl: Optional custom TTL in seconds (defaults to FLAGS_CACHE_TTL)
+
+    Returns:
+        True if cache update succeeded, False otherwise
     """
     if not settings.FLAGS_REDIS_URL:
-        return
+        return False
 
-    flags_hypercache.update_cache(team)
+    success = flags_hypercache.update_cache(team, ttl=ttl)
+
+    team_id = team.id if isinstance(team, Team) else team
+
+    if not success:
+        logger.warning("Failed to update flags cache", team_id=team_id)
+    else:
+        # Track expiration in sorted set for efficient queries
+        ttl_seconds = ttl if ttl is not None else settings.FLAGS_CACHE_TTL
+        _track_cache_expiry(team, ttl_seconds)
+
+    return success
 
 
-def clear_flags_cache(team: Team, kinds: list[str] | None = None) -> None:
+# Initialize hypercache management config after update_flags_cache is defined
+FLAGS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
+    hypercache=flags_hypercache,
+    update_fn=update_flags_cache,
+    cache_name="flags",
+)
+
+# Derive cache expiry config from hypercache management config (eliminates duplication)
+FLAGS_CACHE_EXPIRY_CONFIG = FLAGS_HYPERCACHE_MANAGEMENT_CONFIG.cache_expiry_config
+
+
+def clear_flags_cache(team: Team | int, kinds: list[str] | None = None) -> None:
     """
     Clear the flags cache for a team.
 
     Only operates when FLAGS_REDIS_URL is configured to avoid writing to shared cache.
 
     Args:
-        team: The team to clear cache for
+        team: Team object or team ID
         kinds: Optional list of cache kinds to clear ("redis", "s3")
     """
     if not settings.FLAGS_REDIS_URL:
         return
 
     flags_hypercache.clear_cache(team, kinds=kinds)
+
+    # Remove from expiry tracking sorted set
+    try:
+        redis_client = get_client()
+        team_id = team.id if isinstance(team, Team) else team
+        redis_client.zrem(FLAGS_CACHE_EXPIRY_SORTED_SET, str(team_id))
+    except Exception as e:
+        logger.warning("Failed to remove from expiry tracking", error=str(e), error_type=type(e).__name__)
+
+
+def get_teams_with_expiring_flags_caches(ttl_threshold_hours: int = 24, limit: int = 5000) -> list[Team]:
+    """
+    Get teams whose flags caches are expiring soon using sorted set for efficient lookup.
+
+    Uses ZRANGEBYSCORE on the expiry tracking sorted set instead of scanning all Redis keys.
+    This is O(log N + M) where M is the number of expiring teams, vs O(N) for SCAN.
+
+    Args:
+        ttl_threshold_hours: Refresh caches expiring within this many hours
+        limit: Maximum number of teams to return (default 5000)
+
+    Returns:
+        List of Team objects whose caches need refresh (up to limit)
+    """
+    return get_teams_with_expiring_caches(FLAGS_CACHE_EXPIRY_CONFIG, ttl_threshold_hours, limit)
+
+
+def refresh_expiring_flags_caches(ttl_threshold_hours: int = 24, limit: int = 5000) -> tuple[int, int]:
+    """
+    Refresh flags caches that are expiring soon to prevent cache misses.
+
+    This is the main hourly job that keeps caches fresh. It:
+    1. Finds cache entries with TTL < threshold (up to limit)
+    2. Refreshes them with new data and full TTL
+
+    Processes teams in batches (default 5000). If more teams are expiring than the limit,
+    subsequent runs will process the next batch.
+
+    Note: Metrics are tracked by refresh_expiring_caches() using consolidated HYPERCACHE_TEAMS_PROCESSED_COUNTER
+
+    Args:
+        ttl_threshold_hours: Refresh caches expiring within this many hours
+        limit: Maximum number of teams to refresh per run (default 5000)
+
+    Returns:
+        Tuple of (successful_refreshes, failed_refreshes)
+    """
+    # Metrics are now tracked in cache_expiry_manager.py using consolidated counters
+    return refresh_expiring_caches(FLAGS_CACHE_EXPIRY_CONFIG, ttl_threshold_hours, limit)
+
+
+def cleanup_stale_expiry_tracking() -> int:
+    """
+    Clean up orphaned entries in the expiry tracking sorted set.
+
+    Removes entries for teams that no longer exist in the database.
+    Should be run periodically (e.g., daily) to prevent sorted set bloat.
+
+    Returns:
+        Number of stale entries removed
+    """
+    removed = cleanup_generic(FLAGS_CACHE_EXPIRY_CONFIG)
+
+    if removed > 0:
+        TOMBSTONE_COUNTER.labels(namespace="flags", operation="stale_expiry_tracking", component="flags_cache").inc(
+            removed
+        )
+
+    return removed
+
+
+def get_flags_cache_stats() -> dict[str, Any]:
+    """
+    Get statistics about the flags cache.
+
+    Returns:
+        Dictionary with cache statistics including size information
+    """
+    return get_cache_stats(FLAGS_HYPERCACHE_MANAGEMENT_CONFIG)
 
 
 # Signal handlers for automatic cache invalidation
@@ -150,6 +355,7 @@ def feature_flag_changed_flags_cache(sender, instance: "FeatureFlag", **kwargs):
     from posthog.tasks.feature_flags import update_team_service_flags_cache
 
     # Defer task execution until after the transaction commits to avoid race conditions
+    # Note: Metric tracking happens in the task itself to capture actual success/failure result
     transaction.on_commit(lambda: update_team_service_flags_cache.delay(instance.team_id))
 
 
@@ -166,6 +372,8 @@ def team_created_flags_cache(sender, instance: "Team", created: bool, **kwargs):
 
     from posthog.tasks.feature_flags import update_team_service_flags_cache
 
+    # Defer task execution until after the transaction commits
+    # Note: Metric tracking happens in the task itself to capture actual success/failure result
     transaction.on_commit(lambda: update_team_service_flags_cache.delay(instance.id))
 
 

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -9,8 +9,9 @@ Tests cover:
 """
 
 from posthog.test.base import BaseTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from django.conf import settings
 from django.test import override_settings
 
 from posthog.models import FeatureFlag, Team
@@ -136,7 +137,7 @@ class TestServiceFlagsCache(BaseTest):
 
         # Get from cache (should hit Redis)
         flags = get_flags_from_cache(self.team)
-
+        assert flags is not None
         assert len(flags) == 1
         assert flags[0]["key"] == "cached-flag"
 
@@ -155,6 +156,7 @@ class TestServiceFlagsCache(BaseTest):
 
         # Verify cache was updated
         flags = get_flags_from_cache(self.team)
+        assert flags is not None
         assert len(flags) == 1
         assert flags[0]["key"] == "test-flag"
 
@@ -266,6 +268,7 @@ class TestServiceFlagsSignals(BaseTest):
 
         # Verify cache exists
         flags = get_flags_from_cache(self.team)
+        assert flags is not None
         assert len(flags) == 1
 
         # Delete the team
@@ -301,6 +304,7 @@ class TestServiceFlagsCeleryTasks(BaseTest):
 
         # Verify cache was updated
         flags = get_flags_from_cache(self.team)
+        assert flags is not None
         assert len(flags) == 1
         assert flags[0]["key"] == "test-flag"
 
@@ -394,6 +398,986 @@ class TestServiceFlagsDataFormat(BaseTest):
         assert deserialized["flags"][0]["key"] == "json-test-flag"
 
 
+class TestCacheStats(BaseTest):
+    """Test cache statistics functionality."""
+
+    @patch("posthog.storage.hypercache_manager.get_client")
+    def test_get_cache_stats_basic(self, mock_get_client):
+        """Test basic cache stats gathering with Redis pipelining."""
+        from posthog.models.feature_flag.flags_cache import get_flags_cache_stats
+
+        # Mock Redis client with pipelining support
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        # scan_iter is called twice: once for TTL collection, once for memory sampling
+        # Each call needs to return a fresh iterator
+        mock_redis.scan_iter.side_effect = [
+            iter(
+                [
+                    b"cache/teams/1/feature_flags/flags.json",
+                    b"cache/teams/2/feature_flags/flags.json",
+                ]
+            ),  # TTL scan
+            iter(
+                [
+                    b"cache/teams/1/feature_flags/flags.json",
+                    b"cache/teams/2/feature_flags/flags.json",
+                ]
+            ),  # Memory scan
+        ]
+
+        # Mock pipeline for batched operations
+        mock_pipeline = MagicMock()
+        mock_redis.pipeline.return_value = mock_pipeline
+        mock_pipeline.execute.side_effect = [
+            [3600, 86400],  # TTL results: 1 hour, 1 day
+            [1024, 2048],  # Memory usage results
+        ]
+
+        with patch("posthog.models.team.team.Team.objects.count", return_value=5):
+            stats = get_flags_cache_stats()
+
+        self.assertEqual(stats["total_cached"], 2)
+        self.assertEqual(stats["total_teams"], 5)
+        self.assertEqual(stats["ttl_distribution"]["expires_1h"], 1)
+        self.assertEqual(stats["ttl_distribution"]["expires_24h"], 1)
+        self.assertEqual(stats["size_statistics"]["sample_count"], 2)
+        self.assertEqual(stats["size_statistics"]["avg_size_bytes"], 1536)  # (1024 + 2048) / 2
+
+
+class TestGetTeamsWithExpiringCaches(BaseTest):
+    """Test get_teams_with_expiring_flags_caches functionality."""
+
+    @patch("posthog.storage.cache_expiry_manager.get_client")
+    @patch("posthog.storage.cache_expiry_manager.time")
+    def test_returns_teams_with_expiring_ttl(self, mock_time, mock_get_client):
+        """Teams with expiration timestamp < threshold should be returned."""
+        from posthog.models.feature_flag.flags_cache import (
+            FLAGS_CACHE_EXPIRY_SORTED_SET,
+            get_teams_with_expiring_flags_caches,
+        )
+
+        team1 = self.team
+        team2 = Team.objects.create(
+            organization=self.organization,
+            name="Team 2",
+        )
+
+        # Mock current time and Redis sorted set query
+        mock_time.time.return_value = 1000000
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        # Return teams expiring within next 24 hours
+        mock_redis.zrangebyscore.return_value = [
+            str(team1.id).encode(),
+            str(team2.id).encode(),
+        ]
+
+        result = get_teams_with_expiring_flags_caches(ttl_threshold_hours=24)
+
+        # Both teams have expiring caches
+        self.assertEqual(len(result), 2)
+        self.assertIn(team1, result)
+        self.assertIn(team2, result)
+
+        # Verify sorted set query was called correctly
+        mock_redis.zrangebyscore.assert_called_once_with(
+            FLAGS_CACHE_EXPIRY_SORTED_SET,
+            "-inf",
+            1000000 + (24 * 3600),  # current_time + 24 hours
+            start=0,
+            num=5000,
+        )
+
+    @patch("posthog.storage.cache_expiry_manager.get_client")
+    @patch("posthog.storage.cache_expiry_manager.time")
+    def test_skips_teams_with_fresh_ttl(self, mock_time, mock_get_client):
+        """Teams with expiration timestamp > threshold should not be returned."""
+        from posthog.models.feature_flag.flags_cache import get_teams_with_expiring_flags_caches
+
+        # Mock Redis sorted set returning empty (no teams expiring soon)
+        mock_time.time.return_value = 1000000
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+        mock_redis.zrangebyscore.return_value = []  # No teams expiring within threshold
+
+        result = get_teams_with_expiring_flags_caches(ttl_threshold_hours=24)
+
+        # No teams returned
+        self.assertEqual(len(result), 0)
+
+    @patch("posthog.storage.cache_expiry_manager.get_client")
+    def test_returns_empty_when_no_expiring_caches(self, mock_get_client):
+        """Should return empty list when sorted set is empty."""
+        from posthog.models.feature_flag.flags_cache import get_teams_with_expiring_flags_caches
+
+        # Mock Redis to return empty sorted set
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+        mock_redis.zrangebyscore.return_value = []
+
+        result = get_teams_with_expiring_flags_caches(ttl_threshold_hours=24)
+
+        self.assertEqual(len(result), 0)
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test:6379/0")
+class TestBatchOperations(BaseTest):
+    """Test batch operations for flags cache."""
+
+    @patch("posthog.models.feature_flag.flags_cache.refresh_expiring_caches")
+    def test_refresh_expiring_caches(self, mock_refresh):
+        """Test refreshing expiring caches calls generic function."""
+        from posthog.models.feature_flag.flags_cache import FLAGS_CACHE_EXPIRY_CONFIG, refresh_expiring_flags_caches
+
+        mock_refresh.return_value = (2, 0)  # successful, failed
+
+        successful, failed = refresh_expiring_flags_caches(ttl_threshold_hours=24)
+
+        # Should return result from generic function
+        self.assertEqual(successful, 2)
+        self.assertEqual(failed, 0)
+
+        # Should call generic refresh_expiring_caches with correct config
+        mock_refresh.assert_called_once_with(FLAGS_CACHE_EXPIRY_CONFIG, 24, settings.FLAGS_CACHE_REFRESH_LIMIT)
+
+    @patch("posthog.storage.cache_expiry_manager.get_client")
+    def test_cleanup_stale_expiry_tracking(self, mock_get_client):
+        """Test cleaning up stale expiry tracking entries."""
+        from posthog.models.feature_flag.flags_cache import FLAGS_CACHE_EXPIRY_SORTED_SET, cleanup_stale_expiry_tracking
+
+        team1 = self.team
+        # Create a team that will be deleted
+        team2 = Team.objects.create(
+            organization=self.organization,
+            name="Team 2",
+        )
+        team2_id = team2.id
+        team2.delete()
+
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        # Mock sorted set with both valid and stale team IDs
+        mock_redis.zrange.return_value = [
+            str(team1.id).encode(),
+            str(team2_id).encode(),  # Stale - team deleted
+        ]
+        mock_redis.zrem.return_value = 1  # Redis returns number of elements removed
+
+        removed = cleanup_stale_expiry_tracking()
+
+        # Should remove 1 stale entry
+        self.assertEqual(removed, 1)
+
+        # Should call zrem with the stale team ID
+        mock_redis.zrem.assert_called_once_with(FLAGS_CACHE_EXPIRY_SORTED_SET, str(team2_id))
+
+    @patch("posthog.storage.cache_expiry_manager.get_client")
+    @patch("posthog.storage.cache_expiry_manager.time")
+    def test_warm_without_stagger_tracks_expiry_with_default_ttl(self, mock_time, mock_get_client):
+        """Test that expiry tracking happens even when stagger_ttl=False (uses batch path)."""
+        from posthog.models.feature_flag.flags_cache import (
+            FLAGS_CACHE_EXPIRY_SORTED_SET,
+            FLAGS_HYPERCACHE_MANAGEMENT_CONFIG,
+        )
+        from posthog.storage.hypercache_manager import warm_caches
+
+        # Create a flag so batch loading succeeds
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        mock_time.time.return_value = 1000000
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        # Call warm WITHOUT staggering (ttl_seconds will be None in batch path)
+        warm_caches(
+            FLAGS_HYPERCACHE_MANAGEMENT_CONFIG,
+            stagger_ttl=False,  # This should still track expiry!
+            batch_size=1,
+            team_ids=[self.team.id],  # Ensure we warm only self.team
+        )
+
+        # Should have tracked expiry with default TTL
+        mock_redis.zadd.assert_called()
+        call_args = mock_redis.zadd.call_args
+
+        # Verify it was added to the correct sorted set
+        self.assertEqual(call_args[0][0], FLAGS_CACHE_EXPIRY_SORTED_SET)
+
+        # Verify the TTL is the default (since stagger_ttl=False)
+        team_id_str = str(self.team.id)
+        expiry_timestamp = call_args[0][1][team_id_str]
+        expected_expiry = 1000000 + settings.FLAGS_CACHE_TTL
+        self.assertEqual(expiry_timestamp, expected_expiry)
+
+
+@override_settings(
+    FLAGS_REDIS_URL="redis://test:6379/0",
+    CACHES={
+        **settings.CACHES,
+        "flags_dedicated": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "flags-test",
+        },
+    },
+)
+class TestManagementCommands(BaseTest):
+    """Test management commands for flags cache."""
+
+    @patch("posthog.management.commands.analyze_flags_cache_sizes._get_feature_flags_for_teams_batch")
+    def test_analyze_command(self, mock_batch_get_flags):
+        """Test analyze_flags_cache_sizes command."""
+        from django.core.management import call_command
+
+        # Mock flags data
+        mock_batch_get_flags.return_value = {
+            self.team.id: {
+                "flags": [
+                    {
+                        "id": 1,
+                        "team_id": self.team.id,
+                        "key": "test-flag",
+                        "name": "Test Flag",
+                        "active": True,
+                        "deleted": False,
+                        "filters": {},
+                    }
+                ]
+            }
+        }
+
+        # Call command - should complete without error
+        call_command("analyze_flags_cache_sizes", "--sample-size=1")
+
+        # Should have called the batch function
+        mock_batch_get_flags.assert_called()
+
+    def test_verify_command(self):
+        """Test verify_flags_cache command."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        # Create a real flag for the team
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Call command with specific team
+        out = StringIO()
+        call_command("verify_flags_cache", f"--team-ids={self.team.id}", stdout=out)
+
+        output = out.getvalue()
+        # Should show verification results
+        self.assertIn("Verification Results", output)
+        self.assertIn("Total teams verified: 1", output)
+
+    def test_warm_command_specific_teams(self):
+        """Test warm_flags_cache command with specific teams."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        # Create a real flag for the team
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Call command with specific team
+        out = StringIO()
+        call_command("warm_flags_cache", f"--team-ids={self.team.id}", stdout=out)
+
+        output = out.getvalue()
+        # Should show warming results
+        self.assertIn("Flags cache warm completed", output)
+        self.assertIn("Total teams: 1", output)
+        self.assertIn("Successful: 1", output)
+
+    @patch("builtins.input", return_value="yes")
+    def test_warm_command_invalidate_first(self, mock_input):
+        """Test warm_flags_cache command with --invalidate-first."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        # Create a real flag for the team
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Call command with --invalidate-first
+        out = StringIO()
+        call_command("warm_flags_cache", "--invalidate-first", stdout=out)
+
+        output = out.getvalue()
+        # Should show warning about invalidation
+        self.assertIn("Invalidate first: True", output)
+        self.assertIn("Flags cache warm completed", output)
+
+    def test_analyze_command_validates_sample_size_too_small(self):
+        """Test analyze command rejects sample_size < 1."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("analyze_flags_cache_sizes", "--sample-size=0", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("must be at least 1", output)
+
+    def test_analyze_command_validates_sample_size_too_large(self):
+        """Test analyze command rejects sample_size > 10000."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("analyze_flags_cache_sizes", "--sample-size=10001", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("cannot exceed 10000", output)
+
+    def test_verify_command_validates_sample_too_small(self):
+        """Test verify command rejects sample < 1."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("verify_flags_cache", "--sample=0", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("must be at least 1", output)
+
+    def test_verify_command_validates_sample_too_large(self):
+        """Test verify command rejects sample > 10000."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("verify_flags_cache", "--sample=10001", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("cannot exceed 10000", output)
+
+    @patch("posthog.storage.hypercache_manager.warm_caches")
+    def test_warm_command_validates_batch_size_too_small(self, mock_warm):
+        """Test warm command rejects batch_size < 1."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("warm_flags_cache", "--batch-size=0", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("must be at least 1", output)
+        mock_warm.assert_not_called()
+
+    @patch("posthog.storage.hypercache_manager.warm_caches")
+    def test_warm_command_validates_batch_size_too_large(self, mock_warm):
+        """Test warm command rejects batch_size > 5000."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("warm_flags_cache", "--batch-size=5001", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("cannot be greater than 5000", output)
+        mock_warm.assert_not_called()
+
+    @patch("posthog.storage.hypercache_manager.warm_caches")
+    def test_warm_command_validates_ttl_days_too_small(self, mock_warm):
+        """Test warm command rejects min_ttl_days < 1."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("warm_flags_cache", "--min-ttl-days=0", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("must be at least 1", output)
+        mock_warm.assert_not_called()
+
+    @patch("posthog.storage.hypercache_manager.warm_caches")
+    def test_warm_command_validates_ttl_days_too_large(self, mock_warm):
+        """Test warm command rejects max_ttl_days > 30."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("warm_flags_cache", "--max-ttl-days=31", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("cannot be greater than 30 days", output)
+        mock_warm.assert_not_called()
+
+    @patch("posthog.storage.hypercache_manager.warm_caches")
+    def test_warm_command_validates_min_greater_than_max_ttl(self, mock_warm):
+        """Test warm command rejects min_ttl_days > max_ttl_days."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("warm_flags_cache", "--min-ttl-days=10", "--max-ttl-days=5", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("cannot be greater than", output)
+        mock_warm.assert_not_called()
+
+    # Comprehensive tests for analyze_flags_cache_sizes
+
+    @patch("posthog.models.feature_flag.flags_cache._get_feature_flags_for_teams_batch")
+    def test_analyze_percentile_calculation(self, mock_batch_get_flags):
+        """Test that percentile calculation is accurate."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        # Create multiple teams with varying flag counts to test percentile calculation
+        teams = [self.team]
+        for i in range(9):  # Total 10 teams
+            team = Team.objects.create(organization=self.organization, name=f"Team {i}")
+            teams.append(team)
+
+        # Mock flags with different sizes
+        mock_batch_get_flags.return_value = {
+            team.id: {
+                "flags": [
+                    {
+                        "id": j,
+                        "team_id": team.id,
+                        "key": f"flag-{j}",
+                        "name": f"Flag {j}",
+                        "active": True,
+                        "deleted": False,
+                        "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]},
+                    }
+                    for j in range((i + 1) * 10)  # 10, 20, 30... flags per team
+                ]
+            }
+            for i, team in enumerate(teams)
+        }
+
+        out = StringIO()
+        call_command("analyze_flags_cache_sizes", "--sample-size=10", stdout=out)
+
+        output = out.getvalue()
+        # Should show P95 and P99 values
+        self.assertIn("P95:", output)
+        self.assertIn("P99:", output)
+        # Should show flag counts
+        self.assertIn("Flag counts per team:", output)
+
+    def test_analyze_no_teams_in_database(self):
+        """Test analyze command handles empty database gracefully."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        # Delete all teams
+        Team.objects.all().delete()
+
+        out = StringIO()
+        call_command("analyze_flags_cache_sizes", "--sample-size=100", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("No teams found", output)
+
+    @patch("posthog.management.commands.analyze_flags_cache_sizes._get_feature_flags_for_teams_batch")
+    def test_analyze_detailed_field_analysis(self, mock_batch_get_flags):
+        """Test analyze command with --detailed flag shows field breakdown."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        # Delete all other teams so our test team is the only one selected
+        Team.objects.exclude(id=self.team.id).delete()
+
+        # Mock flags with various field sizes
+        mock_batch_get_flags.return_value = {
+            self.team.id: {
+                "flags": [
+                    {
+                        "id": 1,
+                        "team_id": self.team.id,
+                        "key": "test-flag",
+                        "name": "Test Flag",
+                        "active": True,
+                        "deleted": False,
+                        "filters": {
+                            "groups": [
+                                {
+                                    "properties": [{"key": "email", "value": "test@example.com", "type": "person"}],
+                                    "rollout_percentage": 100,
+                                }
+                            ]
+                        },
+                    }
+                ]
+            }
+        }
+
+        out = StringIO()
+        call_command("analyze_flags_cache_sizes", "--sample-size=1", "--detailed", stdout=out)
+
+        output = out.getvalue()
+        # Should show field-level breakdown
+        self.assertIn("FLAG FIELD SIZE ANALYSIS", output)
+        self.assertIn("Largest flag fields", output)
+
+    @patch("posthog.models.feature_flag.flags_cache._get_feature_flags_for_teams_batch")
+    def test_analyze_compression_ratio(self, mock_batch_get_flags):
+        """Test that compression ratios are calculated correctly."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        mock_batch_get_flags.return_value = {
+            self.team.id: {
+                "flags": [
+                    {
+                        "id": 1,
+                        "team_id": self.team.id,
+                        "key": "test-flag",
+                        "name": "Test Flag with a long name that should compress well" * 10,
+                        "active": True,
+                        "deleted": False,
+                        "filters": {},
+                    }
+                ]
+            }
+        }
+
+        out = StringIO()
+        call_command("analyze_flags_cache_sizes", "--sample-size=1", stdout=out)
+
+        output = out.getvalue()
+        # Should show compression ratios
+        self.assertIn("Compression ratios:", output)
+        self.assertIn(":1", output)  # Ratio format like "3.5:1"
+
+    # Comprehensive tests for warm_flags_cache
+
+    def test_warm_all_teams_success(self):
+        """Test warming all teams completes successfully."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        # Create a real flag for the team
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        out = StringIO()
+        call_command("warm_flags_cache", "--batch-size=50", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("successful", output.lower())
+        self.assertIn("Batch size: 50", output)
+
+    def test_warm_batch_processing_with_failures(self):
+        """Test warm command reports partial failures correctly."""
+        from io import StringIO
+
+        from unittest.mock import patch
+
+        from django.core.management import call_command
+
+        # Create a real flag for the team
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Make the cache write fail by mocking set_cache_value to raise an exception
+        call_count = 0
+
+        def failing_set_cache(team, value, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            # Fail to simulate a cache write error
+            raise Exception("Cache write failed")
+
+        # Mock the hypercache's set_cache_value to fail
+        with patch(
+            "posthog.models.feature_flag.flags_cache.flags_hypercache.set_cache_value", side_effect=failing_set_cache
+        ):
+            out = StringIO()
+            call_command("warm_flags_cache", stdout=out)
+
+            output = out.getvalue()
+            # Should show failed count
+            self.assertIn("Failed:", output)
+            self.assertIn("1", output)  # 1 team failed
+
+    @patch("posthog.storage.hypercache_manager.warm_caches")
+    @patch("builtins.input", return_value="no")
+    def test_warm_invalidate_first_user_cancels(self, mock_input, mock_warm):
+        """Test that user can cancel --invalidate-first operation."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("warm_flags_cache", "--invalidate-first", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("Aborted", output)
+        # Should NOT call warm_caches
+        mock_warm.assert_not_called()
+
+    def test_warm_staggered_ttl_range(self):
+        """Test that TTL staggering parameters are passed correctly."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        # Create a real flag for the team
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        out = StringIO()
+        call_command("warm_flags_cache", "--min-ttl-days=3", "--max-ttl-days=10", stdout=out)
+
+        output = out.getvalue()
+        # Should show TTL range in output
+        self.assertIn("TTL range: 3-10 days", output)
+
+    @patch("posthog.models.feature_flag.flags_cache.update_flags_cache")
+    def test_warm_missing_team_ids_warning(self, mock_update):
+        """Test that warming with non-existent team IDs shows warning."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        mock_update.return_value = True
+
+        out = StringIO()
+        call_command("warm_flags_cache", "--team-ids", str(self.team.id), "99999", "88888", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("Warning", output)
+        self.assertIn("99999", output)
+        self.assertIn("88888", output)
+
+    # Comprehensive tests for verify_flags_cache
+
+    def test_verify_cache_miss_detection_and_fix(self):
+        """Test that cache misses are detected and can be fixed."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        from posthog.models.feature_flag.flags_cache import clear_flags_cache
+
+        # Clear any cache from previous tests
+        clear_flags_cache(self.team, kinds=["redis", "s3"])
+
+        # Create a real flag for the team
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        out = StringIO()
+        call_command("verify_flags_cache", f"--team-ids={self.team.id}", "--fix", stdout=out)
+
+        output = out.getvalue()
+        # The cache starts empty, so this is a CACHE_MISS (no cache entry exists)
+        # This is correct regardless of whether the team has 0 or N flags in DB
+        self.assertIn("CACHE_MISS", output)
+        self.assertIn("FIXED", output)
+        self.assertIn("Cache fixes applied:  1", output)
+
+    def test_verify_cache_mismatch_detection_and_fix(self):
+        """Test that cache mismatches are detected and fixed."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        from posthog.models.feature_flag.flags_cache import update_flags_cache
+
+        # Create a real flag
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Warm the cache first
+        update_flags_cache(self.team)
+
+        # Modify the flag (creates a mismatch)
+        flag.key = "modified-flag"
+        flag.save()
+
+        out = StringIO()
+        call_command("verify_flags_cache", f"--team-ids={self.team.id}", "--fix", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("DATA_MISMATCH", output)
+        self.assertIn("FIXED", output)
+
+    def test_verify_fix_failures_reported(self):
+        """Test that fix failures are properly reported."""
+        from io import StringIO
+
+        from unittest.mock import patch
+
+        from django.core.management import call_command
+
+        # Create a real flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Make the hypercache update fail by mocking update_cache
+        with patch("posthog.models.feature_flag.flags_cache.flags_hypercache.update_cache", return_value=False):
+            out = StringIO()
+            call_command("verify_flags_cache", f"--team-ids={self.team.id}", "--fix", stdout=out)
+
+            output = out.getvalue()
+            self.assertIn("Failed to fix", output)
+            self.assertIn("Cache fixes failed:   1", output)
+
+    @patch("posthog.models.feature_flag.flags_cache.get_flags_from_cache")
+    @patch("posthog.models.feature_flag.flags_cache._get_feature_flags_for_teams_batch")
+    def test_verify_with_sample(self, mock_batch_get_flags, mock_get_cache):
+        """Test verify command with --sample parameter."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        # Create additional teams
+        for i in range(5):
+            Team.objects.create(organization=self.organization, name=f"Team {i}")
+
+        mock_get_cache.return_value = []
+        mock_batch_get_flags.return_value = {}
+
+        out = StringIO()
+        call_command("verify_flags_cache", "--sample=3", stdout=out)
+
+        output = out.getvalue()
+        # Should verify exactly 3 teams (randomly sampled)
+        self.assertIn("3", output)
+
+    def test_verify_all_caches_match(self):
+        """Test verify command when all caches are correct."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        from posthog.models.feature_flag.flags_cache import update_flags_cache
+
+        # Create a real flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Warm the cache so it matches
+        update_flags_cache(self.team)
+
+        out = StringIO()
+        call_command("verify_flags_cache", f"--team-ids={self.team.id}", stdout=out)
+
+        output = out.getvalue()
+        # When cache matches, there are no issues
+        self.assertIn("Cache matches:", output)
+        self.assertIn("1 (100.0%)", output)  # 100% match rate
+
+    def test_verify_detects_missing_cache_for_team_with_zero_flags(self):
+        """Test that teams with 0 flags but no cache entry are detected as CACHE_MISS."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        from posthog.models.feature_flag.flags_cache import clear_flags_cache
+
+        # Delete any existing flags for this team from previous tests
+        FeatureFlag.objects.filter(team=self.team).delete()
+
+        # Clear any cache from previous tests to ensure clean state (both Redis and S3)
+        clear_flags_cache(self.team, kinds=["redis", "s3"])
+
+        # Team has no flags in DB and no cache entry
+        # This should be detected as CACHE_MISS because ALL teams should be cached
+        # (even empty ones) to prevent Rust service from hitting database
+
+        out = StringIO()
+        call_command("verify_flags_cache", f"--team-ids={self.team.id}", stdout=out)
+
+        output = out.getvalue()
+        # Should detect cache miss for team with 0 flags
+        self.assertIn("CACHE_MISS", output)
+        self.assertIn("Cache misses:", output)
+
+    @patch("posthog.models.feature_flag.flags_cache._get_feature_flags_for_teams_batch")
+    def test_analyze_batch_load_fallback(self, mock_batch_get_flags):
+        """Test analyze command falls back gracefully when batch load fails."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        # Create a flag for the team
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Mock batch load to raise exception
+        mock_batch_get_flags.side_effect = Exception("Database connection failed")
+
+        out = StringIO()
+        call_command("analyze_flags_cache_sizes", "--sample-size=1", stdout=out)
+
+        output = out.getvalue()
+        # Should show warning about fallback
+        self.assertIn("Batch load failed", output)
+        self.assertIn("falling back", output)
+        # But should still complete successfully using individual loads
+        self.assertIn("ANALYSIS RESULTS", output)
+
+    def test_verify_batch_load_fallback(self):
+        """Test verify command falls back gracefully when batch load fails."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        from posthog.models.feature_flag.flags_cache import FLAGS_HYPERCACHE_MANAGEMENT_CONFIG
+
+        # Create a flag for the team
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Mock the batch_load_fn on the hypercache instance to raise an exception
+        original_batch_fn = FLAGS_HYPERCACHE_MANAGEMENT_CONFIG.hypercache.batch_load_fn
+
+        def failing_batch_load(teams):
+            raise Exception("Database error")
+
+        FLAGS_HYPERCACHE_MANAGEMENT_CONFIG.hypercache.batch_load_fn = failing_batch_load
+
+        try:
+            out = StringIO()
+            call_command("verify_flags_cache", f"--team-ids={self.team.id}", stdout=out)
+
+            output = out.getvalue()
+            # Should show warning about fallback
+            self.assertIn("Batch load failed", output)
+            self.assertIn("falling back", output)
+            # Should still complete verification (using individual loads)
+            self.assertIn("Verification Results", output)
+        finally:
+            # Restore original batch function
+            FLAGS_HYPERCACHE_MANAGEMENT_CONFIG.hypercache.batch_load_fn = original_batch_fn
+
+
+@override_settings(
+    FLAGS_REDIS_URL=None,
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "default-test",
+        },
+    },
+)
+class TestManagementCommandsWithoutDedicatedCache(BaseTest):
+    """Test management commands properly reject execution without dedicated cache."""
+
+    def test_analyze_command_errors_without_flags_redis_url(self):
+        """Test analyze command errors when FLAGS_REDIS_URL not set."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("analyze_flags_cache_sizes", "--sample-size=1", stdout=out)
+
+        output = out.getvalue()
+        # Should error and explain FLAGS_REDIS_URL requirement
+        self.assertIn("FLAGS_REDIS_URL", output)
+        self.assertIn("NOT configured", output)
+
+    def test_verify_command_errors_without_flags_redis_url(self):
+        """Test verify command errors when FLAGS_REDIS_URL not set."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("verify_flags_cache", f"--team-ids={self.team.id}", stdout=out)
+
+        output = out.getvalue()
+        # Should error and explain FLAGS_REDIS_URL requirement
+        self.assertIn("FLAGS_REDIS_URL", output)
+        self.assertIn("NOT configured", output)
+
+    def test_warm_command_errors_without_flags_redis_url(self):
+        """Test warm command errors when FLAGS_REDIS_URL not set."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("warm_flags_cache", f"--team-ids={self.team.id}", stdout=out)
+
+        output = out.getvalue()
+        # Should error and explain FLAGS_REDIS_URL requirement
+        self.assertIn("FLAGS_REDIS_URL", output)
+        self.assertIn("NOT configured", output)
+
+
 @override_settings(FLAGS_REDIS_URL=None)
 class TestServiceFlagsGuards(BaseTest):
     """Test that cache functions guard against writes when FLAGS_REDIS_URL is not set."""
@@ -408,19 +1392,22 @@ class TestServiceFlagsGuards(BaseTest):
             filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
         )
 
-    def test_get_flags_from_cache_returns_empty_without_redis_url(self):
-        """Test that get_flags_from_cache returns empty list when FLAGS_REDIS_URL is not set."""
+    def test_get_flags_from_cache_returns_none_without_redis_url(self):
+        """Test that get_flags_from_cache returns None when FLAGS_REDIS_URL is not set."""
         flags = get_flags_from_cache(self.team)
-        assert flags == []
+        assert flags is None
 
     def test_update_flags_cache_no_op_without_redis_url(self):
         """Test that update_flags_cache is a no-op when FLAGS_REDIS_URL is not set."""
         # This should not raise an error and should be a no-op
-        update_flags_cache(self.team)
+        result = update_flags_cache(self.team)
 
-        # Since it's a no-op, attempting to get from cache should return empty
+        # Should return False
+        assert result is False
+
+        # Since it's a no-op, attempting to get from cache should return None
         flags = get_flags_from_cache(self.team)
-        assert flags == []
+        assert flags is None
 
     def test_clear_flags_cache_no_op_without_redis_url(self):
         """Test that clear_flags_cache is a no-op when FLAGS_REDIS_URL is not set."""

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -43,3 +43,15 @@ FEATURE_FLAG_LAST_CALLED_AT_SYNC_CLICKHOUSE_LIMIT: int = get_from_env(
 FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS: int = get_from_env(
     "FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS", 1, type_cast=int
 )
+
+# Feature flag cache refresh settings
+FLAGS_CACHE_REFRESH_TTL_THRESHOLD_HOURS: int = get_from_env(
+    "FLAGS_CACHE_REFRESH_TTL_THRESHOLD_HOURS", 24, type_cast=int
+)
+
+# Maximum number of teams to refresh per cache refresh run to prevent memory spikes.
+# With ~200k teams, 5000 is a starting point that processes all teams across ~40 runs.
+# Run `python manage.py analyze_flags_cache_sizes` to measure actual memory usage.
+# Based on typical flag data, 5000 teams ≈ 10-100 MB depending on flag complexity.
+# See cache_expiry_manager.py for implementation details.
+FLAGS_CACHE_REFRESH_LIMIT: int = get_from_env("FLAGS_CACHE_REFRESH_LIMIT", 5000, type_cast=int)

--- a/posthog/storage/cache_expiry_manager.py
+++ b/posthog/storage/cache_expiry_manager.py
@@ -1,0 +1,254 @@
+"""
+Generic cache expiry management for Redis-backed caches.
+
+This module provides a shared abstraction for managing cache expiration tracking
+across different cache types (flags, team metadata, etc.). Each cache type can
+define a CacheExpiryConfig that specifies how to query and refresh that cache.
+"""
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import structlog
+
+from posthog.exceptions_capture import capture_exception
+from posthog.models.team.team import Team
+from posthog.redis import get_client
+from posthog.storage.hypercache_manager import HYPERCACHE_TEAMS_PROCESSED_COUNTER
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class CacheExpiryConfig:
+    """
+    Configuration for managing cache expiration tracking.
+
+    Each cache type (flags, team metadata, etc.) should define one of these
+    configs to specify how its cache expiry is tracked and refreshed.
+
+    Most properties are derived from cache_name to reduce boilerplate.
+    """
+
+    # Required properties
+    cache_name: str  # Canonical cache name (e.g., "flags", "team_metadata")
+    query_field: str  # Team model field to query by ("id" or "api_token")
+    identifier_type: type  # Type to convert identifiers to (int or str)
+    update_fn: Callable[[Team], bool]  # Function to refresh cache for a team
+    namespace: str  # Cache namespace for metrics labeling (e.g., "feature_flags", "team_metadata")
+
+    # Derived properties
+    @property
+    def sorted_set_key(self) -> str:
+        """Redis sorted set key for tracking expiry timestamps."""
+        return f"{self.cache_name}_cache_expiry"
+
+    @property
+    def log_prefix(self) -> str:
+        """Prefix for log messages (e.g., "flags caches", "team metadata caches")."""
+        return f"{self.cache_name.replace('_', ' ')} caches"
+
+
+def track_cache_expiry(sorted_set_key: str, team: Team | int, ttl_seconds: int) -> None:
+    """
+    Track cache expiration in Redis sorted set for efficient expiry queries.
+
+    This is a generic version that works with any sorted set key.
+    Cache-specific modules (flags_cache.py, team_metadata_cache.py) may have
+    their own wrappers that call this function.
+
+    Args:
+        sorted_set_key: Redis sorted set key for tracking expiry
+        team: Team object or team ID
+        ttl_seconds: TTL in seconds from now
+    """
+    try:
+        redis_client = get_client()
+        team_id = team.id if isinstance(team, Team) else team
+        expiry_timestamp = int(time.time()) + ttl_seconds
+
+        # Store team ID with expiry timestamp as score for efficient range queries
+        redis_client.zadd(sorted_set_key, {str(team_id): expiry_timestamp})
+    except Exception as e:
+        # Don't fail the cache update if expiry tracking fails
+        logger.warning("Failed to track cache expiry", team_id=team_id, error=str(e))
+
+
+def get_teams_with_expiring_caches(
+    config: CacheExpiryConfig, ttl_threshold_hours: int = 24, limit: int = 5000
+) -> list[Team]:
+    """
+    Get teams whose caches are expiring soon using sorted set for efficient lookup.
+
+    Uses ZRANGEBYSCORE on the expiry tracking sorted set instead of scanning all Redis keys.
+    This is O(log N + M) where M is the number of expiring teams, vs O(N) for SCAN.
+
+    Args:
+        config: Cache configuration specifying which cache to check
+        ttl_threshold_hours: Refresh caches expiring within this many hours
+        limit: Maximum number of teams to return (default 5000, prevents unbounded results)
+
+    Returns:
+        List of Team objects whose caches need refresh (up to limit)
+    """
+    try:
+        redis_client = get_client()
+
+        # Query sorted set for teams expiring within threshold
+        threshold_timestamp = time.time() + (ttl_threshold_hours * 3600)
+
+        # Get identifiers of teams expiring before threshold (score is expiration timestamp)
+        # Use LIMIT to prevent unbounded results that could cause memory spikes
+        expiring_identifiers = redis_client.zrangebyscore(
+            config.sorted_set_key, "-inf", threshold_timestamp, start=0, num=limit
+        )
+
+        # Decode bytes to strings and convert to appropriate type
+        expiring_identifiers = [
+            config.identifier_type(identifier.decode("utf-8") if isinstance(identifier, bytes) else identifier)
+            for identifier in expiring_identifiers
+        ]
+
+        if not expiring_identifiers:
+            logger.info(f"No {config.log_prefix} expiring soon")
+            return []
+
+        # Build query filter dynamically based on config
+        filter_kwargs = {f"{config.query_field}__in": expiring_identifiers}
+        teams = list(Team.objects.filter(**filter_kwargs).select_related("organization", "project"))
+
+        logger.info(
+            f"Found teams with expiring {config.log_prefix}",
+            team_count=len(teams),
+            ttl_threshold_hours=ttl_threshold_hours,
+        )
+
+        return teams
+
+    except Exception as e:
+        logger.exception(f"Error finding expiring {config.log_prefix}", error=str(e))
+        capture_exception(e)
+        return []
+
+
+def refresh_expiring_caches(
+    config: CacheExpiryConfig, ttl_threshold_hours: int = 24, limit: int = 5000
+) -> tuple[int, int]:
+    """
+    Refresh caches that are expiring soon to prevent cache misses.
+
+    This is the main hourly job that keeps caches fresh. It:
+    1. Finds teams whose caches are expiring within the threshold (up to limit)
+    2. Refreshes each cache by calling the configured update function
+    3. Returns success/failure counts
+
+    Processes teams in batches (default 5000). If more teams are expiring than the limit,
+    subsequent runs will process the next batch. This prevents memory spikes and timeouts
+    from trying to refresh all teams at once.
+
+    Args:
+        config: Cache configuration specifying which cache to refresh
+        ttl_threshold_hours: Refresh caches expiring within this many hours
+        limit: Maximum number of teams to refresh per run (default 5000)
+
+    Returns:
+        Tuple of (successful_count, failed_count)
+    """
+    teams = get_teams_with_expiring_caches(config, ttl_threshold_hours, limit)
+
+    if not teams:
+        logger.info(f"No {config.log_prefix} to refresh")
+        return 0, 0
+
+    successful = 0
+    failed = 0
+
+    for team in teams:
+        try:
+            success = config.update_fn(team)
+            if success:
+                successful += 1
+            else:
+                failed += 1
+        except Exception as e:
+            logger.exception(
+                f"Failed to refresh {config.log_prefix[:-1]}",
+                team_id=team.id,
+                error=str(e),
+            )
+            capture_exception(e)
+            failed += 1
+
+    logger.info(
+        f"Completed refreshing {config.log_prefix}",
+        successful=successful,
+        failed=failed,
+        total=len(teams),
+    )
+
+    # Track metrics using consolidated counters
+    HYPERCACHE_TEAMS_PROCESSED_COUNTER.labels(namespace=config.namespace, result="success").inc(successful)
+    HYPERCACHE_TEAMS_PROCESSED_COUNTER.labels(namespace=config.namespace, result="failure").inc(failed)
+
+    return successful, failed
+
+
+def cleanup_stale_expiry_tracking(config: CacheExpiryConfig) -> int:
+    """
+    Remove stale entries from the expiry tracking sorted set.
+
+    Over time, the sorted set can accumulate entries for deleted teams or teams
+    that no longer have caches. This cleanup job removes those stale entries.
+
+    Args:
+        config: Cache configuration specifying which cache to clean up
+
+    Returns:
+        Number of stale entries removed
+    """
+    try:
+        redis_client = get_client()
+
+        # Get all entries from the sorted set
+        all_identifiers = redis_client.zrange(config.sorted_set_key, 0, -1)
+
+        if not all_identifiers:
+            logger.info(f"No {config.log_prefix} expiry entries to check")
+            return 0
+
+        # Decode to appropriate type
+        all_identifiers = [
+            config.identifier_type(identifier.decode("utf-8") if isinstance(identifier, bytes) else identifier)
+            for identifier in all_identifiers
+        ]
+
+        # Query for valid teams
+        filter_kwargs = {f"{config.query_field}__in": all_identifiers}
+        valid_identifiers = set(Team.objects.filter(**filter_kwargs).values_list(config.query_field, flat=True))
+
+        # Find stale entries (in sorted set but not in database)
+        stale_identifiers = [identifier for identifier in all_identifiers if identifier not in valid_identifiers]
+
+        if not stale_identifiers:
+            logger.info(f"No stale {config.log_prefix} expiry entries found")
+            return 0
+
+        # Convert back to strings for Redis (sorted sets store members as strings/bytes)
+        stale_identifiers_str = [str(identifier) for identifier in stale_identifiers]
+
+        # Remove stale entries
+        removed = redis_client.zrem(config.sorted_set_key, *stale_identifiers_str)
+
+        logger.info(
+            f"Cleaned up stale {config.log_prefix} expiry entries",
+            removed=removed,
+            total_checked=len(all_identifiers),
+        )
+
+        return removed
+
+    except Exception as e:
+        logger.exception(f"Error cleaning up {config.log_prefix} expiry tracking", error=str(e))
+        capture_exception(e)
+        return 0

--- a/posthog/storage/cache_expiry_manager.py
+++ b/posthog/storage/cache_expiry_manager.py
@@ -75,6 +75,7 @@ def track_cache_expiry(sorted_set_key: str, team: Team | int, ttl_seconds: int, 
     except Exception as e:
         # Don't fail the cache update if expiry tracking fails
         logger.warning("Failed to track cache expiry", team_id=team_id, error=str(e))
+        capture_exception(e)
 
 
 def get_teams_with_expiring_caches(

--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -67,6 +67,7 @@ class HyperCache:
         cache_ttl: int = DEFAULT_CACHE_TTL,
         cache_miss_ttl: int = DEFAULT_CACHE_MISS_TTL,
         cache_client: Optional[BaseCache] = None,
+        batch_load_fn: Optional[Callable[[list[Team]], dict[int, dict]]] = None,
     ):
         self.namespace = namespace
         self.value = value
@@ -75,6 +76,7 @@ class HyperCache:
         self.cache_ttl = cache_ttl
         self.cache_miss_ttl = cache_miss_ttl
         self.cache_client = cache_client or cache
+        self.batch_load_fn = batch_load_fn
 
     @staticmethod
     def team_from_key(key: KeyType) -> Team:

--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -3,8 +3,8 @@ import time
 from collections.abc import Callable
 from typing import Optional
 
-from django.core.cache import cache
-from django.core.cache.backends.base import BaseCache
+from django.conf import settings
+from django.core.cache import cache, caches
 
 import structlog
 from posthoganalytics import capture_exception
@@ -19,6 +19,28 @@ logger = structlog.get_logger(__name__)
 
 DEFAULT_CACHE_MISS_TTL = 60 * 60 * 24  # 1 day - it will be invalidated by the daily sync
 DEFAULT_CACHE_TTL = 60 * 60 * 24 * 30  # 30 days
+
+
+def get_cache_writer_url(cache_alias: str) -> str:
+    """
+    Get writer Redis URL from cache alias.
+
+    Django cache backends can have multiple URLs (writer + readers). This extracts
+    the writer URL (first URL if multiple).
+
+    Args:
+        cache_alias: Django cache alias (e.g., 'flags_cache')
+
+    Returns:
+        Redis URL string for the writer
+    """
+    location = settings.CACHES[cache_alias]["LOCATION"]
+    if isinstance(location, list):
+        return location[0]
+    elif isinstance(location, str):
+        return location
+    else:
+        raise TypeError(f"Unsupported LOCATION type for cache alias '{cache_alias}': {type(location)}")
 
 
 CACHE_SYNC_COUNTER = Counter(
@@ -66,7 +88,7 @@ class HyperCache:
         token_based: bool = False,
         cache_ttl: int = DEFAULT_CACHE_TTL,
         cache_miss_ttl: int = DEFAULT_CACHE_MISS_TTL,
-        cache_client: Optional[BaseCache] = None,
+        cache_alias: Optional[str] = None,
         batch_load_fn: Optional[Callable[[list[Team]], dict[int, dict]]] = None,
     ):
         self.namespace = namespace
@@ -75,8 +97,15 @@ class HyperCache:
         self.token_based = token_based
         self.cache_ttl = cache_ttl
         self.cache_miss_ttl = cache_miss_ttl
-        self.cache_client = cache_client or cache
         self.batch_load_fn = batch_load_fn
+
+        # Derive cache_client and redis_url from cache_alias (single source of truth)
+        if cache_alias:
+            self.cache_client = caches[cache_alias]
+            self.redis_url = get_cache_writer_url(cache_alias)
+        else:
+            self.cache_client = cache
+            self.redis_url = settings.REDIS_URL
 
     @staticmethod
     def team_from_key(key: KeyType) -> Team:

--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -145,13 +145,16 @@ class HyperCacheManagementConfig:
         """Name of management command for detailed analysis."""
         return f"analyze_{self.cache_name}_cache_sizes"
 
-    @property
-    def cache_expiry_config(self) -> "CacheExpiryConfig":
+    def cache_expiry_config(self, redis_url: str | None = None) -> "CacheExpiryConfig":
         """
         Derive CacheExpiryConfig from HyperCache management config.
 
         This eliminates the need to maintain separate CacheExpiryConfig instances
         by deriving all expiry config properties from the HyperCache configuration.
+
+        Args:
+            redis_url: Optional Redis URL for dedicated cache (e.g., FLAGS_REDIS_URL).
+                      If not provided, defaults to settings.REDIS_URL.
         """
         from posthog.storage.cache_expiry_manager import CacheExpiryConfig
 
@@ -161,6 +164,7 @@ class HyperCacheManagementConfig:
             identifier_type=str if self.hypercache.token_based else int,
             update_fn=self.update_fn,
             namespace=self.namespace,
+            redis_url=redis_url,
         )
 
 

--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -1,0 +1,490 @@
+"""
+Batch management operations for HyperCache-backed team caches.
+
+This module provides unified batch operations for managing team-indexed HyperCaches
+(flags, team metadata, etc.). Each cache type can define a HyperCacheManagementConfig
+that specifies how to perform batch operations.
+
+Operations include:
+- Invalidating all caches for a namespace
+- Warming all caches with configurable batching and TTL staggering
+- Gathering cache statistics and coverage metrics
+"""
+
+import random
+import statistics
+from dataclasses import dataclass
+
+# Import TYPE_CHECKING to avoid circular import at runtime
+from typing import TYPE_CHECKING, Any, Protocol
+
+from django.conf import settings
+from django.db import connection
+
+import structlog
+from posthoganalytics import capture_exception
+from prometheus_client import Counter, Gauge, Histogram
+
+from posthog.models.team.team import Team
+from posthog.redis import get_client
+from posthog.storage.hypercache import HyperCache
+
+if TYPE_CHECKING:
+    from posthog.storage.cache_expiry_manager import CacheExpiryConfig
+
+logger = structlog.get_logger(__name__)
+
+
+# Consolidated HyperCache metrics with namespace labels
+# These replace cache-specific metrics in flags_cache.py and team_metadata_cache.py
+
+HYPERCACHE_BATCH_REFRESH_COUNTER = Counter(
+    "posthog_hypercache_batch_refresh",
+    "Batch refresh operations for HyperCaches",
+    labelnames=["namespace", "result"],
+)
+
+HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM = Histogram(
+    "posthog_hypercache_batch_refresh_duration_seconds",
+    "Time taken for batch refresh operations",
+    labelnames=["namespace"],
+    buckets=(1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, float("inf")),
+)
+
+HYPERCACHE_TEAMS_PROCESSED_COUNTER = Counter(
+    "posthog_hypercache_teams_processed",
+    "Teams processed by batch refresh operations",
+    labelnames=["namespace", "result"],
+)
+
+HYPERCACHE_SIGNAL_UPDATE_COUNTER = Counter(
+    "posthog_hypercache_signal_updates",
+    "Cache updates triggered by Django signals",
+    labelnames=["namespace", "result"],
+)
+
+HYPERCACHE_INVALIDATION_COUNTER = Counter(
+    "posthog_hypercache_invalidations",
+    "Full cache invalidations (schema changes)",
+    labelnames=["namespace"],
+)
+
+HYPERCACHE_COVERAGE_GAUGE = Gauge(
+    "posthog_hypercache_coverage_percent",
+    "Percentage of teams with cached data",
+    labelnames=["namespace"],
+)
+
+HYPERCACHE_SIZE_GAUGE = Gauge(
+    "posthog_hypercache_size_bytes",
+    "Estimated total cache size in bytes",
+    labelnames=["namespace"],
+)
+
+
+class UpdateFn(Protocol):
+    """Protocol for cache update functions that accept team and optional TTL."""
+
+    def __call__(self, team: Team | int, ttl: int | None = None) -> bool: ...
+
+
+@dataclass
+class HyperCacheManagementConfig:
+    """
+    Configuration for batch HyperCache management operations.
+
+    Each HyperCache (flags, team metadata, etc.) should define one of these
+    configs to specify how batch operations should work.
+
+    Most properties are derived from conventions to reduce boilerplate.
+    Only 3 properties need to be specified explicitly.
+
+    Metrics are now consolidated and use namespace labels instead of per-cache counters.
+    """
+
+    # Required properties
+    hypercache: HyperCache  # HyperCache instance
+    update_fn: UpdateFn  # Function to update cache for a team
+    cache_name: str  # Canonical cache name (e.g., "flags", "team_metadata")
+
+    # Derived properties (computed from required properties using conventions)
+    @property
+    def namespace(self) -> str:
+        """Cache namespace from HyperCache (e.g., "feature_flags", "team_metadata")."""
+        return self.hypercache.namespace
+
+    @property
+    def cache_display_name(self) -> str:
+        """Human-readable cache name for display (e.g., "flags", "team metadata")."""
+        return self.cache_name.replace("_", " ")
+
+    @property
+    def redis_pattern(self) -> str:
+        """Redis key pattern for scanning all cache entries."""
+        prefix = "team_tokens" if self.hypercache.token_based else "teams"
+        return f"cache/{prefix}/*/{self.namespace}/*"
+
+    @property
+    def redis_stats_pattern(self) -> str:
+        """Specific Redis pattern for stats (includes value file)."""
+        prefix = "team_tokens" if self.hypercache.token_based else "teams"
+        return f"cache/{prefix}/*/{self.namespace}/{self.hypercache.value}"
+
+    @property
+    def expiry_sorted_set_key(self) -> str:
+        """Sorted set key for tracking cache expirations."""
+        return f"{self.cache_name}_cache_expiry"
+
+    @property
+    def log_prefix(self) -> str:
+        """Prefix for log messages (e.g., "flags caches", "team metadata caches")."""
+        return f"{self.cache_display_name} caches"
+
+    @property
+    def management_command_name(self) -> str:
+        """Name of management command for detailed analysis."""
+        return f"analyze_{self.cache_name}_cache_sizes"
+
+    @property
+    def cache_expiry_config(self) -> "CacheExpiryConfig":
+        """
+        Derive CacheExpiryConfig from HyperCache management config.
+
+        This eliminates the need to maintain separate CacheExpiryConfig instances
+        by deriving all expiry config properties from the HyperCache configuration.
+        """
+        from posthog.storage.cache_expiry_manager import CacheExpiryConfig
+
+        return CacheExpiryConfig(
+            cache_name=self.cache_name,
+            query_field="api_token" if self.hypercache.token_based else "id",
+            identifier_type=str if self.hypercache.token_based else int,
+            update_fn=self.update_fn,
+            namespace=self.namespace,
+        )
+
+
+def invalidate_all_caches(config: HyperCacheManagementConfig) -> int:
+    """
+    Invalidate all caches for a specific HyperCache namespace.
+
+    Scans Redis for all keys matching the cache pattern, deletes them,
+    and clears the expiry tracking sorted set.
+
+    Args:
+        config: Cache configuration specifying which cache to invalidate
+
+    Returns:
+        Number of cache keys deleted
+    """
+    try:
+        redis_client = get_client()
+
+        deleted = 0
+        for key in redis_client.scan_iter(match=config.redis_pattern, count=1000):
+            redis_client.delete(key)
+            deleted += 1
+
+        # Clear the expiry tracking sorted set
+        redis_client.delete(config.expiry_sorted_set_key)
+
+        HYPERCACHE_INVALIDATION_COUNTER.labels(namespace=config.namespace).inc()
+
+        logger.info(f"Invalidated all {config.log_prefix}", deleted_keys=deleted)
+        return deleted
+    except Exception as e:
+        logger.exception(f"Failed to invalidate {config.log_prefix}", error=str(e))
+        capture_exception(e)
+        return 0
+
+
+def warm_caches(
+    config: HyperCacheManagementConfig,
+    batch_size: int = 100,
+    invalidate_first: bool = False,
+    stagger_ttl: bool = True,
+    min_ttl_days: int = 5,
+    max_ttl_days: int = 7,
+    team_ids: list[int] | None = None,
+) -> tuple[int, int]:
+    """
+    Warm cache for teams (all or specific subset).
+
+    Run as a management command for initial cache build or when schema changes require
+    cache invalidation. Processes teams in batches with staggered TTLs to avoid
+    synchronized expiration. Continues on errors.
+
+    Uses persistent database connection to avoid connection overhead across batches.
+    With CONN_MAX_AGE=0, each query creates a new connection (20-50ms overhead).
+    By maintaining a single connection, we eliminate this overhead for batch operations.
+
+    Args:
+        config: Cache configuration specifying which cache to warm
+        batch_size: Number of teams to process at a time
+        invalidate_first: If True, clear all caches before warming (ignored when team_ids provided)
+        stagger_ttl: If True, randomize TTLs between min/max to avoid synchronized expiration
+        min_ttl_days: Minimum TTL in days (when staggering)
+        max_ttl_days: Maximum TTL in days (when staggering)
+        team_ids: Optional list of team IDs to warm (if None, warms all teams)
+
+    Returns:
+        Tuple of (successful_updates, failed_updates)
+    """
+    # Establish persistent database connection for batch operations
+    # This avoids connection overhead (20-50ms per query) across all batches
+    # Skip in tests to avoid interfering with test database management
+    use_connection_pooling = not settings.TEST
+
+    if use_connection_pooling:
+        connection.ensure_connection()
+
+    try:
+        # Skip invalidation when warming specific teams (doesn't make sense for subset)
+        if invalidate_first:
+            if team_ids:
+                logger.warning("Skipping invalidation when warming specific teams")
+            else:
+                logger.info(f"Invalidating all existing {config.log_prefix} before warming")
+                invalidated = invalidate_all_caches(config)
+                logger.info("Invalidated caches", count=invalidated)
+
+        # Filter to specific teams if requested
+        teams_queryset = Team.objects.select_related("organization", "project")
+        if team_ids:
+            teams_queryset = teams_queryset.filter(id__in=team_ids)
+
+        total_teams = teams_queryset.count()
+
+        logger.info(
+            f"Starting {config.log_prefix} warm",
+            total_teams=total_teams,
+            batch_size=batch_size,
+            stagger_ttl=stagger_ttl,
+            invalidate_first=invalidate_first and not team_ids,
+            specific_teams=team_ids is not None,
+        )
+
+        successful = 0
+        failed = 0
+        processed = 0
+
+        last_id = 0
+        while True:
+            batch = list(teams_queryset.filter(id__gt=last_id).order_by("id")[:batch_size])
+            if not batch:
+                break
+
+            # Pre-load data for all teams in batch if the hypercache has batch loading
+            batch_data = None
+            if config.hypercache.batch_load_fn:
+                try:
+                    batch_data = config.hypercache.batch_load_fn(batch)
+                except Exception as e:
+                    logger.warning(
+                        f"Batch load failed for {config.log_prefix}, falling back to individual loads",
+                        error=str(e),
+                        error_type=type(e).__name__,
+                    )
+
+            for team in batch:
+                try:
+                    # Calculate TTL for this team
+                    if stagger_ttl:
+                        ttl_seconds = random.randint(min_ttl_days * 24 * 3600, max_ttl_days * 24 * 3600)
+                    else:
+                        ttl_seconds = None
+
+                    # Use pre-loaded data if available
+                    if batch_data and team.id in batch_data:
+                        # Directly write pre-loaded data to cache (bypasses load_fn)
+                        config.hypercache.set_cache_value(team, batch_data[team.id], ttl=ttl_seconds)
+
+                        # IMPORTANT: Also track expiry since set_cache_value doesn't do it
+                        # The update_fn normally handles this, but we're bypassing it for performance
+                        from posthog.storage.cache_expiry_manager import track_cache_expiry
+
+                        actual_ttl = ttl_seconds if ttl_seconds is not None else config.hypercache.cache_ttl
+                        track_cache_expiry(config.expiry_sorted_set_key, team, actual_ttl)
+                    else:
+                        # Fall back to regular update (will load individually and track expiry)
+                        config.update_fn(team, ttl=ttl_seconds)
+
+                    successful += 1
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to warm {config.log_prefix[:-1]} for team",
+                        team_id=team.id,
+                        error=str(e),
+                        error_type=type(e).__name__,
+                    )
+                    capture_exception(e)
+                    failed += 1
+
+                processed += 1
+
+            last_id = batch[-1].id
+
+            if processed % (batch_size * 10) == 0:
+                logger.info(
+                    f"{config.log_prefix.capitalize()} warm progress",
+                    processed=processed,
+                    total=total_teams,
+                    successful=successful,
+                    failed=failed,
+                    percent=round(100 * processed / total_teams, 1),
+                )
+
+        logger.info(
+            f"{config.log_prefix.capitalize()} warm completed",
+            total_teams=total_teams,
+            successful=successful,
+            failed=failed,
+        )
+
+        return successful, failed
+    finally:
+        # Close the connection only if we opened it (not in tests)
+        if use_connection_pooling:
+            connection.close()
+
+
+def get_cache_stats(config: HyperCacheManagementConfig) -> dict[str, Any]:
+    """
+    Get statistics about a HyperCache.
+
+    Scans Redis to calculate coverage, TTL distribution, and memory estimates.
+    Updates Prometheus gauges with the latest metrics.
+
+    Uses Redis pipelining to batch operations and reduce network round trips
+    by ~90% (e.g., 100K individual calls → 100 batched calls).
+
+    Args:
+        config: Cache configuration specifying which cache to analyze
+
+    Returns:
+        Dictionary with cache statistics including size information
+    """
+    try:
+        redis_client = get_client()
+
+        total_keys = 0
+        ttl_buckets = {
+            "expired": 0,
+            "expires_1h": 0,
+            "expires_24h": 0,
+            "expires_7d": 0,
+            "expires_later": 0,
+        }
+
+        sample_sizes: list[int] = []
+        sample_limit = 100
+
+        # Use pipelining to batch Redis operations and reduce network round trips
+        pipeline_batch_size = 1000
+        pipeline = redis_client.pipeline(transaction=False)
+        batch_keys: list[bytes] = []
+
+        for key in redis_client.scan_iter(match=config.redis_stats_pattern, count=1000):
+            # Queue TTL command in pipeline
+            pipeline.ttl(key)
+            batch_keys.append(key)
+
+            # Process batch when we hit the batch size
+            if len(batch_keys) >= pipeline_batch_size:
+                ttls = pipeline.execute()
+
+                # Process TTL results
+                for ttl in ttls:
+                    total_keys += 1
+
+                    if ttl <= 0:
+                        ttl_buckets["expired"] += 1
+                    elif ttl <= 3600:
+                        ttl_buckets["expires_1h"] += 1
+                    elif ttl <= 86400:
+                        ttl_buckets["expires_24h"] += 1
+                    elif ttl <= 604800:
+                        ttl_buckets["expires_7d"] += 1
+                    else:
+                        ttl_buckets["expires_later"] += 1
+
+                # Reset for next batch
+                batch_keys = []
+                pipeline = redis_client.pipeline(transaction=False)
+
+        # Process remaining keys in the last batch
+        if batch_keys:
+            ttls = pipeline.execute()
+
+            for ttl in ttls:
+                total_keys += 1
+
+                if ttl <= 0:
+                    ttl_buckets["expired"] += 1
+                elif ttl <= 3600:
+                    ttl_buckets["expires_1h"] += 1
+                elif ttl <= 86400:
+                    ttl_buckets["expires_24h"] += 1
+                elif ttl <= 604800:
+                    ttl_buckets["expires_7d"] += 1
+                else:
+                    ttl_buckets["expires_later"] += 1
+
+        # Sample memory usage for a subset of keys (up to sample_limit)
+        # Use a second scan with pipelining for memory sampling
+        if total_keys > 0:
+            pipeline = redis_client.pipeline(transaction=False)
+            sampled_keys = 0
+
+            for key in redis_client.scan_iter(match=config.redis_stats_pattern, count=100):
+                if sampled_keys >= sample_limit:
+                    break
+
+                pipeline.memory_usage(key)
+                sampled_keys += 1
+
+            if sampled_keys > 0:
+                try:
+                    memory_results = pipeline.execute()
+                    sample_sizes = [mem for mem in memory_results if mem is not None]
+                except Exception as e:
+                    logger.warning(f"Failed to sample memory usage for {config.log_prefix}", error=str(e))
+
+        total_teams = Team.objects.count()
+        coverage_percent = (total_keys / total_teams * 100) if total_teams else 0
+
+        size_stats = {}
+        if sample_sizes:
+            avg_size = statistics.mean(sample_sizes)
+            estimated_total_bytes = avg_size * total_keys
+
+            size_stats = {
+                "sample_count": len(sample_sizes),
+                "avg_size_bytes": int(avg_size),
+                "median_size_bytes": int(statistics.median(sample_sizes)),
+                "min_size_bytes": min(sample_sizes),
+                "max_size_bytes": max(sample_sizes),
+                "estimated_total_mb": round(estimated_total_bytes / (1024 * 1024), 2),
+            }
+
+            HYPERCACHE_SIZE_GAUGE.labels(namespace=config.namespace).set(estimated_total_bytes)
+
+        HYPERCACHE_COVERAGE_GAUGE.labels(namespace=config.namespace).set(coverage_percent)
+
+        return {
+            "total_cached": total_keys,
+            "total_teams": total_teams,
+            "cache_coverage": f"{coverage_percent:.1f}%",
+            "cache_coverage_percent": coverage_percent,
+            "ttl_distribution": ttl_buckets,
+            "size_statistics": size_stats,
+            "namespace": config.hypercache.namespace,
+            "note": f"Run 'python manage.py {config.management_command_name}' for detailed analysis",
+        }
+
+    except Exception as e:
+        logger.exception(f"Error getting {config.log_prefix} stats", error=str(e))
+        return {
+            "error": str(e),
+            "namespace": config.hypercache.namespace,
+        }

--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -60,7 +60,7 @@ HYPERCACHE_TEAMS_PROCESSED_COUNTER = Counter(
 HYPERCACHE_SIGNAL_UPDATE_COUNTER = Counter(
     "posthog_hypercache_signal_updates",
     "Cache updates triggered by Django signals",
-    labelnames=["namespace", "result"],
+    labelnames=["namespace", "operation", "result"],
 )
 
 HYPERCACHE_INVALIDATION_COUNTER = Counter(

--- a/posthog/storage/team_metadata_cache.py
+++ b/posthog/storage/team_metadata_cache.py
@@ -155,7 +155,7 @@ def _track_cache_expiry(team: Team | str | int, ttl_seconds: int) -> None:
         ttl_seconds: TTL in seconds from now
     """
     try:
-        redis_client = get_client()
+        redis_client = get_client(settings.FLAGS_REDIS_URL)
 
         # Get team token for tracking
         if isinstance(team, Team):
@@ -287,7 +287,8 @@ TEAM_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
 )
 
 # Derive cache expiry config from hypercache management config (eliminates duplication)
-TEAM_CACHE_EXPIRY_CONFIG = TEAM_HYPERCACHE_MANAGEMENT_CONFIG.cache_expiry_config
+# Pass FLAGS_REDIS_URL so expiry tracking uses the same Redis database as the cache
+TEAM_CACHE_EXPIRY_CONFIG = TEAM_HYPERCACHE_MANAGEMENT_CONFIG.cache_expiry_config(settings.FLAGS_REDIS_URL)
 
 
 def clear_team_metadata_cache(team: Team | str | int, kinds: list[str] | None = None) -> None:
@@ -302,7 +303,7 @@ def clear_team_metadata_cache(team: Team | str | int, kinds: list[str] | None = 
 
     # Remove from expiry tracking sorted set
     try:
-        redis_client = get_client()
+        redis_client = get_client(settings.FLAGS_REDIS_URL)
 
         if isinstance(team, Team):
             token = team.api_token

--- a/posthog/storage/team_metadata_cache.py
+++ b/posthog/storage/team_metadata_cache.py
@@ -38,14 +38,10 @@ Manual invalidation:
     clear_team_metadata_cache(team_id)
 
 Note: Redis adds ~100 bytes overhead per key. S3 storage uses similar compression.
-
-Note: Redis adds ~100 bytes overhead per key. S3 storage uses similar compression.
 """
 
 import os
 import time
-import random
-import statistics
 from typing import Any
 
 from django.conf import settings
@@ -53,61 +49,23 @@ from django.core.cache import cache, caches
 from django.db import transaction
 
 import structlog
-from posthoganalytics import capture_exception
-from prometheus_client import Counter, Gauge, Histogram
 
 from posthog.caching.flags_redis_cache import FLAGS_DEDICATED_CACHE_ALIAS
+from posthog.metrics import TOMBSTONE_COUNTER
 from posthog.models.team.team import Team
 from posthog.redis import get_client
+from posthog.storage.cache_expiry_manager import (
+    cleanup_stale_expiry_tracking as cleanup_generic,
+    get_teams_with_expiring_caches as get_teams_generic,
+    refresh_expiring_caches as refresh_generic,
+)
 from posthog.storage.hypercache import HyperCache, HyperCacheStoreMissing, KeyType
+from posthog.storage.hypercache_manager import (
+    HyperCacheManagementConfig,
+    get_cache_stats as get_cache_stats_generic,
+)
 
 logger = structlog.get_logger(__name__)
-
-
-TEAM_METADATA_BATCH_REFRESH_COUNTER = Counter(
-    "posthog_team_metadata_batch_refresh",
-    "Number of times the team metadata batch refresh job has been run",
-    labelnames=["result"],
-)
-
-TEAM_METADATA_BATCH_REFRESH_DURATION_HISTOGRAM = Histogram(
-    "posthog_team_metadata_batch_refresh_duration_seconds",
-    "Time taken to run the team metadata batch refresh job in seconds",
-    buckets=(1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, float("inf")),
-)
-
-TEAM_METADATA_TEAMS_PROCESSED_COUNTER = Counter(
-    "posthog_team_metadata_teams_processed",
-    "Number of teams processed by the batch refresh job",
-    labelnames=["result"],
-)
-
-TEAM_METADATA_CACHE_COVERAGE_GAUGE = Gauge(
-    "posthog_team_metadata_cache_coverage_percent",
-    "Percentage of teams with cached metadata",
-)
-
-TEAM_METADATA_CACHE_SIZE_BYTES_GAUGE = Gauge(
-    "posthog_team_metadata_cache_size_bytes",
-    "Estimated total cache size in bytes",
-)
-
-TEAM_METADATA_CACHE_UPDATE_DURATION_HISTOGRAM = Histogram(
-    "posthog_team_metadata_cache_update_duration_seconds",
-    "Time to update a single team's cache entry",
-    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, float("inf")),
-)
-
-TEAM_METADATA_SIGNAL_UPDATE_COUNTER = Counter(
-    "posthog_team_metadata_signal_updates",
-    "Cache updates triggered by Django signals",
-    labelnames=["result"],
-)
-
-TEAM_METADATA_CACHE_INVALIDATION_COUNTER = Counter(
-    "posthog_team_metadata_cache_invalidations",
-    "Full cache invalidations (schema changes)",
-)
 
 
 TEAM_METADATA_CACHE_TTL = int(os.environ.get("TEAM_METADATA_CACHE_TTL", str(60 * 60 * 24 * 7)))
@@ -298,6 +256,8 @@ def update_team_metadata_cache(team: Team | str | int, ttl: int | None = None) -
     """
     Update the metadata cache for a specific team.
 
+    Note: Update duration is tracked by CACHE_SYNC_DURATION_HISTOGRAM in hypercache.py
+
     Args:
         team: Team object, API token string, or team ID
         ttl: Optional custom TTL in seconds (defaults to TEAM_METADATA_CACHE_TTL)
@@ -305,22 +265,29 @@ def update_team_metadata_cache(team: Team | str | int, ttl: int | None = None) -
     Returns:
         True if cache update succeeded, False otherwise
     """
-    start = time.time()
     success = team_metadata_hypercache.update_cache(team, ttl=ttl)
-    duration = time.time() - start
-
-    TEAM_METADATA_CACHE_UPDATE_DURATION_HISTOGRAM.observe(duration)
 
     team_id = team.id if isinstance(team, Team) else "unknown"
 
     if not success:
-        logger.warning("Failed to update metadata cache", team_id=team_id, duration=duration)
+        logger.warning("Failed to update metadata cache", team_id=team_id)
     else:
         # Track expiration in sorted set for efficient queries
         ttl_seconds = ttl if ttl is not None else TEAM_METADATA_CACHE_TTL
         _track_cache_expiry(team, ttl_seconds)
 
     return success
+
+
+# Initialize hypercache management config after update_team_metadata_cache is defined
+TEAM_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
+    hypercache=team_metadata_hypercache,
+    update_fn=update_team_metadata_cache,
+    cache_name="team_metadata",
+)
+
+# Derive cache expiry config from hypercache management config (eliminates duplication)
+TEAM_CACHE_EXPIRY_CONFIG = TEAM_HYPERCACHE_MANAGEMENT_CONFIG.cache_expiry_config
 
 
 def clear_team_metadata_cache(team: Team | str | int, kinds: list[str] | None = None) -> None:
@@ -350,43 +317,12 @@ def clear_team_metadata_cache(team: Team | str | int, kinds: list[str] | None = 
         logger.warning("Failed to remove from expiry tracking", error=str(e), error_type=type(e).__name__)
 
 
-def invalidate_all_team_metadata_caches() -> int:
-    """
-    Invalidate all team metadata caches.
-
-    Used internally by warm_all_team_caches when run with --invalidate-first.
-
-    Returns:
-        Number of cache keys deleted
-    """
-    try:
-        redis_client = get_client()
-        pattern = "cache/team_tokens/*/team_metadata/*"
-
-        deleted = 0
-        for key in redis_client.scan_iter(match=pattern, count=1000):
-            redis_client.delete(key)
-            deleted += 1
-
-        # Clear the expiry tracking sorted set
-        redis_client.delete(TEAM_CACHE_EXPIRY_SORTED_SET)
-
-        TEAM_METADATA_CACHE_INVALIDATION_COUNTER.inc()
-
-        logger.info("Invalidated all team metadata caches", deleted_keys=deleted)
-        return deleted
-    except Exception as e:
-        logger.exception("Failed to invalidate team metadata caches", error=str(e))
-        capture_exception(e)
-        return 0
-
-
 # ===================================================================
 # Batch refresh operations
 # ===================================================================
 
 
-def get_teams_with_expiring_caches(ttl_threshold_hours: int = 24) -> list[Team]:
+def get_teams_with_expiring_caches(ttl_threshold_hours: int = 24, limit: int = 5000) -> list[Team]:
     """
     Get teams whose caches are expiring soon using sorted set for efficient lookup.
 
@@ -395,83 +331,36 @@ def get_teams_with_expiring_caches(ttl_threshold_hours: int = 24) -> list[Team]:
 
     Args:
         ttl_threshold_hours: Refresh caches expiring within this many hours
+        limit: Maximum number of teams to return (default 5000)
 
     Returns:
-        List of Team objects whose caches need refresh
+        List of Team objects whose caches need refresh (up to limit)
     """
-    try:
-        redis_client = get_client()
-
-        # Query sorted set for teams expiring within threshold
-        threshold_timestamp = time.time() + (ttl_threshold_hours * 3600)
-
-        # Get tokens of teams expiring before threshold (score is expiration timestamp)
-        expiring_tokens = redis_client.zrangebyscore(TEAM_CACHE_EXPIRY_SORTED_SET, "-inf", threshold_timestamp)
-
-        # Decode bytes to strings
-        expiring_tokens = [token.decode("utf-8") if isinstance(token, bytes) else token for token in expiring_tokens]
-
-        if not expiring_tokens:
-            logger.info("No caches expiring soon")
-            return []
-
-        teams = list(Team.objects.filter(api_token__in=expiring_tokens).select_related("organization", "project"))
-
-        logger.info(
-            "Found teams with expiring caches",
-            team_count=len(teams),
-            ttl_threshold_hours=ttl_threshold_hours,
-        )
-
-        return teams
-
-    except Exception as e:
-        logger.exception("Error finding expiring caches", error=str(e))
-        capture_exception(e)
-        return []
+    return get_teams_generic(TEAM_CACHE_EXPIRY_CONFIG, ttl_threshold_hours, limit)
 
 
-def refresh_expiring_caches(ttl_threshold_hours: int = 24) -> tuple[int, int]:
+def refresh_expiring_caches(ttl_threshold_hours: int = 24, limit: int = 5000) -> tuple[int, int]:
     """
     Refresh caches that are expiring soon to prevent cache misses.
 
     This is the main hourly job that keeps caches fresh. It:
-    1. Finds all cache entries with TTL < threshold (using sorted set)
+    1. Finds cache entries with TTL < threshold (up to limit)
     2. Refreshes them with new data and full TTL
+
+    Processes teams in batches (default 5000). If more teams are expiring than the limit,
+    subsequent runs will process the next batch.
+
+    Note: Metrics are tracked by refresh_expiring_caches() using consolidated HYPERCACHE_TEAMS_PROCESSED_COUNTER
 
     Args:
         ttl_threshold_hours: Refresh caches expiring within this many hours
+        limit: Maximum number of teams to refresh per run (default 5000)
 
     Returns:
         Tuple of (successful_refreshes, failed_refreshes)
     """
-    teams = get_teams_with_expiring_caches(ttl_threshold_hours=ttl_threshold_hours)
-
-    if not teams:
-        return 0, 0
-
-    successful = 0
-    failed = 0
-
-    for team in teams:
-        try:
-            if update_team_metadata_cache(team):
-                successful += 1
-            else:
-                failed += 1
-        except Exception as e:
-            logger.exception("Error refreshing expiring cache", team_id=team.id, error=str(e))
-            capture_exception(e)
-            failed += 1
-
-    logger.info(
-        "Expiring cache refresh completed",
-        successful=successful,
-        failed=failed,
-        total_teams=len(teams),
-    )
-
-    return successful, failed
+    # Metrics are now tracked in cache_expiry_manager.py using consolidated counters
+    return refresh_generic(TEAM_CACHE_EXPIRY_CONFIG, ttl_threshold_hours, limit)
 
 
 def cleanup_stale_expiry_tracking() -> int:
@@ -484,129 +373,14 @@ def cleanup_stale_expiry_tracking() -> int:
     Returns:
         Number of stale entries removed
     """
-    try:
-        redis_client = get_client()
+    removed = cleanup_generic(TEAM_CACHE_EXPIRY_CONFIG)
 
-        # Get all tokens from sorted set
-        all_tokens = redis_client.zrange(TEAM_CACHE_EXPIRY_SORTED_SET, 0, -1)
-        all_tokens = [token.decode("utf-8") if isinstance(token, bytes) else token for token in all_tokens]
+    if removed > 0:
+        TOMBSTONE_COUNTER.labels(
+            namespace="team_metadata", operation="stale_expiry_tracking", component="team_metadata_cache"
+        ).inc(removed)
 
-        if not all_tokens:
-            logger.info("No entries in expiry tracking sorted set")
-            return 0
-
-        # Query DB for valid tokens
-        valid_tokens = set(Team.objects.filter(api_token__in=all_tokens).values_list("api_token", flat=True))
-
-        # Find stale tokens
-        stale_tokens = [token for token in all_tokens if token not in valid_tokens]
-
-        # Remove stale entries
-        if stale_tokens:
-            redis_client.zrem(TEAM_CACHE_EXPIRY_SORTED_SET, *stale_tokens)
-            logger.info("Cleaned up stale expiry tracking entries", removed_count=len(stale_tokens))
-            return len(stale_tokens)
-
-        logger.info("No stale entries found in expiry tracking")
-        return 0
-
-    except Exception as e:
-        logger.exception("Error cleaning up stale expiry tracking", error=str(e))
-        capture_exception(e)
-        return 0
-
-
-def warm_all_team_caches(
-    batch_size: int = 100,
-    invalidate_first: bool = False,
-    stagger_ttl: bool = True,
-    min_ttl_days: int = 5,
-    max_ttl_days: int = 7,
-) -> tuple[int, int]:
-    """
-    Warm cache for all teams.
-
-    Run as a management command for initial cache build or when schema changes require
-    cache invalidation. Processes all teams in batches with staggered TTLs to avoid
-    synchronized expiration. Continues on errors.
-
-    Args:
-        batch_size: Number of teams to process at a time
-        invalidate_first: If True, clear all caches before warming
-        stagger_ttl: If True, randomize TTLs between min/max to avoid synchronized expiration
-        min_ttl_days: Minimum TTL in days (when staggering)
-        max_ttl_days: Maximum TTL in days (when staggering)
-
-    Returns:
-        Tuple of (successful_updates, failed_updates)
-    """
-    if invalidate_first:
-        logger.info("Invalidating all existing caches before warming")
-        invalidated = invalidate_all_team_metadata_caches()
-        logger.info("Invalidated caches", count=invalidated)
-
-    teams_queryset = Team.objects.select_related("organization", "project")
-    total_teams = teams_queryset.count()
-
-    logger.info(
-        "Starting cache warm",
-        total_teams=total_teams,
-        batch_size=batch_size,
-        stagger_ttl=stagger_ttl,
-        invalidate_first=invalidate_first,
-    )
-
-    successful = 0
-    failed = 0
-    processed = 0
-
-    last_id = 0
-    while True:
-        batch = list(teams_queryset.filter(id__gt=last_id).order_by("id")[:batch_size])
-        if not batch:
-            break
-
-        for team in batch:
-            try:
-                if stagger_ttl:
-                    ttl_seconds = random.randint(min_ttl_days * 24 * 3600, max_ttl_days * 24 * 3600)
-                    update_team_metadata_cache(team, ttl=ttl_seconds)
-                else:
-                    update_team_metadata_cache(team)
-
-                successful += 1
-            except Exception as e:
-                logger.warning(
-                    "Failed to warm cache for team",
-                    team_id=team.id,
-                    error=str(e),
-                    error_type=type(e).__name__,
-                )
-                capture_exception(e)
-                failed += 1
-
-            processed += 1
-
-        last_id = batch[-1].id
-
-        if processed % (batch_size * 10) == 0:
-            logger.info(
-                "Cache warm progress",
-                processed=processed,
-                total=total_teams,
-                successful=successful,
-                failed=failed,
-                percent=round(100 * processed / total_teams, 1),
-            )
-
-    logger.info(
-        "Cache warm completed",
-        total_teams=total_teams,
-        successful=successful,
-        failed=failed,
-    )
-
-    return successful, failed
+    return removed
 
 
 # ===================================================================
@@ -621,79 +395,4 @@ def get_cache_stats() -> dict[str, Any]:
     Returns:
         Dictionary with cache statistics including size information
     """
-    try:
-        redis_client = get_client()
-        # HyperCache uses format: cache/team_tokens/{token}/team_metadata/full_metadata.json
-        pattern = f"cache/team_tokens/*/team_metadata/full_metadata.json"
-
-        total_keys = 0
-        ttl_buckets = {
-            "expired": 0,
-            "expires_1h": 0,
-            "expires_24h": 0,
-            "expires_7d": 0,
-            "expires_later": 0,
-        }
-
-        sample_sizes: list[int] = []
-        sample_limit = 100
-
-        for key in redis_client.scan_iter(match=pattern, count=1000):
-            total_keys += 1
-            ttl = redis_client.ttl(key)
-
-            if ttl <= 0:
-                ttl_buckets["expired"] += 1
-            elif ttl <= 3600:
-                ttl_buckets["expires_1h"] += 1
-            elif ttl <= 86400:
-                ttl_buckets["expires_24h"] += 1
-            elif ttl <= 604800:
-                ttl_buckets["expires_7d"] += 1
-            else:
-                ttl_buckets["expires_later"] += 1
-
-            if len(sample_sizes) < sample_limit:
-                try:
-                    memory_usage = redis_client.memory_usage(key)
-                    if memory_usage:
-                        sample_sizes.append(memory_usage)
-                except:
-                    pass
-
-        total_teams = Team.objects.count()
-        coverage_percent = (total_keys / total_teams * 100) if total_teams else 0
-
-        size_stats = {}
-        if sample_sizes:
-            avg_size = statistics.mean(sample_sizes)
-            estimated_total_bytes = avg_size * total_keys
-
-            size_stats = {
-                "sample_count": len(sample_sizes),
-                "avg_size_bytes": int(avg_size),
-                "median_size_bytes": int(statistics.median(sample_sizes)),
-                "min_size_bytes": min(sample_sizes),
-                "max_size_bytes": max(sample_sizes),
-                "estimated_total_mb": round(estimated_total_bytes / (1024 * 1024), 2),
-            }
-
-            TEAM_METADATA_CACHE_SIZE_BYTES_GAUGE.set(estimated_total_bytes)
-
-        return {
-            "total_cached": total_keys,
-            "total_teams": total_teams,
-            "cache_coverage": f"{coverage_percent:.1f}%",
-            "cache_coverage_percent": coverage_percent,
-            "ttl_distribution": ttl_buckets,
-            "size_statistics": size_stats,
-            "namespace": team_metadata_hypercache.namespace,
-            "note": "Run 'python manage.py analyze_team_cache_sizes' for detailed analysis",
-        }
-
-    except Exception as e:
-        logger.exception("Error getting cache stats", error=str(e))
-        return {
-            "error": str(e),
-            "namespace": team_metadata_hypercache.namespace,
-        }
+    return get_cache_stats_generic(TEAM_HYPERCACHE_MANAGEMENT_CONFIG)

--- a/posthog/storage/test/test_hypercache.py
+++ b/posthog/storage/test/test_hypercache.py
@@ -268,7 +268,7 @@ class TestHyperCacheCustomCacheClient(BaseTest):
         }
     )
     def test_custom_cache_client_isolation(self):
-        """Test that custom cache_client writes to dedicated cache, not default"""
+        """Test that custom cache_alias writes to dedicated cache, not default"""
         from django.core.cache import caches
 
         caches["default"].clear()
@@ -277,12 +277,12 @@ class TestHyperCacheCustomCacheClient(BaseTest):
         def load_fn(team):
             return self.sample_data
 
-        # Create HyperCache with custom cache client
+        # Create HyperCache with custom cache alias
         hc = HyperCache(
             namespace="test",
             value="value",
             load_fn=load_fn,
-            cache_client=caches["flags_dedicated"],
+            cache_alias="flags_dedicated",
         )
 
         team_id = self.team.id
@@ -312,7 +312,7 @@ class TestHyperCacheCustomCacheClient(BaseTest):
         }
     )
     def test_custom_cache_client_reads_from_dedicated(self):
-        """Test that reads use the custom cache client"""
+        """Test that reads use the custom cache alias"""
         from django.core.cache import caches
 
         caches["default"].clear()
@@ -321,12 +321,12 @@ class TestHyperCacheCustomCacheClient(BaseTest):
         def load_fn(team):
             return {"fallback": "data"}
 
-        # Create HyperCache with custom cache client
+        # Create HyperCache with custom cache alias
         hc = HyperCache(
             namespace="test",
             value="value",
             load_fn=load_fn,
-            cache_client=caches["flags_dedicated"],
+            cache_alias="flags_dedicated",
         )
 
         team_id = self.team.id
@@ -354,7 +354,7 @@ class TestHyperCacheCustomCacheClient(BaseTest):
         }
     )
     def test_clear_cache_uses_custom_client(self):
-        """Test that clear_cache targets the custom cache client"""
+        """Test that clear_cache targets the custom cache alias"""
         from django.core.cache import caches
 
         caches["default"].clear()
@@ -363,12 +363,12 @@ class TestHyperCacheCustomCacheClient(BaseTest):
         def load_fn(team):
             return self.sample_data
 
-        # Create HyperCache with custom cache client
+        # Create HyperCache with custom cache alias
         hc = HyperCache(
             namespace="test",
             value="value",
             load_fn=load_fn,
-            cache_client=caches["flags_dedicated"],
+            cache_alias="flags_dedicated",
         )
 
         team_id = self.team.id
@@ -389,13 +389,13 @@ class TestHyperCacheCustomCacheClient(BaseTest):
         default_value = caches["default"].get(cache_key)
         assert default_value == json.dumps(self.sample_data)
 
-    def test_default_cache_client_backward_compatibility(self):
-        """Test that HyperCache without cache_client uses default cache"""
+    def test_default_cache_alias_backward_compatibility(self):
+        """Test that HyperCache without cache_alias uses default cache"""
 
         def load_fn(team):
             return self.sample_data
 
-        # Create HyperCache without cache_client (should use default)
+        # Create HyperCache without cache_alias (should use default)
         hc = HyperCache(
             namespace="test",
             value="value",

--- a/posthog/storage/test/test_team_metadata_cache.py
+++ b/posthog/storage/test/test_team_metadata_cache.py
@@ -185,20 +185,29 @@ class TestTeamMetadataCacheSignals(BaseTest):
 class TestCacheStats(BaseTest):
     """Test cache statistics functionality."""
 
-    @patch("posthog.storage.team_metadata_cache.get_client")
+    @patch("posthog.storage.hypercache_manager.get_client")
     def test_get_cache_stats_basic(self, mock_get_client):
-        """Test basic cache stats gathering."""
+        """Test basic cache stats gathering with Redis pipelining."""
         from posthog.storage.team_metadata_cache import get_cache_stats
 
-        # Mock Redis client
+        # Mock Redis client with pipelining support
         mock_redis = MagicMock()
         mock_get_client.return_value = mock_redis
-        mock_redis.scan_iter.return_value = [
-            b"cache:team_metadata:key1",
-            b"cache:team_metadata:key2",
+
+        # scan_iter is called twice: once for TTL collection, once for memory sampling
+        # Each call needs to return a fresh iterator
+        mock_redis.scan_iter.side_effect = [
+            iter([b"cache:team_metadata:key1", b"cache:team_metadata:key2"]),  # TTL scan
+            iter([b"cache:team_metadata:key1", b"cache:team_metadata:key2"]),  # Memory scan
         ]
-        mock_redis.ttl.side_effect = [3600, 86400]  # 1 hour, 1 day
-        mock_redis.memory_usage.side_effect = [1024, 2048]  # Sample memory sizes in bytes
+
+        # Mock pipeline for batched operations
+        mock_pipeline = MagicMock()
+        mock_redis.pipeline.return_value = mock_pipeline
+        mock_pipeline.execute.side_effect = [
+            [3600, 86400],  # TTL results: 1 hour, 1 day
+            [1024, 2048],  # Memory usage results
+        ]
 
         with patch("posthog.models.team.team.Team.objects.count", return_value=5):
             stats = get_cache_stats()
@@ -207,13 +216,15 @@ class TestCacheStats(BaseTest):
         self.assertEqual(stats["total_teams"], 5)
         self.assertEqual(stats["ttl_distribution"]["expires_1h"], 1)
         self.assertEqual(stats["ttl_distribution"]["expires_24h"], 1)
+        self.assertEqual(stats["size_statistics"]["sample_count"], 2)
+        self.assertEqual(stats["size_statistics"]["avg_size_bytes"], 1536)  # (1024 + 2048) / 2
 
 
 class TestGetTeamsWithExpiringCaches(BaseTest):
     """Test get_teams_with_expiring_caches functionality."""
 
-    @patch("posthog.storage.team_metadata_cache.get_client")
-    @patch("posthog.storage.team_metadata_cache.time")
+    @patch("posthog.storage.cache_expiry_manager.get_client")
+    @patch("posthog.storage.cache_expiry_manager.time")
     def test_returns_teams_with_expiring_ttl(self, mock_time, mock_get_client):
         """Teams with expiration timestamp < threshold should be returned."""
         team1 = self.team
@@ -240,15 +251,17 @@ class TestGetTeamsWithExpiringCaches(BaseTest):
         self.assertIn(team1, result)
         self.assertIn(team2, result)
 
-        # Verify sorted set query was called correctly
+        # Verify sorted set query was called correctly with limit
         mock_redis.zrangebyscore.assert_called_once_with(
             "team_metadata_cache_expiry",
             "-inf",
             1000000 + (24 * 3600),  # current_time + 24 hours
+            start=0,
+            num=5000,
         )
 
-    @patch("posthog.storage.team_metadata_cache.get_client")
-    @patch("posthog.storage.team_metadata_cache.time")
+    @patch("posthog.storage.cache_expiry_manager.get_client")
+    @patch("posthog.storage.cache_expiry_manager.time")
     def test_skips_teams_with_fresh_ttl(self, mock_time, mock_get_client):
         """Teams with expiration timestamp > threshold should not be returned."""
         # Mock Redis sorted set returning empty (no teams expiring soon)
@@ -262,7 +275,7 @@ class TestGetTeamsWithExpiringCaches(BaseTest):
         # Team has fresh cache, not returned
         self.assertEqual(len(result), 0)
 
-    @patch("posthog.storage.team_metadata_cache.get_client")
+    @patch("posthog.storage.cache_expiry_manager.get_client")
     def test_returns_empty_when_no_expiring_caches(self, mock_get_client):
         """Should return empty list when sorted set is empty."""
         # Mock Redis to return empty sorted set

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -1,9 +1,24 @@
+import time
+
+from django.conf import settings
+
 import structlog
 from celery import shared_task
 
-from posthog.models.feature_flag.flags_cache import update_flags_cache
+from posthog.models.feature_flag.flags_cache import (
+    cleanup_stale_expiry_tracking,
+    get_flags_cache_stats,
+    refresh_expiring_flags_caches,
+    update_flags_cache,
+)
 from posthog.models.feature_flag.local_evaluation import update_flag_caches
 from posthog.models.team import Team
+from posthog.storage.hypercache_manager import (
+    HYPERCACHE_BATCH_REFRESH_COUNTER,
+    HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM,
+    HYPERCACHE_COVERAGE_GAUGE,
+    HYPERCACHE_SIGNAL_UPDATE_COUNTER,
+)
 from posthog.tasks.utils import CeleryQueue
 
 logger = structlog.get_logger(__name__)
@@ -31,10 +46,12 @@ def update_team_service_flags_cache(team_id: int) -> None:
     try:
         team = Team.objects.get(id=team_id)
     except Team.DoesNotExist:
-        logger.exception("Team does not exist for service flags cache update", team_id=team_id)
+        logger.debug("Team does not exist for service flags cache update", team_id=team_id)
+        HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="feature_flags", result="team_not_found").inc()
         return
 
-    update_flags_cache(team)
+    success = update_flags_cache(team)
+    HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="feature_flags", result="success" if success else "failure").inc()
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
@@ -44,3 +61,90 @@ def sync_all_flags_cache() -> None:
     # Only select the id from the team queryset
     for team_id in Team.objects.values_list("id", flat=True):
         update_team_flags_cache.delay(team_id)
+
+
+@shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
+def refresh_expiring_flags_cache_entries() -> None:
+    """
+    Periodic task to refresh flags caches before they expire.
+
+    This task runs hourly and refreshes caches with TTL < 24 hours to prevent cache misses.
+
+    Note: Most cache updates happen via Django signals when flags change.
+    This job just prevents expiration-related cache misses.
+
+    For initial cache build or schema migrations, use the management command:
+        python manage.py warm_flags_cache [--invalidate-first]
+    """
+
+    if not settings.FLAGS_REDIS_URL:
+        logger.info("Flags Redis URL not set, skipping flags cache refresh")
+        return
+
+    start_time = time.time()
+    logger.info(
+        "Starting flags cache sync",
+        ttl_threshold_hours=settings.FLAGS_CACHE_REFRESH_TTL_THRESHOLD_HOURS,
+        limit=settings.FLAGS_CACHE_REFRESH_LIMIT,
+    )
+
+    try:
+        successful, failed = refresh_expiring_flags_caches(
+            ttl_threshold_hours=settings.FLAGS_CACHE_REFRESH_TTL_THRESHOLD_HOURS,
+            limit=settings.FLAGS_CACHE_REFRESH_LIMIT,
+        )
+
+        # Note: HYPERCACHE_TEAMS_PROCESSED_COUNTER is already incremented by the generic
+        # cache_expiry_manager.refresh_expiring_caches() function, so we don't increment it again here
+
+        # Only scan once after refresh for metrics
+        stats_after = get_flags_cache_stats()
+
+        coverage_percent = stats_after.get("cache_coverage_percent", 0)
+        HYPERCACHE_COVERAGE_GAUGE.labels(namespace="feature_flags").set(coverage_percent)
+
+        duration = time.time() - start_time
+        HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM.labels(namespace="feature_flags").observe(duration)
+        HYPERCACHE_BATCH_REFRESH_COUNTER.labels(namespace="feature_flags", result="success").inc()
+
+        logger.info(
+            "Completed flags cache refresh",
+            successful_refreshes=successful,
+            failed_refreshes=failed,
+            total_cached=stats_after.get("total_cached", 0),
+            total_teams=stats_after.get("total_teams", 0),
+            cache_coverage=stats_after.get("cache_coverage", "unknown"),
+            ttl_distribution=stats_after.get("ttl_distribution", {}),
+            duration_seconds=duration,
+        )
+
+    except Exception as e:
+        duration = time.time() - start_time
+        HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM.labels(namespace="feature_flags").observe(duration)
+        HYPERCACHE_BATCH_REFRESH_COUNTER.labels(namespace="feature_flags", result="failure").inc()
+        logger.exception(
+            "Failed to complete flags cache batch refresh",
+            error=str(e),
+            duration_seconds=duration,
+        )
+        raise
+
+
+@shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
+def cleanup_stale_flags_expiry_tracking_task() -> None:
+    """
+    Periodic task to clean up stale entries in the flags cache expiry tracking sorted set.
+
+    Removes entries for teams that no longer exist in the database.
+    Runs daily to prevent sorted set bloat from deleted teams.
+    """
+    if not settings.FLAGS_REDIS_URL:
+        logger.info("Flags Redis URL not set, skipping flags expiry tracking cleanup")
+        return
+
+    try:
+        removed_count = cleanup_stale_expiry_tracking()
+        logger.info("Completed flags expiry tracking cleanup", removed_count=removed_count)
+    except Exception as e:
+        logger.exception("Failed to cleanup flags expiry tracking", error=str(e))
+        raise

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -47,11 +47,13 @@ def update_team_service_flags_cache(team_id: int) -> None:
         team = Team.objects.get(id=team_id)
     except Team.DoesNotExist:
         logger.debug("Team does not exist for service flags cache update", team_id=team_id)
-        HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="feature_flags", result="team_not_found").inc()
+        HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="feature_flags", operation="update", result="failure").inc()
         return
 
     success = update_flags_cache(team)
-    HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="feature_flags", result="success" if success else "failure").inc()
+    HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
+        namespace="feature_flags", operation="update", result="success" if success else "failure"
+    ).inc()
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)

--- a/posthog/tasks/team_metadata.py
+++ b/posthog/tasks/team_metadata.py
@@ -16,12 +16,13 @@ import structlog
 from celery import shared_task
 
 from posthog.models.team import Team
+from posthog.storage.hypercache_manager import (
+    HYPERCACHE_BATCH_REFRESH_COUNTER,
+    HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM,
+    HYPERCACHE_COVERAGE_GAUGE,
+    HYPERCACHE_SIGNAL_UPDATE_COUNTER,
+)
 from posthog.storage.team_metadata_cache import (
-    TEAM_METADATA_BATCH_REFRESH_COUNTER,
-    TEAM_METADATA_BATCH_REFRESH_DURATION_HISTOGRAM,
-    TEAM_METADATA_CACHE_COVERAGE_GAUGE,
-    TEAM_METADATA_SIGNAL_UPDATE_COUNTER,
-    TEAM_METADATA_TEAMS_PROCESSED_COUNTER,
     cleanup_stale_expiry_tracking,
     clear_team_metadata_cache,
     get_cache_stats,
@@ -47,11 +48,11 @@ def update_team_metadata_cache_task(team_id: int) -> None:
         team = Team.objects.get(id=team_id)
     except Team.DoesNotExist:
         logger.debug("Team does not exist for metadata cache update", team_id=team_id)
-        TEAM_METADATA_SIGNAL_UPDATE_COUNTER.labels(result="team_not_found").inc()
+        HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="team_metadata", result="team_not_found").inc()
         return
 
     success = update_team_metadata_cache(team)
-    TEAM_METADATA_SIGNAL_UPDATE_COUNTER.labels(result="success" if success else "failed").inc()
+    HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="team_metadata", result="success" if success else "failure").inc()
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
@@ -78,18 +79,18 @@ def refresh_expiring_team_metadata_cache_entries() -> None:
     try:
         successful, failed = refresh_expiring_caches(ttl_threshold_hours=24)
 
-        TEAM_METADATA_TEAMS_PROCESSED_COUNTER.labels(result="success").inc(successful)
-        TEAM_METADATA_TEAMS_PROCESSED_COUNTER.labels(result="failed").inc(failed)
+        # Note: HYPERCACHE_TEAMS_PROCESSED_COUNTER is already incremented by the generic
+        # cache_expiry_manager.refresh_expiring_caches() function, so we don't increment it again here
 
         # Only scan once after refresh for metrics
         stats_after = get_cache_stats()
 
         coverage_percent = stats_after.get("cache_coverage_percent", 0)
-        TEAM_METADATA_CACHE_COVERAGE_GAUGE.set(coverage_percent)
+        HYPERCACHE_COVERAGE_GAUGE.labels(namespace="team_metadata").set(coverage_percent)
 
         duration = time.time() - start_time
-        TEAM_METADATA_BATCH_REFRESH_DURATION_HISTOGRAM.observe(duration)
-        TEAM_METADATA_BATCH_REFRESH_COUNTER.labels(result="success").inc()
+        HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM.labels(namespace="team_metadata").observe(duration)
+        HYPERCACHE_BATCH_REFRESH_COUNTER.labels(namespace="team_metadata", result="success").inc()
 
         logger.info(
             "Completed team metadata cache refresh",
@@ -104,8 +105,8 @@ def refresh_expiring_team_metadata_cache_entries() -> None:
 
     except Exception as e:
         duration = time.time() - start_time
-        TEAM_METADATA_BATCH_REFRESH_DURATION_HISTOGRAM.observe(duration)
-        TEAM_METADATA_BATCH_REFRESH_COUNTER.labels(result="failed").inc()
+        HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM.labels(namespace="team_metadata").observe(duration)
+        HYPERCACHE_BATCH_REFRESH_COUNTER.labels(namespace="team_metadata", result="failure").inc()
         logger.exception(
             "Failed to complete team metadata batch refresh",
             error=str(e),
@@ -124,7 +125,7 @@ def update_team_metadata_cache_on_save(sender: type[Team], instance: Team, creat
         try:
             update_team_metadata_cache_task.delay(instance.id)
         except Exception as e:
-            TEAM_METADATA_SIGNAL_UPDATE_COUNTER.labels(result="enqueue_failed").inc()
+            HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(namespace="team_metadata", result="enqueue_failure").inc()
             logger.exception(
                 "Failed to enqueue cache update task",
                 team_id=instance.id,

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -46,6 +46,8 @@
     'posthog.tasks.email.send_two_factor_auth_disabled_email',
     'posthog.tasks.email.send_two_factor_auth_enabled_email',
     'posthog.tasks.exporter.export_asset',
+    'posthog.tasks.feature_flags.cleanup_stale_flags_expiry_tracking_task',
+    'posthog.tasks.feature_flags.refresh_expiring_flags_cache_entries',
     'posthog.tasks.feature_flags.sync_all_flags_cache',
     'posthog.tasks.feature_flags.update_team_flags_cache',
     'posthog.tasks.feature_flags.update_team_service_flags_cache',


### PR DESCRIPTION
> [!NOTE]
> Most of the changes is refactoring the work @dmarticus did in [this PR](https://github.com/PostHog/posthog/pull/41123) into generic classes/methods and then applying that to the existing team metadata cache and the new flags cache.

## Problem

Per the dedicated [flags redis rfc](https://github.com/PostHog/requests-for-comments-internal/pull/909), the rust flags service needs a cache of flags data in its own dedicated Redis cluster.

That HyperCache has [been built](https://github.com/PostHog/posthog/pull/41497), but we need to schedule it and add management commands.

## Changes

The changes follow and encapsulate the pattern of team metadata management commands and schedule implemented in [this PR](https://github.com/PostHog/posthog/pull/41123).

### Management Commands

- `warm_flags_cache`: Pre-populate cache with staggered TTLs to prevent thundering herd
- `verify_flags_cache`: Detect and optionally fix cache mismatches/misses
- `analyze_flags_cache_sizes`: Report cache size distribution and memory usage

### Automated Jobs

- Hourly refresh of expiring cache entries (configurable via `FLAGS_CACHE_REFRESH_TTL_THRESHOLD_HOURS`)
- Daily cleanup of stale expiry tracking metadata

### Infrastructure

- Generic HyperCache management (`hypercache_manager.py`) for batch operations with Redis pipelining
- Generic cache expiry tracking (`cache_expiry_manager.py`) using Redis sorted sets
- Prometheus metrics for cache coverage, refresh duration, and team processing counts
- Batch loading support in HyperCache to prevent N+1 queries

> [!NOTE]
> I changed the metrics to follow a more generic pattern so we may need to update some dashboards.

### Refactoring:

- Extracted common cache management patterns from `team_metadata_cache` into reusable components
- Both flags cache and team metadata cache now use the same generic infrastructure
- Paves the way for additional team metadata caches (e.g., flag definitions for local evaluation)

### Bug Fix

- I did fix a bug where the cleanup expiry job wasn't necessarily looking at the same cache as the HyperCache (aka the dedicated cache).

## How did you test this code?

Unit Tests
Manual Testhing

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
