### PR TITLE
fix(experiments): Fix shared metrics team bug

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -159,10 +159,12 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
             if "metadata" in saved_metric and "type" not in saved_metric["metadata"]:
                 raise ValidationError("Metadata must have a type key")
 
-        # check if all saved metrics exist
-        saved_metrics = ExperimentSavedMetric.objects.filter(id__in=[saved_metric["id"] for saved_metric in value])
+        # check if all saved metrics exist and belong to the same team
+        saved_metrics = ExperimentSavedMetric.objects.filter(
+            id__in=[saved_metric["id"] for saved_metric in value], team_id=self.context["team_id"]
+        )
         if saved_metrics.count() != len(value):
-            raise ValidationError("Saved metric does not exist")
+            raise ValidationError("Saved metric does not exist or does not belong to this project")
 
         return value
 

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -8,9 +8,8 @@ from django.core.cache import cache
 
 from dateutil import parser
 from rest_framework import status
-from posthog.models import Team
 
-from posthog.models import WebExperiment
+from posthog.models import Team, WebExperiment
 from posthog.models.action.action import Action
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.cohort.cohort import Cohort
@@ -665,7 +664,7 @@ class TestExperimentCRUD(APILicensedTest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["type"], "validation_error")
-        self.assertEqual(response.json()["detail"], "Saved metric does not exist")
+        self.assertEqual(response.json()["detail"], "Saved metric does not exist or does not belong to this project")
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/experiments/",

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -8,6 +8,7 @@ from django.core.cache import cache
 
 from dateutil import parser
 from rest_framework import status
+from posthog.models import Team
 
 from posthog.models import WebExperiment
 from posthog.models.action.action import Action
@@ -3512,3 +3513,49 @@ class TestExperimentAuxiliaryEndpoints(ClickhouseTestMixin, APILicensedTest):
 
         # Verify the fix: the update activity log should NOT show the first user
         self.assertNotEqual(update_logs[0].user, self.user)
+
+    def test_cannot_add_saved_metric_from_different_team(self):
+        team_b = Team.objects.create(organization=self.organization, name="Team B")
+
+        # Create a saved metric in team A (self.team)
+        saved_metric_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_saved_metrics/",
+            {
+                "name": "Team A Metric",
+                "description": "This metric belongs to Team A",
+                "query": {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "funnel",
+                    "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(saved_metric_response.status_code, status.HTTP_201_CREATED)
+        team_a_metric_id = saved_metric_response.json()["id"]
+
+        # Create an experiment in team B
+        experiment_response = self.client.post(
+            f"/api/projects/{team_b.id}/experiments/",
+            {
+                "name": "Team B Experiment",
+                "feature_flag_key": "team-b-flag",
+                "parameters": None,
+            },
+            format="json",
+        )
+        self.assertEqual(experiment_response.status_code, status.HTTP_201_CREATED)
+        team_b_experiment_id = experiment_response.json()["id"]
+
+        # Try to add Team A's saved metric to Team B's experiment
+        # This should fail with validation error
+        update_response = self.client.patch(
+            f"/api/projects/{team_b.id}/experiments/{team_b_experiment_id}/",
+            {
+                "saved_metrics_ids": [{"id": team_a_metric_id, "metadata": {"type": "primary"}}],
+            },
+            format="json",
+        )
+
+        self.assertEqual(update_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("does not exist or does not belong to this project", str(update_response.json()))


### PR DESCRIPTION
## Problem
Prompted by: https://posthog.slack.com/archives/C08AMB3HFK2/p1763744655881649

Experiment somehow _can_ be linked to saved metrics from different teams within the same organization. This happened because the backend validation only checked if the metric existed, but didn't verify it belonged to the same team as the experiment.

Perhaps there's some race condition with project switcher or something similar.

## Changes
Added `team_id` validation in  `ExperimentSerializer.validate_saved_metrics_ids()` to ensure saved  metrics can only be linked to experiments in the same team.

## How did you test your code?
Added a test case that verifies cross-team metric assignments are now rejected with a clear error message.