### PR TITLE
feat(dmat_columns): Add migration to add dmat columns to ingestion

### DIFF
--- a/posthog/clickhouse/migrations/0181_add_materialize_column_slots_ingestion.py
+++ b/posthog/clickhouse/migrations/0181_add_materialize_column_slots_ingestion.py
@@ -7,14 +7,6 @@ from posthog.models.event.sql import (
     WRITABLE_EVENTS_DATA_TABLE,
 )
 
-DETACH_KAFKA = """
-    DETACH TABLE IF EXISTS kafka_events_json;
-"""
-
-ATTACH_KAFKA = """
-    ATTACH TABLE IF EXISTS kafka_events_json;
-"""
-
 DROP_EVENTS_TABLE_JSON_MV = """
     DROP TABLE IF EXISTS events_json_mv SYNC;
 """

--- a/posthog/clickhouse/migrations/0181_add_materialize_column_slots_ingestion.py
+++ b/posthog/clickhouse/migrations/0181_add_materialize_column_slots_ingestion.py
@@ -1,0 +1,56 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.event.sql import (
+    ALTER_TABLE_ADD_DYNAMICALLY_MATERIALIZED_COLUMNS,
+    EVENTS_TABLE_JSON_MV_SQL,
+    WRITABLE_EVENTS_DATA_TABLE,
+)
+
+DETACH_KAFKA = """
+    DETACH TABLE kafka_events_json;
+"""
+
+ATTACH_KAFKA = """
+    ATTACH TABLE kafka_events_json;
+"""
+
+DROP_EVENTS_JSON_MV = """
+    ATTACH TABLE events_json_mv;
+"""
+
+# See when these were added to the sharded / distributed tables in 0179
+
+operations = [
+    # pause ingestion from the kafka tables
+    run_sql_with_exceptions(DETACH_KAFKA, node_roles=[NodeRole.INGESTION_EVENTS]),
+    # writeable table
+    run_sql_with_exceptions(
+        ALTER_TABLE_ADD_DYNAMICALLY_MATERIALIZED_COLUMNS(table=WRITABLE_EVENTS_DATA_TABLE()),
+        node_roles=[NodeRole.INGESTION_EVENTS],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # kafka table
+    run_sql_with_exceptions(
+        ALTER_TABLE_ADD_DYNAMICALLY_MATERIALIZED_COLUMNS(table="kafka_events_json"),
+        node_roles=[NodeRole.INGESTION_EVENTS],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    # drop MV
+    run_sql_with_exceptions(
+        DROP_EVENTS_JSON_MV,
+        node_roles=[NodeRole.INGESTION_EVENTS],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # recreate MV
+    run_sql_with_exceptions(
+        EVENTS_TABLE_JSON_MV_SQL(),
+        node_roles=[NodeRole.INGESTION_EVENTS],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # resume ingestion
+    run_sql_with_exceptions(ATTACH_KAFKA, node_roles=[NodeRole.INGESTION_EVENTS]),
+]

--- a/posthog/clickhouse/migrations/0181_add_materialize_column_slots_ingestion.py
+++ b/posthog/clickhouse/migrations/0181_add_materialize_column_slots_ingestion.py
@@ -3,6 +3,7 @@ from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.event.sql import (
     ALTER_TABLE_ADD_DYNAMICALLY_MATERIALIZED_COLUMNS,
     EVENTS_TABLE_JSON_MV_SQL,
+    KAFKA_EVENTS_TABLE_JSON_SQL,
     WRITABLE_EVENTS_DATA_TABLE,
 )
 
@@ -14,8 +15,12 @@ ATTACH_KAFKA = """
     ATTACH TABLE IF EXISTS kafka_events_json;
 """
 
-DROP_EVENTS_JSON_MV = """
+DROP_EVENTS_TABLE_JSON_MV = """
     DROP TABLE IF EXISTS events_json_mv SYNC;
+"""
+
+DROP_KAFKA_EVENTS_TABLE = """
+    DROP TABLE IF EXISTS kafka_events_json SYNC;
 """
 
 # See when these were added to the sharded / distributed tables in 0179
@@ -28,31 +33,32 @@ operations = [
         sharded=False,
         is_alter_on_replicated_table=False,
     ),
-    # kafka table
+    # drop events mv
     run_sql_with_exceptions(
-        ALTER_TABLE_ADD_DYNAMICALLY_MATERIALIZED_COLUMNS(table="kafka_events_json"),
+        DROP_EVENTS_TABLE_JSON_MV,
         node_roles=[NodeRole.INGESTION_EVENTS],
         sharded=False,
         is_alter_on_replicated_table=False,
     ),
-    # pause ingestion from the kafka tables
+    # drop kafka table
     run_sql_with_exceptions(
-        DETACH_KAFKA, node_roles=[NodeRole.INGESTION_EVENTS], sharded=False, is_alter_on_replicated_table=False
-    ),
-    # drop MV
-    run_sql_with_exceptions(
-        DROP_EVENTS_JSON_MV,
+        DROP_KAFKA_EVENTS_TABLE,
         node_roles=[NodeRole.INGESTION_EVENTS],
         sharded=False,
         is_alter_on_replicated_table=False,
     ),
-    # recreate MV
+    # recreate kafka table
+    run_sql_with_exceptions(
+        KAFKA_EVENTS_TABLE_JSON_SQL(),
+        node_roles=[NodeRole.INGESTION_EVENTS],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # recreate events MV
     run_sql_with_exceptions(
         EVENTS_TABLE_JSON_MV_SQL(),
         node_roles=[NodeRole.INGESTION_EVENTS],
         sharded=False,
         is_alter_on_replicated_table=False,
     ),
-    # resume ingestion
-    run_sql_with_exceptions(ATTACH_KAFKA, node_roles=[NodeRole.INGESTION_EVENTS]),
 ]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0180_sessions_v3_add_event_names
+0181_add_materialize_column_slots_ingestion


### PR DESCRIPTION
## Problem

See https://github.com/PostHog/posthog/pull/41723 for more context. This PR is the clickhouse migration to make that work.

## Changes

I'm not convinced that this doesn't drop events; this definitely needs eyes from @PostHog/clickhouse

## How did you test this code?

The migration runs locally.

If I run this migration, the switch to https://github.com/PostHog/posthog/pull/41723 and set up some dmat columns, I will get data in those columns
👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
