### PR TITLE
fix(customers): Only bind queries to groupLogic when node is displayed for group

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeIssues.tsx
@@ -85,10 +85,11 @@ const IssuesQuery = ({ personId, groupKey, groupTypeIndex, logicKey }: IssuesQue
     const insightProps: InsightLogicProps = {
         dashboardItemId: `new-NotebookNodeIssues-${personId || groupKey}`,
     }
+    const attachTo = groupTypeIndex !== undefined && groupKey ? groupLogic({ groupTypeIndex, groupKey }) : undefined
 
     return (
         <BindLogic logic={issuesDataNodeLogic} props={{ key: insightVizDataNodeKey(insightProps) }}>
-            <Query uniqueKey={logicKey} attachTo={groupLogic} query={{ ...query, embedded: true }} context={context} />
+            <Query uniqueKey={logicKey} attachTo={attachTo} query={{ ...query, embedded: true }} context={context} />
         </BindLogic>
     )
 }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -35,6 +35,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttribu
     const { setDates, setShouldFilterTestAccounts, setPropertyFilters, setTracesQuery } = useActions(logic)
     const { tracesQuery } = useValues(logic)
     const context = useTracesQueryContext()
+    const attachTo = groupTypeIndex !== undefined && groupKey ? groupLogic({ groupTypeIndex, groupKey }) : undefined
 
     if (!expanded) {
         return null
@@ -45,7 +46,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttribu
             <LLMAnalyticsSetupPrompt className="border-none">
                 <Query
                     uniqueKey={logicKey}
-                    attachTo={groupLogic}
+                    attachTo={attachTo}
                     query={{
                         ...tracesQuery,
                         embedded: true,


### PR DESCRIPTION
## Problem

When using notebook nodes for issues and LLM traces in the context of a person, the logic was trying to attach to groupLogic without props, causing the node to break

## Changes

Fixed the attachment of group context in notebook nodes. Only attach the queries to groupLogic when the node is rendered in group feed.

### Before
<img width="1312" height="569" alt="image" src="https://github.com/user-attachments/assets/1152036f-ca65-4516-9b03-6b3e92831673" />

### Now
<img width="891" height="680" alt="image" src="https://github.com/user-attachments/assets/e61d8866-f58a-43d0-9fab-2eb4e1a3c714" />

## How did you test this code?

Tested by:
- Verifying that the nodes correctly display data when associated with a person
- Confirming that nodes work properly both with and without group context

## Changelog
No, under feature flag