### PR TITLE
fix(data-warehouse): Widen the conflict with recovery catching

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -790,7 +790,7 @@ def postgres_source(
 
                             successive_errors = 0
                     except psycopg.errors.SerializationFailure as e:
-                        if "terminating connection due to conflict with recovery" not in "".join(e.args):
+                        if "due to conflict with recovery" not in "".join(e.args):
                             raise
 
                         # This error happens when the read replica is out of sync with the primary


### PR DESCRIPTION
## Problem
- Dependent on the flavour of postgres, the "conflict with recovery" error may not be getting caught correctly, for example, we just saw `canceling statement due to conflict with recovery` which gets immediately re-raised when it shouldn't due to the tight check

## Changes
- Make the check more broad 