### PR TITLE
fix(tests): add retry logic to Temporal test connections

### DIFF
--- a/posthog/management/commands/test/conftest.py
+++ b/posthog/management/commands/test/conftest.py
@@ -28,7 +28,7 @@ def sync_connect_with_retry(max_retries: int = 5, initial_delay: float = 0.5) ->
         RPCError: If connection fails after all retries
     """
     delay = initial_delay
-    last_error = None
+    last_error: RPCError | None = None
 
     for attempt in range(max_retries):
         try:
@@ -52,7 +52,8 @@ def sync_connect_with_retry(max_retries: int = 5, initial_delay: float = 0.5) ->
                 # If it's a different error, don't retry
                 raise
 
-    # If we get here, all retries failed
+    # If we get here, all retries failed and last_error must be set
+    assert last_error is not None
     raise last_error
 
 

--- a/posthog/management/commands/test/conftest.py
+++ b/posthog/management/commands/test/conftest.py
@@ -1,0 +1,68 @@
+import time
+import logging
+
+import pytest
+
+from temporalio.client import Client as TemporalClient
+from temporalio.service import RPCError
+
+from posthog.temporal.common.client import sync_connect
+
+logger = logging.getLogger(__name__)
+
+
+def sync_connect_with_retry(max_retries: int = 5, initial_delay: float = 0.5) -> TemporalClient:
+    """Connect to Temporal with exponential backoff retry logic.
+
+    This helps handle transient connection issues where Temporal might not be ready
+    when tests start, preventing flaky "Not enough hosts to serve the request" errors.
+
+    Args:
+        max_retries: Maximum number of connection attempts
+        initial_delay: Initial delay in seconds between retries (doubles each retry)
+
+    Returns:
+        Connected Temporal client
+
+    Raises:
+        RPCError: If connection fails after all retries
+    """
+    delay = initial_delay
+    last_error = None
+
+    for attempt in range(max_retries):
+        try:
+            logger.info(f"Attempting to connect to Temporal (attempt {attempt + 1}/{max_retries})")
+            client = sync_connect()
+            logger.info("Successfully connected to Temporal")
+            return client
+        except RPCError as e:
+            last_error = e
+            if "Not enough hosts to serve the request" in str(e):
+                if attempt < max_retries - 1:
+                    logger.warning(
+                        f"Temporal connection failed (attempt {attempt + 1}/{max_retries}): {e}. "
+                        f"Retrying in {delay}s..."
+                    )
+                    time.sleep(delay)
+                    delay *= 2  # Exponential backoff
+                else:
+                    logger.exception(f"Failed to connect to Temporal after {max_retries} attempts")
+            else:
+                # If it's a different error, don't retry
+                raise
+
+    # If we get here, all retries failed
+    raise last_error
+
+
+@pytest.fixture(scope="module")
+def temporal():
+    """Return a TemporalClient instance with retry logic.
+
+    This fixture is module-scoped to reuse the same connection across all tests
+    in a module, which is both faster and more reliable than creating a new
+    connection for each test.
+    """
+    client = sync_connect_with_retry()
+    yield client

--- a/posthog/management/commands/test/test_create_batch_export_from_app.py
+++ b/posthog/management/commands/test/test_create_batch_export_from_app.py
@@ -17,7 +17,6 @@ from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.management.commands.create_batch_export_from_app import map_plugin_config_to_destination
 from posthog.models import Plugin, PluginAttachment, PluginConfig
-from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.codec import EncryptionCodec
 
 
@@ -389,6 +388,7 @@ def test_create_batch_export_from_app(
     interval,
     plugin_config,
     disable_plugin_config,
+    temporal,
 ):
     """Test a live run of the create_batch_export_from_app command."""
     args = [
@@ -415,8 +415,6 @@ def test_create_batch_export_from_app(
         "type": export_type,
         "config": config,
     }
-
-    temporal = sync_connect()
 
     schedule = describe_schedule(temporal, str(batch_export_data["id"]))
     expected_interval = dt.timedelta(**{f"{interval}s": 1})
@@ -455,6 +453,7 @@ def test_create_batch_export_from_app_with_disabled_plugin(
     interval,
     plugin_config,
     migrate_disabled_plugin_config,
+    temporal,
 ):
     """Test a live run of the create_batch_export_from_app command."""
     args = [
@@ -487,8 +486,6 @@ def test_create_batch_export_from_app_with_disabled_plugin(
         return
 
     assert "id" in batch_export_data
-
-    temporal = sync_connect()
 
     schedule = describe_schedule(temporal, str(batch_export_data["id"]))
     expected_interval = dt.timedelta(**{f"{interval}s": 1})

--- a/posthog/management/commands/test/test_update_batch_export_schedules.py
+++ b/posthog/management/commands/test/test_update_batch_export_schedules.py
@@ -13,8 +13,8 @@ from temporalio.service import RPCError
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.batch_exports.service import pause_batch_export, sync_batch_export
+from posthog.management.commands.test.conftest import sync_connect_with_retry
 from posthog.models import BatchExport, BatchExportDestination
-from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import describe_schedule, update_schedule
 
 pytestmark = [
@@ -104,7 +104,7 @@ def cleanup_temporal_schedules(temporal: TemporalClient):
 @pytest.fixture
 def temporal():
     """Return a TemporalClient instance."""
-    client = sync_connect()
+    client = sync_connect_with_retry()
     yield client
     cleanup_temporal_schedules(client)
 

--- a/posthog/management/commands/test/test_update_data_import_schedules.py
+++ b/posthog/management/commands/test/test_update_data_import_schedules.py
@@ -11,8 +11,8 @@ from temporalio.service import RPCError
 
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
+from posthog.management.commands.test.conftest import sync_connect_with_retry
 from posthog.management.commands.update_data_import_schedules import _get_external_data_schemas
-from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import describe_schedule, update_schedule
 
 from products.data_warehouse.backend.data_load.service import sync_external_data_job_workflow
@@ -89,7 +89,7 @@ def cleanup_temporal_schedules(client):
 @pytest.fixture(autouse=True)
 def temporal():
     """Return a TemporalClient instance and cleanup any schedules created during the test."""
-    client = sync_connect()
+    client = sync_connect_with_retry()
     yield client
     cleanup_temporal_schedules(client)
 


### PR DESCRIPTION
## Problem

I kept hitting temporal test failures of `" - temporalio.service.RPCError: Not enough hosts to serve the request"` on multiple PRs, which were just flaky and eventually go away, i asked claude to help me fix that 👀 

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

add a retry to connect
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
this is the test itself
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
