### PR TITLE
feat: sample teams onto recorder script via management command

### DIFF
--- a/posthog/management/commands/set_recorder_script.py
+++ b/posthog/management/commands/set_recorder_script.py
@@ -1,0 +1,86 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+
+from posthog.models import Team
+from posthog.sampling import sample_on_property
+
+
+class Command(BaseCommand):
+    help = """
+    Sets the recorder script for a sample of teams based on team ID hashing.
+
+    Example usage:
+        python manage.py set_recorder_script --script my-recorder --sample-rate 0.1
+        python manage.py set_recorder_script --script my-recorder --sample-rate 0.5 --dry-run
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--script",
+            type=str,
+            required=True,
+            help="The recorder script name to set in sdk_config",
+        )
+        parser.add_argument(
+            "--sample-rate",
+            type=float,
+            required=True,
+            help="Sample rate (0.0 to 1.0) for selecting teams",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show which teams would be updated without actually updating them",
+        )
+
+    def handle(self, *args, **options):
+        script = options["script"]
+        sample_rate = options["sample_rate"]
+        dry_run = options["dry_run"]
+
+        if not 0 <= sample_rate <= 1:
+            raise CommandError("Sample rate must be between 0.0 and 1.0")
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("DRY RUN MODE - No changes will be made"))
+
+        # Get all teams that don't already have a recorder_script set
+        teams = Team.objects.filter(Q(sdk_config__isnull=True) | ~Q(sdk_config__has_key="recorder_script")).only(
+            "id", "sdk_config"
+        )
+
+        total_teams = teams.count()
+        self.stdout.write(f"Found {total_teams} teams without recorder_script set")
+
+        # Sample teams based on team ID and update as we go
+        updated_count = 0
+        sampled_count = 0
+
+        for team in teams.iterator(chunk_size=1000):
+            if sample_on_property(str(team.id), sample_rate):
+                sampled_count += 1
+
+                if not dry_run:
+                    if team.sdk_config is None:
+                        team.sdk_config = {}
+                    team.sdk_config["recorder_script"] = script
+                    team.save(update_fields=["sdk_config"])
+                    updated_count += 1
+
+                    if updated_count % 1000 == 0:
+                        self.stdout.write(f"Updated {updated_count} teams so far...")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Sampled {sampled_count} teams ({sampled_count / total_teams * 100:.1f}%) "
+                f"using sample rate {sample_rate}"
+            )
+        )
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING(f"Would update {sampled_count} teams with script: {script}"))
+            return
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Successfully updated {updated_count} teams with recorder script: {script}")
+        )

--- a/posthog/management/commands/test/test_set_recorder_script.py
+++ b/posthog/management/commands/test/test_set_recorder_script.py
@@ -1,0 +1,140 @@
+from io import StringIO
+
+from posthog.test.base import BaseTest
+
+from django.core.management import call_command
+
+from parameterized import parameterized
+
+from posthog.models import Team
+
+
+class TestSetRecorderScriptCommand(BaseTest):
+    def test_dry_run_mode(self):
+        team1 = Team.objects.create(organization=self.organization, name="Team 1")
+        team2 = Team.objects.create(organization=self.organization, name="Team 2")
+
+        out = StringIO()
+        call_command(
+            "set_recorder_script",
+            "--script=test-recorder",
+            "--sample-rate=1.0",
+            "--dry-run",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        assert "DRY RUN MODE" in output
+        assert "Would update" in output
+
+        team1.refresh_from_db()
+        team2.refresh_from_db()
+        assert team1.sdk_config is None
+        assert team2.sdk_config is None
+
+    def test_sets_recorder_script_for_all_teams(self):
+        team1 = Team.objects.create(organization=self.organization, name="Team 1")
+        team2 = Team.objects.create(organization=self.organization, name="Team 2")
+
+        out = StringIO()
+        call_command(
+            "set_recorder_script",
+            "--script=test-recorder",
+            "--sample-rate=1.0",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        assert "Successfully updated" in output
+
+        team1.refresh_from_db()
+        team2.refresh_from_db()
+        assert team1.sdk_config == {"recorder_script": "test-recorder"}
+        assert team2.sdk_config == {"recorder_script": "test-recorder"}
+
+    def test_skips_teams_with_existing_recorder_script(self):
+        # BaseTest creates self.team, so we need to set its script
+        self.team.sdk_config = {"recorder_script": "existing"}
+        self.team.save()
+
+        team_without = Team.objects.create(organization=self.organization, name="Team without")
+
+        out = StringIO()
+        call_command(
+            "set_recorder_script",
+            "--script=new-recorder",
+            "--sample-rate=1.0",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        assert "Found 1 teams without recorder_script set" in output
+
+        self.team.refresh_from_db()
+        team_without.refresh_from_db()
+        assert self.team.sdk_config == {"recorder_script": "existing"}
+        assert team_without.sdk_config == {"recorder_script": "new-recorder"}
+
+    def test_preserves_other_sdk_config_fields(self):
+        team = Team.objects.create(organization=self.organization, name="Team", sdk_config={"other_field": "value"})
+
+        call_command(
+            "set_recorder_script",
+            "--script=test-recorder",
+            "--sample-rate=1.0",
+        )
+
+        team.refresh_from_db()
+        assert team.sdk_config == {"other_field": "value", "recorder_script": "test-recorder"}
+
+    @parameterized.expand(
+        [
+            ("invalid_low", -0.1),
+            ("invalid_high", 1.1),
+        ]
+    )
+    def test_validates_sample_rate(self, _name, sample_rate):
+        from django.core.management.base import CommandError
+
+        with self.assertRaises(CommandError) as cm:
+            call_command(
+                "set_recorder_script",
+                f"--script=test-recorder",
+                f"--sample-rate={sample_rate}",
+            )
+
+        assert "Sample rate must be between 0.0 and 1.0" in str(cm.exception)
+
+    def test_sampling_is_consistent(self):
+        teams = []
+        for i in range(100):
+            teams.append(Team.objects.create(organization=self.organization, name=f"Team {i}"))
+
+        call_command(
+            "set_recorder_script",
+            "--script=test-recorder",
+            "--sample-rate=0.5",
+        )
+
+        updated_teams = Team.objects.filter(sdk_config__has_key="recorder_script").count()
+
+        assert 30 < updated_teams < 70, f"Expected roughly 50 teams updated, got {updated_teams}"
+
+    def test_bulk_updates_in_batches(self):
+        for i in range(2500):
+            Team.objects.create(organization=self.organization, name=f"Team {i}")
+
+        out = StringIO()
+        call_command(
+            "set_recorder_script",
+            "--script=test-recorder",
+            "--sample-rate=1.0",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        assert "Updated 1000 teams so far..." in output
+        assert "Updated 2000 teams so far..." in output
+
+        updated_teams = Team.objects.filter(sdk_config__has_key="recorder_script").count()
+        assert updated_teams > 2400


### PR DESCRIPTION
# new remote config step 4 - add a management command for sampling teams onto the config

- now that we have confidence in this method
- we can sample teams onto the setting
- so that we can track it works for people

---

making remote config changes need to be done in multiple placesso i'm jumping ahead slightly instead of the small steps i was going to take

we want to roll out the posthog-recorder to more teams

and further down the line we want to make a breaking change to posthog-js (e.g. making the library async)

so we need team config to tell us what version people are on

this adds an sdk_config field that holds JSONthat can hold a key recorder_script which we will sample in using a management command

and further down the line it would hold posthog-js version so people could choose to stay on ver 1 or not

i need to make the posthog-recorder change in at least two steps and don't want to handle multiple DB migrations to do it

this PR will be stacked so you can see what the usage will be

Changelog: (features only) Is this feature complete?

No