### PR TITLE
feat: Add monthly job to add products from colleagues to sidebar

### DIFF
--- a/dags/common/common.py
+++ b/dags/common/common.py
@@ -231,3 +231,39 @@ WHERE
 ORDER BY event_time DESC;
 """
     return f"http://localhost:8123/play?user=default#{base64.b64encode(sql.encode("utf-8")).decode("utf-8")}"
+
+
+@dagster.op(
+    out=dagster.DynamicOut(list[int]),
+    config_schema={
+        "team_ids": dagster.Field(
+            dagster.Array(dagster.Int),
+            default_value=[],
+            is_required=False,
+            description="Specific team IDs to process. If empty, processes all teams.",
+        ),
+        "batch_size": dagster.Field(
+            dagster.Int,
+            default_value=1000,
+            is_required=False,
+            description="Number of team IDs per batch.",
+        ),
+    },
+)
+def get_all_team_ids_op(context: dagster.OpExecutionContext):
+    """Fetch all team IDs to process in batches."""
+    from posthog.models.team import Team
+
+    override_team_ids = context.op_config["team_ids"]
+    batch_size = context.op_config.get("batch_size", 1000)
+
+    if override_team_ids:
+        team_ids = override_team_ids
+        context.log.info(f"Processing {len(team_ids)} configured teams: {team_ids}")
+    else:
+        team_ids = list(Team.objects.exclude(id=0).values_list("id", flat=True))
+        context.log.info(f"Processing all {len(team_ids)} teams")
+
+    for i in range(0, len(team_ids), batch_size):
+        batch = team_ids[i : i + batch_size]
+        yield dagster.DynamicOutput(batch, mapping_key=f"batch_{i // batch_size}")

--- a/dags/locations/growth.py
+++ b/dags/locations/growth.py
@@ -11,11 +11,13 @@ defs = dagster.Definitions(
         github_sdk_versions.cache_github_sdk_versions_job,
         team_sdk_versions.cache_all_team_sdk_versions_job,
         user_product_list.populate_user_product_list_job,
+        user_product_list.sync_colleagues_products_monthly_job,
     ],
     schedules=[
         oauth.oauth_clear_expired_oauth_tokens_schedule,
         github_sdk_versions.cache_github_sdk_versions_schedule,
         team_sdk_versions.cache_all_team_sdk_versions_schedule,
+        user_product_list.sync_colleagues_products_monthly_schedule,
     ],
     resources=resources,
 )

--- a/dags/user_product_list.py
+++ b/dags/user_product_list.py
@@ -1,16 +1,19 @@
+from dataclasses import dataclass
 from datetime import datetime
+from typing import Literal
 
 from django.utils import timezone
 
 import dagster
 import pydantic
 
-from posthog.models.file_system.user_product_list import UserProductList
+from posthog.exceptions_capture import capture_exception
+from posthog.models.file_system.user_product_list import UserProductList, get_user_product_list_count
 from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.products import Products
 
-from dags.common import JobOwners
+from dags.common import JobOwners, get_all_team_ids_op
 
 
 def get_valid_product_paths() -> set[str]:
@@ -172,3 +175,151 @@ def populate_user_product_list_job():
     - only_users_without_products: Only process users without existing entries
     """
     populate_user_product_list()
