### PR TITLE
feat(sessions): Don't clobber settings in sessions dags

### DIFF
--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -45,6 +45,7 @@ settings = {
     "max_execution_time": MAX_PARTITIONS_PER_RUN * 4 * ONE_HOUR_IN_SECONDS,
     "max_memory_usage": 100 * ONE_GB_IN_BYTES,
     "distributed_aggregation_memory_efficient": "1",
+    "insert_distributed_sync": "1",
 }
 
 

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -509,7 +509,6 @@ def RAW_SESSION_TABLE_BACKFILL_SQL_V3(where="TRUE", use_sharded_source=True):
     return """
 INSERT INTO {database}.{writable_table}
 {select_sql}
-SETTINGS insert_distributed_sync = 1
 """.format(
         database=settings.CLICKHOUSE_DATABASE,
         writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
@@ -526,7 +525,6 @@ def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(where="TRUE", use_sharded_sourc
     return """
 INSERT INTO {database}.{writable_table}
 {select_sql}
-SETTINGS insert_distributed_sync = 1
 """.format(
         database=settings.CLICKHOUSE_DATABASE,
         writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),


### PR DESCRIPTION
## Problem

We ran OOM on the dagster jobs, https://metabase.prod-us.posthog.dev/question/1671-get-clickhouse-query-log-for-given-dagster-run-id?dagster_run_id=ecc1f809-a809-429e-9a12-773ff818526f#eyJuYW1lIjoiR2V0IGNsaWNraG91c2UgcXVlcnkgbG9nIGZvciBnaXZlbiBEYWdzdGVyIHJ1biBJRCIsImRlc2NyaXB0aW9uIjpudWxsLCJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjo0MiwidHlwZSI6Im5hdGl2ZSIsIm5hdGl2ZSI6eyJ0ZW1wbGF0ZS10YWdzIjp7ImRhZ3N0ZXJfcnVuX2lkIjp7InR5cGUiOiJ0ZXh0IiwibmFtZSI6ImRhZ3N0ZXJfcnVuX2lkIiwiaWQiOiI1Y2NmMTdjYy01YTE5LTQ2ZmMtOGJjYi0xZGYwZGM5OGU4MDAiLCJkaXNwbGF5LW5hbWUiOiJEYWdzdGVyIFJ1biBJRCIsInJlcXVpcmVkIjp0cnVlfX0sInF1ZXJ5IjoiU0VMRUNUIFxuICAgIGhvc3ROYW1lKCkgYXMgaG9zdCxcbiAgICBldmVudF90aW1lLFxuICAgIHR5cGUsXG4gICAgZXhjZXB0aW9uIElTIE5PVCBOVUxMIGFuZCBleGNlcHRpb24gIT0gJycgYXMgaGFzX2V4Y2VwdGlvbixcbiAgICBxdWVyeV9kdXJhdGlvbl9tcyxcbiAgICBmb3JtYXRSZWFkYWJsZVNpemUobWVtb3J5X3VzYWdlKSBhcyBtZW1vcnlfdXNlZCxcbiAgICBmb3JtYXRSZWFkYWJsZVNpemUocmVhZF9ieXRlcykgYXMgZGF0YV9yZWFkLFxuICAgIEpTT05FeHRyYWN0U3RyaW5nKGxvZ19jb21tZW50LCAnZGFnc3RlcicsICdydW5faWQnKSBBUyBkYWdzdGVyX3J1bl9pZCxcbiAgICBKU09ORXh0cmFjdFN0cmluZyhsb2dfY29tbWVudCwgJ2RhZ3N0ZXInLCAnam9iX25hbWUnKSBBUyBkYWdzdGVyX2pvYl9uYW1lLFxuICAgIEpTT05FeHRyYWN0U3RyaW5nKGxvZ19jb21tZW50LCAnZGFnc3RlcicsICdhc3NldF9rZXknKSBBUyBkYWdzdGVyX2Fzc2V0X2tleSxcbiAgICBKU09ORXh0cmFjdFN0cmluZyhsb2dfY29tbWVudCwgJ2RhZ3N0ZXInLCAnb3BfbmFtZScpIEFTIGRhZ3N0ZXJfb3BfbmFtZSxcbiAgICBleGNlcHRpb24sXG4gICAgcXVlcnlcbkZST00gY2x1c3RlckFsbFJlcGxpY2FzKCdwb3N0aG9nJywgc3lzdGVtLnF1ZXJ5X2xvZylcbldIRVJFIFxuICAgIGRhZ3N0ZXJfcnVuX2lkID0ge3tkYWdzdGVyX3J1bl9pZH19XG4gICAgQU5EIGV2ZW50X2RhdGUgPj0gdG9kYXkoKSAtIDFcbk9SREVSIEJZIGV2ZW50X3RpbWUgREVTQzsifX0sImRpc3BsYXkiOiJ0YWJsZSIsImRpc3BsYXlJc0xvY2tlZCI6dHJ1ZSwicGFyYW1ldGVycyI6W3siaWQiOiI1Y2NmMTdjYy01YTE5LTQ2ZmMtOGJjYi0xZGYwZGM5OGU4MDAiLCJ0eXBlIjoiY2F0ZWdvcnkiLCJ0YXJnZXQiOlsidmFyaWFibGUiLFsidGVtcGxhdGUtdGFnIiwiZGFnc3Rlcl9ydW5faWQiXV0sIm5hbWUiOiJEYWdzdGVyIFJ1biBJRCIsInNsdWciOiJkYWdzdGVyX3J1bl9pZCIsInJlcXVpcmVkIjp0cnVlfV0sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsidGFibGUucGl2b3RfY29sdW1uIjoiaG9zdCIsInRhYmxlLmNlbGxfY29sdW1uIjoicXVlcnlfZHVyYXRpb25fbXMifSwib3JpZ2luYWxfY2FyZF9pZCI6MTY3MX0=

I think this might have been because the inline settings were clobbering the query-level settings.

This is only a theory, but I can see a [previous run](https://metabase.prod-us.posthog.dev/question?dagster_run_id=83dc4e4c-e8fe-4317-95f8-da7763d6ee18#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjo0MiwidHlwZSI6Im5hdGl2ZSIsIm5hdGl2ZSI6eyJ0ZW1wbGF0ZS10YWdzIjp7ImRhZ3N0ZXJfcnVuX2lkIjp7InR5cGUiOiJ0ZXh0IiwibmFtZSI6ImRhZ3N0ZXJfcnVuX2lkIiwiaWQiOiI1Y2NmMTdjYy01YTE5LTQ2ZmMtOGJjYi0xZGYwZGM5OGU4MDAiLCJkaXNwbGF5LW5hbWUiOiJEYWdzdGVyIFJ1biBJRCIsInJlcXVpcmVkIjp0cnVlfX0sInF1ZXJ5IjoiU0VMRUNUIFxuICAgIGhvc3ROYW1lKCkgYXMgaG9zdCxcbiAgICBldmVudF90aW1lLFxuICAgIHR5cGUsXG4gICAgZXhjZXB0aW9uIElTIE5PVCBOVUxMIGFuZCBleGNlcHRpb24gIT0gJycgYXMgaGFzX2V4Y2VwdGlvbixcbiAgICBxdWVyeV9kdXJhdGlvbl9tcyxcbiAgICBmb3JtYXRSZWFkYWJsZVNpemUobWVtb3J5X3VzYWdlKSBhcyBtZW1vcnlfdXNlZCxcbiAgICBmb3JtYXRSZWFkYWJsZVNpemUocmVhZF9ieXRlcykgYXMgZGF0YV9yZWFkLFxuICAgIEpTT05FeHRyYWN0U3RyaW5nKGxvZ19jb21tZW50LCAnZGFnc3RlcicsICdydW5faWQnKSBBUyBkYWdzdGVyX3J1bl9pZCxcbiAgICBKU09ORXh0cmFjdFN0cmluZyhsb2dfY29tbWVudCwgJ2RhZ3N0ZXInLCAnam9iX25hbWUnKSBBUyBkYWdzdGVyX2pvYl9uYW1lLFxuICAgIEpTT05FeHRyYWN0U3RyaW5nKGxvZ19jb21tZW50LCAnZGFnc3RlcicsICdhc3NldF9rZXknKSBBUyBkYWdzdGVyX2Fzc2V0X2tleSxcbiAgICBKU09ORXh0cmFjdFN0cmluZyhsb2dfY29tbWVudCwgJ2RhZ3N0ZXInLCAnb3BfbmFtZScpIEFTIGRhZ3N0ZXJfb3BfbmFtZSxcbiAgICBleGNlcHRpb24sXG4gICAgcXVlcnlcbkZST00gY2x1c3RlckFsbFJlcGxpY2FzKCdwb3N0aG9nJywgc3lzdGVtLnF1ZXJ5X2xvZylcbldIRVJFIFxuICAgIGRhZ3N0ZXJfcnVuX2lkID0ge3tkYWdzdGVyX3J1bl9pZH19XG4gICAgQU5EIGV2ZW50X2RhdGUgPj0gdG9kYXkoKSAtIDE0XG5PUkRFUiBCWSBldmVudF90aW1lIERFU0M7In19LCJkaXNwbGF5IjoidGFibGUiLCJkaXNwbGF5SXNMb2NrZWQiOnRydWUsInBhcmFtZXRlcnMiOlt7ImlkIjoiNWNjZjE3Y2MtNWExOS00NmZjLThiY2ItMWRmMGRjOThlODAwIiwidHlwZSI6ImNhdGVnb3J5IiwidGFyZ2V0IjpbInZhcmlhYmxlIixbInRlbXBsYXRlLXRhZyIsImRhZ3N0ZXJfcnVuX2lkIl1dLCJuYW1lIjoiRGFnc3RlciBSdW4gSUQiLCJzbHVnIjoiZGFnc3Rlcl9ydW5faWQiLCJyZXF1aXJlZCI6dHJ1ZX1dLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7InRhYmxlLnBpdm90X2NvbHVtbiI6Imhvc3QiLCJ0YWJsZS5jZWxsX2NvbHVtbiI6InF1ZXJ5X2R1cmF0aW9uX21zIn0sIm9yaWdpbmFsX2NhcmRfaWQiOjE2NzF9) was allowed to use much more memory

## Changes
 Let's only use query-level settings

## How did you test this code?

n/a

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
