### PR TITLE
fix: materialized columns only for enabled tables

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import random
 import logging
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass, replace
@@ -81,7 +82,8 @@ class MaterializedColumn:
 
     @staticmethod
     def _get_all(table: TablesWithMaterializedColumns) -> list[tuple[str, str, bool]]:
-        if MATERIALIZED_COLUMNS_USE_CACHE:
+        refresh_cache = random.random() < 0.002  # we run around 50 of those queries per minute
+        if table in TablesWithMaterializedColumns and not refresh_cache and MATERIALIZED_COLUMNS_USE_CACHE:
             cache_key: str = f"materialized_columns:{table}"
 
             try:
@@ -98,15 +100,15 @@ class MaterializedColumn:
                 SELECT name, comment, type like 'Nullable(%%)' as is_nullable
                 FROM system.columns
                 WHERE database = %(database)s
-                    AND table = %(table)s
-                    AND comment LIKE '%%column_materializer::%%'
-                    AND comment not LIKE '%%column_materializer::elements_chain::%%'
-            """,
+                  AND table = %(table)s
+                  AND comment LIKE '%%column_materializer::%%'
+                  AND comment not LIKE '%%column_materializer::elements_chain::%%'
+                """,
                 {"database": CLICKHOUSE_DATABASE, "table": table},
                 ch_user=ClickHouseUser.HOGQL,
             )
 
-        if MATERIALIZED_COLUMNS_USE_CACHE:
+        if table in TablesWithMaterializedColumns and MATERIALIZED_COLUMNS_USE_CACHE:
             try:
                 cache.set(cache_key, result, MATERIALIZED_COLUMNS_CACHE_TIMEOUT)
             except Exception:
@@ -117,8 +119,11 @@ class MaterializedColumn:
 
     @staticmethod
     def get_all(table: TablesWithMaterializedColumns) -> Iterator[MaterializedColumn]:
-        rows = MaterializedColumn._get_all(table)
+        if table not in TablesWithMaterializedColumns:
+            logger.error("HogQL trying to get materialized columns for table: %s", table)
+            return
 
+        rows = MaterializedColumn._get_all(table)
         for name, comment, is_nullable in rows:
             yield MaterializedColumn(name, MaterializedColumnDetails.from_column_comment(comment), is_nullable)
 
@@ -361,7 +366,9 @@ def check_index_exists(client: Client, table: str, index: str) -> bool:
         """
         SELECT count()
         FROM system.data_skipping_indices
-        WHERE database = currentDatabase() AND table = %(table)s AND name = %(name)s
+        WHERE database = currentDatabase()
+          AND table = %(table)s
+          AND name = %(name)s
         """,
         {"table": table, "name": index},
     )
@@ -374,7 +381,9 @@ def check_column_exists(client: Client, table: str, column: str) -> bool:
         """
         SELECT count()
         FROM system.columns
-        WHERE database = currentDatabase() AND table = %(table)s AND name = %(name)s
+        WHERE database = currentDatabase()
+          AND table = %(table)s
+          AND name = %(name)s
         """,
         {"table": table, "name": column},
     )

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -90,6 +90,9 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
         sync_execute(f"CREATE DATABASE {CLICKHOUSE_DATABASE}")
         create_clickhouse_tables()
 
+    def test_unknown_table(self):
+        assert {} == get_materialized_columns("some weird string")
+
     def test_get_columns_default(self):
         assert sorted([property_name for property_name, _ in get_materialized_columns("events")]) == sorted(
             EVENTS_TABLE_DEFAULT_MATERIALIZED_COLUMNS

--- a/posthog/clickhouse/materialized_columns.py
+++ b/posthog/clickhouse/materialized_columns.py
@@ -6,6 +6,7 @@ from posthog.settings import EE_AVAILABLE
 
 ColumnName = str
 TablesWithMaterializedColumns = TableWithProperties
+MATERIALIZATION_VALID_TABLES = {"events", "person", "groups"}
 
 
 class MaterializedColumn(Protocol):


### PR DESCRIPTION
## Problem

materialized columns are checked for S3 tables

## Changes

- check allow list before fetching materialized columns
- log error
- refresh materialized columns randomly on 1 pod

## Result

<img width="2183" height="865" alt="Screenshot 2025-11-21 at 12 40 39" src="https://github.com/user-attachments/assets/e30df395-be8e-4b28-947d-ee01a1a75b87" />

## How did you test this code?

Added test.


