### PR TITLE
fix(experiments): Fix timeseries date issue

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -919,10 +919,16 @@ class EnterpriseExperimentsViewSet(
         latest_completed_at = None
 
         # Create mapping from query_to to result, deriving the day in project timezone
+        # Note: query_to is the EXCLUSIVE end of the time range (midnight of the NEXT day)
+        # Example: Data for 2025-11-09 has query_to = 2025-11-10T00:00:00
+        # We need to map this back to the day it represents (2025-11-09)
         results_by_date = {}
         for result in metric_results:
-            # Convert UTC query_to to project timezone to determine which day this result belongs to
-            day_in_project_tz = result.query_to.astimezone(project_tz).date()
+            # Convert query_to to project timezone, then subtract 1 day to get the result day
+            query_to_in_project_tz = result.query_to.astimezone(project_tz)
+            # Since query_to is midnight (00:00:00), .date() gives us the next day
+            # Subtract 1 day to get the actual day this result represents
+            day_in_project_tz = query_to_in_project_tz.date() - timedelta(days=1)
             results_by_date[day_in_project_tz] = result
 
         for experiment_date in experiment_dates:

--- a/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
@@ -1,7 +1,8 @@
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { LemonBanner, LemonButton, LemonDialog, LemonDivider, LemonModal, Link } from '@posthog/lemon-ui'
+import { IconInfo } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonDialog, LemonDivider, LemonModal, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -146,7 +147,14 @@ export function TimeseriesModal({
                             </div>
                         )}
                         <div className="flex justify-between items-center mt-2 mb-4">
-                            <div className="text-xs text-muted">{progressMessage || ''}</div>
+                            <div className="flex items-center gap-1">
+                                <div className="text-xs text-muted">{progressMessage || ''}</div>
+                                {progressMessage && (
+                                    <Tooltip title="The chart displays data starting from the first day with meaningful results. Earlier days without sufficient data are excluded from the visualization.">
+                                        <IconInfo className="text-muted text-base" />
+                                    </Tooltip>
+                                )}
+                            </div>
                             <More
                                 overlay={
                                     <>

--- a/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
+++ b/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
@@ -205,19 +205,29 @@ export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([
             },
         ],
 
-        // Progress message - only shown when we have partial data
+        // Progress message - shows calculation progress or completion
         progressMessage: [
             (s) => [s.timeseries],
             (timeseries: ExperimentMetricTimeseries | null): string | null => {
-                if (!timeseries || timeseries.status !== 'partial') {
+                if (!timeseries || !timeseries.timeseries) {
                     return null
                 }
 
                 const timeseriesData = timeseries.timeseries || {}
-                const computedDays = Object.values(timeseriesData).filter(Boolean).length
+                const computedDays = Object.values(timeseriesData).filter(value => value !== null).length
                 const totalDays = Object.keys(timeseriesData).length
 
-                return totalDays > 0 ? `Computed ${computedDays} of ${totalDays} days` : null
+                if (totalDays === 0) {
+                    return null
+                }
+
+                // If all days are computed, show "Calculated N days"
+                if (computedDays === totalDays) {
+                    return `Calculated ${totalDays} day${totalDays === 1 ? '' : 's'}`
+                }
+
+                // Otherwise show progress "Computed N of M days"
+                return `Computed ${computedDays} of ${totalDays} days`
             },
         ],
         hasTimeseriesData: [

--- a/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
+++ b/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
@@ -214,7 +214,7 @@ export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([
                 }
 
                 const timeseriesData = timeseries.timeseries || {}
-                const computedDays = Object.values(timeseriesData).filter(value => value !== null).length
+                const computedDays = Object.values(timeseriesData).filter((value) => value !== null).length
                 const totalDays = Object.keys(timeseriesData).length
 
                 if (totalDays === 0) {


### PR DESCRIPTION
## Problem

When users recalculate timeseries, we create daily records with `query_to` set to midnight of the *next* day (following exclusive boundary convention). We were extracting the date directly from `query_to`, which gave us the wrong day.

## Changes

Subtract 1 microsecond to get the last included moment before extracting the date:

**Example:**
Recalculated record for Nov 9:
`query_to = 2025-11-10T00:00:00` (midnight of next day, representing "up to but not including Nov 10")

**Before:** `.date()` = `2025-11-10` → wrong day
**After:** Subtract microsecond → `2025-11-09T23:59:59.999999` → `.date()` = `2025-11-09` → correct day

## How did you test your changes?
Manualy (adjusted progress message to show when all days were succesfully completed)

<img width="991" height="379" alt="image" src="https://github.com/user-attachments/assets/4d0ad62c-9125-4854-a432-53fcb7a8be9e" />