### PR TITLE
fix: Force Snowflake to not ignore casing in our session

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -412,6 +412,8 @@ class SnowflakeClient:
         # Call this again in case level was reset.
         self.ensure_snowflake_logger_level("INFO")
 
+        await self.execute_async_query("ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE", fetch_results=False)
+
         if use_namespace:
             await self.use_namespace()
         await self.execute_async_query("SET ABORT_DETACHED_QUERY = FALSE", fetch_results=False)

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
@@ -164,7 +164,8 @@ async def test_snowflake_export_workflow_exports_events(
             execute_async_calls.append(call["query"].strip())
 
     warehouse = snowflake_batch_export.destination.config["warehouse"]
-    assert execute_async_calls[0:4] == [
+    assert execute_async_calls[0:5] == [
+        "ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE",
         f'USE DATABASE "{database}"',
         f'USE SCHEMA "{schema}"',
         f'USE WAREHOUSE "{warehouse}"',
@@ -173,9 +174,9 @@ async def test_snowflake_export_workflow_exports_events(
 
     assert all(query.startswith("PUT") for query in execute_calls[0:9])
 
-    assert execute_async_calls[4].startswith(f'CREATE TABLE IF NOT EXISTS "{table_name}"')
-    assert execute_async_calls[5].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
-    assert execute_async_calls[6].startswith(f'COPY INTO "{table_name}"')
+    assert execute_async_calls[5].startswith(f'CREATE TABLE IF NOT EXISTS "{table_name}"')
+    assert execute_async_calls[6].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
+    assert execute_async_calls[7].startswith(f'COPY INTO "{table_name}"')
 
 
 @pytest.mark.parametrize("interval", ["hour"], indirect=True)


### PR DESCRIPTION
## Problem

Snowflake can ignore casing when the `QUOTED_IDENTIFIERS_IGNORE_CASING` setting is set to `True`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Set `QUOTED_IDENTIFIERS_IGNORE_CASING = FALSE` in our session only, this would not impact other Snowflake sessions.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
