### PR TITLE
SUPPORT SUPERDAY: Add report a bug link to support panel

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import React from 'react'
 
-import { IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
+import { IconBug, IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { SupportForm } from 'lib/components/Support/SupportForm'
@@ -411,6 +411,17 @@ export function SidePanelSupport(): JSX.Element {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to="https://github.com/PostHog/posthog/issues/new"
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
## Problem

On the support sidebar in the app there are links to request a feature, upvote a roadmap item, and see the roadmap.
There wasn't an easy way to report an issue or bug there.
This would make it easier for people to get to the right spot to report anything they find.

## Changes

This adds a new button link to the bottom of the list of ways to share feedback to Report a bug.

## How did you test this code?

@abigailbramble I haven't really tested this out locally, but the change is fairly basic and adding in a new button based on an existing pattern. I'm pretty confident.

To see the changes in the app click on the Help button in the side menu and see the new button at the bottom of the list.
