### PR TITLE
feat: add backend validation for survey question shuffling and branching incompatibility

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -491,7 +491,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
             )
 
         # Validate that question shuffling and branching are not used together
-        # For PATCH requests, we need to check both incoming data and existing survey data
+        # Check both incoming data and existing survey data (existing_survey is None for POST)
         appearance = data.get("appearance")
         questions = data.get("questions")
 

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -490,6 +490,32 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 }
             )
 
+        # Validate that question shuffling and branching are not used together
+        # For PATCH requests, we need to check both incoming data and existing survey data
+        appearance = data.get("appearance")
+        questions = data.get("questions")
+
+        effective_appearance = {}
+        if existing_survey and existing_survey.appearance:
+            effective_appearance = dict(existing_survey.appearance)
+        if appearance is not None:
+            effective_appearance.update(appearance)
+
+        effective_questions = (
+            questions if questions is not None else (existing_survey.questions if existing_survey else [])
+        )
+
+        shuffle_questions = effective_appearance.get("shuffleQuestions", False)
+
+        if shuffle_questions and effective_questions:
+            has_branching = any(question.get("branching") is not None for question in effective_questions)
+
+            if has_branching:
+                raise serializers.ValidationError(
+                    "Question shuffling and question branching cannot be used together. "
+                    "Please disable one of these features."
+                )
+
         # Validate external survey constraints
         if data.get("type") == Survey.SurveyType.EXTERNAL_SURVEY:
             errors = {}

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -2217,6 +2217,43 @@ class TestSurveyQuestionValidation(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response_data
         assert "Question shuffling and question branching cannot be used together" in response_data["detail"]
 
+    def test_validate_branching_with_shuffling_on_update_questions(self):
+        survey = Survey.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Test Survey",
+            type="popover",
+            appearance={
+                "shuffleQuestions": True,
+            },
+            questions=[
+                {
+                    "type": "open",
+                    "question": "What do you think?",
+                }
+            ],
+        )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={
+                "questions": [
+                    {
+                        "type": "rating",
+                        "question": "How likely are you to recommend us?",
+                        "scale": 10,
+                        "branching": {
+                            "type": "end",
+                        },
+                    }
+                ],
+            },
+            format="json",
+        )
+        response_data = response.json()
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response_data
+        assert "Question shuffling and question branching cannot be used together" in response_data["detail"]
+
     def test_shuffling_without_branching_is_allowed(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/surveys/",

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -2150,6 +2150,122 @@ class TestSurveyQuestionValidation(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response_data
         assert response_data["detail"] == "Question choices cannot be empty"
 
+    def test_validate_shuffling_with_branching_on_create(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "Survey with shuffling and branching",
+                "type": "popover",
+                "appearance": {
+                    "shuffleQuestions": True,
+                },
+                "questions": [
+                    {
+                        "type": "rating",
+                        "question": "How likely are you to recommend us?",
+                        "scale": 10,
+                        "branching": {
+                            "type": "response_based",
+                            "responseValues": {
+                                "promoters": "end",
+                                "passives": "end",
+                                "detractors": "specific_question",
+                            },
+                            "index": 1,
+                        },
+                    },
+                    {
+                        "type": "open",
+                        "question": "What can we improve?",
+                    },
+                ],
+            },
+            format="json",
+        )
+        response_data = response.json()
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response_data
+        assert "Question shuffling and question branching cannot be used together" in response_data["detail"]
+
+    def test_validate_shuffling_with_branching_on_update(self):
+        survey = Survey.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Test Survey",
+            type="popover",
+            questions=[
+                {
+                    "type": "rating",
+                    "question": "How likely are you to recommend us?",
+                    "scale": 10,
+                    "branching": {
+                        "type": "end",
+                    },
+                }
+            ],
+        )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={
+                "appearance": {
+                    "shuffleQuestions": True,
+                },
+            },
+            format="json",
+        )
+        response_data = response.json()
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response_data
+        assert "Question shuffling and question branching cannot be used together" in response_data["detail"]
+
+    def test_shuffling_without_branching_is_allowed(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "Survey with just shuffling",
+                "type": "popover",
+                "appearance": {
+                    "shuffleQuestions": True,
+                },
+                "questions": [
+                    {
+                        "type": "open",
+                        "question": "Question 1",
+                    },
+                    {
+                        "type": "open",
+                        "question": "Question 2",
+                    },
+                ],
+            },
+            format="json",
+        )
+        response_data = response.json()
+        assert response.status_code == status.HTTP_201_CREATED, response_data
+        assert response_data["appearance"]["shuffleQuestions"] is True
+
+    def test_branching_without_shuffling_is_allowed(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "Survey with just branching",
+                "type": "popover",
+                "questions": [
+                    {
+                        "type": "rating",
+                        "question": "How likely are you to recommend us?",
+                        "scale": 10,
+                        "branching": {
+                            "type": "end",
+                        },
+                    },
+                ],
+            },
+            format="json",
+        )
+        response_data = response.json()
+        assert response.status_code == status.HTTP_201_CREATED, response_data
+        assert response_data["questions"][0]["branching"]["type"] == "end"
+
 
 class TestSurveyQuestionValidationWithEnterpriseFeatures(APIBaseTest):
     def setUp(self):


### PR DESCRIPTION
## Summary

Adds backend validation to prevent using question shuffling and question branching together in surveys, matching the existing frontend validation.

## Background

Question branching allows surveys to direct users to different questions based on their responses, creating a specific question flow. Question shuffling randomizes the order of questions. These features are inherently incompatible because:
- Branching relies on predictable question order to work correctly
- Shuffling randomizes question order, breaking branching logic

This validation already exists in the frontend (`frontend/src/scenes/surveys/components/question-branching/QuestionBranchingInput.tsx:94-117`), where adding branching logic automatically disables shuffling after user confirmation.

## Changes

- **Backend Validation**: Added validation in `SurveySerializerCreateUpdateOnly.validate()` method
  - Prevents creating or updating surveys with both features enabled
  - Handles both POST (create) and PATCH (update) requests properly
  - For PATCH requests, checks both incoming data and existing survey state to determine effective configuration
- **Test Coverage**: Added 4 comprehensive tests covering:
  - Creating a survey with both features (should fail)
  - Updating a survey with branching to enable shuffling (should fail)
  - Creating a survey with only shuffling (should succeed)
  - Creating a survey with only branching (should succeed)

## Test plan

- All new tests pass
- All existing survey validation tests continue to pass
- Validation correctly rejects incompatible configurations
- Validation allows each feature independently