### PR TITLE
fix(ph-ai): improve taxonomy retrieval

### DIFF
--- a/ee/hogai/eval/ci/eval_root.py
+++ b/ee/hogai/eval/ci/eval_root.py
@@ -213,7 +213,7 @@ async def eval_root(call_root, pytestconfig):
                 expected=AssistantToolCall(
                     name="read_taxonomy",
                     args={
-                        "kind": "events",
+                        "query": {"kind": "events"},
                     },
                     id="call_read_events",
                 ),

--- a/ee/hogai/eval/ci/eval_root.py
+++ b/ee/hogai/eval/ci/eval_root.py
@@ -207,6 +207,17 @@ async def eval_root(call_root, pytestconfig):
                     id="call_dau_past_month",
                 ),
             ),
+            # Some models already know about PostHog's events, but they must not rely on this knowledge and use the read_taxonomy tool instead.
+            EvalCase(
+                input="create a pageview trends broken down by countries",
+                expected=AssistantToolCall(
+                    name="read_taxonomy",
+                    args={
+                        "kind": "events",
+                    },
+                    id="call_read_events",
+                ),
+            ),
         ],
         pytestconfig=pytestconfig,
     )

--- a/ee/hogai/graph/query_planner/toolkit.py
+++ b/ee/hogai/graph/query_planner/toolkit.py
@@ -1,5 +1,4 @@
 import re
-import xml.etree.ElementTree as ET
 from collections.abc import Iterable
 from functools import cached_property
 from typing import Literal, Optional, Union, cast
@@ -33,6 +32,7 @@ from ee.hogai.graph.taxonomy.tools import (
     retrieve_event_properties,
     retrieve_event_property_values,
 )
+from ee.hogai.utils.prompt import format_prompt_string
 
 MaxSupportedQueryKind = Literal["trends", "funnel", "retention", "sql"]
 
@@ -75,6 +75,21 @@ class TaxonomyAgentTool(BaseModel):
     arguments: TaxonomyAgentToolUnion
 
 
+PROPERTIES_EXAMPLE_PROMPT = """
+The data format is as follows:
+```
+<Data type>
+- $event – description text here
+- another_event
+</Data type>
+...
+```
+
+Results:
+{{{result}}}
+""".strip()
+
+
 class TaxonomyAgentToolkit:
     _team: Team
 
@@ -100,31 +115,33 @@ class TaxonomyAgentToolkit:
         ]
         return entities
 
-    def _generate_properties_xml(self, children: list[tuple[str, str | None, str | None]]):
-        root = ET.Element("properties")
-        property_type_to_tag = {}
-
-        for name, property_type, description in children:
-            # Do not include properties that are ambiguous.
-            if property_type is None:
-                continue
-            if property_type not in property_type_to_tag:
-                property_type_to_tag[property_type] = ET.SubElement(root, property_type)
-
-            type_tag = property_type_to_tag[property_type]
-            prop = ET.SubElement(type_tag, "prop")
-            ET.SubElement(prop, "name").text = name
-            if description:
-                ET.SubElement(prop, "description").text = description
-
-        return ET.tostring(root, encoding="unicode")
-
     def _generate_properties_output(self, props: list[tuple[str, str | None, str | None]]) -> str:
         """
         Generate the output format for properties. Can be overridden by subclasses.
         Default implementation uses XML format.
         """
-        return self._generate_properties_xml(props)
+        property_type_to_props: dict[str, list[tuple[str, str | None]]] = {}
+
+        for name, property_type, description in props:
+            # Do not include properties that are ambiguous.
+            if property_type is None:
+                continue
+            if property_type not in property_type_to_props:
+                property_type_to_props[property_type] = []
+
+            property_type_to_props[property_type].append((name, description))
+
+        output_parts = []
+        for property_type, prop_list in property_type_to_props.items():
+            output_parts.append(f"<{property_type}>")
+            for name, description in prop_list:
+                if description:
+                    output_parts.append(f"- {name} – {description.replace('\n', ' ')}")
+                else:
+                    output_parts.append(f"- {name}")
+            output_parts.append(f"</{property_type}>")
+
+        return "\n".join(output_parts)
 
     def _enrich_props_with_descriptions(self, entity: str, props: Iterable[tuple[str, str | None]]):
         enriched_props = []
@@ -180,7 +197,7 @@ class TaxonomyAgentToolkit:
         if not props:
             return f"Properties do not exist in the taxonomy for the entity {entity}."
 
-        return self._generate_properties_output(props)
+        return format_prompt_string(PROPERTIES_EXAMPLE_PROMPT, result=self._generate_properties_output(props))
 
     def _retrieve_event_or_action_taxonomy(self, event_name_or_action_id: str | int):
         is_event = isinstance(event_name_or_action_id, str)
@@ -227,7 +244,10 @@ class TaxonomyAgentToolkit:
         if not props:
             return f"Properties do not exist in the taxonomy for the {verbose_name}."
 
-        return self._generate_properties_output(self._enrich_props_with_descriptions("event", props))
+        return format_prompt_string(
+            PROPERTIES_EXAMPLE_PROMPT,
+            result=self._generate_properties_output(self._enrich_props_with_descriptions("event", props)),
+        )
 
     def _format_property_values(
         self, sample_values: list, sample_count: Optional[int] = 0, format_as_string: bool = False

--- a/ee/hogai/graph/query_planner/toolkit.py
+++ b/ee/hogai/graph/query_planner/toolkit.py
@@ -77,14 +77,12 @@ class TaxonomyAgentTool(BaseModel):
 
 PROPERTIES_EXAMPLE_PROMPT = """
 The data format is as follows:
-```
 <Data type>
 - $event – description text here
 - another_event
 </Data type>
 ...
-```
-
+---
 Results:
 {{{result}}}
 """.strip()

--- a/ee/hogai/graph/query_planner/toolkit.py
+++ b/ee/hogai/graph/query_planner/toolkit.py
@@ -118,7 +118,7 @@ class TaxonomyAgentToolkit:
     def _generate_properties_output(self, props: list[tuple[str, str | None, str | None]]) -> str:
         """
         Generate the output format for properties. Can be overridden by subclasses.
-        Default implementation uses XML format.
+        Default implementation uses YAML-like format with bullet points.
         """
         property_type_to_props: dict[str, list[tuple[str, str | None]]] = {}
 

--- a/ee/hogai/tools/read_taxonomy.py
+++ b/ee/hogai/tools/read_taxonomy.py
@@ -17,6 +17,7 @@ Use this tool to explore the user's taxonomy (i.e. data schema).
 The user implements PostHog SDKs to collect events, properties, and property values. They are used by users to create insights with visualizations, SQL queries, watch session recordings, filter data, target particular users or groups by traits or behavior, etc.
 Each event, action, and entity has its own data schema. You must verify that specific combinations exist before using it anywhere else.
 Events or properties starting from "$" are system properties automatically captured by SDKs.
+Do not rely on your training data or PostHog defaults for events or properties. Always use this tool to confirm what actually exists in the user's project before referencing any event, property, or property value.
 
 # Examples of when to use the read_taxonomy tool
 


### PR DESCRIPTION
## Problem

Two potential improvements for Claude:
- Use a yaml-like format instead of xml–fewer tokens, less cluttered, and easier to read.
- Prompt the model not to rely on training data. There are cases when it generates insights for system properties without checking the taxonomy, which is faster, but prone to errors because the schema might have changed, or it just doesn't match the project ($screen in mobile apps and $pageview in web apps).

## Changes

- Updated the `read_taxonomy` prompt.
- Updated serialization of properties.

## How did you test this code?

Unit tests and manual testing
