### PR TITLE
chore(django): prepare codebase for Django 5 upgrade

### DIFF
--- a/ee/api/authentication.py
+++ b/ee/api/authentication.py
@@ -294,7 +294,7 @@ class VercelAuthentication(authentication.BaseAuthentication):
             raise AuthenticationFailed(f"{auth_type.title()} authentication failed")
 
     def _get_bearer_token(self, request: Request) -> str | None:
-        if auth_header := request.META.get("HTTP_AUTHORIZATION"):
+        if auth_header := request.headers.get("authorization"):
             parts = auth_header.split()
             if len(parts) == 2 and parts[0].lower() == "bearer":
                 return parts[1]

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -1062,7 +1062,9 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
             scopes=["project:read"],  # Only project:read, no access_control:read
         )
 
-        response = self.client.get("/api/projects/@current/access_controls", HTTP_AUTHORIZATION=f"Bearer {key_value}")
+        response = self.client.get(
+            "/api/projects/@current/access_controls", headers={"authorization": f"Bearer {key_value}"}
+        )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "access_control:read" in response.json()["detail"]
 
@@ -1077,7 +1079,7 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
         )
 
         response = self.client.get(
-            "/api/projects/@current/resource_access_controls", HTTP_AUTHORIZATION=f"Bearer {key_value}"
+            "/api/projects/@current/resource_access_controls", headers={"authorization": f"Bearer {key_value}"}
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "access_control:read" in response.json()["detail"]
@@ -1093,7 +1095,7 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
         )
 
         response = self.client.get(
-            "/api/projects/@current/global_access_controls", HTTP_AUTHORIZATION=f"Bearer {key_value}"
+            "/api/projects/@current/global_access_controls", headers={"authorization": f"Bearer {key_value}"}
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "access_control:read" in response.json()["detail"]
@@ -1105,7 +1107,9 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
             user=self.user, label="test_key", secure_value=hash_key_value(key_value), scopes=["access_control:read"]
         )
 
-        response = self.client.get("/api/projects/@current/access_controls", HTTP_AUTHORIZATION=f"Bearer {key_value}")
+        response = self.client.get(
+            "/api/projects/@current/access_controls", headers={"authorization": f"Bearer {key_value}"}
+        )
         assert response.status_code == status.HTTP_200_OK
 
     def test_resource_access_controls_get_succeeds_with_access_control_read_scope(self):
@@ -1116,7 +1120,7 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
         )
 
         response = self.client.get(
-            "/api/projects/@current/resource_access_controls", HTTP_AUTHORIZATION=f"Bearer {key_value}"
+            "/api/projects/@current/resource_access_controls", headers={"authorization": f"Bearer {key_value}"}
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -1136,7 +1140,7 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
 
         response = self.client.get(
             f"/api/projects/@current/notebooks/{notebook.short_id}/access_controls",
-            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+            headers={"authorization": f"Bearer {key_value}"},
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "access_control:read" in response.json()["detail"]
@@ -1154,7 +1158,7 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
 
         response = self.client.get(
             f"/api/projects/@current/notebooks/{notebook.short_id}/access_controls",
-            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+            headers={"authorization": f"Bearer {key_value}"},
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -1175,7 +1179,7 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
         response = self.client.put(
             f"/api/projects/@current/notebooks/{notebook.short_id}/access_controls",
             {"organization_member": str(self.organization_membership.id), "access_level": "viewer"},
-            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+            headers={"authorization": f"Bearer {key_value}"},
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "access_control:write" in response.json()["detail"]
@@ -1197,7 +1201,7 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
         response = self.client.put(
             f"/api/projects/@current/notebooks/{notebook.short_id}/access_controls",
             {"organization_member": str(self.organization_membership.id), "access_level": "viewer"},
-            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+            headers={"authorization": f"Bearer {key_value}"},
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -1214,7 +1218,7 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
         response = self.client.put(
             f"/api/projects/@current/access_controls",
             {"access_level": "editor"},
-            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+            headers={"authorization": f"Bearer {key_value}"},
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "access_control:write" in response.json()["detail"]
@@ -1232,7 +1236,7 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
         response = self.client.put(
             f"/api/projects/@current/access_controls",
             {"access_level": "admin", "resource": "project", "resource_id": str(self.team.id)},
-            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+            headers={"authorization": f"Bearer {key_value}"},
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -1249,7 +1253,7 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
         response = self.client.put(
             f"/api/projects/@current/resource_access_controls",
             {"access_level": "editor", "resource": "notebook"},
-            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+            headers={"authorization": f"Bearer {key_value}"},
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "access_control:write" in response.json()["detail"]
@@ -1267,6 +1271,6 @@ class TestAccessControlScopeRequirements(BaseAccessControlTest):
         response = self.client.put(
             f"/api/projects/@current/resource_access_controls",
             {"access_level": "editor", "resource": "dashboard"},
-            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+            headers={"authorization": f"Bearer {key_value}"},
         )
         assert response.status_code == status.HTTP_200_OK

--- a/ee/api/scim/auth.py
+++ b/ee/api/scim/auth.py
@@ -37,7 +37,7 @@ class SCIMBearerTokenAuthentication(BaseAuthentication):
         if not request.path.startswith("/scim/"):
             return None
 
-        auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+        auth_header = request.headers.get("authorization", "")
 
         if not auth_header.startswith("Bearer "):
             raise exceptions.AuthenticationFailed("Bearer token required for SCIM endpoints")

--- a/ee/api/vercel/vercel_region_proxy_mixin.py
+++ b/ee/api/vercel/vercel_region_proxy_mixin.py
@@ -71,7 +71,7 @@ class VercelRegionProxyMixin:
 
     def _extract_installation_id(self, request: HttpRequest) -> Optional[str]:
         try:
-            if not all([request.META.get("HTTP_AUTHORIZATION"), request.META.get("HTTP_X_VERCEL_AUTH")]):
+            if not all([request.headers.get("authorization"), request.headers.get("x-vercel-auth")]):
                 return None
 
             drf_request = Request(request)

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -3,8 +3,7 @@ from typing import Any
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.sites import NotRegistered  # type: ignore[attr-defined]
-from django.urls import include, re_path
-from django.urls.conf import path
+from django.urls import include, path
 from django.views.decorators.csrf import csrf_exempt
 
 from django_otp.plugins.otp_static.models import StaticDevice
@@ -107,11 +106,11 @@ if settings.ADMIN_PORTAL_ENABLED:
     from posthog.admin.admins.resave_cohorts_admin import resave_cohorts_view
 
     admin_urlpatterns = [
-        re_path(r"^admin/oauth2/callback$", admin_oauth2_callback, name="admin_oauth2_callback"),
-        re_path(r"^admin/oauth2/success$", admin_oauth_success, name="admin_oauth_success"),
-        re_path(r"^admin/auth_check$", admin_auth_check, name="admin_auth_check"),
-        re_path(r"^admin/redisvalues$", redis_values_view, name="redis_values"),
-        re_path(r"^admin/apikeysearch$", api_key_search_view, name="api_key_search"),
+        path("admin/oauth2/callback", admin_oauth2_callback, name="admin_oauth2_callback"),
+        path("admin/oauth2/success", admin_oauth_success, name="admin_oauth_success"),
+        path("admin/auth_check", admin_auth_check, name="admin_auth_check"),
+        path("admin/redisvalues", redis_values_view, name="redis_values"),
+        path("admin/apikeysearch", api_key_search_view, name="api_key_search"),
         path(
             "admin/realtime-cohorts-calculation/",
             admin.site.admin_view(analyze_realtime_cohort_calculation_view),

--- a/posthog/api/test/notebooks/test_notebook.py
+++ b/posthog/api/test/notebooks/test_notebook.py
@@ -251,7 +251,7 @@ class TestNotebooks(APIBaseTest, QueryMatchingTest):
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/notebooks/{response.json()['short_id']}",
-            HTTP_IF_NONE_MATCH=response.json()["version"],
+            headers={"if-none-match": response.json()["version"]},
         )
 
         assert response.status_code == status.HTTP_304_NOT_MODIFIED

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -29,7 +29,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 ],
                 "description": "Test description",
             },
-            HTTP_ORIGIN="http://testserver",
+            headers={"origin": "http://testserver"},
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         assert response.json() == {
@@ -102,7 +102,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 ],
                 "description": "Test description",
             },
-            HTTP_ORIGIN="http://testserver",
+            headers={"origin": "http://testserver"},
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         action = Action.objects.get(pk=response.json()["id"])
@@ -119,7 +119,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.post(
             f"/api/projects/{self.team.id}/actions/",
             {"name": "user signed up"},
-            HTTP_ORIGIN="http://testserver",
+            headers={"origin": "http://testserver"},
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -168,7 +168,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 },
                 "pinned_at": "2021-12-11T00:00:00Z",
             },
-            HTTP_ORIGIN="http://testserver",
+            headers={"origin": "http://testserver"},
         )
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json()["name"] == "user signed up 2"
@@ -238,7 +238,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.patch(
             f"/api/projects/{self.team.id}/actions/{action.pk}/",
             data={"name": "user signed up 2", "steps": []},
-            HTTP_ORIGIN="http://testserver",
+            headers={"origin": "http://testserver"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["steps"]), 0)
@@ -253,7 +253,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.post(
             f"/api/projects/{self.team.id}/actions/",
             data={"name": "user signed up"},
-            HTTP_ORIGIN="https://evilwebsite.com",
+            headers={"origin": "https://evilwebsite.com"},
         )
         self.assertEqual(response.status_code, 401)
 
@@ -263,27 +263,26 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.post(
             f"/api/projects/{self.team.id}/actions/?temporary_token=token123",
             data={"name": "user signed up"},
-            HTTP_ORIGIN="https://somewebsite.com",
+            headers={"origin": "https://somewebsite.com"},
         )
         self.assertEqual(response.status_code, 201)
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/actions/?temporary_token=token123",
             data={"name": "user signed up and post to slack", "post_to_slack": True},
-            HTTP_ORIGIN="https://somewebsite.com",
+            headers={"origin": "https://somewebsite.com"},
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()["post_to_slack"], True)
 
         list_response = self.client.get(
-            f"/api/projects/{self.team.id}/actions/",
-            HTTP_ORIGIN="https://evilwebsite.com",
+            f"/api/projects/{self.team.id}/actions/", headers={"origin": "https://evilwebsite.com"}
         )
         self.assertEqual(list_response.status_code, 401)
 
         detail_response = self.client.get(
             f"/api/projects/{self.team.id}/actions/{response.json()['id']}/",
-            HTTP_ORIGIN="https://evilwebsite.com",
+            headers={"origin": "https://evilwebsite.com"},
         )
         self.assertEqual(detail_response.status_code, 401)
 
@@ -291,14 +290,14 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         list_response = self.client.get(
             f"/api/projects/{self.team.id}/actions/",
             data={"temporary_token": "token123"},
-            HTTP_ORIGIN="https://somewebsite.com",
+            headers={"origin": "https://somewebsite.com"},
         )
         self.assertEqual(list_response.status_code, 200)
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/actions/?temporary_token=token123",
             data={"name": "user signed up 22"},
-            HTTP_ORIGIN="https://somewebsite.com",
+            headers={"origin": "https://somewebsite.com"},
         )
         self.assertEqual(response.status_code, 201, response.json())
 
@@ -307,7 +306,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.post(
             f"/api/projects/{self.team.id}/actions/",
             data={"name": "user signed up again"},
-            HTTP_ORIGIN="https://testserver/",
+            headers={"origin": "https://testserver/"},
         )
         self.assertEqual(response.status_code, 201, response.json())
 
@@ -316,7 +315,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.post(
             f"/api/projects/{self.team.id}/actions/",
             data={"name": "test event", "steps": [{"event": "test_event "}]},
-            HTTP_ORIGIN="http://testserver",
+            headers={"origin": "http://testserver"},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         action = Action.objects.get(pk=response.json()["id"])
@@ -435,7 +434,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 ],
                 "description": "Test description",
             },
-            HTTP_ORIGIN="http://testserver",
+            headers={"origin": "http://testserver"},
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -454,7 +453,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 "name": "user signed up in folder",
                 "_create_in_folder": "Special Folder/Actions",
             },
