### PR TITLE
fix: posthog has tabs now, but replay ignores them , so let's make it not

### DIFF
--- a/frontend/src/lib/logic/scenes/tabAwareScene.ts
+++ b/frontend/src/lib/logic/scenes/tabAwareScene.ts
@@ -5,7 +5,7 @@ export const tabAwareScene = <L extends Logic = Logic>() => {
         // add a tab-based key if none present
         key((props) => {
             if (!props.tabId) {
-                throw new Error('Tab-aware scene logic must have a tabId prop')
+                throw new Error('Tab-aware scene logic (' + logic.pathString + ') must have a tabId prop')
             }
             return props.tabId
         })(logic)

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { IconEllipsis, IconGear, IconOpenSidebar } from '@posthog/icons'
@@ -253,12 +253,22 @@ export function SessionRecordingsPageTabs(): JSX.Element {
         </div>
     )
 }
-export function SessionsRecordings(): JSX.Element {
+
+export interface SessionsRecordingsProps {
+    tabId?: string
+}
+
+export function SessionsRecordings({ tabId }: SessionsRecordingsProps = {}): JSX.Element {
+    if (!tabId) {
+        throw new Error('<SessionsRecordings /> must receive a tabId prop')
+    }
     return (
-        <SceneContent className="h-full">
-            <SessionRecordingsPageTabs />
-            <MainPanel />
-        </SceneContent>
+        <BindLogic logic={sessionReplaySceneLogic} props={{ tabId }}>
+            <SceneContent className="h-full">
+                <SessionRecordingsPageTabs />
+                <MainPanel />
+            </SceneContent>
+        </BindLogic>
     )
 }
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
@@ -1,10 +1,11 @@
 import equal from 'fast-deep-equal'
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { beforeUnload, router, urlToAction } from 'kea-router'
+import { beforeUnload, router } from 'kea-router'
 
 import api from 'lib/api'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { removeProjectIdIfPresent } from 'lib/utils/router-utils'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
@@ -38,12 +39,13 @@ import type { sessionRecordingsPlaylistSceneLogicType } from './sessionRecording
 
 export interface SessionRecordingsPlaylistLogicProps {
     shortId: string
+    tabId?: string
 }
 
 export const sessionRecordingsPlaylistSceneLogic = kea<sessionRecordingsPlaylistSceneLogicType>([
     path((key) => ['scenes', 'session-recordings', 'playlist', 'sessionRecordingsPlaylistSceneLogic', key]),
     props({} as SessionRecordingsPlaylistLogicProps),
-    key((props) => props.shortId),
+    key((props) => `${props.tabId ? props.tabId + ':' : ''}${props.shortId}`),
     connect(() => ({
         values: [cohortsModel, ['cohortsById'], sceneLogic, ['activeSceneId'], featureFlagLogic, ['featureFlags']],
         actions: [sessionRecordingEventUsageLogic, ['reportRecordingPlaylistCreated']],
@@ -230,7 +232,7 @@ export const sessionRecordingsPlaylistSceneLogic = kea<sessionRecordingsPlaylist
         }
     }),
 
-    urlToAction(({ actions }) => ({
+    tabAwareUrlToAction(({ actions }) => ({
         '/replay/playlists/new': () => actions.getPlaylist(),
     })),
 ])

--- a/frontend/src/scenes/session-recordings/sessionReplaySceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionReplaySceneLogic.ts
@@ -1,6 +1,9 @@
 import { actions, kea, listeners, path, reducers, selectors } from 'kea'
-import { actionToUrl, router, urlToAction } from 'kea-router'
+import { router } from 'kea-router'
 
+import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
+import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
+import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { Scene } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
@@ -10,6 +13,10 @@ import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigati
 import { ActivityScope, Breadcrumb, ReplayTabs } from '~/types'
 
 import type { sessionReplaySceneLogicType } from './sessionReplaySceneLogicType'
+
+export interface SessionReplaySceneLogicProps {
+    tabId?: string
+}
 
 export const humanFriendlyTabName = (tab: ReplayTabs): string => {
     switch (tab) {
@@ -28,6 +35,7 @@ export const humanFriendlyTabName = (tab: ReplayTabs): string => {
 
 export const sessionReplaySceneLogic = kea<sessionReplaySceneLogicType>([
     path(() => ['scenes', 'session-recordings', 'sessionReplaySceneLogic']),
+    tabAwareScene(),
     actions({
         setTab: (tab: ReplayTabs = ReplayTabs.Home) => ({ tab }),
         hideNewBadge: true,
@@ -56,7 +64,7 @@ export const sessionReplaySceneLogic = kea<sessionReplaySceneLogicType>([
         },
     })),
 
-    actionToUrl(({ values }) => {
+    tabAwareActionToUrl(({ values }) => {
         return {
             setTab: () => [urls.replay(values.tab), router.values.searchParams, router.values.hashParams],
         }
@@ -99,7 +107,7 @@ export const sessionReplaySceneLogic = kea<sessionReplaySceneLogicType>([
         ],
     })),
 
-    urlToAction(({ actions, values }) => {
+    tabAwareUrlToAction(({ actions, values }) => {
         return {
             '/replay/:tab': ({ tab }) => {
                 // we saw a page get stuck in a redirect loop between recent and home

--- a/frontend/src/scenes/session-recordings/settings/SessionRecordingsSettingsScene.tsx
+++ b/frontend/src/scenes/session-recordings/settings/SessionRecordingsSettingsScene.tsx
@@ -1,4 +1,4 @@
-import { kea, path, selectors } from 'kea'
+import { BindLogic, kea, path, selectors } from 'kea'
 import { router } from 'kea-router'
 
 import { Scene, SceneExport } from 'scenes/sceneTypes'
@@ -9,6 +9,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { Breadcrumb } from '~/types'
 
 import { SessionRecordingsPageTabs } from '../SessionRecordings'
+import { sessionReplaySceneLogic } from '../sessionReplaySceneLogic'
 import type { sessionRecordingsSettingsSceneLogicType } from './SessionRecordingsSettingsSceneType'
 
 export const SETTINGS_LOGIC_KEY = 'replaySettings'
@@ -42,9 +43,16 @@ export const scene: SceneExport = {
     settingSectionId: 'environment-replay',
 }
 
-export function SessionRecordingsSettingsScene(): JSX.Element {
+export interface SessionRecordingsSettingsSceneProps {
+    tabId?: string
+}
+
+export function SessionRecordingsSettingsScene({ tabId }: SessionRecordingsSettingsSceneProps = {}): JSX.Element {
+    if (!tabId) {
+        throw new Error('<SessionRecordingsSettingsScene /> must receive a tabId prop')
+    }
     return (
-        <>
+        <BindLogic logic={sessionReplaySceneLogic} props={{ tabId }}>
             <SceneContent className="-mb-14">
                 <SessionRecordingsPageTabs />
                 <Settings
@@ -54,6 +62,6 @@ export function SessionRecordingsSettingsScene(): JSX.Element {
                     handleLocally
                 />
             </SceneContent>
-        </>
+        </BindLogic>
     )
 }


### PR DESCRIPTION
replay can be in tabs

but it doesn't know

make it know

----

many of the logics are used in the sessionrecording player modal, which is mounted all over the place so can't easily be tab aware i don't think. so this is the bare minimum change i can see to make