### PR TITLE
feat(dagster): trigger log scanning job's logic and tests to use LIMIT...OFFSET

### DIFF
--- a/dags/tests/test_delete_persons_from_trigger_log.py
+++ b/dags/tests/test_delete_persons_from_trigger_log.py
@@ -86,7 +86,7 @@ class TestCreateTeamChunksForDpft:
 
     def test_create_chunks_handles_empty_team_list(self):
         """Test that no chunks are created for empty team list."""
-        team_ids = []
+        team_ids: list[int] = []
 
         context = build_op_context()
         chunks = list(create_team_chunks_for_dpft(context, team_ids))

--- a/dags/tests/test_delete_persons_from_trigger_log.py
+++ b/dags/tests/test_delete_persons_from_trigger_log.py
@@ -7,8 +7,8 @@ from dagster import build_op_context
 
 from dags.delete_persons_from_trigger_log import (
     DeletePersonsFromTriggerLogConfig,
-    create_chunks_for_dpft,
-    get_scan_range_for_dpft,
+    create_team_chunks_for_dpft,
+    get_team_ids_for_dpft,
     scan_delete_chunk_for_dpft,
 )
 
@@ -32,199 +32,66 @@ def create_mock_psycopg2_error(message: str, pgcode: str) -> Exception:
     return MockPsycopg2Error(message, pgcode)
 
 
-class TestCreateChunksForDpft:
-    """Test the create_chunks_for_dpft function."""
+class TestGetTeamIdsForDpft:
+    """Test the get_team_ids_for_dpft function."""
 
-    def test_create_chunks_produces_non_overlapping_ranges(self):
-        """Test that chunks produce non-overlapping ranges."""
-        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
-        id_range = (0, 5000)  # min_row=0, max_row=5000 (row count)
+    def test_get_team_ids_returns_distinct_teams(self):
+        """Test that database is queried for distinct team_ids with persons to delete."""
+        mock_db = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [{"team_id": 1}, {"team_id": 2}, {"team_id": 5}]
+        mock_db.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
-        context = build_op_context()
-        chunks = list(create_chunks_for_dpft(context, config, id_range))
+        context = build_op_context(resources={"database": mock_db})
 
-        # Extract all chunk ranges from DynamicOutput objects
-        chunk_ranges = [chunk.value for chunk in chunks]
+        result = get_team_ids_for_dpft(context)
 
-        # Verify no overlaps
-        for i, (min1, max1) in enumerate(chunk_ranges):
-            for j, (min2, max2) in enumerate(chunk_ranges):
-                if i != j:
-                    # Chunks should not overlap
-                    assert not (
-                        min1 <= min2 <= max1 or min1 <= max2 <= max1 or min2 <= min1 <= max2
-                    ), f"Chunks overlap: ({min1}, {max1}) and ({min2}, {max2})"
+        assert result == [1, 2, 5]
 
-    def test_create_chunks_covers_entire_row_space(self):
-        """Test that chunks cover the entire row space from min to max without gaps."""
-        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
-        min_row, max_row = 0, 4999  # Realistic: if COUNT(*) = 5000, max_row = 4999
-        id_range = (min_row, max_row)
+        # Verify query was executed
+        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
+        assert any("SELECT DISTINCT pdl.team_id" in call for call in execute_calls)
+        assert any("FROM posthog_person_deletes_log" in call for call in execute_calls)
+        assert any("EXISTS" in call for call in execute_calls)
 
-        context = build_op_context()
-        chunks = list(create_chunks_for_dpft(context, config, id_range))
+    def test_get_team_ids_returns_empty_list_when_no_teams(self):
+        """Test that empty list is returned when no teams have persons to delete."""
+        mock_db = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        mock_db.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        mock_db.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
-        # Extract all chunk ranges from DynamicOutput objects
-        chunk_ranges = [chunk.value for chunk in chunks]
+        context = build_op_context(resources={"database": mock_db})
 
-        # Find the overall min and max covered
-        all_rows_covered: set[int] = set()
-        for chunk_min, chunk_max in chunk_ranges:
-            all_rows_covered.update(range(chunk_min, chunk_max + 1))
+        result = get_team_ids_for_dpft(context)
 
-        # Verify all rows from min_row to max_row are covered (inclusive)
-        expected_rows = set(range(min_row, max_row + 1))
-        assert all_rows_covered == expected_rows, (
-            f"Missing rows: {expected_rows - all_rows_covered}, " f"Extra rows: {all_rows_covered - expected_rows}"
-        )
+        assert result == []
 
-    def test_create_chunks_non_overlapping_inclusive_coverage(self):
-        """Test that chunks are non-overlapping and cover all offsets from 0 to max_row inclusively."""
-        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
-        # Simulate COUNT(*) = 5000, so max_row = 4999 (0-indexed)
-        min_row, max_row = 0, 4999
-        id_range = (min_row, max_row)
+
+class TestCreateTeamChunksForDpft:
+    """Test the create_team_chunks_for_dpft function."""
+
+    def test_create_chunks_for_each_team(self):
+        """Test that chunks are created for each team_id."""
+        team_ids = [1, 2, 5, 10]
 
         context = build_op_context()