+
+
+@dataclass(kw_only=True)
+class SyncColleaguesProductsResult:
+    team_id: int
+    users_processed: int
+    products_created: int
+    status: Literal["success", "failed", "error"]
+
+
+@dagster.op(
+    retry_policy=dagster.RetryPolicy(
+        max_retries=3,
+        delay=1,
+        backoff=dagster.Backoff.EXPONENTIAL,
+        jitter=dagster.Jitter.PLUS_MINUS,
+    )
+)
+def sync_colleagues_products_for_team_op(
+    context: dagster.OpExecutionContext,
+    team_ids: list[int],
+) -> list[SyncColleaguesProductsResult]:
+    """Sync colleague products for all users in a batch of teams."""
+    results = []
+
+    for team_id in team_ids:
+        try:
+            team = Team.objects.get(id=team_id)
+            users_processed = 0
+            products_created = 0
+
+            colleague_product_counts = get_user_product_list_count(team)
+
+            for user in team.all_users_with_access().iterator():
+                if user.allow_sidebar_suggestions is False:
+                    continue
+
+                created_items = UserProductList.sync_from_team_colleagues(
+                    user=user, team=team, colleague_product_counts=colleague_product_counts
+                )
+                users_processed += 1
+                products_created += len(created_items)
+
+            context.log.info(
+                f"Team {team_id}: processed {users_processed} users, created {products_created} product entries"
+            )
+
+            results.append(
+                SyncColleaguesProductsResult(
+                    team_id=team_id,
+                    users_processed=users_processed,
+                    products_created=products_created,
+                    status="success",
+                )
+            )
+        except Team.DoesNotExist:
+            context.log.warning(f"Team {team_id} not found")
+            results.append(
+                SyncColleaguesProductsResult(
+                    team_id=team_id,
+                    users_processed=0,
+                    products_created=0,
+                    status="failed",
+                )
+            )
+        except Exception as e:
+            context.log.exception(f"Failed to process team {team_id}")
+            capture_exception(e, {"team_id": team_id, "team": "team-growth"})
+            results.append(
+                SyncColleaguesProductsResult(
+                    team_id=team_id,
+                    users_processed=0,
+                    products_created=0,
+                    status="error",
+                )
+            )
+
+    success_results = [r for r in results if r.status == "success"]
+    failed_results = [r for r in results if r.status in ("failed", "error")]
+
+    context.add_output_metadata(
+        {
+            "batch_size": dagster.MetadataValue.int(len(team_ids)),
+            "processed": dagster.MetadataValue.int(len(results)),
+            "success_count": dagster.MetadataValue.int(len(success_results)),
+            "failed_count": dagster.MetadataValue.int(len(failed_results)),
+            "total_users_processed": dagster.MetadataValue.int(sum(r.users_processed for r in results)),
+            "total_products_created": dagster.MetadataValue.int(sum(r.products_created for r in results)),
+        }
+    )
+
+    return results
+
+
+@dagster.op
+def aggregate_colleagues_sync_results_op(
+    context: dagster.OpExecutionContext, results: list[list[SyncColleaguesProductsResult]]
+) -> None:
+    """Aggregate results from all team processing ops."""
+    flat_results = [r for batch in results for r in batch]
+
+    total_teams = len(flat_results)
+    success_count = sum(1 for r in flat_results if r.status == "success")
+    failed_count = sum(1 for r in flat_results if r.status in ("failed", "error"))
+    total_users_processed = sum(r.users_processed for r in flat_results)
+    total_products_created = sum(r.products_created for r in flat_results)
+
+    context.log.info(
+        f"Completed processing {total_teams} teams: {success_count} succeeded, {failed_count} failed. "
+        f"Processed {total_users_processed} users, created {total_products_created} product entries"
+    )
+
+    context.add_output_metadata(
+        {
+            "total_teams": dagster.MetadataValue.int(total_teams),
+            "success_count": dagster.MetadataValue.int(success_count),
+            "failed_count": dagster.MetadataValue.int(failed_count),
+            "total_users_processed": dagster.MetadataValue.int(total_users_processed),
+            "total_products_created": dagster.MetadataValue.int(total_products_created),
+        }
+    )
+
+    if failed_count > 0:
+        failed_team_ids = [r.team_id for r in flat_results if r.status in ("failed", "error")]
+        context.log.warning(f"Failed to sync colleague products for {failed_count} teams: {failed_team_ids}")
+
+
+@dagster.job(
+    description="Syncs products used by colleagues to each user's product list for all teams",
+    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 10}),
+    tags={"owner": JobOwners.TEAM_GROWTH.value},
+)
+def sync_colleagues_products_monthly_job():
+    """
+    Monthly job that syncs products used by colleagues to each user's product list.
+    For each team, finds the most popular products among colleagues and suggests them to users.
+    """
+    team_ids = get_all_team_ids_op()
+    results = team_ids.map(sync_colleagues_products_for_team_op)
+    aggregate_colleagues_sync_results_op(results.collect())
+
+
+sync_colleagues_products_monthly_schedule = dagster.ScheduleDefinition(
+    job=sync_colleagues_products_monthly_job,
+    cron_schedule="0 5 15 * *",  # 15th day of every month at 5am UTC
+    execution_timezone="UTC",
+    name="sync_colleagues_products_monthly_schedule",
+)

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -46,7 +46,7 @@
                WHERE equals(person_distinct_id_overrides.team_id, 99999)
                GROUP BY person_distinct_id_overrides.distinct_id
                HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-08 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
          GROUP BY actor_id) AS source
       ORDER BY source.id ASC
       LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -59,7 +59,7 @@
                                                                                          actor_id AS id
                                                                                   FROM
                                                                                     (SELECT min(toTimeZone(e.timestamp, 'UTC')) AS min_timestamp,
-                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-07 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
+                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-08 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
                                                                                             if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
                                                                                             argMin(e.uuid, toTimeZone(e.timestamp, 'UTC')) AS uuid,
                                                                                             argMin(e.distinct_id, toTimeZone(e.timestamp, 'UTC')) AS distinct_id
@@ -213,7 +213,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-13 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$new_view'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$new_view'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -454,7 +454,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -932,7 +932,7 @@
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
                               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC
                      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1025,7 +1025,7 @@
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
                               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC
                      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1195,7 +1195,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1276,7 +1276,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -1376,7 +1376,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -1397,7 +1397,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), equals(events.event, '$new_view'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')))
+        WHERE and(equals(events.team_id, 99999), equals(events.event, '$new_view'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')))
         GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)
         HAVING ifNull(greaterOrEquals(count(), 1), 0)
         ORDER BY count() DESC)
@@ -1499,7 +1499,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -1519,7 +1519,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')))
+        WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')))
         GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)
         HAVING ifNull(greaterOrEquals(count(), 1), 0)
         ORDER BY count() DESC)
