### PR TITLE
fix: only init snappy once

### DIFF
--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/decompressionWorker.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/decompressionWorker.ts
@@ -1,14 +1,12 @@
 import snappyInit, { decompress_raw } from 'snappy-wasm'
 
-// Initialize snappy-wasm
-let snappyInitialized = false
+let snappyInitPromise: Promise<unknown> | null = null
 
 async function initSnappy(): Promise<void> {
-    if (snappyInitialized) {
-        return
+    if (!snappyInitPromise) {
+        snappyInitPromise = snappyInit()
     }
-    await snappyInit()
-    snappyInitialized = true
+    await snappyInitPromise
 }
 
 export interface DecompressionRequest {

--- a/uv.lock
+++ b/uv.lock
@@ -4778,7 +4778,7 @@ dev = [
     { name = "dagster-dg-cli", specifier = ">=1.10.18" },
     { name = "datamodel-code-generator", specifier = "==0.28.5" },
     { name = "debugpy", specifier = ">=1.8.0" },
-    { name = "deepdiff", specifier = ">=8.5.0" },
+    { name = "deepdiff", specifier = ">=8.6.1" },
     { name = "django-linear-migrations", specifier = "~=2.17.0" },
     { name = "django-stubs", specifier = "~=5.2.0" },
     { name = "djangorestframework-stubs", specifier = "~=3.16.0" },


### PR DESCRIPTION
i was investigating an issue and saw that we init'd snappy multiple times

and that took _forever_

we only want to init snappy once
and we're happy to wait in that happening

therefore...