-            HTTP_ORIGIN="http://testserver",
+            headers={"origin": "http://testserver"},
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
 

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -849,8 +849,7 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
 
         with freeze_time("2021-08-25T22:10:14.252"):
             response = self.client.get(
-                f"/api/projects/{self.team.pk}/feature_flags/",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                f"/api/projects/{self.team.pk}/feature_flags/", headers={"authorization": f"Bearer {personal_api_key}"}
             )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -872,8 +871,7 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
 
         with freeze_time("2022-08-25T22:00:14.252"):
             response = self.client.get(
-                f"/api/projects/{self.team.pk}/feature_flags/",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                f"/api/projects/{self.team.pk}/feature_flags/", headers={"authorization": f"Bearer {personal_api_key}"}
             )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -895,8 +893,7 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
 
         with freeze_time("2021-08-26T22:00:14.252"):
             response = self.client.get(
-                f"/api/projects/{self.team.pk}/feature_flags/",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                f"/api/projects/{self.team.pk}/feature_flags/", headers={"authorization": f"Bearer {personal_api_key}"}
             )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -913,8 +910,7 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
 
         with freeze_time("2022-08-25T22:00:14.252"):
             response = self.client.get(
-                f"/api/projects/{self.team.pk}/feature_flags/",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                f"/api/projects/{self.team.pk}/feature_flags/", headers={"authorization": f"Bearer {personal_api_key}"}
             )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -936,8 +932,7 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
 
         with freeze_time("2021-08-25T21:14:14.252"):
             response = self.client.get(
-                f"/api/projects/{self.team.pk}/feature_flags/",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                f"/api/projects/{self.team.pk}/feature_flags/", headers={"authorization": f"Bearer {personal_api_key}"}
             )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -958,8 +953,7 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
 
         with freeze_time("2021-08-24T21:14:14.252"):
             response = self.client.get(
-                f"/api/projects/{self.team.pk}/feature_flags/",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                f"/api/projects/{self.team.pk}/feature_flags/", headers={"authorization": f"Bearer {personal_api_key}"}
             )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/posthog/api/test/test_cli_auth.py
+++ b/posthog/api/test/test_cli_auth.py
@@ -397,8 +397,7 @@ class TestCLIAuthEndToEnd(APIBaseTest):
         # Step 4: Verify the API key works
         self.client.logout()
         response = self.client.get(
-            f"/api/projects/{self.team.pk}/event_definitions/",
-            HTTP_AUTHORIZATION=f"Bearer {api_key}",
+            f"/api/projects/{self.team.pk}/event_definitions/", headers={"authorization": f"Bearer {api_key}"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -151,9 +151,8 @@ class TestDecide(BaseTest, QueryMatchingTest):
                         },
                     )
                 },
-                HTTP_ORIGIN=origin,
+                headers={"origin": origin, "user-agent": user_agent or "PostHog test"},
                 REMOTE_ADDR=ip,
-                HTTP_USER_AGENT=user_agent or "PostHog test",
             )
 
         if simulate_database_timeout:
@@ -197,7 +196,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
                     }
                 )
             },
-            HTTP_ORIGIN="http://127.0.0.1:8000",
+            headers={"origin": "http://127.0.0.1:8000"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -209,7 +208,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
 
         self.team.app_urls = ["https://example.com"]
         self.team.save()
-        response = self.client.get("/decide/", HTTP_ORIGIN="https://evilsite.com").json()
+        response = self.client.get("/decide/", headers={"origin": "https://evilsite.com"}).json()
         self.assertEqual(response["isAuthenticated"], False)
         self.assertIsNone(response["toolbarParams"].get("toolbarVersion", None))
 
@@ -2962,7 +2961,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         ]
 
         for payload in invalid_payloads:
-            response = self.client.post("/decide/", {"data": payload}, HTTP_ORIGIN="http://127.0.0.1:8000")
+            response = self.client.post("/decide/", {"data": payload}, headers={"origin": "http://127.0.0.1:8000"})
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
             response_data = response.json()
             detail = response_data.pop("detail")
@@ -2976,7 +2975,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         response = self.client.post(
             "/decide/?compression=gzip",
             data=b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03",
-            HTTP_ORIGIN="http://127.0.0.1:8000",
+            headers={"origin": "http://127.0.0.1:8000"},
             content_type="text/plain",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -3411,7 +3410,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         ):
 
             def invalid_request():
-                return self.client.post("/decide/", {"data": "1==1"}, HTTP_ORIGIN="http://127.0.0.1:8000")
+                return self.client.post("/decide/", {"data": "1==1"}, headers={"origin": "http://127.0.0.1:8000"})
 
             for _ in range(4):
                 response = invalid_request()
@@ -4069,7 +4068,7 @@ class TestDatabaseCheckForDecide(BaseTest, QueryMatchingTest):
                     },
                 )
             },
-            HTTP_ORIGIN=origin,
+            headers={"origin": origin},
             REMOTE_ADDR=ip,
         )
 
@@ -4201,7 +4200,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
                     },
                 )
             },
-            HTTP_ORIGIN=origin,
+            headers={"origin": origin},
             REMOTE_ADDR=ip,
         )
 