@@ -1636,7 +1636,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$filter_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$filter_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1702,7 +1702,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1795,7 +1795,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1913,7 +1913,7 @@
                WHERE equals(person_distinct_id_overrides.team_id, 99999)
                GROUP BY person_distinct_id_overrides.distinct_id
                HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-08 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
          GROUP BY actor_id) AS source
       ORDER BY source.id ASC
       LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1942,7 +1942,7 @@
                                                                                          actor_id AS id
                                                                                   FROM
                                                                                     (SELECT min(toTimeZone(e.timestamp, 'UTC')) AS min_timestamp,
-                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-07 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
+                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-08 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
                                                                                             if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
                                                                                             argMin(e.uuid, toTimeZone(e.timestamp, 'UTC')) AS uuid,
                                                                                             argMin(e.distinct_id, toTimeZone(e.timestamp, 'UTC')) AS distinct_id
@@ -2381,7 +2381,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -2466,7 +2466,7 @@
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
                               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC
                      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -2566,7 +2566,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-15 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,

--- a/posthog/models/file_system/test/test_user_product_list.py
+++ b/posthog/models/file_system/test/test_user_product_list.py
@@ -1,0 +1,228 @@
+from posthog.test.base import BaseTest
+
+from posthog.models import User
+from posthog.models.file_system.user_product_list import UserProductList, get_user_product_list_count
+
+
+class TestUserProductList(BaseTest):
+    def test_sync_filters_out_existing_products_with_precomputed_counts(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+        user.join(organization=self.organization)
+
+        UserProductList.objects.create(user=user, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=user, team=self.team, product_path="feature_flags", enabled=True)
+
+        hardcoded_counts = [
+            {"product_path": "product_analytics", "colleague_count": 5},
+            {"product_path": "session_replay", "colleague_count": 4},
+            {"product_path": "feature_flags", "colleague_count": 3},
+            {"product_path": "surveys", "colleague_count": 2},
+        ]
+
+        created_items = UserProductList.sync_from_team_colleagues(
+            user=user, team=self.team, count=2, colleague_product_counts=hardcoded_counts
+        )
+
+        assert len(created_items) == 2
+        product_paths = {item.product_path for item in created_items}
+        assert "product_analytics" not in product_paths
+        assert "feature_flags" not in product_paths
+        assert "session_replay" in product_paths
+        assert "surveys" in product_paths
+
+        all_user_products = UserProductList.objects.filter(user=user, team=self.team, enabled=True)
+        assert all_user_products.filter(product_path="session_replay").exists()
+        assert all_user_products.filter(product_path="surveys").exists()
+        assert all_user_products.filter(product_path="product_analytics").exists()
+        assert all_user_products.filter(product_path="feature_flags").exists()
+
+        for item in created_items:
+            assert item.reason == UserProductList.Reason.USED_BY_COLLEAGUES
+            assert item.enabled is True
+
+    def test_sync_ranks_by_precomputed_counts(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+        user.join(organization=self.organization)
+
+        hardcoded_counts = [
+            {"product_path": "product_analytics", "colleague_count": 10},
+            {"product_path": "session_replay", "colleague_count": 8},
+            {"product_path": "feature_flags", "colleague_count": 5},
+            {"product_path": "surveys", "colleague_count": 3},
+            {"product_path": "experiments", "colleague_count": 1},
+        ]
+
+        created_items = UserProductList.sync_from_team_colleagues(
+            user=user, team=self.team, count=3, colleague_product_counts=hardcoded_counts
+        )
+
+        assert len(created_items) == 3
+        product_paths = [item.product_path for item in created_items]
+        assert set(product_paths) == {"product_analytics", "session_replay", "feature_flags"}
+        assert product_paths[0] == "product_analytics"
+        assert product_paths[1] == "session_replay"
+        assert product_paths[2] == "feature_flags"
+
+    def test_sync_respects_count_limit(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+        user.join(organization=self.organization)
+
+        hardcoded_counts = [
+            {"product_path": "product_analytics", "colleague_count": 10},
+            {"product_path": "session_replay", "colleague_count": 8},
+            {"product_path": "feature_flags", "colleague_count": 5},
+            {"product_path": "surveys", "colleague_count": 3},
+        ]
+
+        created_items = UserProductList.sync_from_team_colleagues(
+            user=user, team=self.team, count=2, colleague_product_counts=hardcoded_counts
+        )
+
+        assert len(created_items) == 2
+        product_paths = {item.product_path for item in created_items}
+        assert product_paths == {"product_analytics", "session_replay"}
+
+    def test_sync_respects_allow_sidebar_suggestions_false(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=False
+        )
+        user.join(organization=self.organization)
+
+        hardcoded_counts = [
+            {"product_path": "product_analytics", "colleague_count": 10},
+            {"product_path": "session_replay", "colleague_count": 8},
+        ]
+
+        created_items = UserProductList.sync_from_team_colleagues(
+            user=user, team=self.team, colleague_product_counts=hardcoded_counts
+        )
+
+        assert len(created_items) == 0
+
+    def test_sync_computes_counts_when_not_provided(self):
+        colleague1 = User.objects.create_user(
+            email="colleague1@posthog.com", password="password", first_name="Colleague1", allow_sidebar_suggestions=True
+        )
+        colleague2 = User.objects.create_user(
+            email="colleague2@posthog.com", password="password", first_name="Colleague2", allow_sidebar_suggestions=True
+        )
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+
+        colleague1.join(organization=self.organization)
+        colleague2.join(organization=self.organization)
+        user.join(organization=self.organization)
+
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="session_replay", enabled=True)
+
+        created_items = UserProductList.sync_from_team_colleagues(user=user, team=self.team, count=2)
+
+        assert len(created_items) == 2
+        product_paths = {item.product_path for item in created_items}
+        assert "product_analytics" in product_paths
+        assert "session_replay" in product_paths
+
+    def test_sync_does_not_duplicate_existing_products(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+        user.join(organization=self.organization)
+
+        UserProductList.objects.create(user=user, team=self.team, product_path="product_analytics", enabled=True)
+
+        hardcoded_counts = [
+            {"product_path": "product_analytics", "colleague_count": 10},
+            {"product_path": "session_replay", "colleague_count": 8},
+        ]
+
+        created_items = UserProductList.sync_from_team_colleagues(
+            user=user, team=self.team, colleague_product_counts=hardcoded_counts
+        )
+
+        assert len(created_items) == 1
+        assert created_items[0].product_path == "session_replay"
+
+        all_user_products = UserProductList.objects.filter(user=user, team=self.team, product_path="product_analytics")
+        assert all_user_products.count() == 1
+
+    def test_get_user_product_list_count(self):
+        colleague1 = User.objects.create_user(
+            email="colleague1@posthog.com", password="password", first_name="Colleague1", allow_sidebar_suggestions=True
+        )
+        colleague2 = User.objects.create_user(
+            email="colleague2@posthog.com", password="password", first_name="Colleague2", allow_sidebar_suggestions=True
+        )
+        colleague3 = User.objects.create_user(
+            email="colleague3@posthog.com", password="password", first_name="Colleague3", allow_sidebar_suggestions=True
+        )
+        colleague4 = User.objects.create_user(
+            email="colleague4@posthog.com", password="password", first_name="Colleague4", allow_sidebar_suggestions=True
+        )
+
+        colleague1.join(organization=self.organization)
+        colleague2.join(organization=self.organization)
+        colleague3.join(organization=self.organization)
+        colleague4.join(organization=self.organization)
+
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=colleague3, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=colleague4, team=self.team, product_path="product_analytics", enabled=True)
+
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="session_replay", enabled=True)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="session_replay", enabled=True)
+        UserProductList.objects.create(user=colleague3, team=self.team, product_path="session_replay", enabled=True)
+
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="feature_flags", enabled=True)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="feature_flags", enabled=True)
+
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="surveys", enabled=True)
+
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="experiments", enabled=False)
+
+        counts = get_user_product_list_count(self.team)
+
+        assert len(counts) == 4
+        assert counts[0]["product_path"] == "product_analytics"
+        assert counts[0]["colleague_count"] == 4
+        assert counts[1]["product_path"] == "session_replay"
+        assert counts[1]["colleague_count"] == 3
+        assert counts[2]["product_path"] == "feature_flags"
+        assert counts[2]["colleague_count"] == 2
+        assert counts[3]["product_path"] == "surveys"
+        assert counts[3]["colleague_count"] == 1
+
+    def test_get_user_product_list_count_excludes_disabled_products(self):
+        colleague1 = User.objects.create_user(
+            email="colleague1@posthog.com", password="password", first_name="Colleague1", allow_sidebar_suggestions=True
+        )
+        colleague2 = User.objects.create_user(
+            email="colleague2@posthog.com", password="password", first_name="Colleague2", allow_sidebar_suggestions=True
+        )
+
+        colleague1.join(organization=self.organization)
+        colleague2.join(organization=self.organization)
+
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="session_replay", enabled=False)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="session_replay", enabled=False)
+
+        counts = get_user_product_list_count(self.team)
+
+        assert len(counts) == 1
+        assert counts[0]["product_path"] == "product_analytics"
+        assert counts[0]["colleague_count"] == 2
+
+    def test_get_user_product_list_count_handles_empty_team(self):
+        counts = get_user_product_list_count(self.team)
+        assert len(counts) == 0

