### PR TITLE
chore(data-warehouse): Hard exit temporal worker when workflows have finished

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -1,8 +1,10 @@
+import os
 import signal
 import typing as t
 import asyncio
 import datetime as dt
 import functools
+import threading
 import faulthandler
 from collections import defaultdict
 
@@ -369,3 +371,16 @@ class Command(BaseCommand):
                 logger.info("Waiting on shutdown_task")
                 _ = runner.run(asyncio.wait([shutdown_task]))
                 logger.info("Finished Temporal worker shutdown")
+
+                logger.info("Listing active threads at shutdown:")
+                for t in threading.enumerate():
+                    logger.info(
+                        "Thread still alive at shutdown",
+                        thread_name=t.name,
+                        daemon=t.daemon,
+                        ident=t.ident,
+                    )
+
+                # _something_ is preventing clean exit after worker shutdown
+                logger.info("Temporal Worker has shut down, hard exiting")
+                os._exit(0)

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -1,6 +1,6 @@
 import os
 import signal
-import typing as t
+import typing
 import asyncio
 import datetime as dt
 import functools
@@ -189,7 +189,7 @@ _task_queue_specs = [
 # registered for a shared queue name are combined, ensuring the worker registers
 # everything it should.
 _workflows: defaultdict[str, set[type[PostHogWorkflow]]] = defaultdict(set)
-_activities: defaultdict[str, set[t.Callable[..., t.Any]]] = defaultdict(set)
+_activities: defaultdict[str, set[typing.Callable[..., typing.Any]]] = defaultdict(set)
 for task_queue_name, workflows_for_queue, activities_for_queue in _task_queue_specs:
     _workflows[task_queue_name].update(workflows_for_queue)  # type: ignore
     _activities[task_queue_name].update(activities_for_queue)
@@ -372,15 +372,15 @@ class Command(BaseCommand):
                 _ = runner.run(asyncio.wait([shutdown_task]))
                 logger.info("Finished Temporal worker shutdown")
 
-                logger.info("Listing active threads at shutdown:")
-                for t in threading.enumerate():
-                    logger.info(
-                        "Thread still alive at shutdown",
-                        thread_name=t.name,
-                        daemon=t.daemon,
-                        ident=t.ident,
-                    )
+        logger.info("Listing active threads at shutdown:")
+        for t in threading.enumerate():
+            logger.info(
+                "Thread still alive at shutdown",
+                thread_name=t.name,
+                daemon=t.daemon,
+                ident=t.ident,
+            )
 
-                # _something_ is preventing clean exit after worker shutdown
-                logger.info("Temporal Worker has shut down, hard exiting")
-                os._exit(0)
+        # _something_ is preventing clean exit after worker shutdown
+        logger.info("Temporal Worker has shut down, hard exiting")
+        os._exit(0)


### PR DESCRIPTION
## Problem
- Regularly, we find that the data warehouse temporal workers get stuck in a terminating state even when all workflows on the worker have finished (confirmed via logs from the worker, and confirmed with @langesven from infra)
- The process gets stuck in a hanging state - there could be a non-daemon thread _somewhere_ blocking the process from exiting

## Changes
- Log out all the active threads during shutdown, then hard exit the process - this is no worse than what's currently happening when Kubernetes hard kills the pod at the end of the graceful termination process
