### PR TITLE
feat: instrument eval execution

### DIFF
--- a/posthog/temporal/llm_analytics/__init__.py
+++ b/posthog/temporal/llm_analytics/__init__.py
@@ -1,6 +1,7 @@
 from posthog.temporal.llm_analytics.run_evaluation import (
     RunEvaluationWorkflow,
     emit_evaluation_event_activity,
+    emit_internal_telemetry_activity,
     execute_llm_judge_activity,
     fetch_evaluation_activity,
 )
@@ -13,4 +14,5 @@ ACTIVITIES = [
     fetch_evaluation_activity,
     execute_llm_judge_activity,
     emit_evaluation_event_activity,
+    emit_internal_telemetry_activity,
 ]


### PR DESCRIPTION
Fires an event when running an eval, includes metadata like token usage.
<img width="1201" height="481" alt="Screenshot 2025-11-21 at 10 37 20" src="https://github.com/user-attachments/assets/cabca2d8-0b78-409e-9c5b-a688ec40f7b5" />