--- a/posthog/models/file_system/test/test_user_product_list.py
+++ b/posthog/models/file_system/test/test_user_product_list.py
@@ -11,14 +11,14 @@ class TestUserProductList(BaseTest):
         )
         user.join(organization=self.organization)
 
-        UserProductList.objects.create(user=user, team=self.team, product_path="product_analytics", enabled=True)
-        UserProductList.objects.create(user=user, team=self.team, product_path="feature_flags", enabled=True)
+        UserProductList.objects.create(user=user, team=self.team, product_path="Product analytics", enabled=True)
+        UserProductList.objects.create(user=user, team=self.team, product_path="Feature flags", enabled=True)
 
         hardcoded_counts = [
-            {"product_path": "product_analytics", "colleague_count": 5},
-            {"product_path": "session_replay", "colleague_count": 4},
-            {"product_path": "feature_flags", "colleague_count": 3},
-            {"product_path": "surveys", "colleague_count": 2},
+            {"product_path": "Product analytics", "colleague_count": 5},
+            {"product_path": "Session replay", "colleague_count": 4},
+            {"product_path": "Feature flags", "colleague_count": 3},
+            {"product_path": "Surveys", "colleague_count": 2},
         ]
 
         created_items = UserProductList.sync_from_team_colleagues(
@@ -27,16 +27,16 @@ class TestUserProductList(BaseTest):
 
         assert len(created_items) == 2
         product_paths = {item.product_path for item in created_items}
-        assert "product_analytics" not in product_paths
-        assert "feature_flags" not in product_paths
-        assert "session_replay" in product_paths
-        assert "surveys" in product_paths
+        assert "Product analytics" not in product_paths
+        assert "Feature flags" not in product_paths
+        assert "Session replay" in product_paths
+        assert "Surveys" in product_paths
 
         all_user_products = UserProductList.objects.filter(user=user, team=self.team, enabled=True)
-        assert all_user_products.filter(product_path="session_replay").exists()
-        assert all_user_products.filter(product_path="surveys").exists()
-        assert all_user_products.filter(product_path="product_analytics").exists()
-        assert all_user_products.filter(product_path="feature_flags").exists()
+        assert all_user_products.filter(product_path="Session replay").exists()
+        assert all_user_products.filter(product_path="Surveys").exists()
+        assert all_user_products.filter(product_path="Product analytics").exists()
+        assert all_user_products.filter(product_path="Feature flags").exists()
 
         for item in created_items:
             assert item.reason == UserProductList.Reason.USED_BY_COLLEAGUES
@@ -49,11 +49,11 @@ class TestUserProductList(BaseTest):
         user.join(organization=self.organization)
 
         hardcoded_counts = [
-            {"product_path": "product_analytics", "colleague_count": 10},
-            {"product_path": "session_replay", "colleague_count": 8},
-            {"product_path": "feature_flags", "colleague_count": 5},
-            {"product_path": "surveys", "colleague_count": 3},
-            {"product_path": "experiments", "colleague_count": 1},
+            {"product_path": "Product analytics", "colleague_count": 10},
+            {"product_path": "Session replay", "colleague_count": 8},
+            {"product_path": "Feature flags", "colleague_count": 5},
+            {"product_path": "Surveys", "colleague_count": 3},
+            {"product_path": "Experiments", "colleague_count": 1},
         ]
 
         created_items = UserProductList.sync_from_team_colleagues(
@@ -62,10 +62,10 @@ class TestUserProductList(BaseTest):
 
         assert len(created_items) == 3
         product_paths = [item.product_path for item in created_items]
-        assert set(product_paths) == {"product_analytics", "session_replay", "feature_flags"}
-        assert product_paths[0] == "product_analytics"
-        assert product_paths[1] == "session_replay"
-        assert product_paths[2] == "feature_flags"
+        assert set(product_paths) == {"Product analytics", "Session replay", "Feature flags"}
+        assert product_paths[0] == "Product analytics"
+        assert product_paths[1] == "Session replay"
+        assert product_paths[2] == "Feature flags"
 
     def test_sync_respects_count_limit(self):
         user = User.objects.create_user(
@@ -74,10 +74,10 @@ class TestUserProductList(BaseTest):
         user.join(organization=self.organization)
 
         hardcoded_counts = [
-            {"product_path": "product_analytics", "colleague_count": 10},
-            {"product_path": "session_replay", "colleague_count": 8},
-            {"product_path": "feature_flags", "colleague_count": 5},
-            {"product_path": "surveys", "colleague_count": 3},
+            {"product_path": "Product analytics", "colleague_count": 10},
+            {"product_path": "Session replay", "colleague_count": 8},
+            {"product_path": "Feature flags", "colleague_count": 5},
+            {"product_path": "Surveys", "colleague_count": 3},
         ]
 
         created_items = UserProductList.sync_from_team_colleagues(
@@ -86,7 +86,7 @@ class TestUserProductList(BaseTest):
 
         assert len(created_items) == 2
         product_paths = {item.product_path for item in created_items}
-        assert product_paths == {"product_analytics", "session_replay"}
+        assert product_paths == {"Product analytics", "Session replay"}
 
     def test_sync_respects_allow_sidebar_suggestions_false(self):
         user = User.objects.create_user(
@@ -95,8 +95,8 @@ class TestUserProductList(BaseTest):
         user.join(organization=self.organization)
 
         hardcoded_counts = [
-            {"product_path": "product_analytics", "colleague_count": 10},
-            {"product_path": "session_replay", "colleague_count": 8},
+            {"product_path": "Product analytics", "colleague_count": 10},
+            {"product_path": "Session replay", "colleague_count": 8},
         ]
 
         created_items = UserProductList.sync_from_team_colleagues(
@@ -120,16 +120,16 @@ class TestUserProductList(BaseTest):
         colleague2.join(organization=self.organization)
         user.join(organization=self.organization)
 
-        UserProductList.objects.create(user=colleague1, team=self.team, product_path="product_analytics", enabled=True)
-        UserProductList.objects.create(user=colleague2, team=self.team, product_path="product_analytics", enabled=True)
-        UserProductList.objects.create(user=colleague1, team=self.team, product_path="session_replay", enabled=True)
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="Product analytics", enabled=True)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="Product analytics", enabled=True)
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="Session replay", enabled=True)
 
         created_items = UserProductList.sync_from_team_colleagues(user=user, team=self.team, count=2)
 
         assert len(created_items) == 2
         product_paths = {item.product_path for item in created_items}
-        assert "product_analytics" in product_paths
-        assert "session_replay" in product_paths
+        assert "Product analytics" in product_paths
+        assert "Session replay" in product_paths
 
     def test_sync_does_not_duplicate_existing_products(self):
         user = User.objects.create_user(
@@ -137,11 +137,11 @@ class TestUserProductList(BaseTest):
         )
         user.join(organization=self.organization)
 
-        UserProductList.objects.create(user=user, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=user, team=self.team, product_path="Product analytics", enabled=True)
 
         hardcoded_counts = [
-            {"product_path": "product_analytics", "colleague_count": 10},
-            {"product_path": "session_replay", "colleague_count": 8},
+            {"product_path": "Product analytics", "colleague_count": 10},
+            {"product_path": "Session replay", "colleague_count": 8},
         ]
 
         created_items = UserProductList.sync_from_team_colleagues(
@@ -149,9 +149,9 @@ class TestUserProductList(BaseTest):
         )
 
         assert len(created_items) == 1
-        assert created_items[0].product_path == "session_replay"
+        assert created_items[0].product_path == "Session replay"
 
-        all_user_products = UserProductList.objects.filter(user=user, team=self.team, product_path="product_analytics")
+        all_user_products = UserProductList.objects.filter(user=user, team=self.team, product_path="Product analytics")
         assert all_user_products.count() == 1
 
     def test_get_user_product_list_count(self):
@@ -173,32 +173,32 @@ class TestUserProductList(BaseTest):
         colleague3.join(organization=self.organization)
         colleague4.join(organization=self.organization)
 
-        UserProductList.objects.create(user=colleague1, team=self.team, product_path="product_analytics", enabled=True)
-        UserProductList.objects.create(user=colleague2, team=self.team, product_path="product_analytics", enabled=True)
-        UserProductList.objects.create(user=colleague3, team=self.team, product_path="product_analytics", enabled=True)
-        UserProductList.objects.create(user=colleague4, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="Product analytics", enabled=True)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="Product analytics", enabled=True)
+        UserProductList.objects.create(user=colleague3, team=self.team, product_path="Product analytics", enabled=True)
+        UserProductList.objects.create(user=colleague4, team=self.team, product_path="Product analytics", enabled=True)
 
-        UserProductList.objects.create(user=colleague1, team=self.team, product_path="session_replay", enabled=True)
-        UserProductList.objects.create(user=colleague2, team=self.team, product_path="session_replay", enabled=True)
-        UserProductList.objects.create(user=colleague3, team=self.team, product_path="session_replay", enabled=True)
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="Session replay", enabled=True)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="Session replay", enabled=True)
+        UserProductList.objects.create(user=colleague3, team=self.team, product_path="Session replay", enabled=True)
 
