### PR TITLE
fix(data-warehouse): Fix accidental table resets

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -99,6 +99,8 @@ class DeltaTableHelper:
                 if "parse decimal overflow" in "".join(e.args):
                     s3 = get_s3_client()
                     s3.delete(delta_uri, recursive=True)
+                else:
+                    raise
 
         self._is_first_sync = True
 


### PR DESCRIPTION
## Problem
- When pulling the delta table from S3, if we run into any exception, we set the table to be overwritten on the write, even in cases like intermittent network issues
- This means tables get wiped out and never resynced fully

## Changes
- Re-raise the caught exception if we're not explicitly handling it 

