### PR TITLE
feat(person-properties): Hide values from deleted persons when getting potential property values

### DIFF
--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -147,18 +147,20 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT value,
-         count(value)
+         uniq(id) - uniqIf(id, is_deleted != 0) as c
   FROM
-    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') as value
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') as value,
+            is_deleted,
+            id
      FROM person
      WHERE team_id = 99999
-       AND is_deleted = 0
-       AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') IS NOT NULL
-       AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') != ''
+       AND value IS NOT NULL
+       AND value != ''
      ORDER BY id DESC
      LIMIT 100000)
   GROUP BY value
-  ORDER BY count(value) DESC
+  HAVING c > 0
+  ORDER BY c DESC
   LIMIT 20
   '''
 # ---
@@ -166,17 +168,19 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT value,
-         count(value)
+         uniq(id) - uniqIf(id, is_deleted != 0) as c
   FROM
-    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') as value
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') as value,
+            is_deleted,
+            id
      FROM person
      WHERE team_id = 99999
-       AND is_deleted = 0
-       AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
+       AND value ILIKE '%qw%'
      ORDER BY id DESC
      LIMIT 100000)
   GROUP BY value
-  ORDER BY count(value) DESC
+  HAVING c > 0
+  ORDER BY c DESC
   LIMIT 20
   '''
 # ---
@@ -184,18 +188,20 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT value,
-         count(value)
+         uniq(id) - uniqIf(id, is_deleted != 0) as c
   FROM
-    (SELECT "pmat_random_prop" as value
+    (SELECT "pmat_random_prop" as value,
+            is_deleted,
+            id
      FROM person
      WHERE team_id = 99999
-       AND is_deleted = 0
-       AND "pmat_random_prop" IS NOT NULL
-       AND "pmat_random_prop" != ''
+       AND value IS NOT NULL
+       AND value != ''
      ORDER BY id DESC
      LIMIT 100000)
   GROUP BY value
-  ORDER BY count(value) DESC
+  HAVING c > 0
+  ORDER BY c DESC
   LIMIT 20
   '''
 # ---
@@ -203,17 +209,19 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT value,
-         count(value)
+         uniq(id) - uniqIf(id, is_deleted != 0) as c
   FROM
-    (SELECT "pmat_random_prop" as value
+    (SELECT "pmat_random_prop" as value,
+            is_deleted,
+            id
      FROM person
      WHERE team_id = 99999
-       AND is_deleted = 0
-       AND "pmat_random_prop" ILIKE '%qw%'
+       AND value ILIKE '%qw%'
      ORDER BY id DESC
      LIMIT 100000)
   GROUP BY value
-  ORDER BY count(value) DESC
+  HAVING c > 0
+  ORDER BY c DESC
   LIMIT 20
   '''
 # ---
@@ -679,18 +687,20 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT value,
-         count(value)
+         uniq(id) - uniqIf(id, is_deleted != 0) as c
   FROM
-    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') as value
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') as value,
+            is_deleted,
+            id
      FROM person
      WHERE team_id = 99999
-       AND is_deleted = 0
-       AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') IS NOT NULL
-       AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') != ''
+       AND value IS NOT NULL
+       AND value != ''
      ORDER BY id DESC
      LIMIT 100000)
   GROUP BY value
-  ORDER BY count(value) DESC
+  HAVING c > 0
+  ORDER BY c DESC
   LIMIT 20
   '''
 # ---
@@ -698,17 +708,19 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT value,
-         count(value)
+         uniq(id) - uniqIf(id, is_deleted != 0) as c
   FROM
-    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') as value
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') as value,
+            is_deleted,
+            id
      FROM person
      WHERE team_id = 99999
-       AND is_deleted = 0
-       AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
+       AND value ILIKE '%qw%'
      ORDER BY id DESC
      LIMIT 100000)
   GROUP BY value
-  ORDER BY count(value) DESC
+  HAVING c > 0
+  ORDER BY c DESC
   LIMIT 20
   '''
 # ---
@@ -716,18 +728,20 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT value,
-         count(value)
+         uniq(id) - uniqIf(id, is_deleted != 0) as c
   FROM