-        chunks = list(create_chunks_for_dpft(context, config, id_range))
+        chunks = list(create_team_chunks_for_dpft(context, team_ids))
 
-        chunk_ranges = [chunk.value for chunk in chunks]
+        assert len(chunks) == 4
+        assert [chunk.value for chunk in chunks] == [1, 2, 5, 10]
+        assert [chunk.mapping_key for chunk in chunks] == ["team_1", "team_2", "team_5", "team_10"]
 
-        # Verify chunks are non-overlapping
-        for i, (min1, max1) in enumerate(chunk_ranges):
-            for j, (min2, max2) in enumerate(chunk_ranges):
-                if i != j:
-                    # Chunks should not overlap
-                    assert not (
-                        min1 <= min2 <= max1 or min1 <= max2 <= max1 or min2 <= min1 <= max2
-                    ), f"Chunks overlap: ({min1}, {max1}) and ({min2}, {max2})"
-
-        # Verify all offsets from 0 to max_row are covered (inclusive)
-        all_offsets_covered: set[int] = set()
-        for chunk_min, chunk_max in chunk_ranges:
-            # Verify chunk is inclusive on both ends
-            assert chunk_min <= chunk_max, f"Invalid chunk: min ({chunk_min}) > max ({chunk_max})"
-            all_offsets_covered.update(range(chunk_min, chunk_max + 1))
-
-        expected_offsets = set(range(0, max_row + 1))
-        assert all_offsets_covered == expected_offsets, (
-            f"Missing offsets: {sorted(expected_offsets - all_offsets_covered)}, "
-            f"Extra offsets: {sorted(all_offsets_covered - expected_offsets)}"
-        )
-
-        # Verify no gaps: each chunk should start where the previous one ended + 1
-        sorted_chunks = sorted(chunk_ranges, key=lambda x: x[0])
-        for i in range(len(sorted_chunks) - 1):
-            current_max = sorted_chunks[i][1]
-            next_min = sorted_chunks[i + 1][0]
-            assert (
-                next_min == current_max + 1
-            ), f"Gap detected: chunk {i} ends at {current_max}, chunk {i+1} starts at {next_min}"
-
-    def test_create_chunks_first_chunk_includes_max_row(self):
-        """Test that the first chunk (in yielded order) includes the source table max_row."""
-        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
-        min_row, max_row = 0, 4999  # Realistic: if COUNT(*) = 5000, max_row = 4999
-        id_range = (min_row, max_row)
+    def test_create_chunks_handles_empty_team_list(self):
+        """Test that no chunks are created for empty team list."""
+        team_ids = []
 
         context = build_op_context()
-        chunks = list(create_chunks_for_dpft(context, config, id_range))
+        chunks = list(create_team_chunks_for_dpft(context, team_ids))
 
