### PR TITLE
fix(ux): changed shortcut menu trigger to be cmd option k

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -105,6 +105,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
     const { firstTabIsActive, activeTabId } = useValues(sceneLogic)
     const { preflight } = useValues(preflightLogic)
     const { setAppShortcutMenuOpen } = useActions(appShortcutLogic)
+    const { appShortcutMenuOpen } = useValues(appShortcutLogic)
 
     const useAppShortcuts = useFeatureFlag('APP_SHORTCUTS')
 
@@ -485,7 +486,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
 
                             <AppShortcut
                                 name="ToggleShortcutMenu"
-                                keybind={['command', 'shift', 'k']}
+                                keybind={keyBinds.toggleShortcutMenu}
                                 intent="Toggle shortcut menu"
                                 interaction="click"
                                 asChild
@@ -496,7 +497,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                     iconOnly={isLayoutNavCollapsed}
                                     tooltip={isLayoutNavCollapsed ? 'Open shortcut menu' : undefined}
                                     tooltipPlacement="right"
-                                    onClick={() => setAppShortcutMenuOpen(true)}
+                                    onClick={() => setAppShortcutMenuOpen(!appShortcutMenuOpen)}
                                     menuItem={!isLayoutNavCollapsed}
                                     className="hidden"
                                 />

--- a/frontend/src/lib/components/Account/AccountMenu.tsx
+++ b/frontend/src/lib/components/Account/AccountMenu.tsx
@@ -62,6 +62,7 @@ import { SidePanelTab, UserTheme } from '~/types'
 
 import { AppShortcut } from '../AppShortcuts/AppShortcut'
 import { appShortcutLogic } from '../AppShortcuts/appShortcutLogic'
+import { keyBinds } from '../AppShortcuts/shortcuts'
 import { openCHQueriesDebugModal } from '../AppShortcuts/utils/DebugCHQueries'
 import { OrgCombobox } from './OrgCombobox'
 
@@ -162,7 +163,6 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                 collisionPadding={{ bottom: 0 }}
                 alignOffset={2}
                 className="min-w-[var(--project-panel-width)]"
-                // Force mount to register app shortcuts
                 forceMount
             >
                 <DropdownMenuGroup>
@@ -320,7 +320,7 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
 
                     <AppShortcut
                         name="ToggleShortcutMenu"
-                        keybind={['command', 'shift', 'k']}
+                        keybind={keyBinds.toggleShortcutMenu}
                         intent="Toggle shortcut menu"
                         interaction="click"
                         asChild
@@ -336,7 +336,7 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                             >
                                 <span className="text-tertiary size-4 flex items-center justify-center">⌘</span>
                                 Shortcuts
-                                <KeyboardShortcut command shift k className="ml-auto" />
+                                <KeyboardShortcut command option k className="ml-auto" />
                             </ButtonPrimitive>
                         </DropdownMenuItem>
                     </AppShortcut>
@@ -435,28 +435,20 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                             (user?.is_impersonated ||
                                 preflight?.is_debug ||
                                 preflight?.instance_preferences?.debug_queries) ? (
-                                <AppShortcut
-                                    name="DebugClickhouseQueries"
-                                    keybind={['command', 'option', 'tab']}
-                                    intent="Debug clickhouse queries"
-                                    interaction="click"
-                                    asChild
-                                >
-                                    <DropdownMenuItem asChild>
-                                        <ButtonPrimitive
-                                            menuItem
-                                            onClick={() => {
-                                                openCHQueriesDebugModal()
-                                            }}
-                                            data-attr="menu-item-debug-ch-queries"
-                                            className={cn(!useAppShortcuts && 'hidden')}
-                                        >
-                                            <IconDatabase />
-                                            Debug CH queries
-                                            <KeyboardShortcut command option tab className="ml-auto" />
-                                        </ButtonPrimitive>
-                                    </DropdownMenuItem>
-                                </AppShortcut>
+                                <DropdownMenuItem asChild>
+                                    <ButtonPrimitive
+                                        menuItem
+                                        onClick={() => {
+                                            openCHQueriesDebugModal()
+                                        }}
+                                        data-attr="menu-item-debug-ch-queries"
+                                        className={cn(!useAppShortcuts && 'hidden')}
+                                    >
+                                        <IconDatabase />
+                                        Debug CH queries
+                                        <KeyboardShortcut command option tab className="ml-auto" />
+                                    </ButtonPrimitive>
+                                </DropdownMenuItem>
                             ) : null}
                         </>
                     )}

--- a/frontend/src/lib/components/AppShortcuts/shortcuts.ts
+++ b/frontend/src/lib/components/AppShortcuts/shortcuts.ts
@@ -3,6 +3,7 @@ export const baseModifier = ['command', 'option']
 export const keyBinds: Record<string, string[]> = {
     newTab: [...baseModifier, 't'],
     closeActiveTab: [...baseModifier, 'w'],
+    toggleShortcutMenu: [...baseModifier, 'k'],
     search: ['command', 'k'],
     new: [...baseModifier, 'n'],
     edit: [...baseModifier, 'e'],


### PR DESCRIPTION
## Problem
Some people had notion installed and that was conflicting with our `cmd shift k` 

![2025-11-19 16 33 10](https://github.com/user-attachments/assets/7287b577-48ac-4a4c-bae8-52c0ef71f9b9)

## Changes
* Remove redundant app shortcuts in Account Menu
* Added toggling for app shortcut menu (so we can press `cmd option k` again to close it)
* Change shortcut for shortcut menu trigger to `cmd option k`

## How did you test this code?
Locally 