### PR TITLE
fix(subscriptions): send error message for assets that timeout

### DIFF
--- a/ee/tasks/subscriptions/email_subscriptions.py
+++ b/ee/tasks/subscriptions/email_subscriptions.py
@@ -8,18 +8,19 @@ from posthog.models.exported_asset import ExportedAsset
 from posthog.models.subscription import Subscription, get_unsubscribe_token
 from posthog.utils import absolute_uri
 
-from ee.tasks.subscriptions.subscription_utils import UTM_TAGS_BASE
+from ee.tasks.subscriptions.subscription_utils import ASSET_GENERATION_FAILED_MESSAGE, UTM_TAGS_BASE, _has_asset_failed
 
 logger = structlog.get_logger(__name__)
 
 
 def _get_asset_data_for_email(asset: ExportedAsset) -> dict:
-    if asset.exception:
+    if _has_asset_failed(asset):
         insight_name = asset.insight.name or asset.insight.derived_name if asset.insight else "Unknown insight"
+        error_message = str(asset.exception) if asset.exception else ASSET_GENERATION_FAILED_MESSAGE
         return {
             "error": True,
             "insight_name": insight_name,
-            "error_message": asset.exception,
+            "error_message": error_message,
         }
 
     return {

--- a/ee/tasks/subscriptions/email_subscriptions.py
+++ b/ee/tasks/subscriptions/email_subscriptions.py
@@ -16,7 +16,16 @@ logger = structlog.get_logger(__name__)
 def _get_asset_data_for_email(asset: ExportedAsset) -> dict:
     if _has_asset_failed(asset):
         insight_name = asset.insight.name or asset.insight.derived_name if asset.insight else "Unknown insight"
-        error_message = str(asset.exception) if asset.exception else ASSET_GENERATION_FAILED_MESSAGE
+
+        # Truncate long error messages to avoid long emails
+        max_error_length = 2000
+        if asset.exception:
+            error_message = str(asset.exception)
+            if len(error_message) > max_error_length:
+                error_message = error_message[:max_error_length] + "... (truncated)"
+        else:
+            error_message = ASSET_GENERATION_FAILED_MESSAGE
+
         return {
             "error": True,
             "insight_name": insight_name,

--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -12,7 +12,7 @@ from posthog.models.exported_asset import ExportedAsset
 from posthog.models.integration import Integration, SlackIntegration
 from posthog.models.subscription import Subscription
 
-from ee.tasks.subscriptions.subscription_utils import _has_asset_failed
+from ee.tasks.subscriptions.subscription_utils import ASSET_GENERATION_FAILED_MESSAGE, _has_asset_failed
 
 logger = structlog.get_logger(__name__)
 
@@ -55,7 +55,7 @@ def _block_for_asset(asset: ExportedAsset) -> dict:
             if len(exception_text) > max_error_length:
                 exception_text = exception_text[:max_error_length] + "... (truncated)"
         else:
-            exception_text = "Failed to generate content"
+            exception_text = ASSET_GENERATION_FAILED_MESSAGE
 
         error_text = (
             f"*{insight_name}*\n"

--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -12,6 +12,8 @@ from posthog.models.exported_asset import ExportedAsset
 from posthog.models.integration import Integration, SlackIntegration
 from posthog.models.subscription import Subscription
 
+from ee.tasks.subscriptions.subscription_utils import _has_asset_failed
+
 logger = structlog.get_logger(__name__)
 
 UTM_TAGS_BASE = "utm_source=posthog&utm_campaign=subscription_report"
@@ -41,17 +43,19 @@ class SlackDeliveryResult:
 
 
 def _block_for_asset(asset: ExportedAsset) -> dict:
-    # If asset has an exception, return an error block instead of an image
-    if asset.exception:
+    if _has_asset_failed(asset):
         insight_name = asset.insight.name or asset.insight.derived_name if asset.insight else "Unknown insight"
 
         # Slack text blocks have a 3000 character limit
         # Reserve space for the insight name, formatting, and support message
         max_error_length = 2000
-        exception_text = str(asset.exception)
 
-        if len(exception_text) > max_error_length:
-            exception_text = exception_text[:max_error_length] + "... (truncated)"
+        if asset.exception:
+            exception_text = str(asset.exception)
+            if len(exception_text) > max_error_length:
+                exception_text = exception_text[:max_error_length] + "... (truncated)"
+        else:
+            exception_text = "Failed to generate content"
 
         error_text = (
             f"*{insight_name}*\n"

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -33,10 +33,6 @@ def _has_asset_failed(asset: ExportedAsset) -> bool:
     return (not asset.content and not asset.content_location) or asset.exception is not None
 
 
-def _has_asset_failed(asset: ExportedAsset) -> bool:
-    return (not asset.content and not asset.content_location) or asset.exception is not None
-
-
 def _get_failed_asset_info(assets: list[ExportedAsset], resource: Union[Subscription, SharingConfiguration]) -> dict:
     failed_assets = [a for a in assets if _has_asset_failed(a)]
     failed_insight_ids = [a.insight_id for a in failed_assets if a.insight_id]

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -33,6 +33,10 @@ def _has_asset_failed(asset: ExportedAsset) -> bool:
     return (not asset.content and not asset.content_location) or asset.exception is not None
 
 
+def _has_asset_failed(asset: ExportedAsset) -> bool:
+    return (not asset.content and not asset.content_location) or asset.exception is not None
+
+
 def _get_failed_asset_info(assets: list[ExportedAsset], resource: Union[Subscription, SharingConfiguration]) -> dict:
     failed_assets = [a for a in assets if _has_asset_failed(a)]
     failed_insight_ids = [a.insight_id for a in failed_assets if a.insight_id]

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -28,8 +28,12 @@ DEFAULT_MAX_ASSET_COUNT = 6
 MAX_SCREENSHOT_HEIGHT_PIXELS = 5000
 
 
+def _has_asset_failed(asset: ExportedAsset) -> bool:
+    return (not asset.content and not asset.content_location) or asset.exception is not None
+
+
 def _get_failed_asset_info(assets: list[ExportedAsset], resource: Union[Subscription, SharingConfiguration]) -> dict:
-    failed_assets = [a for a in assets if not a.content and not a.content_location]
+    failed_assets = [a for a in assets if _has_asset_failed(a)]
     failed_insight_ids = [a.insight_id for a in failed_assets if a.insight_id]
     failed_insight_urls = [
         f"/project/{resource.team_id}/insights/{a.insight.short_id}"

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -26,6 +26,7 @@ DEFAULT_MAX_ASSET_COUNT = 6
 # Maximum height for screenshots in pixels. This prevents Chrome from consuming excessive memory
 # when rendering very tall pages (e.g., tables with thousands of rows).
 MAX_SCREENSHOT_HEIGHT_PIXELS = 5000
+ASSET_GENERATION_FAILED_MESSAGE = "Failed to generate content"
 
 
 def _has_asset_failed(asset: ExportedAsset) -> bool:

--- a/ee/tasks/test/subscriptions/test_email_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_email_subscriptions.py
@@ -32,7 +32,12 @@ class TestEmailSubscriptionsTasks(APIBaseTest):
         set_instance_setting("EMAIL_HOST", "fake_host")
         set_instance_setting("EMAIL_ENABLED", True)
 
-        self.asset = ExportedAsset.objects.create(team=self.team, insight_id=self.insight.id, export_format="image/png")
+        self.asset = ExportedAsset.objects.create(
+            team=self.team,
+            insight_id=self.insight.id,
+            export_format="image/png",
+            content_location="s3://bucket/test.png",
+        )
         self.subscription = create_subscription(team=self.team, insight=self.insight, created_by=self.user)
 
     def test_subscription_delivery(self, MockEmailMessage: MagicMock) -> None:

--- a/ee/tasks/test/subscriptions/test_slack_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_slack_subscriptions.py
@@ -16,6 +16,7 @@ from ee.tasks.subscriptions.slack_subscriptions import (
     send_slack_message_with_integration_async,
     send_slack_subscription_report,
 )
+from ee.tasks.subscriptions.subscription_utils import ASSET_GENERATION_FAILED_MESSAGE
 from ee.tasks.test.subscriptions.subscriptions_test_factory import create_subscription
 
 
@@ -503,5 +504,4 @@ class TestSlackErrorTruncation(APIBaseTest):
         assert block["type"] == "section"
         text = block["text"]["text"]
         assert "*My Test subscription*" in text
-        assert "There was an error generating your asset: Failed to generate content" in text
-        assert "_If this issue persists, please contact support._" in text
+        assert ASSET_GENERATION_FAILED_MESSAGE in text

--- a/ee/tasks/test/subscriptions/test_slack_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_slack_subscriptions.py
@@ -31,7 +31,12 @@ class TestSlackSubscriptionsTasks(APIBaseTest):
     def setUp(self) -> None:
         self.dashboard = Dashboard.objects.create(team=self.team, name="private dashboard", created_by=self.user)
         self.insight = Insight.objects.create(team=self.team, short_id="123456", name="My Test subscription")
-        self.asset = ExportedAsset.objects.create(team=self.team, insight_id=self.insight.id, export_format="image/png")
+        self.asset = ExportedAsset.objects.create(
+            team=self.team,
+            insight_id=self.insight.id,
+            export_format="image/png",
+            content_location="s3://bucket/test.png",
+        )
         self.subscription = create_subscription(
             team=self.team,
             insight=self.insight,
@@ -220,7 +225,12 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
     def setUp(self) -> None:
         self.dashboard = Dashboard.objects.create(team=self.team, name="private dashboard", created_by=self.user)
         self.insight = Insight.objects.create(team=self.team, short_id="123456", name="My Test subscription")
-        self.asset = ExportedAsset.objects.create(team=self.team, insight_id=self.insight.id, export_format="image/png")
+        self.asset = ExportedAsset.objects.create(
+            team=self.team,
+            insight_id=self.insight.id,
+            export_format="image/png",
+            content_location="s3://bucket/test.png",
+        )
         self.subscription = create_subscription(
             team=self.team,
             dashboard=self.dashboard,
@@ -238,8 +248,18 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
         mock_slack_integration.async_client = MagicMock(return_value=mock_async_client)
         mock_async_client.chat_postMessage.return_value = {"ts": "1.234"}
 
-        asset2 = ExportedAsset.objects.create(team=self.team, insight_id=self.insight.id, export_format="image/png")
-        asset3 = ExportedAsset.objects.create(team=self.team, insight_id=self.insight.id, export_format="image/png")
+        asset2 = ExportedAsset.objects.create(
+            team=self.team,
+            insight_id=self.insight.id,
+            export_format="image/png",
+            content_location="s3://bucket/test2.png",
+        )
+        asset3 = ExportedAsset.objects.create(
+            team=self.team,
+            insight_id=self.insight.id,
+            export_format="image/png",
+            content_location="s3://bucket/test3.png",
+        )
         assets = list(
             ExportedAsset.objects.filter(id__in=[self.asset.id, asset2.id, asset3.id]).select_related("insight")
         )
@@ -276,8 +296,18 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
             {"ts": "3.456"},  # Third thread message "Showing 3 of 10"
         ]
 
-        asset2 = ExportedAsset.objects.create(team=self.team, insight_id=self.insight.id, export_format="image/png")
-        asset3 = ExportedAsset.objects.create(team=self.team, insight_id=self.insight.id, export_format="image/png")
+        asset2 = ExportedAsset.objects.create(
+            team=self.team,
+            insight_id=self.insight.id,
+            export_format="image/png",
+            content_location="s3://bucket/test2.png",
+        )
+        asset3 = ExportedAsset.objects.create(
+            team=self.team,
+            insight_id=self.insight.id,
+            export_format="image/png",
+            content_location="s3://bucket/test3.png",
+        )
         assets = list(
             ExportedAsset.objects.filter(id__in=[self.asset.id, asset2.id, asset3.id]).select_related("insight")
         )

--- a/ee/tasks/test/subscriptions/test_slack_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_slack_subscriptions.py
@@ -494,3 +494,14 @@ class TestSlackErrorTruncation(APIBaseTest):
         assert len(text) < 3000
         assert "*My Test subscription*" in text
         assert "There was an error generating your asset:" in text
+
+    def test_block_for_asset_without_content_or_location(self) -> None:
+        asset = ExportedAsset.objects.create(team=self.team, insight_id=self.insight.id, export_format="image/png")
+
+        block = _block_for_asset(asset)
+
+        assert block["type"] == "section"
+        text = block["text"]["text"]
+        assert "*My Test subscription*" in text
+        assert "There was an error generating your asset: Failed to generate content" in text
+        assert "_If this issue persists, please contact support._" in text


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Sometimes subscription failed with `[ERROR] downloading image failed`

subscription 62912 failed on 2025-11-20 11:08:07.031607 with the following error
```
"subscription_id": 62912,
  "next_delivery_date": "2025-11-20 11:00:00+00:00",
  "destination": "slack",
  "level": "error",
  "activity_id": "24",
  "activity_type": "deliver_subscription_report_activity",
  "attempt": 1,
  "task_queue": "analytics-platform-task-queue",
  "workflow_id": "schedule-all-subscriptions-schedule-2025-11-20T10:55:00Z",
  "workflow_namespace": "posthog-prod-us.usz2o",
  "workflow_run_id": "019aa0e7-3c03-7d6c-beff-0a01bb3ed1e4",
  "workflow_type": "schedule-all-subscriptions",
  "timestamp": "2025-11-20 11:08:07.031607",
  "logger": "ee.tasks.subscriptions",
  "func_name": "deliver_subscription_report_async",
  "filename": "__init__.py",
  "lineno": 233,


"e": "SlackApiError(\"The request to the Slack API failed. (url: https://www.slack.com/api/chat.postMessage)\\nThe server responded with: {'ok': False, 'error': 'invalid_blocks', 'errors': ['downloading image failed [json-pointer:/blocks/1/image_url]'], 'response_metadata': {'messages': ['[ERROR] downloading image failed [json-pointer:/blocks/1/image_url]']}}\")"
```
https://grafana.prod-us.posthog.dev/goto/p0mMSPmvg?orgId=1

It was because there was a 404 when the Slack API tries to get the image

<details>
<summary>404 log</summary>

```
{
  "@timestamp": "2025-11-20T11:08:06.905Z",
  "authority": "us.posthog.com",
  "downstream_local_address": "10.31.217.220:8080",
  "downstream_remote_address": "18.212.85.139:0",
  "duration": 22,
  "method": "GET",
  "path": "/exporter/export-money-movement-transactions-in-last-24-hours.png?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjczODEzNSwiZXhwIjoxNzk1MTcyODgyLCJhdWQiOiJwb3N0aG9nOmV4cG9ydGVkX2Fzc2V0In0.g0Rwp8eSeB2OYuLdGsoraDSeEjdyCzA9NLBPePa5PKk",
  "protocol": "HTTP/1.1",
  "request_id": "d51d3dc1-707d-434d-886f-20bbba756983",
  "response_code": 404,
  "response_code_details": "via_upstream",
  "upstream_cluster": "posthog_posthog-web-django_8000",
  "upstream_host": "10.32.179.225:8000",
  "user_agent": "Slackbot 1.0 (+https://api.slack.com/robots)",
  "x_forwarded_for": "18.212.85.139,10.0.28.93",
  "x_forwarded_host": null,
  "x_forwarded_port": "443",
  "x_forwarded_proto": "https"
}
```
https://grafana.prod-us.posthog.dev/goto/nP9NIPmvR?orgId=1

</details>

404 happened because there was a timeout error when generating the export which results with the asset missing the content_location field.

```
select content_location from posthog_exportedasset where id = 2738135

null
```

<details>
<summary>Timeout logs</summary>
```
{
  "asset_count": 1,
  "subscription_id": 62912,
  "dashboard_id": null,
  "team_id": 35627,
  "failed_asset_count": 1,
  "failed_insight_ids": [
    3376341
  ],
  "failed_insight_urls": [
    "/project/35627/insights/lcCwvpZc"
  ],
  "dashboard_url": null,
  "level": "warning",
  "activity_id": "24",
  "activity_type": "deliver_subscription_report_activity",
  "attempt": 1,
  "task_queue": "analytics-platform-task-queue",
  "workflow_id": "schedule-all-subscriptions-schedule-2025-11-20T10:55:00Z",
  "workflow_namespace": "posthog-prod-us.usz2o",
  "workflow_run_id": "019aa0e7-3c03-7d6c-beff-0a01bb3ed1e4",
  "workflow_type": "schedule-all-subscriptions",
  "timestamp": "2025-11-20 11:08:01.867748",
  "logger": "ee.tasks.subscriptions.subscription_utils",
  "func_name": "generate_assets_async",
  "filename": "subscription_utils.py",
  "lineno": 246,
  "msg": "generate_assets_async.exports_timeout"
}
```
</details>

Usually, when there is a ClickHouse exception when generating the asset, the `exception` field of the asset is populated. However the asyncio timeout path doe not set the exception, so when we generate the slack message we think the image was successful and send the dead link.


## Changes

Update slack and email path to use `_has_asset_failed` which checks that wither content_location or content field is populated. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
