### PR TITLE
chore(flags): Remove old unnecessary metric

### DIFF
--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1,4 +1,4 @@
-use crate::metrics::consts::{FLAG_FILTER_DESERIALIZATION_ERROR_COUNTER, TOMBSTONE_COUNTER};
+use crate::metrics::consts::TOMBSTONE_COUNTER;
 use metrics::counter;
 use std::sync::Arc;
 use tracing;
@@ -166,13 +166,6 @@ impl FeatureFlagList {
                             row.team_id,
                             e
                         );
-                        counter!(
-                            FLAG_FILTER_DESERIALIZATION_ERROR_COUNTER,
-                            "team_id" => row.team_id.to_string(),
-                            "flag_key" => row.key.clone(),
-                        )
-                        .increment(1);
-
                         // Also track as a tombstone - invalid data in postgres should never happen
                         counter!(
                             TOMBSTONE_COUNTER,

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -61,8 +61,6 @@ pub const FLAG_ACQUIRE_TIMEOUT_COUNTER: &str = "flags_acquire_timeout_total";
 
 // Error classification
 pub const FLAG_DATABASE_ERROR_COUNTER: &str = "flags_database_error_total";
-pub const FLAG_FILTER_DESERIALIZATION_ERROR_COUNTER: &str =
-    "flags_filter_deserialization_error_total";
 
 // Tombstone metric for tracking "impossible" failures that should never happen in production
 // Different failure types are tracked via the "failure_type" label


### PR DESCRIPTION
We now have the tombstone metric.

## Problem

We used to track a metric named `flags_filter_deserialization_error_total` which should never happen. However, we created a pattern for these types of metrics using the new `posthog_tombstone_total` metric. That metric is being incremented here, making `flags_filter_deserialization_error_total` redundant.

## Changes

Removed the code to increment the `flags_filter_deserialization_error_total` metric. The code to increment `posthog_tombstone_total` is already there.

## How did you test this code?

Unit tests

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
