### PR TITLE
fix(ph-ai): mode reminder after compaction

### DIFF
--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -42,6 +42,7 @@ from ee.hogai.utils.prompt import format_prompt_string
 from ee.hogai.utils.types.base import AnyAssistantSupportedQuery, AssistantMessageUnion, BaseStateWithMessages
 
 from .prompts import (
+    CONTEXT_INITIAL_MODE_PROMPT,
     CONTEXT_MODE_PROMPT,
     CONTEXTUAL_TOOLS_REMINDER_PROMPT,
     ROOT_DASHBOARD_CONTEXT_PROMPT,
@@ -431,4 +432,8 @@ class AssistantContextManager(AssistantContextMixin):
         return insert_messages_before_start(state.messages, context_messages, start_id=state.start_id)
 
     def _get_mode_prompt(self, mode: AgentMode | None) -> str:
-        return format_prompt_string(CONTEXT_MODE_PROMPT, mode=mode.value if mode else AgentMode.PRODUCT_ANALYTICS.value)
+        return format_prompt_string(
+            CONTEXT_MODE_PROMPT,
+            initial_mode_prompt=CONTEXT_INITIAL_MODE_PROMPT,
+            mode=mode.value if mode else AgentMode.PRODUCT_ANALYTICS.value,
+        )

--- a/ee/hogai/context/prompts.py
+++ b/ee/hogai/context/prompts.py
@@ -64,6 +64,7 @@ IMPORTANT: this context may or may not be relevant to your tasks. You should not
 </system_reminder>
 """.strip()
 
+CONTEXT_INITIAL_MODE_PROMPT = "Your initial mode is"
 CONTEXT_MODE_PROMPT = """
-<system_reminder>Your initial mode is {{{mode}}}.</system_reminder>
+<system_reminder>{{{initial_mode_prompt}}} {{{mode}}}.</system_reminder>
 """.strip()

--- a/ee/hogai/graph/agent_modes/compaction_manager.py
+++ b/ee/hogai/graph/agent_modes/compaction_manager.py
@@ -109,7 +109,7 @@ class ConversationCompactionManager(ABC):
         summary_message: ContextMessage,
         agent_mode: AgentMode,
         start_id: str | None = None,
-        # Delete when modes are rolled out
+        # TODO: Delete when modes are rolled out
         is_modes_feature_flag_enabled: bool = False,
     ) -> InsertionResult:
         """Finds the optimal position to insert the summary message in the conversation window."""

--- a/ee/hogai/graph/agent_modes/nodes.py
+++ b/ee/hogai/graph/agent_modes/nodes.py
@@ -487,8 +487,10 @@ class AgentExecutable(BaseAgentExecutable):
         return normalize_ai_message(message)
 
     def _get_updated_agent_mode(self, generated_message: AssistantMessage, current_mode: AgentMode) -> AgentMode | None:
+        from ee.hogai.tools.switch_mode import SWITCH_MODE_TOOL_NAME
+
         for tool_call in generated_message.tool_calls or []:
-            if tool_call.name == "switch_mode" and (new_mode := validate_mode(tool_call.args.get("new_mode"))):
+            if tool_call.name == SWITCH_MODE_TOOL_NAME and (new_mode := validate_mode(tool_call.args.get("new_mode"))):
                 return new_mode
         return current_mode
 

--- a/ee/hogai/graph/agent_modes/nodes.py
+++ b/ee/hogai/graph/agent_modes/nodes.py
@@ -272,7 +272,11 @@ class AgentExecutable(BaseAgentExecutable):
 
             # Insert the summary message before the last human message
             insertion_result = self._window_manager.update_window(
-                messages_to_replace or state.messages, summary_message, start_id=start_id
+                messages_to_replace or state.messages,
+                summary_message,
+                state.agent_mode_or_default,
+                start_id=start_id,
+                is_modes_feature_flag_enabled=has_agent_modes_feature_flag(self._team, self._user),
             )
             window_id = insertion_result.updated_window_start_id
             start_id = insertion_result.updated_start_id
@@ -312,7 +316,7 @@ class AgentExecutable(BaseAgentExecutable):
             root_tool_calls_count=tool_call_count,
             root_conversation_start_id=window_id,
             start_id=start_id,
-            agent_mode=self._get_updated_agent_mode(assistant_message, state.agent_mode),
+            agent_mode=self._get_updated_agent_mode(assistant_message, state.agent_mode_or_default),
         )
 
     def router(self, state: AssistantState):
@@ -482,9 +486,7 @@ class AgentExecutable(BaseAgentExecutable):
         """Process the output message."""
         return normalize_ai_message(message)
 
-    def _get_updated_agent_mode(
-        self, generated_message: AssistantMessage, current_mode: AgentMode | None
-    ) -> AgentMode | None:
+    def _get_updated_agent_mode(self, generated_message: AssistantMessage, current_mode: AgentMode) -> AgentMode | None:
         for tool_call in generated_message.tool_calls or []:
             if tool_call.name == "switch_mode" and (new_mode := validate_mode(tool_call.args.get("new_mode"))):
                 return new_mode

--- a/ee/hogai/graph/agent_modes/prompts.py
+++ b/ee/hogai/graph/agent_modes/prompts.py
@@ -269,3 +269,9 @@ This tool does not exist.
 Only use tools that are available to you.
 </system_reminder>
 """.strip()
+
+ROOT_AGENT_MODE_REMINDER_PROMPT = """
+<system_reminder>
+You are currently in {mode} mode. This mode was enabled earlier in the conversation.
+</system_reminder>
+""".strip()

--- a/ee/hogai/graph/agent_modes/test/test_nodes.py
+++ b/ee/hogai/graph/agent_modes/test/test_nodes.py
@@ -789,7 +789,215 @@ class TestAgentNode(ClickhouseTestMixin, BaseTest):
         self.assertEqual(
             node._get_updated_agent_mode(message, AgentMode.PRODUCT_ANALYTICS), AgentMode.PRODUCT_ANALYTICS
         )
-        self.assertIsNone(node._get_updated_agent_mode(message, None))
+
+    def test_is_mode_evident_in_window_with_switch_mode_call(self):
+        """Test that mode is considered evident when there's a switch_mode tool call in the window"""
+        from ee.hogai.graph.agent_modes.compaction_manager import AnthropicConversationCompactionManager
+
+        compaction_manager = AnthropicConversationCompactionManager()
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Switch to SQL mode", id="1"),
+            AssistantMessage(
+                content="Switching to SQL mode",
+                id="2",
+                tool_calls=[AssistantToolCall(id="t1", name="switch_mode", args={"new_mode": "sql"})],
+            ),
+            AssistantToolCallMessage(content="Switched successfully", id="3", tool_call_id="t1"),
+        ]
+        self.assertTrue(compaction_manager._is_mode_evident_in_window(messages, AgentMode.SQL))
+
+    def test_is_mode_evident_in_window_without_switch_mode_call(self):
+        """Test that mode is not evident when there's no switch_mode tool call in the window"""
+        from ee.hogai.graph.agent_modes.compaction_manager import AnthropicConversationCompactionManager
+
+        compaction_manager = AnthropicConversationCompactionManager()
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Show me some data", id="1"),
+            AssistantMessage(content="Here's the data", id="2"),
+        ]
+        self.assertFalse(compaction_manager._is_mode_evident_in_window(messages, AgentMode.SQL))
+
+    def test_is_mode_evident_in_window_with_different_mode(self):
+        """Test that mode is not evident when switch_mode call is for a different mode"""
+        from ee.hogai.graph.agent_modes.compaction_manager import AnthropicConversationCompactionManager
+
+        compaction_manager = AnthropicConversationCompactionManager()
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Switch to session replay mode", id="1"),
+            AssistantMessage(
+                content="Switching",
+                id="2",
+                tool_calls=[AssistantToolCall(id="t1", name="switch_mode", args={"new_mode": "session_replay"})],
+            ),
+        ]
+        self.assertFalse(compaction_manager._is_mode_evident_in_window(messages, AgentMode.SQL))
+
+    def test_is_mode_evident_in_window_with_no_mode_set(self):
+        """Test that when no mode is set, it returns True (nothing to remind)"""
+        from ee.hogai.graph.agent_modes.compaction_manager import AnthropicConversationCompactionManager
+
+        compaction_manager = AnthropicConversationCompactionManager()
+        messages: list[AssistantMessageUnion] = [HumanMessage(content="Hello", id="1")]
+        # _is_mode_evident_in_window still accepts None and returns True, but _should_add_mode_reminder won't call it with None
+        self.assertTrue(compaction_manager._is_mode_evident_in_window(messages, None))
+
+    def test_has_initial_mode_message(self):
+        """Test that initial mode message is correctly detected"""
+        from ee.hogai.graph.agent_modes.compaction_manager import AnthropicConversationCompactionManager
+
+        compaction_manager = AnthropicConversationCompactionManager()
+        messages: list[AssistantMessageUnion] = [
+            ContextMessage(
+                content="<system_reminder>Your initial mode is product_analytics.</system_reminder>", id="1"
+            ),
+            HumanMessage(content="Hello", id="2"),
+        ]
+        self.assertTrue(compaction_manager._has_initial_mode_message(messages))
+
+        messages_without = [HumanMessage(content="Hello", id="1")]
+        self.assertFalse(compaction_manager._has_initial_mode_message(messages_without))
+
+    @patch("ee.hogai.graph.agent_modes.nodes.AgentExecutable._get_model", return_value=FakeChatOpenAI(responses=[]))
+    @patch("ee.hogai.graph.agent_modes.compaction_manager.AnthropicConversationCompactionManager.calculate_token_count")
+    @patch("ee.hogai.graph.conversation_summarizer.nodes.AnthropicConversationSummarizer.summarize")
+    @patch("ee.hogai.graph.agent_modes.nodes.has_agent_modes_feature_flag", return_value=True)
+    async def test_compaction_adds_mode_reminder_when_mode_not_evident(
+        self, mock_feature_flag, mock_summarize, mock_calculate_tokens, mock_model
+    ):
+        """Test that mode reminder is added when compaction happens and mode is not evident in window"""
+        # Return a token count higher than CONVERSATION_WINDOW_SIZE
+        mock_calculate_tokens.return_value = 150_000
+        mock_summarize.return_value = "Summary of conversation"
+
+        mock_model_instance = FakeChatOpenAI(responses=[LangchainAIMessage(content="Response")])
+        mock_model.return_value = mock_model_instance
+
+        node = _create_agent_node(self.team, self.user)
+        state = AssistantState(
+            messages=[
+                HumanMessage(content="First message", id="1"),
+                AssistantMessage(content="First response", id="2"),
+                HumanMessage(content="Second message", id="3"),
+            ],
+            agent_mode=AgentMode.SQL,  # Mode is set but not evident in messages
+        )
+        result = await node.arun(state, {})
+
+        # Verify mode reminder was added
+        self.assertIsInstance(result, PartialAssistantState)
+        context_messages = [msg for msg in result.messages if isinstance(msg, ContextMessage)]
+        # Should have summary message + mode reminder message
+        self.assertEqual(len(context_messages), 2)
+        mode_reminder_messages = [msg for msg in context_messages if "sql mode" in msg.content.lower()]
+        self.assertEqual(len(mode_reminder_messages), 1)
+        self.assertIn("currently in sql mode", mode_reminder_messages[0].content.lower())
+
+    @patch("ee.hogai.graph.agent_modes.nodes.AgentExecutable._get_model", return_value=FakeChatOpenAI(responses=[]))
+    @patch("ee.hogai.graph.agent_modes.compaction_manager.AnthropicConversationCompactionManager.calculate_token_count")
+    @patch("ee.hogai.graph.conversation_summarizer.nodes.AnthropicConversationSummarizer.summarize")
+    @patch("ee.hogai.graph.agent_modes.nodes.has_agent_modes_feature_flag", return_value=True)
+    async def test_compaction_does_not_add_mode_reminder_when_mode_is_evident(
+        self, mock_feature_flag, mock_summarize, mock_calculate_tokens, mock_model
+    ):
+        """Test that mode reminder is NOT added when mode is already evident in the window"""
+        mock_calculate_tokens.return_value = 150_000
+        mock_summarize.return_value = "Summary of conversation"
+
+        mock_model_instance = FakeChatOpenAI(responses=[LangchainAIMessage(content="Response")])
+        mock_model.return_value = mock_model_instance
+
+        node = _create_agent_node(self.team, self.user)
+        state = AssistantState(
+            messages=[
+                HumanMessage(content="Switch to SQL", id="1"),
+                AssistantMessage(
+                    content="Switching",
+                    id="2",
+                    tool_calls=[AssistantToolCall(id="t1", name="switch_mode", args={"new_mode": "sql"})],
+                ),
+                AssistantToolCallMessage(content="Switched", id="3", tool_call_id="t1"),
+                HumanMessage(content="Second message", id="4"),
+            ],
+            agent_mode=AgentMode.SQL,
+        )
+        result = await node.arun(state, {})
+
+        # Verify mode reminder was NOT added
+        self.assertIsInstance(result, PartialAssistantState)
+        context_messages = [msg for msg in result.messages if isinstance(msg, ContextMessage)]
+        # Should only have summary message, no mode reminder
+        mode_reminder_messages = [msg for msg in context_messages if "currently in" in msg.content.lower()]
+        self.assertEqual(len(mode_reminder_messages), 0)
+
+    @patch("ee.hogai.graph.agent_modes.nodes.AgentExecutable._get_model", return_value=FakeChatOpenAI(responses=[]))
+    @patch("ee.hogai.graph.agent_modes.compaction_manager.AnthropicConversationCompactionManager.calculate_token_count")
+    @patch("ee.hogai.graph.conversation_summarizer.nodes.AnthropicConversationSummarizer.summarize")
+    @patch("ee.hogai.graph.agent_modes.nodes.has_agent_modes_feature_flag", return_value=True)
+    async def test_compaction_adds_mode_reminder_with_default_mode(
+        self, mock_feature_flag, mock_summarize, mock_calculate_tokens, mock_model
+    ):
+        """Test that mode reminder IS added with the default mode when agent_mode is None"""
+        mock_calculate_tokens.return_value = 150_000
+        mock_summarize.return_value = "Summary of conversation"
+
+        mock_model_instance = FakeChatOpenAI(responses=[LangchainAIMessage(content="Response")])
+        mock_model.return_value = mock_model_instance
+
+        node = _create_agent_node(self.team, self.user)
+        state = AssistantState(
+            messages=[
+                HumanMessage(content="First message", id="1"),
+                AssistantMessage(content="First response", id="2"),
+                HumanMessage(content="Second message", id="3"),
+            ],
+            agent_mode=None,  # No mode set - will use default PRODUCT_ANALYTICS
+        )
+        result = await node.arun(state, {})
+
+        # Verify mode reminder WAS added with default mode
+        self.assertIsInstance(result, PartialAssistantState)
+        context_messages = [msg for msg in result.messages if isinstance(msg, ContextMessage)]
+        # Should have summary message + mode reminder message for default mode
+        self.assertEqual(len(context_messages), 2)
+        mode_reminder_messages = [msg for msg in context_messages if "product_analytics mode" in msg.content.lower()]
+        self.assertEqual(len(mode_reminder_messages), 1)
+        self.assertIn("currently in product_analytics mode", mode_reminder_messages[0].content.lower())
+
+    @patch("ee.hogai.graph.agent_modes.nodes.AgentExecutable._get_model", return_value=FakeChatOpenAI(responses=[]))
+    @patch("ee.hogai.graph.agent_modes.compaction_manager.AnthropicConversationCompactionManager.calculate_token_count")
+    @patch("ee.hogai.graph.conversation_summarizer.nodes.AnthropicConversationSummarizer.summarize")
+    @patch("ee.hogai.graph.agent_modes.nodes.has_agent_modes_feature_flag", return_value=True)
+    async def test_compaction_does_not_add_mode_reminder_when_initial_mode_message_present(
+        self, mock_feature_flag, mock_summarize, mock_calculate_tokens, mock_model
+    ):
+        """Test that mode reminder is NOT added when initial mode message is present"""
+        mock_calculate_tokens.return_value = 150_000
+        mock_summarize.return_value = "Summary of conversation"
+
+        mock_model_instance = FakeChatOpenAI(responses=[LangchainAIMessage(content="Response")])
+        mock_model.return_value = mock_model_instance
+
+        node = _create_agent_node(self.team, self.user)
+        state = AssistantState(
+            messages=[
+                ContextMessage(content="<system_reminder>Your initial mode is sql.</system_reminder>", id="0"),
+                HumanMessage(content="First message", id="1"),
+                AssistantMessage(content="First response", id="2"),
+                HumanMessage(content="Second message", id="3"),
+            ],
+            agent_mode=AgentMode.SQL,  # Mode is set and initial message is present
+        )
+        result = await node.arun(state, {})
+
+        # Verify mode reminder was NOT added (initial mode message is sufficient)
+        self.assertIsInstance(result, PartialAssistantState)
+        context_messages = [msg for msg in result.messages if isinstance(msg, ContextMessage)]
+        # Should have summary message + initial mode message, but NO mode reminder
+        mode_reminder_messages = [msg for msg in context_messages if "currently in" in msg.content.lower()]
+        self.assertEqual(len(mode_reminder_messages), 0)
+        # Verify initial mode message is still present
+        initial_mode_messages = [msg for msg in context_messages if "Your initial mode is" in msg.content]
+        self.assertEqual(len(initial_mode_messages), 1)
 
 
 class TestRootNodeTools(BaseTest):

