### PR TITLE
feat(sessions): Add list of event names to sessions

### DIFF
--- a/posthog/clickhouse/migrations/0180_sessions_v3_add_event_names.py
+++ b/posthog/clickhouse/migrations/0180_sessions_v3_add_event_names.py
@@ -1,0 +1,39 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.raw_sessions.migrations_v3 import ADD_EVENT_NAMES, ADD_EVENT_NAMES_BLOOM_FILTER
+from posthog.models.raw_sessions.sessions_v3 import (
+    DISTRIBUTED_RAW_SESSIONS_TABLE_V3,
+    SHARDED_RAW_SESSIONS_TABLE_V3,
+    WRITABLE_RAW_SESSIONS_TABLE_V3,
+)
+
+operations = [
+    # add event_names column to sharded table
+    run_sql_with_exceptions(
+        ADD_EVENT_NAMES.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    # add event_names column to writable table
+    run_sql_with_exceptions(
+        ADD_EVENT_NAMES.format(table_name=WRITABLE_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # add event_names column to distributed table
+    run_sql_with_exceptions(
+        ADD_EVENT_NAMES.format(table_name=DISTRIBUTED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # add bloom filter index to sharded table only
+    run_sql_with_exceptions(
+        ADD_EVENT_NAMES_BLOOM_FILTER.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+]

--- a/posthog/clickhouse/migrations/0180_sessions_v3_add_event_names.py
+++ b/posthog/clickhouse/migrations/0180_sessions_v3_add_event_names.py
@@ -5,6 +5,8 @@ from posthog.models.raw_sessions.migrations_v3 import (
     ADD_EVENT_NAMES_BLOOM_FILTER,
     ADD_FLAG_KEYS,
     ADD_FLAG_KEYS_BLOOM_FILTER,
+    ADD_URLS,
+    DROP_URLS,
 )
 from posthog.models.raw_sessions.sessions_v3 import (
     DISTRIBUTED_RAW_SESSIONS_TABLE_V3,
@@ -68,5 +70,47 @@ operations = [
         node_roles=[NodeRole.DATA],
         sharded=True,
         is_alter_on_replicated_table=True,
+    ),
+    # drop urls column from sharded table
+    run_sql_with_exceptions(
+        DROP_URLS.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    # add urls column back to sharded table with correct position
+    run_sql_with_exceptions(
+        ADD_URLS.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    # drop urls column from writable table
+    run_sql_with_exceptions(
+        DROP_URLS.format(table_name=WRITABLE_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # add urls column back to writable table with correct position
+    run_sql_with_exceptions(
+        ADD_URLS.format(table_name=WRITABLE_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # drop urls column from distributed table
+    run_sql_with_exceptions(
+        DROP_URLS.format(table_name=DISTRIBUTED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # add urls column back to distributed table with correct position
+    run_sql_with_exceptions(
+        ADD_URLS.format(table_name=DISTRIBUTED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+        sharded=False,
+        is_alter_on_replicated_table=False,
     ),
 ]

--- a/posthog/clickhouse/migrations/0180_sessions_v3_add_event_names.py
+++ b/posthog/clickhouse/migrations/0180_sessions_v3_add_event_names.py
@@ -1,6 +1,11 @@
 from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.models.raw_sessions.migrations_v3 import ADD_EVENT_NAMES, ADD_EVENT_NAMES_BLOOM_FILTER
+from posthog.models.raw_sessions.migrations_v3 import (
+    ADD_EVENT_NAMES,
+    ADD_EVENT_NAMES_BLOOM_FILTER,
+    ADD_FLAG_KEYS,
+    ADD_FLAG_KEYS_BLOOM_FILTER,
+)
 from posthog.models.raw_sessions.sessions_v3 import (
     DISTRIBUTED_RAW_SESSIONS_TABLE_V3,
     SHARDED_RAW_SESSIONS_TABLE_V3,
@@ -32,6 +37,34 @@ operations = [
     # add bloom filter index to sharded table only
     run_sql_with_exceptions(
         ADD_EVENT_NAMES_BLOOM_FILTER.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    # add flag_keys column to sharded table
+    run_sql_with_exceptions(
+        ADD_FLAG_KEYS.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    # add flag_keys column to writable table
+    run_sql_with_exceptions(
+        ADD_FLAG_KEYS.format(table_name=WRITABLE_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # add flag_keys column to distributed table
+    run_sql_with_exceptions(
+        ADD_FLAG_KEYS.format(table_name=DISTRIBUTED_RAW_SESSIONS_TABLE_V3()),
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # add bloom filter index for flag_keys to sharded table only
+    run_sql_with_exceptions(
+        ADD_FLAG_KEYS_BLOOM_FILTER.format(table_name=SHARDED_RAW_SESSIONS_TABLE_V3()),
         node_roles=[NodeRole.DATA],
         sharded=True,
         is_alter_on_replicated_table=True,

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,2 +1,1 @@
 0180_sessions_v3_add_event_names
-

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,2 @@
-0179_add_materialize_column_slots
+0180_sessions_v3_add_event_names
+

--- a/posthog/clickhouse/test/__snapshots__/test_raw_sessions_v3_model.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_raw_sessions_v3_model.ambr
@@ -44,6 +44,24 @@
     AND team_id = 99999
   '''
 # ---
+# name: TestRawSessionsModel.test_event_names_are_collected
+  '''
+  
+  select *
+  from raw_sessions_v3_v
+  where session_id_v7 = toUInt128(toUUID('00000000-0000-0000-0000-000000000000'))
+    AND team_id = 99999
+  '''
+# ---
+# name: TestRawSessionsModel.test_flag_keys_are_collected
+  '''
+  
+  select *
+  from raw_sessions_v3_v
+  where session_id_v7 = toUInt128(toUUID('00000000-0000-0000-0000-000000000000'))
+    AND team_id = 99999
+  '''
+# ---
 # name: TestRawSessionsModel.test_handles_different_distinct_id_across_same_session
   '''
   

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2968,6 +2968,9 @@
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),
   
+      -- Event names - store unique event names seen in this session
+      event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+  
       -- Replay
       has_replay_events SimpleAggregateFunction(max, Boolean)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_raw_sessions_v3', cityHash64(session_id_v7))
@@ -3166,6 +3169,9 @@
       -- flags
       initializeAggregation('groupUniqArrayMapState', properties_group_feature_flags) as flag_values,
   
+      -- event names
+      [event] as event_names,
+  
       false as has_replay_events
   FROM posthog_test.sharded_events AS source_table
   WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7
@@ -3254,6 +3260,9 @@
   
       -- flags
       initializeAggregation('groupUniqArrayMapState', CAST(map(), 'Map(String, String)')) as flag_values,
+  
+      -- event names
+      CAST([], 'Array(String)') as event_names,
   
       -- replay
       true as has_replay_events
@@ -4171,8 +4180,15 @@
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),
   
+      -- Event names - store unique event names seen in this session
+      event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+  
       -- Replay
       has_replay_events SimpleAggregateFunction(max, Boolean)
+  ,
+  
+      -- Indexes
+      INDEX event_names_bloom_filter event_names TYPE bloom_filter() GRANULARITY 1
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.raw_sessions_v3', '{replica}')
   
   PARTITION BY toYYYYMM(session_timestamp)
@@ -5364,6 +5380,9 @@
   
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),
+  
+      -- Event names - store unique event names seen in this session
+      event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
   
       -- Replay
       has_replay_events SimpleAggregateFunction(max, Boolean)
@@ -6754,8 +6773,15 @@
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),
   
+      -- Event names - store unique event names seen in this session
+      event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+  
       -- Replay
       has_replay_events SimpleAggregateFunction(max, Boolean)
+  ,
+  
+      -- Indexes
+      INDEX event_names_bloom_filter event_names TYPE bloom_filter() GRANULARITY 1
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.raw_sessions_v3', '{replica}')
   
   PARTITION BY toYYYYMM(session_timestamp)

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2967,6 +2967,7 @@
   
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),
+      flag_keys SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
   
       -- Event names - store unique event names seen in this session
       event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
@@ -3168,6 +3169,7 @@
   
       -- flags
       initializeAggregation('groupUniqArrayMapState', properties_group_feature_flags) as flag_values,
+      mapKeys(properties_group_feature_flags) as flag_keys,
   
       -- event names
       [event] as event_names,
@@ -3260,6 +3262,7 @@
   
       -- flags
       initializeAggregation('groupUniqArrayMapState', CAST(map(), 'Map(String, String)')) as flag_values,
+      CAST([], 'Array(String)') as flag_keys,
   
       -- event names
       CAST([], 'Array(String)') as event_names,
@@ -4179,6 +4182,7 @@
   
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),
+      flag_keys SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
   
       -- Event names - store unique event names seen in this session
       event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
@@ -4188,7 +4192,8 @@
   ,
   
       -- Indexes
-      INDEX event_names_bloom_filter event_names TYPE bloom_filter() GRANULARITY 1
+      INDEX event_names_bloom_filter event_names TYPE bloom_filter() GRANULARITY 1,
+      INDEX flag_keys_bloom_filter flag_keys TYPE bloom_filter() GRANULARITY 1
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.raw_sessions_v3', '{replica}')
   
   PARTITION BY toYYYYMM(session_timestamp)
@@ -5380,6 +5385,7 @@
   
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),
+      flag_keys SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
   
       -- Event names - store unique event names seen in this session
       event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
@@ -6772,6 +6778,7 @@
   
       -- Flags - store every seen value for each flag
       flag_values AggregateFunction(groupUniqArrayMap, Map(String, String)),
+      flag_keys SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
   
       -- Event names - store unique event names seen in this session
       event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
@@ -6781,7 +6788,8 @@
   ,
   
       -- Indexes
-      INDEX event_names_bloom_filter event_names TYPE bloom_filter() GRANULARITY 1
+      INDEX event_names_bloom_filter event_names TYPE bloom_filter() GRANULARITY 1,
+      INDEX flag_keys_bloom_filter flag_keys TYPE bloom_filter() GRANULARITY 1
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.raw_sessions_v3', '{replica}')
   
   PARTITION BY toYYYYMM(session_timestamp)

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2907,7 +2907,7 @@
       max_inserted_at SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
   
       -- urls
-      urls SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      urls SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String)),
       entry_url AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       end_url AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC')),
       last_external_click_url AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC')),
@@ -2970,7 +2970,7 @@
       flag_keys SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
   
       -- Event names - store unique event names seen in this session
-      event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      event_names SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String)),
   
       -- Replay
       has_replay_events SimpleAggregateFunction(max, Boolean)
@@ -4122,7 +4122,7 @@
       max_inserted_at SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
   
       -- urls
-      urls SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      urls SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String)),
       entry_url AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       end_url AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC')),
       last_external_click_url AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC')),
@@ -4185,7 +4185,7 @@
       flag_keys SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
   
       -- Event names - store unique event names seen in this session
-      event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      event_names SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String)),
   
       -- Replay
       has_replay_events SimpleAggregateFunction(max, Boolean)
@@ -5325,7 +5325,7 @@
       max_inserted_at SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
   
       -- urls
-      urls SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      urls SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String)),
       entry_url AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       end_url AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC')),
       last_external_click_url AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC')),
@@ -5388,7 +5388,7 @@
       flag_keys SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
   
       -- Event names - store unique event names seen in this session
-      event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      event_names SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String)),
   
       -- Replay
       has_replay_events SimpleAggregateFunction(max, Boolean)
@@ -6718,7 +6718,7 @@
       max_inserted_at SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
   
       -- urls
-      urls SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      urls SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String)),
       entry_url AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
       end_url AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC')),
       last_external_click_url AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC')),
@@ -6781,7 +6781,7 @@
       flag_keys SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
   
       -- Event names - store unique event names seen in this session
-      event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      event_names SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String)),
   
       -- Replay
       has_replay_events SimpleAggregateFunction(max, Boolean)

