### PR TITLE
fix: Fixing copying from datatable

### DIFF
--- a/frontend/src/lib/utils/dataTableTransformations.ts
+++ b/frontend/src/lib/utils/dataTableTransformations.ts
@@ -9,6 +9,10 @@ export function transformDataTableToDataTableRows(rows: Record<string, any>[], c
     }
 
     return rows.map((row) => ({
-        result: columns.map((col) => row[col]),
+        result: columns.map((col, index) => {
+            // Handle both direct column access and column_index format
+            const columnKey = `${col}_${index}`
+            return row[columnKey] !== undefined ? row[columnKey] : row[col]
+        }),
     }))
 }


### PR DESCRIPTION
## Problem

When copy pasting on the sql editor I get an empty response.

## Changes

This was due to some changes on how the row maps the columns.

## How did you test this code?
Manually