### PR TITLE
feat: Add monthly job for cross-selling products

### DIFF
--- a/dags/locations/growth.py
+++ b/dags/locations/growth.py
@@ -12,12 +12,14 @@ defs = dagster.Definitions(
         team_sdk_versions.cache_all_team_sdk_versions_job,
         user_product_list.populate_user_product_list_job,
         user_product_list.sync_colleagues_products_monthly_job,
+        user_product_list.sync_cross_sell_products_monthly_job,
     ],
     schedules=[
         oauth.oauth_clear_expired_oauth_tokens_schedule,
         github_sdk_versions.cache_github_sdk_versions_schedule,
         team_sdk_versions.cache_all_team_sdk_versions_schedule,
         user_product_list.sync_colleagues_products_monthly_schedule,
+        user_product_list.sync_cross_sell_products_monthly_schedule,
     ],
     resources=resources,
 )

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -46,7 +46,7 @@
                WHERE equals(person_distinct_id_overrides.team_id, 99999)
                GROUP BY person_distinct_id_overrides.distinct_id
                HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-11 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-12 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
          GROUP BY actor_id) AS source
       ORDER BY source.id ASC
       LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -59,7 +59,7 @@
                                                                                          actor_id AS id
                                                                                   FROM
                                                                                     (SELECT min(toTimeZone(e.timestamp, 'UTC')) AS min_timestamp,
-                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-11 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
+                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-12 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
                                                                                             if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
                                                                                             argMin(e.uuid, toTimeZone(e.timestamp, 'UTC')) AS uuid,
                                                                                             argMin(e.distinct_id, toTimeZone(e.timestamp, 'UTC')) AS distinct_id
@@ -213,7 +213,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-17 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$new_view'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$new_view'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -454,7 +454,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -932,7 +932,7 @@
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
                               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC
                      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1195,7 +1195,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1276,7 +1276,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -1376,7 +1376,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -1397,7 +1397,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), equals(events.event, '$new_view'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')))
+        WHERE and(equals(events.team_id, 99999), equals(events.event, '$new_view'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')))
         GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)
         HAVING ifNull(greaterOrEquals(count(), 1), 0)
         ORDER BY count() DESC)
@@ -1499,7 +1499,7 @@
                  WHERE equals(person_distinct_id_overrides.team_id, 99999)
                  GROUP BY person_distinct_id_overrides.distinct_id
                  HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
            GROUP BY aggregation_target
            HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
         WHERE bitTest(steps_bitfield, 1)
@@ -1519,7 +1519,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')))
+        WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')))
         GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)
         HAVING ifNull(greaterOrEquals(count(), 1), 0)
         ORDER BY count() DESC)
