### PR TITLE
chore(flags): Replace dependency graph error metric with tombstone metrics

### DIFF
--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -8,7 +8,7 @@ use petgraph::{
 
 use crate::api::errors::FlagError;
 use crate::flags::flag_models::FeatureFlag;
-use crate::metrics::consts::FLAG_EVALUATION_ERROR_COUNTER;
+use crate::metrics::consts::{FLAG_EVALUATION_ERROR_COUNTER, TOMBSTONE_COUNTER};
 use common_metrics::inc;
 use tracing::warn;
 
@@ -485,14 +485,23 @@ pub fn log_dependency_graph_construction_errors(
     errors: &[GraphError<i32>],
     team_id: common_types::TeamId,
 ) {
-    inc(
-        FLAG_EVALUATION_ERROR_COUNTER,
-        &[
-            ("reason".to_string(), "dependency_graph_error".to_string()),
-            ("team_id".to_string(), team_id.to_string()),
-        ],
-        1,
-    );
+    for error in errors {
+        let (failure_type, flag_id) = match error {
+            GraphError::MissingDependency(id) => ("flag_dependency_missing", id),
+            GraphError::CycleDetected(id) => ("flag_dependency_cycle", id),
+        };
+
+        inc(
+            TOMBSTONE_COUNTER,
+            &[
+                ("failure_type".to_string(), failure_type.to_string()),
+                ("team_id".to_string(), team_id.to_string()),
+                ("flag_id".to_string(), flag_id.to_string()),
+            ],
+            1,
+        );
+    }
+
     tracing::error!(
         "There were errors building the feature flag dependency graph for team {}. Will attempt to evaluate the rest of the flags: {:?}",
         team_id, errors


### PR DESCRIPTION
## Problem

We have a new tombstone metric useful for events we expect to never happen. But with James Bond, never say die and with code, never say never.

## Changes

Replace the single `dependency_graph_error` metric with two distinct tombstone metrics to better track configuration issues:
- `flag_dependency_cycle` for circular dependencies
- `flag_dependency_missing` for missing flag dependencies

Each metric now includes `flag_id` label to identify which flags have configuration problems.

## How did you test this code?

Unit tests
Manually.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
