### PR TITLE
fix(funnels): prevent exploring actors for funnels aggregated by sessions

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
@@ -135,11 +135,15 @@ export function FunnelBarHorizontal({
                                     })}
                                     <div
                                         className="funnel-bar-empty-space"
-                                        onClick={() => openPersonsModalForStep({ step, converted: false })} // dropoff value for steps is negative
+                                        onClick={
+                                            showPersonsModal
+                                                ? () => openPersonsModalForStep({ step, converted: false }) // dropoff value for steps is negative
+                                                : undefined
+                                        }
                                         // eslint-disable-next-line react/forbid-dom-props
                                         style={{
                                             flex: `${1 - breakdownSum / basisStep.count} 1 0`,
-                                            cursor: `${!inCardView ? 'pointer' : ''}`,
+                                            cursor: `${showPersonsModal && !inCardView ? 'pointer' : ''}`,
                                         }}
                                     >
                                         {isBreakdown && (
@@ -163,11 +167,15 @@ export function FunnelBarHorizontal({
                                     />
                                     <div
                                         className="funnel-bar-empty-space"
-                                        onClick={() => openPersonsModalForStep({ step, converted: false })} // dropoff value for steps is negative
+                                        onClick={
+                                            showPersonsModal
+                                                ? () => openPersonsModalForStep({ step, converted: false }) // dropoff value for steps is negative
+                                                : undefined
+                                        }
                                         // eslint-disable-next-line react/forbid-dom-props
                                         style={{
                                             flex: `${1 - step.conversionRates.fromBasisStep} 1 0`,
-                                            cursor: `${!inCardView ? 'pointer' : ''}`,
+                                            cursor: `${showPersonsModal && !inCardView ? 'pointer' : ''}`,
                                         }}
                                     />
                                 </>


### PR DESCRIPTION
## Problem
Currently, we do not support exploring the sessions when aggregating funnels by "unique sessions".
Prevent both converted and dropped users from being explored for this aggregation

https://posthoghelp.zendesk.com/agent/tickets/42943 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/53766)

## Changes

Do not allow clicking on the "converted" bar in funnels

## How did you test this code?

Manually
