### PR TITLE
feat(logs): negative text search with !

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -198,20 +198,29 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
             )
 
         if self.query.searchTerm:
-            exprs.append(
-                parse_expr(
-                    "body LIKE {searchTerm}",
-                    placeholders={"searchTerm": ast.Constant(value=f"%{self.query.searchTerm}%")},
+            # negative search match if first character of search string is !
+            if self.query.searchTerm.startswith("!"):
+                exprs.append(
+                    parse_expr(
+                        "body NOT LIKE {searchTerm}",
+                        placeholders={"searchTerm": ast.Constant(value=f"%{self.query.searchTerm[1:]}%")},
+                    )
                 )
-            )
-            # ip addresses are particularly bad at full text searches with our ngram 3 index
-            # match them separately against a materialized column of ip addresses
-            exprs.append(
-                parse_expr(
-                    "indexHint(hasAll(mat_body_ipv4_matches, extractIPv4Substrings({searchTerm})))",
-                    placeholders={"searchTerm": ast.Constant(value=f"{self.query.searchTerm}")},
+            else:
+                exprs.append(
+                    parse_expr(
+                        "body LIKE {searchTerm}",
+                        placeholders={"searchTerm": ast.Constant(value=f"%{self.query.searchTerm}%")},
+                    )
                 )
-            )
+                # ip addresses are particularly bad at full text searches with our ngram 3 index
+                # match them separately against a materialized column of ip addresses
+                exprs.append(
+                    parse_expr(
+                        "indexHint(hasAll(mat_body_ipv4_matches, extractIPv4Substrings({searchTerm})))",
+                        placeholders={"searchTerm": ast.Constant(value=f"{self.query.searchTerm}")},
+                    )
+                )
 
         if self.query.filterGroup:
             exprs.append(property_to_expr(self.query.filterGroup, team=self.team))

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -199,7 +199,7 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
 
         if self.query.searchTerm:
             # negative search match if first character of search string is !
-            if self.query.searchTerm.startswith("!"):
+            if self.query.searchTerm.startswith("!") and len(self.query.searchTerm) > 1:
                 exprs.append(
                     parse_expr(
                         "body NOT LIKE {searchTerm}",


### PR DESCRIPTION
## Problem

we can search for text, but not for NOT text

## Changes

if the search query starts with `!` make it a negative text search (we'll want more advanced syntax for this, but this is a good start)

## How did you test this code?
locally

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
