### PR TITLE
fix(flags): Fix search bar width

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagFilters.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagFilters.tsx
@@ -46,7 +46,7 @@ export function FeatureFlagFiltersSection({
         <div className="flex justify-between gap-2 flex-wrap">
             {config.search && (
                 <LemonInput
-                    className="w-60"
+                    className="w-[335px] !max-w-[335px]"
                     type="search"
                     placeholder={searchPlaceholder}
                     onChange={(search) => setFeatureFlagsFilters({ search, page: 1 })}


### PR DESCRIPTION
## Changes
Had to override the default max width of the search bar, but in this UI it works fine.

|Before|After|
|----|----|
|<img width="264" height="66" alt="image" src="https://github.com/user-attachments/assets/1d8ba5a3-2ade-4f21-aed6-e473165aafc9" />|<img width="361" height="70" alt="image" src="https://github.com/user-attachments/assets/acf3b51a-f7af-41b6-a9f4-7d5fcb6443bb" />|