### PR TITLE
fix(hogql): update hogql expression example for is_identified

### DIFF
--- a/frontend/src/lib/components/HogQLEditor/HogQLEditor.tsx
+++ b/frontend/src/lib/components/HogQLEditor/HogQLEditor.tsx
@@ -59,7 +59,7 @@ export function HogQLEditor({
                 <pre>
                     {placeholder ??
                         (metadataSource && isActorsQuery(metadataSource)
-                            ? "Enter SQL expression, such as:\n- properties.$geoip_country_name\n- toInt(properties.$browser_version) * 10\n- concat(properties.name, ' <', properties.email, '>')\n- is_identified ? 'user' : 'anon'"
+                            ? "Enter SQL expression, such as:\n- properties.$geoip_country_name\n- toInt(properties.$browser_version) * 10\n- concat(properties.name, ' <', properties.email, '>')\n- toBool(is_identified) ? 'user' : 'anon'"
                             : "Enter SQL Expression, such as:\n- properties.$current_url\n- person.properties.$geoip_country_name\n- pdi.person.properties.email\n- toInt(properties.`Long Field Name`) * 10\n- concat(event, ' ', distinct_id)")}
                 </pre>
             </div>


### PR DESCRIPTION
## Problem

A user is complaining that the example for HogQL expressions doesn't work: https://posthog.slack.com/archives/C0368RPHLQH/p1763987652283949

From the screenshot we can see that he's looking at a HogQL Expression editor for an `ActorsQuery`, where `person` properties are directly available.

Testing the `is_identified ? 'user' : 'anon'` example, I found that it errors with `Illegal type Int8 of first argument (condition) of function if. Must be UInt8: While processing ...if (persons.is_identified, 'user', 'anon')...`

~No recent change seems to have changed the behaviour (I bisected the last couple days), so I'm assuming this is outdated for some while.~

Looks like this has worked in ClickHouse [versions <= `24.2.3`](https://fiddle.clickhouse.com/ea0030e3-d74b-48b2-9621-2931f74513cb) and broke with ClickHouse version [24.3](https://fiddle.clickhouse.com/ac9f2123-8977-42a1-bc65-eb18843d3742).

## Changes

Adapts the example to include a type cast: `toBool(is_identified) ? 'user' : 'anon'`

## How did you test this code?

Locally, 👀 