### PR TITLE
feat(llma): improve error grouping with additional normalization patterns

### DIFF
--- a/products/llm_analytics/backend/queries/__init__.py
+++ b/products/llm_analytics/backend/queries/__init__.py
@@ -1,21 +1,22 @@
 from pathlib import Path
 
 
-def get_errors_query(filters: str = "true", order_by: str = "last_seen", order_direction: str = "DESC") -> str:
+def get_errors_query(order_by: str = "last_seen", order_direction: str = "DESC") -> str:
     """
     Load and parameterize the errors normalization query from errors.sql.
 
     Args:
-        filters: HogQL WHERE clause conditions (default: "true")
         order_by: Column to sort by (default: "last_seen")
         order_direction: Sort direction "ASC" or "DESC" (default: "DESC")
 
     Returns:
-        Complete HogQL query string with parameters substituted
+        HogQL query string with ORDER BY placeholders substituted.
+        The {filters} placeholder is left as-is for HogQL engine to handle.
     """
     query_path = Path(__file__).parent / "errors.sql"
     with open(query_path) as f:
         query_template = f.read()
 
-    # Replace template placeholders with actual values
-    return query_template.format(filters=filters, orderBy=order_by, orderDirection=order_direction)
+    # Simple string replacement for ORDER BY placeholders
+    # {filters} is left as-is - HogQL engine will handle it
+    return query_template.replace("__ORDER_BY__", order_by).replace("__ORDER_DIRECTION__", order_direction)

--- a/products/llm_analytics/backend/queries/errors.sql
+++ b/products/llm_analytics/backend/queries/errors.sql
@@ -20,7 +20,7 @@ extract
 -- Ordered from most specific to least specific to prevent pattern interference
 */
 
