### PR TITLE
fix: fix adding people to notebooks

### DIFF
--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import React from 'react'
 
-import { IconArrowLeft, IconChevronLeft, IconExternal, IconOpenSidebar, IconPlus, IconSidePanel } from '@posthog/icons'
+import { IconArrowLeft, IconChevronLeft, IconOpenSidebar, IconPlus, IconSidePanel } from '@posthog/icons'
 import { LemonBanner, LemonTag } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
@@ -203,7 +203,6 @@ export const MaxInstance = React.memo(function MaxInstance({
                     {!isAIOnlyMode && (
                         <LemonButton
                             size="small"
-                            sideIcon={<IconExternal />}
                             to={urls.max(conversationId ?? undefined)}
                             onClick={() => {
                                 closeSidePanel()

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
@@ -70,7 +70,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeRecordingAttrib
                           insertAfter({
                               type: NotebookNodeType.Person,
                               attrs: {
-                                  id: String(person.distinct_ids[0]),
+                                  id: person.uuid,
                               },
                           })
                       },

--- a/frontend/src/scenes/notebooks/NotebookPanel/NotebookPanel.tsx
+++ b/frontend/src/scenes/notebooks/NotebookPanel/NotebookPanel.tsx
@@ -3,7 +3,6 @@ import './NotebookPanel.scss'
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { IconExternal } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
@@ -54,7 +53,6 @@ export function NotebookPanel(): JSX.Element | null {
                             size="small"
                             to={urls.notebook(selectedNotebook)}
                             onClick={() => closeSidePanel()}
-                            icon={<IconExternal />}
                             targetBlank
                             tooltip="Open as main focus"
                             tooltipPlacement="bottom-end"

--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -91,7 +91,7 @@ export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
                 <NotebookSelectButton
                     resource={{
                         type: NotebookNodeType.Person,
-                        attrs: { id: person?.distinct_ids[0] },
+                        attrs: { id: person?.uuid },
                     }}
                     onNotebookOpened={() => props.onClose?.()}
                     size="small"

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -157,7 +157,7 @@ export function PersonScene(): JSX.Element | null {
                         <NotebookSelectButton
                             resource={{
                                 type: NotebookNodeType.Person,
-                                attrs: { distinctId: person?.distinct_ids[0] },
+                                attrs: { id: person?.uuid },
                             }}
                             type="secondary"
                             size="small"


### PR DESCRIPTION
## Problem

This panel (in persons view) does not work as intended.

<img width="1019" height="511" alt="image" src="https://github.com/user-attachments/assets/b21296ce-8d29-4fdb-ad00-25bfafaa9db3" />

I think how it was expected to work:
- `continue in` - if that person is already in a notebook, then display that notebook here,
- `add to` - if that person is not already in a notebook, then display that notebook here.

How it currently works:
- `continue in` - displays notebooks which contain ANY person. So If I am on person A and have notebook N which contains person B then this notebook is in the continue section anyways,
- `add to` - displays notebooks which do not have ANY person. It is possible to only add one person to a notebook and then this notebook never appears in that section again.

I believe all of this is caused by the fact that we wrongly reference person's distinct ID thinking it is ID whereas it is not true.

When looking in the network tab I noticed that we send query to notebooks with
```
contains: person
```

Which explains current behavior of "continue in" and "add to" sections. It just checks if ANY person is in the notebook. Not a specific one.

## Changes

Changed these references to `.uuid` - which fixes all of those issues and in the network tab now I correctly see
```
contains: person:019983fb-b853-0000-663d-d9b2d4f74064
```

Also we had double icon being displayed (one set explicitly and second one automatically because of `targetBlank`)


## How did you test this code?

Locally
