### PR TITLE
fix: SDK Doctor repair for intermittent stale cache, improve status badges and tooltips

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -1195,7 +1195,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1276,7 +1276,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -1376,7 +1376,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -1397,7 +1397,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), equals(events.event, '$new_view'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')))
+        WHERE and(equals(events.team_id, 99999), equals(events.event, '$new_view'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')))
         GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)
         HAVING ifNull(greaterOrEquals(count(), 1), 0)
         ORDER BY count() DESC)
@@ -1499,7 +1499,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -1519,7 +1519,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')))
+        WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')))
         GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)
         HAVING ifNull(greaterOrEquals(count(), 1), 0)
         ORDER BY count() DESC)
@@ -1636,7 +1636,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$filter_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0), greaterOrEquals(timestamp, toDateTime64('2025-11-22 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$filter_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0), greaterOrEquals(timestamp, toDateTime64('2025-11-23 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1702,7 +1702,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1795,7 +1795,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1913,7 +1913,7 @@
                WHERE equals(person_distinct_id_overrides.team_id, 99999)
                GROUP BY person_distinct_id_overrides.distinct_id
                HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-11 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-12 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
          GROUP BY actor_id) AS source
       ORDER BY source.id ASC
       LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1942,7 +1942,7 @@
                                                                                          actor_id AS id
                                                                                   FROM
                                                                                     (SELECT min(toTimeZone(e.timestamp, 'UTC')) AS min_timestamp,
-                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-11 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
+                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-12 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
                                                                                             if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
                                                                                             argMin(e.uuid, toTimeZone(e.timestamp, 'UTC')) AS uuid,
                                                                                             argMin(e.distinct_id, toTimeZone(e.timestamp, 'UTC')) AS distinct_id
@@ -2381,7 +2381,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -2466,7 +2466,7 @@
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
                               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC
                      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -2566,7 +2566,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -46,7 +46,7 @@
                WHERE equals(person_distinct_id_overrides.team_id, 99999)
                GROUP BY person_distinct_id_overrides.distinct_id
                HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-11 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-12 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
          GROUP BY actor_id) AS source
       ORDER BY source.id ASC
       LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -59,7 +59,7 @@
                                                                                          actor_id AS id
                                                                                   FROM
                                                                                     (SELECT min(toTimeZone(e.timestamp, 'UTC')) AS min_timestamp,
-                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-11 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
+                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-12 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
                                                                                             if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
                                                                                             argMin(e.uuid, toTimeZone(e.timestamp, 'UTC')) AS uuid,
                                                                                             argMin(e.distinct_id, toTimeZone(e.timestamp, 'UTC')) AS distinct_id
@@ -213,7 +213,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-17 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$new_view'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$new_view'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -454,7 +454,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -932,7 +932,7 @@
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
                               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC
                      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSdkDoctor.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSdkDoctor.tsx
@@ -362,7 +362,7 @@ function SdkSection({ sdkType }: { sdkType: SdkType }): JSX.Element {
                         <Tooltip
                             title={
                                 <>
-                                    This is the latest available version
+                                    This was the latest available version
                                     {cachedAt ? ` as of ${dayjs().diff(dayjs(cachedAt), 'hour')} hours ago` : ''}
                                     .
                                     <br />

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
@@ -373,28 +373,30 @@ export const sidePanelSdkDoctorLogic = kea<sidePanelSdkDoctorLogicType>([
             }
 
             // Find versions with missing release dates
-            Object.entries(teamSdkVersions).forEach(([sdkType, teamVersions]) => {
-                const sdkVersion = sdkVersions[sdkType as SdkType]
-                if (!sdkVersion) {
-                    return
-                }
-
-                teamVersions.forEach((versionInfo) => {
-                    if (typeof versionInfo !== 'object' || !('lib_version' in versionInfo)) {
+            Object.entries(teamSdkVersions)
+                .filter(([, value]) => Array.isArray(value))
+                .forEach(([sdkType, teamVersions]) => {
+                    const sdkVersion = sdkVersions[sdkType as SdkType]
+                    if (!sdkVersion) {
                         return
                     }
-                    const version = versionInfo.lib_version
-                    // Avoid duplicate API calls for already-loaded dates
-                    const hasReleaseDate =
-                        sdkVersion.releaseDates[version] !== undefined ||
-                        values.lazyLoadedDates[`${sdkType}:${version}`] !== undefined
 
-                    if (!hasReleaseDate) {
-                        // Background load updates state when ready
-                        actions.loadVersionDate({ sdkType: sdkType as SdkType, version })
-                    }
+                    ;(teamVersions as TeamSdkVersionInfo[]).forEach((versionInfo) => {
+                        if (typeof versionInfo !== 'object' || !('lib_version' in versionInfo)) {
+                            return
+                        }
+                        const version = versionInfo.lib_version
+                        // Avoid duplicate API calls for already-loaded dates
+                        const hasReleaseDate =
+                            sdkVersion.releaseDates[version] !== undefined ||
+                            values.lazyLoadedDates[`${sdkType}:${version}`] !== undefined
+
+                        if (!hasReleaseDate) {
+                            // Background load updates state when ready
+                            actions.loadVersionDate({ sdkType: sdkType as SdkType, version })
+                        }
+                    })
                 })
-            })
         },
         loadSdkVersionsSuccess: () => {
             // Team SDK versions lazy-loaded in loadTeamSdkVersionsSuccess listener

--- a/posthog/api/github_sdk_versions.py
+++ b/posthog/api/github_sdk_versions.py
@@ -3,6 +3,7 @@ from typing import cast
 
 from django.http import JsonResponse
 
+import requests
 import structlog
 import posthoganalytics
 from rest_framework import exceptions
@@ -18,13 +19,29 @@ from dags.sdk_doctor.github_sdk_versions import SDK_TYPES
 
 logger = structlog.get_logger(__name__)
 
+# SDK to GitHub repo mapping for lazy-loading individual version dates
+SDK_REPO_MAP = {
+    "web": ("PostHog/posthog-js", "posthog-js@{version}"),
+    "posthog-node": ("PostHog/posthog-js", "posthog-node@{version}"),
+    "posthog-react-native": ("PostHog/posthog-js", "posthog-react-native@{version}"),
+    "posthog-python": ("PostHog/posthog-python", "v{version}"),
+    "posthog-flutter": ("PostHog/posthog-flutter", "{version}"),
+    "posthog-ios": ("PostHog/posthog-ios", "{version}"),
+    "posthog-android": ("PostHog/posthog-android", "android-v{version}"),
+    "posthog-go": ("PostHog/posthog-go", "v{version}"),
+    "posthog-php": ("PostHog/posthog-php", "v{version}"),
+    "posthog-ruby": ("PostHog/posthog-ruby", "v{version}"),
+    "posthog-elixir": ("PostHog/posthog-elixir", "v{version}"),
+    "posthog-dotnet": ("PostHog/posthog-dotnet", "v{version}"),
+}
+
 
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def github_sdk_versions(request: Request) -> JsonResponse:
     """
     Serve cached GitHub SDK version data for SDK Doctor.
-    Data is cached by Dagster job that runs every 6 hours.
+    Data is cached by Dagster job that runs daily at midnight UTC.
     Protected by sdk-doctor-beta feature flag.
     """
     user = cast(User, request.user)
@@ -39,6 +56,7 @@ def github_sdk_versions(request: Request) -> JsonResponse:
         if cached_data:
             try:
                 data = json.loads(cached_data.decode("utf-8") if isinstance(cached_data, bytes) else cached_data)
+                # cachedAt is now stored in the cache data itself (no need to calculate from TTL)
                 response[sdk_type] = data
             except (json.JSONDecodeError, AttributeError) as e:
                 logger.warning(f"[SDK Doctor] Cache corrupted for {sdk_type}", error=str(e))
@@ -48,3 +66,64 @@ def github_sdk_versions(request: Request) -> JsonResponse:
             response[sdk_type] = {"error": "SDK data not available. Please try again later."}
 
     return JsonResponse(response)
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def sdk_version_date(request: Request, sdk_type: str, version: str) -> JsonResponse:
+    """
+    Lazy-load release dates for versions not in main cache.
+    Fetches from GitHub on-demand and caches permanently (release dates are immutable).
+    """
+    user = cast(User, request.user)
+    if not posthoganalytics.feature_enabled("sdk-doctor-beta", str(user.distinct_id)):
+        raise exceptions.ValidationError("SDK Doctor is not enabled for this user")
+
+    # Validate SDK type
+    if sdk_type not in SDK_REPO_MAP:
+        raise exceptions.ValidationError(f"Invalid SDK type: {sdk_type}")
+
+    redis_client = get_client()
+    cache_key = f"github:sdk_version_date:{sdk_type}:{version}"
+
+    # Check cache first
+    cached_date = redis_client.get(cache_key)
+    if cached_date:
+        try:
+            return JsonResponse(
+                {
+                    "releaseDate": cached_date.decode("utf-8") if isinstance(cached_date, bytes) else cached_date,
+                    "cached": True,
+                }
+            )
+        except (AttributeError, UnicodeDecodeError) as e:
+            logger.warning(f"[SDK Doctor] Cache corrupted for {sdk_type}@{version}", error=str(e))
+            capture_exception(e, {"sdk_type": sdk_type, "version": version, "cache_key": cache_key})
+
+    # Fetch from GitHub API
+    repo, tag_template = SDK_REPO_MAP[sdk_type]
+    tag_name = tag_template.format(version=version)
+
+    try:
+        github_url = f"https://api.github.com/repos/{repo}/releases/tags/{tag_name}"
+        response = requests.get(github_url, timeout=10)
+
+        if response.status_code == 200:
+            release_data = response.json()
+            release_date = release_data.get("published_at")
+
+            if release_date:
+                # Permanent cache (immutable data)
+                redis_client.set(cache_key, release_date)
+                logger.info(f"[SDK Doctor] Lazy-loaded date for {sdk_type}@{version}: {release_date}")
+                return JsonResponse({"releaseDate": release_date, "cached": False})
+
+        logger.warning(
+            f"[SDK Doctor] Could not fetch release date for {sdk_type}@{version}", status=response.status_code
+        )
+        return JsonResponse({"error": "Release date not available"}, status=404)
+
+    except Exception as e:
+        logger.exception(f"[SDK Doctor] Error fetching release date for {sdk_type}@{version}")
+        capture_exception(e, {"sdk_type": sdk_type, "version": version})
+        return JsonResponse({"error": "Failed to fetch release date"}, status=500)

--- a/posthog/api/github_sdk_versions.py
+++ b/posthog/api/github_sdk_versions.py
@@ -1,4 +1,6 @@
+import re
 import json
+import time
 from typing import cast
 
 from django.http import JsonResponse
@@ -39,6 +41,12 @@ SDK_REPO_MAP = {
 # Old posthog-js versions used v-prefixed tags (e.g., "v1.187.2")
 FALLBACK_TAG_TEMPLATES = {
     "web": "v{version}",  # Legacy format: v-prefixed (e.g., v1.187.2)
+}
+
+# CHANGELOG paths for monorepo SDKs with pre-monorepo history
+CHANGELOG_PATHS = {
+    "posthog-node": "packages/node/CHANGELOG.md",
+    "posthog-react-native": "packages/react-native/CHANGELOG.md",
 }
 
 
@@ -106,13 +114,26 @@ def sdk_version_date(request: Request, sdk_type: str, version: str) -> JsonRespo
             logger.warning(f"[SDK Doctor] Cache corrupted for {sdk_type}@{version}", error=str(e))
             capture_exception(e, {"sdk_type": sdk_type, "version": version, "cache_key": cache_key})
 
-    # Fetch from GitHub API
+    # Fetch from GitHub API with retry for rate limits
     repo, tag_template = SDK_REPO_MAP[sdk_type]
     tag_name = tag_template.format(version=version)
 
     try:
         github_url = f"https://api.github.com/repos/{repo}/releases/tags/{tag_name}"
         response = requests.get(github_url, timeout=10)
+
+        if response.status_code in [403, 429]:
+            logger.warning(
+                f"[SDK Doctor] GitHub API rate limit hit for {sdk_type}@{version} (status {response.status_code}), retrying after 2s"
+            )
+            time.sleep(2)
+            response = requests.get(github_url, timeout=10)
+
+        if response.status_code in [403, 429]:
+            logger.error(
+                f"[SDK Doctor] GitHub API rate limit exceeded for {sdk_type}@{version} after retry (status {response.status_code})"
+            )
+            return JsonResponse({"error": "GitHub API rate limit exceeded. Please try again later."}, status=503)
 
         if response.status_code == 200:
             release_data = response.json()
@@ -124,13 +145,26 @@ def sdk_version_date(request: Request, sdk_type: str, version: str) -> JsonRespo
                 logger.info(f"[SDK Doctor] Lazy-loaded date for {sdk_type}@{version}: {release_date}")
                 return JsonResponse({"releaseDate": release_date, "cached": False})
 
-        # Try fallback tag format if primary format failed and fallback exists
+        # Try fallback tag format for legacy versions
         elif response.status_code == 404 and sdk_type in FALLBACK_TAG_TEMPLATES:
             fallback_tag = FALLBACK_TAG_TEMPLATES[sdk_type].format(version=version)
             fallback_url = f"https://api.github.com/repos/{repo}/releases/tags/{fallback_tag}"
 
             logger.info(f"[SDK Doctor] Trying fallback tag format for {sdk_type}@{version}: {fallback_tag}")
             fallback_response = requests.get(fallback_url, timeout=10)
+
+            if fallback_response.status_code in [403, 429]:
+                logger.warning(
+                    f"[SDK Doctor] GitHub API rate limit hit on fallback for {sdk_type}@{version} (status {fallback_response.status_code}), retrying after 2s"
+                )
+                time.sleep(2)
+                fallback_response = requests.get(fallback_url, timeout=10)
+
+            if fallback_response.status_code in [403, 429]:
+                logger.error(
+                    f"[SDK Doctor] GitHub API rate limit exceeded on fallback for {sdk_type}@{version} after retry (status {fallback_response.status_code})"
+                )
+                return JsonResponse({"error": "GitHub API rate limit exceeded. Please try again later."}, status=503)
 
             if fallback_response.status_code == 200:
                 release_data = fallback_response.json()
@@ -143,6 +177,28 @@ def sdk_version_date(request: Request, sdk_type: str, version: str) -> JsonRespo
                         f"[SDK Doctor] Lazy-loaded date for {sdk_type}@{version} using fallback tag: {release_date}"
                     )
                     return JsonResponse({"releaseDate": release_date, "cached": False})
+
+        # Try CHANGELOG fallback for monorepo SDKs with pre-monorepo history
+        if response.status_code == 404 and sdk_type in CHANGELOG_PATHS:
+            changelog_path = CHANGELOG_PATHS[sdk_type]
+            changelog_url = f"https://raw.githubusercontent.com/{repo}/main/{changelog_path}"
+
+            logger.info(f"[SDK Doctor] Trying CHANGELOG fallback for {sdk_type}@{version}")
+            changelog_response = requests.get(changelog_url, timeout=10)
+
+            if changelog_response.status_code == 200:
+                changelog_content = changelog_response.text
+                version_pattern = re.compile(r"^## (\d+\.\d+\.\d+) - (\d{4}-\d{2}-\d{2})", re.MULTILINE)
+                matches = version_pattern.findall(changelog_content)
+
+                for found_version, date in matches:
+                    if found_version == version:
+                        release_date = f"{date}T00:00:00Z"
+                        redis_client.set(cache_key, release_date)
+                        logger.info(
+                            f"[SDK Doctor] Lazy-loaded date for {sdk_type}@{version} from CHANGELOG: {release_date}"
+                        )
+                        return JsonResponse({"releaseDate": release_date, "cached": False})
 
         logger.warning(
             f"[SDK Doctor] Could not fetch release date for {sdk_type}@{version}", status=response.status_code

--- a/posthog/api/team_sdk_versions.py
+++ b/posthog/api/team_sdk_versions.py
@@ -89,6 +89,7 @@ def team_sdk_versions(request: Request) -> JsonResponse:
                     )
                     cached_at = cache_payload.get("cachedAt")
                 except (json.JSONDecodeError, AttributeError):
+                    # cachedAt is optional metadata - graceful degradation if extraction fails
                     pass
 
             response = {"sdk_versions": sdk_versions, "cached": False}

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -30,7 +30,7 @@ from posthog.api import (
     uploaded_media,
     user,
 )
-from posthog.api.github_sdk_versions import github_sdk_versions
+from posthog.api.github_sdk_versions import github_sdk_versions, sdk_version_date
 from posthog.api.query import progress
 from posthog.api.slack import slack_interactivity_callback
 from posthog.api.survey import public_survey_page, surveys
@@ -174,6 +174,7 @@ urlpatterns = [
     path("api/unsubscribe", unsubscribe.unsubscribe),
     path("api/alerts/github", github.SecretAlert.as_view()),
     path("api/sdk_versions/", github_sdk_versions),
+    path("api/sdk_version_date/<str:sdk_type>/<str:version>/", sdk_version_date),
     path("api/team_sdk_versions/", team_sdk_versions),
     opt_slash_path("api/support/ensure-zendesk-organization", csrf_exempt(ensure_zendesk_organization)),
     path("api/", include(router.urls)),


### PR DESCRIPTION
This PR addresses SDK Doctor feedback related to some issues with versions, release dates, status badges, and an intermittent stale cache problem we've seen (e.g. what Robbie saw in [this slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1762620477407479?thread_ts=1762615681.932089&cid=C09BDQLM8KA). I've seen it a lot as well when impersonating users while working on support tickets.)

### Problem:
Intermittent stale cache problem [slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1762620477407479?thread_ts=1762615681.932089&cid=C09BDQLM8KA)

### Changes 
(some of these also relate to other changes mentioned further below):
- Implemented auto-refresh logic to detect stale caches (>26 hours) and trigger background refresh
- Fixed `cachedAt` timestamp accuracy: Store actual timestamp when writing to Redis instead of calculating from TTL
- Added `cachedAt` field to GitHub SDK versions API response
- Added `cachedAt` field to team SDK versions API response with backward compatibility for old cache format
- Fixed outdated comments: 
	- Changed "every 6-12 hours" to "daily at midnight UTC" in 3 locations
	- Changed "72 hours" to "7 days"

### Problem: 
Feedback from users confused by versions displayed, badges, lack of release date info, and versions less than a week old flagged as `Outdated` (ZD tickets [41473](https://posthoghelp.zendesk.com/agent/tickets/41473), [41482](https://posthoghelp.zendesk.com/agent/tickets/41482 ), and [this slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1763396733557709))

### Changes:
- Removed redundant badges next to SDK name. Redundant and confusing because we're already Showing `SDK health is good` with a green box saying `All caught up...` etc, OR `Time for an update!` with a yellow or red (in dark mode) box  saying `An outdated SDK means...` etc., as well as next to the version number. The badge I'm removing here looked as if it was referring to the latest available version, as mentioned in a feedback ticket cited above (more related changes below these first two screenshots): 

    **before:** 
<img width="800"  alt="CleanShot 2025-11-20 at 17 40 50@2x" src="https://github.com/user-attachments/assets/2785fabd-847b-466b-9808-de8de2d118ef" />

    **after:**
<img width="800" alt="CleanShot 2025-11-20 at 17 47 43@2x" src="https://github.com/user-attachments/assets/c26946a8-18c9-4d11-abd2-1d328b31d3d6" />

- Restored streetlight color scheme (green/amber/red), now using amber for `Recent` (Related: fixed the problem with newer than github version cache so they are marked `Current`, details further below)
- Add Web SDK-specific minor version threshold: 9+ minors behind to reduce false positives resulting from frequent minor version releases on the web SDK (other SDKs still using 3+ behind)
- Fixed grace period off-by-one: versions `≤7` days old now marked `Recent` (was `<7` days)
- Added cache timestamp to "Current" badge tooltip, with a hint to click `Releases` link for versions released since cache time
- Added a tooltip to the Latest available version with cached time, and a hint to check Releases for newer
- Improved tooltips, including release date info for all versions of SDKs in the posthog-js monorepo, regardless of age, lazy-loaded to tooltips so it doesn't slow page load (see next problem/changes for details.) (may still need to do the same for some other SDKs which have also changed the formatting of version numbers since inception)

### Problem: 
For monorepo SDKs, versions less than a month old had no release date info (because they were already out of reach of the 100 we're caching from GitHub.)

### Changes:
- Added an endpoint for release dates for versions which aren't in the github version cache. 
- Now checks existing cache for the version's release date first, if not found it fetches the release date and caches it forever (past release dates will never change)

### Problem:
After using `Scan events`, events can include releases newer than the github cache, so the newest version was incorrectly marked `Recent`.

###  Changes:
Check most recent version against cached `Latest version available` and mark it as `Current` (instead of `Recent`) if the semver of the team version is higher that then cached github version

Screenshots of the tooltips (because they make more sense when seen in the UI than when reading the code)...

**Hovering over `Latest version available` (screenshot taken just after midnight UTC):**
<img width="800" alt="CleanShot 2025-11-20 at 19 20 09@2x" src="https://github.com/user-attachments/assets/2a882030-860c-41db-9082-5679686e6a32" />

**Hovering over a `Current` badge:**
<img width="800" alt="CleanShot 2025-11-20 at 19 07 31@2x" src="https://github.com/user-attachments/assets/3fcc77d1-f81d-4961-8281-a36e067da084" />

**Hovering over a `Recent` badge:**
<img width="800"  alt="CleanShot 2025-11-20 at 19 07 52@2x" src="https://github.com/user-attachments/assets/2dec16cc-d792-4198-b0b7-77a33ff889a2" />

**Hovering over an  `Outdated` badge of a legacy version format:**
<img width="800" alt="CleanShot 2025-11-20 at 19 08 03@2x" src="https://github.com/user-attachments/assets/60e6731d-3efa-45bd-af37-23f9bc93d1f0" />


## How did you test this code?
On my local.
