### PR TITLE
test: create separate test database for persons to enforce cross-database isolation

### DIFF
--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -517,6 +517,7 @@ def pytest_sessionstart():
         "pendingpersonoverride",
         "flatpersonoverride",
         "featureflaghashkeyoverride",
+        "cohort",
         "cohortpeople",
         "group",
         "grouptypemapping",

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -527,3 +527,18 @@ def pytest_sessionstart():
         # Keep sqlx-managed models unmanaged
         if m._meta.model_name and m._meta.model_name.lower() not in SQLX_MANAGED_MODELS:
             m._meta.managed = True
+
+
+def pytest_configure(config):
+    """Configure pytest-django to allow access to persons databases by default.
+
+    This ensures all Django test classes (TestCase, TransactionTestCase) have access
+    to the persons_db_writer and persons_db_reader databases without needing to
+    explicitly declare databases attribute on each test class.
+    """
+    from django.test import TestCase, TransactionTestCase
+
+    # Set default databases for Django test classes
+    # This allows tests to access Person/PersonDistinctId models in separate persons database
+    TestCase.databases = {"default", "persons_db_writer", "persons_db_reader"}
+    TransactionTestCase.databases = {"default", "persons_db_writer", "persons_db_reader"}

--- a/posthog/models/test/test_person_schema.py
+++ b/posthog/models/test/test_person_schema.py
@@ -82,9 +82,6 @@ def get_partition_count(parent_table: str) -> int:
 class TestPersonSchemaConsistency(TestCase):
     """Verify person table structure created by sqlx migrations."""
 
-    # Person tables are in separate persons_db_writer database
-    databases = ["default", "persons_db_writer"]
-
     def test_person_table_exists(self):
         """Verify person table exists."""
         self.assertTrue(

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -183,6 +183,17 @@ if persons_db_writer_url:
         DATABASES["persons_db_writer"]["DISABLE_SERVER_SIDE_CURSORS"] = True
         DATABASES["persons_db_reader"]["DISABLE_SERVER_SIDE_CURSORS"] = True
 
+    # Configure test database creation for persons databases
+    if TEST:
+        # Tell Django to create separate test database for persons
+        # Use same test database name as writer for reader (they're the same in tests)
+        DATABASES["persons_db_writer"]["TEST"] = {
+            "NAME": DATABASES["persons_db_writer"]["NAME"],
+        }
+        DATABASES["persons_db_reader"]["TEST"] = {
+            "NAME": DATABASES["persons_db_writer"]["NAME"],  # Point to same test DB as writer
+        }
+
     # Register PersonDBRouter in both test and production modes
     # This ensures cross-database joins are properly blocked in tests (mirroring production)
     DATABASE_ROUTERS.insert(0, "posthog.person_db_router.PersonDBRouter")


### PR DESCRIPTION
**Stacked on #41513**

Create separate `test_posthog_persons` database for person-related tables, mirroring production setup where persons DB is separate from default DB.

**Problem**
Tests currently run against a single test database, allowing Django ORM to create joins between person tables and other tables (like Team, Project, etc.). In production, these tables are in separate databases, so joins break or return wrong data. We need to mirror the production setup in tests.

**Changes**
- Configure `persons_db_writer`/`persons_db_reader` for test mode pointing to `posthog_persons_test`
- Enable `PersonDBRouter` in test mode to enforce cross-database join restrictions
- Update conftest.py to use persons_db_writer connection for all person table operations
- Update sqlx migration runner to target persons test database
- Fix person schema tests to use persons connection and declare both databases

**Impact**
Tests that attempt cross-database joins (Person→Team, etc.) will now fail appropriately, helping catch production issues early. The PersonDBRouter's `allow_relation=False` is now enforced in tests.

**Test plan**
- All person schema tests pass (6 tests validating partitioned table structure)
- Separate test databases created: `test_posthog` and `test_posthog_persons_test`
- Ready to identify and fix tests that rely on cross-database joins