### PR TITLE
chore(env): temporarily disable pnpm install for flox and direnv

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -121,7 +121,8 @@ fi
 # Install top-level Node dependencies - This also sets up pre-commit hooks via Husky
 echo -e "  \033[1;34m📦 Node packages\033[0m"
 echo -e "    \033[1;33m📦 Installing Node dependencies and pre-commits hooks...\033[0m"
-pnpm install --silent
+# TEMPORARILY DISABLED DUE TO SUPPLY CHAIN ATTACK
+# pnpm install --silent
 echo -e "    \033[32m✅ Node dependencies installed\033[0m"
 
 # Add required entries to /etc/hosts if not present


### PR DESCRIPTION


## Problem

Flox / direnv installs node deps automatically

## Changes

Temporarily disable Node dependencies installation due to security concerns.

## How did you test this code?

local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._