### PR TITLE
fix(feature-flags): improve UX around non-matching multi-variant users

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -1396,17 +1396,28 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
                                 </span>
                             ) : (
                                 <>
-                                    {capitalizeFirstLetter(aggregationTargetName)} will be served{' '}
-                                    {multivariateEnabled ? (
-                                        <>
-                                            <strong>a variant key</strong> according to the below distribution
-                                        </>
-                                    ) : (
-                                        <strong>
-                                            <code>true</code>
-                                        </strong>
-                                    )}{' '}
-                                    <span>if they match one or more release condition groups.</span>
+                                    <div>
+                                        {capitalizeFirstLetter(aggregationTargetName)} will be served{' '}
+                                        {multivariateEnabled ? (
+                                            <>
+                                                <strong>a variant key</strong> according to the below distribution
+                                            </>
+                                        ) : (
+                                            <strong>
+                                                <code>true</code>
+                                            </strong>
+                                        )}{' '}
+                                        if they match one or more release condition groups.
+                                    </div>
+                                    {multivariateEnabled && (
+                                        <div>
+                                            {capitalizeFirstLetter(aggregationTargetName)} will be served{' '}
+                                            <strong>
+                                                <code>false</code>
+                                            </strong>{' '}
+                                            otherwise.
+                                        </div>
+                                    )}
                                 </>
                             )}
                         </div>


### PR DESCRIPTION
## Problem

As described in the issue.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #41549

## Changes
Add extra explanatory text for multivariate flag behavior.

<img width="880" height="173" alt="Screenshot 2025-11-21 at 15 43 14" src="https://github.com/user-attachments/assets/ef08477c-8819-477d-b0c9-c1f892698813" />

## How did you test this code?

Locally tested for all types of *Served value*.
