### PR TITLE
chore(flags): Remove project id from the code

### DIFF
--- a/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
+++ b/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
@@ -5,7 +5,7 @@ use crate::metrics::consts::{
     DB_COHORT_READS_COUNTER,
 };
 use common_database::PostgresReader;
-use common_types::ProjectId;
+use common_types::TeamId;
 use moka::future::Cache;
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,7 +20,7 @@ use tokio::sync::Mutex;
 /// ```text
 /// CohortCacheManager {
 ///     reader: PostgresReader,
-///     cache: Cache<ProjectId, Vec<Cohort>> {
+///     cache: Cache<TeamId, Vec<Cohort>> {
 ///         // Example:
 ///         2: [
 ///             Cohort { id: 1, name: "Power Users", filters: {...} },
@@ -37,7 +37,7 @@ use tokio::sync::Mutex;
 #[derive(Clone)]
 pub struct CohortCacheManager {
     reader: PostgresReader,
-    cache: Cache<ProjectId, Vec<Cohort>>,
+    cache: Cache<TeamId, Vec<Cohort>>,
     fetch_lock: Arc<Mutex<()>>, // Added fetch_lock
 }
 
@@ -48,7 +48,7 @@ impl CohortCacheManager {
         ttl_seconds: Option<u64>,
     ) -> Self {
         // We use the size of the cohort list (i.e., the number of cohorts for a given team) as the weight of the entry
-        let weigher = |_: &ProjectId, value: &Vec<Cohort>| -> u32 { value.len() as u32 };
+        let weigher = |_: &TeamId, value: &Vec<Cohort>| -> u32 { value.len() as u32 };
 
         let cache = Cache::builder()
             .time_to_live(Duration::from_secs(ttl_seconds.unwrap_or(300))) // Default to 5 minutes
@@ -63,13 +63,13 @@ impl CohortCacheManager {
         }
     }
 
-    /// Retrieves cohorts for a given project.
+    /// Retrieves cohorts for a given team.
     ///
     /// If the cohorts are not present in the cache or have expired, it fetches them from the database,
     /// caches the result upon successful retrieval, and then returns it.