--- a/ee/hogai/tools/switch_mode.py
+++ b/ee/hogai/tools/switch_mode.py
@@ -104,8 +104,12 @@ async def _get_default_tools_prompt(
     return ", ".join([tool.get_name() for tool in resolved_tools]) + ", switch_mode"
 
 
+SwitchModeToolType = Literal["switch_mode"]
+SWITCH_MODE_TOOL_NAME: SwitchModeToolType = "switch_mode"
+
+
 class SwitchModeTool(MaxTool):
-    name: Literal["switch_mode"] = "switch_mode"
+    name: SwitchModeToolType = SWITCH_MODE_TOOL_NAME
 
     async def _arun_impl(self, new_mode: str) -> tuple[str, AgentMode | None]:
         from ee.hogai.mode_registry import MODE_REGISTRY

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -253,6 +253,10 @@ class BaseStateWithMessages(BaseState):
     The mode of the agent.
     """
 
+    @property
+    def agent_mode_or_default(self) -> AgentMode:
+        return self.agent_mode or AgentMode.PRODUCT_ANALYTICS
+
 
 class BaseStateWithTasks(BaseState):
     tasks: Annotated[Optional[list[TaskExecutionItem]], replace] = Field(default=None)

--- a/uv.lock
+++ b/uv.lock
@@ -4778,7 +4778,7 @@ dev = [
     { name = "dagster-dg-cli", specifier = ">=1.10.18" },
     { name = "datamodel-code-generator", specifier = "==0.28.5" },
     { name = "debugpy", specifier = ">=1.8.0" },
-    { name = "deepdiff", specifier = ">=8.5.0" },
+    { name = "deepdiff", specifier = ">=8.6.1" },
     { name = "django-linear-migrations", specifier = "~=2.17.0" },
     { name = "django-stubs", specifier = "~=5.2.0" },
     { name = "djangorestframework-stubs", specifier = "~=3.16.0" },


### PR DESCRIPTION
## Problem

The history compaction didn't handle mode reminders:
- It can completely omit appending previous messages because the last message was too large.
- The initial mode message might be far away.
- The last switch_mode message might also be out of the allowed trajectory window.

[Trace](https://us.posthog.com/project/2/llm-analytics/traces/7e9c8b1f-4e5b-4e0b-ac8a-5c6c6aa68ab6?event=8da6867b-f5e9-4317-8978-b0a6252e6472&timestamp=2025-11-21T07:32:16Z)

## Changes

Implemented appending a mode message in various scenarios.

## How did you test this code?

Unit tests & manual testing