@@ -5034,7 +5033,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
 
             response = self.client.get(
                 f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                headers={"authorization": f"Bearer {personal_api_key}"},
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
@@ -5288,7 +5287,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
 
             response = self.client.get(
                 f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                headers={"authorization": f"Bearer {personal_api_key}"},
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             response_data = response.json()
@@ -5558,7 +5557,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
 
             response = self.client.get(
                 f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                headers={"authorization": f"Bearer {personal_api_key}"},
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             response_data = response.json()

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1293,7 +1293,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/feature_flags/my-remote-config-flag/remote_config",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            headers={"authorization": f"Bearer {personal_api_key}"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), '{"test": true}')
@@ -1319,7 +1319,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.client.logout()
         response = self.client.get(
             f"/api/projects/{self.team.id}/feature_flags/my-remote-config-flag/remote_config",
-            HTTP_AUTHORIZATION=f"Bearer {self.team.secret_api_token}",
+            headers={"authorization": f"Bearer {self.team.secret_api_token}"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), '{"test": true}')
@@ -1355,7 +1355,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         # Try to access other team's flag using this team's secret key + other team's project_api_key in body
         response = self.client.get(
             f"/api/projects/{other_team.id}/feature_flags/other-team-flag/remote_config?token={other_team.api_token}",
-            HTTP_AUTHORIZATION=f"Bearer {self.team.secret_api_token}",
+            headers={"authorization": f"Bearer {self.team.secret_api_token}"},
         )
 
         # Should be forbidden due to team mismatch
@@ -3288,7 +3288,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
             response = self.client.get(
                 f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                headers={"authorization": f"Bearer {personal_api_key}"},
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
@@ -3373,7 +3373,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         response = self.client.get(
             f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            headers={"authorization": f"Bearer {personal_api_key}"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
@@ -3483,7 +3483,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         response = self.client.get(
             f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            headers={"authorization": f"Bearer {personal_api_key}"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
@@ -3669,7 +3669,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         response = self.client.get(
             f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            headers={"authorization": f"Bearer {personal_api_key}"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
@@ -3839,7 +3839,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
             response = self.client.get(
                 f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                headers={"authorization": f"Bearer {personal_api_key}"},
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(
@@ -3850,7 +3850,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             for _ in range(5):
                 response = self.client.get(
                     f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
-                    HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                    headers={"authorization": f"Bearer {personal_api_key}"},
                 )
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -3911,7 +3911,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
             response = self.client.get(
                 f"/api/feature_flag/?token={self.team.api_token}",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                headers={"authorization": f"Bearer {personal_api_key}"},
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(
@@ -3922,14 +3922,14 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             for _ in range(4):
                 response = self.client.get(
                     f"/api/feature_flag/?token={self.team.api_token}",
-                    HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                    headers={"authorization": f"Bearer {personal_api_key}"},
                 )
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
 
             # local evaluation still works
             response = self.client.get(
                 f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                headers={"authorization": f"Bearer {personal_api_key}"},
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -4068,7 +4068,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             def make_request_and_assert_requests_recorded(expected_requests=None):
                 response = self.client.get(
                     f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
-                    HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                    headers={"authorization": f"Bearer {personal_api_key}"},
                 )
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
                 self.assertEqual(
@@ -4146,7 +4146,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         # Make request using project secret key authentication
         response = self.client.get(
             f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
-            HTTP_AUTHORIZATION=f"Bearer {self.team.secret_api_token}",
+            headers={"authorization": f"Bearer {self.team.secret_api_token}"},
         )
 
         # Verify successful response
@@ -5452,15 +5452,13 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         for _ in range(5):
             response = self.client.get(
-                f"/api/projects/{self.team.pk}/feature_flags",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                f"/api/projects/{self.team.pk}/feature_flags", headers={"authorization": f"Bearer {personal_api_key}"}
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Call to flags gets rate limited
         response = self.client.get(
-            f"/api/projects/{self.team.pk}/feature_flags",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            f"/api/projects/{self.team.pk}/feature_flags", headers={"authorization": f"Bearer {personal_api_key}"}
         )
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
         self.assertEqual(
@@ -5483,8 +5481,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         # but not call to local evaluation
         for _ in range(7):
             response = self.client.get(
-                f"/api/feature_flag/local_evaluation",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                f"/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
@@ -6090,8 +6087,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         # First request should miss cache and populate it
         self.client.logout()
         response = self.client.get(
-            f"/api/feature_flag/local_evaluation",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            f"/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -6133,8 +6129,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         # Test cache for send_cohorts=true
         self.client.logout()
         response = self.client.get(
-            f"/api/feature_flag/local_evaluation?send_cohorts",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            f"/api/feature_flag/local_evaluation?send_cohorts", headers={"authorization": f"Bearer {personal_api_key}"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -6166,8 +6161,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         # Populate cache
         self.client.logout()
         response = self.client.get(
-            f"/api/feature_flag/local_evaluation",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            f"/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -6221,12 +6215,10 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         # Populate both cache variants
         self.client.logout()
         response1 = self.client.get(
-            f"/api/feature_flag/local_evaluation",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            f"/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
         )
         response2 = self.client.get(
-            f"/api/feature_flag/local_evaluation?send_cohorts",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            f"/api/feature_flag/local_evaluation?send_cohorts", headers={"authorization": f"Bearer {personal_api_key}"}
         )
 
         self.assertEqual(response1.status_code, status.HTTP_200_OK)
@@ -6239,12 +6231,10 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         # Make new requests to get potentially updated cache
         self.client.logout()
         updated_response1 = self.client.get(
-            f"/api/feature_flag/local_evaluation",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            f"/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
         )
         updated_response2 = self.client.get(
-            f"/api/feature_flag/local_evaluation?send_cohorts",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            f"/api/feature_flag/local_evaluation?send_cohorts", headers={"authorization": f"Bearer {personal_api_key}"}
         )
 
         self.assertEqual(updated_response1.status_code, status.HTTP_200_OK)

--- a/posthog/api/test/test_github.py
+++ b/posthog/api/test/test_github.py
@@ -214,8 +214,7 @@ dYtHUlWNMx0y6YwVG8nlBiJk2e0n+zpzs2WwszrnC7wfCqgU6rU3TkDvBQ==
             "/api/alerts/github",
             data=json.dumps(self.valid_payload),
             content_type="application/json",
-            HTTP_GITHUB_PUBLIC_KEY_IDENTIFIER="test_kid",
-            HTTP_GITHUB_PUBLIC_KEY_SIGNATURE="test_signature",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_signature"},
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -249,8 +248,7 @@ dYtHUlWNMx0y6YwVG8nlBiJk2e0n+zpzs2WwszrnC7wfCqgU6rU3TkDvBQ==
             "/api/alerts/github",
             data=json.dumps(self.valid_payload),
             content_type="application/json",
-            HTTP_GITHUB_PUBLIC_KEY_IDENTIFIER="test_kid",
-            HTTP_GITHUB_PUBLIC_KEY_SIGNATURE="invalid_signature",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "invalid_signature"},
         )
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
@@ -269,8 +267,7 @@ dYtHUlWNMx0y6YwVG8nlBiJk2e0n+zpzs2WwszrnC7wfCqgU6rU3TkDvBQ==
             "/api/alerts/github",
             data=json.dumps(self.valid_payload),
             content_type="application/json",
-            HTTP_GITHUB_PUBLIC_KEY_IDENTIFIER="test_kid",
-            HTTP_GITHUB_PUBLIC_KEY_SIGNATURE="invalid_signature",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "invalid_signature"},
         )
 
         # Should get 401 for invalid signature, not 500 for RawPostDataException

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -183,7 +183,7 @@ class TestOrganizationAPI(APIBaseTest):
             scoped_organizations=[other_org.id],
         )
 
-        response = self.client.get("/api/organizations/", HTTP_AUTHORIZATION=f"Bearer {personal_api_key}")
+        response = self.client.get("/api/organizations/", headers={"authorization": f"Bearer {personal_api_key}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
@@ -221,7 +221,7 @@ class TestOrganizationAPI(APIBaseTest):
             scoped_organizations=[str(other_org.id)],
         )
 
-        response = self.client.get("/api/organizations/", HTTP_AUTHORIZATION=f"Bearer {access_token.token}")
+        response = self.client.get("/api/organizations/", headers={"authorization": f"Bearer {access_token.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 

--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -272,7 +272,7 @@ class PersonalAPIKeysBaseTest(APIBaseTest):
     key: PersonalAPIKey
 
     def _do_request(self, url: str):
-        return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.value}")
+        return self.client.get(url, headers={"authorization": f"Bearer {self.value}"})
 
     def setUp(self):
         other_organization, _, other_team = Organization.objects.bootstrap(self.user)
@@ -335,8 +335,7 @@ class TestPersonalAPIKeysAPIAuthentication(PersonalAPIKeysBaseTest):
         self.assertTrue(key_before.startswith("sha256$"))
 
         response = self.client.get(
-            f"/api/projects/{self.team.id}/dashboards/",
-            HTTP_AUTHORIZATION=f"Bearer  {self.value}  ",
+            f"/api/projects/{self.team.id}/dashboards/", headers={"authorization": f"Bearer  {self.value}  "}
         )
         assert response.status_code == 200
 
@@ -349,8 +348,7 @@ class TestPersonalAPIKeysAPIAuthentication(PersonalAPIKeysBaseTest):
         self.assertTrue(key_before.startswith("pbkdf2_sha256$390000$"))
 
         response = self.client.get(
-            f"/api/projects/{self.team.id}/dashboards/",
-            HTTP_AUTHORIZATION=f"Bearer {self.value_390000}",
+            f"/api/projects/{self.team.id}/dashboards/", headers={"authorization": f"Bearer {self.value_390000}"}
         )
         assert response.status_code == 200
 
@@ -361,8 +359,7 @@ class TestPersonalAPIKeysAPIAuthentication(PersonalAPIKeysBaseTest):
 
     def test_header_hardcoded(self):
         response = self.client.get(
-            f"/api/projects/{self.team.id}/dashboards/",
-            HTTP_AUTHORIZATION=f"Bearer {self.value_hardcoded}",
+            f"/api/projects/{self.team.id}/dashboards/", headers={"authorization": f"Bearer {self.value_hardcoded}"}
         )
         assert response.status_code == 200
 
@@ -381,19 +378,18 @@ class TestPersonalAPIKeysAPIAuthentication(PersonalAPIKeysBaseTest):
         self.user.is_active = False
         self.user.save()
         response = self.client.get(
-            f"/api/projects/{self.team.id}/dashboards", HTTP_AUTHORIZATION=f"Bearer {self.value}"
+            f"/api/projects/{self.team.id}/dashboards", headers={"authorization": f"Bearer {self.value}"}
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_user_endpoint(self):
         # NOTE: This is not actually supported currently by new scopes but needs to work for pre-scoped api keys
-        response = self.client.get("/api/users/@me/", HTTP_AUTHORIZATION=f"Bearer {self.value}")
+        response = self.client.get("/api/users/@me/", headers={"authorization": f"Bearer {self.value}"})
         assert response.status_code == status.HTTP_200_OK
 
     def test_does_not_interfere_with_temporary_token_auth(self):
         response = self.client.get(
-            f"/api/projects/{self.team.id}/dashboards/",
-            HTTP_AUTHORIZATION=f"Bearer {self.value}",
+            f"/api/projects/{self.team.id}/dashboards/", headers={"authorization": f"Bearer {self.value}"}
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -405,7 +401,7 @@ class TestPersonalAPIKeysAPIAuthentication(PersonalAPIKeysBaseTest):
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/dashboards/",
-            HTTP_AUTHORIZATION=f"Bearer {impersonated_access_token}",
+            headers={"authorization": f"Bearer {impersonated_access_token}"},
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -413,7 +409,7 @@ class TestPersonalAPIKeysAPIAuthentication(PersonalAPIKeysBaseTest):
         response = self.client.post(
             "/api/personal_api_keys",
             {"label": "test", "scopes": ["insight:read"], "scoped_organizations": [], "scoped_teams": []},
-            HTTP_AUTHORIZATION=f"Bearer {self.value}",
+            headers={"authorization": f"Bearer {self.value}"},
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
@@ -422,7 +418,7 @@ class TestPersonalAPIKeysAPIAuthentication(PersonalAPIKeysBaseTest):
         response = self.client.post(
             f"/api/personal_api_keys/{self.key.id}/",
             {"scopes": ["*"]},
-            HTTP_AUTHORIZATION=f"Bearer {self.value}",
+            headers={"authorization": f"Bearer {self.value}"},
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
@@ -439,8 +435,7 @@ class TestPersonalAPIKeysAPIAuthentication(PersonalAPIKeysBaseTest):
 
         # use key
         response = self.client.get(
-            f"/api/projects/{self.team.id}/dashboards/",
-            HTTP_AUTHORIZATION=f"Bearer {value}",
+            f"/api/projects/{self.team.id}/dashboards/", headers={"authorization": f"Bearer {value}"}
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -481,9 +476,7 @@ class TestPersonalAPIKeysWithScopeAPIAuthentication(PersonalAPIKeysBaseTest):
 
     def test_denies_derived_scope_for_write(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/feature_flags/",
-            data={},
-            HTTP_AUTHORIZATION=f"Bearer {self.value}",
+            f"/api/projects/{self.team.id}/feature_flags/", data={}, headers={"authorization": f"Bearer {self.value}"}
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json()["detail"] == "API key missing required scope 'feature_flag:write'"
@@ -537,7 +530,9 @@ class TestPersonalAPIKeysWithScopeAPIAuthentication(PersonalAPIKeysBaseTest):
 
         query = EventsQuery(select=["event", "distinct_id"])
         response = self.client.post(
-            f"/api/projects/{self.team.id}/query/", {"query": query.dict()}, HTTP_AUTHORIZATION=f"Bearer {self.value}"
+            f"/api/projects/{self.team.id}/query/",
+            {"query": query.dict()},
+            headers={"authorization": f"Bearer {self.value}"},
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -567,7 +562,7 @@ class TestPersonalAPIKeysWithScopeAPIAuthentication(PersonalAPIKeysBaseTest):
         response = self.client.patch(
             f"/api/projects/{self.team.id}/insights/{insight.id}/sharing",
             {"enabled": True},
-            HTTP_AUTHORIZATION=f"Bearer {self.value}",
+            headers={"authorization": f"Bearer {self.value}"},
         )
         assert response.status_code == status.HTTP_200_OK
         initial_token = response.json()["access_token"]
@@ -577,7 +572,7 @@ class TestPersonalAPIKeysWithScopeAPIAuthentication(PersonalAPIKeysBaseTest):
         self.key.save()
         response = self.client.post(
             f"/api/projects/{self.team.id}/insights/{insight.id}/sharing/refresh/",
-            HTTP_AUTHORIZATION=f"Bearer {self.value}",
+            headers={"authorization": f"Bearer {self.value}"},
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json()["detail"] == "API key missing required scope 'sharing_configuration:write'"
@@ -587,7 +582,7 @@ class TestPersonalAPIKeysWithScopeAPIAuthentication(PersonalAPIKeysBaseTest):
         self.key.save()
         response = self.client.post(
             f"/api/projects/{self.team.id}/insights/{insight.id}/sharing/refresh/",
-            HTTP_AUTHORIZATION=f"Bearer {self.value}",
+            headers={"authorization": f"Bearer {self.value}"},
         )
         assert response.status_code == status.HTTP_200_OK
         new_token = response.json()["access_token"]

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -30,7 +30,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
             scoped_organizations=[other_org.id],
         )
 
-        response = self.client.get("/api/projects/", HTTP_AUTHORIZATION=f"Bearer {personal_api_key}")
+        response = self.client.get("/api/projects/", headers={"authorization": f"Bearer {personal_api_key}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(

--- a/posthog/api/test/test_remote_config.py
+++ b/posthog/api/test/test_remote_config.py
@@ -50,10 +50,14 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
     def test_valid_config(self):
         # Not sure why but there is sometimes one extra query here
         with self.assertNumQueries(FuzzyInt(CONFIG_REFRESH_QUERY_COUNT, CONFIG_REFRESH_QUERY_COUNT + 1)):
-            response = self.client.get(f"/array/{self.team.api_token}/config", HTTP_ORIGIN="https://foo.example.com")
+            response = self.client.get(
+                f"/array/{self.team.api_token}/config", headers={"origin": "https://foo.example.com"}
+            )
 
         with self.assertNumQueries(0):
-            response = self.client.get(f"/array/{self.team.api_token}/config", HTTP_ORIGIN="https://foo.example.com")
+            response = self.client.get(
+                f"/array/{self.team.api_token}/config", headers={"origin": "https://foo.example.com"}
+            )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.headers["Content-Type"] == "application/json"
@@ -92,7 +96,9 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         )
 
     def test_vary_header_response(self):
-        response = self.client.get(f"/array/{self.team.api_token}/config", HTTP_ORIGIN="https://foo.example.com")
+        response = self.client.get(
+            f"/array/{self.team.api_token}/config", headers={"origin": "https://foo.example.com"}
+        )
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert "Origin" in response.headers["Vary"]
         assert "Referer" in response.headers["Vary"]
@@ -100,26 +106,36 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
     def test_different_response_for_other_domains(self):
         # Not sure why but there is sometimes one extra query here
         with self.assertNumQueries(FuzzyInt(CONFIG_REFRESH_QUERY_COUNT, CONFIG_REFRESH_QUERY_COUNT + 2)):
-            response = self.client.get(f"/array/{self.team.api_token}/config", HTTP_ORIGIN="https://foo.example.com")
+            response = self.client.get(
+                f"/array/{self.team.api_token}/config", headers={"origin": "https://foo.example.com"}
+            )
             assert response.status_code == status.HTTP_200_OK, response.json()
             assert response.json()["sessionRecording"]
 
         with self.assertNumQueries(0):
-            response = self.client.get(f"/array/{self.team.api_token}/config", HTTP_ORIGIN="https://foo.example.com")
+            response = self.client.get(
+                f"/array/{self.team.api_token}/config", headers={"origin": "https://foo.example.com"}
+            )
             assert response.status_code == status.HTTP_200_OK, response.json()
             assert response.json()["sessionRecording"]
 
         with self.assertNumQueries(0):
-            response = self.client.get(f"/array/{self.team.api_token}/config", HTTP_ORIGIN="https://bar.other.com")
+            response = self.client.get(
+                f"/array/{self.team.api_token}/config", headers={"origin": "https://bar.other.com"}
+            )
             assert response.status_code == status.HTTP_200_OK, response.json()
             assert not response.json()["sessionRecording"]
 
     def test_valid_config_js(self):
         with self.assertNumQueries(FuzzyInt(CONFIG_REFRESH_QUERY_COUNT - 1, CONFIG_REFRESH_QUERY_COUNT + 1)):
-            response = self.client.get(f"/array/{self.team.api_token}/config.js", HTTP_ORIGIN="https://foo.example.com")
+            response = self.client.get(
+                f"/array/{self.team.api_token}/config.js", headers={"origin": "https://foo.example.com"}
+            )
 
         with self.assertNumQueries(0):
-            response = self.client.get(f"/array/{self.team.api_token}/config.js", HTTP_ORIGIN="https://foo.example.com")
+            response = self.client.get(
+                f"/array/{self.team.api_token}/config.js", headers={"origin": "https://foo.example.com"}
+            )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.headers["Content-Type"] == "application/javascript"
@@ -131,10 +147,14 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
     @patch("posthog.models.remote_config.get_array_js_content", return_value="[MOCKED_ARRAY_JS_CONTENT]")
     def test_valid_array_js(self, mock_get_array_js_content):
         with self.assertNumQueries(FuzzyInt(CONFIG_REFRESH_QUERY_COUNT - 1, CONFIG_REFRESH_QUERY_COUNT + 1)):
-            response = self.client.get(f"/array/{self.team.api_token}/array.js", HTTP_ORIGIN="https://foo.example.com")
+            response = self.client.get(
+                f"/array/{self.team.api_token}/array.js", headers={"origin": "https://foo.example.com"}
+            )
 
         with self.assertNumQueries(0):
-            response = self.client.get(f"/array/{self.team.api_token}/array.js", HTTP_ORIGIN="https://foo.example.com")
+            response = self.client.get(
+                f"/array/{self.team.api_token}/array.js", headers={"origin": "https://foo.example.com"}
+            )
         assert response.status_code == status.HTTP_200_OK
         assert response.headers["Content-Type"] == "application/javascript"
         assert response.content
@@ -148,8 +168,12 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
     @patch("posthog.models.remote_config.get_array_js_content", return_value="[MOCKED_ARRAY_JS_CONTENT]")
     def test_valid_array_uses_config_js_cache(self, mock_get_array_js_content):
         with self.assertNumQueries(FuzzyInt(CONFIG_REFRESH_QUERY_COUNT, CONFIG_REFRESH_QUERY_COUNT + 1)):
-            response = self.client.get(f"/array/{self.team.api_token}/config.js", HTTP_ORIGIN="https://foo.example.com")
+            response = self.client.get(
+                f"/array/{self.team.api_token}/config.js", headers={"origin": "https://foo.example.com"}
+            )
 
         with self.assertNumQueries(0):
-            response = self.client.get(f"/array/{self.team.api_token}/array.js", HTTP_ORIGIN="https://foo.example.com")
+            response = self.client.get(
+                f"/array/{self.team.api_token}/array.js", headers={"origin": "https://foo.example.com"}
+            )
         assert response.status_code == status.HTTP_200_OK

--- a/posthog/api/test/test_routing.py
+++ b/posthog/api/test/test_routing.py
@@ -177,7 +177,7 @@ class TestOAuthAccessTokenAuthentication(APIBaseTest):
 
         response = self.client.get(
             f"/api/scoped_environments/{self.team.id}/scoped_foos/",
-            HTTP_AUTHORIZATION=f"Bearer {self.access_token.token}",
+            headers={"authorization": f"Bearer {self.access_token.token}"},
         )
 
         self.assertEqual(response.status_code, 200)
@@ -195,7 +195,7 @@ class TestOAuthAccessTokenAuthentication(APIBaseTest):
 
         response = self.client.get(
             f"/api/scoped_environments/{other_team.id}/scoped_foos/",
-            HTTP_AUTHORIZATION=f"Bearer {self.access_token.token}",
+            headers={"authorization": f"Bearer {self.access_token.token}"},
         )
 
         # Should not have access to other org's team (self.user is not a member of other_org)
@@ -207,7 +207,7 @@ class TestOAuthAccessTokenAuthentication(APIBaseTest):
 
         response = self.client.get(
             f"/api/scoped_organizations/{self.organization.id}/scoped_foos/",
-            HTTP_AUTHORIZATION=f"Bearer {self.access_token.token}",
+            headers={"authorization": f"Bearer {self.access_token.token}"},
         )
 
         self.assertEqual(response.status_code, 200)
@@ -225,7 +225,7 @@ class TestOAuthAccessTokenAuthentication(APIBaseTest):
 
         response = self.client.get(
             f"/api/scoped_environments/{self.team.id}/scoped_foos/",
-            HTTP_AUTHORIZATION=f"Bearer {expired_token.token}",
+            headers={"authorization": f"Bearer {expired_token.token}"},
         )
 
         self.assertEqual(response.status_code, 401)
@@ -246,7 +246,7 @@ class TestOAuthAccessTokenAuthentication(APIBaseTest):
         # Now use OAuth token
         response = self.client.get(
             f"/api/scoped_environments/{self.team.id}/scoped_foos/",
-            HTTP_AUTHORIZATION=f"Bearer {self.access_token.token}",
+            headers={"authorization": f"Bearer {self.access_token.token}"},
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 1)

--- a/posthog/api/test/test_share_password_api.py
+++ b/posthog/api/test/test_share_password_api.py
@@ -207,15 +207,13 @@ class TestSharePasswordAPI(APIBaseTest):
         # Verify both JWT tokens work initially
         response = self.client.get(
             f"/shared/{self.sharing_config.access_token}",
-            HTTP_AUTHORIZATION=f"Bearer {jwt_token1}",
-            HTTP_ACCEPT="application/json",
+            headers={"authorization": f"Bearer {jwt_token1}", "accept": "application/json"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self.client.get(
             f"/shared/{self.sharing_config.access_token}",
-            HTTP_AUTHORIZATION=f"Bearer {jwt_token2}",
-            HTTP_ACCEPT="application/json",
+            headers={"authorization": f"Bearer {jwt_token2}", "accept": "application/json"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -228,8 +226,7 @@ class TestSharePasswordAPI(APIBaseTest):
         # jwt_token1 should still be valid since it was created with password1
         response = self.client.get(
             f"/shared/{self.sharing_config.access_token}",
-            HTTP_AUTHORIZATION=f"Bearer {jwt_token1}",
-            HTTP_ACCEPT="application/json",
+            headers={"authorization": f"Bearer {jwt_token1}", "accept": "application/json"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # Should contain dashboard data, not unlock page
@@ -238,8 +235,7 @@ class TestSharePasswordAPI(APIBaseTest):
         # jwt_token2 should now be invalid since password2 was deleted
         response = self.client.get(
             f"/shared/{self.sharing_config.access_token}",
-            HTTP_AUTHORIZATION=f"Bearer {jwt_token2}",
-            HTTP_ACCEPT="application/json",
+            headers={"authorization": f"Bearer {jwt_token2}", "accept": "application/json"},
         )
         # Should not be authenticated anymore, so should show unlock page
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -256,8 +252,7 @@ class TestSharePasswordAPI(APIBaseTest):
         # jwt_token1 should now also be invalid
         response = self.client.get(
             f"/shared/{self.sharing_config.access_token}",
-            HTTP_AUTHORIZATION=f"Bearer {jwt_token1}",
-            HTTP_ACCEPT="application/json",
+            headers={"authorization": f"Bearer {jwt_token1}", "accept": "application/json"},
         )
         # Should not be authenticated anymore, so should show unlock page
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -1029,6 +1029,7 @@ class TestSharePasswordLogging(APIBaseTest):
         # Mock request with IP
         mock_request = Mock()
         mock_request.META = {"REMOTE_ADDR": "192.168.1.100"}
+        mock_request.headers = {}
 
         # Clear any existing activity logs
         ActivityLog.objects.filter(scope="Dashboard").delete()
@@ -1074,6 +1075,7 @@ class TestSharePasswordLogging(APIBaseTest):
         # Mock request with different IP
         mock_request = Mock()
         mock_request.META = {"REMOTE_ADDR": "10.0.0.5"}
+        mock_request.headers = {}
 
         # Clear any existing activity logs
         ActivityLog.objects.filter(scope="Dashboard").delete()

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -1143,7 +1143,7 @@ class TestSignupAPI(APIBaseTest):
                     "password": VALID_TEST_PASSWORD,
                     "organization_name": f"Org{i}",
                 },
-                HTTP_X_FORWARDED_FOR="192.168.1.100",
+                headers={"x-forwarded-for": "192.168.1.100"},
             )
 
             if i < 5:
@@ -1177,7 +1177,7 @@ class TestSignupAPI(APIBaseTest):
                         "password": VALID_TEST_PASSWORD,
                         "organization_name": f"Org{ip_suffix}_{i}",
                     },
-                    HTTP_X_FORWARDED_FOR=ip,
+                    headers={"x-forwarded-for": ip},
                 )
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED, f"Request from IP {ip} should succeed")
                 # Clean up the created org and user to allow next signup

--- a/posthog/api/test/test_site_app.py
+++ b/posthog/api/test/test_site_app.py
@@ -34,8 +34,7 @@ class TestSiteApp(BaseTest):
         )
 
         response = self.client.get(
-            f"/site_app/{plugin_config.id}/tokentoken/somehash/",
-            HTTP_ORIGIN="http://127.0.0.1:8000",
+            f"/site_app/{plugin_config.id}/tokentoken/somehash/", headers={"origin": "http://127.0.0.1:8000"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -2875,7 +2875,7 @@ class TestSurveysAPIList(BaseTest, QueryMatchingTest):
         return self.client.get(
             "/api/surveys/",
             data={"token": token or self.team.api_token},
-            HTTP_ORIGIN=origin,
+            headers={"origin": origin},
             REMOTE_ADDR=ip,
         )
 

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -1918,7 +1918,7 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
             scoped_teams=[other_team_in_project.id],
         )
 
-        response = self.client.get("/api/environments/", HTTP_AUTHORIZATION=f"Bearer {personal_api_key}")
+        response = self.client.get("/api/environments/", headers={"authorization": f"Bearer {personal_api_key}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
@@ -1938,7 +1938,7 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
             scoped_organizations=[other_org.id],
         )
 
-        response = self.client.get("/api/environments/", HTTP_AUTHORIZATION=f"Bearer {personal_api_key}")
+        response = self.client.get("/api/environments/", headers={"authorization": f"Bearer {personal_api_key}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
@@ -1979,7 +1979,7 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
             scoped_teams=[other_team_in_project.id],
         )
 
-        response = self.client.get("/api/environments/", HTTP_AUTHORIZATION=f"Bearer {access_token.token}")
+        response = self.client.get("/api/environments/", headers={"authorization": f"Bearer {access_token.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -2011,7 +2011,7 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
             scoped_organizations=[str(other_org.id)],
         )
 
-        response = self.client.get("/api/environments/", HTTP_AUTHORIZATION=f"Bearer {access_token.token}")
+        response = self.client.get("/api/environments/", headers={"authorization": f"Bearer {access_token.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1850,7 +1850,7 @@ class TestUserTwoFactor(APIBaseTest):
             scoped_teams=[self.team.id],
         )
 
-        response = self.client.get("/api/users/@me/", HTTP_AUTHORIZATION=f"Bearer {access_token.token}")
+        response = self.client.get("/api/users/@me/", headers={"authorization": f"Bearer {access_token.token}"})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -452,7 +452,7 @@ def on_permitted_recording_domain(permitted_domains: list[str], request: HttpReq
     origin = parse_domain(request.headers.get("Origin"))
     referer = parse_domain(request.headers.get("Referer"))
 
-    user_agent = request.META.get("HTTP_USER_AGENT")
+    user_agent = request.headers.get("user-agent")
 
     is_authorized_web_client: bool = hostname_in_allowed_url_list(
         permitted_domains, origin

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -35,7 +35,7 @@ class SetupWizardTests(APIBaseTest):
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_data_endpoint_returns_data(self):
-        response = self.client.get(self.data_url, HTTP_X_POSTHOG_WIZARD_HASH=self.hash)
+        response = self.client.get(self.data_url, headers={"x-posthog-wizard-hash": self.hash})
         assert response.status_code == status.HTTP_200_OK
         assert response.data["project_api_key"] == "test-key"
         assert response.data["host"] == "http://localhost:8010"
@@ -70,7 +70,7 @@ class SetupWizardTests(APIBaseTest):
                     {"message": "test", "json_schema": {"type": "object", "properties": {"name": {"type": "string"}}}}
                 ),
                 content_type="application/json",
-                HTTP_X_POSTHOG_WIZARD_HASH=self.hash,
+                headers={"x-posthog-wizard-hash": self.hash},
             )
             assert response.status_code == status.HTTP_200_OK
 
@@ -80,7 +80,7 @@ class SetupWizardTests(APIBaseTest):
                 {"message": "test", "json_schema": {"type": "object", "properties": {"name": {"type": "string"}}}}
             ),
             content_type="application/json",
-            HTTP_X_POSTHOG_WIZARD_HASH=self.hash,
+            headers={"x-posthog-wizard-hash": self.hash},
         )
         assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
@@ -93,7 +93,7 @@ class SetupWizardTests(APIBaseTest):
                 {"message": "test", "json_schema": {"type": "object", "properties": {"name": {"type": "string"}}}}
             ),
             content_type="application/json",
-            HTTP_X_POSTHOG_WIZARD_HASH="invalidhash",
+            headers={"x-posthog-wizard-hash": "invalidhash"},
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -111,7 +111,7 @@ class SetupWizardTests(APIBaseTest):
                 {"message": "test", "json_schema": {"type": "object", "properties": {"name": {"type": "number"}}}}
             ),
             content_type="application/json",
-            HTTP_X_POSTHOG_WIZARD_HASH=self.hash,
+            headers={"x-posthog-wizard-hash": self.hash},
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"data": {"foo": "bar"}}
@@ -133,7 +133,7 @@ class SetupWizardTests(APIBaseTest):
                 }
             ),
             content_type="application/json",
-            HTTP_X_POSTHOG_WIZARD_HASH=self.hash,
+            headers={"x-posthog-wizard-hash": self.hash},
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -159,7 +159,7 @@ class SetupWizardTests(APIBaseTest):
                 }
             ),
             content_type="application/json",
-            HTTP_X_POSTHOG_WIZARD_HASH=self.hash,
+            headers={"x-posthog-wizard-hash": self.hash},
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -185,7 +185,7 @@ class SetupWizardTests(APIBaseTest):
                 }
             ),
             content_type="application/json",
-            HTTP_X_POSTHOG_WIZARD_HASH=self.hash,
+            headers={"x-posthog-wizard-hash": self.hash},
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -203,7 +203,7 @@ class SetupWizardTests(APIBaseTest):
                 }
             ),
             content_type="application/json",
-            HTTP_X_POSTHOG_WIZARD_HASH=self.hash,
+            headers={"x-posthog-wizard-hash": self.hash},
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -232,8 +232,7 @@ class SetupWizardTests(APIBaseTest):
                 }
             ),
             content_type="application/json",
-            HTTP_X_POSTHOG_WIZARD_HASH=self.hash,
-            HTTP_X_POSTHOG_WIZARD_FIXTURE_GENERATION="true",
+            headers={"x-posthog-wizard-hash": self.hash, "x-posthog-wizard-fixture-generation": "true"},
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -270,8 +269,7 @@ class SetupWizardTests(APIBaseTest):
                 }
             ),
             content_type="application/json",
-            HTTP_X_POSTHOG_WIZARD_HASH=self.hash,
-            HTTP_X_POSTHOG_WIZARD_FIXTURE_GENERATION="true",
+            headers={"x-posthog-wizard-hash": self.hash, "x-posthog-wizard-fixture-generation": "true"},
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -300,8 +298,7 @@ class SetupWizardTests(APIBaseTest):
                 }
             ),
             content_type="application/json",
-            HTTP_X_POSTHOG_WIZARD_HASH=self.hash,
-            HTTP_X_POSTHOG_WIZARD_FIXTURE_GENERATION="true",
+            headers={"x-posthog-wizard-hash": self.hash, "x-posthog-wizard-fixture-generation": "true"},
         )
 
         # Should fail authentication because no cache data exists and mock is not used
@@ -324,7 +321,7 @@ class SetupWizardTests(APIBaseTest):
                 }
             ),
             content_type="application/json",
-            HTTP_X_POSTHOG_WIZARD_HASH=self.hash,
+            headers={"x-posthog-wizard-hash": self.hash},
         )
 
         # Should fail authentication because no cache data exists and mock is not used

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -108,8 +108,8 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
         extra_data: Optional[dict[str, Any]] = None,
     ) -> Optional[tuple[str, str]]:
         """Try to find personal API key in request and return it along with where it was found."""
-        if "HTTP_AUTHORIZATION" in request.META:
-            authorization_match = re.match(rf"^{cls.keyword}\s+(\S.+)$", request.META["HTTP_AUTHORIZATION"])
+        if "authorization" in request.headers:
+            authorization_match = re.match(rf"^{cls.keyword}\s+(\S.+)$", request.headers["authorization"])
             if authorization_match:
                 token = authorization_match.group(1).strip()
 
@@ -229,8 +229,8 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
         request: Union[HttpRequest, Request],
     ) -> Optional[str]:
         """Try to find project secret API key in request and return it"""
-        if "HTTP_AUTHORIZATION" in request.META:
-            authorization_match = re.match(rf"^{cls.keyword}\s+(phs_[a-zA-Z0-9]+)$", request.META["HTTP_AUTHORIZATION"])
+        if "authorization" in request.headers:
+            authorization_match = re.match(rf"^{cls.keyword}\s+(phs_[a-zA-Z0-9]+)$", request.headers["authorization"])
             if authorization_match:
                 return authorization_match.group(1).strip()
 
@@ -326,8 +326,8 @@ class JwtAuthentication(authentication.BaseAuthentication):
 
     @classmethod
     def authenticate(cls, request: Union[HttpRequest, Request]) -> Optional[tuple[Any, None]]:
-        if "HTTP_AUTHORIZATION" in request.META:
-            authorization_match = re.match(rf"^Bearer\s+(\S.+)$", request.META["HTTP_AUTHORIZATION"])
+        if "authorization" in request.headers:
+            authorization_match = re.match(rf"^Bearer\s+(\S.+)$", request.headers["authorization"])
             if authorization_match:
                 try:
                     token = authorization_match.group(1).strip()
@@ -395,8 +395,8 @@ class SharingPasswordProtectedAuthentication(authentication.BaseAuthentication):
 
         # Extract JWT token from Authorization header or cookie
         sharing_jwt_token = None
-        if "HTTP_AUTHORIZATION" in request.META:
-            authorization_match = re.match(rf"^{self.keyword}\s+(\S.+)$", request.META["HTTP_AUTHORIZATION"])
+        if "authorization" in request.headers:
+            authorization_match = re.match(rf"^{self.keyword}\s+(\S.+)$", request.headers["authorization"])
             if authorization_match:
                 sharing_jwt_token = authorization_match.group(1).strip()
         elif hasattr(request, "COOKIES") and request.COOKIES.get("posthog_sharing_token"):
@@ -480,8 +480,8 @@ class OAuthAccessTokenAuthentication(authentication.BaseAuthentication):
             raise AuthenticationFailed(detail="Invalid access token.")
 
     def _extract_token(self, request: Union[HttpRequest, Request]) -> Optional[str]:
-        if "HTTP_AUTHORIZATION" in request.META:
-            authorization_match = re.match(rf"^{self.keyword}\s+(\S.+)$", request.META["HTTP_AUTHORIZATION"])
+        if "authorization" in request.headers:
+            authorization_match = re.match(rf"^{self.keyword}\s+(\S.+)$", request.headers["authorization"])
             if authorization_match:
                 token = authorization_match.group(1).strip()
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -81,7 +81,7 @@ class AllowIPMiddleware:
         self.get_response = get_response
 
     def get_forwarded_for(self, request: HttpRequest):
-        forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+        forwarded_for = request.headers.get("x-forwarded-for")
         if forwarded_for is not None:
             return [ip.strip() for ip in forwarded_for.split(",") if ip.strip()]
         else:
@@ -318,8 +318,8 @@ class CHQueries:
             route_id=route.route,
             client_query_id=self._get_param(request, "client_query_id"),
             session_id=self._get_param(request, "session_id"),
-            http_referer=request.META.get("HTTP_REFERER"),
-            http_user_agent=request.META.get("HTTP_USER_AGENT"),
+            http_referer=request.headers.get("referer"),
+            http_user_agent=request.headers.get("user-agent"),
         )
 
         try:
@@ -405,8 +405,8 @@ class ShortCircuitMiddleware:
                     kind="request",
                     id=request.path,
                     route_id=resolve(request.path).route,
-                    http_referer=request.META.get("HTTP_REFERER"),
-                    http_user_agent=request.META.get("HTTP_USER_AGENT"),
+                    http_referer=request.headers.get("referer"),
+                    http_user_agent=request.headers.get("user-agent"),
                 )
                 if self.decide_throttler.allow_request(request, None):
                     return get_decide(request)
@@ -448,9 +448,9 @@ def per_request_logging_context_middleware(
         # header from NGINX, but we really want to have a way to get to the
         # team_id given a host header, and we can't do that with NGINX.
         structlog.contextvars.bind_contextvars(
-            host=request.META.get("HTTP_HOST", ""),
+            host=request.headers.get("host", ""),
             container_hostname=settings.CONTAINER_HOSTNAME,
-            x_forwarded_for=request.META.get("HTTP_X_FORWARDED_FOR", ""),
+            x_forwarded_for=request.headers.get("x-forwarded-for", ""),
         )
 
         return get_response(request)

--- a/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v1.py
+++ b/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v1.py
@@ -427,7 +427,7 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/session_recordings/{session_id}/snapshots",
-            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            headers={"authorization": f"Bearer {personal_api_key}"},
         )
         assert response.status_code == status.HTTP_200_OK, response.json()
 

--- a/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v2.py
+++ b/posthog/session_recordings/test/test_session_recording_snapshots_api_blob_v2.py
@@ -237,7 +237,7 @@ class TestSessionRecordingSnapshotsAPI(APIBaseTest, ClickhouseTestMixin, QueryMa
 
         url = f"/api/projects/{self.team.pk}/session_recordings/{session_id}/snapshots/?source=blob_v2&start_blob_key=12&end_blob_key=33"
 
-        response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {personal_api_key}")
+        response = self.client.get(url, headers={"authorization": f"Bearer {personal_api_key}"})
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
         assert "Cannot request more than 20 blob keys at once" in response.json()["detail"]
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -272,7 +272,6 @@ PASSWORD_RESET_TIMEOUT = 86_400  # 1 day
 LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 ####
@@ -284,7 +283,14 @@ STATIC_URL = "/static/"
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "frontend/dist"),
 ]
-STATICFILES_STORAGE = "whitenoise.storage.ManifestStaticFilesStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.ManifestStaticFilesStorage",
+    },
+}
 
 
 def static_varies_origin(headers, path, url):

--- a/posthog/temporal/tests/test_codec_server.py
+++ b/posthog/temporal/tests/test_codec_server.py
@@ -20,7 +20,7 @@ class CodecServerTestCase(TestCase):
         self.auth_headers = {"HTTP_AUTHORIZATION": f"Bearer {self.test_token}"}
 
     def test_decode_endpoint_handles_options(self):
-        response = self.client.options("/decode", HTTP_ORIGIN="https://temporal-ui.posthog.orb.local")
+        response = self.client.options("/decode", headers={"origin": "https://temporal-ui.posthog.orb.local"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Access-Control-Allow-Origin"], "https://temporal-ui.posthog.orb.local")
         self.assertEqual(response["Access-Control-Allow-Methods"], "POST, OPTIONS")
@@ -80,7 +80,7 @@ class CodecServerTestCase(TestCase):
             "/decode",
             request_data,
             content_type="application/json",
-            HTTP_ORIGIN="https://temporal-ui.posthog.orb.local",
+            headers={"origin": "https://temporal-ui.posthog.orb.local"},
         )
         # Should be rejected when token is configured but not provided
         self.assertEqual(response.status_code, 401)
@@ -96,8 +96,7 @@ class CodecServerTestCase(TestCase):
             "/decode",
             request_data,
             content_type="application/json",
-            HTTP_ORIGIN="https://temporal-ui.posthog.orb.local",
-            HTTP_AUTHORIZATION="Bearer wrong-token",
+            headers={"origin": "https://temporal-ui.posthog.orb.local", "authorization": "Bearer wrong-token"},
         )
         self.assertEqual(response.status_code, 401)
         self.assertIn("Unauthorized", response.content.decode())

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -70,9 +70,7 @@ class TestAccessMiddleware(APIBaseTest):
         ):
             with self.settings(TRUSTED_PROXIES="10.0.0.1"):
                 response = self.client.get(
-                    "/",
-                    REMOTE_ADDR="10.0.0.1",
-                    HTTP_X_FORWARDED_FOR="192.168.0.1,10.0.0.1",
+                    "/", REMOTE_ADDR="10.0.0.1", headers={"x-forwarded-for": "192.168.0.1,10.0.0.1"}
                 )
                 self.assertNotIn(b"PostHog is not available", response.content)
 
@@ -83,9 +81,7 @@ class TestAccessMiddleware(APIBaseTest):
         ):
             with self.settings(TRUSTED_PROXIES="10.0.0.1"):
                 response = self.client.get(
-                    "/",
-                    REMOTE_ADDR="10.0.0.1",
-                    HTTP_X_FORWARDED_FOR="192.168.0.1,10.0.0.2",
+                    "/", REMOTE_ADDR="10.0.0.1", headers={"x-forwarded-for": "192.168.0.1,10.0.0.2"}
                 )
                 self.assertEqual(response.status_code, 403)
                 self.assertIn(b"PostHog is not available", response.content)
@@ -97,9 +93,7 @@ class TestAccessMiddleware(APIBaseTest):
         ):
             with self.settings(TRUST_ALL_PROXIES=True):
                 response = self.client.get(
-                    "/",
-                    REMOTE_ADDR="10.0.0.1",
-                    HTTP_X_FORWARDED_FOR="192.168.0.1,10.0.0.1",
+                    "/", REMOTE_ADDR="10.0.0.1", headers={"x-forwarded-for": "192.168.0.1,10.0.0.1"}
                 )
                 self.assertNotIn(b"PostHog is not available", response.content)
 
