### PR TITLE
fix: Update logs banner message from beta to alpha

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -96,7 +96,7 @@ export function LogsScene(): JSX.Element {
                 action={{ children: 'Send feedback', id: 'logs-feedback-button' }}
             >
                 <p>
-                    Logs is in beta and things will change as we figure out what works. Right now you have 7-day
+                    Logs is in alpha and things will change as we figure out what works. Right now you have 7-day
                     retention with ingestion rate limits. Tell us what you need, what's broken, or if you're hitting
                     limits, we want to hear from you.
                 </p>


### PR DESCRIPTION
Big banner at the top of logs says it's in beta, while it's actually in alpha. This PR adjusts that. very important pr as you can see.
