### PR TITLE
feat: generate api key in onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsModal.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsModal.tsx
@@ -20,7 +20,7 @@ export function SourceMapsInstructionsModal({
     const InstructionComponent = sdkInstructions as (() => JSX.Element) | undefined
 
     return (
-        <LemonModal isOpen={isOpen} onClose={onClose} simple title="">
+        <LemonModal isOpen={isOpen} onClose={onClose} simple title="" zIndex="1161">
             <div className="overflow-y-auto p-6">
                 {InstructionComponent && (
                     <div className="space-y-4">

--- a/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsModal.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsModal.tsx
@@ -20,7 +20,7 @@ export function SourceMapsInstructionsModal({
     const InstructionComponent = sdkInstructions as (() => JSX.Element) | undefined
 
     return (
-        <LemonModal isOpen={isOpen} onClose={onClose} simple title="" zIndex="1161">
+        <LemonModal isOpen={isOpen} onClose={onClose} simple title="">
             <div className="overflow-y-auto p-6">
                 {InstructionComponent && (
                     <div className="space-y-4">

--- a/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsStep.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsStep.tsx
@@ -6,6 +6,7 @@ import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 
 import { OnboardingStepKey } from '~/types'
 
+import { EditKeyModal } from '../../settings/user/PersonalAPIKeys'
 import { OnboardingStep } from '../OnboardingStep'
 import { SourceMapsInstructionsModal } from './OnboardingErrorTrackingSourceMapsModal'
 import { SourceMapOptionCard } from './source-maps/SourceMapOptionCard'
@@ -126,6 +127,8 @@ export function OnboardingErrorTrackingSourceMapsStep({ stepKey }: { stepKey: On
             )}
 
             {shouldShowSourceMapStatus && <SourceMapStatus />}
+
+            <EditKeyModal />
         </OnboardingStep>
     )
 }

--- a/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsStep.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsStep.tsx
@@ -128,7 +128,7 @@ export function OnboardingErrorTrackingSourceMapsStep({ stepKey }: { stepKey: On
 
             {shouldShowSourceMapStatus && <SourceMapStatus />}
 
-            <EditKeyModal zIndex="1169" />
+            <EditKeyModal zIndex="1162" />
         </OnboardingStep>
     )
 }

--- a/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsStep.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/OnboardingErrorTrackingSourceMapsStep.tsx
@@ -128,7 +128,7 @@ export function OnboardingErrorTrackingSourceMapsStep({ stepKey }: { stepKey: On
 
             {shouldShowSourceMapStatus && <SourceMapStatus />}
 
-            <EditKeyModal />
+            <EditKeyModal zIndex="1169" />
         </OnboardingStep>
     )
 }

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/SourceMapsAPIKeyBanner.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/SourceMapsAPIKeyBanner.tsx
@@ -16,18 +16,20 @@ export function SourceMapsAPIKeyBanner(): JSX.Element {
                 preset: preset.value,
                 label: preset.label,
                 scopes: preset.scopes,
-                access_type: preset.access_type || 'all',
+                access_type: preset.access_type,
             })
         }
     }
 
     return (
         <LemonBanner type="info" className="mb-4">
-            <strong>Note:</strong> The project API key is not the same as the personal API token required to upload
-            source maps.{' '}
-            <LemonButton type="secondary" size="xsmall" onClick={openAPIKeyModal}>
-                Generate personal API key
-            </LemonButton>
+            <div className="flex items-center gap-2 justify-between">
+                The project API key used to initialize PostHog is not the same as the personal API key required to
+                upload source maps.{' '}
+                <LemonButton type="primary" onClick={openAPIKeyModal}>
+                    Generate personal API key
+                </LemonButton>
+            </div>
         </LemonBanner>
     )
 }

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/SourceMapsAPIKeyBanner.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/SourceMapsAPIKeyBanner.tsx
@@ -27,7 +27,7 @@ export function SourceMapsAPIKeyBanner(): JSX.Element {
                 The project API key used to initialize PostHog is not the same as the personal API key required to
                 upload source maps.{' '}
                 <LemonButton type="primary" onClick={openAPIKeyModal}>
-                    Generate personal API key
+                    Create personal API key
                 </LemonButton>
             </div>
         </LemonBanner>

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/SourceMapsAPIKeyBanner.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/SourceMapsAPIKeyBanner.tsx
@@ -1,0 +1,33 @@
+import { useActions } from 'kea'
+
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+
+import { API_KEY_SCOPE_PRESETS } from 'lib/scopes'
+import { personalAPIKeysLogic } from 'scenes/settings/user/personalAPIKeysLogic'
+
+export function SourceMapsAPIKeyBanner(): JSX.Element {
+    const { setEditingKeyId, setEditingKeyValues } = useActions(personalAPIKeysLogic)
+
+    const openAPIKeyModal = (): void => {
+        const preset = API_KEY_SCOPE_PRESETS.find((p) => p.value === 'source_map_upload')
+        if (preset) {
+            setEditingKeyId('new')
+            setEditingKeyValues({
+                preset: preset.value,
+                label: preset.label,
+                scopes: preset.scopes,
+                access_type: preset.access_type || 'all',
+            })
+        }
+    }
+
+    return (
+        <LemonBanner type="info" className="mb-4">
+            <strong>Note:</strong> The project API key is not the same as the personal API token required to upload
+            source maps.{' '}
+            <LemonButton type="secondary" size="xsmall" onClick={openAPIKeyModal}>
+                Generate personal API key
+            </LemonButton>
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/SourceMapsAPIKeyBanner.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/SourceMapsAPIKeyBanner.tsx
@@ -25,7 +25,7 @@ export function SourceMapsAPIKeyBanner(): JSX.Element {
         <LemonBanner type="info" className="mb-4">
             <div className="flex items-center gap-2 justify-between">
                 The project API key used to initialize PostHog is not the same as the personal API key required to
-                upload source maps.{' '}
+                upload source maps. If you want to upload source maps, you can create a personal API key here.
                 <LemonButton type="primary" onClick={openAPIKeyModal}>
                     Create personal API key
                 </LemonButton>

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NextJSSourceMapsInstructions.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NextJSSourceMapsInstructions.tsx
@@ -1,17 +1,43 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { API_KEY_SCOPE_PRESETS } from 'lib/scopes'
 import { apiHostOrigin } from 'lib/utils/apiHost'
+import { personalAPIKeysLogic } from 'scenes/settings/user/personalAPIKeysLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { VerifySourceMaps } from '../VerifySourceMaps'
 
 export function NextJSSourceMapsInstructions(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
+    const { setEditingKeyId, setEditingKeyValues } = useActions(personalAPIKeysLogic)
     const host = apiHostOrigin()
+
+    const openAPIKeyModal = (): void => {
+        const preset = API_KEY_SCOPE_PRESETS.find((p) => p.value === 'source_map_upload')
+        if (preset) {
+            setEditingKeyId('new')
+            setEditingKeyValues({
+                preset: preset.value,
+                label: preset.label,
+                scopes: preset.scopes,
+                access_type: preset.access_type || 'all',
+            })
+        }
+    }
 
     return (
         <>
+            <LemonBanner type="info" className="mb-4">
+                <strong>Note:</strong> The project API key is not the same as the personal API token required to upload
+                source maps.{' '}
+                <LemonButton type="secondary" size="xsmall" onClick={openAPIKeyModal}>
+                    Generate personal API key
+                </LemonButton>
+            </LemonBanner>
+
             <h3>Install the PostHog Next.js config package</h3>
             <p>
                 This package handles automatic source map generation and upload for error tracking. Install it using

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NextJSSourceMapsInstructions.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NextJSSourceMapsInstructions.tsx
@@ -1,42 +1,19 @@
-import { useActions, useValues } from 'kea'
-
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { useValues } from 'kea'
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
-import { API_KEY_SCOPE_PRESETS } from 'lib/scopes'
 import { apiHostOrigin } from 'lib/utils/apiHost'
-import { personalAPIKeysLogic } from 'scenes/settings/user/personalAPIKeysLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { SourceMapsAPIKeyBanner } from '../SourceMapsAPIKeyBanner'
 import { VerifySourceMaps } from '../VerifySourceMaps'
 
 export function NextJSSourceMapsInstructions(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
-    const { setEditingKeyId, setEditingKeyValues } = useActions(personalAPIKeysLogic)
     const host = apiHostOrigin()
-
-    const openAPIKeyModal = (): void => {
-        const preset = API_KEY_SCOPE_PRESETS.find((p) => p.value === 'source_map_upload')
-        if (preset) {
-            setEditingKeyId('new')
-            setEditingKeyValues({
-                preset: preset.value,
-                label: preset.label,
-                scopes: preset.scopes,
-                access_type: preset.access_type || 'all',
-            })
-        }
-    }
 
     return (
         <>
-            <LemonBanner type="info" className="mb-4">
-                <strong>Note:</strong> The project API key is not the same as the personal API token required to upload
-                source maps.{' '}
-                <LemonButton type="secondary" size="xsmall" onClick={openAPIKeyModal}>
-                    Generate personal API key
-                </LemonButton>
-            </LemonBanner>
+            <SourceMapsAPIKeyBanner />
 
             <h3>Install the PostHog Next.js config package</h3>
             <p>

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NuxtSourceMapsInstructions.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NuxtSourceMapsInstructions.tsx
@@ -1,17 +1,43 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { API_KEY_SCOPE_PRESETS } from 'lib/scopes'
 import { apiHostOrigin } from 'lib/utils/apiHost'
+import { personalAPIKeysLogic } from 'scenes/settings/user/personalAPIKeysLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { VerifySourceMaps } from '../VerifySourceMaps'
 
 export function NuxtSourceMapsInstructions(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
+    const { setEditingKeyId, setEditingKeyValues } = useActions(personalAPIKeysLogic)
     const host = apiHostOrigin()
+
+    const openAPIKeyModal = (): void => {
+        const preset = API_KEY_SCOPE_PRESETS.find((p) => p.value === 'source_map_upload')
+        if (preset) {
+            setEditingKeyId('new')
+            setEditingKeyValues({
+                preset: preset.value,
+                label: preset.label,
+                scopes: preset.scopes,
+                access_type: preset.access_type || 'all',
+            })
+        }
+    }
 
     return (
         <>
+            <LemonBanner type="info" className="mb-4">
+                <strong>Note:</strong> The project API key is not the same as the personal API token required to upload
+                source maps.{' '}
+                <LemonButton type="secondary" size="xsmall" onClick={openAPIKeyModal}>
+                    Generate personal API key
+                </LemonButton>
+            </LemonBanner>
+
             <p>
                 For Nuxt v3.7 and above, the official <code>@posthog/nuxt</code> module provides automatic source map
                 generation and upload.

--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NuxtSourceMapsInstructions.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/automated-technologies/NuxtSourceMapsInstructions.tsx
@@ -1,42 +1,19 @@
-import { useActions, useValues } from 'kea'
-
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { useValues } from 'kea'
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
-import { API_KEY_SCOPE_PRESETS } from 'lib/scopes'
 import { apiHostOrigin } from 'lib/utils/apiHost'
-import { personalAPIKeysLogic } from 'scenes/settings/user/personalAPIKeysLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { SourceMapsAPIKeyBanner } from '../SourceMapsAPIKeyBanner'
 import { VerifySourceMaps } from '../VerifySourceMaps'
 
 export function NuxtSourceMapsInstructions(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
-    const { setEditingKeyId, setEditingKeyValues } = useActions(personalAPIKeysLogic)
     const host = apiHostOrigin()
-
-    const openAPIKeyModal = (): void => {
-        const preset = API_KEY_SCOPE_PRESETS.find((p) => p.value === 'source_map_upload')
-        if (preset) {
-            setEditingKeyId('new')
-            setEditingKeyValues({
-                preset: preset.value,
-                label: preset.label,
-                scopes: preset.scopes,
-                access_type: preset.access_type || 'all',
-            })
-        }
-    }
 
     return (
         <>
-            <LemonBanner type="info" className="mb-4">
-                <strong>Note:</strong> The project API key is not the same as the personal API token required to upload
-                source maps.{' '}
-                <LemonButton type="secondary" size="xsmall" onClick={openAPIKeyModal}>
-                    Generate personal API key
-                </LemonButton>
-            </LemonBanner>
+            <SourceMapsAPIKeyBanner />
 
             <p>
                 For Nuxt v3.7 and above, the official <code>@posthog/nuxt</code> module provides automatic source map

--- a/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
@@ -12,6 +12,7 @@ import {
     LemonLabel,
     LemonMenu,
     LemonModal,
+    LemonModalProps,
     LemonSegmentedButton,
     LemonSelect,
     LemonTable,
@@ -30,7 +31,11 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { personalAPIKeysLogic } from './personalAPIKeysLogic'
 import ScopeAccessSelector from './scopes/ScopeAccessSelector'
 
-export function EditKeyModal(): JSX.Element {
+interface EditKeyModalProps {
+    zIndex?: LemonModalProps['zIndex']
+}
+
+export function EditKeyModal({ zIndex }: EditKeyModalProps): JSX.Element {
     const {
         editingKeyId,
         isEditingKeySubmitting,
@@ -54,6 +59,7 @@ export function EditKeyModal(): JSX.Element {
                 isOpen={!!editingKeyId}
                 width="40rem"
                 hasUnsavedInput={editingKeyChanged}
+                zIndex={zIndex}
                 footer={
                     <>
                         <LemonButton type="secondary" onClick={() => setEditingKeyId(null)}>

--- a/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
@@ -30,7 +30,7 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { personalAPIKeysLogic } from './personalAPIKeysLogic'
 import ScopeAccessSelector from './scopes/ScopeAccessSelector'
 
-function EditKeyModal(): JSX.Element {
+export function EditKeyModal(): JSX.Element {
     const {
         editingKeyId,
         isEditingKeySubmitting,

--- a/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
+++ b/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
@@ -461,7 +461,8 @@ export const personalAPIKeysLogic = kea<personalAPIKeysLogicType>([
         setEditingKeyId: ({ id }) => {
             if (!id) {
                 // When the modal is closed, remove the preset from the URL
-                return [router.values.location.pathname, {}, router.values.location.hash]
+                const { preset, ...searchParams } = router.values.searchParams
+                return [router.values.location.pathname, searchParams, router.values.location.hash]
             }
         },
     })),

--- a/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
+++ b/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
@@ -394,6 +394,7 @@ export const personalAPIKeysLogic = kea<personalAPIKeysLogicType>([
             LemonDialog.open({
                 title: 'Personal API key ready',
                 width: 536,
+                zIndex: '1168',
                 content: (
                     <>
                         <p className="mb-4">You can now use key "{key.label}" for authentication:</p>


### PR DESCRIPTION
## Problem

Saw couple of customer complaints that it is not exactly clear that personal api key used to upload source maps is not the same as api key used to send exceptions.

Working on a ticket where it was mentioned again.

## Changes

In onboarding in modals related to technologies where providing personal api key is required there is a new banner which let's you directly create a personal api key with required scope.

| Source maps onboarding step | Next/Nuxt modal |
|--------|--------|
| <img width="1914" height="921" alt="image" src="https://github.com/user-attachments/assets/ffbd980c-855a-4ff7-96e6-16e1365b87e7" /> | <img width="1912" height="954" alt="image" src="https://github.com/user-attachments/assets/fcf7c8a2-8f9a-41a5-bbd0-bef3a161ea82" /> | 

| Create key modal | Key is ready |
|--------|--------|
| <img width="1910" height="923" alt="image" src="https://github.com/user-attachments/assets/2862dc5d-98db-4d6a-870e-8e93f4250984" /> | <img width="1915" height="921" alt="image" src="https://github.com/user-attachments/assets/ec51535e-ad76-400c-a2ff-fc63a6538c36" /> | 

## How did you test this code?

Locally
