### PR TITLE
chore(docker): isolate sourcemap upload into dedicated stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@
 # The stages are used to:
 #
 # - frontend-build: build the frontend (static assets)
+# - sourcemap-upload: upload sourcemaps to PostHog (isolated, no artifacts)
 # - plugin-server-build: build plugin-server (Node.js app) & fetch its runtime dependencies
 # - posthog-build: fetch PostHog (Django app) dependencies & build Django collectstatic
 # - fetch-geoip-db: fetch the GeoIP database
@@ -44,19 +45,34 @@ RUN --mount=type=cache,id=pnpm,target=/tmp/pnpm-store-v24 \
 COPY frontend/ frontend/
 RUN bin/turbo --filter=@posthog/frontend build
 
-# Process sourcemaps using posthog-cli
+
+#
+# ---------------------------------------------------------
+#
+# Isolated stage for sourcemap upload - keeps secrets and external network calls
+# out of the main build cache. This stage produces no artifacts for the final image.
+#
+FROM node:22.17.1-bookworm-slim AS sourcemap-upload
+WORKDIR /code
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+COPY --from=frontend-build /code/frontend/dist /code/frontend/dist
+
 RUN --mount=type=secret,id=posthog_upload_sourcemaps_cli_api_key \
     ( \
-      if [ -f /run/secrets/posthog_upload_sourcemaps_cli_api_key ]; then \
-        apt-get update && \
-        apt-get install -y --no-install-recommends ca-certificates curl && \
-        curl --proto '=https' --tlsv1.2 -LsSf https://download.posthog.com/cli | sh && \
-        export PATH="/root/.posthog:$PATH" && \
-        export POSTHOG_CLI_TOKEN="$(cat /run/secrets/posthog_upload_sourcemaps_cli_api_key)" && \
-        export POSTHOG_CLI_ENV_ID=2 && \
-        posthog-cli --no-fail sourcemap process --directory /code/frontend/dist --public-path-prefix /static; \
-      fi \
-    ) || true
+        if [ -f /run/secrets/posthog_upload_sourcemaps_cli_api_key ]; then \
+            apt-get update && \
+            apt-get install -y --no-install-recommends ca-certificates curl && \
+            curl --proto '=https' --tlsv1.2 -LsSf https://download.posthog.com/cli | sh && \
+            export PATH="/root/.posthog:$PATH" && \
+            export POSTHOG_CLI_TOKEN="$(cat /run/secrets/posthog_upload_sourcemaps_cli_api_key)" && \
+            export POSTHOG_CLI_ENV_ID=2 && \
+            posthog-cli --no-fail sourcemap process \
+                --directory /code/frontend/dist \
+                --public-path-prefix /static; \
+        fi \
+    ) || true && \
+    touch /tmp/.sourcemaps-processed
 
 
 #
@@ -327,6 +343,9 @@ RUN /python-runtime/bin/python -c "from playwright.sync_api import sync_playwrig
 # Copy the frontend assets from the frontend-build stage.
 # TODO: this copy should not be necessary, we should remove it once we verify everything still works.
 COPY --from=frontend-build --chown=posthog:posthog /code/frontend/dist /code/frontend/dist
+
+# Ensure sourcemap-upload stage runs (the file itself is not needed in the final image).
+COPY --from=sourcemap-upload /tmp/.sourcemaps-processed /tmp/.sourcemaps-processed
 
 # Copy products.json from the frontend-build stage
 COPY --from=frontend-build --chown=posthog:posthog /code/frontend/src/products.json /code/frontend/src/products.json


### PR DESCRIPTION
Moves sourcemap upload from `frontend-build` into its own Docker stage.

**Why:** The previous setup had sourcemap upload (with secret mounts, curl|sh, external network calls) inside `frontend-build`, which invalidated cache for `pnpm install` and `turbo build` layers. This also polluted the build stage with transient packages (curl, ca-certificates).

**Changes:**
- New `sourcemap-upload` stage after `frontend-build`
- Copies only `/code/frontend/dist` from frontend-build
- Installs PostHog CLI and uploads sourcemaps (when secret present)
- Creates marker file copied to final image to ensure stage runs

Follows the standard pattern used by Sentry, Rollbar, etc. for sourcemap uploads.