### PR TITLE
fix: Retention period dropdown not updating when value changes

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
@@ -66,7 +66,7 @@ function CustomBrackets({ insightProps }: { insightProps: EditorFilterProps['ins
             <div className="flex items-center gap-2">
                 <div>Bracket By</div>
                 <LemonSelect
-                    value={period}
+                    value={period ?? RetentionPeriod.Day}
                     onChange={(value): void => {
                         updateInsightFilter({ period: value ? value : undefined })
                     }}
@@ -237,7 +237,7 @@ export function RetentionCondition({ insightProps }: EditorFilterProps): JSX.Ele
                             }}
                         />
                         <LemonSelect
-                            value={period}
+                            value={period ?? RetentionPeriod.Day}
                             onChange={(value): void => {
                                 updateInsightFilter({ period: value ? value : undefined })
                                 // reset date range when we change interval type


### PR DESCRIPTION
## Problem

The period dropdown in retention insights wasn't reflecting the selected interval (day/week/month) even though the query and data updated correctly.

Root cause: When period is undefined, LemonSelect receives null and can't find a matching option, so it displays a fallback instead of highlighting the correct default.

## Changes

Fix: Apply the same pattern used in IntervalFilter - provide a default fallback value directly in the value prop using the nullish coalescing operator.

Changed value={period} to value={period ?? RetentionPeriod.Day} in both locations (custom brackets and main selector).

## How did you test this code?

locally