### PR TITLE
fix(experiments): update breakdown_value type.

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12596,9 +12596,19 @@
                     "description": "Control variant stats for this breakdown"
                 },
                 "breakdown_value": {
-                    "description": "The breakdown values as an array (e.g., [\"MacOS\", \"Chrome\"] for multi-breakdown, [\"Chrome\"] for single)",
+                    "description": "The breakdown values as an array (e.g., [\"MacOS\", \"Chrome\"] for multi-breakdown, [\"Chrome\"] for single) Although `BreakdownKeyType` could be an array, we only use the array form for the breakdown_value. The way `BreakdownKeyType` is defined is problematic. It should be treated as a primitive and allow for the types using it to define if it's and array or an optional value.",
                     "items": {
-                        "$ref": "#/definitions/BreakdownKeyType"
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/integer"
+                            },
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ]
                     },
                     "type": "array"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3056,8 +3056,13 @@ export interface ExperimentVariantResultBayesian extends ExperimentStatsBaseVali
  * For multiple breakdowns, values are in the same order as breakdownFilter.breakdowns.
  */
 export interface ExperimentBreakdownResult {
-    /** The breakdown values as an array (e.g., ["MacOS", "Chrome"] for multi-breakdown, ["Chrome"] for single) */
-    breakdown_value: BreakdownKeyType[]
+    /**
+     * The breakdown values as an array (e.g., ["MacOS", "Chrome"] for multi-breakdown, ["Chrome"] for single)
+     * Although `BreakdownKeyType` could be an array, we only use the array form for the breakdown_value.
+     * The way `BreakdownKeyType` is defined is problematic. It should be treated as a primitive and allow
+     * for the types using it to define if it's and array or an optional value.
+     */
+    breakdown_value: (integer | string | number)[]
     /** Control variant stats for this breakdown */
     baseline: ExperimentStatsBaseValidated
     /** Test variant results with statistical comparisons for this breakdown */

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -19,7 +19,7 @@ import {
     ExperimentStatsBaseValidated,
     NewExperimentQueryResponse,
 } from '~/queries/schema/schema-general'
-import { BreakdownKeyType, Experiment, InsightType } from '~/types'
+import { Experiment, InsightType } from '~/types'
 
 import { experimentLogic } from '../../experimentLogic'
 import { ChartEmptyState } from '../shared/ChartEmptyState'
@@ -549,7 +549,7 @@ export function MetricRowGroup({
                                 } ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
                             >
                                 {formatBreakdownLabel(
-                                    breakdownResult.breakdown_value as BreakdownKeyType,
+                                    breakdownResult.breakdown_value,
                                     metric.breakdownFilter,
                                     [],
                                     undefined,
@@ -599,7 +599,7 @@ export function MetricRowGroup({
                                 }}
                             >
                                 {formatBreakdownLabel(
-                                    breakdownResult.breakdown_value as BreakdownKeyType,
+                                    breakdownResult.breakdown_value,
                                     metric.breakdownFilter,
                                     [],
                                     undefined,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -9338,10 +9338,13 @@ class ExperimentBreakdownResult(BaseModel):
         extra="forbid",
     )
     baseline: ExperimentStatsBaseValidated = Field(..., description="Control variant stats for this breakdown")
-    breakdown_value: list[Optional[Union[int, str, float, list[Union[int, str, float]]]]] = Field(
+    breakdown_value: list[Union[str, float, int]] = Field(
         ...,
         description=(
             'The breakdown values as an array (e.g., ["MacOS", "Chrome"] for multi-breakdown, ["Chrome"] for single)'
+            " Although `BreakdownKeyType` could be an array, we only use the array form for the breakdown_value. The"
+            " way `BreakdownKeyType` is defined is problematic. It should be treated as a primitive and allow for the"
+            " types using it to define if it's and array or an optional value."
         ),
     )
     variants: Union[list[ExperimentVariantResultFrequentist], list[ExperimentVariantResultBayesian]] = Field(


### PR DESCRIPTION
## Problem

The `BreakdownKeyType` is not great.

```ts
export type BreakdownKeyType = integer | string | number | (integer | string | number)[] | null
```

Ideally, you want your types to be extended via unions or derived via utility types. In the case of `BreakdownKeyType`, you would like to treat it as a primitive and either allow it to be used as an array or make it nullable in the final type or variable.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We were inadvertently deriving `BreakdownKeyType` as an array when it already includes the array form as a union. That was causing some problems with type inference, which we fixed by adding a type assertion. 

This change acknowledges the weirdness of `BreakdownKeyType` and documents why we are using primitives instead when defining `breakdown_values`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/bf623c33-226d-4303-a8d6-11d00ed5feef)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