--- a/posthog/clickhouse/test/test_raw_sessions_v3_model.py
+++ b/posthog/clickhouse/test/test_raw_sessions_v3_model.py
@@ -2,6 +2,7 @@ import datetime
 
 from posthog.test.base import (
     BaseTest,
+    ClickhouseDestroyTablesMixin,
     ClickhouseTestMixin,
     _create_event,
     flush_persons_and_events,
@@ -33,7 +34,7 @@ def create_session_id():
 
 
 @snapshot_clickhouse_queries
-class TestRawSessionsModel(ClickhouseTestMixin, BaseTest):
+class TestRawSessionsModel(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, BaseTest):
     snapshot_replace_all_numbers = True
 
     def select_by_session_id(self, session_id):

--- a/posthog/clickhouse/test/test_raw_sessions_v3_model.py
+++ b/posthog/clickhouse/test/test_raw_sessions_v3_model.py
@@ -2,7 +2,6 @@ import datetime
 
 from posthog.test.base import (
     BaseTest,
-    ClickhouseDestroyTablesMixin,
     ClickhouseTestMixin,
     _create_event,
     flush_persons_and_events,
@@ -34,7 +33,7 @@ def create_session_id():
 
 
 @snapshot_clickhouse_queries
-class TestRawSessionsModel(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, BaseTest):
+class TestRawSessionsModel(ClickhouseTestMixin, BaseTest):
     snapshot_replace_all_numbers = True
 
     def select_by_session_id(self, session_id):
@@ -614,6 +613,7 @@ class TestRawSessionsModel(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, Ba
             session_id=session_id,
             first_timestamp="2024-03-08",
             last_timestamp="2024-03-08",
+            ensure_analytics_event_in_session=False,
         )
 
         result_2 = self.select_by_session_id(session_id)

--- a/posthog/models/raw_sessions/migrations_v3.py
+++ b/posthog/models/raw_sessions/migrations_v3.py
@@ -29,3 +29,15 @@ ADD_EVENT_NAMES_BLOOM_FILTER = """
 ALTER TABLE {table_name}
 ADD INDEX IF NOT EXISTS event_names_bloom_filter event_names TYPE bloom_filter() GRANULARITY 1
 """
+
+
+ADD_FLAG_KEYS = """
+ALTER TABLE {table_name}
+ADD COLUMN IF NOT EXISTS flag_keys SimpleAggregateFunction(groupUniqArrayArray, Array(String)) AFTER flag_values
+"""
+
+
+ADD_FLAG_KEYS_BLOOM_FILTER = """
+ALTER TABLE {table_name}
+ADD INDEX IF NOT EXISTS flag_keys_bloom_filter flag_keys TYPE bloom_filter() GRANULARITY 1
+"""

--- a/posthog/models/raw_sessions/migrations_v3.py
+++ b/posthog/models/raw_sessions/migrations_v3.py
@@ -41,3 +41,15 @@ ADD_FLAG_KEYS_BLOOM_FILTER = """
 ALTER TABLE {table_name}
 ADD INDEX IF NOT EXISTS flag_keys_bloom_filter flag_keys TYPE bloom_filter() GRANULARITY 1
 """
+
+
+DROP_URLS = """
+ALTER TABLE {table_name}
+DROP COLUMN IF EXISTS urls
+"""
+
+
+ADD_URLS = """
+ALTER TABLE {table_name}
+ADD COLUMN IF NOT EXISTS urls SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String)) AFTER max_inserted_at
+"""

--- a/posthog/models/raw_sessions/migrations_v3.py
+++ b/posthog/models/raw_sessions/migrations_v3.py
@@ -17,3 +17,15 @@ ADD COLUMN IF NOT EXISTS has_autocapture SimpleAggregateFunction(max, Boolean) A
 ;
 
 """
+
+
+ADD_EVENT_NAMES = """
+ALTER TABLE {table_name}
+ADD COLUMN IF NOT EXISTS event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)) AFTER flag_values
+"""
+
+
+ADD_EVENT_NAMES_BLOOM_FILTER = """
+ALTER TABLE {table_name}
+ADD INDEX IF NOT EXISTS event_names_bloom_filter event_names TYPE bloom_filter() GRANULARITY 1
+"""

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -660,10 +660,10 @@ SELECT
 
     -- flags
     groupUniqArrayMapMerge(flag_values) as flag_values,
-    arrayDistinct(arrayFlatten(groupArray(flag_keys))) as flag_keys,
+    groupUniqArrayArray(flag_keys) as flag_keys,
 
     -- event names
-    arrayDistinct(arrayFlatten(groupArray(event_names))) as event_names,
+    groupUniqArrayArray(event_names) as event_names,
 
     -- replay
     max(has_replay_events) as has_replay_events

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -101,7 +101,7 @@ CREATE TABLE IF NOT EXISTS {table_name}
     max_inserted_at SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
 
     -- urls
-    urls SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+    urls SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String)),
     entry_url AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
     end_url AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC')),
     last_external_click_url AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC')),
@@ -164,7 +164,7 @@ CREATE TABLE IF NOT EXISTS {table_name}
     flag_keys SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
 
     -- Event names - store unique event names seen in this session
-    event_names SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+    event_names SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String)),
 
     -- Replay
     has_replay_events SimpleAggregateFunction(max, Boolean)
@@ -609,7 +609,7 @@ SELECT
     max(max_inserted_at) as max_inserted_at,
 
     -- urls
-    arrayDistinct(arrayFlatten(groupArray(urls))) AS urls,
+    groupUniqArrayArray(2000)(urls) AS urls,
     argMinMerge(entry_url) as entry_url,
     argMaxMerge(end_url) as end_url,
     argMaxMerge(last_external_click_url) as last_external_click_url,
@@ -663,7 +663,7 @@ SELECT
     groupUniqArrayArray(flag_keys) as flag_keys,
 
     -- event names
-    groupUniqArrayArray(event_names) as event_names,
+    groupUniqArrayArray(2000)(event_names) as event_names,
 
     -- replay
     max(has_replay_events) as has_replay_events


### PR DESCRIPTION
## Problem

We want an efficient way of finding all session IDs where a particular event happened

## Changes

Add a list of event names, and a bloom filter.

This is useful for finding e.g. all replays where event Foo happened.

Note that the bloom filter will be challenging to use in a query where you also want session data, as retrieving data from this table requires a GROUP BY on the session ID, and the filter should be placed in the HAVING clause rather than the WHERE clause, otherwise you'lll miss data from that sessions


## How did you test this code?

Existing tests still pass!

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
