### PR TITLE
fix(ph-ai): Update memory setting text from "Max" to "PostHog AI"

### DIFF
--- a/frontend/src/scenes/settings/environment/MaxMemorySettings.tsx
+++ b/frontend/src/scenes/settings/environment/MaxMemorySettings.tsx
@@ -25,7 +25,7 @@ export function MaxMemorySettings(): JSX.Element {
                     <LemonSkeleton className="h-16" />
                 </div>
             ) : (
-                <LemonField name="text" label="Max’s memory">
+                <LemonField name="text" label="PostHog AI's memory">
                     <LemonTextArea
                         id="product-description-textarea" // Slightly dirty ID for .focus() elsewhere
                         placeholder={`What should PostHog AI know about ${


### PR DESCRIPTION
## Problem

The label "Max's memory" in organization settings needed to be updated to "PostHog AI's memory" for branding consistency.

## Changes

Updated the label for the AI memory setting in `frontend/src/scenes/settings/environment/MaxMemorySettings.tsx`.

```diff
-                <LemonField name="text" label="Max’s memory">
+                <LemonField name="text" label="PostHog AI's memory">
```

## How did you test this code?

Manually verified the text change in the organization settings UI. No automated tests were run as this is a text-only change.

## Changelog: (features only) Is this feature complete?

Yes

---
<a href="https://cursor.com/background-agent?bcId=bc-bf53ee94-d51b-4ac1-a0b3-2219ce16ec86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf53ee94-d51b-4ac1-a0b3-2219ce16ec86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

