### PR TITLE
chore: Update comment to trigger image builds for workers

### DIFF
--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -21,7 +21,7 @@ from ee.tasks.subscriptions import deliver_subscription_report_async, team_use_t
 
 LOGGER = get_logger(__name__)
 
-# Changed 10/10/2025
+# Changed 21/11/2025
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Similarly to: https://github.com/PostHog/posthog/pull/39496 this updates a comment to trigger a new worker build as this is one of the files tracked to decide if we should build/publish the worker image or not: https://github.com/PostHog/posthog/blob/e9320b52d269eb3246bde2fe06e8190b4cacce14/.github/workflows/container-images-cd.yml#L281-L284.

This will update the images of the workers to contain the fix introduced in: https://github.com/PostHog/posthog/pull/41836.  

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

No actual changes

## How did you test this code?

No actual changes

## Changelog: (features only) Is this feature complete?

N/A 