@@ -1636,7 +1636,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$filter_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0), greaterOrEquals(timestamp, toDateTime64('2025-11-22 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$filter_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0), greaterOrEquals(timestamp, toDateTime64('2025-11-23 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1702,7 +1702,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1795,7 +1795,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1913,7 +1913,7 @@
                WHERE equals(person_distinct_id_overrides.team_id, 99999)
                GROUP BY person_distinct_id_overrides.distinct_id
                HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-11 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-12 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
          GROUP BY actor_id) AS source
       ORDER BY source.id ASC
       LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -1942,7 +1942,7 @@
                                                                                          actor_id AS id
                                                                                   FROM
                                                                                     (SELECT min(toTimeZone(e.timestamp, 'UTC')) AS min_timestamp,
-                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-11 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
+                                                                                            minIf(toTimeZone(e.timestamp, 'UTC'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2025-11-12 00:00:00.000000', 6, 'UTC'))) AS min_timestamp_with_condition,
                                                                                             if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
                                                                                             argMin(e.uuid, toTimeZone(e.timestamp, 'UTC')) AS uuid,
                                                                                             argMin(e.distinct_id, toTimeZone(e.timestamp, 'UTC')) AS distinct_id
@@ -2381,7 +2381,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -2466,7 +2466,7 @@
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
                               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC
                      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -2566,7 +2566,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-19 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
         GROUP BY actor_id) AS source
      ORDER BY source.id ASC
      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,

--- a/posthog/models/file_system/test/test_user_product_list.py
+++ b/posthog/models/file_system/test/test_user_product_list.py
@@ -2,6 +2,7 @@ from posthog.test.base import BaseTest
 
 from posthog.models import User
 from posthog.models.file_system.user_product_list import UserProductList, get_user_product_list_count
+from posthog.products import Products
 
 
 class TestUserProductList(BaseTest):
@@ -226,3 +227,133 @@ class TestUserProductList(BaseTest):
     def test_get_user_product_list_count_handles_empty_team(self):
         counts = get_user_product_list_count(self.team)
         assert len(counts) == 0
+
+    def test_sync_cross_sell_products_suggests_same_category(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+        user.join(organization=self.organization)
+
+        UserProductList.objects.create(user=user, team=self.team, product_path="Product analytics", enabled=True)
+
+        created_items = UserProductList.sync_cross_sell_products(user=user, team=self.team)
+
+        by_category = Products.get_products_by_category()
+        analytics_category = by_category.get("Analytics")
+        assert analytics_category is not None
+
+        assert len(created_items) >= 0
+        for item in created_items:
+            assert item.reason == UserProductList.Reason.USED_SIMILAR_PRODUCTS
+            assert item.enabled is True
+            assert item.product_path in analytics_category
+
+    def test_sync_cross_sell_products_excludes_existing_products(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+        user.join(organization=self.organization)
+
+        UserProductList.objects.create(user=user, team=self.team, product_path="Product analytics", enabled=True)
+        UserProductList.objects.create(user=user, team=self.team, product_path="Dashboards", enabled=True)
+
+        created_items: list[UserProductList] = []
+        while True:
+            items = UserProductList.sync_cross_sell_products(user=user, team=self.team)
+            if len(items) == 0:
+                break
+            items.extend(created_items)
+
+        created_paths = {item.product_path for item in created_items}
+        assert "Product analytics" not in created_paths
+        assert "Dashboards" not in created_paths
+
+    def test_sync_cross_sell_products_respects_allow_sidebar_suggestions_false(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=False
+        )
+        user.join(organization=self.organization)
+
+        UserProductList.objects.create(user=user, team=self.team, product_path="Product analytics", enabled=True)
+
+        created_items = UserProductList.sync_cross_sell_products(user=user, team=self.team)
+        assert len(created_items) == 0
+
+    def test_sync_cross_sell_products_respects_max_products(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+        user.join(organization=self.organization)
+
+        UserProductList.objects.create(user=user, team=self.team, product_path="Product analytics", enabled=True)
+
+        created_items = UserProductList.sync_cross_sell_products(user=user, team=self.team, max_products=2)
+        assert len(created_items) == 2
+
+    def test_sync_cross_sell_products_handles_empty_cross_sell_options(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+        user.join(organization=self.organization)
+
+        created_items = UserProductList.sync_cross_sell_products(user=user, team=self.team)
+        assert len(created_items) == 0
+
+    def test_sync_cross_sell_products_suggests_from_analytics_category(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+        user.join(organization=self.organization)
+
+        UserProductList.objects.create(user=user, team=self.team, product_path="Product analytics", enabled=True)
+
+        created_items = UserProductList.sync_cross_sell_products(user=user, team=self.team)
+
+        products_by_category = Products.get_products_by_category()
+        analytics_products = set(products_by_category.get("Analytics", []))
+
+        created_paths = {item.product_path for item in created_items}
+        for path in created_paths:
+            assert path in analytics_products
+            assert path != "Product analytics"
+
+    def test_sync_cross_sell_products_ignores_tools_and_unreleased_categories(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+        user.join(organization=self.organization)
+
+        products_by_category = Products.get_products_by_category()
+        tools_products = products_by_category.get("Tools", [])
+        unreleased_products = products_by_category.get("Unreleased", [])
+
+        # Add a product from the Tools category
+        assert "Data pipelines" in products_by_category.get("Tools", [])
+        UserProductList.objects.create(user=user, team=self.team, product_path="Data pipelines", enabled=True)
+
+        # Add a product from the Unreleased category
+        assert "Customer analytics" in products_by_category.get("Unreleased", [])
+        UserProductList.objects.create(user=user, team=self.team, product_path="Customer analytics", enabled=True)
+
+        created_items = UserProductList.sync_cross_sell_products(user=user, team=self.team)
+        created_paths = {item.product_path for item in created_items}
+        assert not created_paths.intersection(tools_products)
+        assert not created_paths.intersection(unreleased_products)
+
+    def test_sync_cross_sell_products_respects_custom_ignored_categories(self):
+        user = User.objects.create_user(
+            email="user@posthog.com", password="password", first_name="User", allow_sidebar_suggestions=True
+        )
+        user.join(organization=self.organization)
+
+        UserProductList.objects.create(user=user, team=self.team, product_path="Product analytics", enabled=True)
+
+        created_items = UserProductList.sync_cross_sell_products(
+            user=user, team=self.team, ignored_categories=["Analytics"]
+        )
+
+        products_by_category = Products.get_products_by_category()
+        analytics_products = set(products_by_category.get("Analytics", []))
+
+        created_paths = {item.product_path for item in created_items}
+        assert not created_paths.intersection(analytics_products)

--- a/posthog/models/file_system/test/test_user_product_list.py
+++ b/posthog/models/file_system/test/test_user_product_list.py
@@ -262,7 +262,7 @@ class TestUserProductList(BaseTest):
             items = UserProductList.sync_cross_sell_products(user=user, team=self.team)
             if len(items) == 0:
                 break
-            items.extend(created_items)
+            created_items.extend(items)
 
         created_paths = {item.product_path for item in created_items}
         assert "Product analytics" not in created_paths

--- a/posthog/products.py
+++ b/posthog/products.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 from pathlib import Path
 from typing import Optional
 
@@ -78,3 +79,12 @@ class Products:
     def get_products_by_intent(intent: ProductKey) -> list[ProductItem]:
         """Get all products that the intent is associated with."""
         return [product for product in Products.products() if intent in product.intents]
+
+    @staticmethod
+    def get_products_by_category() -> dict[str, list[str]]:
+        """Get product mappings grouped by category."""
+        products_by_category: dict[str, list[str]] = defaultdict(list)
+        for product in Products.products():
+            category = product.category or "Other"
+            products_by_category[category].append(product.path)
+        return dict(products_by_category)

--- a/posthog/test/test_products.py
+++ b/posthog/test/test_products.py
@@ -1,0 +1,63 @@
+from posthog.test.base import BaseTest
+
+from posthog.schema import ProductKey
+
+from posthog.products import Products
+
+
+class TestProducts(BaseTest):
+    def test_products_returns_list(self):
+        products = Products.products()
+        assert isinstance(products, list)
+
+    def test_games_returns_list(self):
+        games = Products.games()
+        assert isinstance(games, list)
+
+    def test_metadata_returns_list(self):
+        metadata = Products.metadata()
+        assert isinstance(metadata, list)
+
+    def test_get_products_by_intent_returns_list(self):
+        products = Products.get_products_by_intent(ProductKey.PRODUCT_ANALYTICS)
+        assert isinstance(products, list)
+
+    def test_get_products_by_category_returns_dict(self):
+        products_by_category = Products.get_products_by_category()
+        assert isinstance(products_by_category, dict)
+
+    def test_get_product_paths_returns_list_of_strings(self):
+        paths = Products.get_product_paths()
+        assert isinstance(paths, list)
+        assert all(isinstance(path, str) for path in paths)
+
+    def test_get_products_by_category_has_expected_categories(self):
+        products_by_category = Products.get_products_by_category()
+        categories = set(products_by_category.keys())
+
+        expected_categories = {"Analytics", "Behavior", "Features", "Tools", "Unreleased"}
+        assert categories == expected_categories
+
+    def test_get_products_by_category_each_category_has_list_of_strings(self):
+        products_by_category = Products.get_products_by_category()
+        for category, products in products_by_category.items():
+            assert isinstance(category, str)
+            assert isinstance(products, list)
+            assert all(isinstance(product_path, str) for product_path in products)
+
+    def test_get_products_by_category_products_in_category_exist(self):
+        products_by_category = Products.get_products_by_category()
+        all_product_paths = set(Products.get_product_paths())
+
+        for category, product_paths in products_by_category.items():
+            for product_path in product_paths:
+                assert (
+                    product_path in all_product_paths
+                ), f"Product {product_path} in category {category} not found in all products"
+
+    def test_reload_does_not_raise_error(self):
+        try:
+            Products.reload()
+            assert True
+        except Exception as e:
+            raise AssertionError(f"Products.reload() raised an exception: {e}") from e


### PR DESCRIPTION
Every month we add a new product to the user's sidebar by looking at the products they already have and add a new one from one of their existing categories.
This does mean that we aren't doing cross-selling across categories but that's much harder to do - different ICPs - so let's ignore that for now :)