-        # First chunk in the list (yielded first, highest rows)
-        first_chunk_min, first_chunk_max = chunks[0].value
-
-        assert (
-            first_chunk_max == max_row
-        ), f"First chunk max ({first_chunk_max}) should equal source max_row ({max_row})"
-        assert (
-            first_chunk_min <= max_row <= first_chunk_max
-        ), f"First chunk ({first_chunk_min}, {first_chunk_max}) should include max_row ({max_row})"
-
-    def test_create_chunks_final_chunk_includes_min_row(self):
-        """Test that the final chunk (in yielded order) includes the source table min_row."""
-        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
-        min_row, max_row = 0, 5000
-        id_range = (min_row, max_row)
-
-        context = build_op_context()
-        chunks = list(create_chunks_for_dpft(context, config, id_range))
-
-        # Last chunk in the list (yielded last, lowest rows)
-        final_chunk_min, final_chunk_max = chunks[-1].value
-
-        assert (
-            final_chunk_min == min_row
-        ), f"Final chunk min ({final_chunk_min}) should equal source min_row ({min_row})"
-        assert (
-            final_chunk_min <= min_row <= final_chunk_max
-        ), f"Final chunk ({final_chunk_min}, {final_chunk_max}) should include min_row ({min_row})"
-
-    def test_create_chunks_reverse_order(self):
-        """Test that chunks are yielded in reverse order (highest rows first)."""
-        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
-        min_row, max_row = 0, 5000
-        id_range = (min_row, max_row)
-
-        context = build_op_context()
-        chunks = list(create_chunks_for_dpft(context, config, id_range))
-
-        # Verify chunks are in descending order by max_row
-        for i in range(len(chunks) - 1):
-            current_max = chunks[i].value[1]
-            next_max = chunks[i + 1].value[1]
-            assert (
-                current_max > next_max
-            ), f"Chunks not in reverse order: chunk {i} max ({current_max}) should be > chunk {i+1} max ({next_max})"
-
-    def test_create_chunks_exact_multiple(self):
-        """Test chunk creation when row range is an exact multiple of chunk_size."""
-        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
-        min_row, max_row = (
-            0,
-            4999,
-        )  # Exactly 5 chunks of 1000 rows each (0-999, 1000-1999, 2000-2999, 3000-3999, 4000-4999)
-        id_range = (min_row, max_row)
-
-        context = build_op_context()
-        chunks = list(create_chunks_for_dpft(context, config, id_range))
-
-        assert len(chunks) == 5, f"Expected 5 chunks, got {len(chunks)}"
-
-        # Verify first chunk (highest rows, yielded first in reverse order)
-        assert chunks[0].value == (4000, 4999), f"First chunk should be (4000, 4999), got {chunks[0].value}"
-
-        # Verify last chunk (lowest rows, yielded last in reverse order)
-        assert chunks[-1].value == (0, 999), f"Last chunk should be (0, 999), got {chunks[-1].value}"
-
-    def test_create_chunks_non_exact_multiple(self):
-        """Test chunk creation when row range is not an exact multiple of chunk_size."""
-        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
-        min_row, max_row = 0, 3750  # 3 full chunks + 1 partial chunk (0-999, 1000-1999, 2000-2999, 3000-3750)
-        id_range = (min_row, max_row)
-
-        context = build_op_context()
-        chunks = list(create_chunks_for_dpft(context, config, id_range))
-
-        assert len(chunks) == 4, f"Expected 4 chunks, got {len(chunks)}"
-
-        # Verify first chunk (highest rows) - should be the partial chunk
-        assert chunks[0].value == (3000, 3750), f"First chunk should be (3000, 3750), got {chunks[0].value}"
-
-        # Verify last chunk (lowest rows)
-        assert chunks[-1].value == (0, 999), f"Last chunk should be (0, 999), got {chunks[-1].value}"
-
-    def test_create_chunks_single_chunk(self):
-        """Test chunk creation when row range fits in a single chunk."""
-        config = DeletePersonsFromTriggerLogConfig(chunk_size=1000)
-        min_row, max_row = 0, 500
-        id_range = (min_row, max_row)
-
-        context = build_op_context()
-        chunks = list(create_chunks_for_dpft(context, config, id_range))
-
-        assert len(chunks) == 1, f"Expected 1 chunk, got {len(chunks)}"
-        assert chunks[0].value == (0, 500), f"Chunk should be (0, 500), got {chunks[0].value}"
-        assert chunks[0].value[0] == min_row and chunks[0].value[1] == max_row
+        assert len(chunks) == 0
 
 
 def create_mock_database_resource(rowcount_values=None, fetchall_results=None):
@@ -235,7 +102,7 @@ def create_mock_database_resource(rowcount_values=None, fetchall_results=None):
         rowcount_values: List of rowcount values to return per DELETE call.
                         If None, defaults to 0. If a single int, uses that for all calls.
         fetchall_results: List of results to return from fetchall() calls (for SELECT queries).
