### PR TITLE
feat(ph-ai): added FF for removing beta label in prod

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -309,6 +309,7 @@ export const FEATURE_FLAGS = {
     POSTHOG_AI_BILLING_DISPLAY: 'posthog-ai-billing-display', // owner: #team-posthog-ai
     POSTHOG_AI_BILLING_USAGE_COMMAND: 'posthog-ai-billing-usage-command', // owner: #team-posthog-ai
     POSTHOG_AI_BILLING_USAGE_REPORT: 'posthog-ai-billing-usage-report', // owner: #team-posthog-ai
+    POSTHOG_AI_GENERAL_AVAILABILITY: 'posthog-ai-general-availability', // owner: #team-posthog-ai
     AMPLITUDE_BATCH_IMPORT_OPTIONS: 'amplitude-batch-import-options', // owner: #team-ingestion
     MAX_DEEP_RESEARCH: 'max-deep-research', // owner: @kappa90 #team-posthog-ai
     NOTEBOOKS_COLLAPSIBLE_SECTIONS: 'notebooks-collapsible-sections', // owner: @daibhin @benjackwhite

--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -94,6 +94,7 @@ export const MaxInstance = React.memo(function MaxInstance({
     tabId,
     isAIOnlyMode,
 }: MaxInstanceProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
     const {
         threadVisible,
         conversationHistoryVisible,
@@ -189,9 +190,11 @@ export const MaxInstance = React.memo(function MaxInstance({
                             {chatTitle || (
                                 <>
                                     PostHog AI
-                                    <LemonTag size="small" type="warning" className="ml-2">
-                                        BETA
-                                    </LemonTag>
+                                    {!featureFlags[FEATURE_FLAGS.POSTHOG_AI_GENERAL_AVAILABILITY] && (
+                                        <LemonTag size="small" type="warning" className="ml-2">
+                                            BETA
+                                        </LemonTag>
+                                    )}
                                 </>
                             )}
                         </h3>


### PR DESCRIPTION
## Problem

Remove `beta` label of `ph-ai` since we are close to GA.

## Changes

* Controlling display with [posthog-ai-general-availability](https://us.posthog.com/project/2/feature_flags/252916)

## How did you test this code?

**Before**:

<img width="270" height="80" alt="beta_hi" src="https://github.com/user-attachments/assets/85e63855-e006-48dd-9c2a-ad49b3e834d5" />

**After**:

<img width="190" height="76" alt="beta_bye" src="https://github.com/user-attachments/assets/8115d0ab-002d-415f-8600-d85a125c903f" />
