### PR TITLE
feat: add confirmation prompts for destructive commands

### DIFF
--- a/common/hogli/core/command_types.py
+++ b/common/hogli/core/command_types.py
@@ -89,7 +89,7 @@ class Command:
 
         Returns True if confirmation was given (via --yes flag or user prompt), False otherwise.
         """
-        if not self.config.get("requires_confirmation", False):
+        if not self.config.get("destructive", False):
             return False
 
         if yes:

--- a/common/hogli/core/command_types.py
+++ b/common/hogli/core/command_types.py
@@ -84,6 +84,30 @@ class Command:
         """Generate formatted help text with service context and underlying command."""
         return _format_command_help(self.name, self.config, self.get_underlying_command())
 
+    def _confirm(self, yes: bool = False) -> bool:
+        """Prompt for confirmation if required.
+
+        Returns True if confirmation was given (via --yes flag or user prompt), False otherwise.
+        """
+        if not self.config.get("requires_confirmation", False):
+            return False
+
+        if yes:
+            return True
+
+        click.echo()
+        click.echo(click.style("⚠️  This command may be destructive!", fg="yellow", bold=True))
+        click.echo(f"   Command: {self.name}")
+        if self.description:
+            click.echo(f"   {self.description}")
+        click.echo()
+
+        if not click.confirm("Are you sure you want to continue?", default=False):
+            click.echo(click.style("Aborted.", fg="red"))
+            raise SystemExit(0)
+
+        return True
+
     def execute(self, *args: str) -> None:
         """Override in subclasses."""
         raise NotImplementedError("Subclasses must implement execute()")
@@ -93,8 +117,11 @@ class Command:
         help_text = self.get_help_text()
 
         @cli_group.command(self.name, help=help_text)
-        def cmd() -> None:
+        @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+        @click.pass_context
+        def cmd(ctx: click.Context, yes: bool) -> None:
             try:
+                self._confirm(yes=yes)
                 self.execute()
             except SystemExit:
                 raise
@@ -131,9 +158,11 @@ class BinScriptCommand(Command):
             help=help_text,
             context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
         )
+        @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
         @click.pass_context
-        def cmd(ctx: click.Context) -> None:
+        def cmd(ctx: click.Context, yes: bool) -> None:
             try:
+                self._confirm(yes=yes)
                 self.execute(*ctx.args)
             except SystemExit:
                 raise
@@ -163,9 +192,11 @@ class DirectCommand(Command):
             help=help_text,
             context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
         )
+        @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
         @click.pass_context
-        def cmd(ctx: click.Context) -> None:
+        def cmd(ctx: click.Context, yes: bool) -> None:
             try:
+                self._confirm(yes=yes)
                 self.execute(*ctx.args)
             except SystemExit:
                 raise
@@ -200,6 +231,27 @@ class CompositeCommand(Command):
         steps = self.config.get("steps", [])
         return f"hogli {' && hogli '.join(steps)}"
 
+    def register(self, cli_group: click.Group) -> Any:
+        """Register command with extra args support."""
+        help_text = self.get_help_text()
+
+        @cli_group.command(self.name, help=help_text)
+        @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+        @click.pass_context
+        def cmd(ctx: click.Context, yes: bool) -> None:
+            try:
+                confirmed = self._confirm(yes=yes)
+                # Store whether confirmation was given (via --yes or prompt)
+                # Child commands should always get --yes if parent was confirmed
+                self._confirmed = confirmed or yes
+                self.execute()
+            except SystemExit:
+                raise
+
+        # Store config on the Click command for visibility filtering
+        cmd.hogli_config = self.config  # type: ignore[attr-defined]
+        return cmd
+
     def execute(self, *args: str) -> None:
         """Execute each step in sequence."""
         from hogli.core.manifest import REPO_ROOT
@@ -207,10 +259,18 @@ class CompositeCommand(Command):
         steps = self.config.get("steps", [])
         bin_hogli = str(REPO_ROOT / "bin" / "hogli")
 
+        # Pass --yes to children if parent required confirmation and it was confirmed
+        confirmed = getattr(self, "_confirmed", False)
+
         for step in steps:
             click.echo(f"✨ Executing: {step}")
             try:
                 # Use bin/hogli for both Flox and non-Flox compatibility
-                _run([bin_hogli, step])
+                # Always pass --yes to child commands if parent was confirmed
+                # This ensures children don't prompt again even if they require confirmation
+                if confirmed:
+                    _run([bin_hogli, step, "--yes"])
+                else:
+                    _run([bin_hogli, step])
             except SystemExit:
                 raise

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -102,7 +102,7 @@ core:
             - dev:demo-data
             - migrations:sync-flags
         description: Full reset - wipe volumes, migrate, load demo data, sync flags
-        requires_confirmation: true
+        destructive: true
 health_checks:
     check:clickhouse:
         bin_script: check_clickhouse_up
@@ -210,7 +210,7 @@ deploy:
         bin_script: upgrade-hobby
         description: Upgrade existing hobby deployment with data loss warnings and volume
             checks
-        requires_confirmation: true
+        destructive: true
     deploy:migrate-recordings:
         bin_script: migrate-session-recordings-hobby
         description: Migrate session recordings from MinIO to SeaweedFS for hobby deployments
@@ -222,11 +222,11 @@ deploy:
             \  --mode sync     Bidirectional sync\n\nExamples:\n  hogli deploy:migrate-storage\
             \ --service query-cache --mode sync --dry-run\n  hogli deploy:migrate-storage\
             \ --service media-uploads --mode migrate"
-        requires_confirmation: true
+        destructive: true
     deploy:migrate-storage-hobby:
         bin_script: migrate-storage-hobby
         description: "Hobby: Migrate or sync ALL services between MinIO and SeaweedFS via docker-compose\n\nExamples:\n  hogli deploy:migrate-storage-hobby               # Sync all services\n  hogli deploy:migrate-storage-hobby --mode migrate # One-way migrate all (MinIO → SeaweedFS)\n  hogli deploy:migrate-storage-hobby exports -n     # Dry run exports only"
-        requires_confirmation: true
+        destructive: true
 build:
     build:frontend:
         cmd: pnpm --filter=@posthog/frontend build
@@ -275,7 +275,7 @@ docker:
         description: Stop Docker infrastructure services and remove all volumes (complete wipe)
         services:
             - docker
-        requires_confirmation: true
+        destructive: true
     docker:deprecated:
         bin_script: docker
         description: '[DEPRECATED] Use `hogli start` instead'

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -102,6 +102,7 @@ core:
             - dev:demo-data
             - migrations:sync-flags
         description: Full reset - wipe volumes, migrate, load demo data, sync flags
+        requires_confirmation: true
 health_checks:
     check:clickhouse:
         bin_script: check_clickhouse_up
@@ -209,6 +210,7 @@ deploy:
         bin_script: upgrade-hobby
         description: Upgrade existing hobby deployment with data loss warnings and volume
             checks
+        requires_confirmation: true
     deploy:migrate-recordings:
         bin_script: migrate-session-recordings-hobby
         description: Migrate session recordings from MinIO to SeaweedFS for hobby deployments
@@ -220,9 +222,11 @@ deploy:
             \  --mode sync     Bidirectional sync\n\nExamples:\n  hogli deploy:migrate-storage\
             \ --service query-cache --mode sync --dry-run\n  hogli deploy:migrate-storage\
             \ --service media-uploads --mode migrate"
+        requires_confirmation: true
     deploy:migrate-storage-hobby:
         bin_script: migrate-storage-hobby
         description: "Hobby: Migrate or sync ALL services between MinIO and SeaweedFS via docker-compose\n\nExamples:\n  hogli deploy:migrate-storage-hobby               # Sync all services\n  hogli deploy:migrate-storage-hobby --mode migrate # One-way migrate all (MinIO → SeaweedFS)\n  hogli deploy:migrate-storage-hobby exports -n     # Dry run exports only"
+        requires_confirmation: true
 build:
     build:frontend:
         cmd: pnpm --filter=@posthog/frontend build
@@ -271,6 +275,7 @@ docker:
         description: Stop Docker infrastructure services and remove all volumes (complete wipe)
         services:
             - docker
+        requires_confirmation: true
     docker:deprecated:
         bin_script: docker
         description: '[DEPRECATED] Use `hogli start` instead'

--- a/common/hogli/tests/test_command_types.py
+++ b/common/hogli/tests/test_command_types.py
@@ -129,3 +129,99 @@ class TestRunFunctionErrorHandling:
             _run(["some-command"])
 
         assert exc_info.value.code == 1
+
+
+class TestConfirmationFeature:
+    """Test confirmation prompts for destructive commands."""
+
+    @patch("click.confirm")
+    @patch("hogli.core.command_types._run")
+    def test_requires_confirmation_prompts_user(self, mock_run: MagicMock, mock_confirm: MagicMock) -> None:
+        """Test command with requires_confirmation prompts user."""
+        mock_confirm.return_value = True
+
+        cmd = DirectCommand("test:destructive", {"cmd": "rm -rf /", "requires_confirmation": True})
+
+        cmd._confirm(yes=False)
+
+        mock_confirm.assert_called_once_with("Are you sure you want to continue?", default=False)
+
+    @patch("click.confirm")
+    @patch("hogli.core.command_types._run")
+    def test_requires_confirmation_skips_with_yes_flag(self, mock_run: MagicMock, mock_confirm: MagicMock) -> None:
+        """Test --yes flag skips confirmation prompt."""
+        cmd = DirectCommand("test:destructive", {"cmd": "rm -rf /", "requires_confirmation": True})
+
+        cmd._confirm(yes=True)
+
+        mock_confirm.assert_not_called()
+
+    @patch("click.confirm")
+    @patch("hogli.core.command_types._run")
+    def test_no_confirmation_for_normal_commands(self, mock_run: MagicMock, mock_confirm: MagicMock) -> None:
+        """Test commands without requires_confirmation don't prompt."""
+        cmd = DirectCommand("test:safe", {"cmd": "echo hello"})
+
+        cmd._confirm(yes=False)
+
+        mock_confirm.assert_not_called()
+
+    @patch("click.confirm")
+    @patch("hogli.core.command_types._run")
+    def test_confirmation_abort_exits_gracefully(self, mock_run: MagicMock, mock_confirm: MagicMock) -> None:
+        """Test aborting confirmation exits with code 0."""
+        mock_confirm.return_value = False
+
+        cmd = DirectCommand("test:destructive", {"cmd": "rm -rf /", "requires_confirmation": True})
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd._confirm(yes=False)
+
+        assert exc_info.value.code == 0
+        mock_run.assert_not_called()
+
+    @patch("hogli.core.command_types._run")
+    def test_composite_command_passes_yes_flag_to_steps(self, mock_run: MagicMock) -> None:
+        """Test CompositeCommand passes --yes to child commands when confirmed."""
+        from hogli.core.manifest import REPO_ROOT
+
+        bin_hogli = str(REPO_ROOT / "bin" / "hogli")
+
+        cmd = CompositeCommand(
+            "reset",
+            {"steps": ["docker:services:down", "docker:services:up"], "requires_confirmation": True},
+        )
+        cmd._confirmed = True
+
+        cmd.execute()
+
+        assert mock_run.call_count == 2
+        calls = [call[0][0] for call in mock_run.call_args_list]
+        assert calls == [
+            [bin_hogli, "docker:services:down", "--yes"],
+            [bin_hogli, "docker:services:up", "--yes"],
+        ]
+
+    @patch("click.confirm")
+    @patch("hogli.core.command_types._run")
+    def test_composite_command_passes_yes_after_user_confirms(
+        self, mock_run: MagicMock, mock_confirm: MagicMock
+    ) -> None:
+        """Test CompositeCommand passes --yes to children after user confirms via prompt."""
+        from hogli.core.manifest import REPO_ROOT
+
+        bin_hogli = str(REPO_ROOT / "bin" / "hogli")
+        mock_confirm.return_value = True
+
+        cmd = CompositeCommand(
+            "reset",
+            {"steps": ["docker:services:down"], "requires_confirmation": True},
+        )
+        # Simulate user confirming via prompt (not --yes flag)
+        confirmed = cmd._confirm(yes=False)
+        cmd._confirmed = confirmed
+
+        cmd.execute()
+
+        # Should pass --yes to child even though user didn't pass --yes flag
+        mock_run.assert_called_once_with([bin_hogli, "docker:services:down", "--yes"])

