### PR TITLE
feat: prepare for using team `extra_settings` for replay script choosing

### DIFF
--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -443,8 +443,8 @@ class Team(UUIDTClassicModel):
 
     default_data_theme = models.IntegerField(null=True, blank=True)
 
-    # Generic field for storing any team-specific context that is more temporary in nature and thus
-    # likely doesn't deserve a dedicated column. Can be used for things like settings and overrides
+    # Generic field for storing any team-specific context
+    # that likely doesn't deserve a dedicated column. Can be used for things like settings and overrides
     # during feature releases.
     extra_settings = models.JSONField(null=True, blank=True)
 

--- a/posthog/storage/team_metadata_cache.py
+++ b/posthog/storage/team_metadata_cache.py
@@ -1,7 +1,7 @@
 """
 Team metadata HyperCache - Full team object caching using existing HyperCache infrastructure.
 
-This module provides dedicated caching of complete Team objects (38 fields) using the
+This module provides dedicated caching of complete Team objects (39 fields) using the
 existing HyperCache system which handles Redis + S3 backup automatically.
 
 Memory Usage Estimation:
@@ -95,6 +95,7 @@ TEAM_METADATA_FIELDS = [
     "onboarding_tasks",
     "ingested_event",
     "person_processing_opt_out",
+    "extra_settings",
     "session_recording_opt_in",
     "session_recording_sample_rate",
     "session_recording_minimum_duration_milliseconds",

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -272,6 +272,7 @@ mod tests {
             session_recording_masking_config: None,
             session_replay_config: None,
             survey_config: None,
+            extra_settings: None,
             session_recording_url_trigger_config: None,
             session_recording_url_blocklist_config: None,
             session_recording_event_trigger_config: None,
@@ -867,5 +868,22 @@ mod tests {
         } else {
             panic!("Expected SessionRecordingField::Config when recording_domains is empty list");
         }
+    }
+
+    #[test]
+    fn test_extra_settings_not_exposed_in_response() {
+        let mut response = create_base_response();
+        let config = Config::default_test_config();
+        let mut team = create_base_team();
+
+        team.extra_settings = Some(Json(json!({"internal_config": {"nested": "data"}})));
+
+        apply_core_config_fields(&mut response, &config, &team);
+
+        let serialized = serde_json::to_string(&response).expect("Failed to serialize response");
+        assert!(
+            !serialized.contains("extra_settings"),
+            "Response should not contain extra_settings field"
+        );
     }
 }

--- a/rust/feature-flags/src/team/team_models.rs
+++ b/rust/feature-flags/src/team/team_models.rs
@@ -33,6 +33,7 @@ pub struct Team {
     pub session_recording_masking_config: Option<Json<serde_json::Value>>,
     pub session_replay_config: Option<Json<serde_json::Value>>,
     pub survey_config: Option<Json<serde_json::Value>>,
+    pub extra_settings: Option<Json<serde_json::Value>>,
     pub session_recording_url_trigger_config: Option<Vec<Json<serde_json::Value>>>, // jsonb[] in postgres
     pub session_recording_url_blocklist_config: Option<Vec<Json<serde_json::Value>>>, // jsonb[] in postgres
     pub session_recording_event_trigger_config: Option<Vec<Option<String>>>, // text[] in postgres. NB: this also contains NULL entries along with strings.

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -89,6 +89,7 @@ const TEAM_COLUMNS: &str = "
     session_recording_masking_config,
     session_replay_config,
     survey_config,
+    extra_settings,
     session_recording_url_trigger_config,
     session_recording_url_blocklist_config,
     session_recording_event_trigger_config,


### PR DESCRIPTION
# new remote config step 1 - add the config

this adds the config but does not use it anywhere  
it is to 

- agree the shape of things
- avoid merge conflicts as we work
- check that adding the unued field doesn't break anything

---

making remote config changes need to be done in multiple places
so i'm jumping ahead slightly instead of the small steps i was going to take

we want to roll out the posthog-recorder to more teams

and further down the line we want to make a breaking change to posthog-js (e.g. making the library async)

so we need team config to tell us what version people are on

---

this adds an `sdk_config` field that holds JSON
that can hold a key `recorder_script` which we will sample in using a management command

and further down the line it would hold `posthog-js` version so people could choose to stay on ver 1 or not

---

i need to make the posthog-recorder change in at least two steps and don't want to handle multiple DB migrations to do it

---

this PR will be stacked so you can see what the usage will be

## Changelog: (features only) Is this feature complete?

No