### PR TITLE
chore(flags): Refactor to use ReadWriteClient for automatic read/write routing

### DIFF
--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -40,8 +40,7 @@ pub async fn validate_secret_api_token(state: &AppState, token: &str) -> Result<
     let token_str = token.to_string();
 
     team_operations::fetch_team_from_redis_with_fallback(
-        state.redis_reader.clone(),
-        state.redis_writer.clone(),
+        state.redis_client.clone(),
         token,
         Some(state.config.team_cache_ttl_seconds),
         || async move {

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -105,8 +105,7 @@ async fn fetch_team_by_token(state: &AppState, token: &str) -> Result<Team, Flag
     let token_str = token.to_string();
 
     team_operations::fetch_team_from_redis_with_fallback(
-        state.redis_reader.clone(),
-        state.redis_writer.clone(),
+        state.redis_client.clone(),
         token,
         Some(state.config.team_cache_ttl_seconds),
         || async move {
@@ -143,7 +142,7 @@ async fn get_from_cache(
     }
 
     // Create HyperCacheReader with the Redis client from state
-    let hypercache_reader = HyperCacheReader::new(state.redis_reader.clone(), config)
+    let hypercache_reader = HyperCacheReader::new(state.redis_client.clone(), config)
         .await
         .map_err(|e| {
             warn!(team_id = team.id, error = %e, "Failed to create HyperCacheReader");

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -480,9 +480,7 @@ mod tests {
 
         let flag_service = FlagService::new(
             redis_client.clone(),
-            redis_client.clone(),
             None, // No dedicated flags Redis in tests
-            None,
             pg_client.clone(),
             DEFAULT_CACHE_TTL_SECONDS,
             DEFAULT_CACHE_TTL_SECONDS,
@@ -497,8 +495,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_error_cases() {
-        let redis_reader_client = setup_redis_client(None).await;
-        let redis_writer_client = setup_redis_client(None).await;
+        let redis_client = setup_redis_client(None).await;
         let pg_client = setup_pg_reader_client(None).await;
 
         // Test invalid token
@@ -511,10 +508,8 @@ mod tests {
             .expect("failed to extract token");
 
         let flag_service = FlagService::new(
-            redis_reader_client.clone(),
-            redis_writer_client.clone(),
+            redis_client.clone(),
             None, // No dedicated flags Redis in tests
-            None,
             pg_client.clone(),
             DEFAULT_CACHE_TTL_SECONDS,
             DEFAULT_CACHE_TTL_SECONDS,

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -24,39 +24,32 @@ pub struct FlagResult {
 
 /// Service layer for handling feature flag operations
 pub struct FlagService {
-    shared_redis_reader: Arc<dyn RedisClient + Send + Sync>,
-    shared_redis_writer: Arc<dyn RedisClient + Send + Sync>,
+    shared_redis_client: Arc<dyn RedisClient + Send + Sync>,
     pg_client: PostgresReader,
     team_cache_ttl_seconds: u64,
     flags_cache: FlagsReadThroughCache,
 }
 
 impl FlagService {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        shared_redis_reader: Arc<dyn RedisClient + Send + Sync>,
-        shared_redis_writer: Arc<dyn RedisClient + Send + Sync>,
-        dedicated_redis_reader: Option<Arc<dyn RedisClient + Send + Sync>>,
-        dedicated_redis_writer: Option<Arc<dyn RedisClient + Send + Sync>>,
+        shared_redis_client: Arc<dyn RedisClient + Send + Sync>,
+        dedicated_redis_client: Option<Arc<dyn RedisClient + Send + Sync>>,
         pg_client: PostgresReader,
         team_cache_ttl_seconds: u64,
         flags_cache_ttl_seconds: u64,
         config: Config,
     ) -> Self {
         // Flags cache uses FlagsReadThroughCache which handles migration logic
-        let flags_cache = FlagsReadThroughCache::from_redis_clients(
-            shared_redis_reader.clone(),
-            shared_redis_writer.clone(),
-            dedicated_redis_reader,
-            dedicated_redis_writer,
+        let flags_cache = FlagsReadThroughCache::from_redis_client(
+            shared_redis_client.clone(),
+            dedicated_redis_client,
             flags_cache_ttl_seconds,
             config,
         );
 
         // Shared Redis for team cache and other non-flags operations (not part of migration)
         Self {
-            shared_redis_reader,
-            shared_redis_writer,
+            shared_redis_client,
             pg_client,
             team_cache_ttl_seconds,
             flags_cache,
@@ -67,7 +60,7 @@ impl FlagService {
     /// If the token is not found in the cache, it will be verified against the database,
     /// and the result will be cached in redis.
     pub async fn verify_token(&self, token: &str) -> Result<String, FlagError> {
-        let (result, cache_hit) = match Team::from_redis(self.shared_redis_reader.clone(), token)
+        let (result, cache_hit) = match Team::from_redis(self.shared_redis_client.clone(), token)
             .await
         {
             Ok(_) => (Ok(token.to_string()), true),
@@ -77,7 +70,7 @@ impl FlagService {
                         inc(DB_TEAM_READS_COUNTER, &[], 1);
                         // Token found in PostgreSQL, update Redis cache so that we can verify it from Redis next time
                         if let Err(e) = Team::update_redis_cache(
-                            self.shared_redis_writer.clone(),
+                            self.shared_redis_client.clone(),
                             &team,
                             Some(self.team_cache_ttl_seconds),
                         )
@@ -119,14 +112,14 @@ impl FlagService {
     /// Returns the team if found, otherwise an error.
     pub async fn get_team_from_cache_or_pg(&self, token: &str) -> Result<Team, FlagError> {
         let (team_result, cache_hit) =
-            match Team::from_redis(self.shared_redis_reader.clone(), token).await {
+            match Team::from_redis(self.shared_redis_client.clone(), token).await {
                 Ok(team) => (Ok(team), true),
                 Err(_) => match Team::from_pg(self.pg_client.clone(), token).await {
                     Ok(team) => {
                         inc(DB_TEAM_READS_COUNTER, &[], 1);
                         // If we have the team in postgres, but not redis, update redis so we're faster next time
                         if Team::update_redis_cache(
-                            self.shared_redis_writer.clone(),
+                            self.shared_redis_client.clone(),
                             &team,
                             Some(self.team_cache_ttl_seconds),
                         )
@@ -216,9 +209,7 @@ mod tests {
 
         let flag_service = FlagService::new(
             redis_client.clone(),
-            redis_client.clone(),
             None, // No dedicated flags Redis in tests
-            None,
             pg_client.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
@@ -260,9 +251,7 @@ mod tests {
 
         let flag_service = FlagService::new(
             redis_client.clone(),
-            redis_client.clone(),
             None, // No dedicated flags Redis in tests
-            None,
             pg_client.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
@@ -285,9 +274,7 @@ mod tests {
 
         let flag_service = FlagService::new(
             redis_client.clone(),
-            redis_client.clone(),
             None, // No dedicated flags Redis in tests
-            None,
             pg_client.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
@@ -407,9 +394,7 @@ mod tests {
 
         let flag_service = FlagService::new(
             redis_client.clone(),
-            redis_client.clone(),
             None, // No dedicated flags Redis in tests
-            None,
             pg_client.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
@@ -497,24 +482,18 @@ mod tests {
             .await
             .expect("Failed to insert team");
 
-        // Set up mock redis_reader to return Timeout
-        let mut mock_reader = MockRedisClient::new();
-        mock_reader.get_ret(
+        // Set up mock redis client to return Timeout on read
+        let mut mock_client = MockRedisClient::new();
+        mock_client.get_ret(
             &format!("{TEAM_FLAGS_CACHE_PREFIX}{}", team.project_id()),
             Err(CustomRedisError::Timeout),
         );
 
-        // Set up mock redis_writer to track SET calls
-        let mock_writer = MockRedisClient::new();
-
-        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
-        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
+        let redis_client: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_client.clone());
 
         let flag_service = FlagService::new(
-            reader,
-            writer,
+            redis_client,
             None, // No dedicated flags Redis in tests
-            None,
             context.non_persons_reader.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
@@ -531,9 +510,10 @@ mod tests {
         assert!(!flag_result.was_cache_hit);
 
         // Verify SET was NOT called (cache write was skipped)
-        let writer_calls = mock_writer.get_calls();
+        // This is tested via FlagsReadThroughCache behavior
+        let client_calls = mock_client.get_calls();
         assert!(
-            !writer_calls.iter().any(|call| call.op == "set"),
+            !client_calls.iter().any(|call| call.op == "set"),
             "Expected SET to NOT be called for Timeout error, but it was"
         );
     }
@@ -548,9 +528,9 @@ mod tests {
             .await
             .expect("Failed to insert team");
 
-        // Set up mock redis_reader to return Redis error (maps to RedisUnavailable)
-        let mut mock_reader = MockRedisClient::new();
-        mock_reader.get_ret(
+        // Set up mock redis client to return Redis error (maps to RedisUnavailable)
+        let mut mock_client = MockRedisClient::new();
+        mock_client.get_ret(
             &format!("{TEAM_FLAGS_CACHE_PREFIX}{}", team.project_id()),
             Err(CustomRedisError::from_redis_kind(
                 RedisErrorKind::IoError,
@@ -558,17 +538,11 @@ mod tests {
             )),
         );
 
-        // Set up mock redis_writer to track SET calls
-        let mock_writer = MockRedisClient::new();
-
-        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
-        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
+        let redis_client: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_client.clone());
 
         let flag_service = FlagService::new(
-            reader,
-            writer,
+            redis_client,
             None, // No dedicated flags Redis in tests
-            None,
             context.non_persons_reader.clone(),
             432000, // team_cache_ttl_seconds
             432000, // flags_cache_ttl_seconds
@@ -585,9 +559,10 @@ mod tests {
         assert!(!flag_result.was_cache_hit);
 
         // Verify SET was NOT called (cache write was skipped)
-        let writer_calls = mock_writer.get_calls();
+        // This is tested via FlagsReadThroughCache behavior
+        let client_calls = mock_client.get_calls();
         assert!(
-            !writer_calls.iter().any(|call| call.op == "set"),
+            !client_calls.iter().any(|call| call.op == "set"),
             "Expected SET to NOT be called for RedisUnavailable error, but it was"
         );
     }
@@ -602,25 +577,19 @@ mod tests {
             .await
             .expect("Failed to insert team");
 
-        // Set up mock redis_reader to return NotFound (cache miss)
-        let mut mock_reader = MockRedisClient::new();
-        mock_reader.get_ret(&team.api_token, Err(CustomRedisError::NotFound));
+        // Set up mock redis client to return NotFound (cache miss) and track setex calls
+        let mut mock_client = MockRedisClient::new();
+        mock_client.get_ret(&team.api_token, Err(CustomRedisError::NotFound));
 
-        // Set up mock redis_writer to track setex calls
-        let mock_writer = MockRedisClient::new();
-
-        let reader: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_reader.clone());
-        let writer: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_writer.clone());
+        let redis_client: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_client.clone());
 
         // Test with custom TTL values (different from default 432000)
         let custom_team_ttl = 7200u64; // 2 hours
         let custom_flags_ttl = 1800u64; // 30 minutes
 
         let flag_service = FlagService::new(
-            reader,
-            writer,
+            redis_client,
             None, // No dedicated flags Redis in tests
-            None,
             context.non_persons_reader.clone(),
             custom_team_ttl,
             custom_flags_ttl,
@@ -633,8 +602,8 @@ mod tests {
             .await;
 
         // Verify setex was called with the custom team TTL
-        let writer_calls = mock_writer.get_calls();
-        let setex_calls: Vec<_> = writer_calls
+        let client_calls = mock_client.get_calls();
+        let setex_calls: Vec<_> = client_calls
             .iter()
             .filter(|call| call.op == "setex")
             .collect();

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -46,7 +46,7 @@ pub async fn record_usage(
 
     if has_billable_flags {
         if let Err(e) = increment_request_count(
-            context.state.redis_writer.clone(),
+            context.state.redis_client.clone(),
             team_id,
             1,
             FlagRequestType::Decide,

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -32,7 +32,7 @@ impl ConfigContext {
         Self {
             config: context.state.config.clone(),
             database_pools: context.state.database_pools.clone(),
-            redis: context.state.redis_reader.clone(),
+            redis: context.state.redis_client.clone(),
             session_replay_billing_limiter: context.state.session_replay_billing_limiter.clone(),
             headers: context.headers.clone(),
         }

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -93,10 +93,8 @@ async fn process_request_inner(
 
     let result = async {
         let flag_service = FlagService::new(
-            context.state.redis_reader.clone(),
-            context.state.redis_writer.clone(),
-            context.state.dedicated_redis_reader.clone(),
-            context.state.dedicated_redis_writer.clone(),
+            context.state.redis_client.clone(),
+            context.state.dedicated_redis_client.clone(),
             context.state.database_pools.non_persons_reader.clone(),
             context.state.config.team_cache_ttl_seconds,
             context.state.config.flags_cache_ttl_seconds,

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1145,14 +1145,11 @@ fn test_decode_request_content_types() {
 
 #[tokio::test]
 async fn test_fetch_and_filter_flags() {
-    let redis_reader_client = setup_redis_client(None).await;
-    let redis_writer_client = setup_redis_client(None).await;
+    let redis_client = setup_redis_client(None).await;
     let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None).await;
     let flag_service = FlagService::new(
-        redis_reader_client.clone(),
-        redis_writer_client.clone(),
+        redis_client.clone(),
         None, // No dedicated flags Redis in tests
-        None,
         reader.clone(),
         432000, // team_cache_ttl_seconds
         432000, // flags_cache_ttl_seconds
@@ -1220,7 +1217,7 @@ async fn test_fetch_and_filter_flags() {
     // Insert flags into redis
     let flags_json = serde_json::to_string(&flags).unwrap();
     insert_flags_for_team_in_redis(
-        redis_reader_client.clone(),
+        redis_client.clone(),
         team.id,
         team.project_id(),
         Some(flags_json),

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -35,12 +35,12 @@ use crate::{
 #[derive(Clone)]
 pub struct State {
     // Shared Redis for non-critical path (analytics counters, billing limits)
-    pub redis_reader: Arc<dyn RedisClient + Send + Sync>,
-    pub redis_writer: Arc<dyn RedisClient + Send + Sync>,
+    // ReadWriteClient automatically routes reads to replica and writes to primary
+    pub redis_client: Arc<dyn RedisClient + Send + Sync>,
     // Dedicated Redis for flags cache (critical path isolation)
     // None if not configured (falls back to shared Redis)
-    pub dedicated_redis_reader: Option<Arc<dyn RedisClient + Send + Sync>>,
-    pub dedicated_redis_writer: Option<Arc<dyn RedisClient + Send + Sync>>,
+    // ReadWriteClient automatically routes reads to replica and writes to primary
+    pub dedicated_redis_client: Option<Arc<dyn RedisClient + Send + Sync>>,
     pub database_pools: Arc<DatabasePools>,
     pub cohort_cache_manager: Arc<CohortCacheManager>,
     pub geoip: Arc<GeoIpClient>,
@@ -55,11 +55,9 @@ pub struct State {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn router<RR, RW, DRR, DRW>(
-    redis_reader: Arc<RR>,
-    redis_writer: Arc<RW>,
-    dedicated_redis_reader: Option<Arc<DRR>>,
-    dedicated_redis_writer: Option<Arc<DRW>>,
+pub fn router(
+    redis_client: Arc<dyn RedisClient + Send + Sync>,
+    dedicated_redis_client: Option<Arc<dyn RedisClient + Send + Sync>>,
     database_pools: Arc<DatabasePools>,
     cohort_cache: Arc<CohortCacheManager>,
     geoip: Arc<GeoIpClient>,
@@ -68,13 +66,7 @@ pub fn router<RR, RW, DRR, DRW>(
     session_replay_billing_limiter: SessionReplayLimiter,
     cookieless_manager: Arc<CookielessManager>,
     config: Config,
-) -> Router
-where
-    RR: RedisClient + Send + Sync + 'static,
-    RW: RedisClient + Send + Sync + 'static,
-    DRR: RedisClient + Send + Sync + 'static,
-    DRW: RedisClient + Send + Sync + 'static,
-{
+) -> Router {
     // Initialize flag definitions rate limiter with default and custom team rates
     let flag_definitions_limiter = FlagDefinitionsRateLimiter::new(
         config.flag_definitions_default_rate_per_minute,
@@ -115,17 +107,9 @@ where
     // Clone database_pools for readiness check before moving into State
     let db_pools_for_readiness = database_pools.clone();
 
-    // Convert generic Arc types to trait objects for State
-    let dedicated_redis_reader_trait: Option<Arc<dyn RedisClient + Send + Sync>> =
-        dedicated_redis_reader.map(|arc| -> Arc<dyn RedisClient + Send + Sync> { arc });
-    let dedicated_redis_writer_trait: Option<Arc<dyn RedisClient + Send + Sync>> =
-        dedicated_redis_writer.map(|arc| -> Arc<dyn RedisClient + Send + Sync> { arc });
-
     let state = State {
-        redis_reader,
-        redis_writer,
-        dedicated_redis_reader: dedicated_redis_reader_trait,
-        dedicated_redis_writer: dedicated_redis_writer_trait,
+        redis_client,
+        dedicated_redis_client,
         database_pools,
         cohort_cache_manager: cohort_cache,
         geoip,

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common_geoip::GeoIpClient;
-use common_redis::{CompressionConfig, RedisClient};
+use common_redis::{
+    Client, CompressionConfig, ReadWriteClient, ReadWriteClientConfig, RedisClient,
+};
 use health::{HealthHandle, HealthRegistry};
 use limiters::redis::QUOTA_LIMITER_CACHE_KEY;
 use tokio::net::TcpListener;
@@ -36,24 +38,13 @@ where
         CompressionConfig::disabled()
     };
 
-    // Create separate Redis clients for shared Redis (non-critical path: analytics, billing, cookieless)
-    // "shared" means the Redis client shares the cache with the Dango PostHog web app.
-    let Some(redis_reader_client) = create_redis_client(
-        config.get_redis_reader_url(),
-        "shared reader",
-        compression_config.clone(),
-        config.redis_response_timeout_ms,
-        config.redis_connection_timeout_ms,
-        config.redis_client_retry_count,
-    )
-    .await
-    else {
-        return;
-    };
-
-    let Some(redis_writer_client) = create_redis_client(
+    // Create ReadWriteClient for shared Redis (non-critical path: analytics, billing, cookieless)
+    // "shared" means the Redis client shares the cache with the Django PostHog web app.
+    // Automatically routes reads to replica and writes to primary
+    let Some(redis_client) = create_readwrite_client(
         config.get_redis_writer_url(),
-        "shared writer",
+        config.get_redis_reader_url(),
+        "shared",
         compression_config.clone(),
         config.redis_response_timeout_ms,
         config.redis_connection_timeout_ms,
@@ -64,13 +55,13 @@ where
         return;
     };
 
-    // Create dedicated Redis clients for flags cache (critical path isolation)
-    let (dedicated_redis_reader_client, dedicated_redis_writer_client) =
-        create_dedicated_redis_clients(&config, compression_config.clone()).await;
+    // Create dedicated ReadWriteClient for flags cache (critical path isolation)
+    let dedicated_redis_client =
+        create_dedicated_readwrite_client(&config, compression_config.clone()).await;
 
     // Log the cache migration mode based on configuration
     let cache_mode = match (
-        dedicated_redis_reader_client.is_some(),
+        dedicated_redis_client.is_some(),
         *config.flags_redis_enabled,
     ) {
         (false, _) => "Mode 1 (Shared-only): All caches use shared Redis",
@@ -137,7 +128,7 @@ where
 
     let feature_flags_billing_limiter = match FeatureFlagsLimiter::new(
         Duration::from_secs(config.billing_limiter_cache_ttl_secs),
-        redis_reader_client.clone(), // NB: the limiter only reads from redis, so it's safe to just use the reader client
+        redis_client.clone(), // Limiter only reads from redis, ReadWriteClient automatically routes reads to replica
         QUOTA_LIMITER_CACHE_KEY.to_string(),
         None,
     ) {
@@ -150,7 +141,7 @@ where
 
     let session_replay_billing_limiter = match SessionReplayLimiter::new(
         Duration::from_secs(config.billing_limiter_cache_ttl_secs),
-        redis_reader_client.clone(), // NB: the limiter only reads from redis, so it's safe to just use the reader client
+        redis_client.clone(), // Limiter only reads from redis, ReadWriteClient automatically routes reads to replica
         QUOTA_LIMITER_CACHE_KEY.to_string(),
         None,
     ) {
@@ -180,10 +171,8 @@ where
     ));
 
     let app = router::router(
-        redis_reader_client,
-        redis_writer_client,
-        dedicated_redis_reader_client,
-        dedicated_redis_writer_client,
+        redis_client,
+        dedicated_redis_client,
         database_pools,
         cohort_cache,
         geoip_service,
@@ -204,83 +193,144 @@ where
     .unwrap()
 }
 
-/// Create dedicated Redis clients for flags cache with graceful fallback
+/// Create a ReadWriteClient that automatically routes reads to replica and writes to primary
+///
+/// Returns None and logs error if client creation fails after all retries
+async fn create_readwrite_client(
+    writer_url: &str,
+    reader_url: &str,
+    client_type: &str,
+    compression_config: CompressionConfig,
+    response_timeout_ms: u64,
+    connection_timeout_ms: u64,
+    retry_count: u32,
+) -> Option<Arc<dyn Client + Send + Sync>> {
+    let rw_config = ReadWriteClientConfig::new(
+        writer_url.to_string(),
+        reader_url.to_string(),
+        compression_config,
+        common_redis::RedisValueFormat::default(),
+        if response_timeout_ms == 0 {
+            None
+        } else {
+            Some(Duration::from_millis(response_timeout_ms))
+        },
+        if connection_timeout_ms == 0 {
+            None
+        } else {
+            Some(Duration::from_millis(connection_timeout_ms))
+        },
+    );
+
+    // Use exponential backoff with jitter: 100ms, 200ms, 400ms, etc.
+    let retry_strategy = ExponentialBackoff::from_millis(100)
+        .map(jitter)
+        .take(retry_count as usize);
+
+    let client_type_owned = client_type.to_string();
+
+    let result = Retry::spawn(retry_strategy, || async {
+        match ReadWriteClient::with_config(rw_config.clone()).await {
+            Ok(client) => Ok(Ok(client)),
+            Err(e) => {
+                if e.is_unrecoverable_error() {
+                    tracing::error!(
+                        "Permanent error creating {} ReadWriteClient: {}",
+                        client_type_owned,
+                        e
+                    );
+                    Ok(Err(e))
+                } else {
+                    tracing::debug!(
+                        "Transient error creating {} ReadWriteClient, will retry: {}",
+                        client_type_owned,
+                        e
+                    );
+                    Err(e)
+                }
+            }
+        }
+    })
+    .await;
+
+    match result {
+        Ok(Ok(client)) => {
+            tracing::info!(
+                "Created {} ReadWriteClient (writer: {}, reader: {})",
+                client_type,
+                writer_url,
+                reader_url
+            );
+            Some(Arc::new(client))
+        }
+        Ok(Err(_)) => None,
+        Err(e) => {
+            tracing::error!(
+                "Failed to create {} ReadWriteClient after {} retries: {}",
+                client_type_owned,
+                retry_count,
+                e
+            );
+            None
+        }
+    }
+}
+
+/// Create dedicated ReadWriteClient for flags cache with graceful fallback
 ///
 /// Implements fallback strategy:
-/// 1. FLAGS_REDIS_READER_URL fails or is not set → use FLAGS_REDIS_URL for reads
-/// 2. FLAGS_REDIS_URL fails or is not set → return None (use shared Redis)
+/// 1. FLAGS_REDIS_READER_URL is not set → use FLAGS_REDIS_URL for both reads and writes
+/// 2. FLAGS_REDIS_URL is not set → return None (use shared Redis)
 ///
-/// Returns: (reader_client, writer_client)
-async fn create_dedicated_redis_clients(
+/// Returns: Optional ReadWriteClient
+async fn create_dedicated_readwrite_client(
     config: &Config,
     compression_config: CompressionConfig,
-) -> (Option<Arc<RedisClient>>, Option<Arc<RedisClient>>) {
+) -> Option<Arc<dyn Client + Send + Sync>> {
     let writer_url = config.get_flags_redis_writer_url();
     let reader_url = config.get_flags_redis_reader_url();
 
-    // Try to create writer client
-    let writer = if let Some(url) = writer_url {
-        create_redis_client(
-            url,
-            "dedicated flags writer",
-            compression_config.clone(),
-            config.redis_response_timeout_ms,
-            config.redis_connection_timeout_ms,
-            config.redis_client_retry_count,
-        )
-        .await
-    } else {
-        None
-    };
-
-    // Try to create reader client independently (don't depend on writer success)
-    let reader = if let Some(url) = reader_url {
-        create_redis_client(
-            url,
-            "dedicated flags reader",
-            compression_config.clone(),
-            config.redis_response_timeout_ms,
-            config.redis_connection_timeout_ms,
-            config.redis_client_retry_count,
-        )
-        .await
-    } else {
-        None
-    };
-
-    // Determine final configuration with fallback logic
-    match (reader, writer) {
-        (Some(r), Some(w)) => {
-            tracing::info!("Dedicated flags Redis configured with separate reader endpoint");
-            (Some(r), Some(w))
+    match (writer_url, reader_url) {
+        (Some(w_url), Some(r_url)) => {
+            tracing::info!(
+                "Creating dedicated flags ReadWriteClient with separate reader endpoint"
+            );
+            create_readwrite_client(
+                w_url,
+                r_url,
+                "dedicated flags",
+                compression_config,
+                config.redis_response_timeout_ms,
+                config.redis_connection_timeout_ms,
+                config.redis_client_retry_count,
+            )
+            .await
         }
-        (None, Some(w)) => {
-            if reader_url.is_some() {
-                tracing::warn!(
-                    "FLAGS_REDIS_READER_URL connection failed, falling back to FLAGS_REDIS_URL for reads"
-                );
-            }
-            (Some(w.clone()), Some(w))
+        (Some(w_url), None) => {
+            tracing::info!("Creating dedicated flags ReadWriteClient using writer URL for both reads and writes");
+            create_readwrite_client(
+                w_url,
+                w_url,
+                "dedicated flags",
+                compression_config,
+                config.redis_response_timeout_ms,
+                config.redis_connection_timeout_ms,
+                config.redis_client_retry_count,
+            )
+            .await
         }
-        (Some(_), None) => {
-            // Reader succeeded but writer failed - can't use reader without writer
+        (None, Some(_)) => {
             tracing::warn!(
-                "FLAGS_REDIS_URL connection failed but FLAGS_REDIS_READER_URL succeeded. \
+                "FLAGS_REDIS_READER_URL set but FLAGS_REDIS_URL not set. \
                  Cannot use reader without writer. Falling back to shared Redis."
             );
-            (None, None)
+            None
         }
         (None, None) => {
-            if writer_url.is_some() || reader_url.is_some() {
-                tracing::warn!(
-                    "Both dedicated flags Redis connections failed falling back to shared Redis"
-                );
-            } else {
-                tracing::info!(
-                    "Using shared Redis for flags cache (no dedicated flags Redis configured)"
-                );
-            }
-            (None, None)
+            tracing::info!(
+                "Using shared Redis for flags cache (no dedicated flags Redis configured)"
+            );
+            None
         }
     }
 }
@@ -387,8 +437,8 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_create_dedicated_redis_clients_no_config() {
-        // When FLAGS_REDIS_URL is not set, should return (None, None)
+    async fn test_create_dedicated_readwrite_client_no_config() {
+        // When FLAGS_REDIS_URL is not set, should return None
         let config = Config {
             flags_redis_url: "".to_string(),
             flags_redis_reader_url: "".to_string(),
@@ -397,15 +447,14 @@ mod tests {
         };
 
         let compression_config = CompressionConfig::disabled();
-        let (reader, writer) = create_dedicated_redis_clients(&config, compression_config).await;
+        let client = create_dedicated_readwrite_client(&config, compression_config).await;
 
-        assert!(reader.is_none());
-        assert!(writer.is_none());
+        assert!(client.is_none());
     }
 
     #[tokio::test]
-    async fn test_create_dedicated_redis_clients_with_invalid_url() {
-        // When FLAGS_REDIS_URL is set but unreachable, should return (None, None)
+    async fn test_create_dedicated_readwrite_client_with_invalid_url() {
+        // When FLAGS_REDIS_URL is set but unreachable, should return None
         let config = Config {
             flags_redis_url: "redis://invalid-host:6379/".to_string(),
             flags_redis_reader_url: "".to_string(),
@@ -414,15 +463,14 @@ mod tests {
         };
 
         let compression_config = CompressionConfig::disabled();
-        let (reader, writer) = create_dedicated_redis_clients(&config, compression_config).await;
+        let client = create_dedicated_readwrite_client(&config, compression_config).await;
 
-        assert!(reader.is_none());
-        assert!(writer.is_none());
+        assert!(client.is_none());
     }
 
     #[tokio::test]
-    async fn test_create_dedicated_redis_clients_reader_without_writer() {
-        // When only FLAGS_REDIS_READER_URL is set (misconfiguration), should return (None, None)
+    async fn test_create_dedicated_readwrite_client_reader_without_writer() {
+        // When only FLAGS_REDIS_READER_URL is set (misconfiguration), should return None
         let config = Config {
             flags_redis_url: "".to_string(),
             flags_redis_reader_url: "redis://localhost:6379/".to_string(),
@@ -431,10 +479,9 @@ mod tests {
         };
 
         let compression_config = CompressionConfig::disabled();
-        let (reader, writer) = create_dedicated_redis_clients(&config, compression_config).await;
+        let client = create_dedicated_readwrite_client(&config, compression_config).await;
 
-        assert!(reader.is_none());
-        assert!(writer.is_none());
+        assert!(client.is_none());
     }
 
     #[tokio::test]

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -74,7 +74,8 @@ impl ServerHandle {
         }
 
         tokio::spawn(async move {
-            let redis_reader_client = Arc::new(mock_client);
+            let redis_reader_client: Arc<dyn common_redis::Client + Send + Sync> =
+                Arc::new(mock_client);
             let redis_writer_client = redis_reader_client.clone();
 
             let (persons_reader, persons_writer, non_persons_reader, non_persons_writer) = if config
@@ -213,10 +214,8 @@ impl ServerHandle {
             });
 
             let app = feature_flags::router::router(
-                redis_reader_client.clone(),
-                redis_writer_client.clone(),
-                None::<Arc<MockRedisClient>>, // No dedicated flags Redis in tests
-                None::<Arc<MockRedisClient>>,
+                redis_writer_client.clone(), // Use writer client for both reads and writes in tests
+                None,                        // No dedicated flags Redis in tests
                 database_pools,
                 cohort_cache,
                 geoip_service,


### PR DESCRIPTION
## Problem

The flags service has separate Redis clients for read and write operations. This makes the code a little more complicated than it needs to be. Lets take inspiration from Django's cache abstraction.

## Changes

Simplifies Redis client management by replacing 4 separate clients (shared reader/writer, dedicated reader/writer) with 2 `ReadWriteClient` instances that automatically route read operations to replicas and write operations to primary.

The `ReadWriteClient` was introduced in this PR: https://github.com/PostHog/posthog/pull/41492

Benefits:
- Reduces client parameter count from 4→2 throughout the codebase
- Automatic read/write routing eliminates manual client selection
- Built-in fallback for transient reader failures
- Cleaner, more maintainable code

## How did you test this code?

Unit Tests
Manual test

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
