### PR TITLE
feat(customers): Add session insights to customer analytics dashboard

### DIFF
--- a/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
+++ b/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
@@ -4,6 +4,8 @@ import { sceneConfigurations } from 'scenes/scenes'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
+import { SessionInsights } from 'products/customer_analytics/frontend/components/Insights/SessionInsights'
+
 import { ActiveUsersInsights } from './components/Insights/ActiveUsersInsights'
 import { customerAnalyticsSceneLogic } from './customerAnalyticsSceneLogic'
 
@@ -28,6 +30,7 @@ export function CustomerAnalyticsScene({ tabId }: { tabId?: string }): JSX.Eleme
             />
             <div className="space-y-2">
                 <ActiveUsersInsights />
+                <SessionInsights />
             </div>
         </SceneContent>
     )

--- a/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
@@ -23,7 +23,7 @@ export function ActiveUsersInsights(): JSX.Element {
     const isOnlyPageview = isEventsNode(activityEvent) && activityEvent.event === '$pageview'
 
     return (
-        <div className="space-y-2 mb-0">
+        <div className="space-y-2">
             {isOnlyPageview && (
                 <LemonBanner type="warning">
                     You are currently using the pageview event to define user activity. Consider using a more specific
@@ -92,16 +92,9 @@ function PowerUsersTable(): JSX.Element {
 
     return (
         <>
-            <div className="flex items-center gap-2 ml-1">
-                <h2 className="-mb-2">Power Users</h2>
-                <LemonButton
-                    size="small"
-                    noPadding
-                    targetBlank
-                    to={urls.persons()}
-                    tooltip="Open people list"
-                    className="-mb-2"
-                />
+            <div className="flex items-center gap-2 -mb-2">
+                <h2 className="mb-0 ml-1">Power Users</h2>
+                <LemonButton size="small" noPadding targetBlank to={urls.persons()} tooltip="Open people list" />
             </div>
             <Query
                 uniqueKey={`power-users-${tabId}`}

--- a/products/customer_analytics/frontend/components/Insights/SessionInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/SessionInsights.tsx
@@ -1,0 +1,41 @@
+import { useValues } from 'kea'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
+import { urls } from 'scenes/urls'
+
+import { ActivityTab } from '~/types'
+
+import { CustomerAnalyticsQueryCard } from 'products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard'
+import { customerAnalyticsSceneLogic } from 'products/customer_analytics/frontend/customerAnalyticsSceneLogic'
+import { InsightDefinition } from 'products/customer_analytics/frontend/insightDefinitions'
+
+export function SessionInsights(): JSX.Element {
+    const { sessionInsights, tabId } = useValues(customerAnalyticsSceneLogic)
+    const { featureFlags } = useValues(featureFlagsLogic)
+
+    return (
+        <div className="space-y-2">
+            <div className="flex items-center gap-2">
+                <h2 className="mb-0 ml-1">Session insights</h2>
+                {featureFlags[FEATURE_FLAGS.SESSIONS_EXPLORER] && (
+                    <LemonButton
+                        size="small"
+                        noPadding
+                        targetBlank
+                        to={urls.activity(ActivityTab.ExploreSessions)}
+                        tooltip="Open session explorer"
+                    />
+                )}
+            </div>
+            <div className="grid grid-cols-3 gap-2">
+                {sessionInsights.map((insight, index) => {
+                    return (
+                        <CustomerAnalyticsQueryCard key={index} insight={insight as InsightDefinition} tabId={tabId} />
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/products/customer_analytics/frontend/components/Insights/SessionInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/SessionInsights.tsx
@@ -2,7 +2,7 @@ import { useValues } from 'kea'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import { ActivityTab } from '~/types'
@@ -13,7 +13,7 @@ import { InsightDefinition } from 'products/customer_analytics/frontend/insightD
 
 export function SessionInsights(): JSX.Element {
     const { sessionInsights, tabId } = useValues(customerAnalyticsSceneLogic)
-    const { featureFlags } = useValues(featureFlagsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <div className="space-y-2">

--- a/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
+++ b/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
@@ -10,7 +10,7 @@ import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/fil
 import { seriesToActionsAndEvents } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { ActionsNode, EventsNode, NodeKind } from '~/queries/schema/schema-general'
 import { isDataWarehouseNode } from '~/queries/utils'
-import { BaseMathType, Breadcrumb, ChartDisplayType, FilterType, InsightType } from '~/types'
+import { BaseMathType, Breadcrumb, ChartDisplayType, FilterType, InsightType, PropertyMathType } from '~/types'
 
 import { customerAnalyticsConfigLogic } from './customerAnalyticsConfigLogic'
 import type { customerAnalyticsSceneLogicType } from './customerAnalyticsSceneLogicType'
@@ -220,6 +220,139 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
                     },
                 ]
             },
+        ],
+        sessionInsights: [
+            () => [],
+            () => [
+                {
+                    name: 'Unique sessions (last 1h)',
+                    description: 'Events without session IDs are excluded.',
+                    needsConfig: false,
+                    className: 'h-[284px]',
+                    query: {
+                        kind: NodeKind.InsightVizNode,
+                        source: {
+                            kind: NodeKind.TrendsQuery,
+                            series: [
+                                {
+                                    kind: NodeKind.EventsNode,
+                                    math: BaseMathType.UniqueSessions,
+                                    name: 'All events',
+                                    event: null,
+                                },
+                            ],
+                            interval: 'minute',
+                            dateRange: {
+                                date_to: '',
+                                date_from: '-1h',
+                                explicitDate: false,
+                            },
+                            properties: [],
+                            trendsFilter: {
+                                display: ChartDisplayType.BoldNumber,
+                                showLegend: false,
+                                yAxisScaleType: 'linear',
+                                showValuesOnSeries: false,
+                                showPercentStackView: false,
+                                aggregationAxisFormat: 'numeric',
+                                showAlertThresholdLines: false,
+                            },
+                            compareFilter: {
+                                compare: true,
+                            },
+                            breakdownFilter: undefined,
+                            filterTestAccounts: true,
+                        },
+                    },
+                },
+                {
+                    name: 'Unique users (last 1h)',
+                    description: 'Number of unique users recently.',
+                    needsConfig: false,
+                    className: 'h-[284px]',
+                    query: {
+                        kind: NodeKind.InsightVizNode,
+                        source: {
+                            kind: NodeKind.TrendsQuery,
+                            series: [
+                                {
+                                    kind: NodeKind.EventsNode,
+                                    math: BaseMathType.UniqueUsers,
+                                    name: 'All events',
+                                    event: null,
+                                },
+                            ],
+                            interval: 'hour',
+                            dateRange: {
+                                date_to: '',
+                                date_from: '-1h',
+                                explicitDate: false,
+                            },
+                            properties: [],
+                            trendsFilter: {
+                                display: ChartDisplayType.BoldNumber,
+                                showLegend: false,
+                                yAxisScaleType: 'linear',
+                                showValuesOnSeries: false,
+                                showPercentStackView: false,
+                                aggregationAxisFormat: 'numeric',
+                                showAlertThresholdLines: false,
+                            },
+                            compareFilter: {
+                                compare: true,
+                            },
+                            breakdownFilter: {
+                                breakdown_type: 'event',
+                            },
+                            filterTestAccounts: true,
+                        },
+                    },
+                },
+                {
+                    name: 'Average session duration (last 1h)',
+                    description: 'Average session duration for recent sessions.',
+                    needsConfig: false,
+                    className: 'h-[284px]',
+                    query: {
+                        kind: NodeKind.InsightVizNode,
+                        source: {
+                            kind: NodeKind.TrendsQuery,
+                            series: [
+                                {
+                                    kind: NodeKind.EventsNode,
+                                    math: PropertyMathType.Average,
+                                    name: '$pageview',
+                                    event: '$pageview',
+                                    math_property: '$session_duration',
+                                },
+                            ],
+                            interval: 'minute',
+                            dateRange: {
+                                date_to: '',
+                                date_from: '-1h',
+                                explicitDate: false,
+                            },
+                            properties: [],
+                            trendsFilter: {
+                                display: ChartDisplayType.BoldNumber,
+                                showLegend: false,
+                                yAxisScaleType: 'linear',
+                                showValuesOnSeries: false,
+                                showPercentStackView: false,
+                                aggregationAxisFormat: 'duration',
+                                showAlertThresholdLines: false,
+                            },
+                            compareFilter: {
+                                compare: true,
+                            },
+                            breakdownFilter: {
+                                breakdown_type: 'event',
+                            },
+                            filterTestAccounts: true,
+                        },
+                    },
+                },
+            ],
         ],
         activityEventFilters: [
             (s) => [s.activityEvent, s.activityEventSelection],

--- a/products/customer_analytics/frontend/insightDefinitions.ts
+++ b/products/customer_analytics/frontend/insightDefinitions.ts
@@ -2,13 +2,11 @@ import { FunnelLayout } from 'lib/constants'
 
 import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import {
-    BaseMathType,
     BreakdownAttributionType,
     ChartDisplayType,
     FunnelConversionWindowTimeUnit,
     FunnelStepReference,
     FunnelVizType,
-    PropertyMathType,
     StepOrderValue,
 } from '~/types'
 
@@ -116,137 +114,6 @@ export const CUSTOMER_ANALYTICS_ENGAGEMENT_AND_CONVERSION_INSIGHTS: InsightDefin
                     funnelWindowInterval: 6,
                     breakdownAttributionType: BreakdownAttributionType.FirstTouch,
                     funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Week,
-                },
-                breakdownFilter: {
-                    breakdown_type: 'event',
-                },
-                filterTestAccounts: true,
-            },
-        },
-    },
-]
-
-export const CUSTOMER_ANALYTICS_SESSION_INSIGHTS: InsightDefinition[] = [
-    {
-        name: 'Unique sessions (last 1h)',
-        description: 'Events without session IDs are excluded.',
-        needsConfig: false,
-        className: 'h-[284px]',
-        query: {
-            kind: NodeKind.InsightVizNode,
-            source: {
-                kind: NodeKind.TrendsQuery,
-                series: [
-                    {
-                        kind: NodeKind.EventsNode,
-                        math: BaseMathType.UniqueSessions,
-                        name: 'All events',
-                        event: null,
-                    },
-                ],
-                interval: 'minute',
-                dateRange: {
-                    date_to: '',
-                    date_from: '-1h',
-                    explicitDate: false,
-                },
-                properties: [],
-                trendsFilter: {
-                    display: ChartDisplayType.BoldNumber,
-                    showLegend: false,
-                    yAxisScaleType: 'linear',
-                    showValuesOnSeries: false,
-                    showPercentStackView: false,
-                    aggregationAxisFormat: 'numeric',
-                    showAlertThresholdLines: false,
-                },
-                compareFilter: {
-                    compare: true,
-                },
-                breakdownFilter: undefined,
-                filterTestAccounts: true,
-            },
-        },
-    },
-    {
-        name: 'Unique users (last 1h)',
-        description: 'Number of unique users recently.',
-        needsConfig: false,
-        className: 'h-[284px]',
-        query: {
-            kind: NodeKind.InsightVizNode,
-            source: {
-                kind: NodeKind.TrendsQuery,
-                series: [
-                    {
-                        kind: NodeKind.EventsNode,
-                        math: BaseMathType.UniqueUsers,
-                        name: 'All events',
-                        event: null,
-                    },
-                ],
-                interval: 'hour',
-                dateRange: {
-                    date_to: '',
-                    date_from: '-1h',
-                    explicitDate: false,
-                },
-                properties: [],
-                trendsFilter: {
-                    display: ChartDisplayType.BoldNumber,
-                    showLegend: false,
-                    yAxisScaleType: 'linear',
-                    showValuesOnSeries: false,
-                    showPercentStackView: false,
-                    aggregationAxisFormat: 'numeric',
-                    showAlertThresholdLines: false,
-                },
-                compareFilter: {
-                    compare: true,
-                },
-                breakdownFilter: {
-                    breakdown_type: 'event',
-                },
-                filterTestAccounts: true,
-            },
-        },
-    },
-    {
-        name: 'Average session duration (last 1h)',
-        description: 'Average session duration for recent sessions.',
-        needsConfig: false,
-        className: 'h-[284px]',
-        query: {
-            kind: NodeKind.InsightVizNode,
-            source: {
-                kind: NodeKind.TrendsQuery,
-                series: [
-                    {
-                        kind: NodeKind.EventsNode,
-                        math: PropertyMathType.Average,
-                        name: '$pageview',
-                        event: '$pageview',
-                        math_property: '$session_duration',
-                    },
-                ],
-                interval: 'minute',
-                dateRange: {
-                    date_to: '',
-                    date_from: '-1h',
-                    explicitDate: false,
-                },
-                properties: [],
-                trendsFilter: {
-                    display: ChartDisplayType.BoldNumber,
-                    showLegend: false,
-                    yAxisScaleType: 'linear',
-                    showValuesOnSeries: false,
-                    showPercentStackView: false,
-                    aggregationAxisFormat: 'duration',
-                    showAlertThresholdLines: false,
-                },
-                compareFilter: {
-                    compare: true,
                 },
                 breakdownFilter: {
                     breakdown_type: 'event',


### PR DESCRIPTION
## Problem

Let's add some visibility to customer sessions in customer analytics.

Closes https://github.com/PostHog/posthog/issues/41537
## Changes

- Added a new `SessionInsights` component to display session-related metrics
- Integrated the component into the Customer Analytics scene
- Moved session insight definitions from `insightDefinitions.ts` to the `customerAnalyticsSceneLogic`
- Added three key session metrics:
  - Unique sessions (last 1h)
  - Unique users (last 1h)
  - Average session duration (last 1h)
- Fixed styling inconsistencies in the Power Users section
- Added a link to the Session Explorer when the feature flag is enabled

## How did you test this code?

Tested the component rendering in the Customer Analytics scene, verified that all three session metrics display correctly, and confirmed that the Session Explorer link appears only when the feature flag is enabled.

## Changelog: (features only) Is this feature complete?
No, under feature flag