-WITH 
+WITH
 
 extracted_errors AS (
     -- Step 1: Extract error messages from various JSON structures in $ai_error
@@ -58,7 +58,7 @@ uuids_normalized AS (
         event,
         ai_trace_id,
         ai_session_id,
-        replaceRegexpAll(raw_error, '(req_[a-zA-Z0-9]+|[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}})', '<ID>') as error_text
+        replaceRegexpAll(raw_error, '(req_[a-zA-Z0-9]+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})', '<ID>') as error_text
     FROM extracted_errors
 ),
 
@@ -70,7 +70,7 @@ timestamps_normalized AS (
         event,
         ai_trace_id,
         ai_session_id,
-        replaceRegexpAll(error_text, '[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}T[0-9]{{2}}:[0-9]{{2}}:[0-9]{{2}}.[0-9]+Z?', '<TIMESTAMP>') as error_text
+        replaceRegexpAll(error_text, '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]+Z?', '<TIMESTAMP>') as error_text
     FROM uuids_normalized
 ),
 
@@ -105,7 +105,7 @@ json_id_fields_normalized AS (
         event,
         ai_trace_id,
         ai_session_id,
-        replaceRegexpAll(error_text, '"id":\s*"[a-zA-Z0-9_-]+"', '"id": "<ID>"') as error_text
+        replaceRegexpAll(error_text, '"id":\\s*"[a-zA-Z0-9_-]+"', '"id": "<ID>"') as error_text
     FROM response_ids_normalized
 ),
 
@@ -134,14 +134,14 @@ call_ids_normalized AS (
 ),
 
 user_ids_normalized AS (
-    -- Step 9: Normalize user IDs ('user_id': 'user_xxx' pattern)
+    -- Step 9: Normalize user IDs (user_id.{0,4}user_xxx pattern)
     SELECT
         distinct_id,
         timestamp,
         event,
         ai_trace_id,
         ai_session_id,
-        replaceRegexpAll(error_text, '''user_id'':\s*''user_[a-zA-Z0-9]+''', '''user_id'': ''user_<USER_ID>''') as error_text
+        replaceRegexpAll(error_text, '(user_id.{0,4})user_[a-zA-Z0-9]+', '\\1user_<USER_ID>') as error_text
     FROM call_ids_normalized
 ),
 
@@ -189,7 +189,7 @@ ids_normalized AS (
         event,
         ai_trace_id,
         ai_session_id,
-        replaceRegexpAll(error_text, '[0-9]{{9,}}', '<ID>') as error_text
+        replaceRegexpAll(error_text, '[0-9]{9,}', '<ID>') as error_text
     FROM token_counts_normalized
 ),
 
@@ -218,5 +218,5 @@ SELECT
     max(timestamp) as last_seen
 FROM all_numbers_normalized
 GROUP BY normalized_error
-ORDER BY {orderBy} {orderDirection}
+ORDER BY __ORDER_BY__ __ORDER_DIRECTION__
 LIMIT 50

--- a/products/llm_analytics/backend/queries/errors.sql
+++ b/products/llm_analytics/backend/queries/errors.sql
@@ -235,4 +235,4 @@ SELECT
 FROM whitespace_normalized
 GROUP BY normalized_error
 ORDER BY __ORDER_BY__ __ORDER_DIRECTION__
-LIMIT 50
+LIMIT 100

--- a/products/llm_analytics/backend/queries/errors.sql
+++ b/products/llm_analytics/backend/queries/errors.sql
@@ -122,26 +122,26 @@ tool_call_ids_normalized AS (
 ),
 
 call_ids_normalized AS (
-    -- Step 8: Normalize function call IDs (call_xxx pattern)
+    -- Step 8: Normalize function call IDs (function call call_xxx pattern)
     SELECT
         distinct_id,
         timestamp,
         event,
         ai_trace_id,
         ai_session_id,
-        replaceRegexpAll(error_text, 'call_[a-zA-Z0-9]+', 'call_<CALL_ID>') as error_text
+        replaceRegexpAll(error_text, 'function call call_[a-zA-Z0-9]+', 'function call call_<CALL_ID>') as error_text
     FROM tool_call_ids_normalized
 ),
 
 user_ids_normalized AS (
-    -- Step 9: Normalize user IDs (user_xxx pattern)
+    -- Step 9: Normalize user IDs ('user_id': 'user_xxx' pattern)
     SELECT
         distinct_id,
         timestamp,
         event,
         ai_trace_id,
         ai_session_id,
-        replaceRegexpAll(error_text, 'user_[a-zA-Z0-9]+', 'user_<USER_ID>') as error_text
+        replaceRegexpAll(error_text, '''user_id'':\s*''user_[a-zA-Z0-9]+''', '''user_id'': ''user_<USER_ID>''') as error_text
     FROM call_ids_normalized
 ),
 

--- a/products/llm_analytics/backend/test/test_error_normalization.py
+++ b/products/llm_analytics/backend/test/test_error_normalization.py
@@ -17,7 +17,7 @@ from products.llm_analytics.backend.queries import get_errors_query
 
 
 class TestErrorNormalization(ClickhouseTestMixin, APIBaseTest):
-    """Test the 10-step error normalization pipeline."""
+    """Test the 15-step error normalization pipeline."""
 
     # Test constants for long error messages
     GCP_PATH_1 = "Model projects/123/locations/us-west2/publishers/google/models/gemini-pro not found"

--- a/products/llm_analytics/backend/test/test_error_normalization.py
+++ b/products/llm_analytics/backend/test/test_error_normalization.py
@@ -222,6 +222,15 @@ ORDER BY occurrences DESC""",
     @parameterized.expand(
         [
             (
+                "JSON ID field normalization",
+                [
+                    '{"id": "oJf6eVw-z1gNr-99c2d11d156dff07", "error": "test"}',
+                    '{"id": "abc123xyz789", "error": "test"}',
+                    '{"id":"different-id-format", "error": "test"}',
+                ],
+                '{"id": "<ID>", "error": "test"}',
+            ),
+            (
                 "Call ID normalization",
                 [
                     "No tool output found for function call call_edLiisyOJybNZLouC6MCNxyC.",
@@ -273,11 +282,11 @@ ORDER BY occurrences DESC""",
     def test_new_patterns_combined(self):
         """Test that new normalization patterns work together with existing ones."""
         error_variants = [
-            "BadRequestError: No tool output found for function call call_edLiisyOJybNZLouC6MCNxyC for user_32yQoBNWxpvzxVJG0S0zxnnVSCJ at <object object at 0xfffced405130>",
-            "BadRequestError: No tool output found for function call call_abc123xyz789 for user_xyz789abc123def456 at <object object at 0xaaabec123456>",
+            '{"id": "oJf6eVw-z1gNr-99c2d11d156dff07"} call call_edLiisyOJybNZLouC6MCNxyC for user_32yQoBNWxpvzxVJG0S0zxnnVSCJ at <object object at 0xfffced405130>',
+            '{"id": "abc123xyz789"} call call_abc123xyz789 for user_xyz789abc123def456 at <object object at 0xaaabec123456>',
         ]
 
-        expected = "BadRequestError: No tool output found for function call call_<CALL_ID> for user_<USER_ID> at <object object at <OBJECT_ID>>"
+        expected = '{"id": "<ID>"} call call_<CALL_ID> for user_<USER_ID> at <object object at <OBJECT_ID>>'
 
         for error in error_variants:
             self._create_ai_event_with_error(error)

--- a/products/llm_analytics/frontend/llmAnalyticsLogic.tsx
+++ b/products/llm_analytics/frontend/llmAnalyticsLogic.tsx
@@ -1168,12 +1168,10 @@ export const llmAnalyticsLogic = kea<llmAnalyticsLogicType>([
                 groupsTaxonomicTypes: TaxonomicFilterGroupType[]
             ): DataTableNode => {
                 // Use the shared query template
-                // The SQL template uses Python's .format() escaping ({{ for literal {), so normalize those for HogQL
+                // Simple placeholder replacement - no escaping needed
                 const query = errorsQueryTemplate
-                    .replace(/\{\{/g, '{')
-                    .replace(/\}\}/g, '}')
-                    .replace('{orderBy}', errorsSort.column)
-                    .replace('{orderDirection}', errorsSort.direction)
+                    .replace('__ORDER_BY__', errorsSort.column)
+                    .replace('__ORDER_DIRECTION__', errorsSort.direction)
 
                 return {
                     kind: NodeKind.DataTableNode,


### PR DESCRIPTION
## Problem

The LLM analytics errors tab was not properly grouping errors that differ only in dynamic values like function call IDs, user IDs, memory addresses, and JSON ID fields. This made it difficult to identify and analyze recurring error patterns.

## Changes

**New normalization patterns added:**

1. **JSON "id" fields**: `"id": "oJf6eVw-z1gNr-99c2d11d156dff07"` → `"id": "<ID>"`
2. **Function call IDs**: `call_edLiisyOJybNZLouC6MCNxyC` → `call_<CALL_ID>`
3. **User IDs**: `user_32yQoBNWxpvzxVJG0S0zxnnVSCJ` → `user_<USER_ID>`
4. **Memory object IDs**: `0xfffced405130` → `<OBJECT_ID>`
5. **Standalone toolu_ IDs**: `toolu_01Bj5f7R5g9vhe7MkEyFT6Ty` → `<TOOL_ID>`
6. **Whitespace normalization**: Collapses multiple spaces and trims

**Query improvements:**

- Refactored `errors.sql` from Python `.format()` to pure HogQL with `__ORDER_BY__` placeholders
- Increased error groups limit from 50 to 100
- Added final whitespace normalization step

**Test improvements:**

- Extracted 30+ error message strings into class constants for readability
- Tests now use actual production query via `get_errors_query()` instead of duplicating SQL
- Reduced `@parameterized.expand` decorators from ~80 lines to ~15 lines

Updated the normalization pipeline from 10 steps to 15 steps total, with new patterns inserted at appropriate positions to maintain specificity ordering.

## How did you test this code?

Added parameterized tests in `products/llm_analytics/backend/test/test_error_normalization.py`:
- Individual test cases for each new normalization pattern
- Combined test cases verifying multiple patterns work together
- Tests that ensure different errors remain distinct (don't over-normalize)
- Tests for edge cases like empty/null errors and whitespace handling

All tests follow the existing test pattern and verify both the normalized output and occurrence counts.

**Performance verified:**
- Confirmed materialized column `mat_$ai_is_error` with set index is used
- Query execution time: 50-200ms with 1-day date filter (default)

## Changelog: (features only) Is this feature complete?

Not relevant as still behind feature flag under active development