--- a/common/hogli/tests/test_command_types.py
+++ b/common/hogli/tests/test_command_types.py
@@ -136,11 +136,11 @@ class TestConfirmationFeature:
 
     @patch("click.confirm")
     @patch("hogli.core.command_types._run")
-    def test_requires_confirmation_prompts_user(self, mock_run: MagicMock, mock_confirm: MagicMock) -> None:
-        """Test command with requires_confirmation prompts user."""
+    def test_destructive_prompts_user(self, mock_run: MagicMock, mock_confirm: MagicMock) -> None:
+        """Test command with destructive prompts user."""
         mock_confirm.return_value = True
 
-        cmd = DirectCommand("test:destructive", {"cmd": "rm -rf /", "requires_confirmation": True})
+        cmd = DirectCommand("test:destructive", {"cmd": "rm -rf /", "destructive": True})
 
         cmd._confirm(yes=False)
 
@@ -148,9 +148,9 @@ class TestConfirmationFeature:
 
     @patch("click.confirm")
     @patch("hogli.core.command_types._run")
-    def test_requires_confirmation_skips_with_yes_flag(self, mock_run: MagicMock, mock_confirm: MagicMock) -> None:
+    def test_destructive_skips_with_yes_flag(self, mock_run: MagicMock, mock_confirm: MagicMock) -> None:
         """Test --yes flag skips confirmation prompt."""