-        UserProductList.objects.create(user=colleague1, team=self.team, product_path="feature_flags", enabled=True)
-        UserProductList.objects.create(user=colleague2, team=self.team, product_path="feature_flags", enabled=True)
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="Feature flags", enabled=True)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="Feature flags", enabled=True)
 
-        UserProductList.objects.create(user=colleague1, team=self.team, product_path="surveys", enabled=True)
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="Surveys", enabled=True)
 
-        UserProductList.objects.create(user=colleague1, team=self.team, product_path="experiments", enabled=False)
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="Experiments", enabled=False)
 
         counts = get_user_product_list_count(self.team)
 
         assert len(counts) == 4
-        assert counts[0]["product_path"] == "product_analytics"
+        assert counts[0]["product_path"] == "Product analytics"
         assert counts[0]["colleague_count"] == 4
-        assert counts[1]["product_path"] == "session_replay"
+        assert counts[1]["product_path"] == "Session replay"
         assert counts[1]["colleague_count"] == 3
-        assert counts[2]["product_path"] == "feature_flags"
+        assert counts[2]["product_path"] == "Feature flags"
         assert counts[2]["colleague_count"] == 2
-        assert counts[3]["product_path"] == "surveys"
+        assert counts[3]["product_path"] == "Surveys"
         assert counts[3]["colleague_count"] == 1
 
     def test_get_user_product_list_count_excludes_disabled_products(self):