@@ -125,11 +119,7 @@ class TestAccessMiddleware(APIBaseTest):
             USE_X_FORWARDED_HOST=True,
         ):
             with self.settings(TRUST_ALL_PROXIES=True):
-                response = self.client.get(
-                    "/",
-                    REMOTE_ADDR="28.160.62.192",
-                    HTTP_X_FORWARDED_FOR="",
-                )
+                response = self.client.get("/", REMOTE_ADDR="28.160.62.192", headers={"x-forwarded-for": ""})
                 self.assertNotIn(b"PostHog is not available", response.content)
 
 

--- a/posthog/test/test_permissions.py
+++ b/posthog/test/test_permissions.py
@@ -578,14 +578,14 @@ class TestOAuthAccessTokenAPIScopePermission(BaseTest):
     def _do_request(self, url, method="GET", data=None):
         """Helper to make requests with OAuth token"""
         if method == "GET":
-            return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.access_token.token}")
+            return self.client.get(url, headers={"authorization": f"Bearer {self.access_token.token}"})
         elif method == "POST":
             return self.client.post(
-                url, data or {}, format="json", HTTP_AUTHORIZATION=f"Bearer {self.access_token.token}"
+                url, data or {}, format="json", headers={"authorization": f"Bearer {self.access_token.token}"}
             )
         elif method == "PATCH":
             return self.client.patch(
-                url, data or {}, format="json", HTTP_AUTHORIZATION=f"Bearer {self.access_token.token}"
+                url, data or {}, format="json", headers={"authorization": f"Bearer {self.access_token.token}"}
             )
 
     def test_denies_token_with_no_scopes(self):