-        cmd = DirectCommand("test:destructive", {"cmd": "rm -rf /", "requires_confirmation": True})
+        cmd = DirectCommand("test:destructive", {"cmd": "rm -rf /", "destructive": True})
 
         cmd._confirm(yes=True)
 
@@ -159,7 +159,7 @@ class TestConfirmationFeature:
     @patch("click.confirm")
     @patch("hogli.core.command_types._run")
     def test_no_confirmation_for_normal_commands(self, mock_run: MagicMock, mock_confirm: MagicMock) -> None:
-        """Test commands without requires_confirmation don't prompt."""
+        """Test commands without destructive don't prompt."""
         cmd = DirectCommand("test:safe", {"cmd": "echo hello"})
 
         cmd._confirm(yes=False)
@@ -172,7 +172,7 @@ class TestConfirmationFeature:
         """Test aborting confirmation exits with code 0."""
         mock_confirm.return_value = False
 
-        cmd = DirectCommand("test:destructive", {"cmd": "rm -rf /", "requires_confirmation": True})
+        cmd = DirectCommand("test:destructive", {"cmd": "rm -rf /", "destructive": True})
 
         with pytest.raises(SystemExit) as exc_info:
             cmd._confirm(yes=False)
@@ -189,7 +189,7 @@ class TestConfirmationFeature:
 
         cmd = CompositeCommand(
             "reset",
-            {"steps": ["docker:services:down", "docker:services:up"], "requires_confirmation": True},
+            {"steps": ["docker:services:down", "docker:services:up"], "destructive": True},
         )
         cmd._confirmed = True
 
@@ -215,7 +215,7 @@ class TestConfirmationFeature:
 
         cmd = CompositeCommand(
             "reset",
-            {"steps": ["docker:services:down"], "requires_confirmation": True},
+            {"steps": ["docker:services:down"], "destructive": True},
         )
         # Simulate user confirming via prompt (not --yes flag)
         confirmed = cmd._confirm(yes=False)


### PR DESCRIPTION
- Implemented `requires_confirmation` in manifest for various commands.
- Added `_confirm` method in `Command` class to handle user confirmation.
- Updated command execution to respect confirmation requirements, passing `--yes` to child commands when confirmed.
- Added tests to verify confirmation behavior for commands requiring confirmation.