@@ -212,15 +212,15 @@ class TestUserProductList(BaseTest):
         colleague1.join(organization=self.organization)
         colleague2.join(organization=self.organization)
 
-        UserProductList.objects.create(user=colleague1, team=self.team, product_path="product_analytics", enabled=True)
-        UserProductList.objects.create(user=colleague2, team=self.team, product_path="product_analytics", enabled=True)
-        UserProductList.objects.create(user=colleague1, team=self.team, product_path="session_replay", enabled=False)
-        UserProductList.objects.create(user=colleague2, team=self.team, product_path="session_replay", enabled=False)
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="Product analytics", enabled=True)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="Product analytics", enabled=True)
+        UserProductList.objects.create(user=colleague1, team=self.team, product_path="Session replay", enabled=False)
+        UserProductList.objects.create(user=colleague2, team=self.team, product_path="Session replay", enabled=False)
 
         counts = get_user_product_list_count(self.team)
 
         assert len(counts) == 1
-        assert counts[0]["product_path"] == "product_analytics"
+        assert counts[0]["product_path"] == "Product analytics"
         assert counts[0]["colleague_count"] == 2
 
     def test_get_user_product_list_count_handles_empty_team(self):

--- a/posthog/models/file_system/user_product_list.py
+++ b/posthog/models/file_system/user_product_list.py
@@ -18,6 +18,19 @@ if TYPE_CHECKING:
     from posthog.models.product_intent.product_intent import ProductIntent
 
 
