### PR TITLE
fix(data-imports): check soft deleted tables in pipeline

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -1118,7 +1118,7 @@
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
                               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-14 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-17 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC
                      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -137,7 +137,7 @@ class PipelineNonDLT(Generic[ResumableData]):
                 self._schema.update_sync_type_config_for_reset_pipeline()
 
             # If the schema has no DWH table (or it's soft-deleted), it's a first ever sync
-            is_first_ever_sync: bool = self._schema.table is None or self._schema.table.deleted
+            is_first_ever_sync: bool = self._schema.table is None or bool(self._schema.table.deleted)
 
             for item in self._resource.items():
                 py_table = None

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -136,8 +136,8 @@ class PipelineNonDLT(Generic[ResumableData]):
                 self._delta_table_helper.reset_table()
                 self._schema.update_sync_type_config_for_reset_pipeline()
 
-            # If the schema has no DWH table, it's a first ever sync
-            is_first_ever_sync: bool = self._schema.table is None
+            # If the schema has no DWH table (or it's soft-deleted), it's a first ever sync
+            is_first_ever_sync: bool = self._schema.table is None or self._schema.table.deleted
 
             for item in self._resource.items():
                 py_table = None
@@ -349,7 +349,9 @@ class PipelineNonDLT(Generic[ResumableData]):
             self._resource_name,
             file_uris,
             delete_existing=True,
-            existing_queryable_folder=self._schema.table.queryable_folder if self._schema.table else None,
+            existing_queryable_folder=self._schema.table.queryable_folder
+            if self._schema.table and not self._schema.table.deleted
+            else None,
             logger=self._logger,
         )
 

--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -129,11 +129,12 @@ def validate_schema_and_update_table_sync(
             }
 
             # create or update
-            table_created: DataWarehouseTable | None = external_data_schema.table
+            table_created: DataWarehouseTable | None = None
             # Check if the table exists and is not soft-deleted
-            if table_created and table_created.deleted:
-                logger.info(f"Table {table_created.id} is soft-deleted, treating as non-existent")
-                table_created = None
+            if external_data_schema.table and not external_data_schema.table.deleted:
+                table_created = external_data_schema.table
+            elif external_data_schema.table and external_data_schema.table.deleted:
+                logger.info(f"Table {external_data_schema.table.id} is soft-deleted, treating as non-existent")
 
             if table_created:
                 table_created.credential = table_params["credential"]

--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -1,7 +1,7 @@
 import uuid
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Any, Optional
+from typing import Any
 
 from django.conf import settings
 from django.db import transaction
@@ -70,7 +70,7 @@ def validate_schema_and_update_table_sync(
     row_count: int,
     table_format: DataWarehouseTable.TableFormat,
     queryable_folder: str,
-    table_schema_dict: Optional[dict[str, str]] = None,
+    table_schema_dict: dict[str, str] | None = None,
 ) -> None:
     """
 
@@ -130,6 +130,11 @@ def validate_schema_and_update_table_sync(
 
             # create or update
             table_created: DataWarehouseTable | None = external_data_schema.table
+            # Check if the table exists and is not soft-deleted
+            if table_created and table_created.deleted:
+                logger.info(f"Table {table_created.id} is soft-deleted, treating as non-existent")
+                table_created = None
+
             if table_created:
                 table_created.credential = table_params["credential"]
                 table_created.format = table_params["format"]

--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -131,10 +131,11 @@ def validate_schema_and_update_table_sync(
             # create or update
             table_created: DataWarehouseTable | None = None
             # Check if the table exists and is not soft-deleted
-            if external_data_schema.table and not external_data_schema.table.deleted:
-                table_created = external_data_schema.table
-            elif external_data_schema.table and external_data_schema.table.deleted:
-                logger.info(f"Table {external_data_schema.table.id} is soft-deleted, treating as non-existent")
+            if external_data_schema.table:
+                if external_data_schema.table.deleted:
+                    logger.info(f"Table {external_data_schema.table.id} is soft-deleted, treating as non-existent")
+                else:
+                    table_created = external_data_schema.table
 
             if table_created:
                 table_created.credential = table_params["credential"]


### PR DESCRIPTION
## Problem

- soft deletion can end up in a semi finished state which means subsequent syncs will incorrectly continue to update the existing table

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- check the soft deletion in pipeline

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
