### PR TITLE
fix(shortcuts): prevent browser (and others) interference on non-mac

### DIFF
--- a/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
+++ b/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
@@ -85,7 +85,7 @@ export const appShortcutLogic = kea<appShortcutLogicType>([
                 pressedKeys.push(keyToAdd)
                 const pressedKeyString = pressedKeys.join('+')
 
-                // Find matching shortcut
+                // Find matching shortcut - if found, prevent default immediately
                 const matchingShortcut = values.registeredAppShortcuts.find((shortcut) => {
                     return shortcut.keybind.some((keybind) => {
                         const shortcutKeyString = keybind.map((k: string) => k.toLowerCase()).join('+')
@@ -106,13 +106,13 @@ export const appShortcutLogic = kea<appShortcutLogicType>([
             }
         }
 
-        window.addEventListener('keydown', cache.onKeyDown)
+        window.addEventListener('keydown', cache.onKeyDown, { capture: true })
         window.addEventListener('keyup', cache.onKeyUp)
         window.addEventListener('blur', cache.onBlur)
     }),
     beforeUnmount(({ cache }) => {
         // unregister app shortcuts
-        window.removeEventListener('keydown', cache.onKeyDown)
+        window.removeEventListener('keydown', cache.onKeyDown, { capture: true })
         window.removeEventListener('keyup', cache.onKeyUp)
         window.removeEventListener('blur', cache.onBlur)
     }),

--- a/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
+++ b/frontend/src/lib/components/AppShortcuts/appShortcutLogic.tsx
@@ -85,7 +85,7 @@ export const appShortcutLogic = kea<appShortcutLogicType>([
                 pressedKeys.push(keyToAdd)
                 const pressedKeyString = pressedKeys.join('+')
 
-                // Find matching shortcut - if found, prevent default immediately
+                // Find matching shortcut
                 const matchingShortcut = values.registeredAppShortcuts.find((shortcut) => {
                     return shortcut.keybind.some((keybind) => {
                         const shortcutKeyString = keybind.map((k: string) => k.toLowerCase()).join('+')


### PR DESCRIPTION
## Problem
Windows didn't allow for our app shortcut `ctrl+...` and others from working.

## Changes
  - add { capture: true } on the event listener, which should intercept keyboard events before the browser's default
  handling kicks in.

`capture: true` lets us "hijack" events before they reach the browser's built-in keyboard shortcuts
  
## How did you test this code?
locally, mac works as usual