### PR TITLE
chore: Extract typegen to separate mprocs worker

### DIFF
--- a/bin/mprocs-with-logging.yaml
+++ b/bin/mprocs-with-logging.yaml
@@ -17,7 +17,6 @@ procs:
 
     typegen:
         shell: 'if [ -n "$SKIP_TYPEGEN" ]; then exit 0; fi && cd frontend && pnpm run typegen:watch 2>&1 | tee /tmp/posthog-typegen.log'
-        autorestart: true
 
     temporal-worker:
         shell: |-

--- a/bin/mprocs-with-logging.yaml
+++ b/bin/mprocs-with-logging.yaml
@@ -15,6 +15,10 @@ procs:
         shell: './bin/start-frontend 2>&1 | tee /tmp/posthog-frontend.log'
         autorestart: true
 
+    typegen:
+        shell: 'if [ -n "$SKIP_TYPEGEN" ]; then exit 0; fi && cd frontend && pnpm run typegen:watch 2>&1 | tee /tmp/posthog-typegen.log'
+        autorestart: true
+
     temporal-worker:
         shell: |-
             bin/check_kafka_clickhouse_up && \

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -15,6 +15,9 @@ procs:
         shell: './bin/start-frontend'
         autorestart: true
 
+    typegen:
+        shell: 'if [ -n "$SKIP_TYPEGEN" ]; then exit 0; fi && cd frontend && pnpm run typegen:watch'
+
     temporal-worker:
         shell: |-
             bin/check_kafka_clickhouse_up && \

--- a/bin/start
+++ b/bin/start
@@ -37,7 +37,7 @@ else
 fi
 
 if [[ "$*" == *"--skip-typegen"* ]]; then
-    export SKIP_TYPEGEN="exit 0"
+    export SKIP_TYPEGEN="1"
 fi
 
 if [ -f .env ]; then

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,9 +24,7 @@
         "build:products": "DEBUG=0 node build-products.mjs",
         "build:tailwind": "pnpm --filter=@posthog/tailwind build",
         "watch:tailwind": "pnpm --filter=@posthog/tailwind start",
-        "start": "if [ -n \"$SKIP_TYPEGEN\" ]; then pnpm start-no-typegen; else pnpm start-all; fi",
-        "start-all": "concurrently -n ESBUILD,TYPEGEN,TAILWIND -c yellow,green,blue \"pnpm start-http\" \"${SKIP_TYPEGEN:-pnpm run typegen:watch}\" \"pnpm watch:tailwind\"",
-        "start-no-typegen": "concurrently -n ESBUILD,TAILWIND -c yellow,green,blue \"pnpm start-http\" \"pnpm watch:tailwind\"",
+        "start": "concurrently -n ESBUILD,TAILWIND -c yellow,blue \"pnpm start-http\" \"pnpm watch:tailwind\"",
         "start-http": "pnpm clean && pnpm copy-scripts && pnpm build:esbuild --dev",
         "start-docker": "pnpm start-http --host 0.0.0.0",
         "typegen:check": "cd .. && NODE_OPTIONS=\"--max-old-space-size=16384\" kea-typegen check",
@@ -46,7 +44,7 @@
         "format": "cd .. && oxlint --fix --fix-suggestions --fix-dangerously --quiet && pnpm prettier -w \"./{products,frontend/src}/**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\"",
         "visualize-toolbar-bundle": "pnpm exec esbuild-visualizer --metadata ./toolbar-esbuild-meta.json --filename=toolbar-esbuild-bundle-visualization.html",
         "check-toolbar-csp-eval": "node ./bin/check-toolbar-csp-eval.mjs",
-        "start-vite": "pnpm build:products && concurrently -n VITE,TYPEGEN,TAILWIND -c green,blue,yellow  \"vite --host 0.0.0.0\" \"${SKIP_TYPEGEN:-pnpm run typegen:watch}\" \"pnpm watch:tailwind\""
+        "start-vite": "pnpm build:products && concurrently -n VITE,TAILWIND -c green,yellow \"vite --host 0.0.0.0\" \"pnpm watch:tailwind\""
     },
     "dependencies": {
         "@babel/runtime": "^7.24.0",


### PR DESCRIPTION
This makes turning off typegen much easier by abstracting it away from the existing `frontend` service