### PR TITLE
fix(trends): display negative values correctly in trends table

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/columns/AggregationColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/AggregationColumn.tsx
@@ -81,7 +81,7 @@ export function AggregationColumnItem({
     let value: number | undefined = undefined
     if (aggregation === 'total' || isNonTimeSeriesDisplay) {
         value = item.count ?? item.aggregated_value
-        if (item.aggregated_value > item.count) {
+        if (item.aggregated_value > item.count || (item.aggregated_value < 0 && item.aggregated_value < item.count)) {
             value = item.aggregated_value
         }
     } else if (aggregation === 'average') {


### PR DESCRIPTION
## Problem

The table visualization of trends insights always displays negative values as 0.

Related ticket: https://posthoghelp.zendesk.com/agent/tickets/43132 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/45016)

## Changes

Add handling of negative numbers.

## How did you test this code?

Used a `-A` formula locally