### PR TITLE
feat(ux): app shortcuts + shortcut menu

### DIFF
--- a/common/tailwind/tailwind.config.js
+++ b/common/tailwind/tailwind.config.js
@@ -162,7 +162,7 @@ const deprecatedColors = {
     // Z-indexes
     'z-top': 'var(--z-top)',
     'z-bottom-notice': 'var(--z-bottom-notice)',
-    'z-command-palette': 'var(--z-command-palette)',
+    'z-shortcut-menu': 'var(--z-shortcut-menu)',
     'z-force-modal-above-popovers': 'var(--z-force-modal-above-popovers)',
     'z-tooltip': 'var(--z-tooltip)',
 

--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -4,8 +4,6 @@ import { useActions, useValues } from 'kea'
 import { ReactNode, useEffect, useRef } from 'react'
 
 import { BillingAlertsV2 } from 'lib/components/BillingAlertsV2'
-import { CommandBar } from 'lib/components/CommandBar/CommandBar'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { FloatingContainerContext } from 'lib/hooks/useFloatingContainerContext'
 import { cn } from 'lib/utils/css-classes'
 import { SceneConfig } from 'scenes/sceneTypes'
@@ -34,7 +32,6 @@ export function Navigation({
     const mainRef = useRef<HTMLElement>(null)
     const { mainContentRect } = useValues(panelLayoutLogic)
     const { setMainContentRef, setMainContentRect } = useActions(panelLayoutLogic)
-    const useAppShortcuts = useFeatureFlag('APP_SHORTCUTS')
 
     // Set container ref so we can measure the width of the scene layout in logic
     useEffect(() => {
@@ -114,7 +111,6 @@ export function Navigation({
                     </SceneLayout>
                 </main>
                 <SidePanel />
-                {!useAppShortcuts && <CommandBar />}
             </FloatingContainerContext.Provider>
         </div>
     )

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -457,7 +457,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
 
                             <AppShortcut
                                 name="Search"
-                                keybind={keyBinds.search}
+                                keybind={[keyBinds.search]}
                                 intent="Search"
                                 interaction="click"
                                 asChild
@@ -486,7 +486,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
 
                             <AppShortcut
                                 name="ToggleShortcutMenu"
-                                keybind={keyBinds.toggleShortcutMenu}
+                                keybind={[keyBinds.toggleShortcutMenu, keyBinds.toggleShortcutMenuFallback]}
                                 intent="Toggle shortcut menu"
                                 interaction="click"
                                 asChild
@@ -547,7 +547,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                 preflight?.instance_preferences?.debug_queries) && (
                                 <AppShortcut
                                     name="DebugClickhouseQueries"
-                                    keybind={['command', 'option', 'tab']}
+                                    keybind={[['command', 'option', 'tab']]}
                                     intent="Debug clickhouse queries"
                                     interaction="click"
                                     asChild
@@ -569,6 +569,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                     </ButtonPrimitive>
                                 </AppShortcut>
                             )}
+
                             <Link
                                 buttonProps={{
                                     menuItem: !isLayoutNavCollapsed,

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -29,7 +29,6 @@ import { DebugNotice } from 'lib/components/DebugNotice'
 import { NavPanelAdvertisement } from 'lib/components/NavPanelAdvertisement/NavPanelAdvertisement'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { ButtonGroupPrimitive, ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import {
@@ -106,8 +105,6 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
     const { preflight } = useValues(preflightLogic)
     const { setAppShortcutMenuOpen } = useActions(appShortcutLogic)
     const { appShortcutMenuOpen } = useValues(appShortcutLogic)
-
-    const useAppShortcuts = useFeatureFlag('APP_SHORTCUTS')
 
     function handlePanelTriggerClick(item: PanelLayoutNavIdentifier): void {
         if (activePanelIdentifier !== item) {
@@ -461,7 +458,6 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                 intent="Search"
                                 interaction="click"
                                 asChild
-                                disabled={!useAppShortcuts}
                             >
                                 {/* Button is hidden, keep to register shortcut */}
                                 <ButtonPrimitive
@@ -490,7 +486,6 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                 intent="Toggle shortcut menu"
                                 interaction="click"
                                 asChild
-                                disabled={!useAppShortcuts}
                             >
                                 {/* Button is hidden, keep to register shortcut */}
                                 <ButtonPrimitive

--- a/frontend/src/layout/scenes/SceneLayout.tsx
+++ b/frontend/src/layout/scenes/SceneLayout.tsx
@@ -9,7 +9,6 @@ import { LemonDivider } from '@posthog/lemon-ui'
 
 import { AppShortcutMenu } from 'lib/components/AppShortcuts/AppShortcutMenu'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label, LabelProps } from 'lib/ui/Label/Label'
 import { cn } from 'lib/utils/css-classes'
@@ -76,7 +75,6 @@ export function SceneLayout({ children, sceneConfig }: SceneLayoutProps): JSX.El
     const { isLayoutPanelVisible, isLayoutPanelPinned } = useValues(panelLayoutLogic)
     const { scenePanelIsPresent, scenePanelOpen, scenePanelIsRelative } = useValues(sceneLayoutLogic)
     const { firstTabIsActive } = useValues(sceneLogic)
-    const useAppShortcuts = useFeatureFlag('APP_SHORTCUTS')
 
     // Set layout config
     useEffect(() => {
@@ -184,7 +182,7 @@ export function SceneLayout({ children, sceneConfig }: SceneLayoutProps): JSX.El
                 </>
             )}
 
-            {useAppShortcuts && <AppShortcutMenu />}
+            <AppShortcutMenu />
         </>
     )
 }

--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -144,7 +144,7 @@ export function SceneTabs({ className }: SceneTabsProps): JSX.Element {
                         </div>
                         <AppShortcut
                             name="NewTab"
-                            keybind={keyBinds.newTab}
+                            keybind={[keyBinds.newTab]}
                             intent="New tab"
                             interaction="click"
                             asChild
@@ -269,7 +269,7 @@ function SceneTabComponent({ tab, className, isDragging, containerClassName, ind
                 {canRemoveTab && (
                     <AppShortcut
                         name="CloseActiveTab"
-                        keybind={keyBinds.closeActiveTab}
+                        keybind={[keyBinds.closeActiveTab]}
                         intent="Close active tab"
                         interaction="click"
                         asChild

--- a/frontend/src/lib/components/Account/AccountMenu.tsx
+++ b/frontend/src/lib/components/Account/AccountMenu.tsx
@@ -163,7 +163,6 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                 collisionPadding={{ bottom: 0 }}
                 alignOffset={2}
                 className="min-w-[var(--project-panel-width)]"
-                forceMount
             >
                 <DropdownMenuGroup>
                     <Label intent="menu" className="px-2">
@@ -320,7 +319,7 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
 
                     <AppShortcut
                         name="ToggleShortcutMenu"
-                        keybind={keyBinds.toggleShortcutMenu}
+                        keybind={[keyBinds.toggleShortcutMenu]}
                         intent="Toggle shortcut menu"
                         interaction="click"
                         asChild
@@ -334,9 +333,13 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                                 menuItem
                                 className={cn(!useAppShortcuts && 'hidden')}
                             >
-                                <span className="text-tertiary size-4 flex items-center justify-center">⌘</span>
+                                <span className="size-4 flex items-center justify-center">⌘</span>
                                 Shortcuts
-                                <KeyboardShortcut command option k className="ml-auto" />
+                                <div className="flex gap-1 ml-auto items-center">
+                                    <KeyboardShortcut command option k />
+                                    <span className="text-xs opacity-75">or</span>
+                                    <KeyboardShortcut command shift k />
+                                </div>
                             </ButtonPrimitive>
                         </DropdownMenuItem>
                     </AppShortcut>

--- a/frontend/src/lib/components/Account/AccountMenu.tsx
+++ b/frontend/src/lib/components/Account/AccountMenu.tsx
@@ -21,7 +21,6 @@ import {
 } from '@posthog/icons'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Link } from 'lib/lemon-ui/Link/Link'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture/ProfilePicture'
@@ -43,7 +42,6 @@ import {
 } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { Label } from 'lib/ui/Label/Label'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
-import { cn } from 'lib/utils/css-classes'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
@@ -153,7 +151,6 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
     const { mobileLayout } = useValues(navigationLogic)
     const { openSidePanel } = useActions(sidePanelStateLogic)
     const { setAppShortcutMenuOpen } = useActions(appShortcutLogic)
-    const useAppShortcuts = useFeatureFlag('APP_SHORTCUTS')
 
     return (
         <DropdownMenu>
@@ -323,15 +320,13 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                         intent="Toggle shortcut menu"
                         interaction="click"
                         asChild
-                        disabled={!useAppShortcuts}
                     >
                         <DropdownMenuItem asChild>
                             <ButtonPrimitive
-                                tooltip={useAppShortcuts ? 'Open shortcut menu' : undefined}
+                                tooltip="Open shortcut menu"
                                 tooltipPlacement="right"
                                 onClick={() => setAppShortcutMenuOpen(true)}
                                 menuItem
-                                className={cn(!useAppShortcuts && 'hidden')}
                             >
                                 <span className="size-4 flex items-center justify-center">⌘</span>
                                 Shortcuts
@@ -434,10 +429,9 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                                 </Link>
                             </DropdownMenuItem>
 
-                            {useAppShortcuts &&
-                            (user?.is_impersonated ||
-                                preflight?.is_debug ||
-                                preflight?.instance_preferences?.debug_queries) ? (
+                            {user?.is_impersonated ||
+                            preflight?.is_debug ||
+                            preflight?.instance_preferences?.debug_queries ? (
                                 <DropdownMenuItem asChild>
                                     <ButtonPrimitive
                                         menuItem
@@ -445,7 +439,6 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                                             openCHQueriesDebugModal()
                                         }}
                                         data-attr="menu-item-debug-ch-queries"
-                                        className={cn(!useAppShortcuts && 'hidden')}
                                     >
                                         <IconDatabase />
                                         Debug CH queries

--- a/frontend/src/lib/components/Account/AccountMenu.tsx
+++ b/frontend/src/lib/components/Account/AccountMenu.tsx
@@ -58,9 +58,7 @@ import { navigationLogic } from '~/layout/navigation/navigationLogic'
 import { getTreeItemsGames } from '~/products'
 import { SidePanelTab, UserTheme } from '~/types'
 
-import { AppShortcut } from '../AppShortcuts/AppShortcut'
 import { appShortcutLogic } from '../AppShortcuts/appShortcutLogic'
-import { keyBinds } from '../AppShortcuts/shortcuts'
 import { openCHQueriesDebugModal } from '../AppShortcuts/utils/DebugCHQueries'
 import { OrgCombobox } from './OrgCombobox'
 
@@ -314,30 +312,22 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
 
                     <ThemeMenu />
 
-                    <AppShortcut
-                        name="ToggleShortcutMenu"
-                        keybind={[keyBinds.toggleShortcutMenu]}
-                        intent="Toggle shortcut menu"
-                        interaction="click"
-                        asChild
-                    >
-                        <DropdownMenuItem asChild>
-                            <ButtonPrimitive
-                                tooltip="Open shortcut menu"
-                                tooltipPlacement="right"
-                                onClick={() => setAppShortcutMenuOpen(true)}
-                                menuItem
-                            >
-                                <span className="size-4 flex items-center justify-center">⌘</span>
-                                Shortcuts
-                                <div className="flex gap-1 ml-auto items-center">
-                                    <KeyboardShortcut command option k />
-                                    <span className="text-xs opacity-75">or</span>
-                                    <KeyboardShortcut command shift k />
-                                </div>
-                            </ButtonPrimitive>
-                        </DropdownMenuItem>
-                    </AppShortcut>
+                    <DropdownMenuItem asChild>
+                        <ButtonPrimitive
+                            tooltip="Open shortcut menu"
+                            tooltipPlacement="right"
+                            onClick={() => setAppShortcutMenuOpen(true)}
+                            menuItem
+                        >
+                            <span className="size-4 flex items-center justify-center">⌘</span>
+                            Shortcuts
+                            <div className="flex gap-1 ml-auto items-center">
+                                <KeyboardShortcut command option k />
+                                <span className="text-xs opacity-75">or</span>
+                                <KeyboardShortcut command shift k />
+                            </div>
+                        </ButtonPrimitive>
+                    </DropdownMenuItem>
 
                     <DropdownMenuItem asChild>
                         <Link

--- a/frontend/src/lib/components/AppShortcuts/AppShortcutMenu.tsx
+++ b/frontend/src/lib/components/AppShortcuts/AppShortcutMenu.tsx
@@ -188,7 +188,7 @@ export function AppShortcutMenu(): JSX.Element | null {
     }
 
     const paletteContent = (
-        <div className="fixed inset-0 z-[var(--z-command-palette)] flex items-end justify-center p-6 backdrop-blur-[var(--modal-backdrop-blur)]">
+        <div className="fixed inset-0 z-[var(--z-shortcut-menu)] flex items-end justify-center p-6 backdrop-blur-[var(--modal-backdrop-blur)]">
             <div
                 className="bg-surface-secondary border-3 border-tertiary rounded-lg shadow-2xl w-96 max-h-[calc(100vh-(var(--spacing)*6))] overflow-x-hidden overflow-y-auto backdrop-blur-sm"
                 id="app-shortcut-menu"

--- a/frontend/src/lib/components/AppShortcuts/AppShortcutMenu.tsx
+++ b/frontend/src/lib/components/AppShortcuts/AppShortcutMenu.tsx
@@ -188,7 +188,7 @@ export function AppShortcutMenu(): JSX.Element | null {
     }
 
     const paletteContent = (
-        <div className="fixed inset-0 z-top flex items-end justify-center p-6 backdrop-blur-[var(--modal-backdrop-blur)]">
+        <div className="fixed inset-0 z-[var(--z-command-palette)] flex items-end justify-center p-6 backdrop-blur-[var(--modal-backdrop-blur)]">
             <div
                 className="bg-surface-secondary border-3 border-tertiary rounded-lg shadow-2xl w-96 max-h-[calc(100vh-(var(--spacing)*6))] overflow-x-hidden overflow-y-auto backdrop-blur-sm"
                 id="app-shortcut-menu"
@@ -229,13 +229,27 @@ export function AppShortcutMenu(): JSX.Element | null {
                                                             {getShortcutIcon(shortcut)}
                                                             {shortcut.intent}
                                                         </span>
-                                                        <span className="ml-auto">
-                                                            <KeyboardShortcut
-                                                                {...Object.fromEntries(
-                                                                    shortcut.keybind.map((key) => [key, true])
-                                                                )}
-                                                                className="text-xs"
-                                                            />
+                                                        <span className="ml-auto flex items-center gap-1">
+                                                            {(shortcut.keybind as string[][]).map(
+                                                                (keybindOption, index) => (
+                                                                    <React.Fragment key={index}>
+                                                                        {index > 0 && (
+                                                                            <span className="text-xs opacity-75">
+                                                                                or
+                                                                            </span>
+                                                                        )}
+                                                                        <KeyboardShortcut
+                                                                            {...Object.fromEntries(
+                                                                                keybindOption.map((key: string) => [
+                                                                                    key,
+                                                                                    true,
+                                                                                ])
+                                                                            )}
+                                                                            className="text-xs"
+                                                                        />
+                                                                    </React.Fragment>
+                                                                )
+                                                            )}
                                                         </span>
                                                     </ButtonPrimitive>
                                                 </Combobox.Item>

--- a/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
+++ b/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
@@ -9,8 +9,8 @@ export interface AppShortcutType {
     ref: React.RefObject<HTMLElement>
     /* The name of the shortcut used for reference */
     name: string
-    /* The keybind to use for the shortcut */
-    keybind: string[]
+    /* The keybind(s) to use for the shortcut - array of keybind arrays for multiple alternative keybinds */
+    keybind: string[][]
     /* Describe what the shortcut does */
     intent: string
     /* The type of interaction to trigger */
@@ -87,8 +87,10 @@ export const appShortcutLogic = kea<appShortcutLogicType>([
 
                 // Find matching shortcut
                 const matchingShortcut = values.registeredAppShortcuts.find((shortcut) => {
-                    const shortcutKeyString = shortcut.keybind.map((k: string) => k.toLowerCase()).join('+')
-                    return shortcutKeyString === pressedKeyString
+                    return shortcut.keybind.some((keybind) => {
+                        const shortcutKeyString = keybind.map((k: string) => k.toLowerCase()).join('+')
+                        return shortcutKeyString === pressedKeyString
+                    })
                 })
 
                 if (matchingShortcut) {

--- a/frontend/src/lib/components/AppShortcuts/shortcuts.ts
+++ b/frontend/src/lib/components/AppShortcuts/shortcuts.ts
@@ -4,6 +4,7 @@ export const keyBinds: Record<string, string[]> = {
     newTab: [...baseModifier, 't'],
     closeActiveTab: [...baseModifier, 'w'],
     toggleShortcutMenu: [...baseModifier, 'k'],
+    toggleShortcutMenuFallback: ['command', 'shift', 'k'],
     search: ['command', 'k'],
     new: [...baseModifier, 'n'],
     edit: [...baseModifier, 'e'],

--- a/frontend/src/lib/components/CommandBar/index.scss
+++ b/frontend/src/lib/components/CommandBar/index.scss
@@ -21,7 +21,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: var(--z-command-palette);
+    z-index: var(--z-shortcut-menu);
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -341,7 +341,6 @@ export const FEATURE_FLAGS = {
     REPLAY_NEW_DETECTED_URL_COLLECTIONS: 'replay-new-detected-url-collections', // owner: @ksvat #team-replay multivariate
     EXPERIMENTS_USE_NEW_CREATE_FORM: 'experiments-use-new-create-form', // owner: @rodrigoi #team-experiments
     AGENT_MODES: 'phai-agent-modes', // owner: @skoob13 #team-posthog-ai
-    APP_SHORTCUTS: 'app-shortcuts', // owner: @adamleithp #team-platform-ux
 } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -7,12 +7,9 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 import { AccessDenied } from 'lib/components/AccessDenied'
 import { NotFound } from 'lib/components/NotFound'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
-import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { cn } from 'lib/utils/css-classes'
-import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { DashboardEditBar } from 'scenes/dashboard/DashboardEditBar'
 import { DashboardItems } from 'scenes/dashboard/DashboardItems'
 import { DashboardReloadAction, LastRefreshText } from 'scenes/dashboard/DashboardReloadAction'
@@ -72,8 +69,7 @@ function DashboardScene(): JSX.Element {
         hasVariables,
     } = useValues(dashboardLogic)
     const { currentTeamId } = useValues(teamLogic)
-    const { setDashboardMode, reportDashboardViewed, abortAnyRunningQuery } = useActions(dashboardLogic)
-    const useAppShortcuts = useFeatureFlag('APP_SHORTCUTS')
+    const { reportDashboardViewed, abortAnyRunningQuery } = useActions(dashboardLogic)
 
     useFileSystemLogView({
         type: 'dashboard',
@@ -88,35 +84,6 @@ function DashboardScene(): JSX.Element {
         // request cancellation of any running queries when this component is no longer in the dom
         return () => abortAnyRunningQuery()
     })
-
-    useKeyboardHotkeys(
-        placement == DashboardPlacement.Dashboard && !useAppShortcuts
-            ? {
-                  e: {
-                      action: () =>
-                          setDashboardMode(
-                              dashboardMode === DashboardMode.Edit ? null : DashboardMode.Edit,
-                              DashboardEventSource.Hotkey
-                          ),
-                      disabled: !canEditDashboard || (dashboardMode !== null && dashboardMode !== DashboardMode.Edit),
-                  },
-                  f: {
-                      action: () =>
-                          setDashboardMode(
-                              dashboardMode === DashboardMode.Fullscreen ? null : DashboardMode.Fullscreen,
-                              DashboardEventSource.Hotkey
-                          ),
-                      disabled: dashboardMode !== null && dashboardMode !== DashboardMode.Fullscreen,
-                  },
-                  escape: {
-                      // Exit edit mode with Esc. Full screen mode is also exited with Esc, but this behavior is native to the browser.
-                      action: () => setDashboardMode(null, DashboardEventSource.Hotkey),
-                      disabled: dashboardMode !== DashboardMode.Edit,
-                  },
-              }
-            : {},
-        [setDashboardMode, dashboardMode, placement]
-    )
 
     if (!dashboard && !itemsLoading && !dashboardFailedToLoad) {
         return <NotFound object="dashboard" />

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -252,7 +252,7 @@ export function DashboardHeader(): JSX.Element | null {
                         <AppShortcut
                             name="ToggleEditMode"
                             scope={Scene.Dashboard}
-                            keybind={keyBinds.edit}
+                            keybind={[keyBinds.edit]}
                             intent="Toggle edit mode"
                             interaction="click"
                             asChild
@@ -428,7 +428,7 @@ export function DashboardHeader(): JSX.Element | null {
                                 </LemonButton>
                                 <AppShortcut
                                     name="SaveDashboard"
-                                    keybind={keyBinds.save}
+                                    keybind={[keyBinds.save]}
                                     intent="Save dashboard"
                                     interaction="click"
                                     scope={Scene.Dashboard}
@@ -491,7 +491,7 @@ export function DashboardHeader(): JSX.Element | null {
                                             <AppShortcut
                                                 name="AddTextTileToDashboard"
                                                 scope={Scene.Dashboard}
-                                                keybind={keyBinds.dashboardAddTextTile}
+                                                keybind={[keyBinds.dashboardAddTextTile]}
                                                 intent="Add text card"
                                                 interaction="click"
                                                 asChild

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -37,7 +37,6 @@ import { sceneConfigurations } from 'scenes/scenes'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import {
     ScenePanel,
@@ -123,7 +122,6 @@ export function DashboardHeader(): JSX.Element | null {
     }, [dashboard, dashboardLoading])
 
     const hasDashboardColors = useFeatureFlag('DASHBOARD_COLORS')
-    const useAppShortcuts = useFeatureFlag('APP_SHORTCUTS')
 
     const exportOptions: ExportButtonItem[] = [
         {
@@ -256,7 +254,6 @@ export function DashboardHeader(): JSX.Element | null {
                             intent="Toggle edit mode"
                             interaction="click"
                             asChild
-                            disabled={!useAppShortcuts}
                         >
                             <ButtonPrimitive
                                 onClick={() => {
@@ -269,11 +266,11 @@ export function DashboardHeader(): JSX.Element | null {
                                 menuItem
                                 active={dashboardMode === DashboardMode.Edit}
                                 data-attr={`${RESOURCE_TYPE}-edit-layout`}
-                                tooltip={useAppShortcuts ? 'Toggle edit mode' : null}
+                                tooltip="Toggle edit mode"
                                 tooltipPlacement="left"
                             >
                                 <IconGridMasonry />
-                                Edit layout {useAppShortcuts ? null : <KeyboardShortcut e />}
+                                Edit layout
                             </ButtonPrimitive>
                         </AppShortcut>
                     )}
@@ -433,7 +430,6 @@ export function DashboardHeader(): JSX.Element | null {
                                     interaction="click"
                                     scope={Scene.Dashboard}
                                     asChild
-                                    disabled={!useAppShortcuts}
                                 >
                                     <LemonButton
                                         data-attr="dashboard-edit-mode-save"
@@ -495,7 +491,6 @@ export function DashboardHeader(): JSX.Element | null {
                                                 intent="Add text card"
                                                 interaction="click"
                                                 asChild
-                                                disabled={!useAppShortcuts}
                                             >
                                                 <LemonButton
                                                     onClick={() => {
@@ -504,7 +499,7 @@ export function DashboardHeader(): JSX.Element | null {
                                                     data-attr="add-text-tile-to-dashboard"
                                                     type="secondary"
                                                     size="small"
-                                                    tooltip={useAppShortcuts ? 'Add text card' : null}
+                                                    tooltip="Add text card"
                                                     tooltipPlacement="top"
                                                 >
                                                     Add text card

--- a/frontend/src/scenes/dashboard/dashboards/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/Dashboards.tsx
@@ -68,7 +68,7 @@ export function Dashboards(): JSX.Element {
                         >
                             <AppShortcut
                                 name="NewDashboard"
-                                keybind={keyBinds.new}
+                                keybind={[keyBinds.new]}
                                 intent="New dashboard"
                                 interaction="click"
                                 asChild

--- a/frontend/src/scenes/experiments/experimentSceneLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.test.ts
@@ -54,6 +54,7 @@ jest.mock('scenes/sceneLogic', () => ({
         actions: {
             setTabs: jest.fn(),
         },
+        isMounted: jest.fn(() => true),
     },
 }))
 

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -14,7 +14,7 @@ import { trackFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { getRelativeNextPath, identifierToHuman, isMac } from 'lib/utils'
+import { getRelativeNextPath, identifierToHuman } from 'lib/utils'
 import { getAppContext, getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
 import { NEW_INTERNAL_TAB } from 'lib/utils/newInternalTab'
 import { addProjectIdIfMissing, removeProjectIdIfPresent } from 'lib/utils/router-utils'
@@ -45,7 +45,6 @@ import { AccessControlLevel, OnboardingStepKey } from '~/types'
 import { preflightLogic } from './PreflightCheck/preflightLogic'
 import { handleLoginRedirect } from './authentication/loginLogic'
 import { billingLogic } from './billing/billingLogic'
-import { newTabSceneLogic } from './new-tab/newTabSceneLogic'
 import { organizationLogic } from './organizationLogic'
 import type { sceneLogicType } from './sceneLogicType'
 import { inviteLogic } from './settings/organization/inviteLogic'
@@ -1552,77 +1551,5 @@ export const sceneLogic = kea<sceneLogicType>([
             window.addEventListener('storage', onStorage)
             return () => window.removeEventListener('storage', onStorage)
         }, 'pinnedTabsStorageListener')
-    }),
-    afterMount(({ actions, cache, values }) => {
-        const useAppShortcuts = values.featureFlags[FEATURE_FLAGS.APP_SHORTCUTS]
-
-        if (useAppShortcuts) {
-            return
-        }
-
-        cache.disposables.add(() => {
-            const onKeyDown = (event: KeyboardEvent): void => {
-                const commandKey = isMac() ? event.metaKey : event.ctrlKey
-                const shiftKey = event.shiftKey
-                const optionKey = event.altKey
-                const keyCode = event.code?.toLowerCase()
-                const key = event.key?.toLowerCase()
-                const activeTab = values.activeTab
-
-                // Handle both physical key and typed character (cross-layout support).
-                const isTKey = keyCode === 'keyt' || key === 't'
-                const isWKey = keyCode === 'keyw' || key === 'w'
-                const isKKey = keyCode === 'keyk' || key === 'k'
-
-                // New shortcuts: Command+Option+T for new tab, Command+Option+W for close tab
-                if (commandKey && optionKey) {
-                    const element = event.target as HTMLElement
-                    if (element?.closest('.NotebookEditor')) {
-                        return
-                    }
-
-                    if (isTKey) {
-                        event.preventDefault()
-                        event.stopPropagation()
-                        actions.newTab()
-                        return
-                    }
-
-                    if (isWKey) {
-                        event.preventDefault()
-                        event.stopPropagation()
-                        if (activeTab) {
-                            actions.removeTab(activeTab)
-                        }
-                        return
-                    }
-                }
-
-                // If cmd k, open current page new tab page / if already on the new tab page focus the search input
-                if (commandKey && isKKey && !shiftKey) {
-                    event.preventDefault()
-                    event.stopPropagation()
-
-                    if (removeProjectIdIfPresent(router.values.location.pathname) === urls.newTab()) {
-                        const activeTabId = values.activeTabId
-                        const mountedLogic = activeTabId ? newTabSceneLogic.findMounted({ tabId: activeTabId }) : null
-                        if (mountedLogic) {
-                            mountedLogic.actions.focusNewTabSearchInput()
-                        } else {
-                            // If no mounted logic found, try with default key
-                            const defaultLogic = newTabSceneLogic.findMounted({ tabId: 'default' })
-                            if (defaultLogic) {
-                                defaultLogic.actions.focusNewTabSearchInput()
-                            }
-                        }
-                        return
-                    }
-                    router.actions.push(urls.newTab())
-                    return
-                }
-            }
-            window.addEventListener('keydown', onKeyDown)
-            return () => window.removeEventListener('keydown', onKeyDown)
-        }, 'keydownListener')
     }),
 ])

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -631,7 +631,7 @@
 
     // Z-indexes
     --z-bottom-notice: 1450;
-    --z-command-palette: 1400;
+    --z-shortcut-menu: 1400;
     --z-force-modal-above-popovers: 1350;
     --z-tooltip: 1300;
     --z-definition-popover: 1250;

--- a/uv.lock
+++ b/uv.lock
@@ -4778,7 +4778,7 @@ dev = [
     { name = "dagster-dg-cli", specifier = ">=1.10.18" },
     { name = "datamodel-code-generator", specifier = "==0.28.5" },
     { name = "debugpy", specifier = ">=1.8.0" },
-    { name = "deepdiff", specifier = ">=8.5.0" },
+    { name = "deepdiff", specifier = ">=8.6.1" },
     { name = "django-linear-migrations", specifier = "~=2.17.0" },
     { name = "django-stubs", specifier = "~=5.2.0" },
     { name = "djangorestframework-stubs", specifier = "~=3.16.0" },


### PR DESCRIPTION
## Problem
Keyboard shortcuts are defined in many of places, through many different methods.

<img width="500" height="283" alt="image" src="https://github.com/user-attachments/assets/99d78eb5-03ce-4ca8-9954-6c435948b882" />

## Changes
[As defined in this PR](https://github.com/PostHog/posthog/pull/41677)
But this changes a few things:
> You can now open the `AppShortcutMenu` with `cmd+option+k` (existing) and now also `cmd+shift+k`. We did this because some of our users had Notion installed and their `cmd+shift+k` was too powerful.

![2025-11-21 13 34 01](https://github.com/user-attachments/assets/57abbfea-1b1b-4eb3-a716-fbafc6dbbe9a)

> You now define `AppShortcut` prop `keybind` as a `string[][]` in case devs want to support two different shortcuts for the same action (not really recommended, but it exists)

<img width="564" height="117" alt="image" src="https://github.com/user-attachments/assets/36227542-e914-4563-8402-8879907c5990" />

> Remove flag, remove non-flagged else statements >> Everything works as intended.

![2025-11-21 13 35 55](https://github.com/user-attachments/assets/c2811215-90ca-4bc8-812d-6250abd06761)


## How did you test this code?
Locally

## Changelog: (features only) Is this feature complete?
Yes