-    (SELECT "pmat_random_prop" as value
+    (SELECT "pmat_random_prop" as value,
+            is_deleted,
+            id
      FROM person
      WHERE team_id = 99999
-       AND is_deleted = 0
-       AND "pmat_random_prop" IS NOT NULL
-       AND "pmat_random_prop" != ''
+       AND value IS NOT NULL
+       AND value != ''
      ORDER BY id DESC
      LIMIT 100000)
   GROUP BY value
-  ORDER BY count(value) DESC
+  HAVING c > 0
+  ORDER BY c DESC
   LIMIT 20
   '''
 # ---
@@ -735,17 +749,19 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT value,
-         count(value)
+         uniq(id) - uniqIf(id, is_deleted != 0) as c
   FROM
-    (SELECT "pmat_random_prop" as value
+    (SELECT "pmat_random_prop" as value,
+            is_deleted,
+            id
      FROM person
      WHERE team_id = 99999
-       AND is_deleted = 0
-       AND "pmat_random_prop" ILIKE '%qw%'
+       AND value ILIKE '%qw%'
      ORDER BY id DESC
      LIMIT 100000)
   GROUP BY value
-  ORDER BY count(value) DESC
+  HAVING c > 0
+  ORDER BY c DESC
   LIMIT 20
   '''
 # ---

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -563,16 +563,18 @@ COMMENT_DISTINCT_ID_COLUMN_SQL = (
 SELECT_PERSON_PROP_VALUES_SQL = """
 SELECT
     value,
-    uniq(id) - uniqIf(id, is_deleted)  as c
+    uniq(id) - uniqIf(id, is_deleted != 0)  as c
 FROM (
     SELECT
-        {property_field} as value
+        {property_field} as value,
+        is_deleted,
+        id
     FROM
         person
     WHERE
         team_id = %(team_id)s AND
-        {property_field} IS NOT NULL AND
-        {property_field} != ''
+        value IS NOT NULL AND
+        value != ''
     ORDER BY id DESC
     LIMIT 100000
 )
@@ -585,7 +587,7 @@ LIMIT 20
 SELECT_PERSON_PROP_VALUES_SQL_WITH_FILTER = """
 SELECT
     value,
-    uniq(id) - uniqIf(id, is_deleted)  as c
+    uniq(id) - uniqIf(id, is_deleted != 0)  as c
 FROM (
     SELECT
         {property_field} as value,
@@ -595,7 +597,7 @@ FROM (
         person
     WHERE
         team_id = %(team_id)s AND
-        {property_field} ILIKE %(value)s
+        value ILIKE %(value)s
     ORDER BY id DESC
     LIMIT 100000
 )

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -554,6 +554,12 @@ COMMENT_DISTINCT_ID_COLUMN_SQL = (
 )
 
 
+# Tricky: the person table uses a ReplacingMergeTree, but it is not guaranteed by Clickhouse that the replacement has
+# actually happened. This means we can have multiple rows for a particular person ID. This can happen if a property has
+# changed, or if the user was deleted.
+# The following query will make an attempt to hide values that come from deleted users, however it will only hide the
+# values that are set at the time of deletion (or after). This is to avoid needing to GROUP BY id on the persons table,
+# which would make this query take ~20x as long and be unacceptable in the UI.
 SELECT_PERSON_PROP_VALUES_SQL = """
 SELECT
     value,

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -557,7 +557,7 @@ COMMENT_DISTINCT_ID_COLUMN_SQL = (
 SELECT_PERSON_PROP_VALUES_SQL = """
 SELECT
     value,
-    count(value)
+    uniq(id) - uniqIf(id, is_deleted)  as c
 FROM (
     SELECT
         {property_field} as value
@@ -565,35 +565,37 @@ FROM (
         person
     WHERE
         team_id = %(team_id)s AND
-        is_deleted = 0 AND
         {property_field} IS NOT NULL AND
         {property_field} != ''
     ORDER BY id DESC
     LIMIT 100000
 )
 GROUP BY value
-ORDER BY count(value) DESC
+HAVING c > 0
+ORDER BY c DESC
 LIMIT 20
 """
 
 SELECT_PERSON_PROP_VALUES_SQL_WITH_FILTER = """
 SELECT
     value,
-    count(value)
+    uniq(id) - uniqIf(id, is_deleted)  as c
 FROM (
     SELECT
-        {property_field} as value
+        {property_field} as value,
+        is_deleted,
+        id
     FROM
         person
     WHERE
         team_id = %(team_id)s AND
-        is_deleted = 0 AND
         {property_field} ILIKE %(value)s
     ORDER BY id DESC
     LIMIT 100000
 )
 GROUP BY value
-ORDER BY count(value) DESC
+HAVING c > 0
+ORDER BY c DESC
 LIMIT 20
 """
 


### PR DESCRIPTION
## Problem
See https://posthog.slack.com/archives/C09BDQLM8KA/p1763485240868379

If a Person is deleted, we create a new row with `is_deleted = 1`. The row with `is_deleted = 0` will still be present until the ReplacingMergeTree engine does the replacement.

This means that the query for person property values can return values from a deleted Person.

The problem is that the correct solution to this would involving adding a `GROUP BY` and `argMax` to find the latest version of the person, and use the property from that. Unfortunately, this query takes ~20x as long.

## Changes

We can do slightly better than the previous approach by `uniq`-ing the person IDs in total and deleted, and then subtracting to get a count of the values coming only from non-deleted person IDs.

This doesn't completely work, e.g. if you have this chain of operations

* set foo = a
* set foo = b
* delete

We will not return b, but we will return a. 

This is still a huge improvement over the previous query, which returned both a & b.

The performance characteristics are approximately the same.

## How did you test this code?

Existing tests still pass


For perf, I measured the previous and this new approach at approximately the same, metabase links for my test queries are here: 

[count()-based approach](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1RcbiAgICB2YWx1ZSxcbiAgICAtLSB1bmlxKGlkKSAtIHVuaXFJZihpZCwgaXNfZGVsZXRlZCAhPSAwKSAgYXMgYyxcbiAgICBjb3VudCgpIGFzIGNcbkZST00gKFxuICAgIFNFTEVDVFxuICAgICAgICByZXBsYWNlUmVnZXhwQWxsKG51bGxJZihudWxsSWYoSlNPTkV4dHJhY3RSYXcocGVyc29uLnByb3BlcnRpZXMsICdlbWFpbCcpLCAnJyksICdudWxsJyksICdeXCJ8XCIkJywgJycpIGFzIHZhbHVlLFxuICAgICAgICBpc19kZWxldGVkLFxuICAgICAgICBpZFxuICAgIEZST01cbiAgICAgICAgcGVyc29uXG4gICAgV0hFUkVcbiAgICAgICAgdGVhbV9pZCA9IDIgQU5EXG4gICAgICAgIHZhbHVlIElTIE5PVCBOVUxMIEFORFxuICAgICAgICB2YWx1ZSAhPSAnJ1xuICAgIE9SREVSIEJZIGlkIERFU0NcbiAgICBMSU1JVCAxMDAwMDBcbilcbkdST1VQIEJZIHZhbHVlXG5IQVZJTkcgYyA-IDBcbk9SREVSIEJZIGMgREVTQ1xuTElNSVQgMjAiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjo0Mn0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=)

[uniq()-based approach](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1RcbiAgICB2YWx1ZSxcbiAgICAtLSB1bmlxKGlkKSAtIHVuaXFJZihpZCwgaXNfZGVsZXRlZCAhPSAwKSAgYXMgY1xuICAgIGNvdW50KCkgYXMgY1xuRlJPTSAoXG4gICAgU0VMRUNUXG4gICAgICAgIHJlcGxhY2VSZWdleHBBbGwobnVsbElmKG51bGxJZihKU09ORXh0cmFjdFJhdyhwZXJzb24ucHJvcGVydGllcywgJ2VtYWlsJyksICcnKSwgJ251bGwnKSwgJ15cInxcIiQnLCAnJykgYXMgdmFsdWUsXG4gICAgICAgIGlzX2RlbGV0ZWQsXG4gICAgICAgIGlkXG4gICAgRlJPTVxuICAgICAgICBwZXJzb25cbiAgICBXSEVSRVxuICAgICAgICB0ZWFtX2lkID0gMiBBTkRcbiAgICAgICAgdmFsdWUgSVMgTk9UIE5VTEwgQU5EXG4gICAgICAgIHZhbHVlICE9ICcnXG4gICAgT1JERVIgQlkgaWQgREVTQ1xuICAgIExJTUlUIDEwMDAwMFxuKVxuR1JPVVAgQlkgdmFsdWVcbkhBVklORyBjID4gMFxuT1JERVIgQlkgYyBERVNDXG5MSU1JVCAyMCIsInRlbXBsYXRlLXRhZ3MiOnt9fSwiZGF0YWJhc2UiOjQyfSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
