### PR TITLE
chore: add cymbal to hobby docker

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -292,6 +292,11 @@ services:
         environment:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             KAFKA_HOSTS: 'kafka:9092'
+        depends_on:
+            db:
+                condition: service_healthy
+            kafka:
+                condition: service_started
 
     feature-flags:
         image: ghcr.io/posthog/posthog/feature-flags:master

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -282,6 +282,17 @@ services:
             SKIP_READS: 'false'
             FILTER_MODE: 'opt-out'
 
+    cymbal:
+        image: ghcr.io/posthog/posthog/cymbal:master
+        build:
+            context: rust/
+            args:
+                BIN: cymbal
+        restart: on-failure
+        environment:
+            DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
+            KAFKA_HOSTS: 'kafka:9092'
+
     feature-flags:
         image: ghcr.io/posthog/posthog/feature-flags:master
         build:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -286,6 +286,13 @@ services:
             file: docker-compose.base.yml
             service: property-defs-rs
 
+    cymbal:
+        build:
+            context: ./posthog/rust
+        extends:
+            file: docker-compose.base.yml
+            service: cymbal
+
     livestream:
         extends:
             file: docker-compose.base.yml

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -292,6 +292,11 @@ services:
         extends:
             file: docker-compose.base.yml
             service: cymbal
+        depends_on:
+            db:
+                condition: service_healthy
+            kafka:
+                condition: service_started
 
     livestream:
         extends:


### PR DESCRIPTION
## Problem

$exception events do not go through the normal plugin-server ingestion flow. Cymbal is currently not started in the self hosted docker environment so they are never processed

## Changes

Add cymbal to the hobby docker compose file