-                         Each result should be a list of dict-like objects with "id" key.
+                         Each result should be a list of dict-like objects with "id" and "team_id" keys.
                          If None, defaults to empty list.
     """
     mock_cursor = MagicMock()
@@ -270,7 +137,7 @@ def create_mock_database_resource(rowcount_values=None, fetchall_results=None):
                 result = fetchall_results[fetchall_call_count[0]]
                 fetchall_call_count[0] += 1
                 return result
-            return fetchall_results[-1] if fetchall_results else []
+            return []
 
         mock_cursor.fetchall = MagicMock(side_effect=get_fetchall_result)
     else:
@@ -293,96 +160,63 @@ class TestScanDeleteChunkForDpft:
     """Test the scan_delete_chunk_for_dpft function."""
 
     def test_scan_delete_chunk_single_batch_success(self):
-        """Test successful scan and delete of a single batch within a chunk."""
-        config = DeletePersonsFromTriggerLogConfig(
-            chunk_size=1000,
-            batch_size=100,
-        )
-        chunk = (0, 100)  # Single batch covers entire chunk (row range)
+        """Test successful scan and delete of a single batch for a team."""
+        config = DeletePersonsFromTriggerLogConfig(batch_size=100)
+        team_id = 1
 
-        # Create 50 person records to delete - each has id and team_id
-        # The scan query returns records from posthog_person_deletes_log that don't exist in posthog_person_new
+        # Create 50 person records to delete for this team
         ids_to_delete = [{"id": i, "team_id": 1} for i in range(1, 51)]
 
-        # Mock: fetchall returns the IDs with team_id, DELETE returns rowcount of 1 per delete
         mock_db = create_mock_database_resource(
             rowcount_values=1,  # Each DELETE deletes 1 person
-            fetchall_results=[ids_to_delete],
+            fetchall_results=[ids_to_delete, []],  # First batch returns IDs, second returns empty (done)
         )
         mock_cluster = create_mock_cluster_resource()
 
         context = build_op_context(
             resources={"database": mock_db, "cluster": mock_cluster},
         )
-        # Patch context.run.job_name where it's accessed in scan_delete_chunk_for_dpft
         from unittest.mock import PropertyMock
 
         with patch.object(type(context), "run", PropertyMock(return_value=MagicMock(job_name="test_job"))):
-            result = scan_delete_chunk_for_dpft(context, config, chunk)
+            result = scan_delete_chunk_for_dpft(context, config, team_id)
 
         # Verify result
-        assert result["chunk_min_row"] == 0
-        assert result["chunk_max_row"] == 100
-        assert result["records_deleted"] == 50  # 50 deletes, each with rowcount=1
-
-        # Verify SET statements called once (session-level, before loop)
-        set_statements = [
-            "SET application_name = 'delete_persons_from_trigger_log'",
-            "SET lock_timeout = '5s'",
-            "SET statement_timeout = '30min'",
-            "SET maintenance_work_mem = '12GB'",
-            "SET work_mem = '512MB'",
-            "SET temp_buffers = '512MB'",
-            "SET max_parallel_workers_per_gather = 2",
-            "SET max_parallel_maintenance_workers = 2",
-            "SET synchronous_commit = off",
-        ]
+        assert result["team_id"] == 1
+        assert result["records_deleted"] == 50
 
         cursor = mock_db.cursor.return_value.__enter__.return_value
         execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
 
-        # Check SET statements were called
-        for stmt in set_statements:
-            assert any(stmt in call for call in execute_calls), f"SET statement not found: {stmt}"
-
-        # Verify BEGIN, SELECT scan, COMMIT called
-        # Should have: 1 BEGIN for scan, 1 COMMIT after scan, then 50 BEGIN/COMMIT pairs for deletes
-        assert execute_calls.count("BEGIN") >= 51  # 1 for scan + 50 for deletes
-        assert execute_calls.count("COMMIT") >= 51  # 1 for scan + 50 for deletes
-
-        # Verify SELECT scan query format
+        # Verify SELECT scan query format (keyset pagination, no OFFSET)
         scan_calls = [call for call in execute_calls if "FROM posthog_person_deletes_log" in call]
-        assert len(scan_calls) == 1
+        assert len(scan_calls) >= 1
         scan_query = scan_calls[0]
-        assert "SELECT" in scan_query
-        assert "FROM posthog_person_deletes_log" in scan_query
+        assert "WHERE pdl.team_id = %s" in scan_query
         assert "ORDER BY pdl.id" in scan_query
         assert "LIMIT" in scan_query
-        assert "OFFSET" in scan_query
+        assert "OFFSET" not in scan_query  # Keyset pagination doesn't use OFFSET
         assert "EXISTS" in scan_query
 
         # Verify DELETE queries were called (one per person)
         delete_calls = [call for call in execute_calls if "DELETE FROM posthog_person_new" in call]
-        assert len(delete_calls) == 50  # One delete per person
+        assert len(delete_calls) == 50
 
-    def test_scan_delete_chunk_multiple_batches(self):
-        """Test scan and delete with multiple batches in a chunk."""
-        config = DeletePersonsFromTriggerLogConfig(
-            chunk_size=1000,
-            batch_size=100,
-        )
-        chunk = (0, 250)  # 3 scan batches: (0,100), (101,200), (201,250)
+    def test_scan_delete_chunk_multiple_batches_with_keyset_pagination(self):
+        """Test scan and delete with multiple batches using keyset pagination."""
+        config = DeletePersonsFromTriggerLogConfig(batch_size=50)
+        team_id = 1
 
-        # Create IDs to delete for each scan batch - each needs id and team_id
-        # Batch 1: 50 IDs (1-50), Batch 2: 75 IDs (101-175), Batch 3: 25 IDs (201-225)
+        # Create IDs to delete for each batch (simulate keyset pagination)
+        # Batch 1: IDs 1-50, Batch 2: IDs 51-100, Batch 3: empty (done)
         fetchall_results = [
-            [{"id": i, "team_id": 1} for i in range(1, 51)],  # 50 IDs from first scan batch
-            [{"id": i, "team_id": 1} for i in range(101, 176)],  # 75 IDs from second scan batch
-            [{"id": i, "team_id": 1} for i in range(201, 226)],  # 25 IDs from third scan batch
+            [{"id": i, "team_id": 1} for i in range(1, 51)],
+            [{"id": i, "team_id": 1} for i in range(51, 101)],
+            [],  # Empty result to signal completion
         ]
 
         mock_db = create_mock_database_resource(
-            rowcount_values=1,  # Each DELETE deletes 1 person
+            rowcount_values=1,
             fetchall_results=fetchall_results,
         )
         mock_cluster = create_mock_cluster_resource()
@@ -390,75 +224,58 @@ class TestScanDeleteChunkForDpft:
         context = build_op_context(
             resources={"database": mock_db, "cluster": mock_cluster},
         )
-        # Patch context.run.job_name where it's accessed in scan_delete_chunk_for_dpft
         from unittest.mock import PropertyMock
 
         with patch.object(type(context), "run", PropertyMock(return_value=MagicMock(job_name="test_job"))):
-            result = scan_delete_chunk_for_dpft(context, config, chunk)
+            result = scan_delete_chunk_for_dpft(context, config, team_id)
 
-        # Verify result
-        assert result["chunk_min_row"] == 0
-        assert result["chunk_max_row"] == 250
-        assert result["records_deleted"] == 150  # 50 + 75 + 25 = 150
+        assert result["team_id"] == 1
+        assert result["records_deleted"] == 100
 
-        # Verify SET statements called once (before loop)
         cursor = mock_db.cursor.return_value.__enter__.return_value
         execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
 
-        # Verify BEGIN/COMMIT called multiple times:
-        # 3 scan batches: 3 BEGIN + 3 COMMIT for scans
-        # 150 delete operations: 150 BEGIN + 150 COMMIT for deletes (one per person)
-        # Total: 153 BEGIN, 153 COMMIT
-        assert execute_calls.count("BEGIN") >= 153  # 3 scans + 150 deletes
-        assert execute_calls.count("COMMIT") >= 153  # 3 scans + 150 deletes
-
-        # Verify SELECT scan called 3 times (one per scan batch)
+        # Verify SELECT scan called multiple times (keyset pagination)
         scan_calls = [call for call in execute_calls if "FROM posthog_person_deletes_log" in call]
-        assert len(scan_calls) == 3
+        assert len(scan_calls) >= 2
 
-        # Verify DELETE called 150 times (one per person)
+        # Second scan should include "WHERE pdl.id > %s" for keyset pagination
+        if len(scan_calls) > 1:
+            second_scan = scan_calls[1]
+            assert "WHERE pdl.team_id = %s" in second_scan
+            assert "AND pdl.id > %s" in second_scan
+
+        # Verify DELETE called 100 times
         delete_calls = [call for call in execute_calls if "DELETE FROM posthog_person_new" in call]
-        assert len(delete_calls) == 150
+        assert len(delete_calls) == 100
 
     def test_scan_delete_chunk_serialization_failure_retry(self):
         """Test that serialization failure triggers retry."""
-        config = DeletePersonsFromTriggerLogConfig(
-            chunk_size=1000,
-            batch_size=100,
-        )
-        chunk = (0, 100)
+        config = DeletePersonsFromTriggerLogConfig(batch_size=100)
+        team_id = 1
 
-        # Create IDs to delete - each needs id and team_id
         ids_to_delete = [{"id": i, "team_id": 1} for i in range(1, 51)]
-        mock_db = create_mock_database_resource(fetchall_results=[ids_to_delete])
+        mock_db = create_mock_database_resource(fetchall_results=[ids_to_delete, []])
         mock_cluster = create_mock_cluster_resource()
 
         cursor = mock_db.cursor.return_value.__enter__.return_value
 
-        # Track scan query attempts
         scan_attempts = [0]
 
-        # First SELECT scan query raises SerializationFailure, second succeeds
         def execute_side_effect(query, *args):
             if "FROM posthog_person_deletes_log" in query:
                 scan_attempts[0] += 1
                 if scan_attempts[0] == 1:
-                    # First scan attempt raises error
-                    # Create a mock error with pgcode 40001 for serialization failure
-                    error = create_mock_psycopg2_error("could not serialize access due to concurrent update", "40001")
+                    error = create_mock_psycopg2_error("could not serialize access", "40001")
                     raise error
-                # Subsequent calls succeed - fetchall will return the IDs
             elif "DELETE FROM posthog_person_new" in query:
-                # DELETE succeeds
                 cursor.rowcount = 1
-            # MagicMock will automatically record the call via side_effect
 
         cursor.execute.side_effect = execute_side_effect
 
         context = build_op_context(
             resources={"database": mock_db, "cluster": mock_cluster},
         )
-        # Need to patch time.sleep and run.job_name
         from unittest.mock import PropertyMock
 
         mock_run = MagicMock(job_name="test_job")
@@ -466,55 +283,41 @@ class TestScanDeleteChunkForDpft:
             patch("dags.delete_persons_from_trigger_log.time.sleep"),
             patch.object(type(context), "run", PropertyMock(return_value=mock_run)),
         ):
-            scan_delete_chunk_for_dpft(context, config, chunk)
+            scan_delete_chunk_for_dpft(context, config, team_id)
 
-        # Verify ROLLBACK was called on error
         execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
         assert "ROLLBACK" in execute_calls
 
-        # Verify retry succeeded (should have SELECT called twice - once failed, once succeeded)
         scan_calls = [call for call in execute_calls if "FROM posthog_person_deletes_log" in call]
-        assert len(scan_calls) >= 2  # At least one failed attempt and one successful scan
+        assert len(scan_calls) >= 2
 
     def test_scan_delete_chunk_deadlock_retry(self):
         """Test that deadlock triggers retry."""
-        config = DeletePersonsFromTriggerLogConfig(
-            chunk_size=1000,
-            batch_size=100,
-        )
-        chunk = (0, 100)
+        config = DeletePersonsFromTriggerLogConfig(batch_size=100)
+        team_id = 1
 
-        # Create IDs to delete - each needs id and team_id
         ids_to_delete = [{"id": i, "team_id": 1} for i in range(1, 51)]
-        mock_db = create_mock_database_resource(fetchall_results=[ids_to_delete])
+        mock_db = create_mock_database_resource(fetchall_results=[ids_to_delete, []])
         mock_cluster = create_mock_cluster_resource()
 
         cursor = mock_db.cursor.return_value.__enter__.return_value
 
-        # Track scan query attempts
         scan_attempts = [0]
 
-        # First SELECT scan query raises deadlock, second succeeds
         def execute_side_effect(query, *args):
             if "FROM posthog_person_deletes_log" in query:
                 scan_attempts[0] += 1
                 if scan_attempts[0] == 1:
-                    # First scan attempt raises error
-                    # Create a mock error with pgcode 40P01 for deadlock
                     error = create_mock_psycopg2_error("deadlock detected", "40P01")
                     raise error
-                # Subsequent calls succeed - fetchall will return the IDs
             elif "DELETE FROM posthog_person_new" in query:
-                # DELETE succeeds
                 cursor.rowcount = 1
-            # MagicMock will automatically record the call via side_effect
 
         cursor.execute.side_effect = execute_side_effect
 
         context = build_op_context(
             resources={"database": mock_db, "cluster": mock_cluster},
         )
-        # Need to patch time.sleep and run.job_name
         from unittest.mock import PropertyMock
 
         mock_run = MagicMock(job_name="test_job")
@@ -522,130 +325,103 @@ class TestScanDeleteChunkForDpft:
             patch("dags.delete_persons_from_trigger_log.time.sleep"),
             patch.object(type(context), "run", PropertyMock(return_value=mock_run)),
         ):
-            scan_delete_chunk_for_dpft(context, config, chunk)
+            scan_delete_chunk_for_dpft(context, config, team_id)
 
-        # Verify ROLLBACK was called on error
         execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
         assert "ROLLBACK" in execute_calls
 
-        # Verify retry succeeded (should have SELECT called twice - once failed, once succeeded)
         scan_calls = [call for call in execute_calls if "FROM posthog_person_deletes_log" in call]
-        assert len(scan_calls) >= 2  # At least one failed attempt and one successful scan
+        assert len(scan_calls) >= 2
 
-    def test_scan_delete_chunk_error_handling_and_rollback(self):
-        """Test error handling and rollback on non-retryable errors."""
-        config = DeletePersonsFromTriggerLogConfig(
-            chunk_size=1000,
-            batch_size=100,
-        )
-        chunk = (0, 100)
+    def test_scan_delete_chunk_error_handling(self):
+        """Test error handling on non-retryable errors."""
+        config = DeletePersonsFromTriggerLogConfig(batch_size=100)
+        team_id = 1
 
-        # Create IDs to delete - each needs id and team_id
         ids_to_delete = [{"id": i, "team_id": 1} for i in range(1, 51)]
         mock_db = create_mock_database_resource(fetchall_results=[ids_to_delete])
         mock_cluster = create_mock_cluster_resource()
 
         cursor = mock_db.cursor.return_value.__enter__.return_value
 
-        # Raise generic error on scan query (non-retryable error)
         def execute_side_effect(query, *args):
             if "FROM posthog_person_deletes_log" in query:
                 raise Exception("Connection lost")
-            # MagicMock will automatically record the call via side_effect
 
         cursor.execute.side_effect = execute_side_effect
 
         context = build_op_context(
             resources={"database": mock_db, "cluster": mock_cluster},
         )
-        # Patch context.run.job_name where it's accessed in scan_delete_chunk_for_dpft
         from unittest.mock import PropertyMock
 
         mock_run = MagicMock(job_name="test_job")
         with patch.object(type(context), "run", PropertyMock(return_value=mock_run)):
-            # Should raise Dagster.Failure
             from dagster import Failure
 
             try:
-                scan_delete_chunk_for_dpft(context, config, chunk)
-                raise AssertionError("Expected Dagster.Failure to be raised")
+                scan_delete_chunk_for_dpft(context, config, team_id)
+                raise AssertionError("Expected Failure to be raised")
             except Failure as e:
-                # Verify error metadata
                 assert e.description is not None
-                assert "Failed to scan and delete rows in batch" in e.description
+                assert "team_id" in e.description
 
-                # Verify ROLLBACK was called
                 execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
                 assert "ROLLBACK" in execute_calls
 
     def test_scan_delete_chunk_query_format(self):
-        """Test that DELETE query has correct format."""
-        config = DeletePersonsFromTriggerLogConfig(
-            chunk_size=1000,
-            batch_size=100,
-        )
-        chunk = (0, 100)
+        """Test that queries have correct format for team-based processing."""
+        config = DeletePersonsFromTriggerLogConfig(batch_size=100)
+        team_id = 1
 
-        # Create IDs to delete - each needs id and team_id
-        ids_to_delete = [{"id": i, "team_id": 1} for i in range(1, 11)]  # 10 IDs
+        ids_to_delete = [{"id": i, "team_id": 1} for i in range(1, 11)]
         mock_db = create_mock_database_resource(
-            rowcount_values=1,  # Each DELETE deletes 1 person
-            fetchall_results=[ids_to_delete],
+            rowcount_values=1,
+            fetchall_results=[ids_to_delete, []],
         )
         mock_cluster = create_mock_cluster_resource()
 
         context = build_op_context(
             resources={"database": mock_db, "cluster": mock_cluster},
         )
-        # Patch context.run.job_name where it's accessed in scan_delete_chunk_for_dpft
         from unittest.mock import PropertyMock
 
         with patch.object(type(context), "run", PropertyMock(return_value=MagicMock(job_name="test_job"))):
-            scan_delete_chunk_for_dpft(context, config, chunk)
+            scan_delete_chunk_for_dpft(context, config, team_id)
 
         cursor = mock_db.cursor.return_value.__enter__.return_value
         execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
 
-        # Find DELETE query (should be multiple, one per person)
+        # Verify DELETE queries
         delete_queries = [call for call in execute_calls if "DELETE FROM posthog_person_new" in call]
-        assert len(delete_queries) == 10  # One delete per person
+        assert len(delete_queries) == 10
 
-        # Verify DELETE query components (check first one)
         delete_query = delete_queries[0]
         assert "DELETE FROM posthog_person_new" in delete_query
         assert "WHERE team_id = %s AND id = %s" in delete_query
 
-        # Find SELECT query (scan query)
-        scan_query = next(
-            (call for call in execute_calls if "FROM posthog_person_deletes_log" in call),
-            None,
-        )
+        # Verify SELECT query for team-based filtering
+        scan_query = next((call for call in execute_calls if "FROM posthog_person_deletes_log" in call), None)
         assert scan_query is not None
-
-        # Verify SELECT query components
+        assert "WHERE pdl.team_id = %s" in scan_query
         assert "FROM posthog_person_deletes_log" in scan_query
         assert "ORDER BY pdl.id" in scan_query
         assert "LIMIT" in scan_query
-        assert "OFFSET" in scan_query
         assert "EXISTS" in scan_query
-        assert "SELECT" in scan_query
+        assert "OFFSET" not in scan_query  # Keyset pagination
 
     def test_scan_delete_chunk_session_settings_applied_once(self):
-        """Test that SET statements are applied once at session level before batch loop."""
-        config = DeletePersonsFromTriggerLogConfig(
-            chunk_size=1000,
-            batch_size=50,
-        )
-        chunk = (0, 150)  # 3 scan batches
+        """Test that SET statements are applied once at session level."""
+        config = DeletePersonsFromTriggerLogConfig(batch_size=50)
+        team_id = 1
 
-        # Create IDs to delete for each scan batch - each needs id and team_id
         fetchall_results = [
-            [{"id": i, "team_id": 1} for i in range(1, 26)],  # 25 IDs from first scan batch
-            [{"id": i, "team_id": 1} for i in range(51, 76)],  # 25 IDs from second scan batch
-            [{"id": i, "team_id": 1} for i in range(101, 126)],  # 25 IDs from third scan batch
+            [{"id": i, "team_id": 1} for i in range(1, 26)],
+            [{"id": i, "team_id": 1} for i in range(51, 76)],
+            [],
         ]
         mock_db = create_mock_database_resource(
-            rowcount_values=1,  # Each DELETE deletes 1 person
+            rowcount_values=1,
             fetchall_results=fetchall_results,
         )
         mock_cluster = create_mock_cluster_resource()
@@ -653,16 +429,14 @@ class TestScanDeleteChunkForDpft:
         context = build_op_context(
             resources={"database": mock_db, "cluster": mock_cluster},
         )
-        # Patch context.run.job_name where it's accessed in scan_delete_chunk_for_dpft
         from unittest.mock import PropertyMock
 
         with patch.object(type(context), "run", PropertyMock(return_value=MagicMock(job_name="test_job"))):
-            scan_delete_chunk_for_dpft(context, config, chunk)
+            scan_delete_chunk_for_dpft(context, config, team_id)
 
         cursor = mock_db.cursor.return_value.__enter__.return_value
         execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
 
-        # Count SET statements (should be called once each, before loop)
         set_statements = [
             "SET application_name",
             "SET lock_timeout",
@@ -684,83 +458,4 @@ class TestScanDeleteChunkForDpft:
         begin_indices = [i for i, call in enumerate(execute_calls) if call == "BEGIN"]
 
         if set_indices and begin_indices:
-            assert max(set_indices) < min(begin_indices), "SET statements should come before BEGIN statements"
-
-
-class TestGetScanRangeForDpft:
-    """Test the get_scan_range_for_dpft function."""
-
-    def test_get_scan_range_queries_row_count(self):
-        """Test that database is queried for row count and converts to 0-indexed max_row."""
-        config = DeletePersonsFromTriggerLogConfig()
-        mock_db = create_mock_database_resource()
-
-        cursor = mock_db.cursor.return_value.__enter__.return_value
-        cursor.fetchone.return_value = {"row_count": 5000}
-
-        context = build_op_context(resources={"database": mock_db})
-
-        result = get_scan_range_for_dpft(context, config)
-
-        # If COUNT(*) = 5000, rows are 0-indexed 0-4999, so max_row should be 4999
-        assert result == (0, 4999)
-        assert result[0] == 0  # min_row is always 0
-        assert result[1] == 4999  # max_row is last 0-indexed row (row_count - 1)
-
-        # Verify row count query was executed
-        execute_calls = [call[0][0] for call in cursor.execute.call_args_list]
-        row_count_queries = [
-            call for call in execute_calls if "count(*)" in call.lower() and "posthog_person_deletes_log" in call
-        ]
-        assert len(row_count_queries) == 1, "Should query for row count from posthog_person_deletes_log"
-
-    def test_get_scan_range_handles_zero_rows(self):
-        """Test that zero rows returns (0, 0)."""
-        config = DeletePersonsFromTriggerLogConfig()
-        mock_db = create_mock_database_resource()
-
-        cursor = mock_db.cursor.return_value.__enter__.return_value
-        cursor.fetchone.return_value = {"row_count": 0}
-
-        context = build_op_context(resources={"database": mock_db})
-
-        result = get_scan_range_for_dpft(context, config)
-
-        assert result == (0, 0)
-
-    def test_get_scan_range_handles_none_row_count(self):
-        """Test that None row count raises Failure."""
-        config = DeletePersonsFromTriggerLogConfig()
-        mock_db = create_mock_database_resource()
-
-        cursor = mock_db.cursor.return_value.__enter__.return_value
-        cursor.fetchone.return_value = {"row_count": None}
-
-        context = build_op_context(resources={"database": mock_db})
-
-        from dagster import Failure
-
-        try:
-            get_scan_range_for_dpft(context, config)
-            raise AssertionError("Expected Dagster.Failure to be raised")
-        except Failure as e:
-            assert e.description is not None
-            assert "no valid row count" in e.description.lower()
-
-    def test_get_scan_range_handles_query_failure(self):
-        """Test that query failures are properly handled when the row count query fails."""
-        config = DeletePersonsFromTriggerLogConfig()
-        mock_db = create_mock_database_resource()
-
-        cursor = mock_db.cursor.return_value.__enter__.return_value
-        # Simulate query failure by raising an exception on execute
-        cursor.execute.side_effect = Exception("Database connection lost")
-
-        context = build_op_context(resources={"database": mock_db})
-
-        try:
-            get_scan_range_for_dpft(context, config)
-            raise AssertionError("Expected exception to be raised")
-        except Exception:
-            # Query failure should bubble up
-            assert True
+            assert max(set_indices) < min(begin_indices)


### PR DESCRIPTION
## Problem
After a dry run of the job to delete all `posthog_person_new` rows tracked in `posthog_person_deletes_log`, we found performance issues with the OFFSET-based pagination approach. The `LIMIT...OFFSET` pattern gets progressively slower as the offset increases, and doesn't leverage the existing indexes effectively.

We decided then to change the approach to paralelize the job by team id

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Refactored the deletion job to use team-based chunking with keyset pagination:
* Changed chunking strategy fro row ranges to one chunk per `team_id`
* Replaced `LIMIT...OFFSET` with keyset pagination (`WHERE id > last_id`) for efficient scanning
* Uses `idx_person_deletes_log_team_id` index for fast team-based lookups
* Updated entire test suite to reflect team-based processing and keyset pagination

## How did you test this code?
Locally and in CI (test suite overhaul etc.)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required ✅ 
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
