### PR TITLE
fix: use more secure hash function

### DIFF
--- a/posthog/caching/login_device_cache.py
+++ b/posthog/caching/login_device_cache.py
@@ -10,8 +10,7 @@ def check_and_cache_login_device(user_id: int, location: str, short_user_agent: 
 
     # Create a unique device identifier based on location + user agent
     device_fingerprint = f"{location}:{short_user_agent}"
-    # nosemgrep: python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
-    device_hash = hashlib.md5(device_fingerprint.encode()).hexdigest()
+    device_hash = hashlib.sha256(device_fingerprint.encode()).hexdigest()
     cache_key = f"login_device:{user_id}:{device_hash}"
 
     # Check if this device has logged in before

--- a/posthog/caching/login_device_cache.py
+++ b/posthog/caching/login_device_cache.py
@@ -10,7 +10,10 @@ def check_and_cache_login_device(user_id: int, location: str, short_user_agent: 
 
     # Create a unique device identifier based on location + user agent
     device_fingerprint = f"{location}:{short_user_agent}"
-    device_hash = hashlib.sha256(device_fingerprint.encode()).hexdigest()
+    # TODO switch to sha256 hash
+    # device_fingerprint is user controllable. a hash collision might be possible with md5
+    # nosemgrep: python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
+    device_hash = hashlib.md5(device_fingerprint.encode()).hexdigest()
     cache_key = f"login_device:{user_id}:{device_hash}"
 
     # Check if this device has logged in before

--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -64,7 +64,7 @@ def cached_by_filters(f: Callable[[U, Request], T]) -> Callable[[U, Request], T]
         if request.GET.get("cache_invalidation_key"):
             cache_key += f"_{request.GET['cache_invalidation_key']}"
 
-        cache_key = generate_cache_key(cache_key)
+        cache_key = generate_cache_key(team.pk, cache_key)
 
         tag_queries(cache_key=cache_key)
 

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1290,7 +1290,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         }
 
     def get_cache_key(self) -> str:
-        return generate_cache_key(f"query_{bytes.decode(to_json(self.get_cache_payload()))}")
+        return generate_cache_key(self.team.pk, f"query_{bytes.decode(to_json(self.get_cache_payload()))}")
 
     def _get_cache_age_override(self, last_refresh: Optional[datetime]) -> Optional[datetime]:
         """

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -209,7 +209,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_1856f58194a164d6377559b7190b2dc1687a938082ba3727fa368acaa4735df9"
+        assert cache_key == "cache_42_1856f58194a164d6377559b7190b2dc1687a938082ba3727fa368acaa4735df9"
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -223,7 +223,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_a1d7ba3cb42fe2a2868f6bdd661d44446019ba7778da08a4966342d70dcea4ad"
+        assert cache_key == "cache_42_a1d7ba3cb42fe2a2868f6bdd661d44446019ba7778da08a4966342d70dcea4ad"
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -234,7 +234,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_46d82b43c9202b9cfa615147a7c2b718ad15fa6bbe11deceddc3015277f48c04"
+        assert cache_key == "cache_42_46d82b43c9202b9cfa615147a7c2b718ad15fa6bbe11deceddc3015277f48c04"
 
     @mock.patch("django.db.transaction.on_commit")
     def test_cache_response(self, mock_on_commit):

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -209,7 +209,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_c4703f06a15b578567a681d01f5a63cc"
+        assert cache_key == "cache_1856f58194a164d6377559b7190b2dc1687a938082ba3727fa368acaa4735df9"
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -223,7 +223,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_559d7f88353a23dc6b1aa69fe5afef87"
+        assert cache_key == "cache_a1d7ba3cb42fe2a2868f6bdd661d44446019ba7778da08a4966342d70dcea4ad"
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -234,7 +234,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_6157b47affc8c1d502b7f53b9a3279d3"
+        assert cache_key == "cache_46d82b43c9202b9cfa615147a7c2b718ad15fa6bbe11deceddc3015277f48c04"
 
     @mock.patch("django.db.transaction.on_commit")
     def test_cache_response(self, mock_on_commit):

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -416,7 +416,8 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
 
     def _sample_rate_cache_key(self) -> str:
         return generate_cache_key(
-            f"web_analytics_sample_rate_{self.query.dateRange.model_dump_json() if self.query.dateRange else None}_{self.team.pk}_{self.team.timezone}"
+            self.team.pk,
+            f"web_analytics_sample_rate_{self.query.dateRange.model_dump_json() if self.query.dateRange else None}_{self.team.pk}_{self.team.timezone}",
         )
 
     def _get_or_calculate_sample_ratio(self) -> SamplingRate:

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -320,7 +320,9 @@ class InsightViewed(models.Model):
 def generate_insight_filters_hash(insight: Insight, dashboard: Optional[Dashboard]) -> str:
     try:
         dashboard_insight_filter = get_filter(data=insight.dashboard_filters(dashboard=dashboard), team=insight.team)
-        candidate_filters_hash = generate_cache_key("{}_{}".format(dashboard_insight_filter.toJSON(), insight.team_id))
+        candidate_filters_hash = generate_cache_key(
+            insight.team.pk, "{}_{}".format(dashboard_insight_filter.toJSON(), insight.team_id)
+        )
         return candidate_filters_hash
     except Exception as e:
         logger.error(

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -8633,7 +8633,7 @@ class TestTrendUtils(ClickhouseTestMixin, APIBaseTest):
                 "interval": "hour",
             },
         )
-        cache_key = generate_cache_key(f"{filter.toJSON()}_{self.team.pk}")
+        cache_key = generate_cache_key(self.team.pk, f"{filter.toJSON()}_{self.team.pk}")
         cache.set(cache_key, fake_cached, settings.CACHED_RESULTS_TTL)
 
         is_present = Trends().get_cached_result(filter, self.team)
@@ -8663,7 +8663,7 @@ class TestTrendUtils(ClickhouseTestMixin, APIBaseTest):
                 "interval": "hour",
             },
         )
-        cache_key = generate_cache_key(f"{filter.toJSON()}_{self.team.pk}")
+        cache_key = generate_cache_key(self.team.pk, f"{filter.toJSON()}_{self.team.pk}")
         cache.set(cache_key, fake_cached, settings.CACHED_RESULTS_TTL)
 
         res = Trends().get_cached_result(filter, self.team)
@@ -8699,7 +8699,7 @@ class TestTrendUtils(ClickhouseTestMixin, APIBaseTest):
                 "events": [{"id": "sign up", "name": "sign up"}],
             },
         )
-        cache_key = generate_cache_key(f"{filter.toJSON()}_{self.team.pk}")
+        cache_key = generate_cache_key(self.team.pk, f"{filter.toJSON()}_{self.team.pk}")
         cache.set(cache_key, fake_cached, settings.CACHED_RESULTS_TTL)
 
         res = Trends().get_cached_result(filter, self.team)
@@ -8739,7 +8739,7 @@ class TestTrendUtils(ClickhouseTestMixin, APIBaseTest):
                 "interval": "week",
             },
         )
-        cache_key = generate_cache_key(f"{filter.toJSON()}_{self.team.pk}")
+        cache_key = generate_cache_key(self.team.pk, f"{filter.toJSON()}_{self.team.pk}")
         cache.set(cache_key, fake_cached, settings.CACHED_RESULTS_TTL)
 
         res = Trends().get_cached_result(filter, self.team)
@@ -8777,7 +8777,7 @@ class TestTrendUtils(ClickhouseTestMixin, APIBaseTest):
                 "interval": "month",
             },
         )
-        cache_key = generate_cache_key(f"{filter.toJSON()}_{self.team.pk}")
+        cache_key = generate_cache_key(self.team.pk, f"{filter.toJSON()}_{self.team.pk}")
         cache.set(cache_key, fake_cached, settings.CACHED_RESULTS_TTL)
 
         res = Trends().get_cached_result(filter, self.team)

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -56,7 +56,7 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
         if not team.strict_caching_enabled or filter.breakdown or filter.display != TRENDS_LINEAR:
             return None
 
-        cache_key = generate_cache_key(f"{filter.toJSON()}_{team.pk}")
+        cache_key = generate_cache_key(team.pk, f"{filter.toJSON()}_{team.pk}")
         cached_result_package = get_safe_cache(cache_key)
         cached_result = (
             cached_result_package.get("result")

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -731,7 +731,7 @@ def get_compare_period_dates(
     return new_date_from, new_date_to
 
 
-def generate_cache_key(team_pk: str, stringified: str) -> str:
+def generate_cache_key(team_pk: int, stringified: str) -> str:
     return f"cache_{team_pk}_{hashlib.sha256(stringified.encode('utf-8')).hexdigest()}"
 
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -731,8 +731,8 @@ def get_compare_period_dates(
     return new_date_from, new_date_to
 
 
-def generate_cache_key(stringified: str) -> str:
-    return "cache_" + hashlib.sha256(stringified.encode("utf-8")).hexdigest()
+def generate_cache_key(team_pk: str, stringified: str) -> str:
+    return f"cache_{team_pk}_{hashlib.sha256(stringified.encode('utf-8')).hexdigest()}"
 
 
 def get_celery_heartbeat() -> Union[str, int]:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -732,9 +732,7 @@ def get_compare_period_dates(
 
 
 def generate_cache_key(stringified: str) -> str:
-    # TODO this value might be user controllable, so we should switch from md5
-    # nosemgrep: python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
-    return "cache_" + hashlib.md5(stringified.encode("utf-8")).hexdigest()
+    return "cache_" + hashlib.sha256(stringified.encode("utf-8")).hexdigest()
 
 
 def get_celery_heartbeat() -> Union[str, int]:


### PR DESCRIPTION
This cache key holds user input, so we want stronger collision resistance. This change will invalidate the existing cache.

Will deploy this over the weekend when the cache is the least used.