### PR TITLE
feat(sessions): Add config and team_id splitting to sessions dags

### DIFF
--- a/dags/sessions.py
+++ b/dags/sessions.py
@@ -123,7 +123,7 @@ def _do_backfill(
         merged_settings.update(config.clickhouse_settings)
         context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
-    team_id_chunks = config.team_id_chunks or 1
+    team_id_chunks = max(1, config.team_id_chunks or 1)
 
     context.log.info(
         f"Running backfill for {partition_range_str} (where='{where_clause}') using commit {get_git_commit_short() or 'unknown'} "


### PR DESCRIPTION
## Problem

It is a pain to keep changing settings via PR to see if they do anything, so I have just exposed some config to do this via the dagster UI.

I'm also going to try chunking the team_ids

(the underlying problem is that my job ran OOM at 100GiB)

## Changes

* Add config
* Add team_id chunking
* Dedup code between the 2 backfill functions, putting the common code in `_do_backfill`

## How did you test this code?

Materialized this asset in local dev

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
