### PR TITLE
feat(dagster): delete persons from trigger log table job

### DIFF
--- a/dags/delete_persons_from_trigger_log_job.py
+++ b/dags/delete_persons_from_trigger_log_job.py
@@ -191,12 +191,12 @@ def scan_delete_chunk(
                     # Begin transaction (settings already applied at session level)
                     cursor.execute("BEGIN")
 
-                    # Query to find posthog_persondistinctid rows without a parent posthog_person row
+                    # Query to find posthog_person_deletes_log rows
                     scan_query = f"""
-SELECT p.id, p.team_id
+SELECT pdl.id, pdl.team_id
 FROM posthog_person_deletes_log AS pdl
 WHERE pdl.id >= %s AND pdl.id <= %s
-  AND NOT EXISTS (
+  AND EXISTS (
     SELECT 1
     FROM {config.persons_table} AS p
     WHERE pdl.id = p.id

--- a/dags/delete_persons_from_trigger_log_job.py
+++ b/dags/delete_persons_from_trigger_log_job.py
@@ -1,0 +1,437 @@
+"""Dagster job for deleting posthog_person_new rows (cascading to N associated posthog_persondistinctid rows)
+that are present in the trigger log table used to capture deletes on the unpartitioned DB while we
+transitioned to the new, partitioned DB."""
+
+import os
+import time
+from typing import Any
+
+import dagster
+import psycopg2
+import psycopg2.errors
+from dagster_k8s import k8s_job_executor
+
+from posthog.clickhouse.cluster import ClickhouseCluster
+from posthog.clickhouse.custom_metrics import MetricsClient
+
+from dags.common import JobOwners
+
+MAX_RETRY_ATTEMPTS = 5
+
+
+class DeletePersonsFromTriggerLogConfig(dagster.Config):
+    """Configuration for the delete persons from trigger log job."""
+
+    persons_table: str = "posthog_person_new"
+    chunk_size: int = 10_000  # ID range per chunk
+    batch_size: int = 100  # Work in small batches since each person ID will cascade a delete to many distinct ID rows
+    max_id: int | None = None  # Optional override for max ID to resume from partial state
+    min_id: int | None = None  # Optional override for min ID to resume from partial state
+
+
+@dagster.op
+def get_id_range(
+    context: dagster.OpExecutionContext,
+    config: DeletePersonsFromTriggerLogConfig,
+    database: dagster.ResourceParam[psycopg2.extensions.connection],
+) -> tuple[int, int]:
+    """
+    Query source database for MIN(id) and MAX(id) from posthog_person_deletes_log
+    table. If min_id and max_id are provided in config, uses that instead of querying.
+    Returns tuple (min_id, max_id).
+    """
+    with database.cursor() as cursor:
+        # Use config min_id if provided, otherwise query database
+        if config.min_id is not None:
+            min_id = config.min_id
+            context.log.info(f"Using configured min_id override: {min_id}")
+        else:
+            min_query = f"SELECT MIN(id) as min_id FROM posthog_person_deletes_log"
+            context.log.info(f"Querying min ID: {min_query}")
+            cursor.execute(min_query)
+            min_result = cursor.fetchone()
+
+            if min_result is None or min_result["min_id"] is None:
+                context.log.exception("Source table has no valid min ID")
+                # Note: No metrics client here as this is get_id_range op, not copy_chunk
+                raise dagster.Failure("Source table has no valid min ID")
+
+            min_id = int(min_result["min_id"])
+
+        # Use config max_id if provided, otherwise query database
+        if config.max_id is not None:
+            max_id = config.max_id
+            context.log.info(f"Using configured max_id override: {max_id}")
+        else:
+            max_query = f"SELECT MAX(id) as max_id FROM posthog_person_deletes_log"
+            context.log.info(f"Querying max ID: {max_query}")
+            cursor.execute(max_query)
+            max_result = cursor.fetchone()
+
+            if max_result is None or max_result["max_id"] is None:
+                context.log.exception(f"{config.persons_table} table has no valid max ID")
+                # Note: No metrics client here as this is get_id_range op, not copy_chunk
+                raise dagster.Failure(f"{config.persons_table} table has no valid max ID")
+
+            max_id = int(max_result["max_id"])
+
+        # Validate that max_id >= min_id
+        if max_id < min_id:
+            error_msg = f"Invalid ID range: max_id ({max_id}) < min_id ({min_id})"
+            context.log.error(error_msg)
+            # Note: No metrics client here as this is get_id_range op, not copy_chunk
+            raise dagster.Failure(error_msg)
+
+        context.log.info(f"ID range: min={min_id}, max={max_id}, total_ids={max_id - min_id + 1}")
+        context.add_output_metadata(
+            {
+                "min_id": dagster.MetadataValue.int(min_id),
+                "min_id_source": dagster.MetadataValue.text("config" if config.min_id is not None else "database"),
+                "max_id": dagster.MetadataValue.int(max_id),
+                "max_id_source": dagster.MetadataValue.text("config" if config.max_id is not None else "database"),
+                "total_ids": dagster.MetadataValue.int(max_id - min_id + 1),
+            }
+        )
+
+        return (min_id, max_id)
+
+
+@dagster.op(out=dagster.DynamicOut(tuple[int, int]))
+def create_chunks(
+    context: dagster.OpExecutionContext,
+    config: DeletePersonsFromTriggerLogConfig,
+    id_range: tuple[int, int],
+):
+    """
+    Divide ID space into chunks of chunk_size.
+    Yields DynamicOutput for each chunk in reverse order (highest IDs first, lowest IDs last).
+    This ensures that if the job fails partway through, the final chunk to process will be
+    the one starting at the source table's min_id.
+    """
+    min_id, max_id = id_range
+    chunk_size = config.chunk_size
+
+    # First, collect all chunks
+    chunks = []
+    chunk_min = min_id
+    chunk_num = 0
+
+    while chunk_min <= max_id:
+        chunk_max = min(chunk_min + chunk_size - 1, max_id)
+        chunks.append((chunk_min, chunk_max, chunk_num))
+        chunk_min = chunk_max + 1
+        chunk_num += 1
+
+    context.log.info(f"Created {chunk_num} chunks total")
+
+    # Yield chunks in reverse order (highest IDs first)
+    for chunk_min, chunk_max, chunk_num in reversed(chunks):
+        chunk_key = f"chunk_{chunk_min}_{chunk_max}"
+        context.log.info(f"Yielding chunk {chunk_num}: {chunk_min} to {chunk_max}")
+        yield dagster.DynamicOutput(
+            value=(chunk_min, chunk_max),
+            mapping_key=chunk_key,
+        )
+
+
+@dagster.op
+def scan_delete_chunk(
+    context: dagster.OpExecutionContext,
+    config: DeletePersonsFromTriggerLogConfig,
+    chunk: tuple[int, int],
+    database: dagster.ResourceParam[psycopg2.extensions.connection],
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> dict[str, Any]:
+    """
+    Scan posthog_person_deletes_log table for records that have an associated posthog_person_new row,
+    and deletes the corresponding posthog_person_new row. Processes in batches of batch_size person IDs,
+    and deletes the corresponding posthog_person_new rows in batches of delete_batch_size person IDs.
+    """
+    chunk_min, chunk_max = chunk
+    batch_size = config.batch_size
+    chunk_id = f"chunk_{chunk_min}_{chunk_max}"
+    job_name = context.run.job_name
+
+    # Initialize metrics client
+    metrics_client = MetricsClient(cluster)
+
+    context.log.info(f"Starting chunk scan and delete for ID range: {chunk_min} to {chunk_max}")
+
+    total_records_deleted = 0
+    batch_start_id = chunk_min
+    failed_batch_start_id: int | None = None
+
+    try:
+        with database.cursor() as cursor:
+            # Set session-level settings once for the entire chunk
+            cursor.execute("SET application_name = 'delete_persons_from_trigger_log'")
+            cursor.execute("SET lock_timeout = '5s'")
+            cursor.execute("SET statement_timeout = '30min'")
+            cursor.execute("SET maintenance_work_mem = '12GB'")
+            cursor.execute("SET work_mem = '512MB'")
+            cursor.execute("SET temp_buffers = '512MB'")
+            cursor.execute("SET max_parallel_workers_per_gather = 2")
+            cursor.execute("SET max_parallel_maintenance_workers = 2")
+            cursor.execute("SET synchronous_commit = off")
+
+            retry_attempt = 0
+            while batch_start_id <= chunk_max:
+                try:
+                    # Track batch start time for duration metric
+                    batch_start_time = time.time()
+
+                    # Calculate batch end ID
+                    batch_end_id = min(batch_start_id + batch_size, chunk_max)
+
+                    # Track records attempted - this is also our exit condition
+                    records_scanned = batch_end_id - batch_start_id
+                    if records_scanned <= 0:
+                        break
+
+                    # Begin transaction (settings already applied at session level)
+                    cursor.execute("BEGIN")
+
+                    # Query to find posthog_persondistinctid rows without a parent posthog_person row
+                    scan_query = f"""
+SELECT p.id, p.team_id
+FROM posthog_person_deletes_log AS pdl
+WHERE pdl.id >= %s AND pdl.id <= %s
+  AND NOT EXISTS (
+    SELECT 1
+    FROM {config.persons_table} AS p
+    WHERE pdl.id = p.id
+      AND pdl.team_id = p.team_id
+  )
+ORDER BY pdl.id
+"""
+                    cursor.execute(scan_query, (batch_start_id, batch_end_id))
+                    rows = cursor.fetchall()
+                    ids_to_delete = set[tuple[int, int]]({(int(row["team_id"]), int(row["id"])) for row in rows})
+
+                    # Commit the transaction
+                    cursor.execute("COMMIT")
+
+                    records_deleted = 0
+                    for team_id, person_id in ids_to_delete:
+                        try:
+                            context.log.info(
+                                f"Deleting person={person_id}, team_id={team_id} from {config.persons_table} (attempt {retry_attempt + 1})"
+                            )
+                            cursor.execute("BEGIN")
+                            cursor.execute(
+                                f"DELETE FROM {config.persons_table} WHERE team_id = %s AND id = %s",
+                                (team_id, person_id),
+                            )
+                            records_deleted += cursor.rowcount
+                            cursor.execute("COMMIT")
+                        except Exception as delete_error:
+                            # bubble up errors to be retried on deadlock etc. or fail the job
+                            context.log.exception(
+                                f"Failed to delete person={person_id}, team_id={team_id} from {config.persons_table} (attempt {retry_attempt + 1}): {delete_error}"
+                            )
+                            raise
+
+                    try:
+                        metrics_client.increment(
+                            "delete_persons_from_trigger_log_records_deleted_total",
+                            labels={"job_name": job_name, "chunk_id": chunk_id},
+                            value=float(records_deleted),
+                        ).result()
+                    except Exception:
+                        pass  # Don't fail on metrics error
+
+                    try:
+                        metrics_client.increment(
+                            "delete_persons_from_trigger_log_batches_scanned_total",
+                            labels={"job_name": job_name, "chunk_id": chunk_id},
+                            value=records_scanned,
+                        ).result()
+                    except Exception:
+                        pass
+
+                    # Track batch duration metric (IV)
+                    batch_duration_seconds = time.time() - batch_start_time
+                    try:
+                        metrics_client.increment(
+                            "delete_persons_from_trigger_log_batch_duration_seconds_total",
+                            labels={"job_name": job_name, "chunk_id": chunk_id},
+                            value=batch_duration_seconds,
+                        ).result()
+                    except Exception:
+                        pass
+
+                    total_records_deleted += records_deleted
+
+                    context.log.info(
+                        f"Deleted batch: {records_deleted} of {records_scanned} records "
+                        f"(chunk {chunk_min}-{chunk_max}, batch ID range {batch_start_id} to {batch_end_id})"
+                    )
+
+                    # Update batch_start_id for next iteration
+                    batch_start_id = batch_end_id + 1
+                    retry_attempt = 0
+
+                except Exception as batch_error:
+                    # Rollback transaction on error
+                    try:
+                        cursor.execute("ROLLBACK")
+                    except Exception as rollback_error:
+                        context.log.exception(
+                            f"Failed to rollback transaction for batch starting at ID {batch_start_id}"
+                            f"in chunk {chunk_min}-{chunk_max}: {str(rollback_error)}"
+                        )
+                        pass  # Ignore rollback errors
+
+                    # Check if error is a serialization failure, pause and retry if so
+                    serialization_failure_class = getattr(psycopg2.errors, "SerializationFailure", None)
+                    is_serialization_failure = (
+                        serialization_failure_class is not None and isinstance(batch_error, serialization_failure_class)
+                    ) or (isinstance(batch_error, psycopg2.Error) and getattr(batch_error, "pgcode", None) == "40001")
+                    if is_serialization_failure:
+                        error_msg = (
+                            f"Serialization failure detected for batch starting at ID {batch_start_id} "
+                            f"in chunk {chunk_min}-{chunk_max}. Error is: {batch_error}. "
+                            "This is expected due to concurrent transactions. "
+                        )
+                        context.log.warning(error_msg)
+                        if retry_attempt < MAX_RETRY_ATTEMPTS:
+                            retry_attempt += 1
+                            context.log.warning(f"Retrying batch {retry_attempt} of {MAX_RETRY_ATTEMPTS}...")
+                            time.sleep(1)
+                            continue
+
+                    # Check if error is a deadlock, pause and retry if so
+                    deadlock_detected_class = getattr(psycopg2.errors, "DeadlockDetected", None)
+                    is_deadlock = (
+                        deadlock_detected_class is not None and isinstance(batch_error, deadlock_detected_class)
+                    ) or (isinstance(batch_error, psycopg2.Error) and getattr(batch_error, "pgcode", None) == "40P01")
+                    if is_deadlock:
+                        error_msg = (
+                            f"Deadlock detected for batch starting at ID {batch_start_id} "
+                            f"in chunk {chunk_min}-{chunk_max}. Error is: {batch_error}. "
+                            "This is expected due to concurrent transactions. "
+                        )
+                        context.log.warning(error_msg)
+                        if retry_attempt < MAX_RETRY_ATTEMPTS:
+                            retry_attempt += 1
+                            context.log.warning(f"Retrying batch {retry_attempt} of {MAX_RETRY_ATTEMPTS}...")
+                            time.sleep(1)
+                            continue
+
+                    # Handle unexpected errors by bubbling up to dagster.Failure
+                    failed_batch_start_id = batch_start_id
+                    error_msg = (
+                        f"Failed to scan and delete rows in batch starting at ID {batch_start_id} "
+                        f"in chunk {chunk_min}-{chunk_max}: {str(batch_error)}"
+                    )
+                    context.log.exception(error_msg)
+                    # Report fatal error metric before raising
+                    try:
+                        metrics_client.increment(
+                            "delete_persons_from_trigger_log_error",
+                            labels={"job_name": job_name, "chunk_id": chunk_id, "reason": "batch_scan_delete_failed"},
+                            value=1.0,
+                        ).result()
+                    except Exception:
+                        pass  # Don't fail on metrics error
+
+                    raise dagster.Failure(
+                        description=error_msg,
+                        metadata={
+                            "chunk_min_id": dagster.MetadataValue.int(chunk_min),
+                            "chunk_max_id": dagster.MetadataValue.int(chunk_max),
+                            "failed_batch_start_id": dagster.MetadataValue.int(failed_batch_start_id)
+                            if failed_batch_start_id
+                            else dagster.MetadataValue.text("N/A"),
+                            "error_message": dagster.MetadataValue.text(str(batch_error)),
+                            "records_deleted_before_failure": dagster.MetadataValue.int(total_records_deleted),
+                        },
+                    ) from batch_error
+
+    except dagster.Failure:
+        # Re-raise Dagster failures as-is (they already have metadata and metrics)
+        raise
+    except Exception as e:
+        # Catch any other unexpected errors
+        error_msg = f"Unexpected error scanning and deleting from chunk {chunk_min}-{chunk_max}: {str(e)}"
+        context.log.exception(error_msg)
+        # Report fatal error metric before raising
+        try:
+            metrics_client.increment(
+                "delete_persons_from_trigger_log_error",
+                labels={"job_name": job_name, "chunk_id": chunk_id, "reason": "unexpected_scan_delete_error"},
+                value=1.0,
+            ).result()
+        except Exception:
+            pass  # Don't fail on metrics error
+        raise dagster.Failure(
+            description=error_msg,
+            metadata={
+                "chunk_min_id": dagster.MetadataValue.int(chunk_min),
+                "chunk_max_id": dagster.MetadataValue.int(chunk_max),
+                "failed_batch_start_id": dagster.MetadataValue.int(failed_batch_start_id)
+                if failed_batch_start_id
+                else dagster.MetadataValue.int(batch_start_id),
+                "error_message": dagster.MetadataValue.text(str(e)),
+                "records_deleted_before_failure": dagster.MetadataValue.int(total_records_deleted),
+            },
+        ) from e
+
+    context.log.info(f"Completed chunk {chunk_min}-{chunk_max}: deleted {total_records_deleted} records")
+
+    # Emit metric for chunk completion
+    run_id = context.run.run_id
+    try:
+        metrics_client.increment(
+            "distinct_ids_without_person_chunks_completed_total",
+            labels={"job_name": job_name, "run_id": run_id, "chunk_id": chunk_id},
+            value=1.0,
+        ).result()
+    except Exception:
+        pass  # Don't fail on metrics error
+
+    context.add_output_metadata(
+        {
+            "chunk_min": dagster.MetadataValue.int(chunk_min),
+            "chunk_max": dagster.MetadataValue.int(chunk_max),
+            "records_deleted": dagster.MetadataValue.int(total_records_deleted),
+        }
+    )
+
+    return {
+        "chunk_min": chunk_min,
+        "chunk_max": chunk_max,
+        "records_deleted": total_records_deleted,
+    }
+
+
+@dagster.asset
+def postgres_env_check(context: dagster.AssetExecutionContext) -> None:
+    """
+    Simple asset that prints PostgreSQL environment variables being used.
+    Useful for debugging connection configuration.
+    """
+    env_vars = {
+        "POSTGRES_HOST": os.getenv("POSTGRES_HOST", "not set"),
+        "POSTGRES_PORT": os.getenv("POSTGRES_PORT", "not set"),
+        "POSTGRES_DATABASE": os.getenv("POSTGRES_DATABASE", "not set"),
+        "POSTGRES_USER": os.getenv("POSTGRES_USER", "not set"),
+        "POSTGRES_PASSWORD": "***" if os.getenv("POSTGRES_PASSWORD") else "not set",
+    }
+
+    context.log.info("PostgreSQL environment variables:")
+    for key, value in env_vars.items():
+        context.log.info(f"  {key}: {value}")
+
+
+@dagster.job(
+    tags={"owner": JobOwners.TEAM_INGESTION.value},
+    executor_def=k8s_job_executor,
+)
+def delete_persons_from_trigger_log_job():
+    """
+    Scan posthog_person_deletes_log table, and deletes the corresponding posthog_person_new rows.
+    """
+    id_range = get_id_range()
+    chunks = create_chunks(id_range)
+    chunks.map(scan_delete_chunk)

--- a/dags/delete_persons_from_trigger_log_job.py
+++ b/dags/delete_persons_from_trigger_log_job.py
@@ -2,7 +2,6 @@
 that are present in the trigger log table used to capture deletes on the unpartitioned DB while we
 transitioned to the new, partitioned DB."""
 
-import os
 import time
 from typing import Any
 
@@ -403,25 +402,6 @@ ORDER BY pdl.id
         "chunk_max": chunk_max,
         "records_deleted": total_records_deleted,
     }
