### PR TITLE
fix(insights): Retain the legend configuration inside the subscriptions as well

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -17,7 +17,6 @@ import { OnlineExportContext, QueryExportContext } from '~/types'
 
 import {
     HogQLQueryString,
-    getShowLegend,
     isAsyncResponse,
     isDataTableNode,
     isDataVisualizationNode,
@@ -40,12 +39,8 @@ export function queryExportContext<N extends DataNode>(
     if (isDataTableNode(query) || isDataVisualizationNode(query)) {
         return queryExportContext(query.source, methodOptions, refresh)
     } else if (isInsightQueryNode(query)) {
-        let showLegend = getShowLegend(query)
-
         return {
             source: query,
-            // Include show_legend for PNG exports
-            show_legend: showLegend === true,
         }
     } else if (isPersonsNode(query)) {
         return { path: getPersonsEndpoint(query) }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4487,7 +4487,6 @@ export type OnlineExportContext = {
 export type QueryExportContext = {
     source: Record<string, any>
     filename?: string
-    show_legend?: boolean
 }
 
 export interface ReplayExportContext {

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -289,6 +289,22 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
     def url(self):
         return absolute_uri(f"/insights/{self.short_id}")
 
+    @property
+    def show_legend(self) -> bool:
+        """Extract show_legend display setting from insight configuration"""
+        try:
+            if self.query:
+                source = self.query.get("source", {})
+
+                # Check any filter which might contain `showLegend`
+                for value in source.values():
+                    if isinstance(value, dict) and "showLegend" in value:
+                        return bool(value.get("showLegend", False))
+
+            return bool(self.filters.get("show_legend", False) if self.filters else False)
+        except (AttributeError, TypeError, KeyError):
+            return False
+
     def generate_query_metadata(self):
         from posthog.hogql_queries.query_metadata import extract_query_metadata
 

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -105,10 +105,7 @@ def _export_to_png(exported_asset: ExportedAsset, max_height_pixels: Optional[in
         wait_for_css_selector: CSSSelector
         screenshot_height: int = 600
         if exported_asset.insight is not None:
-            show_legend = False
-            if exported_asset.export_context:
-                show_legend = exported_asset.export_context.get("show_legend", False)
-
+            show_legend = exported_asset.insight.show_legend
             legend_param = "&legend=true" if show_legend else ""
             url_to_render = absolute_uri(f"/exporter?token={access_token}{legend_param}")
             wait_for_css_selector = ".ExportedInsight"

--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -21,7 +21,7 @@ from ee.tasks.subscriptions import deliver_subscription_report_async, team_use_t
 
 LOGGER = get_logger(__name__)
 
-# Changed 21/11/2025
+# Changed 21-Nov-2025
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

With: https://github.com/PostHog/posthog/pull/41836 we introduced a fix so that the `show legend` field was correctly being picked up when Insights were exported to PNGs. However post release, we found out that there are also requests to solve this for subscriptions (e.g.: https://github.com/PostHog/posthog/issues/40630). 

This PR therefore fixes it for both the PNG exports, and for the subscriptions.

Fixes: https://github.com/PostHog/posthog/issues/40630

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Subscriptions have their own path to generate the `ExportAsset` object which eventually will be rendered to be exported: https://github.com/PostHog/posthog/blob/9f676110edb9a3f10dfce9ff907202b6548a35d5/ee/tasks/subscriptions/subscription_utils.py#L110-L118.

In order to avoid having multiple solutions (frontend extracting it from the display options, backend querying the DB), there is now 1 source of truth where the backend will fetch the "showLegend / show_legend" status of the `Insight` when sending it off to be rendered on the worker. 

This means that this PR also cleans up a little bit of the frontend code introduced in the previous PR. This does however mean that a user _must_ save their insight "Show Legend" option before the export will respect it, this is currently a little bit tricky as modifying the "Show Legend" button does not immediatly change the "Edit" -> "Save" button, however for the scope of this issue we will leave that behaviour as is. In order to work around this, users can first hit "Edit" -> "Change Show Legend" -> "Save". This is likely a path that they are familiar with as this hasn't changed.

<img width="240" height="96" alt="Screenshot 2025-11-21 at 16 59 23" src="https://github.com/user-attachments/assets/b54c4270-13be-4e27-afba-478770a343a2" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

1. Run the Posthog application locally
1. Create an insight (ensuring there is no legend)
1. Run the png export and confirm that there is no legend in the export
1. Adjust the display options, setting the Show Legend to true
1. Run the png export and confirm that this time, there is a legend on the export
1. Also ran an export of the dashboards to confirm it's all okay
1. Ran an export of the shared page for an insight with / without the show legend option enabled.
1. And finally ran a subscription test. I tried configuring an email with Twilio / mailgun but neither seemed to work for me, so I just retrieved the generated exported image from MinIO instead (see below). 

**With show_legend: false**

_Insight > export > png:_
![Uploading export-test-insights-for-export-fix-without-legend.png…]()

_Share insight:_
<img width="1795" height="1014" alt="Screenshot 2025-11-21 at 17 02 10" src="https://github.com/user-attachments/assets/87d14f97-3c3f-444a-84b5-961f45be30a9" />


**With show_legend: true**

_Insight > export > png:_
<img width="1600" height="1018" alt="export-test-insights-for-export-fix-with-legend" src="https://github.com/user-attachments/assets/75baedb8-c620-493b-8c16-ffbe1f20bef7" />

_Share insight_:
<img width="1789" height="1025" alt="Screenshot 2025-11-21 at 17 02 38" src="https://github.com/user-attachments/assets/554a03a5-41ef-4131-ac10-34ee7ffafa3b" />

**Dashboard export:**
<img width="3840" height="2352" alt="export-this-dashboard-contains-helpful-insights-for-our-product-at-a-glance(4)" src="https://github.com/user-attachments/assets/e016aab4-7e68-489f-b1b5-1a5ebf70f48d" />

**Subscription export (fetched from MinIO):**
<img width="1600" height="1018" alt="019aa743-8207-0000-9b9d-0ad7afb50788" src="https://github.com/user-attachments/assets/dce9aa8f-8808-4ec9-b635-e8135e45a262" />

## Changelog: (features only) Is this feature complete?

N/A this is a small fix to an existing feature.
