### PR TITLE
feat(surveys): customize response columns

### DIFF
--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -89,6 +89,7 @@ export function ColumnConfigurator({ query, setQuery }: ColumnConfiguratorProps)
             : isGroupsQuery(query.source)
               ? { type: 'groups', groupTypeIndex: query.source.group_type_index as GroupTypeIndex }
               : { type: 'team_columns' },
+        contextKey: query.contextKey,
     }
     const { showModal } = useActions(columnConfiguratorLogic(columnConfiguratorLogicProps))
 

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -195,7 +195,10 @@ export const dataTableLogic = kea<dataTableLogicType>([
                 columnsInQuery,
                 featureFlags,
                 context
-            ): RequiredExcept<Omit<DataTableNode, 'response'>, 'version' | 'tags' | 'defaultColumns'> => {
+            ): RequiredExcept<
+                Omit<DataTableNode, 'response'>,
+                'version' | 'tags' | 'defaultColumns' | 'contextKey'
+            > => {
                 const { kind, columns: _columns, source, ...rest } = query
                 const showIfFull = !!query.full
                 const flagQueryRunningTimeEnabled = !!featureFlags[FEATURE_FLAGS.QUERY_RUNNING_TIME]

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -8338,6 +8338,10 @@
                     "$ref": "#/definitions/DataTableNodeViewPropsContext",
                     "description": "Context for the table, used by components like ColumnConfigurator"
                 },
+                "contextKey": {
+                    "description": "Context key for universal column configuration (e.g., \"survey:123\")",
+                    "type": "string"
+                },
                 "defaultColumns": {
                     "description": "Default columns to use when resetting column configuration",
                     "items": {
@@ -25687,6 +25691,10 @@
                 "context": {
                     "$ref": "#/definitions/DataTableNodeViewPropsContext",
                     "description": "Context for the table, used by components like ColumnConfigurator"
+                },
+                "contextKey": {
+                    "description": "Context key for universal column configuration (e.g., \"survey:123\")",
+                    "type": "string"
                 },
                 "defaultColumns": {
                     "description": "Default columns to use when resetting column configuration",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1069,6 +1069,8 @@ interface DataTableNodeViewProps {
     showColumnConfigurator?: boolean
     /** Show a button to configure and persist the table's default columns if possible */
     showPersistentColumnConfigurator?: boolean
+    /** Context key for universal column configuration (e.g., "survey:123") */
+    contextKey?: string
     /** Shows a list of saved queries */
     showSavedQueries?: boolean
     /** Show saved filters feature for this table (requires uniqueKey) */

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1539,25 +1539,26 @@ export const surveyLogic = kea<surveyLogicType>([
                     where.push(archivedResponsesFilter.substring(4))
                 }
 
+                const defaultColumns = [
+                    '*',
+                    ...survey.questions.map((q, i) => {
+                        if (q.type === SurveyQuestionType.MultipleChoice) {
+                            return `arrayStringConcat(${getSurveyResponse(q, i)}, ', ') -- ${getExpressionCommentForQuestion(q, i)}`
+                        }
+                        return `${getSurveyResponse(q, i)} -- ${getExpressionCommentForQuestion(q, i)}`
+                    }),
+                    'timestamp',
+                    'person',
+                    `coalesce(JSONExtractString(properties, '$lib_version')) -- Library Version`,
+                    `coalesce(JSONExtractString(properties, '$lib')) -- Library`,
+                    `coalesce(JSONExtractString(properties, '$current_url')) -- URL`,
+                ]
+
                 return {
                     kind: NodeKind.DataTableNode,
                     source: {
                         kind: NodeKind.EventsQuery,
-                        select: [
-                            '*',
-                            ...survey.questions.map((q, i) => {
-                                if (q.type === SurveyQuestionType.MultipleChoice) {
-                                    return `arrayStringConcat(${getSurveyResponse(q, i)}, ', ') -- ${getExpressionCommentForQuestion(q, i)}`
-                                }
-                                // Use the new condition that checks both formats
-                                return `${getSurveyResponse(q, i)} -- ${getExpressionCommentForQuestion(q, i)}`
-                            }),
-                            'timestamp',
-                            'person',
-                            `coalesce(JSONExtractString(properties, '$lib_version')) -- Library Version`,
-                            `coalesce(JSONExtractString(properties, '$lib')) -- Library`,
-                            `coalesce(JSONExtractString(properties, '$current_url')) -- URL`,
-                        ],
+                        select: defaultColumns,
                         orderBy: ['timestamp DESC'],
                         where,
                         after: dateRange?.date_from || startDate,
@@ -1572,6 +1573,7 @@ export const surveyLogic = kea<surveyLogicType>([
                             ...propertyFilters,
                         ],
                     },
+                    defaultColumns,
                     propertiesViaUrl: true,
                     showExport: true,
                     showReload: true,
@@ -1579,6 +1581,8 @@ export const surveyLogic = kea<surveyLogicType>([
                     showEventFilter: false,
                     showPropertyFilter: false,
                     showTimings: false,
+                    showPersistentColumnConfigurator: true,
+                    contextKey: `survey:${survey.id}`,
                 }
             },
         ],

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5108,6 +5108,9 @@ class SavedInsightNode(BaseModel):
     context: Optional[DataTableNodeViewPropsContext] = Field(
         default=None, description="Context for the table, used by components like ColumnConfigurator"
     )
+    contextKey: Optional[str] = Field(
+        default=None, description='Context key for universal column configuration (e.g., "survey:123")'
+    )
     defaultColumns: Optional[list[str]] = Field(
         default=None, description="Default columns to use when resetting column configuration"
     )
@@ -15897,6 +15900,9 @@ class DataTableNode(BaseModel):
     )
     context: Optional[DataTableNodeViewPropsContext] = Field(
         default=None, description="Context for the table, used by components like ColumnConfigurator"
+    )
+    contextKey: Optional[str] = Field(
+        default=None, description='Context key for universal column configuration (e.g., "survey:123")'
     )
     defaultColumns: Optional[list[str]] = Field(
         default=None, description="Default columns to use when resetting column configuration"


### PR DESCRIPTION
## Problem

survey users cannot customize the columns when reviewing response data

closes https://github.com/PostHog/posthog/issues/29844

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

prev PR added a new universal column config store. this PR updates the column config component to support the new contextKey param, and implements this functionality for surveys!

[survey-columns-demo.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0d82bc87-c362-49ee-8931-9669e170cdb8.mp4" />](https://app.graphite.com/user-attachments/video/0d82bc87-c362-49ee-8931-9669e170cdb8.mp4)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing, unit tests on the column config api

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->

yes