-    pub async fn get_cohorts(&self, project_id: ProjectId) -> Result<Vec<Cohort>, FlagError> {
+    pub async fn get_cohorts(&self, team_id: TeamId) -> Result<Vec<Cohort>, FlagError> {
         // First check cache before acquiring lock
-        if let Some(cached_cohorts) = self.cache.get(&project_id).await {
+        if let Some(cached_cohorts) = self.cache.get(&team_id).await {
             common_metrics::inc(COHORT_CACHE_HIT_COUNTER, &[], 1);
             return Ok(cached_cohorts.clone());
         }
@@ -78,7 +78,7 @@ impl CohortCacheManager {
         let _lock = self.fetch_lock.lock().await;
 
         // Double-check the cache after acquiring lock
-        if let Some(cached_cohorts) = self.cache.get(&project_id).await {
+        if let Some(cached_cohorts) = self.cache.get(&team_id).await {
             common_metrics::inc(COHORT_CACHE_HIT_COUNTER, &[], 1);
             return Ok(cached_cohorts.clone());
         }
@@ -87,10 +87,10 @@ impl CohortCacheManager {
         common_metrics::inc(COHORT_CACHE_MISS_COUNTER, &[], 1);
 
         // Attempt to fetch from DB
-        match Cohort::list_from_pg(self.reader.clone(), project_id).await {
+        match Cohort::list_from_pg(self.reader.clone(), team_id).await {
             Ok(fetched_cohorts) => {
                 common_metrics::inc(DB_COHORT_READS_COUNTER, &[], 1);
-                self.cache.insert(project_id, fetched_cohorts.clone()).await;
+                self.cache.insert(team_id, fetched_cohorts.clone()).await;
                 Ok(fetched_cohorts)
             }
             Err(e) => {
@@ -123,18 +123,18 @@ mod tests {
             Some(1), // 1-second TTL
         );
 
-        let cohorts = cohort_cache.get_cohorts(team.project_id()).await?;
+        let cohorts = cohort_cache.get_cohorts(team.id).await?;
         assert_eq!(cohorts.len(), 1);
         assert_eq!(cohorts[0].team_id, team.id);
 
-        let cached_cohorts = cohort_cache.cache.get(&team.project_id()).await;
+        let cached_cohorts = cohort_cache.cache.get(&team.id).await;
         assert!(cached_cohorts.is_some());
 
         // Wait for TTL to expire
         sleep(Duration::from_secs(2)).await;
 
         // Attempt to retrieve from cache again
-        let cached_cohorts = cohort_cache.cache.get(&team.project_id()).await;
+        let cached_cohorts = cohort_cache.cache.get(&team.id).await;
         assert!(cached_cohorts.is_none(), "Cache entry should have expired");
 
         Ok(())
@@ -157,7 +157,7 @@ mod tests {
         let filters = serde_json::json!({"properties": {"type": "OR", "values": [{"type": "OR", "values": [{"key": "$active", "type": "person", "value": [true], "negation": false, "operator": "exact"}]}]}});
         for _ in 0..max_capacity {
             let team = context.insert_new_team(None).await?;
-            let project_id = team.project_id();
+            let project_id = team.id;
             inserted_project_ids.push(project_id);
             context
                 .insert_cohort(team.id, None, filters.clone(), false)
@@ -173,7 +173,7 @@ mod tests {
         );
 
         let new_team = context.insert_new_team(None).await?;
-        let new_project_id = new_team.project_id();
+        let new_project_id = new_team.id;
         let new_team_id = new_team.id;
         context
             .insert_cohort(new_team_id, None, filters, false)
@@ -207,7 +207,7 @@ mod tests {
     async fn test_get_cohorts() -> Result<(), anyhow::Error> {
         let context = TestContext::new(None).await;
         let team = context.insert_new_team(None).await?;
-        let project_id = team.project_id();
+        let project_id = team.id;
         let team_id = team.id;
 
         let filters = serde_json::json!({"properties": {"type": "OR", "values": [{"type": "OR", "values": [{"key": "$active", "type": "person", "value": [true], "negation": false, "operator": "exact"}]}]}});

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -28,7 +28,7 @@ use crate::utils::graph_utils::{
 };
 use anyhow::Result;
 use common_metrics::{inc, timing_guard};
-use common_types::{PersonId, ProjectId, TeamId};
+use common_types::{PersonId, TeamId};
 use rayon::prelude::*;
 use serde_json::Value;
 use std::collections::hash_map::Entry;
@@ -164,8 +164,6 @@ pub struct FeatureFlagMatcher {
     pub distinct_id: String,
     /// Team ID for scoping flag evaluations
     pub team_id: TeamId,
-    /// Project ID for scoping flag evaluations
-    pub project_id: ProjectId,
     /// Router for database connections across persons/non-persons pools
     pub router: PostgresRouter,
     /// Cache manager for cohort definitions and memberships
@@ -188,7 +186,6 @@ impl FeatureFlagMatcher {
     pub fn new(
         distinct_id: String,
         team_id: TeamId,
-        project_id: ProjectId,
         router: PostgresRouter,
         cohort_cache: Arc<CohortCacheManager>,
         group_type_mapping_cache: Option<GroupTypeMappingCache>,
@@ -197,11 +194,10 @@ impl FeatureFlagMatcher {
         FeatureFlagMatcher {
             distinct_id,
             team_id,
-            project_id,
             router,
             cohort_cache,
             group_type_mapping_cache: group_type_mapping_cache
-                .unwrap_or_else(|| GroupTypeMappingCache::new(project_id)),
+                .unwrap_or_else(|| GroupTypeMappingCache::new(team_id)),
             groups: groups.unwrap_or_default(),
             flag_evaluation_state: FlagEvaluationState::default(),
         }
@@ -219,7 +215,7 @@ impl FeatureFlagMatcher {
     /// ## Returns
     ///
     /// * `FlagsResponse` - The result containing flag evaluations and any errors.
-    #[instrument(skip_all, fields(team_id = %self.team_id, project_id = %self.project_id, distinct_id = %self.distinct_id, flags_len = feature_flags.flags.len()))]
+    #[instrument(skip_all, fields(team_id = %self.team_id, distinct_id = %self.distinct_id, flags_len = feature_flags.flags.len()))]
     pub async fn evaluate_all_feature_flags(
         &mut self,
         feature_flags: FeatureFlagList,
@@ -288,7 +284,7 @@ impl FeatureFlagMatcher {
     /// Returns a tuple containing:
     /// - Option<HashMap<String, String>>: The hash key overrides if successfully retrieved, None if there was an error
     /// - bool: Whether there was an error during processing (true = error occurred)
-    #[instrument(skip_all, fields(team_id = %self.team_id, project_id = %self.project_id, distinct_id = %self.distinct_id))]
+    #[instrument(skip_all, fields(team_id = %self.team_id, distinct_id = %self.distinct_id))]
     async fn process_hash_key_override(
         &self,
         hash_key: String,
@@ -298,7 +294,6 @@ impl FeatureFlagMatcher {
             &self.router,
             self.team_id,
             self.distinct_id.clone(),
-            self.project_id,
             hash_key.clone(),
         )
         .await
@@ -306,8 +301,8 @@ impl FeatureFlagMatcher {
             Ok(should_write) => should_write,
             Err(e) => {
                 error!(
-                    "Failed to check if hash key override should be written for team {} project {} distinct_id {}: {:?}",
-                    self.team_id, self.project_id, self.distinct_id, e
+                    "Failed to check if hash key override should be written for team {} distinct_id {}: {:?}",
+                    self.team_id, self.distinct_id, e
                 );
                 let reason = parse_exception_for_prometheus_label(&e);
                 inc(
@@ -327,12 +322,11 @@ impl FeatureFlagMatcher {
                 &self.router,
                 self.team_id,
                 target_distinct_ids.clone(),
-                self.project_id,
                 hash_key.clone(),
             )
             .await
             {
-                error!("Failed to set feature flag hash key overrides for team {} project {} distinct_id {} hash_key {}: {:?}", self.team_id, self.project_id, self.distinct_id, hash_key, e);
+                error!("Failed to set feature flag hash key overrides for team {} distinct_id {} hash_key {}: {:?}", self.team_id, self.distinct_id, hash_key, e);
                 let reason = parse_exception_for_prometheus_label(&e);
                 inc(
                     FLAG_EVALUATION_ERROR_COUNTER,
@@ -371,7 +365,7 @@ impl FeatureFlagMatcher {
         {
             Ok(overrides) => (Some(overrides), false),
             Err(e) => {
-                error!("Failed to get feature flag hash key overrides for team {} project {} distinct_id {}: {:?}", self.team_id, self.project_id, self.distinct_id, e);
+                error!("Failed to get feature flag hash key overrides for team {} distinct_id {}: {:?}", self.team_id, self.distinct_id, e);
                 let reason = parse_exception_for_prometheus_label(&e);
                 inc(
                     FLAG_EVALUATION_ERROR_COUNTER,
@@ -545,7 +539,7 @@ impl FeatureFlagMatcher {
 
     /// Prepares evaluation state for flags that require database properties.
     /// Returns true if there were errors during preparation.
-    #[instrument(skip_all, fields(team_id = %self.team_id, project_id = %self.project_id, distinct_id = %self.distinct_id))]
+    #[instrument(skip_all, fields(team_id = %self.team_id, distinct_id = %self.distinct_id))]
     async fn prepare_evaluation_state_if_needed(
         &mut self,
         feature_flags: &FeatureFlagList,
@@ -595,8 +589,8 @@ impl FeatureFlagMatcher {
         }));
 
         error!(
-            "Error preparing flag evaluation state for team {} project {} distinct_id {}: {:?}",
-            self.team_id, self.project_id, self.distinct_id, error
+            "Error preparing flag evaluation state for team {} distinct_id {}: {:?}",
+            self.team_id, self.distinct_id, error
         );
 
         inc(
@@ -610,7 +604,7 @@ impl FeatureFlagMatcher {
     ///
     /// This function is designed to be used as part of a level-based evaluation strategy
     /// (e.g., Kahn's algorithm) for handling flag dependencies.
-    #[instrument(skip_all, fields(team_id = %self.team_id, project_id = %self.project_id, distinct_id = %self.distinct_id))]
+    #[instrument(skip_all, fields(team_id = %self.team_id, distinct_id = %self.distinct_id))]
     async fn evaluate_flags_in_level(
         &mut self,
         flags: &[&FeatureFlag],
@@ -1305,7 +1299,7 @@ impl FeatureFlagMatcher {
         flags: &[&FeatureFlag],
     ) -> Result<(), FlagError> {
         // Get cohorts first since we need the IDs
-        let cohorts = self.cohort_cache.get_cohorts(self.project_id).await?;
+        let cohorts = self.cohort_cache.get_cohorts(self.team_id).await?;
         self.flag_evaluation_state.set_cohorts(cohorts.clone());
 
         // Get static cohort IDs
@@ -1341,8 +1335,8 @@ impl FeatureFlagMatcher {
             }
             Err(e) => {
                 error!(
-                    "Error fetching properties for team {} project {} distinct_id {}: {:?}",
-                    self.team_id, self.project_id, self.distinct_id, e
+                    "Error fetching properties for team {} distinct_id {}: {:?}",
+                    self.team_id, self.distinct_id, e
                 );
                 db_fetch_timer.label("outcome", "error").fin();
                 Err(e)
@@ -1487,8 +1481,8 @@ impl FeatureFlagMatcher {
                             Ok(overrides) => (Some(overrides), false),
                             Err(e) => {
                                 error!(
-                                    "Failed to get feature flag hash key overrides for team {} project {} distinct_id {}: {:?}",
-                                    self.team_id, self.project_id, self.distinct_id, e
+                                    "Failed to get feature flag hash key overrides for team {} distinct_id {}: {:?}",
+                                    self.team_id, self.distinct_id, e
                                 );
                                 (None, true)
                             }

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -11,7 +11,7 @@ use crate::database::{
     get_connection_with_metrics, get_writer_connection_with_metrics, PostgresRouter,
 };
 use common_database::PostgresReader;
-use common_types::{Person, PersonId, ProjectId, TeamId};
+use common_types::{Person, PersonId, TeamId};
 use serde_json::Value;
 use sha1::{Digest, Sha1};
 use sqlx::{Acquire, Row};
@@ -643,7 +643,6 @@ pub async fn set_feature_flag_hash_key_overrides(
     router: &PostgresRouter,
     team_id: TeamId,
     distinct_ids: Vec<String>,
-    project_id: ProjectId,
     hash_key_override: String,
 ) -> Result<bool, FlagError> {
     let retry_strategy = ExponentialBackoff::from_millis(100)
@@ -657,7 +656,6 @@ pub async fn set_feature_flag_hash_key_overrides(
             router,
             team_id,
             &distinct_ids,
-            project_id,
             &hash_key_override,
         )
         .await;
@@ -703,7 +701,6 @@ async fn try_set_feature_flag_hash_key_overrides(
     router: &PostgresRouter,
     team_id: TeamId,
     distinct_ids: &[String],
-    project_id: ProjectId,
     hash_key_override: &str,
 ) -> Result<bool, FlagError> {
     // Get connection from persons writer for the transaction
@@ -737,7 +734,7 @@ async fn try_set_feature_flag_hash_key_overrides(
             SELECT flag.key
             FROM posthog_featureflag flag
             JOIN posthog_team team ON flag.team_id = team.id
-            WHERE team.project_id = $1
+            WHERE team.id = $1
                 AND flag.ensure_experience_continuity = TRUE
                 AND flag.active = TRUE
                 AND flag.deleted = FALSE
@@ -842,7 +839,7 @@ async fn try_set_feature_flag_hash_key_overrides(
         let flags_query_timer =
             common_metrics::timing_guard(FLAG_DEFINITION_QUERY_TIME, &flags_labels);
         let flag_rows = sqlx::query(flags_query)
-            .bind(project_id)
+            .bind(team_id)
             .fetch_all(&mut *non_persons_conn)
             .await
             .map_err(FlagError::from)?;
@@ -852,7 +849,7 @@ async fn try_set_feature_flag_hash_key_overrides(
         if flags_query_duration.as_millis() > 200 {
             warn!(
                 duration_ms = flags_query_duration.as_millis(),
-                project_id = project_id,
+                team_id = team_id,
                 sql_summary =
                     "SELECT active feature flags with ensure_experience_continuity = true",
                 "Slow active flags query detected in set_hash_key_overrides"
@@ -860,7 +857,7 @@ async fn try_set_feature_flag_hash_key_overrides(
         } else {
             info!(
                 duration_ms = flags_query_duration.as_millis(),
-                project_id = project_id,
+                team_id = team_id,
                 "Active flags query completed in set_hash_key_overrides"
             );
         }
@@ -963,7 +960,6 @@ pub async fn should_write_hash_key_override(
     router: &PostgresRouter,
     team_id: TeamId,
     distinct_id: String,
-    project_id: ProjectId,
     hash_key_override: String,
 ) -> Result<bool, FlagError> {
     let retry_strategy = ExponentialBackoff::from_millis(100)
@@ -975,8 +971,7 @@ pub async fn should_write_hash_key_override(
 
     // Use tokio-retry to automatically retry on transient failures
     Retry::spawn(retry_strategy, || async {
-        let result =
-            try_should_write_hash_key_override(router, team_id, &distinct_ids, project_id).await;
+        let result = try_should_write_hash_key_override(router, team_id, &distinct_ids).await;
 
         match &result {
             Err(e) => {
@@ -1016,7 +1011,6 @@ async fn try_should_write_hash_key_override(
     router: &PostgresRouter,
     team_id: TeamId,
     distinct_ids: &[String],
-    project_id: ProjectId,
 ) -> Result<bool, FlagError> {
     // Query 1: Get person_ids and existing overrides from person pool in one shot
     let person_data_query = r#"
@@ -1038,7 +1032,7 @@ async fn try_should_write_hash_key_override(
     let flags_query = r#"
         SELECT key FROM posthog_featureflag flag
         JOIN posthog_team team ON flag.team_id = team.id
-        WHERE team.project_id = $1
+        WHERE team.id = $1
             AND flag.ensure_experience_continuity = TRUE
             AND flag.active = TRUE
             AND flag.deleted = FALSE
@@ -1205,7 +1199,7 @@ async fn try_should_write_hash_key_override(
         let flags_query_timer =
             common_metrics::timing_guard(FLAG_DEFINITION_QUERY_TIME, &flags_labels);
         let rows = sqlx::query(flags_query)
-            .bind(project_id)
+            .bind(team_id)
             .fetch_all(&mut *non_persons_conn)
             .await
             .map_err(|e| {
@@ -1348,7 +1342,6 @@ mod tests {
             &router,
             team.id,
             vec![distinct_id.clone()],
-            team.project_id(),
             "hash_key_2".to_string(),
         )
         .await
@@ -1461,7 +1454,6 @@ mod tests {
             &router,
             team.id,
             distinct_ids.clone(),
-            team.project_id(),
             hash_key.clone(),
         )
         .await
@@ -1597,7 +1589,6 @@ mod tests {
             &router,
             team.id,
             distinct_ids.clone(),
-            team.project_id(),
             new_hash.clone(),
         )
         .await
@@ -1744,7 +1735,6 @@ mod tests {
             &router,
             team.id,
             vec!["filter_test_user".to_string()],
-            team.project_id(),
             "filter_hash".to_string(),
         )
         .await
@@ -1823,7 +1813,6 @@ mod tests {
             &router,
             team.id,
             "should_write_user".to_string(),
-            team.project_id(),
             "hash_key_1".to_string(),
         )
         .await
@@ -1837,7 +1826,6 @@ mod tests {
             &router,
             team.id,
             vec!["should_write_user".to_string()],
-            team.project_id(),
             "hash_key_1".to_string(),
         )
         .await
@@ -1849,7 +1837,6 @@ mod tests {
             &router,
             team.id,
             "should_write_user".to_string(),
-            team.project_id(),
             "hash_key_1".to_string(),
         )
         .await
@@ -1866,7 +1853,6 @@ mod tests {
             &router,
             team.id,
             "non_existent_user".to_string(),
-            team.project_id(),
             "hash_key_2".to_string(),
         )
         .await
@@ -1911,7 +1897,6 @@ mod tests {
                 "nonexistent_user1".to_string(),
                 "nonexistent_user2".to_string(),
             ],
-            team.project_id(),
             "some_hash".to_string(),
         )
         .await

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -451,7 +451,6 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id(),
             Some(json!([multivariate_flag]).to_string()),
         )
         .await
@@ -479,7 +478,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.id)
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -489,10 +488,9 @@ mod tests {
         assert_eq!(redis_flag.get_variants().len(), 3);
 
         // Fetch and verify from Postgres
-        let pg_flags =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
-                .await
-                .expect("Failed to fetch flags from Postgres");
+        let pg_flags = FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.id)
+            .await
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.len(), 1);
         let pg_flag = &pg_flags[0];
         assert_eq!(pg_flag.key, "multivariate_flag");
@@ -553,7 +551,6 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id(),
             Some(json!([multivariate_flag_with_payloads]).to_string()),
         )
         .await
@@ -581,7 +578,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.id)
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -590,10 +587,9 @@ mod tests {
         assert_eq!(redis_flag.key, "multivariate_flag_with_payloads");
 
         // Fetch and verify from Postgres
-        let pg_flags =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
-                .await
-                .expect("Failed to fetch flags from Postgres");
+        let pg_flags = FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.id)
+            .await
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.len(), 1);
         let pg_flag = &pg_flags[0];
         assert_eq!(pg_flag.key, "multivariate_flag_with_payloads");
@@ -686,7 +682,6 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id(),
             Some(json!([flag_with_super_groups]).to_string()),
         )
         .await
@@ -714,7 +709,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.id)
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -725,10 +720,9 @@ mod tests {
         assert_eq!(redis_flag.filters.super_groups.as_ref().unwrap().len(), 1);
 
         // Fetch and verify from Postgres
-        let pg_flags =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
-                .await
-                .expect("Failed to fetch flags from Postgres");
+        let pg_flags = FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.id)
+            .await
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.len(), 1);
         let pg_flag = &pg_flags[0];
         assert_eq!(pg_flag.key, "flag_with_super_groups");
@@ -786,7 +780,6 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id(),
             Some(json!([flag_with_different_properties]).to_string()),
         )
         .await
@@ -814,7 +807,7 @@ mod tests {
             .expect("Failed to insert flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.id)
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -828,10 +821,9 @@ mod tests {
         assert_eq!(redis_properties[2].prop_type, PropertyType::Cohort);
 
         // Fetch and verify from Postgres
-        let pg_flags =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
-                .await
-                .expect("Failed to fetch flags from Postgres");
+        let pg_flags = FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.id)
+            .await
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.len(), 1);
         let pg_flag = &pg_flags[0];
         assert_eq!(pg_flag.key, "flag_with_different_properties");
@@ -865,7 +857,6 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id(),
             Some(json!([deleted_flag]).to_string()),
         )
         .await
@@ -893,7 +884,7 @@ mod tests {
             .expect("Failed to insert deleted flag in Postgres");
 
         // Fetch and verify from Redis
-        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.id)
             .await
             .expect("Failed to fetch flags from Redis");
 
@@ -901,10 +892,9 @@ mod tests {
         assert!(redis_flags.flags.iter().any(|f| f.deleted));
 
         // Fetch and verify from Postgres
-        let pg_flags =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
-                .await
-                .expect("Failed to fetch flags from Postgres");
+        let pg_flags = FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.id)
+            .await
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(pg_flags.len(), 0);
         assert!(!pg_flags.iter().any(|f| f.deleted)); // no deleted flags
     }
@@ -928,7 +918,7 @@ mod tests {
             .await
             .expect("Failed to set malformed JSON in Redis");
 
-        let result = get_flags_from_redis(redis_client, team.project_id()).await;
+        let result = get_flags_from_redis(redis_client, team.id).await;
         assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
 
         // Test database query error (using a non-existent table)
@@ -960,7 +950,6 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id(),
             Some(json!([flag]).to_string()),
         )
         .await
@@ -990,7 +979,7 @@ mod tests {
         for _ in 0..10 {
             let redis_client = redis_client.clone();
             let reader = context.non_persons_reader.clone();
-            let project_id = team.project_id();
+            let project_id = team.id;
 
             let handle = task::spawn(async move {
                 let redis_flags = get_flags_from_redis(redis_client, project_id)
@@ -1041,7 +1030,6 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id(),
             Some(json!(flags).to_string()),
         )
         .await
@@ -1070,13 +1058,13 @@ mod tests {
         }
 
         let start = Instant::now();
-        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.id)
             .await
             .expect("Failed to fetch flags from Redis");
         let redis_duration = start.elapsed();
 
         let start = Instant::now();
-        let pg_flags = FeatureFlagList::from_pg(context.non_persons_reader, team.project_id())
+        let pg_flags = FeatureFlagList::from_pg(context.non_persons_reader, team.id)
             .await
             .expect("Failed to fetch flags from Postgres");
         let pg_duration = start.elapsed();
@@ -1134,7 +1122,6 @@ mod tests {
         insert_flags_for_team_in_redis(
             redis_client.clone(),
             team.id,
-            team.project_id(),
             Some(edge_case_flags.to_string()),
         )
         .await
@@ -1163,13 +1150,12 @@ mod tests {
         }
 
         // Fetch and verify edge case flags
-        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.id)
             .await
             .expect("Failed to fetch flags from Redis");
-        let pg_flags =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
-                .await
-                .expect("Failed to fetch flags from Postgres");
+        let pg_flags = FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.id)
+            .await
+            .expect("Failed to fetch flags from Postgres");
         assert_eq!(redis_flags.flags.len(), 3);
         assert_eq!(pg_flags.len(), 3);
 
@@ -1219,14 +1205,9 @@ mod tests {
         ]);
 
         // Insert flags in both Redis and Postgres
-        insert_flags_for_team_in_redis(
-            redis_client.clone(),
-            team.id,
-            team.project_id(),
-            Some(flags.to_string()),
-        )
-        .await
-        .expect("Failed to insert flags in Redis");
+        insert_flags_for_team_in_redis(redis_client.clone(), team.id, Some(flags.to_string()))
+            .await
+            .expect("Failed to insert flags in Redis");
 
         for flag in flags.as_array().unwrap() {
             context
@@ -1251,13 +1232,12 @@ mod tests {
         }
 
         // Fetch flags from both sources
-        let mut redis_flags = get_flags_from_redis(redis_client, team.project_id())
+        let mut redis_flags = get_flags_from_redis(redis_client, team.id)
             .await
             .expect("Failed to fetch flags from Redis");
-        let mut pg_flags =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
-                .await
-                .expect("Failed to fetch flags from Postgres");
+        let mut pg_flags = FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.id)
+            .await
+            .expect("Failed to fetch flags from Postgres");
 
         // Sort flags by key to ensure consistent order
         redis_flags.flags.sort_by(|a, b| a.key.cmp(&b.key));
@@ -1339,14 +1319,9 @@ mod tests {
         ]);
 
         // Insert flags in both Redis and Postgres
-        insert_flags_for_team_in_redis(
-            redis_client.clone(),
-            team.id,
-            team.project_id(),
-            Some(flags.to_string()),
-        )
-        .await
-        .expect("Failed to insert flags in Redis");
+        insert_flags_for_team_in_redis(redis_client.clone(), team.id, Some(flags.to_string()))
+            .await
+            .expect("Failed to insert flags in Redis");
 
         for flag in flags.as_array().unwrap() {
             context
@@ -1371,13 +1346,12 @@ mod tests {
         }
 
         // Fetch flags from both sources
-        let redis_flags = get_flags_from_redis(redis_client, team.project_id())
+        let redis_flags = get_flags_from_redis(redis_client, team.id)
             .await
             .expect("Failed to fetch flags from Redis");
-        let pg_flags =
-            FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.project_id())
-                .await
-                .expect("Failed to fetch flags from Postgres");
+        let pg_flags = FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.id)
+            .await
+            .expect("Failed to fetch flags from Postgres");
 
         // Verify rollout percentages
         for flags in &[redis_flags, FeatureFlagList { flags: pg_flags }] {

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -12,7 +12,7 @@ use crate::{
 use common_database::PostgresReader;
 use common_metrics::inc;
 use common_redis::Client as RedisClient;
-use common_types::ProjectId;
+use common_types::TeamId;
 use std::sync::Arc;
 
 /// Result of fetching feature flags, including cache hit status
@@ -155,17 +155,17 @@ impl FlagService {
     /// tracking cache metrics.
     pub async fn get_flags_from_cache_or_pg(
         &self,
-        project_id: ProjectId,
+        team_id: TeamId,
     ) -> Result<FlagResult, FlagError> {
         let pg_client = self.pg_client.clone();
         let cache_result = self
             .flags_cache
-            .get_or_load(&project_id, move |&project_id| {
+            .get_or_load(&team_id, move |&team_id| {
                 let pg_client = pg_client.clone();
                 async move {
                     // Load from PostgreSQL - always returns Some, even for empty results
                     // This ensures empty flag lists are cached to prevent repeated DB queries
-                    let flags = FeatureFlagList::from_pg(pg_client, project_id).await?;
+                    let flags = FeatureFlagList::from_pg(pg_client, team_id).await?;
                     Ok::<Option<Vec<_>>, FlagError>(Some(flags))
                 }
             })
@@ -388,7 +388,7 @@ mod tests {
             ],
         };
 
-        update_flags_in_redis(redis_client.clone(), team.project_id(), &mock_flags, None)
+        update_flags_in_redis(redis_client.clone(), team.id, &mock_flags, None)
             .await
             .expect("Failed to insert mock flags in Redis");
 
@@ -402,9 +402,7 @@ mod tests {
         );
 
         // Test fetching from Redis
-        let result = flag_service
-            .get_flags_from_cache_or_pg(team.project_id())
-            .await;
+        let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
         assert!(result.is_ok());
         let flag_result = result.unwrap();
         assert_eq!(flag_result.flag_list.flags.len(), mock_flags.flags.len());
@@ -462,12 +460,10 @@ mod tests {
             .await
             .expect("Failed to remove flags from Redis");
 
-        let result = flag_service
-            .get_flags_from_cache_or_pg(team.project_id())
-            .await;
+        let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
         assert!(result.is_ok());
         // Verify that the flags were re-added to Redis
-        let redis_flags = get_flags_from_redis(redis_client.clone(), team.project_id()).await;
+        let redis_flags = get_flags_from_redis(redis_client.clone(), team.id).await;
         assert!(redis_flags.is_ok());
         assert_eq!(redis_flags.unwrap().flags.len(), mock_flags.flags.len());
     }
@@ -485,7 +481,7 @@ mod tests {
         // Set up mock redis client to return Timeout on read
         let mut mock_client = MockRedisClient::new();
         mock_client.get_ret(
-            &format!("{TEAM_FLAGS_CACHE_PREFIX}{}", team.project_id()),
+            &format!("{TEAM_FLAGS_CACHE_PREFIX}{}", team.id),
             Err(CustomRedisError::Timeout),
         );
 
@@ -500,9 +496,7 @@ mod tests {
             crate::config::DEFAULT_TEST_CONFIG.clone(),
         );
 
-        let result = flag_service
-            .get_flags_from_cache_or_pg(team.project_id())
-            .await;
+        let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
 
         // Should succeed despite Redis timeout
         assert!(result.is_ok());
@@ -531,7 +525,7 @@ mod tests {
         // Set up mock redis client to return Redis error (maps to RedisUnavailable)
         let mut mock_client = MockRedisClient::new();
         mock_client.get_ret(
-            &format!("{TEAM_FLAGS_CACHE_PREFIX}{}", team.project_id()),
+            &format!("{TEAM_FLAGS_CACHE_PREFIX}{}", team.id),
             Err(CustomRedisError::from_redis_kind(
                 RedisErrorKind::IoError,
                 "Connection refused",
@@ -549,9 +543,7 @@ mod tests {
             crate::config::DEFAULT_TEST_CONFIG.clone(),
         );
 
-        let result = flag_service
-            .get_flags_from_cache_or_pg(team.project_id())
-            .await;
+        let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
 
         // Should succeed despite Redis being unavailable
         assert!(result.is_ok());

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -85,7 +85,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -106,7 +105,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             not_matching_distinct_id.clone(),
             team.id,
-            team.project_id(),
             router2,
             cohort_cache.clone(),
             None,
@@ -127,7 +125,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "other_distinct_id".to_string(),
             team.id,
-            team.project_id(),
             router3,
             cohort_cache.clone(),
             None,
@@ -190,7 +187,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache,
             None,
@@ -249,7 +245,7 @@ mod tests {
             None,
         );
 
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.id);
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -272,7 +268,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             context.create_postgres_router(),
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
@@ -355,7 +350,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache,
             None,
@@ -513,7 +507,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache,
             None,
@@ -669,7 +662,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user_distinct_id".to_string(),
             team.id,
-            team.project_id(),
             context.create_postgres_router(),
             cohort_cache,
             None,
@@ -793,7 +785,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache,
             None,
@@ -946,7 +937,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache,
             None,
@@ -1038,7 +1028,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             1,
-            1,
             context.create_postgres_router(),
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
@@ -1064,7 +1053,7 @@ mod tests {
 
         let flag = create_test_flag_with_variants(team.id);
 
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.id);
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -1074,7 +1063,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
@@ -1124,7 +1112,6 @@ mod tests {
 
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
-            1,
             1,
             context.create_postgres_router(),
             cohort_cache,
@@ -1183,7 +1170,6 @@ mod tests {
 
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
-            1,
             1,
             context.create_postgres_router(),
             cohort_cache,
@@ -1291,7 +1277,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -1339,7 +1324,6 @@ mod tests {
         ));
         let team = context.insert_new_team(None).await.unwrap();
         let team_id = team.id;
-        let project_id = team.project_id();
         let flag = Arc::new(create_test_flag(
             None,
             Some(team.id),
@@ -1371,7 +1355,6 @@ mod tests {
                 let matcher = FeatureFlagMatcher::new(
                     format!("test_user_{i}"),
                     team_id,
-                    project_id,
                     router,
                     cohort_cache_clone,
                     None,
@@ -1453,7 +1436,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -1503,7 +1485,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "".to_string(),
             1,
-            1,
             context.create_postgres_router(),
             cohort_cache,
             None,
@@ -1549,7 +1530,6 @@ mod tests {
 
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
-            1,
             1,
             context.create_postgres_router(),
             cohort_cache,
@@ -1603,7 +1583,6 @@ mod tests {
 
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
-            1,
             1,
             context.create_postgres_router(),
             cohort_cache,
@@ -1682,7 +1661,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             context.create_postgres_router(),
             cohort_cache,
             None,
@@ -1746,7 +1724,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             context.create_postgres_router(),
             cohort_cache,
             None,
@@ -1791,7 +1768,6 @@ mod tests {
 
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
-            1,
             1,
             context.create_postgres_router(),
             cohort_cache,
@@ -1872,7 +1848,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             context.create_postgres_router(),
             cohort_cache,
             None,
@@ -2105,7 +2080,6 @@ mod tests {
             let mut matcher = FeatureFlagMatcher::new(
                 user_id.to_string(),
                 team.id,
-                team.project_id(),
                 router,
                 cohort_cache.clone(),
                 None,
@@ -2220,7 +2194,6 @@ mod tests {
         let mut matcher_test_id = FeatureFlagMatcher::new(
             "test_id".to_string(),
             team.id,
-            team.project_id(),
             router.clone(),
             cohort_cache.clone(),
             None,
@@ -2230,7 +2203,6 @@ mod tests {
         let mut matcher_example_id = FeatureFlagMatcher::new(
             "lil_id".to_string(),
             team.id,
-            team.project_id(),
             router.clone(),
             cohort_cache.clone(),
             None,
@@ -2240,7 +2212,6 @@ mod tests {
         let mut matcher_another_id = FeatureFlagMatcher::new(
             "another_id".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2356,7 +2327,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_id".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2467,7 +2437,6 @@ mod tests {
         let mut matcher_test_id = FeatureFlagMatcher::new(
             "test_id".to_string(),
             team.id,
-            team.project_id(),
             router.clone(),
             cohort_cache.clone(),
             None,
@@ -2477,7 +2446,6 @@ mod tests {
         let mut matcher_example_id = FeatureFlagMatcher::new(
             "lil_id".to_string(),
             team.id,
-            team.project_id(),
             router.clone(),
             cohort_cache.clone(),
             None,
@@ -2487,7 +2455,6 @@ mod tests {
         let mut matcher_another_id = FeatureFlagMatcher::new(
             "another_id".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2614,7 +2581,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2710,7 +2676,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2806,7 +2771,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -2923,7 +2887,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3019,7 +2982,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3115,7 +3077,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3203,7 +3164,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3286,7 +3246,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3384,7 +3343,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -3420,7 +3378,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.id);
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -3462,7 +3420,6 @@ mod tests {
             &router,
             team.id,
             vec![distinct_id.clone()],
-            team.project_id(),
             "hash_key_continuity".to_string(),
         )
         .await
@@ -3476,7 +3433,6 @@ mod tests {
         let result = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
@@ -3524,7 +3480,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.id);
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -3568,7 +3524,6 @@ mod tests {
         let result = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
@@ -3611,7 +3566,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.id);
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -3683,7 +3638,6 @@ mod tests {
             &router2,
             team.id,
             vec![distinct_id.clone()],
-            team.project_id(),
             "hash_key_mixed".to_string(),
         )
         .await
@@ -3697,7 +3651,6 @@ mod tests {
         let result = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache),
@@ -3803,7 +3756,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4034,7 +3986,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "example_id".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4056,7 +4007,6 @@ mod tests {
         let mut matcher2 = FeatureFlagMatcher::new(
             "example_id2".to_string(),
             team.id,
-            team.project_id(),
             router2,
             cohort_cache.clone(),
             None,
@@ -4169,7 +4119,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "11".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4192,7 +4141,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "example_id".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4215,7 +4163,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "3".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4310,7 +4257,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4376,7 +4322,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "nonexistent_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4435,7 +4380,7 @@ mod tests {
         );
 
         // Set up group type mapping cache
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.id);
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -4447,7 +4392,6 @@ mod tests {
         let mut matcher_numeric = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -4467,7 +4411,6 @@ mod tests {
         let mut matcher_string = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router2,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -4499,7 +4442,6 @@ mod tests {
         let mut matcher_float = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router3,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -4520,7 +4462,6 @@ mod tests {
         let mut matcher_bool = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router4,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -4664,7 +4605,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "super_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4689,7 +4629,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "posthog_user".to_string(),
             team.id,
-            team.project_id(),
             router2,
             cohort_cache.clone(),
             None,
@@ -4714,7 +4653,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "regular_user".to_string(),
             team.id,
-            team.project_id(),
             router3,
             cohort_cache.clone(),
             None,
@@ -4787,7 +4725,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4907,7 +4844,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -4952,7 +4888,6 @@ mod tests {
         let mut matcher2 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router2,
             cohort_cache.clone(),
             None,
@@ -4986,7 +4921,6 @@ mod tests {
         let mut matcher3 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router3,
             cohort_cache.clone(),
             None,
@@ -5022,7 +4956,6 @@ mod tests {
         let mut matcher4 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router4,
             cohort_cache.clone(),
             None,
@@ -5144,7 +5077,7 @@ mod tests {
         );
 
         // Set up group type mappings
-        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.project_id());
+        let mut group_type_mapping_cache = GroupTypeMappingCache::new(team.id);
         group_type_mapping_cache
             .init(context.persons_reader.clone())
             .await
@@ -5175,7 +5108,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -5219,7 +5151,6 @@ mod tests {
         let mut matcher2 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router2,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -5259,7 +5190,6 @@ mod tests {
         let mut matcher3 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router3,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -5295,7 +5225,6 @@ mod tests {
         let mut matcher4 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router4,
             cohort_cache.clone(),
             Some(group_type_mapping_cache.clone()),
@@ -5335,7 +5264,6 @@ mod tests {
         let mut matcher5 = FeatureFlagMatcher::new(
             distinct_id.clone(),
             team.id,
-            team.project_id(),
             router5,
             cohort_cache.clone(),
             None,
@@ -5438,7 +5366,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "specific_user".to_string(),
             team.id,
-            team.project_id(),
             router.clone(),
             cohort_cache.clone(),
             None,
@@ -5468,7 +5395,6 @@ mod tests {
         let matcher2 = FeatureFlagMatcher::new(
             "other_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache.clone(),
             None,
@@ -5510,15 +5436,8 @@ mod tests {
             .expect("Failed to insert team in pg");
 
         let distinct_id = "user_distinct_id".to_string();
-        let mut matcher = FeatureFlagMatcher::new(
-            distinct_id,
-            team.id,
-            team.project_id(),
-            router,
-            cohort_cache,
-            None,
-            None,
-        );
+        let mut matcher =
+            FeatureFlagMatcher::new(distinct_id, team.id, router, cohort_cache, None, None);
 
         // Create flags: one with experience continuity enabled, one without
         let flag_with_continuity = create_test_flag(
@@ -5633,7 +5552,6 @@ mod tests {
         let matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache,
             None,
@@ -5710,7 +5628,6 @@ mod tests {
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
             team.id,
-            team.project_id(),
             router,
             cohort_cache,
             None,

--- a/rust/feature-flags/src/flags/test_helpers.rs
+++ b/rust/feature-flags/src/flags/test_helpers.rs
@@ -11,7 +11,7 @@ use crate::{
     properties::property_models::{OperatorType, PropertyFilter, PropertyType},
 };
 use common_redis::Client as RedisClient;
-use common_types::ProjectId;
+use common_types::TeamId;
 
 pub fn create_simple_property_filter(
     key: &str,
@@ -75,21 +75,21 @@ pub fn create_simple_flag(properties: Vec<PropertyFilter>, rollout_percentage: f
 /// useful for setting up test data and verifying cache updates.
 pub async fn update_flags_in_redis(
     client: Arc<dyn RedisClient + Send + Sync>,
-    project_id: ProjectId,
+    team_id: TeamId,
     flags: &FeatureFlagList,
     ttl_seconds: Option<u64>,
 ) -> Result<(), FlagError> {
     let payload = serde_json::to_string(&flags.flags).map_err(|e| {
         tracing::error!(
-            "Failed to serialize {} flags for project {}: {}",
+            "Failed to serialize {} flags for team {}: {}",
             flags.flags.len(),
-            project_id,
+            team_id,
             e
         );
         FlagError::RedisDataParsingError
     })?;
 
-    let cache_key = format!("{TEAM_FLAGS_CACHE_PREFIX}{project_id}");
+    let cache_key = format!("{TEAM_FLAGS_CACHE_PREFIX}{team_id}");
 
     match ttl_seconds {
         Some(ttl) => {
@@ -102,7 +102,7 @@ pub async fn update_flags_in_redis(
             client.setex(cache_key, payload, ttl).await.map_err(|e| {
                 tracing::error!(
                     "Failed to update Redis cache with TTL for project {}: {}",
-                    project_id,
+                    team_id,
                     e
                 );
                 FlagError::CacheUpdateError
@@ -117,7 +117,7 @@ pub async fn update_flags_in_redis(
             client.set(cache_key, payload).await.map_err(|e| {
                 tracing::error!(
                     "Failed to update Redis cache for project {}: {}",
-                    project_id,
+                    team_id,
                     e
                 );
                 FlagError::CacheUpdateError
@@ -134,22 +134,22 @@ pub async fn update_flags_in_redis(
 /// useful for testing cache behavior and verifying cache contents.
 pub async fn get_flags_from_redis(
     client: Arc<dyn RedisClient + Send + Sync>,
-    project_id: ProjectId,
+    team_id: TeamId,
 ) -> Result<FeatureFlagList, FlagError> {
     tracing::debug!(
         "Attempting to read flags from Redis at key '{}{}'",
         TEAM_FLAGS_CACHE_PREFIX,
-        project_id
+        team_id
     );
 
     let serialized_flags = client
-        .get(format!("{TEAM_FLAGS_CACHE_PREFIX}{project_id}"))
+        .get(format!("{TEAM_FLAGS_CACHE_PREFIX}{team_id}"))
         .await?;
 
     let flags_list: Vec<FeatureFlag> = serde_json::from_str(&serialized_flags).map_err(|e| {
         tracing::error!(
-            "failed to parse data to flags list for project {}: {}",
-            project_id,
+            "failed to parse data to flags list for team {}: {}",
+            team_id,
             e
         );
         FlagError::RedisDataParsingError
@@ -159,7 +159,7 @@ pub async fn get_flags_from_redis(
         "Successfully read {} flags from Redis at key '{}{}'",
         flags_list.len(),
         TEAM_FLAGS_CACHE_PREFIX,
-        project_id
+        team_id
     );
 
     Ok(FeatureFlagList { flags: flags_list })

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -250,7 +250,6 @@ mod tests {
             id: 1,
             name: "Test Team".to_string(),
             api_token: "test-token".to_string(),
-            project_id: Some(1),
             uuid: Uuid::new_v4(),
             organization_id: None,
             autocapture_opt_out: None,

--- a/rust/feature-flags/src/handler/evaluation.rs
+++ b/rust/feature-flags/src/handler/evaluation.rs
@@ -12,7 +12,7 @@ pub async fn evaluate_feature_flags(
     context: FeatureFlagEvaluationContext,
     request_id: Uuid,
 ) -> FlagsResponse {
-    let group_type_mapping_cache = GroupTypeMappingCache::new(context.project_id);
+    let group_type_mapping_cache = GroupTypeMappingCache::new(context.team_id);
 
     // Create router from the context
     let router = PostgresRouter::new(
@@ -25,7 +25,6 @@ pub async fn evaluate_feature_flags(
     let mut matcher = FeatureFlagMatcher::new(
         context.distinct_id,
         context.team_id,
-        context.project_id,
         router,
         context.cohort_cache,
         Some(group_type_mapping_cache),

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 use axum::extract::State;
-use common_types::ProjectId;
+use common_types::TeamId;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -170,13 +170,13 @@ fn filter_flags_by_runtime(
 
 pub async fn fetch_and_filter(
     flag_service: &FlagService,
-    project_id: ProjectId,
+    team_id: TeamId,
     query_params: &FlagsQueryParams,
     headers: &axum::http::HeaderMap,
     explicit_runtime: Option<EvaluationRuntime>,
     environment_tags: Option<&Vec<String>>,
 ) -> Result<FeatureFlagList, FlagError> {
-    let flag_result = flag_service.get_flags_from_cache_or_pg(project_id).await?;
+    let flag_result = flag_service.get_flags_from_cache_or_pg(team_id).await?;
 
     // First filter by survey flags if requested
     let flags_after_survey_filter = filter_survey_flags(
@@ -245,7 +245,6 @@ fn filter_flags_by_evaluation_tags(
 pub async fn evaluate_for_request(
     state: &State<router::State>,
     team_id: i32,
-    project_id: ProjectId,
     distinct_id: String,
     filtered_flags: FeatureFlagList,
     person_property_overrides: Option<HashMap<String, Value>>,
@@ -267,7 +266,6 @@ pub async fn evaluate_for_request(
 
     let ctx = FeatureFlagEvaluationContext {
         team_id,
-        project_id,
         distinct_id,
         feature_flags: filtered_flags,
         persons_reader: state.database_pools.persons_reader.clone(),

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -120,11 +120,7 @@ async fn process_request_inner(
         metrics_data.team_id = Some(team.id);
         metrics_data.flags_disabled = Some(request.is_flags_disabled());
 
-        tracing::debug!(
-            "Team fetched: team_id={}, project_id={}",
-            team.id,
-            team.project_id()
-        );
+        tracing::debug!("Team fetched: team_id={}", team.id);
 
         // Early exit if flags are disabled
         let flags_response = if request.is_flags_disabled() {
@@ -148,7 +144,7 @@ async fn process_request_inner(
 
             let filtered_flags = flags::fetch_and_filter(
                 &flag_service,
-                team.project_id(),
+                team.id,
                 &context.meta,
                 &context.headers,
                 request.evaluation_runtime,
@@ -164,7 +160,6 @@ async fn process_request_inner(
             let response = flags::evaluate_for_request(
                 &context.state,
                 team.id,
-                team.project_id(),
                 distinct_id.clone(),
                 filtered_flags.clone(),
                 property_overrides.person_properties,
@@ -195,7 +190,6 @@ async fn process_request_inner(
             request_id = %context.request_id,
             distinct_id = %distinct_id_for_logging,
             team_id = team.id,
-            project_id = team.project_id(),
             flags_count = response.flags.len(),
             flags_disabled = request.is_flags_disabled(),
             quota_limited = response.quota_limited.is_some(),

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -176,7 +176,6 @@ async fn test_evaluate_feature_flags() {
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id(),
         distinct_id: "user123".to_string(),
         feature_flags: feature_flag_list,
         persons_reader: reader.clone(),
@@ -265,7 +264,6 @@ async fn test_evaluate_feature_flags_with_errors() {
     // Set up evaluation context
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id(),
         distinct_id: "user123".to_string(),
         feature_flags: feature_flag_list,
         persons_reader: context.persons_reader.clone(),
@@ -666,7 +664,6 @@ async fn test_evaluate_feature_flags_multiple_flags() {
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id(),
         distinct_id: distinct_id.clone(),
         feature_flags: feature_flag_list,
         persons_reader: reader.clone(),
@@ -767,7 +764,6 @@ async fn test_evaluate_feature_flags_details() {
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id(),
         distinct_id: distinct_id.clone(),
         feature_flags: feature_flag_list,
         persons_reader: reader.clone(),
@@ -919,7 +915,6 @@ async fn test_evaluate_feature_flags_with_overrides() {
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id(),
         distinct_id: "user123".to_string(),
         feature_flags: feature_flag_list,
         persons_reader: context.persons_reader.clone(),
@@ -1008,7 +1003,6 @@ async fn test_long_distinct_id() {
 
     let evaluation_context = FeatureFlagEvaluationContext {
         team_id: team.id,
-        project_id: team.project_id(),
         distinct_id: long_id,
         feature_flags: feature_flag_list,
         persons_reader: context.persons_reader.clone(),
@@ -1216,14 +1210,9 @@ async fn test_fetch_and_filter_flags() {
 
     // Insert flags into redis
     let flags_json = serde_json::to_string(&flags).unwrap();
-    insert_flags_for_team_in_redis(
-        redis_client.clone(),
-        team.id,
-        team.project_id(),
-        Some(flags_json),
-    )
-    .await
-    .unwrap();
+    insert_flags_for_team_in_redis(redis_client.clone(), team.id, Some(flags_json))
+        .await
+        .unwrap();
 
     // Test 1: only_evaluate_survey_feature_flags = true
     let query_params = FlagsQueryParams {
@@ -1232,7 +1221,7 @@ async fn test_fetch_and_filter_flags() {
     };
     let result = fetch_and_filter(
         &flag_service,
-        team.project_id(),
+        team.id,
         &query_params,
         &axum::http::HeaderMap::new(),
         None,
@@ -1253,7 +1242,7 @@ async fn test_fetch_and_filter_flags() {
     };
     let result = fetch_and_filter(
         &flag_service,
-        team.project_id(),
+        team.id,
         &query_params,
         &axum::http::HeaderMap::new(),
         None,
@@ -1267,7 +1256,7 @@ async fn test_fetch_and_filter_flags() {
     let query_params = FlagsQueryParams::default();
     let result = fetch_and_filter(
         &flag_service,
-        team.project_id(),
+        team.id,
         &query_params,
         &axum::http::HeaderMap::new(),
         None,
@@ -1289,7 +1278,7 @@ async fn test_fetch_and_filter_flags() {
 
     let result = fetch_and_filter(
         &flag_service,
-        team.project_id(),
+        team.id,
         &query_params,
         &axum::http::HeaderMap::new(),
         None,

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -1,6 +1,5 @@
 use axum::{extract::State, http::HeaderMap};
 use bytes::Bytes;
-use common_types::ProjectId;
 use serde_json::Value;
 use std::{collections::HashMap, net::IpAddr, sync::Arc};
 use uuid::Uuid;
@@ -43,7 +42,6 @@ pub struct RequestPropertyOverrides {
 /// Represents all context required for evaluating a set of feature flags.
 pub struct FeatureFlagEvaluationContext {
     pub team_id: i32,
-    pub project_id: ProjectId,
     pub distinct_id: String,
     pub feature_flags: FeatureFlagList,
     pub persons_reader: Arc<dyn common_database::Client + Send + Sync>,

--- a/rust/feature-flags/src/team/team_models.rs
+++ b/rust/feature-flags/src/team/team_models.rs
@@ -1,4 +1,4 @@
-use common_types::{ProjectId, TeamId, TeamIdentifier};
+use common_types::{TeamId, TeamIdentifier};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::types::{Json, Uuid};
@@ -10,9 +10,6 @@ pub struct Team {
     pub id: TeamId,
     pub name: String,
     pub api_token: String,
-    /// Project ID. This field may be None in Redis cache for teams created before Dec 2024.
-    /// For such teams, project_id equals the team id. Use Team::project_id() to get the resolved value.
-    pub project_id: Option<ProjectId>,
     pub uuid: Uuid,
     pub organization_id: Option<Uuid>,
     pub autocapture_opt_out: Option<bool>,

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -12,7 +12,7 @@ use anyhow::Error;
 use axum::async_trait;
 use common_database::{get_pool, Client, CustomDatabaseError};
 use common_redis::{Client as RedisClientTrait, RedisClient};
-use common_types::{Person, PersonId, ProjectId, TeamId};
+use common_types::{Person, PersonId, TeamId};
 use rand::{distributions::Alphanumeric, Rng};
 use serde_json::{json, Value};
 use sqlx::{pool::PoolConnection, Error as SqlxError, Postgres, Row};
@@ -36,7 +36,6 @@ pub async fn insert_new_team_in_redis(
     let token = random_string("phc_", 12);
     let team = Team {
         id,
-        project_id: Some(i64::from(id)),
         name: "team".to_string(),
         api_token: token,
         cookieless_server_hash_mode: Some(0),
@@ -58,7 +57,6 @@ pub async fn insert_new_team_in_redis(
 pub async fn insert_flags_for_team_in_redis(
     client: Arc<dyn RedisClientTrait + Send + Sync>,
     team_id: i32,
-    project_id: ProjectId,
     json_value: Option<String>,
 ) -> Result<(), Error> {
     let payload = match json_value {
@@ -88,7 +86,7 @@ pub async fn insert_flags_for_team_in_redis(
     };
 
     client
-        .set(format!("{TEAM_FLAGS_CACHE_PREFIX}{project_id}"), payload)
+        .set(format!("{TEAM_FLAGS_CACHE_PREFIX}{team_id}"), payload)
         .await?;
 
     Ok(())
@@ -304,7 +302,7 @@ async fn insert_team_group_mappings(
         .bind(group_type)
         .bind(group_type_index)
         .bind(team.id)
-        .bind(team.project_id())
+        .bind(team.id)
         .execute(&mut *persons_conn)
         .await?;
         assert_eq!(res.rows_affected(), 1);
@@ -329,7 +327,6 @@ pub async fn insert_new_team_in_pg(
     let token = random_string("phc_", 12);
     let team = Team {
         id,
-        project_id: Some(id as i64),
         name: "Test Team".to_string(),
         api_token: token.clone(),
         cookieless_server_hash_mode: Some(0),
@@ -347,7 +344,7 @@ pub async fn insert_new_team_in_pg(
         (id, organization_id, name, created_at) VALUES
         ($1, $2::uuid, $3, '2024-06-17 14:40:51.332036+00:00')"#,
     )
-    .bind(team.project_id())
+    .bind(team.id)
     .bind(org_id)
     .bind(&team.name)
     .execute(&mut *non_persons_conn)
@@ -359,7 +356,7 @@ pub async fn insert_new_team_in_pg(
         r#"INSERT INTO posthog_team
         (id, uuid, organization_id, project_id, api_token, name, created_at, updated_at, app_urls, anonymize_ips, completed_snippet_onboarding, ingested_event, session_recording_opt_in, is_demo, access_control, test_account_filters, timezone, data_attributes, plugins_opt_in, opt_out_capture, event_names, event_names_with_usage, event_properties, event_properties_with_usage, event_properties_numerical, cookieless_server_hash_mode, base_currency, session_recording_retention_period, web_analytics_pre_aggregated_tables_enabled) VALUES
         ($1, $2, $3::uuid, $4, $5, $6, '2024-06-17 14:40:51.332036+00:00', '2024-06-17', '{}', false, false, false, false, false, false, '{}', 'UTC', '["data-attr"]', false, false, '[]', '[]', '[]', '[]', '[]', $7, 'USD', '30d', false)"#
-    ).bind(team.id).bind(uuid).bind(org_id).bind(team.project_id()).bind(&team.api_token).bind(&team.name).bind(team.cookieless_server_hash_mode.unwrap_or(0)).execute(&mut *non_persons_conn).await?;
+    ).bind(team.id).bind(uuid).bind(org_id).bind(team.id).bind(&team.api_token).bind(&team.name).bind(team.cookieless_server_hash_mode.unwrap_or(0)).execute(&mut *non_persons_conn).await?;
     assert_eq!(res.rows_affected(), 1);
 
     // Insert group type mappings
@@ -1119,7 +1116,6 @@ impl TestContext {
         let id = rand::thread_rng().gen_range(1_000_000..100_000_000);
         let team = Team {
             id,
-            project_id: Some(id as i64),
             name: "Test Team".to_string(),
             api_token: public_token.clone(),
             cookieless_server_hash_mode: Some(0),
@@ -1137,7 +1133,7 @@ impl TestContext {
             (id, organization_id, name, created_at) VALUES
             ($1, $2::uuid, $3, '2024-06-17 14:40:51.332036+00:00')"#,
         )
-        .bind(team.project_id())
+        .bind(team.id)
         .bind(ORG_ID)
         .bind(&team.name)
         .execute(&mut *conn)
@@ -1168,7 +1164,7 @@ impl TestContext {
             .bind(team.id)
             .bind(uuid)
             .bind(ORG_ID)
-            .bind(team.project_id())
+            .bind(team.id)
             .bind(&team.api_token)
             .bind(&secret_token);
 
@@ -1222,7 +1218,7 @@ impl TestContext {
         let mut conn = self.non_persons_reader.get_connection().await?;
         let org_id: uuid::Uuid =
             sqlx::query_scalar("SELECT organization_id FROM posthog_project WHERE id = $1")
-                .bind(team.project_id())
+                .bind(team.id)
                 .fetch_one(&mut *conn)
                 .await?;
         Ok(org_id)

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -57,7 +57,6 @@ impl ServerHandle {
             // Create a minimal valid Team object
             let team = Team {
                 id: team_id,
-                project_id: Some(team_id as i64),
                 name: "Test Team".to_string(),
                 api_token: token.clone(),
                 cookieless_server_hash_mode: Some(0),

--- a/rust/feature-flags/tests/test_flag_matching_consistency.rs
+++ b/rust/feature-flags/tests/test_flag_matching_consistency.rs
@@ -125,7 +125,7 @@ async fn it_is_consistent_with_rollout_calculation_for_simple_flags() {
                 reader.clone(),
                 writer.clone(),
             );
-            FeatureFlagMatcher::new(distinct_id, 1, 1, router, cohort_cache, None, None)
+            FeatureFlagMatcher::new(distinct_id, 1, router, cohort_cache, None, None)
         }
         .get_match(&flags[0], None, None)
         .unwrap();
@@ -1223,7 +1223,7 @@ async fn it_is_consistent_with_rollout_calculation_for_multivariate_flags() {
                 reader.clone(),
                 writer.clone(),
             );
-            FeatureFlagMatcher::new(distinct_id, 1, 1, router, cohort_cache, None, None)
+            FeatureFlagMatcher::new(distinct_id, 1, router, cohort_cache, None, None)
         }
         .get_match(&flags[0], None, None)
         .unwrap();

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -103,13 +103,7 @@ async fn it_gets_legacy_response_for_v1_or_invalid_version(
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -175,13 +169,7 @@ async fn it_gets_v2_response_by_default_when_no_params() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -263,13 +251,7 @@ async fn it_get_new_response_when_version_is_2_or_more(#[case] version: &str) ->
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -537,7 +519,7 @@ async fn it_handles_disable_flags_without_distinct_id() -> Result<()> {
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();
 
-    insert_flags_for_team_in_redis(client.clone(), team.id, team.project_id(), None)
+    insert_flags_for_team_in_redis(client.clone(), team.id, None)
         .await
         .unwrap();
 
@@ -693,13 +675,7 @@ async fn it_handles_multivariate_flags() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -770,13 +746,7 @@ async fn it_handles_flag_with_property_filter() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -870,13 +840,7 @@ async fn it_matches_flags_to_a_request_with_group_property_overrides() -> Result
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -995,13 +959,7 @@ async fn test_feature_flags_with_json_payloads() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        redis_client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(redis_client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -1104,13 +1062,8 @@ async fn test_feature_flags_with_group_relationships() -> Result<()> {
     ]);
 
     // Insert the feature flags into Redis
-    insert_flags_for_team_in_redis(
-        redis_client.clone(),
-        team.id,
-        team.project_id(),
-        Some(flags_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(redis_client.clone(), team.id, Some(flags_json.to_string()))
+        .await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -1240,13 +1193,7 @@ async fn it_handles_not_contains_property_filter() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -1339,13 +1286,7 @@ async fn it_handles_not_equal_and_not_regex_property_filters() -> Result<()> {
         }
     ]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -1499,13 +1440,7 @@ async fn test_complex_regex_and_name_match_flag() -> Result<()> {
         }
     }]);
 
-    insert_flags_for_team_in_redis(
-        redis_client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(redis_client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -1626,13 +1561,7 @@ async fn test_super_condition_with_complex_request() -> Result<()> {
         }
     }]);
 
-    insert_flags_for_team_in_redis(
-        redis_client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(redis_client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -1719,13 +1648,7 @@ async fn test_flag_matches_with_no_person_profile() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -1839,13 +1762,7 @@ async fn it_only_includes_config_fields_when_requested() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -1905,13 +1822,7 @@ async fn test_config_basic_fields() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -2239,13 +2150,7 @@ async fn test_config_included_in_legacy_response() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -3255,13 +3160,7 @@ async fn test_disable_flags_returns_empty_response() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -3326,13 +3225,7 @@ async fn test_disable_flags_returns_empty_response_v2() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -3396,13 +3289,7 @@ async fn test_disable_flags_false_still_returns_flags() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -3468,13 +3355,7 @@ async fn test_disable_flags_with_config_still_returns_config_data() -> Result<()
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -3555,13 +3436,7 @@ async fn test_disable_flags_with_config_v2_still_returns_config_data() -> Result
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -3642,13 +3517,7 @@ async fn test_disable_flags_without_config_param_has_minimal_response() -> Resul
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -3730,13 +3599,8 @@ async fn test_numeric_group_ids_work_correctly() -> Result<()> {
         }
     ]);
 
-    insert_flags_for_team_in_redis(
-        redis_client.clone(),
-        team.id,
-        team.project_id(),
-        Some(flags_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(redis_client.clone(), team.id, Some(flags_json.to_string()))
+        .await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -3908,13 +3772,7 @@ async fn test_super_condition_property_overrides_bug_fix() -> Result<()> {
         }
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -4126,13 +3984,7 @@ async fn test_property_override_bug_real_scenario() -> Result<()> {
         }
     ]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -4244,13 +4096,7 @@ async fn test_super_condition_with_cohort_filters() -> Result<()> {
         }
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -4437,13 +4283,7 @@ async fn test_returns_empty_flags_when_no_active_flags_configured() -> Result<()
         }
     ]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -4546,13 +4386,7 @@ async fn test_group_key_property_matching() -> Result<()> {
         },
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -4727,13 +4561,7 @@ async fn test_cohort_filter_with_regex_and_negation() -> Result<()> {
         }
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -4962,13 +4790,7 @@ async fn test_flag_keys_should_include_dependency_graph() -> Result<()> {
         }
     ]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -5150,14 +4972,9 @@ async fn test_flag_keys_to_evaluate_parameter() -> Result<()> {
         }
     ]);
 
-    insert_flags_for_team_in_redis(
-        client.clone(),
-        team.id,
-        team.project_id(),
-        Some(flags.to_string()),
-    )
-    .await
-    .unwrap();
+    insert_flags_for_team_in_redis(client.clone(), team.id, Some(flags.to_string()))
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
@@ -5493,13 +5310,7 @@ async fn test_nested_cohort_targeting_with_days_since_paid_plan() -> Result<()> 
         }
     }]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -5755,13 +5566,7 @@ async fn test_empty_distinct_id_flag_matching() -> Result<()> {
         }
     ]);
 
-    insert_flags_for_team_in_redis(
-        client.clone(),
-        team.id,
-        team.project_id(),
-        Some(flags_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client.clone(), team.id, Some(flags_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -6009,13 +5814,7 @@ async fn test_cohort_with_and_negated_cohort_condition() -> Result<()> {
         }
     }]);
 
-    insert_flags_for_team_in_redis(
-        client.clone(),
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client.clone(), team.id, Some(flag_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -6213,14 +6012,9 @@ async fn test_date_string_property_matching_with_is_date_after() -> Result<()> {
         }
     }]);
 
-    insert_flags_for_team_in_redis(
-        redis_client.clone(),
-        team.id,
-        team.project_id(),
-        Some(flag_json.to_string()),
-    )
-    .await
-    .unwrap();
+    insert_flags_for_team_in_redis(redis_client.clone(), team.id, Some(flag_json.to_string()))
+        .await
+        .unwrap();
 
     let server = ServerHandle::for_config(config).await;
 

--- a/rust/feature-flags/tests/test_legacy_decide_formats.rs
+++ b/rust/feature-flags/tests/test_legacy_decide_formats.rs
@@ -87,13 +87,7 @@ async fn test_legacy_decide_v1_format() -> Result<()> {
         }
     ]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flags_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flags_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -219,13 +213,7 @@ async fn test_legacy_decide_v2_format() -> Result<()> {
         }
     ]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flags_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flags_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 
@@ -313,13 +301,7 @@ async fn test_decide_header_changes_version_interpretation() -> Result<()> {
         }
     ]);
 
-    insert_flags_for_team_in_redis(
-        client,
-        team.id,
-        team.project_id(),
-        Some(flags_json.to_string()),
-    )
-    .await?;
+    insert_flags_for_team_in_redis(client, team.id, Some(flags_json.to_string())).await?;
 
     let server = ServerHandle::for_config(config).await;
 


### PR DESCRIPTION
See [this discussion for more context](https://posthog.slack.com/archives/C07Q2U4BH4L/p1763972209372179?thread_ts=1763774169.602879&cid=C07Q2U4BH4L).

## Problem

The project_id is a remnant of a concept that was abandoned and we've rolled back from this approach. However, it still exists in our code and is a source of confusion. 

## Changes

Remove all traces of project id from the Rust feature-flags code. Use `team_id` instead.

## How did you test this code?

* Unit Tests
* Manual smoke test

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