@@ -684,7 +684,7 @@ class TestOAuthAccessTokenWithOrganizationScoping(BaseTest):
         )
 
     def _do_request(self, url):
-        return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.access_token.token}")
+        return self.client.get(url, headers={"authorization": f"Bearer {self.access_token.token}"})
 
     def test_allows_access_to_scoped_org(self):
         """OAuth token scoped to an org can access that org"""
@@ -743,7 +743,7 @@ class TestOAuthAccessTokenWithTeamScoping(BaseTest):
         )
 
     def _do_request(self, url):
-        return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.access_token.token}")
+        return self.client.get(url, headers={"authorization": f"Bearer {self.access_token.token}"})
 
     def test_allows_access_to_scoped_team(self):
         """OAuth token scoped to a team can access that team"""
@@ -805,7 +805,7 @@ class TestOAuthAccessTokenWithBothTeamAndOrgScoping(BaseTest):
         )
 
     def _do_request(self, url):
-        return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.access_token.token}")
+        return self.client.get(url, headers={"authorization": f"Bearer {self.access_token.token}"})
 
     def test_allows_access_to_scoped_team(self):
         """OAuth token with both org and team scopes allows access to the scoped team"""
@@ -867,8 +867,7 @@ class TestOAuthAccessTokenExpiration(BaseTest):
     def _do_request(self, token=None):
         token = token or self.access_token.token
         return self.client.get(
-            f"/api/projects/{self.team.id}/feature_flags/",
-            HTTP_AUTHORIZATION=f"Bearer {token}",
+            f"/api/projects/{self.team.id}/feature_flags/", headers={"authorization": f"Bearer {token}"}
         )
 
     def test_valid_token_allows_access(self):