-
-
-@dagster.asset
-def postgres_env_check(context: dagster.AssetExecutionContext) -> None:
-    """
-    Simple asset that prints PostgreSQL environment variables being used.
-    Useful for debugging connection configuration.
-    """
-    env_vars = {
-        "POSTGRES_HOST": os.getenv("POSTGRES_HOST", "not set"),
-        "POSTGRES_PORT": os.getenv("POSTGRES_PORT", "not set"),
-        "POSTGRES_DATABASE": os.getenv("POSTGRES_DATABASE", "not set"),
-        "POSTGRES_USER": os.getenv("POSTGRES_USER", "not set"),
-        "POSTGRES_PASSWORD": "***" if os.getenv("POSTGRES_PASSWORD") else "not set",
-    }
-
-    context.log.info("PostgreSQL environment variables:")
-    for key, value in env_vars.items():
-        context.log.info(f"  {key}: {value}")
 
 
 @dagster.job(

--- a/dags/ingestion_assets.py
+++ b/dags/ingestion_assets.py
@@ -1,0 +1,22 @@
+import os
+
+import dagster
+
+
+@dagster.asset
+def postgres_env_check(context: dagster.AssetExecutionContext) -> None:
+    """
+    Simple asset that prints PostgreSQL environment variables being used.
+    Useful for debugging connection configuration.
+    """
+    env_vars = {
+        "POSTGRES_HOST": os.getenv("POSTGRES_HOST", "not set"),
+        "POSTGRES_PORT": os.getenv("POSTGRES_PORT", "not set"),
+        "POSTGRES_DATABASE": os.getenv("POSTGRES_DATABASE", "not set"),
+        "POSTGRES_USER": os.getenv("POSTGRES_USER", "not set"),
+        "POSTGRES_PASSWORD": "***" if os.getenv("POSTGRES_PASSWORD") else "not set",
+    }
+
+    context.log.info("PostgreSQL environment variables:")
+    for key, value in env_vars.items():
+        context.log.info(f"  {key}: {value}")

--- a/dags/locations/ingestion.py
+++ b/dags/locations/ingestion.py
@@ -1,15 +1,17 @@
 import dagster
 
-from dags import persons_new_backfill
+from dags import delete_persons_from_trigger_log_job, persons_new_backfill
 
 from . import resources
 
 defs = dagster.Definitions(
     assets=[
         persons_new_backfill.postgres_env_check,
+        delete_persons_from_trigger_log_job.postgres_env_check,
     ],
     jobs=[
         persons_new_backfill.persons_new_backfill_job,
+        delete_persons_from_trigger_log_job.delete_persons_from_trigger_log_job,
     ],
     resources=resources,
 )

--- a/dags/locations/ingestion.py
+++ b/dags/locations/ingestion.py
@@ -1,13 +1,12 @@
 import dagster
 
-from dags import delete_persons_from_trigger_log_job, persons_new_backfill
+from dags import delete_persons_from_trigger_log_job, ingestion_assets, persons_new_backfill
 
 from . import resources
 
 defs = dagster.Definitions(
     assets=[
-        persons_new_backfill.postgres_env_check,
-        delete_persons_from_trigger_log_job.postgres_env_check,
+        ingestion_assets.postgres_env_check,
     ],
     jobs=[
         persons_new_backfill.persons_new_backfill_job,

--- a/dags/tests/test_delete_persons_from_trigger_log_job.py
+++ b/dags/tests/test_delete_persons_from_trigger_log_job.py
@@ -308,7 +308,7 @@ class TestScanDeleteChunk:
         assert "FROM posthog_person_deletes_log" in scan_query
         assert "WHERE pdl.id >=" in scan_query
         assert "AND pdl.id <=" in scan_query
-        assert "NOT EXISTS" in scan_query
+        assert "EXISTS" in scan_query
 
         # Verify DELETE queries were called (one per person)
         delete_calls = [call for call in execute_calls if "DELETE FROM posthog_person_new" in call]
@@ -575,7 +575,7 @@ class TestScanDeleteChunk:
         assert "FROM posthog_person_deletes_log" in scan_query
         assert "WHERE pdl.id >=" in scan_query
         assert "AND pdl.id <=" in scan_query
-        assert "NOT EXISTS" in scan_query
+        assert "EXISTS" in scan_query
         assert "SELECT" in scan_query
 
     def test_scan_delete_chunk_session_settings_applied_once(self):

--- a/dags/tests/test_delete_persons_from_trigger_log_job.py
+++ b/dags/tests/test_delete_persons_from_trigger_log_job.py
@@ -1,0 +1,792 @@
+"""Tests for the delete persons from trigger log job."""
+
+from unittest.mock import MagicMock, patch
+
+import psycopg2
+from dagster import build_op_context
+
+from dags.delete_persons_from_trigger_log_job import (
+    DeletePersonsFromTriggerLogConfig,
+    create_chunks,
+    get_id_range,
+    scan_delete_chunk,
+)
+
+
+class MockPsycopg2Error(psycopg2.Error):
+    """Mock psycopg2.Error that allows setting pgcode."""
+
+    def __init__(self, message: str, pgcode: str):
+        super().__init__(message)
+        # Store pgcode in a private attribute
+        self._pgcode = pgcode
+
+    @property
+    def pgcode(self) -> str:
+        """Override pgcode property to return our custom value."""
+        return self._pgcode
+
+
+def create_mock_psycopg2_error(message: str, pgcode: str) -> Exception:
+    """Create a mock psycopg2.Error with a specific pgcode."""
+    return MockPsycopg2Error(message, pgcode)
+
+
+class TestCreateChunks:
+    """Test the create_chunks function."""
+
+    def test_create_chunks_produces_non_overlapping_ranges(self):
+        """Test that chunks produce non-overlapping ranges."""
+        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
+        id_range = (1, 5000)  # min_id=1, max_id=5000
+
+        context = build_op_context()
+        chunks = list(create_chunks(context, config, id_range))
+
+        # Extract all chunk ranges from DynamicOutput objects
+        chunk_ranges = [chunk.value for chunk in chunks]
+
+        # Verify no overlaps
+        for i, (min1, max1) in enumerate(chunk_ranges):
+            for j, (min2, max2) in enumerate(chunk_ranges):
+                if i != j:
+                    # Chunks should not overlap
+                    assert not (
+                        min1 <= min2 <= max1 or min1 <= max2 <= max1 or min2 <= min1 <= max2
+                    ), f"Chunks overlap: ({min1}, {max1}) and ({min2}, {max2})"
+
+    def test_create_chunks_covers_entire_id_space(self):
+        """Test that chunks cover the entire ID space from min to max."""
+        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
+        min_id, max_id = 1, 5000
+        id_range = (min_id, max_id)
+
+        context = build_op_context()
+        chunks = list(create_chunks(context, config, id_range))
+
+        # Extract all chunk ranges from DynamicOutput objects
+        chunk_ranges = [chunk.value for chunk in chunks]
+
+        # Find the overall min and max covered
+        all_ids_covered: set[int] = set()
+        for chunk_min, chunk_max in chunk_ranges:
+            all_ids_covered.update(range(chunk_min, chunk_max + 1))
+
+        # Verify all IDs from min_id to max_id are covered
+        expected_ids = set(range(min_id, max_id + 1))
+        assert all_ids_covered == expected_ids, (
+            f"Missing IDs: {expected_ids - all_ids_covered}, " f"Extra IDs: {all_ids_covered - expected_ids}"
+        )
+
+    def test_create_chunks_first_chunk_includes_max_id(self):
+        """Test that the first chunk (in yielded order) includes the source table max_id."""
+        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
+        min_id, max_id = 1, 5000
+        id_range = (min_id, max_id)
+
+        context = build_op_context()
+        chunks = list(create_chunks(context, config, id_range))
+
+        # First chunk in the list (yielded first, highest IDs)
+        first_chunk_min, first_chunk_max = chunks[0].value
+
+        assert first_chunk_max == max_id, f"First chunk max ({first_chunk_max}) should equal source max_id ({max_id})"
+        assert (
+            first_chunk_min <= max_id <= first_chunk_max
+        ), f"First chunk ({first_chunk_min}, {first_chunk_max}) should include max_id ({max_id})"
+
+    def test_create_chunks_final_chunk_includes_min_id(self):
+        """Test that the final chunk (in yielded order) includes the source table min_id."""
+        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
+        min_id, max_id = 1, 5000
+        id_range = (min_id, max_id)
+
+        context = build_op_context()
+        chunks = list(create_chunks(context, config, id_range))
+
+        # Last chunk in the list (yielded last, lowest IDs)
+        final_chunk_min, final_chunk_max = chunks[-1].value
+
+        assert final_chunk_min == min_id, f"Final chunk min ({final_chunk_min}) should equal source min_id ({min_id})"
+        assert (
+            final_chunk_min <= min_id <= final_chunk_max
+        ), f"Final chunk ({final_chunk_min}, {final_chunk_max}) should include min_id ({min_id})"
+
+    def test_create_chunks_reverse_order(self):
+        """Test that chunks are yielded in reverse order (highest IDs first)."""
+        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
+        min_id, max_id = 1, 5000
+        id_range = (min_id, max_id)
+
+        context = build_op_context()
+        chunks = list(create_chunks(context, config, id_range))
+
+        # Verify chunks are in descending order by max_id
+        for i in range(len(chunks) - 1):
+            current_max = chunks[i].value[1]
+            next_max = chunks[i + 1].value[1]
+            assert (
+                current_max > next_max
+            ), f"Chunks not in reverse order: chunk {i} max ({current_max}) should be > chunk {i+1} max ({next_max})"
+
+    def test_create_chunks_exact_multiple(self):
+        """Test chunk creation when ID range is an exact multiple of chunk_size."""
+        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
+        min_id, max_id = 1, 5000  # Exactly 5 chunks of 1000
+        id_range = (min_id, max_id)
+
+        context = build_op_context()
+        chunks = list(create_chunks(context, config, id_range))
+
+        assert len(chunks) == 5, f"Expected 5 chunks, got {len(chunks)}"
+
+        # Verify first chunk (highest IDs)
+        assert chunks[0].value == (4001, 5000), f"First chunk should be (4001, 5000), got {chunks[0].value}"
+
+        # Verify last chunk (lowest IDs)
+        assert chunks[-1].value == (1, 1000), f"Last chunk should be (1, 1000), got {chunks[-1].value}"
+
+    def test_create_chunks_non_exact_multiple(self):
+        """Test chunk creation when ID range is not an exact multiple of chunk_size."""
+        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
+        min_id, max_id = 1, 3750  # 3 full chunks + 1 partial chunk
+        id_range = (min_id, max_id)
+
+        context = build_op_context()
+        chunks = list(create_chunks(context, config, id_range))
+
+        assert len(chunks) == 4, f"Expected 4 chunks, got {len(chunks)}"
+
+        # Verify first chunk (highest IDs) - should be the partial chunk
+        assert chunks[0].value == (3001, 3750), f"First chunk should be (3001, 3750), got {chunks[0].value}"
+
+        # Verify last chunk (lowest IDs)
+        assert chunks[-1].value == (1, 1000), f"Last chunk should be (1, 1000), got {chunks[-1].value}"
+
+    def test_create_chunks_single_chunk(self):
+        """Test chunk creation when ID range fits in a single chunk."""
+        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
+        min_id, max_id = 100, 500
+        id_range = (min_id, max_id)
+
+        context = build_op_context()
+        chunks = list(create_chunks(context, config, id_range))
+
+        assert len(chunks) == 1, f"Expected 1 chunk, got {len(chunks)}"
+        assert chunks[0].value == (100, 500), f"Chunk should be (100, 500), got {chunks[0].value}"
+        assert chunks[0].value[0] == min_id and chunks[0].value[1] == max_id
+
+
+def create_mock_database_resource(rowcount_values=None, fetchall_results=None):
+    """
+    Create a mock database resource that mimics psycopg2.extensions.connection.
+
+    Args:
+        rowcount_values: List of rowcount values to return per DELETE call.
+                        If None, defaults to 0. If a single int, uses that for all calls.
+        fetchall_results: List of results to return from fetchall() calls (for SELECT queries).
+                         Each result should be a list of dict-like objects with "id" key.
+                         If None, defaults to empty list.
+    """
+    mock_cursor = MagicMock()
+    if rowcount_values is None:
+        mock_cursor.rowcount = 0
+    elif isinstance(rowcount_values, int):
+        mock_cursor.rowcount = rowcount_values
+    else:
+        # Use side_effect to return different rowcounts per call
+        call_count = [0]
+
+        def get_rowcount():
+            if call_count[0] < len(rowcount_values):
+                result = rowcount_values[call_count[0]]
+                call_count[0] += 1
+                return result
+            return rowcount_values[-1] if rowcount_values else 0
+
+        mock_cursor.rowcount = property(lambda self: get_rowcount())
+
+    mock_cursor.execute = MagicMock()
+    mock_cursor.fetchone = MagicMock()
+
+    # Setup fetchall to return scan results
+    if fetchall_results is None:
+        mock_cursor.fetchall = MagicMock(return_value=[])
+    elif isinstance(fetchall_results, list):
+        fetchall_call_count = [0]
+
+        def get_fetchall_result():
+            if fetchall_call_count[0] < len(fetchall_results):
+                result = fetchall_results[fetchall_call_count[0]]
+                fetchall_call_count[0] += 1
+                return result
+            return fetchall_results[-1] if fetchall_results else []
+
+        mock_cursor.fetchall = MagicMock(side_effect=get_fetchall_result)
+    else:
+        mock_cursor.fetchall = MagicMock(return_value=fetchall_results)
+
+    # Make cursor() return a context manager
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    return mock_conn
+
+
+def create_mock_cluster_resource():
+    """Create a mock ClickhouseCluster resource."""
+    return MagicMock()
+
+
+class TestScanDeleteChunk:
+    """Test the scan_delete_chunk function."""
+
+    def test_scan_delete_chunk_single_batch_success(self):
+        """Test successful scan and delete of a single batch within a chunk."""
+        config = DeletePersonsFromTriggerLogConfig(
+            chunk_size=1000,
+            batch_size=100,
+        )
+        chunk = (1, 100)  # Single batch covers entire chunk
+
+        # Create 50 person records to delete - each has id and team_id
+        # The scan query returns records from posthog_person_deletes_log that don't exist in posthog_person_new
+        ids_to_delete = [{"id": i, "team_id": 1} for i in range(1, 51)]
+
+        # Mock: fetchall returns the IDs with team_id, DELETE returns rowcount of 1 per delete
+        mock_db = create_mock_database_resource(
+            rowcount_values=1,  # Each DELETE deletes 1 person
+            fetchall_results=[ids_to_delete],
+        )
+        mock_cluster = create_mock_cluster_resource()
+
+        context = build_op_context(
+            resources={"database": mock_db, "cluster": mock_cluster},
+        )
+        # Patch context.run.job_name where it's accessed in scan_delete_chunk
+        from unittest.mock import PropertyMock
+
+        with patch.object(type(context), "run", PropertyMock(return_value=MagicMock(job_name="test_job"))):
+            result = scan_delete_chunk(context, config, chunk)
+
+        # Verify result
+        assert result["chunk_min"] == 1
+        assert result["chunk_max"] == 100
+        assert result["records_deleted"] == 50  # 50 deletes, each with rowcount=1
+
+        # Verify SET statements called once (session-level, before loop)
+        set_statements = [
+            "SET application_name = 'delete_persons_from_trigger_log'",
+            "SET lock_timeout = '5s'",
+            "SET statement_timeout = '30min'",
+            "SET maintenance_work_mem = '12GB'",
+            "SET work_mem = '512MB'",
+            "SET temp_buffers = '512MB'",
+            "SET max_parallel_workers_per_gather = 2",
+            "SET max_parallel_maintenance_workers = 2",
+            "SET synchronous_commit = off",
+        ]
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+
+        # Check SET statements were called
+        for stmt in set_statements:
+            assert any(stmt in call for call in execute_calls), f"SET statement not found: {stmt}"
+
+        # Verify BEGIN, SELECT scan, COMMIT called
+        # Should have: 1 BEGIN for scan, 1 COMMIT after scan, then 50 BEGIN/COMMIT pairs for deletes
+        assert execute_calls.count("BEGIN") >= 51  # 1 for scan + 50 for deletes
+        assert execute_calls.count("COMMIT") >= 51  # 1 for scan + 50 for deletes
+
+        # Verify SELECT scan query format
+        scan_calls = [call for call in execute_calls if "FROM posthog_person_deletes_log" in call]
+        assert len(scan_calls) == 1
+        scan_query = scan_calls[0]
+        assert "SELECT" in scan_query
+        assert "FROM posthog_person_deletes_log" in scan_query
+        assert "WHERE pdl.id >=" in scan_query
+        assert "AND pdl.id <=" in scan_query
+        assert "NOT EXISTS" in scan_query
+
+        # Verify DELETE queries were called (one per person)
+        delete_calls = [call for call in execute_calls if "DELETE FROM posthog_person_new" in call]
+        assert len(delete_calls) == 50  # One delete per person
+
+    def test_scan_delete_chunk_multiple_batches(self):
+        """Test scan and delete with multiple batches in a chunk."""
+        config = DeletePersonsFromTriggerLogConfig(
+            chunk_size=1000,
+            batch_size=100,
+        )
+        chunk = (1, 250)  # 3 scan batches: (1,100), (101,200), (201,250)
+
+        # Create IDs to delete for each scan batch - each needs id and team_id
+        # Batch 1: 50 IDs (1-50), Batch 2: 75 IDs (101-175), Batch 3: 25 IDs (201-225)
+        fetchall_results = [
+            [{"id": i, "team_id": 1} for i in range(1, 51)],  # 50 IDs from first scan batch
+            [{"id": i, "team_id": 1} for i in range(101, 176)],  # 75 IDs from second scan batch
+            [{"id": i, "team_id": 1} for i in range(201, 226)],  # 25 IDs from third scan batch
+        ]
+
+        mock_db = create_mock_database_resource(
+            rowcount_values=1,  # Each DELETE deletes 1 person
+            fetchall_results=fetchall_results,
+        )
+        mock_cluster = create_mock_cluster_resource()
+
+        context = build_op_context(
+            resources={"database": mock_db, "cluster": mock_cluster},
+        )
+        # Patch context.run.job_name where it's accessed in scan_delete_chunk
+        from unittest.mock import PropertyMock
+
+        with patch.object(type(context), "run", PropertyMock(return_value=MagicMock(job_name="test_job"))):
+            result = scan_delete_chunk(context, config, chunk)
+
+        # Verify result
+        assert result["chunk_min"] == 1
+        assert result["chunk_max"] == 250
+        assert result["records_deleted"] == 150  # 50 + 75 + 25 = 150
+
+        # Verify SET statements called once (before loop)
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+
+        # Verify BEGIN/COMMIT called multiple times:
+        # 3 scan batches: 3 BEGIN + 3 COMMIT for scans
+        # 150 delete operations: 150 BEGIN + 150 COMMIT for deletes (one per person)
+        # Total: 153 BEGIN, 153 COMMIT
+        assert execute_calls.count("BEGIN") >= 153  # 3 scans + 150 deletes
+        assert execute_calls.count("COMMIT") >= 153  # 3 scans + 150 deletes
+
+        # Verify SELECT scan called 3 times (one per scan batch)
+        scan_calls = [call for call in execute_calls if "FROM posthog_person_deletes_log" in call]
+        assert len(scan_calls) == 3
+
+        # Verify DELETE called 150 times (one per person)
+        delete_calls = [call for call in execute_calls if "DELETE FROM posthog_person_new" in call]
+        assert len(delete_calls) == 150
+
+    def test_scan_delete_chunk_serialization_failure_retry(self):
+        """Test that serialization failure triggers retry."""
+        config = DeletePersonsFromTriggerLogConfig(
+            chunk_size=1000,
+            batch_size=100,
+        )
+        chunk = (1, 100)
+
+        # Create IDs to delete - each needs id and team_id
+        ids_to_delete = [{"id": i, "team_id": 1} for i in range(1, 51)]
+        mock_db = create_mock_database_resource(fetchall_results=[ids_to_delete])
+        mock_cluster = create_mock_cluster_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+
+        # Track scan query attempts
+        scan_attempts = [0]
+
+        # First SELECT scan query raises SerializationFailure, second succeeds
+        def execute_side_effect(query, *args):
+            if "FROM posthog_person_deletes_log" in query:
+                scan_attempts[0] += 1
+                if scan_attempts[0] == 1:
+                    # First scan attempt raises error
+                    # Create a mock error with pgcode 40001 for serialization failure
+                    error = create_mock_psycopg2_error("could not serialize access due to concurrent update", "40001")
+                    raise error
+                # Subsequent calls succeed - fetchall will return the IDs
+            elif "DELETE FROM posthog_person_new" in query:
+                # DELETE succeeds
+                cursor.rowcount = 1
+            # MagicMock will automatically record the call via side_effect
+
+        cursor.execute.side_effect = execute_side_effect
+
+        context = build_op_context(
+            resources={"database": mock_db, "cluster": mock_cluster},
+        )
+        # Need to patch time.sleep and run.job_name
+        from unittest.mock import PropertyMock
+
+        mock_run = MagicMock(job_name="test_job")
+        with (
+            patch("dags.delete_persons_from_trigger_log_job.time.sleep"),
+            patch.object(type(context), "run", PropertyMock(return_value=mock_run)),
+        ):
+            scan_delete_chunk(context, config, chunk)
+
+        # Verify ROLLBACK was called on error
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        assert "ROLLBACK" in execute_calls
+
+        # Verify retry succeeded (should have SELECT called twice - once failed, once succeeded)
+        scan_calls = [call for call in execute_calls if "FROM posthog_person_deletes_log" in call]
+        assert len(scan_calls) >= 2  # At least one failed attempt and one successful scan
+
+    def test_scan_delete_chunk_deadlock_retry(self):
+        """Test that deadlock triggers retry."""
+        config = DeletePersonsFromTriggerLogConfig(
+            chunk_size=1000,
+            batch_size=100,
+        )
+        chunk = (1, 100)
+
+        # Create IDs to delete - each needs id and team_id
+        ids_to_delete = [{"id": i, "team_id": 1} for i in range(1, 51)]
+        mock_db = create_mock_database_resource(fetchall_results=[ids_to_delete])
+        mock_cluster = create_mock_cluster_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+
+        # Track scan query attempts
+        scan_attempts = [0]
+
+        # First SELECT scan query raises deadlock, second succeeds
+        def execute_side_effect(query, *args):
+            if "FROM posthog_person_deletes_log" in query:
+                scan_attempts[0] += 1
+                if scan_attempts[0] == 1:
+                    # First scan attempt raises error
+                    # Create a mock error with pgcode 40P01 for deadlock
+                    error = create_mock_psycopg2_error("deadlock detected", "40P01")
+                    raise error
+                # Subsequent calls succeed - fetchall will return the IDs
+            elif "DELETE FROM posthog_person_new" in query:
+                # DELETE succeeds
+                cursor.rowcount = 1
+            # MagicMock will automatically record the call via side_effect
+
+        cursor.execute.side_effect = execute_side_effect
+
+        context = build_op_context(
+            resources={"database": mock_db, "cluster": mock_cluster},
+        )
+        # Need to patch time.sleep and run.job_name
+        from unittest.mock import PropertyMock
+
+        mock_run = MagicMock(job_name="test_job")
+        with (
+            patch("dags.delete_persons_from_trigger_log_job.time.sleep"),
+            patch.object(type(context), "run", PropertyMock(return_value=mock_run)),
+        ):
+            scan_delete_chunk(context, config, chunk)
+
+        # Verify ROLLBACK was called on error
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        assert "ROLLBACK" in execute_calls
+
+        # Verify retry succeeded (should have SELECT called twice - once failed, once succeeded)
+        scan_calls = [call for call in execute_calls if "FROM posthog_person_deletes_log" in call]
+        assert len(scan_calls) >= 2  # At least one failed attempt and one successful scan
+
+    def test_scan_delete_chunk_error_handling_and_rollback(self):
+        """Test error handling and rollback on non-retryable errors."""
+        config = DeletePersonsFromTriggerLogConfig(
+            chunk_size=1000,
+            batch_size=100,
+        )
+        chunk = (1, 100)
+
+        # Create IDs to delete - each needs id and team_id
+        ids_to_delete = [{"id": i, "team_id": 1} for i in range(1, 51)]
+        mock_db = create_mock_database_resource(fetchall_results=[ids_to_delete])
+        mock_cluster = create_mock_cluster_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+
+        # Raise generic error on scan query (non-retryable error)
+        def execute_side_effect(query, *args):
+            if "FROM posthog_person_deletes_log" in query:
+                raise Exception("Connection lost")
+            # MagicMock will automatically record the call via side_effect
+
+        cursor.execute.side_effect = execute_side_effect
+
+        context = build_op_context(
+            resources={"database": mock_db, "cluster": mock_cluster},
+        )
+        # Patch context.run.job_name where it's accessed in scan_delete_chunk
+        from unittest.mock import PropertyMock
+
+        mock_run = MagicMock(job_name="test_job")
+        with patch.object(type(context), "run", PropertyMock(return_value=mock_run)):
+            # Should raise Dagster.Failure
+            from dagster import Failure
+
+            try:
+                scan_delete_chunk(context, config, chunk)
+                raise AssertionError("Expected Dagster.Failure to be raised")
+            except Failure as e:
+                # Verify error metadata
+                assert e.description is not None
+                assert "Failed to scan and delete rows in batch" in e.description
+
+                # Verify ROLLBACK was called
+                execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+                assert "ROLLBACK" in execute_calls
+
+    def test_scan_delete_chunk_query_format(self):
+        """Test that DELETE query has correct format."""
+        config = DeletePersonsFromTriggerLogConfig(
+            chunk_size=1000,
+            batch_size=100,
+        )
+        chunk = (1, 100)
+
+        # Create IDs to delete - each needs id and team_id
+        ids_to_delete = [{"id": i, "team_id": 1} for i in range(1, 11)]  # 10 IDs
+        mock_db = create_mock_database_resource(
+            rowcount_values=1,  # Each DELETE deletes 1 person
+            fetchall_results=[ids_to_delete],
+        )
+        mock_cluster = create_mock_cluster_resource()
+
+        context = build_op_context(
+            resources={"database": mock_db, "cluster": mock_cluster},
+        )
+        # Patch context.run.job_name where it's accessed in scan_delete_chunk
+        from unittest.mock import PropertyMock
+
+        with patch.object(type(context), "run", PropertyMock(return_value=MagicMock(job_name="test_job"))):
+            scan_delete_chunk(context, config, chunk)
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+
+        # Find DELETE query (should be multiple, one per person)
+        delete_queries = [call for call in execute_calls if "DELETE FROM posthog_person_new" in call]
+        assert len(delete_queries) == 10  # One delete per person
+
+        # Verify DELETE query components (check first one)
+        delete_query = delete_queries[0]
+        assert "DELETE FROM posthog_person_new" in delete_query
+        assert "WHERE team_id = %s AND id = %s" in delete_query
+
+        # Find SELECT query (scan query)
+        scan_query = next(
+            (call for call in execute_calls if "FROM posthog_person_deletes_log" in call),
+            None,
+        )
+        assert scan_query is not None
+
+        # Verify SELECT query components
+        assert "FROM posthog_person_deletes_log" in scan_query
+        assert "WHERE pdl.id >=" in scan_query
+        assert "AND pdl.id <=" in scan_query
+        assert "NOT EXISTS" in scan_query
+        assert "SELECT" in scan_query
+
+    def test_scan_delete_chunk_session_settings_applied_once(self):
+        """Test that SET statements are applied once at session level before batch loop."""
+        config = DeletePersonsFromTriggerLogConfig(
+            chunk_size=1000,
+            batch_size=50,
+        )
+        chunk = (1, 150)  # 3 scan batches
+
+        # Create IDs to delete for each scan batch - each needs id and team_id
+        fetchall_results = [
+            [{"id": i, "team_id": 1} for i in range(1, 26)],  # 25 IDs from first scan batch
+            [{"id": i, "team_id": 1} for i in range(51, 76)],  # 25 IDs from second scan batch
+            [{"id": i, "team_id": 1} for i in range(101, 126)],  # 25 IDs from third scan batch
+        ]
+        mock_db = create_mock_database_resource(
+            rowcount_values=1,  # Each DELETE deletes 1 person
+            fetchall_results=fetchall_results,
+        )
+        mock_cluster = create_mock_cluster_resource()
+
+        context = build_op_context(
+            resources={"database": mock_db, "cluster": mock_cluster},
+        )
+        # Patch context.run.job_name where it's accessed in scan_delete_chunk
+        from unittest.mock import PropertyMock
+
+        with patch.object(type(context), "run", PropertyMock(return_value=MagicMock(job_name="test_job"))):
+            scan_delete_chunk(context, config, chunk)
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+
+        # Count SET statements (should be called once each, before loop)
+        set_statements = [
+            "SET application_name",
+            "SET lock_timeout",
+            "SET statement_timeout",
+            "SET maintenance_work_mem",
+            "SET work_mem",
+            "SET temp_buffers",
+            "SET max_parallel_workers_per_gather",
+            "SET max_parallel_maintenance_workers",
+            "SET synchronous_commit",
+        ]
+
+        for stmt in set_statements:
+            count = sum(1 for call in execute_calls if stmt in call)
+            assert count == 1, f"Expected {stmt} to be called once, but it was called {count} times"
+
+        # Verify SET statements come before BEGIN statements
+        set_indices = [i for i, call in enumerate(execute_calls) if any(stmt in call for stmt in set_statements)]
+        begin_indices = [i for i, call in enumerate(execute_calls) if call == "BEGIN"]
+
+        if set_indices and begin_indices:
+            assert max(set_indices) < min(begin_indices), "SET statements should come before BEGIN statements"
+
+
+class TestGetIdRange:
+    """Test the get_id_range function."""
+
+    def test_get_id_range_uses_min_id_override(self):
+        """Test that min_id override is honored when provided."""
+        config = DeletePersonsFromTriggerLogConfig(min_id=100, max_id=None)
+        mock_db = create_mock_database_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = {"max_id": 5000}
+
+        context = build_op_context(resources={"database": mock_db})
+
+        result = get_id_range(context, config)
+
+        assert result == (100, 5000)
+        assert result[0] == 100  # min_id override used
+
+        # Verify min_id query was NOT executed (override used)
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        min_queries = [call for call in execute_calls if "MIN(id)" in call]
+        assert len(min_queries) == 0, "Should not query for min_id when override is provided"
+
+        # Verify max_id query WAS executed (queries posthog_person_deletes_log)
+        max_queries = [call for call in execute_calls if "MAX(id)" in call and "posthog_person_deletes_log" in call]
+        assert (
+            len(max_queries) == 1
+        ), "Should query for max_id from posthog_person_deletes_log when override is not provided"
+
+    def test_get_id_range_uses_max_id_override(self):
+        """Test that max_id override is honored when provided."""
+        config = DeletePersonsFromTriggerLogConfig(min_id=1, max_id=5000)
+        mock_db = create_mock_database_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+
+        context = build_op_context(resources={"database": mock_db})
+
+        result = get_id_range(context, config)
+
+        assert result == (1, 5000)
+        assert result[1] == 5000  # max_id override used
+
+        # Verify max_id query was NOT executed (override used)
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        max_queries = [call for call in execute_calls if "MAX(id)" in call]
+        assert len(max_queries) == 0, "Should not query for max_id when override is provided"
+
+    def test_get_id_range_uses_both_overrides(self):
+        """Test that both min_id and max_id overrides are honored when provided."""
+        config = DeletePersonsFromTriggerLogConfig(min_id=100, max_id=5000)
+        mock_db = create_mock_database_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+
+        context = build_op_context(resources={"database": mock_db})
+
+        result = get_id_range(context, config)
+
+        assert result == (100, 5000)
+        assert result[0] == 100  # min_id override used
+        assert result[1] == 5000  # max_id override used
+
+        # Verify NO queries were executed (both overrides used)
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        min_queries = [call for call in execute_calls if "MIN(id)" in call]
+        max_queries = [call for call in execute_calls if "MAX(id)" in call]
+        assert len(min_queries) == 0, "Should not query for min_id when override is provided"
+        assert len(max_queries) == 0, "Should not query for max_id when override is provided"
+
+    def test_get_id_range_queries_database_when_min_id_not_provided(self):
+        """Test that database is queried for min_id when override is not provided."""
+        config = DeletePersonsFromTriggerLogConfig(min_id=None, max_id=5000)
+        mock_db = create_mock_database_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = {"min_id": 1}
+
+        context = build_op_context(resources={"database": mock_db})
+
+        result = get_id_range(context, config)
+
+        assert result == (1, 5000)
+
+        # Verify min_id query was executed (queries posthog_person_deletes_log)
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        min_queries = [call for call in execute_calls if "MIN(id)" in call and "posthog_person_deletes_log" in call]
+        assert (
+            len(min_queries) == 1
+        ), "Should query for min_id from posthog_person_deletes_log when override is not provided"
+
+    def test_get_id_range_queries_database_when_both_not_provided(self):
+        """Test that database is queried for both min_id and max_id when overrides are not provided."""
+        config = DeletePersonsFromTriggerLogConfig(min_id=None, max_id=None)
+        mock_db = create_mock_database_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+        # fetchone will be called twice - once for MIN, once for MAX
+        cursor.fetchone.side_effect = [{"min_id": 1}, {"max_id": 5000}]
+
+        context = build_op_context(resources={"database": mock_db})
+
+        result = get_id_range(context, config)
+
+        assert result == (1, 5000)
+
+        # Verify both queries were executed (queries posthog_person_deletes_log)
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        min_queries = [call for call in execute_calls if "MIN(id)" in call and "posthog_person_deletes_log" in call]
+        max_queries = [call for call in execute_calls if "MAX(id)" in call and "posthog_person_deletes_log" in call]
+        assert (
+            len(min_queries) == 1
+        ), "Should query for min_id from posthog_person_deletes_log when override is not provided"
+        assert (
+            len(max_queries) == 1
+        ), "Should query for max_id from posthog_person_deletes_log when override is not provided"
+
+    def test_get_id_range_queries_database_when_max_id_not_provided(self):
+        """Test that database is queried for max_id when override is not provided."""
+        config = DeletePersonsFromTriggerLogConfig(min_id=1, max_id=None)
+        mock_db = create_mock_database_resource()
+
+        cursor = mock_db.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = {"max_id": 5000}
+
+        context = build_op_context(resources={"database": mock_db})
+
+        result = get_id_range(context, config)
+
+        assert result == (1, 5000)
+
+        # Verify max_id query was executed (queries posthog_person_deletes_log)
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        max_queries = [call for call in execute_calls if "MAX(id)" in call and "posthog_person_deletes_log" in call]
+        assert (
+            len(max_queries) == 1
+        ), "Should query for max_id from posthog_person_deletes_log when override is not provided"
+
+    def test_get_id_range_validates_max_id_greater_than_min_id(self):
+        """Test that validation fails when max_id < min_id."""
+        config = DeletePersonsFromTriggerLogConfig(min_id=5000, max_id=100)
+        mock_db = create_mock_database_resource()
+
+        context = build_op_context(resources={"database": mock_db})
+
+        from dagster import Failure
+
+        try:
+            get_id_range(context, config)
+            raise AssertionError("Expected Dagster.Failure to be raised")
+        except Failure as e:
+            assert e.description is not None
+            description = e.description
+            assert "max_id" in description.lower() or "invalid" in description.lower()
+            assert "5000" in description or "100" in description


### PR DESCRIPTION
## Problem
We need to run a pass over the delete trigger log table and clean up undeleted person rows from the new partitioned database.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement dagster job to do this in small batches
* Does not cover the associated `posthog_persondistinctid` rows (we have another job that will clean this up later)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
