### PR TITLE
feat(llma): Add user action tracking to some LLM endpoints

### DIFF
--- a/products/llm_analytics/backend/api/summarization.py
+++ b/products/llm_analytics/backend/api/summarization.py
@@ -8,6 +8,8 @@ Endpoint:
 - POST /api/projects/:id/llm_analytics/summarize/ - Summarize trace or event
 """
 
+from typing import cast
+
 from django.conf import settings
 from django.core.cache import cache
 
@@ -22,6 +24,8 @@ from rest_framework.response import Response
 
 from posthog.api.monitoring import monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.event_usage import report_user_action
+from posthog.models import User
 from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle
 
 from products.llm_analytics.backend.summarization.constants import SUMMARIZATION_FEATURE_FLAG
@@ -352,6 +356,20 @@ The response includes the summary text and optional metadata.
                 mode=mode,
                 team_id=self.team_id,
                 force_refresh=force_refresh,
+            )
+
+            # Track user action
+            report_user_action(
+                cast(User, self.request.user),
+                "llma summarization generated",
+                {
+                    "summarize_type": summarize_type,
+                    "entity_id": entity_id,
+                    "mode": mode,
+                    "text_repr_length": len(text_repr),
+                    "force_refresh": force_refresh,
+                },
+                self.team,
             )
 
             return Response(result, status=status.HTTP_200_OK)


### PR DESCRIPTION


Add report_user_action() events to track usage of:
- text_repr endpoint: tracks event_type, entity_id, char_count, truncated status
- summarization endpoint: tracks summarize_type, entity_id, mode, text_repr_length, force_refresh

Similar to PR #41656, this enables better analytics on LLMA feature usage.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