@@ -936,8 +935,7 @@ class TestOAuthAccessTokenUserMembership(BaseTest):
     def _do_request(self, token=None):
         token = token or self.access_token.token
         return self.client.get(
-            f"/api/projects/{self.team.id}/feature_flags/",
-            HTTP_AUTHORIZATION=f"Bearer {token}",
+            f"/api/projects/{self.team.id}/feature_flags/", headers={"authorization": f"Bearer {token}"}
         )
 
     def test_token_works_with_membership(self):
@@ -981,6 +979,6 @@ class TestOAuthAccessTokenUserMembership(BaseTest):
         # Verify token does NOT work because user is not in that org
         response = self.client.get(
             f"/api/projects/{other_team.id}/feature_flags/",
-            HTTP_AUTHORIZATION=f"Bearer {other_team_token.token}",
+            headers={"authorization": f"Bearer {other_team_token.token}"},
         )
         self.assertEqual(response.status_code, 403)  # Forbidden - user not in org

--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -124,13 +124,12 @@ class TestUserAPI(APIBaseTest):
         for _ in range(5):
             response = self.client.get(
                 f"/api/projects/{self.team.pk}/feature_flags",
-                HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                headers={"authorization": f"Bearer {self.personal_api_key}"},
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self.client.get(
-            f"/api/projects/{self.team.pk}/feature_flags",
-            HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+            f"/api/projects/{self.team.pk}/feature_flags", headers={"authorization": f"Bearer {self.personal_api_key}"}
         )
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
@@ -160,7 +159,7 @@ class TestUserAPI(APIBaseTest):
             with freeze_time(base_time):
                 response = self.client.get(
                     f"/api/projects/{self.team.pk}/feature_flags",
-                    HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                    headers={"authorization": f"Bearer {self.personal_api_key}"},
                 )
                 base_time += timedelta(seconds=61)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -169,7 +168,7 @@ class TestUserAPI(APIBaseTest):
             for _ in range(2):
                 response = self.client.get(
                     f"/api/projects/{self.team.pk}/feature_flags",
-                    HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                    headers={"authorization": f"Bearer {self.personal_api_key}"},
                 )
                 self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
             self.assertEqual(
@@ -195,22 +194,20 @@ class TestUserAPI(APIBaseTest):
         for _ in range(10):
             response = self.client.get(
                 f"/api/projects/{self.team.pk}/feature_flags",
-                HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                headers={"authorization": f"Bearer {self.personal_api_key}"},
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert call("rate_limit_exceeded", tags=ANY) not in incr_mock.mock_calls
 
         for _ in range(5):
             response = self.client.get(
-                f"/api/projects/{self.team.pk}/events",
-                HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                f"/api/projects/{self.team.pk}/events", headers={"authorization": f"Bearer {self.personal_api_key}"}
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Does not actually block the request, but increments the counter
         response = self.client.get(
-            f"/api/projects/{self.team.pk}/events",
-            HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+            f"/api/projects/{self.team.pk}/events", headers={"authorization": f"Bearer {self.personal_api_key}"}
         )
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
@@ -237,14 +234,13 @@ class TestUserAPI(APIBaseTest):
         for _ in range(5):
             response = self.client.get(
                 f"/api/projects/{self.team.pk}/feature_flags",
-                HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                headers={"authorization": f"Bearer {self.personal_api_key}"},
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # First user gets rate limited
         response = self.client.get(
-            f"/api/projects/{self.team.pk}/feature_flags",
-            HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+            f"/api/projects/{self.team.pk}/feature_flags", headers={"authorization": f"Bearer {self.personal_api_key}"}
         )
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
         self.assertEqual(
@@ -272,8 +268,7 @@ class TestUserAPI(APIBaseTest):
 
         # Second user gets rate limited after a single request
         response = self.client.get(
-            f"/api/projects/{self.team.pk}/feature_flags",
-            HTTP_AUTHORIZATION=f"Bearer {new_personal_api_key}",
+            f"/api/projects/{self.team.pk}/feature_flags", headers={"authorization": f"Bearer {new_personal_api_key}"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -287,8 +282,7 @@ class TestUserAPI(APIBaseTest):
 
         # Requests to the new team are not rate limited
         response = self.client.get(
-            f"/api/projects/{new_team.pk}/feature_flags",
-            HTTP_AUTHORIZATION=f"Bearer {new_personal_api_key}",
+            f"/api/projects/{new_team.pk}/feature_flags", headers={"authorization": f"Bearer {new_personal_api_key}"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
@@ -300,7 +294,7 @@ class TestUserAPI(APIBaseTest):
         for _ in range(5):
             response = self.client.get(
                 f"/api/projects/{new_team.pk}/feature_flags",
-                HTTP_AUTHORIZATION=f"Bearer {new_personal_api_key}",
+                headers={"authorization": f"Bearer {new_personal_api_key}"},
             )
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
         self.assertEqual(
@@ -316,13 +310,13 @@ class TestUserAPI(APIBaseTest):
         for _ in range(5):
             response = self.client.get(
                 f"/api/organizations/{self.organization.pk}/plugins",
-                HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                headers={"authorization": f"Bearer {self.personal_api_key}"},
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self.client.get(
             f"/api/organizations/{self.organization.pk}/plugins",
-            HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+            headers={"authorization": f"Bearer {self.personal_api_key}"},
         )
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
@@ -350,7 +344,7 @@ class TestUserAPI(APIBaseTest):
         for _ in range(6):
             response = self.client.get(
                 f"/api/organizations/{self.organization.pk}/plugins",
-                HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                headers={"authorization": f"Bearer {self.personal_api_key}"},
             )
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
         # got rate limited with personal API key
@@ -412,7 +406,9 @@ class TestUserAPI(APIBaseTest):
             "properties": {"distinct_id": 2, "token": self.team.api_token},
         }
         for _ in range(6):
-            response = self.client.get("/e/?data={}".format(quote(json.dumps(data))), HTTP_ORIGIN="https://localhost")
+            response = self.client.get(
+                "/e/?data={}".format(quote(json.dumps(data))), headers={"origin": "https://localhost"}
+            )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert call("rate_limit_exceeded", tags=ANY) not in incr_mock.mock_calls
 
@@ -458,7 +454,7 @@ class TestUserAPI(APIBaseTest):
                     for _ in range(10):
                         self.client.get(
                             f"/api/projects/{self.team.pk}/feature_flags",
-                            HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                            headers={"authorization": f"Bearer {self.personal_api_key}"},
                         )
 
                     assert wrapped_get_instance_setting.call_count == 1
@@ -467,7 +463,7 @@ class TestUserAPI(APIBaseTest):
                     for _ in range(10):
                         self.client.get(
                             f"/api/projects/{self.team.pk}/feature_flags",
-                            HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                            headers={"authorization": f"Bearer {self.personal_api_key}"},
                         )
                     assert wrapped_get_instance_setting.call_count == 2
 
@@ -480,7 +476,7 @@ class TestUserAPI(APIBaseTest):
                 for _ in range(10):
                     response = self.client.get(
                         f"/api/projects/{self.team.pk}/feature_flags",
-                        HTTP_AUTHORIZATION=f"Bearer {self.personal_api_key}",
+                        headers={"authorization": f"Bearer {self.personal_api_key}"},
                     )
                     self.assertEqual(response.status_code, status.HTTP_200_OK)
                 assert call("rate_limit_exceeded", tags=ANY) not in incr_mock.mock_calls

--- a/posthog/test/test_urls.py
+++ b/posthog/test/test_urls.py
@@ -59,42 +59,38 @@ class TestUrls(APIBaseTest):
 
         response = self.client.get(
             "/authorize_and_redirect/?redirect=https://not-permitted.com",
-            HTTP_REFERER="https://not-permitted.com",
+            headers={"referer": "https://not-permitted.com"},
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertTrue("Can only redirect to a permitted domain." in str(response.content))
 
         response = self.client.get(
-            "/authorize_and_redirect/?redirect=https://domain.com",
-            HTTP_REFERER="https://not.com",
+            "/authorize_and_redirect/?redirect=https://domain.com", headers={"referer": "https://not.com"}
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertTrue("Can only redirect to the same domain as the referer: not.com" in str(response.content))
 
         response = self.client.get(
-            "/authorize_and_redirect/?redirect=http://domain.com",
-            HTTP_REFERER="https://domain.com",
+            "/authorize_and_redirect/?redirect=http://domain.com", headers={"referer": "https://domain.com"}
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertTrue("Can only redirect to the same scheme as the referer: https" in str(response.content))
 
         response = self.client.get(
-            "/authorize_and_redirect/?redirect=https://domain.com:555",
-            HTTP_REFERER="https://domain.com:443",
+            "/authorize_and_redirect/?redirect=https://domain.com:555", headers={"referer": "https://domain.com:443"}
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertTrue("Can only redirect to the same port as the referer: 443" in str(response.content))
 
         response = self.client.get(
             "/authorize_and_redirect/?redirect=https://domain.com:555",
-            HTTP_REFERER="https://domain.com/no-port",
+            headers={"referer": "https://domain.com/no-port"},
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertTrue("Can only redirect to the same port as the referer: no port in URL" in str(response.content))
 
         response = self.client.get(
-            "/authorize_and_redirect/?redirect=https://domain.com/sdf",
-            HTTP_REFERER="https://domain.com/asd",
+            "/authorize_and_redirect/?redirect=https://domain.com/sdf", headers={"referer": "https://domain.com/asd"}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # TODO: build frontend before backend tests, or find a way to mock the template

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -101,11 +101,11 @@ def home(request, *args, **kwargs):
 def authorize_and_redirect(request: HttpRequest) -> HttpResponse:
     if not request.GET.get("redirect"):
         return HttpResponse("You need to pass a url to ?redirect=", status=400)
-    if not request.META.get("HTTP_REFERER"):
+    if not request.headers.get("referer"):
         return HttpResponse('You need to make a request that includes the "Referer" header.', status=400)
 
     current_team = cast(User, request.user).team
-    referer_url = urlparse(request.META["HTTP_REFERER"])
+    referer_url = urlparse(request.headers["referer"])
     redirect_url = urlparse(request.GET["redirect"])
     is_forum_login = request.GET.get("forum_login", "").lower() == "true"
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -639,7 +639,7 @@ def get_ip_address(request: HttpRequest) -> str:
     """use requestobject to fetch client machine's IP Address"""
     x_forwarded_for = request.headers.get("x-forwarded-for")
     if x_forwarded_for:
-        ip = x_forwarded_for.split(",")[0]
+        ip: str | None = x_forwarded_for.split(",")[0]
     else:
         ip = request.META.get("REMOTE_ADDR")  # Real IP address of client Machine
 
@@ -647,7 +647,7 @@ def get_ip_address(request: HttpRequest) -> str:
     if ip and len(ip.split(":")) == 2:
         ip = ip.split(":")[0]
 
-    return ip
+    return ip or ""
 
 
 def get_short_user_agent(request: HttpRequest) -> str:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -637,7 +637,7 @@ def friendly_time(seconds: float):
 
 def get_ip_address(request: HttpRequest) -> str:
     """use requestobject to fetch client machine's IP Address"""
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+    x_forwarded_for = request.headers.get("x-forwarded-for")
     if x_forwarded_for:
         ip = x_forwarded_for.split(",")[0]
     else:
@@ -652,7 +652,7 @@ def get_ip_address(request: HttpRequest) -> str:
 
 def get_short_user_agent(request: HttpRequest) -> str:
     """Returns browser and OS info from user agent, eg: 'Chrome 135.0.0 on macOS 10.15'"""
-    user_agent_str = request.META.get("HTTP_USER_AGENT")
+    user_agent_str = request.headers.get("user-agent")
     if not user_agent_str:
         return ""
 

--- a/posthog/utils_cors.py
+++ b/posthog/utils_cors.py
@@ -40,9 +40,9 @@ def cors_response(request: HttpRequest, response: HttpResponse) -> HttpResponse:
     Returns a HttpResponse with CORS headers set to allow all origins.
     Only use this for endpoints that get called by the PostHog JS SDK.
     """
-    if not request.META.get("HTTP_ORIGIN"):
+    if not request.headers.get("origin"):
         return response
-    url = urlparse(request.META["HTTP_ORIGIN"])
+    url = urlparse(request.headers["origin"])
     if url.netloc == "":
         response["Access-Control-Allow-Origin"] = "*"
         logger.info("cors_empty_netloc", path=request.path, method=request.method)
@@ -55,8 +55,8 @@ def cors_response(request: HttpRequest, response: HttpResponse) -> HttpResponse:
                 origin=url.netloc,
                 path=request.path,
                 method=request.method,
-                referer=request.META.get("HTTP_REFERER"),
-                user_agent=request.META.get("HTTP_USER_AGENT"),
+                referer=request.headers.get("referer"),
+                user_agent=request.headers.get("user-agent"),
             )
 
     response["Access-Control-Allow-Credentials"] = "true"
@@ -65,7 +65,7 @@ def cors_response(request: HttpRequest, response: HttpResponse) -> HttpResponse:
     # Handle headers that sentry randomly sends for every request.
     # Would cause a CORS failure otherwise.
     # specified here to override the default added by the cors headers package in web.py
-    allow_headers = request.META.get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS", "").split(",")
+    allow_headers = request.headers.get("access-control-request-headers", "").split(",")
     allow_headers = [header for header in allow_headers if header in CORS_ALLOWED_TRACING_HEADERS]
 
     response["Access-Control-Allow-Headers"] = "X-Requested-With,Content-Type" + (

--- a/products/early_access_features/backend/test/test_early_access_feature.py
+++ b/products/early_access_features/backend/test/test_early_access_feature.py
@@ -624,7 +624,7 @@ class TestPreviewList(BaseTest, QueryMatchingTest):
         return self.client.get(
             f"/api/early_access_features/",
             data={"token": token or self.team.api_token},
-            HTTP_ORIGIN=origin,
+            headers={"origin": origin},
             REMOTE_ADDR=ip,
         )
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -521,13 +521,13 @@ class TestTasksAPIPermissions(BaseTaskAPITest):
             data = {"title": "Updated Task"}
 
         if method == "GET":
-            response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {api_key_value}")
+            response = self.client.get(url, headers={"authorization": f"Bearer {api_key_value}"})
         elif method == "POST":
-            response = self.client.post(url, data, format="json", HTTP_AUTHORIZATION=f"Bearer {api_key_value}")
+            response = self.client.post(url, data, format="json", headers={"authorization": f"Bearer {api_key_value}"})
         elif method == "PATCH":
-            response = self.client.patch(url, data, format="json", HTTP_AUTHORIZATION=f"Bearer {api_key_value}")
+            response = self.client.patch(url, data, format="json", headers={"authorization": f"Bearer {api_key_value}"})
         elif method == "DELETE":
-            response = self.client.delete(url, HTTP_AUTHORIZATION=f"Bearer {api_key_value}")
+            response = self.client.delete(url, headers={"authorization": f"Bearer {api_key_value}"})
         else:
             self.fail(f"Unsupported method: {method}")
 


### PR DESCRIPTION
Prepare codebase for Django 5 upgrade by applying django-upgrade tool to modernize deprecated patterns.

**Changes made:**

Run `django-upgrade --target-version 5.0` to apply Django 4.2+ deprecation fixes:
- Convert `HTTP_*` test client header kwargs to `headers={}` dict syntax
- Replace deprecated `STATICFILES_STORAGE` with new `STORAGES` setting format
- Remove deprecated `USE_L10N` setting (always True in Django 4.2+)

**Backward compatibility:**

All changes are backward compatible with Django 4.2.26 (current master version). This PR reduces the size of the upcoming Django 5 upgrade PR by handling deprecation warnings that can be fixed while still on Django 4.2.

**What's NOT included:**

CheckConstraint `check=` → `condition=` parameter rename is NOT included since `condition` was only introduced in Django 5.1. That change will be part of the Django 5 upgrade PR.