+def get_user_product_list_count(team: Team) -> list[dict[str, int]]:
+    """
+    Get product counts for all items in a team, ranked by popularity.
+    Returns a list of dicts with 'product_path' and 'colleague_count' keys, ordered by count descending.
+    """
+    return list(
+        UserProductList.objects.filter(team=team, enabled=True)
+        .values("product_path")
+        .annotate(colleague_count=Count("user", distinct=True))
+        .order_by("-colleague_count")
+    )
+
+
 class UserProductList(UUIDModel, UpdatedMetaFields):
     """
     Stores a user's custom list of products they care about.
@@ -112,11 +125,23 @@ class UserProductList(UUIDModel, UpdatedMetaFields):
         return user_product_lists
 
     @staticmethod
-    def sync_from_team_colleagues(user: User, team: Team, count: int = 1) -> "list[UserProductList]":
+    def sync_from_team_colleagues(
+        user: User,
+        team: Team,
+        count: int = 1,
+        colleague_product_counts: list[dict[str, int]] | None = None,
+    ) -> "list[UserProductList]":
         """
         Create UserProductList entries for a user based on what their team colleagues have.
         Products are ranked by how many colleagues have them enabled, and only the top `count`
         items that the user doesn't already have enabled are included.
+
+        Args:
+            user: The user to sync products for
+            team: The team to check colleagues in
+            count: Maximum number of products to suggest
+            colleague_product_counts: Optional precomputed colleague product counts.
+                If not provided, will be computed automatically.
         """
         if user.allow_sidebar_suggestions is False:
             return []
@@ -127,13 +152,8 @@ class UserProductList(UUIDModel, UpdatedMetaFields):
         )
 
         # Count how many colleagues have each product_path enabled
-        colleague_product_counts = (
-            UserProductList.objects.filter(team=team, enabled=True)
-            .exclude(user=user)
-            .values("product_path")
-            .annotate(colleague_count=Count("user", distinct=True))
-            .order_by("-colleague_count")
-        )
+        if colleague_product_counts is None:
+            colleague_product_counts = get_user_product_list_count(team)
 
         # Filter out products user already has and take top `count` items
         top_products = [

--- a/posthog/models/file_system/user_product_list.py
+++ b/posthog/models/file_system/user_product_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from django.conf import settings
 from django.db import models, transaction
@@ -18,12 +18,12 @@ if TYPE_CHECKING:
     from posthog.models.product_intent.product_intent import ProductIntent
 
 
-def get_user_product_list_count(team: Team) -> list[dict[str, int]]:
+def get_user_product_list_count(team: Team) -> list[dict[str, Any]]:
     """
     Get product counts for all items in a team, ranked by popularity.
     Returns a list of dicts with 'product_path' and 'colleague_count' keys, ordered by count descending.
     """
-    return list(
+    return list[dict[str, Any]](
         UserProductList.objects.filter(team=team, enabled=True)
         .values("product_path")
         .annotate(colleague_count=Count("user", distinct=True))
@@ -129,7 +129,7 @@ class UserProductList(UUIDModel, UpdatedMetaFields):
         user: User,
         team: Team,
         count: int = 1,
-        colleague_product_counts: list[dict[str, int]] | None = None,
+        colleague_product_counts: list[dict[str, Any]] | None = None,
     ) -> "list[UserProductList]":
         """
         Create UserProductList entries for a user based on what their team colleagues have.


### PR DESCRIPTION
We're now running a monthly job (every 15th of the monster) to add some items to your sidebar
as suggested by what your colleagues on the same team are using.

This will guarantee people slowly see more stuff in their sidebar and improve cross-selling across different teams of people using PostHog (for example one posthog team using error tracking will slowly infect other teams with error tracking on their sidebar)