### PR TITLE
chore(dagster): fix ingestion namespace fn name clashes

### DIFF
--- a/dags/delete_persons_from_trigger_log.py
+++ b/dags/delete_persons_from_trigger_log.py
@@ -29,7 +29,7 @@ class DeletePersonsFromTriggerLogConfig(dagster.Config):
 
 
 @dagster.op
-def get_id_range(
+def get_id_range_for_dpft(
     context: dagster.OpExecutionContext,
     config: DeletePersonsFromTriggerLogConfig,
     database: dagster.ResourceParam[psycopg2.extensions.connection],
@@ -96,7 +96,7 @@ def get_id_range(
 
 
 @dagster.op(out=dagster.DynamicOut(tuple[int, int]))
-def create_chunks(
+def create_chunks_for_dpft(
     context: dagster.OpExecutionContext,
     config: DeletePersonsFromTriggerLogConfig,
     id_range: tuple[int, int],
@@ -134,7 +134,7 @@ def create_chunks(
 
 
 @dagster.op
-def scan_delete_chunk(
+def scan_delete_chunk_for_dpft(
     context: dagster.OpExecutionContext,
     config: DeletePersonsFromTriggerLogConfig,
     chunk: tuple[int, int],
@@ -412,6 +412,6 @@ def delete_persons_from_trigger_log_job():
     """
     Scan posthog_person_deletes_log table, and deletes the corresponding posthog_person_new rows.
     """
-    id_range = get_id_range()
-    chunks = create_chunks(id_range)
-    chunks.map(scan_delete_chunk)
+    id_range = get_id_range_for_dpft()
+    chunks = create_chunks_for_dpft(id_range)
+    chunks.map(scan_delete_chunk_for_dpft)

--- a/dags/locations/ingestion.py
+++ b/dags/locations/ingestion.py
@@ -1,6 +1,6 @@
 import dagster
 
-from dags import delete_persons_from_trigger_log_job, ingestion_assets, persons_new_backfill
+from dags import delete_persons_from_trigger_log, ingestion_assets, persons_new_backfill
 
 from . import resources
 
@@ -10,7 +10,7 @@ defs = dagster.Definitions(
     ],
     jobs=[
         persons_new_backfill.persons_new_backfill_job,
-        delete_persons_from_trigger_log_job.delete_persons_from_trigger_log_job,
+        delete_persons_from_trigger_log.delete_persons_from_trigger_log_job,
     ],
     resources=resources,
 )

--- a/dags/locations/ingestion.py
+++ b/dags/locations/ingestion.py
@@ -9,8 +9,8 @@ defs = dagster.Definitions(
         ingestion_assets.postgres_env_check,
     ],
     jobs=[
-        persons_new_backfill.persons_new_backfill_job,
         delete_persons_from_trigger_log.delete_persons_from_trigger_log_job,
+        persons_new_backfill.persons_new_backfill_job,
     ],
     resources=resources,
 )

--- a/dags/persons_new_backfill.py
+++ b/dags/persons_new_backfill.py
@@ -27,7 +27,7 @@ class PersonsNewBackfillConfig(dagster.Config):
 
 
 @dagster.op
-def get_id_range(
+def get_id_range_for_pnb(
     context: dagster.OpExecutionContext,
     config: PersonsNewBackfillConfig,
     database: dagster.ResourceParam[psycopg2.extensions.connection],
@@ -95,7 +95,7 @@ def get_id_range(
 
 
 @dagster.op(out=dagster.DynamicOut(tuple[int, int]))
-def create_chunks(
+def create_chunks_for_pnb(
     context: dagster.OpExecutionContext,
     config: PersonsNewBackfillConfig,
     id_range: tuple[int, int],
@@ -400,6 +400,6 @@ def persons_new_backfill_job():
     Backfill posthog_persons data from source to destination Postgres database.
     Divides the ID space into chunks and processes them in parallel.
     """
-    id_range = get_id_range()
-    chunks = create_chunks(id_range)
+    id_range = get_id_range_for_pnb()
+    chunks = create_chunks_for_pnb(id_range)
     chunks.map(copy_chunk)

--- a/dags/tests/test_persons_new_backfill.py
+++ b/dags/tests/test_persons_new_backfill.py
@@ -5,11 +5,11 @@ from unittest.mock import MagicMock, patch
 import psycopg2.errors
 from dagster import build_op_context
 
-from dags.persons_new_backfill import PersonsNewBackfillConfig, copy_chunk, create_chunks, get_id_range
+from dags.persons_new_backfill import PersonsNewBackfillConfig, copy_chunk, create_chunks_for_pnb, get_id_range_for_pnb
 
 
-class TestCreateChunks:
-    """Test the create_chunks function."""
+class TestCreateChunksForPnb:
+    """Test the create_chunks_for_pnb function."""
 
     def test_create_chunks_produces_non_overlapping_ranges(self):
         """Test that chunks produce non-overlapping ranges."""
@@ -17,7 +17,7 @@ class TestCreateChunks:
         id_range = (1, 5000)  # min_id=1, max_id=5000
 
         context = build_op_context()
-        chunks = list(create_chunks(context, config, id_range))
+        chunks = list(create_chunks_for_pnb(context, config, id_range))
 
         # Extract all chunk ranges from DynamicOutput objects
         chunk_ranges = [chunk.value for chunk in chunks]
@@ -38,7 +38,7 @@ class TestCreateChunks:
         id_range = (min_id, max_id)
 
         context = build_op_context()
-        chunks = list(create_chunks(context, config, id_range))
+        chunks = list(create_chunks_for_pnb(context, config, id_range))
 
         # Extract all chunk ranges from DynamicOutput objects
         chunk_ranges = [chunk.value for chunk in chunks]
@@ -61,7 +61,7 @@ class TestCreateChunks:
         id_range = (min_id, max_id)
 
         context = build_op_context()
-        chunks = list(create_chunks(context, config, id_range))
+        chunks = list(create_chunks_for_pnb(context, config, id_range))
 
         # First chunk in the list (yielded first, highest IDs)
         first_chunk_min, first_chunk_max = chunks[0].value
@@ -78,7 +78,7 @@ class TestCreateChunks:
         id_range = (min_id, max_id)
 
         context = build_op_context()
-        chunks = list(create_chunks(context, config, id_range))
+        chunks = list(create_chunks_for_pnb(context, config, id_range))
 
         # Last chunk in the list (yielded last, lowest IDs)
         final_chunk_min, final_chunk_max = chunks[-1].value
@@ -95,7 +95,7 @@ class TestCreateChunks:
         id_range = (min_id, max_id)
 
         context = build_op_context()
-        chunks = list(create_chunks(context, config, id_range))
+        chunks = list(create_chunks_for_pnb(context, config, id_range))
 
         # Verify chunks are in descending order by max_id
         for i in range(len(chunks) - 1):
@@ -112,7 +112,7 @@ class TestCreateChunks:
         id_range = (min_id, max_id)
 
         context = build_op_context()
-        chunks = list(create_chunks(context, config, id_range))
+        chunks = list(create_chunks_for_pnb(context, config, id_range))
 
         assert len(chunks) == 5, f"Expected 5 chunks, got {len(chunks)}"
 
@@ -129,7 +129,7 @@ class TestCreateChunks:
         id_range = (min_id, max_id)
 
         context = build_op_context()
-        chunks = list(create_chunks(context, config, id_range))
+        chunks = list(create_chunks_for_pnb(context, config, id_range))
 
         assert len(chunks) == 4, f"Expected 4 chunks, got {len(chunks)}"
 
@@ -146,7 +146,7 @@ class TestCreateChunks:
         id_range = (min_id, max_id)
 
         context = build_op_context()
-        chunks = list(create_chunks(context, config, id_range))
+        chunks = list(create_chunks_for_pnb(context, config, id_range))
 
         assert len(chunks) == 1, f"Expected 1 chunk, got {len(chunks)}"
         assert chunks[0].value == (100, 500), f"Chunk should be (100, 500), got {chunks[0].value}"
@@ -485,8 +485,8 @@ class TestCopyChunk:
             assert max(set_indices) < min(begin_indices), "SET statements should come before BEGIN statements"
 
 
-class TestGetIdRange:
-    """Test the get_id_range function."""
+class TestGetIdRangeForPnb:
+    """Test the get_id_range_for_pnb function."""
 
     def test_get_id_range_uses_min_id_override(self):
         """Test that min_id override is honored when provided."""
@@ -498,7 +498,7 @@ class TestGetIdRange:
 
         context = build_op_context(resources={"database": mock_db})
 
-        result = get_id_range(context, config)
+        result = get_id_range_for_pnb(context, config)
 
         assert result == (100, 5000)
         assert result[0] == 100  # min_id override used
@@ -522,7 +522,7 @@ class TestGetIdRange:
 
         context = build_op_context(resources={"database": mock_db})
 
-        result = get_id_range(context, config)
+        result = get_id_range_for_pnb(context, config)
 
         assert result == (1, 5000)
         assert result[1] == 5000  # max_id override used
@@ -545,7 +545,7 @@ class TestGetIdRange:
 
         context = build_op_context(resources={"database": mock_db})
 
-        result = get_id_range(context, config)
+        result = get_id_range_for_pnb(context, config)
 
         assert result == (100, 5000)
         assert result[0] == 100  # min_id override used
@@ -569,7 +569,7 @@ class TestGetIdRange:
 
         context = build_op_context(resources={"database": mock_db})
 
-        result = get_id_range(context, config)
+        result = get_id_range_for_pnb(context, config)
 
         assert result == (1, 5000)
 
@@ -590,7 +590,7 @@ class TestGetIdRange:
         from dagster import Failure
 
         try:
-            get_id_range(context, config)
+            get_id_range_for_pnb(context, config)
             raise AssertionError("Expected Dagster.Failure to be raised")
         except Failure as e:
             assert e.description is not None


### PR DESCRIPTION
## Problem
Now that we have more than one job defined in the `team-ingestion` code location for Dagster, we have to avoid func name conflicts. CI doesn't catch this atm. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add namespace scoping to common task and test functions in the new ingestion jobs
* Related updates to plumbing
* Rename file
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI (will smoke test in Dagster job upload)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
