### PR TITLE
feat: Add Temporal workflow for materialized property backfill

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -26,7 +26,46 @@
       group3_created_at DateTime64,
       group4_created_at DateTime64,
       person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
-      
+          , `dmat_string_0` Nullable(String)
+      , `dmat_string_1` Nullable(String)
+      , `dmat_string_2` Nullable(String)
+      , `dmat_string_3` Nullable(String)
+      , `dmat_string_4` Nullable(String)
+      , `dmat_string_5` Nullable(String)
+      , `dmat_string_6` Nullable(String)
+      , `dmat_string_7` Nullable(String)
+      , `dmat_string_8` Nullable(String)
+      , `dmat_string_9` Nullable(String)
+      , `dmat_numeric_0` Nullable(Float64)
+      , `dmat_numeric_1` Nullable(Float64)
+      , `dmat_numeric_2` Nullable(Float64)
+      , `dmat_numeric_3` Nullable(Float64)
+      , `dmat_numeric_4` Nullable(Float64)
+      , `dmat_numeric_5` Nullable(Float64)
+      , `dmat_numeric_6` Nullable(Float64)
+      , `dmat_numeric_7` Nullable(Float64)
+      , `dmat_numeric_8` Nullable(Float64)
+      , `dmat_numeric_9` Nullable(Float64)
+      , `dmat_bool_0` Nullable(UInt8)
+      , `dmat_bool_1` Nullable(UInt8)
+      , `dmat_bool_2` Nullable(UInt8)
+      , `dmat_bool_3` Nullable(UInt8)
+      , `dmat_bool_4` Nullable(UInt8)
+      , `dmat_bool_5` Nullable(UInt8)
+      , `dmat_bool_6` Nullable(UInt8)
+      , `dmat_bool_7` Nullable(UInt8)
+      , `dmat_bool_8` Nullable(UInt8)
+      , `dmat_bool_9` Nullable(UInt8)
+      , `dmat_datetime_0` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_1` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_2` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_3` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_4` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_5` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_6` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_7` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_8` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_9` Nullable(DateTime64(6, 'UTC'))
       
       
       
@@ -189,7 +228,46 @@
       group3_created_at DateTime64,
       group4_created_at DateTime64,
       person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
-      
+          , `dmat_string_0` Nullable(String)
+      , `dmat_string_1` Nullable(String)
+      , `dmat_string_2` Nullable(String)
+      , `dmat_string_3` Nullable(String)
+      , `dmat_string_4` Nullable(String)
+      , `dmat_string_5` Nullable(String)
+      , `dmat_string_6` Nullable(String)
+      , `dmat_string_7` Nullable(String)
+      , `dmat_string_8` Nullable(String)
+      , `dmat_string_9` Nullable(String)
+      , `dmat_numeric_0` Nullable(Float64)
+      , `dmat_numeric_1` Nullable(Float64)
+      , `dmat_numeric_2` Nullable(Float64)
+      , `dmat_numeric_3` Nullable(Float64)
+      , `dmat_numeric_4` Nullable(Float64)
+      , `dmat_numeric_5` Nullable(Float64)
+      , `dmat_numeric_6` Nullable(Float64)
+      , `dmat_numeric_7` Nullable(Float64)
+      , `dmat_numeric_8` Nullable(Float64)
+      , `dmat_numeric_9` Nullable(Float64)
+      , `dmat_bool_0` Nullable(UInt8)
+      , `dmat_bool_1` Nullable(UInt8)
+      , `dmat_bool_2` Nullable(UInt8)
+      , `dmat_bool_3` Nullable(UInt8)
+      , `dmat_bool_4` Nullable(UInt8)
+      , `dmat_bool_5` Nullable(UInt8)
+      , `dmat_bool_6` Nullable(UInt8)
+      , `dmat_bool_7` Nullable(UInt8)
+      , `dmat_bool_8` Nullable(UInt8)
+      , `dmat_bool_9` Nullable(UInt8)
+      , `dmat_datetime_0` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_1` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_2` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_3` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_4` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_5` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_6` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_7` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_8` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_9` Nullable(DateTime64(6, 'UTC'))
       
       
       
@@ -1122,6 +1200,46 @@
   group3_created_at,
   group4_created_at,
   person_mode,
+  dmat_string_0,
+  dmat_string_1,
+  dmat_string_2,
+  dmat_string_3,
+  dmat_string_4,
+  dmat_string_5,
+  dmat_string_6,
+  dmat_string_7,
+  dmat_string_8,
+  dmat_string_9,
+  dmat_numeric_0,
+  dmat_numeric_1,
+  dmat_numeric_2,
+  dmat_numeric_3,
+  dmat_numeric_4,
+  dmat_numeric_5,
+  dmat_numeric_6,
+  dmat_numeric_7,
+  dmat_numeric_8,
+  dmat_numeric_9,
+  dmat_bool_0,
+  dmat_bool_1,
+  dmat_bool_2,
+  dmat_bool_3,
+  dmat_bool_4,
+  dmat_bool_5,
+  dmat_bool_6,
+  dmat_bool_7,
+  dmat_bool_8,
+  dmat_bool_9,
+  dmat_datetime_0,
+  dmat_datetime_1,
+  dmat_datetime_2,
+  dmat_datetime_3,
+  dmat_datetime_4,
+  dmat_datetime_5,
+  dmat_datetime_6,
+  dmat_datetime_7,
+  dmat_datetime_8,
+  dmat_datetime_9,
   _timestamp,
   _offset,
   arrayMap(
@@ -1511,7 +1629,46 @@
       group3_created_at DateTime64,
       group4_created_at DateTime64,
       person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
-      
+          , `dmat_string_0` Nullable(String)
+      , `dmat_string_1` Nullable(String)
+      , `dmat_string_2` Nullable(String)
+      , `dmat_string_3` Nullable(String)
+      , `dmat_string_4` Nullable(String)
+      , `dmat_string_5` Nullable(String)
+      , `dmat_string_6` Nullable(String)
+      , `dmat_string_7` Nullable(String)
+      , `dmat_string_8` Nullable(String)
+      , `dmat_string_9` Nullable(String)
+      , `dmat_numeric_0` Nullable(Float64)
+      , `dmat_numeric_1` Nullable(Float64)
+      , `dmat_numeric_2` Nullable(Float64)
+      , `dmat_numeric_3` Nullable(Float64)
+      , `dmat_numeric_4` Nullable(Float64)
+      , `dmat_numeric_5` Nullable(Float64)
+      , `dmat_numeric_6` Nullable(Float64)
+      , `dmat_numeric_7` Nullable(Float64)
+      , `dmat_numeric_8` Nullable(Float64)
+      , `dmat_numeric_9` Nullable(Float64)
+      , `dmat_bool_0` Nullable(UInt8)
+      , `dmat_bool_1` Nullable(UInt8)
+      , `dmat_bool_2` Nullable(UInt8)
+      , `dmat_bool_3` Nullable(UInt8)
+      , `dmat_bool_4` Nullable(UInt8)
+      , `dmat_bool_5` Nullable(UInt8)
+      , `dmat_bool_6` Nullable(UInt8)
+      , `dmat_bool_7` Nullable(UInt8)
+      , `dmat_bool_8` Nullable(UInt8)
+      , `dmat_bool_9` Nullable(UInt8)
+      , `dmat_datetime_0` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_1` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_2` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_3` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_4` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_5` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_6` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_7` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_8` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_9` Nullable(DateTime64(6, 'UTC'))
       
       
       
@@ -4958,7 +5115,46 @@
       group3_created_at DateTime64,
       group4_created_at DateTime64,
       person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
-      
+          , `dmat_string_0` Nullable(String)
+      , `dmat_string_1` Nullable(String)
+      , `dmat_string_2` Nullable(String)
+      , `dmat_string_3` Nullable(String)
+      , `dmat_string_4` Nullable(String)
+      , `dmat_string_5` Nullable(String)
+      , `dmat_string_6` Nullable(String)
+      , `dmat_string_7` Nullable(String)
+      , `dmat_string_8` Nullable(String)
+      , `dmat_string_9` Nullable(String)
+      , `dmat_numeric_0` Nullable(Float64)
+      , `dmat_numeric_1` Nullable(Float64)
+      , `dmat_numeric_2` Nullable(Float64)
+      , `dmat_numeric_3` Nullable(Float64)
+      , `dmat_numeric_4` Nullable(Float64)
+      , `dmat_numeric_5` Nullable(Float64)
+      , `dmat_numeric_6` Nullable(Float64)
+      , `dmat_numeric_7` Nullable(Float64)
+      , `dmat_numeric_8` Nullable(Float64)
+      , `dmat_numeric_9` Nullable(Float64)
+      , `dmat_bool_0` Nullable(UInt8)
+      , `dmat_bool_1` Nullable(UInt8)
+      , `dmat_bool_2` Nullable(UInt8)
+      , `dmat_bool_3` Nullable(UInt8)
+      , `dmat_bool_4` Nullable(UInt8)
+      , `dmat_bool_5` Nullable(UInt8)
+      , `dmat_bool_6` Nullable(UInt8)
+      , `dmat_bool_7` Nullable(UInt8)
+      , `dmat_bool_8` Nullable(UInt8)
+      , `dmat_bool_9` Nullable(UInt8)
+      , `dmat_datetime_0` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_1` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_2` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_3` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_4` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_5` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_6` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_7` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_8` Nullable(DateTime64(6, 'UTC'))
+      , `dmat_datetime_9` Nullable(DateTime64(6, 'UTC'))
       
       
   , _timestamp DateTime

--- a/posthog/temporal/backfill_materialized_property/__init__.py
+++ b/posthog/temporal/backfill_materialized_property/__init__.py
@@ -1,0 +1,27 @@
+"""Temporal workflow for backfilling materialized property columns."""
+
+from posthog.temporal.backfill_materialized_property.activities import (
+    BackfillMaterializedColumnInputs,
+    UpdateSlotStateInputs,
+    backfill_materialized_column,
+    update_slot_state,
+)
+from posthog.temporal.backfill_materialized_property.workflows import (
+    BackfillMaterializedPropertyInputs,
+    BackfillMaterializedPropertyWorkflow,
+)
+
+ACTIVITIES = [
+    backfill_materialized_column,
+    update_slot_state,
+]
+
+__all__ = [
+    "BackfillMaterializedPropertyWorkflow",
+    "BackfillMaterializedPropertyInputs",
+    "ACTIVITIES",
+    "backfill_materialized_column",
+    "BackfillMaterializedColumnInputs",
+    "update_slot_state",
+    "UpdateSlotStateInputs",
+]

--- a/posthog/temporal/backfill_materialized_property/activities.py
+++ b/posthog/temporal/backfill_materialized_property/activities.py
@@ -1,0 +1,209 @@
+"""Activities for materialized property backfill workflow."""
+
+import dataclasses
+from typing import Optional
+
+import structlog
+from temporalio import activity
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.kafka_engine import trim_quotes_expr
+from posthog.models import MaterializedColumnSlot
+from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
+from posthog.models.property_definition import PropertyType
+
+logger = structlog.get_logger(__name__)
+
+PROPERTY_TYPE_TO_COLUMN_NAME: dict[str, str] = {
+    str(PropertyType.String): "string",
+    str(PropertyType.Numeric): "numeric",
+    str(PropertyType.Boolean): "bool",
+    str(PropertyType.Datetime): "datetime",
+}
+
+MATERIALIZABLE_PROPERTY_TYPES: set[str] = set(PROPERTY_TYPE_TO_COLUMN_NAME.keys())
+
+
+@dataclasses.dataclass
+class BackfillMaterializedColumnInputs:
+    team_id: int
+    property_name: str
+    property_type: str
+    mat_column_name: str
+    partition_id: Optional[str] = None
+
+
+@dataclasses.dataclass
+class UpdateSlotStateInputs:
+    slot_id: str
+    state: str
+    error_message: Optional[str] = None
+
+
+def _generate_property_extraction_sql(property_name: str, property_type: str) -> str:
+    """
+    Generate SQL expression to extract property value from JSON properties column.
+
+    Mimics the HogQL property type wrappers (toFloat, toBool, toDateTime) applied
+    to JSON-extracted values to ensure identical behavior.
+    """
+    # Base JSON extraction with quote trimming (same as HogQL printer)
+    base_extract = trim_quotes_expr(f"JSONExtractRaw(properties, '{property_name}')")
+
+    if property_type == PropertyType.String:
+        return base_extract
+
+    elif property_type == PropertyType.Numeric:
+        # Match HogQL's toFloat() - no whitespace trimming, just direct conversion
+        return f"toFloat64OrNull({base_extract})"
+
+    elif property_type == PropertyType.Boolean:
+        # Match HogQL's toBool(transform(toString(...), ["true", "false"], [1, 0], None))
+        # Need to use toString() wrapper to match HogQL behavior
+        return f"transform(toString({base_extract}), ['true', 'false'], [1, 0], NULL)"
+
+    elif property_type == PropertyType.Datetime:
+        # Match HogQL's toDateTime() which uses parseDateTimeBestEffort
+        return f"""coalesce(
+            parseDateTimeBestEffortOrNull({base_extract}),
+            parseDateTimeBestEffortOrNull(substring({base_extract}, 1, 10))
+        )"""
+
+    else:
+        raise ValueError(f"Unsupported property type for materialization: {property_type}")
+
+
+@activity.defn
+def backfill_materialized_column(inputs: BackfillMaterializedColumnInputs) -> int:
+    """
+    Backfill a materialized column by running ALTER TABLE UPDATE on historical events.
+
+    Returns the number of rows affected (from ClickHouse mutation info).
+    """
+    # Generate the SQL expression for extracting the property
+    extraction_sql = _generate_property_extraction_sql(inputs.property_name, inputs.property_type)
+
+    # Build the ALTER TABLE UPDATE query
+    partition_clause = f"IN PARTITION '{inputs.partition_id}'" if inputs.partition_id else ""
+
+    # Note: Using sharded_events table directly (not distributed table)
+    query = f"""
+        ALTER TABLE sharded_events
+        UPDATE {inputs.mat_column_name} = {extraction_sql}
+        {partition_clause}
+        WHERE team_id = %(team_id)s
+    """
+
+    logger.info(
+        "Starting backfill for materialized column",
+        team_id=inputs.team_id,
+        property_name=inputs.property_name,
+        property_type=inputs.property_type,
+        mat_column_name=inputs.mat_column_name,
+        partition_id=inputs.partition_id,
+    )
+
+    try:
+        # Execute the ALTER TABLE UPDATE mutation
+        sync_execute(query, {"team_id": inputs.team_id})
+
+        # Note: ClickHouse mutations are async, so we can't get exact row count immediately
+        # The mutation will complete in the background
+        logger.info(
+            "Backfill mutation submitted successfully",
+            team_id=inputs.team_id,
+            property_name=inputs.property_name,
+            mat_column_name=inputs.mat_column_name,
+        )
+
+        # Return 0 since we don't have row count (mutation is async in ClickHouse)
+        return 0
+
+    except Exception as e:
+        logger.exception(
+            "Backfill failed",
+            team_id=inputs.team_id,
+            property_name=inputs.property_name,
+            mat_column_name=inputs.mat_column_name,
+            error=str(e),
+        )
+        raise
+
+
+@activity.defn
+def update_slot_state(inputs: UpdateSlotStateInputs) -> bool:
+    """
+    Update the state of a materialized column slot with activity logging.
+
+    Returns True if update succeeded.
+    """
+    try:
+        slot = MaterializedColumnSlot.objects.select_related("team", "property_definition").get(id=inputs.slot_id)
+        old_state = slot.state
+
+        slot.state = inputs.state
+
+        # Store or clear error message
+        if inputs.error_message:
+            slot.error_message = inputs.error_message
+            logger.error(
+                "Slot state update with error",
+                slot_id=inputs.slot_id,
+                old_state=old_state,
+                new_state=inputs.state,
+                error_message=inputs.error_message,
+            )
+        elif inputs.state == "BACKFILL":
+            # Clear error message when transitioning to BACKFILL (e.g., on retry)
+            slot.error_message = None
+
+        slot.save()
+
+        logger.info(
+            "Updated slot state",
+            slot_id=inputs.slot_id,
+            team_id=slot.team_id,
+            old_state=old_state,
+            new_state=inputs.state,
+        )
+
+        # Log activity for state transitions to READY or ERROR
+        if inputs.state in ["READY", "ERROR"]:
+            property_name = slot.property_definition.name if slot.property_definition else "Unknown"
+
+            activity_name = (
+                "materialized_column_backfill_completed"
+                if inputs.state == "READY"
+                else "materialized_column_backfill_failed"
+            )
+
+            log_activity(
+                organization_id=slot.team.organization_id,
+                team_id=slot.team_id,
+                user=None,  # System user for workflow-triggered updates
+                was_impersonated=False,
+                item_id=str(slot.id),
+                scope="DataManagement",
+                activity=activity_name,
+                detail=Detail(
+                    name=property_name,
+                    changes=[
+                        Change(
+                            type="MaterializedColumnSlot",
+                            action="changed",
+                            field="state",
+                            before=old_state,
+                            after=inputs.state,
+                        ),
+                    ],
+                ),
+            )
+
+        return True
+
+    except MaterializedColumnSlot.DoesNotExist:
+        logger.warning("Slot not found for state update", slot_id=inputs.slot_id)
+        return False
+    except Exception as e:
+        logger.exception("Failed to update slot state", slot_id=inputs.slot_id, error=str(e))
+        raise

--- a/posthog/temporal/backfill_materialized_property/workflows.py
+++ b/posthog/temporal/backfill_materialized_property/workflows.py
@@ -1,0 +1,147 @@
+"""Workflow for backfilling materialized property columns."""
+
+import os
+import json
+import datetime as dt
+import dataclasses
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+from posthog.temporal.backfill_materialized_property.activities import (
+    BackfillMaterializedColumnInputs,
+    UpdateSlotStateInputs,
+    backfill_materialized_column,
+    update_slot_state,
+)
+from posthog.temporal.common.base import PostHogWorkflow
+
+
+@dataclasses.dataclass
+class BackfillMaterializedPropertyInputs:
+    """Inputs for the backfill materialized property workflow."""
+
+    team_id: int
+    slot_id: str
+    property_name: str
+    property_type: str
+    mat_column_name: str
+    # Wait time for ingestion cache refresh (default 180s, can be 0 for tests)
+    cache_refresh_wait_seconds: int = 180
+    # Retry interval for state updates (default 10s, can be shorter for tests)
+    state_update_retry_interval_seconds: int = 10
+
+
+@workflow.defn(name="backfill-materialized-property")
+class BackfillMaterializedPropertyWorkflow(PostHogWorkflow):
+    """
+    Workflow to backfill a materialized property column.
+
+    Flow:
+    1. Wait 3 minutes for plugin-server ingestion cache to refresh
+       (ensures no gap between backfill and future new events being materialized)
+    2. Run ClickHouse ALTER TABLE UPDATE to backfill historical events
+    3. Update slot state to READY (or ERROR if failed)
+    """
+
+    @classmethod
+    def parse_inputs(cls, inputs: list[str]) -> BackfillMaterializedPropertyInputs:
+        """Parse inputs from the management command CLI."""
+        loaded = json.loads(inputs[0])
+        return BackfillMaterializedPropertyInputs(**loaded)
+
+    @workflow.run
+    async def run(self, inputs: BackfillMaterializedPropertyInputs) -> None:
+        """Execute the backfill workflow."""
+
+        # Disable logging in tests (workflow.logger hangs in Temporal test environments)
+        is_test = os.environ.get("PYTEST_CURRENT_TEST") is not None
+
+        try:
+            # Wait for plugin-server TeamManager cache to refresh
+            # IMPORTANT: plugin-server/src/utils/team-manager.ts has refreshAgeMs=2min + refreshJitterMs=30s
+            # We wait 3 minutes to account for max refresh time (2.5min) + buffer
+            # This prevents a gap where new events come in after backfill completes
+            # but before the ingestion server knows about the new materialized column
+            if inputs.cache_refresh_wait_seconds > 0:
+                if not is_test:
+                    workflow.logger.info(
+                        "Waiting for ingestion cache refresh",
+                        team_id=inputs.team_id,
+                        slot_id=inputs.slot_id,
+                        wait_seconds=inputs.cache_refresh_wait_seconds,
+                    )
+                await workflow.sleep(dt.timedelta(seconds=inputs.cache_refresh_wait_seconds))
+
+            # Run backfill
+            if not is_test:
+                workflow.logger.info(
+                    "Starting backfill",
+                    team_id=inputs.team_id,
+                    property_name=inputs.property_name,
+                    mat_column_name=inputs.mat_column_name,
+                )
+            await workflow.execute_activity(
+                backfill_materialized_column,
+                BackfillMaterializedColumnInputs(
+                    team_id=inputs.team_id,
+                    property_name=inputs.property_name,
+                    property_type=inputs.property_type,
+                    mat_column_name=inputs.mat_column_name,
+                ),
+                start_to_close_timeout=dt.timedelta(hours=2),
+                retry_policy=RetryPolicy(
+                    initial_interval=dt.timedelta(minutes=1),
+                    maximum_interval=dt.timedelta(minutes=10),
+                    maximum_attempts=3,
+                ),
+            )
+
+            # Update state to READY
+            if not is_test:
+                workflow.logger.info("Backfill complete, updating state to READY", slot_id=inputs.slot_id)
+            await workflow.execute_activity(
+                update_slot_state,
+                UpdateSlotStateInputs(slot_id=inputs.slot_id, state="READY"),
+                start_to_close_timeout=dt.timedelta(minutes=5),
+                retry_policy=RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=inputs.state_update_retry_interval_seconds),
+                    maximum_interval=dt.timedelta(minutes=1),
+                    maximum_attempts=5,  # State update is important, retry more
+                ),
+            )
+
+            if not is_test:
+                workflow.logger.info("Workflow completed successfully", slot_id=inputs.slot_id)
+
+        except Exception as e:
+            # Update state to ERROR
+            if not is_test:
+                workflow.logger.error("Workflow failed", slot_id=inputs.slot_id, error=str(e))
+
+            try:
+                await workflow.execute_activity(
+                    update_slot_state,
+                    UpdateSlotStateInputs(
+                        slot_id=inputs.slot_id,
+                        state="ERROR",
+                        error_message=str(e),
+                    ),
+                    start_to_close_timeout=dt.timedelta(minutes=5),
+                    retry_policy=RetryPolicy(
+                        initial_interval=dt.timedelta(seconds=inputs.state_update_retry_interval_seconds),
+                        maximum_interval=dt.timedelta(minutes=1),
+                        maximum_attempts=5,
+                    ),
+                )
+            except Exception as state_update_error:
+                if not is_test:
+                    workflow.logger.error(
+                        "Failed to update state to ERROR",
+                        slot_id=inputs.slot_id,
+                        original_error=str(e),
+                        state_update_error=str(state_update_error),
+                    )
+
+            # Re-raise the original exception
+            raise

--- a/posthog/temporal/product_analytics/__init__.py
+++ b/posthog/temporal/product_analytics/__init__.py
@@ -1,10 +1,17 @@
+from posthog.temporal.backfill_materialized_property import (
+    ACTIVITIES as BACKFILL_ACTIVITIES,
+    BackfillMaterializedPropertyWorkflow,
+)
+
 from .upgrade_queries_activities import get_insights_to_migrate, migrate_insights_batch
 from .upgrade_queries_workflow import UpgradeQueriesWorkflow
 
 WORKFLOWS = [
     UpgradeQueriesWorkflow,
+    BackfillMaterializedPropertyWorkflow,
 ]
 ACTIVITIES = [
     get_insights_to_migrate,
     migrate_insights_batch,
+    *BACKFILL_ACTIVITIES,
 ]

--- a/posthog/temporal/tests/backfill_materialized_property/__init__.py
+++ b/posthog/temporal/tests/backfill_materialized_property/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for materialized property backfill workflow."""

--- a/posthog/temporal/tests/backfill_materialized_property/conftest.py
+++ b/posthog/temporal/tests/backfill_materialized_property/conftest.py
@@ -1,0 +1,125 @@
+"""Fixtures for materialized property backfill tests."""
+
+import random
+
+import pytest
+
+from asgiref.sync import sync_to_async
+
+from posthog.models import MaterializedColumnSlot, MaterializedColumnSlotState, PropertyDefinition
+from posthog.models.property_definition import PropertyType
+
+
+@pytest.fixture
+def property_definition(team):
+    """Create a test property definition."""
+    return PropertyDefinition.objects.create(
+        team=team,
+        name=f"test_property_{random.randint(1, 99999)}",
+        property_type=PropertyType.String,
+        type=PropertyDefinition.Type.EVENT,
+    )
+
+
+@pytest.fixture
+def string_property_definition(team):
+    """Create a String type property definition."""
+    return PropertyDefinition.objects.create(
+        team=team,
+        name=f"string_prop_{random.randint(1, 99999)}",
+        property_type=PropertyType.String,
+        type=PropertyDefinition.Type.EVENT,
+    )
+
+
+@pytest.fixture
+def numeric_property_definition(team):
+    """Create a Numeric type property definition."""
+    return PropertyDefinition.objects.create(
+        team=team,
+        name=f"numeric_prop_{random.randint(1, 99999)}",
+        property_type=PropertyType.Numeric,
+        type=PropertyDefinition.Type.EVENT,
+    )
+
+
+@pytest.fixture
+def boolean_property_definition(team):
+    """Create a Boolean type property definition."""
+    return PropertyDefinition.objects.create(
+        team=team,
+        name=f"bool_prop_{random.randint(1, 99999)}",
+        property_type=PropertyType.Boolean,
+        type=PropertyDefinition.Type.EVENT,
+    )
+
+
+@pytest.fixture
+def datetime_property_definition(team):
+    """Create a DateTime type property definition."""
+    return PropertyDefinition.objects.create(
+        team=team,
+        name=f"datetime_prop_{random.randint(1, 99999)}",
+        property_type=PropertyType.Datetime,
+        type=PropertyDefinition.Type.EVENT,
+    )
+
+
+@pytest.fixture
+def materialized_slot(team, property_definition):
+    """Create a test materialized column slot in BACKFILL state."""
+    return MaterializedColumnSlot.objects.create(
+        team=team,
+        property_definition=property_definition,
+        property_type=property_definition.property_type,
+        slot_index=0,
+        state=MaterializedColumnSlotState.BACKFILL,
+    )
+
+
+@pytest.fixture
+def materialized_slot_ready(team, property_definition):
+    """Create a test materialized column slot in READY state."""
+    return MaterializedColumnSlot.objects.create(
+        team=team,
+        property_definition=property_definition,
+        property_type=property_definition.property_type,
+        slot_index=0,
+        state=MaterializedColumnSlotState.READY,
+    )
+
+
+@pytest.fixture
+def materialized_slot_error(team, property_definition):
+    """Create a test materialized column slot in ERROR state."""
+    return MaterializedColumnSlot.objects.create(
+        team=team,
+        property_definition=property_definition,
+        property_type=property_definition.property_type,
+        slot_index=0,
+        state=MaterializedColumnSlotState.ERROR,
+        error_message="Test error message",
+    )
+
+
+@pytest.fixture
+async def aproperty_definition(ateam):
+    """Create a test property definition (async)."""
+    return await sync_to_async(PropertyDefinition.objects.create)(
+        team=ateam,
+        name=f"test_property_{random.randint(1, 99999)}",
+        property_type=PropertyType.String,
+        type=PropertyDefinition.Type.EVENT,
+    )
+
+
+@pytest.fixture
+async def amaterialized_slot(ateam, aproperty_definition):
+    """Create a test materialized column slot (async)."""
+    return await sync_to_async(MaterializedColumnSlot.objects.create)(
+        team=ateam,
+        property_definition=aproperty_definition,
+        property_type=aproperty_definition.property_type,
+        slot_index=0,
+        state=MaterializedColumnSlotState.BACKFILL,
+    )

--- a/posthog/temporal/tests/backfill_materialized_property/test_activities.py
+++ b/posthog/temporal/tests/backfill_materialized_property/test_activities.py
@@ -1,0 +1,185 @@
+"""Tests for backfill materialized property activities."""
+
+import pytest
+from unittest.mock import patch
+
+from posthog.models import MaterializedColumnSlotState
+from posthog.temporal.backfill_materialized_property.activities import (
+    BackfillMaterializedColumnInputs,
+    UpdateSlotStateInputs,
+    _generate_property_extraction_sql,
+    backfill_materialized_column,
+    update_slot_state,
+)
+
+
+@pytest.mark.django_db(transaction=True)
+class TestPropertyExtractionSQL:
+    """Test SQL generation for extracting properties."""
+
+    @pytest.mark.parametrize(
+        "property_name,property_type,expected_fragments",
+        [
+            ("custom_prop", "String", ["replaceRegexpAll(JSONExtractRaw(properties, 'custom_prop')"]),
+            ("revenue", "Numeric", ["toFloat64OrNull("]),
+            ("is_active", "Boolean", ["transform(toString(", "['true', 'false'], [1, 0], NULL)"]),
+            ("last_login", "DateTime", ["coalesce(", "parseDateTimeBestEffortOrNull("]),
+        ],
+    )
+    def test_property_extraction_sql_generation(
+        self,
+        property_name,
+        property_type,
+        expected_fragments,
+    ):
+        sql = _generate_property_extraction_sql(property_name, property_type)
+        for fragment in expected_fragments:
+            assert fragment in sql, f"Expected '{fragment}' in SQL: {sql}"
+
+    def test_property_extraction_unsupported_type(self):
+        """Test that unsupported property types raise error."""
+        with pytest.raises(ValueError, match="Unsupported property type"):
+            _generate_property_extraction_sql("prop", "UnsupportedType")
+
+
+@pytest.mark.django_db(transaction=True)
+class TestBackfillMaterializedColumn:
+    """Test backfill_materialized_column activity."""
+
+    @patch("posthog.temporal.backfill_materialized_property.activities.sync_execute")
+    def test_backfill_executes_alter_table(self, mock_sync_execute, activity_environment):
+        """Test that backfill executes ALTER TABLE UPDATE."""
+        activity_environment.run(
+            backfill_materialized_column,
+            BackfillMaterializedColumnInputs(
+                team_id=123,
+                property_name="test_prop",
+                property_type="String",
+                mat_column_name="dmat_string_0",
+            ),
+        )
+
+        # Verify sync_execute was called with ALTER TABLE UPDATE
+        assert mock_sync_execute.called
+        query = mock_sync_execute.call_args[0][0]
+        assert "ALTER TABLE sharded_events" in query
+        assert "UPDATE dmat_string_0" in query
+        assert "WHERE team_id = %(team_id)s" in query
+
+    @patch("posthog.temporal.backfill_materialized_property.activities.sync_execute")
+    def test_backfill_with_partition_id(self, mock_sync_execute, activity_environment):
+        """Test backfilling a specific partition."""
+        activity_environment.run(
+            backfill_materialized_column,
+            BackfillMaterializedColumnInputs(
+                team_id=123,
+                property_name="test_prop",
+                property_type="String",
+                mat_column_name="dmat_string_0",
+                partition_id="202401",
+            ),
+        )
+
+        query = mock_sync_execute.call_args[0][0]
+        assert "IN PARTITION '202401'" in query
+
+    @patch("posthog.temporal.backfill_materialized_property.activities.sync_execute")
+    def test_backfill_without_partition_id(self, mock_sync_execute, activity_environment):
+        """Test backfilling all partitions (partition_id=None)."""
+        activity_environment.run(
+            backfill_materialized_column,
+            BackfillMaterializedColumnInputs(
+                team_id=123,
+                property_name="test_prop",
+                property_type="String",
+                mat_column_name="dmat_string_0",
+                partition_id=None,
+            ),
+        )
+
+        query = mock_sync_execute.call_args[0][0]
+        # Should NOT have partition clause
+        assert "IN PARTITION" not in query
+
+    @patch("posthog.temporal.backfill_materialized_property.activities.sync_execute")
+    def test_backfill_clickhouse_error(self, mock_sync_execute, activity_environment):
+        """Test error handling when ClickHouse query fails."""
+        mock_sync_execute.side_effect = Exception("ClickHouse connection failed")
+
+        with pytest.raises(Exception, match="ClickHouse connection failed"):
+            activity_environment.run(
+                backfill_materialized_column,
+                BackfillMaterializedColumnInputs(
+                    team_id=123,
+                    property_name="test_prop",
+                    property_type="String",
+                    mat_column_name="dmat_string_0",
+                ),
+            )
+
+
+@pytest.mark.django_db(transaction=True)
+class TestUpdateSlotState:
+    """Test update_slot_state activity."""
+
+    @pytest.mark.parametrize(
+        "new_state,error_message",
+        [
+            ("READY", None),
+            ("ERROR", "Something went wrong"),
+            ("BACKFILL", None),
+        ],
+    )
+    def test_update_slot_state(
+        self,
+        materialized_slot,
+        activity_environment,
+        new_state,
+        error_message,
+    ):
+        """Test updating slot state."""
+        result = activity_environment.run(
+            update_slot_state,
+            UpdateSlotStateInputs(
+                slot_id=str(materialized_slot.id),
+                state=new_state,
+                error_message=error_message,
+            ),
+        )
+
+        assert result is True
+
+        # Verify state was updated
+        materialized_slot.refresh_from_db()
+        assert materialized_slot.state == new_state
+
+        if error_message:
+            assert materialized_slot.error_message == error_message
+
+    def test_update_slot_state_clears_error_on_backfill(self, materialized_slot_error, activity_environment):
+        """Test that transitioning to BACKFILL clears error_message."""
+        assert materialized_slot_error.error_message is not None
+
+        activity_environment.run(
+            update_slot_state,
+            UpdateSlotStateInputs(
+                slot_id=str(materialized_slot_error.id),
+                state="BACKFILL",
+            ),
+        )
+
+        materialized_slot_error.refresh_from_db()
+        assert materialized_slot_error.state == MaterializedColumnSlotState.BACKFILL
+        assert materialized_slot_error.error_message is None
+
+    def test_update_slot_state_not_found(self, activity_environment):
+        """Test that activity returns False when slot not found."""
+        result = activity_environment.run(
+            update_slot_state,
+            UpdateSlotStateInputs(
+                slot_id="00000000-0000-0000-0000-000000000000",
+                state="READY",
+            ),
+        )
+
+        assert result is False

--- a/posthog/temporal/tests/backfill_materialized_property/test_workflow.py
+++ b/posthog/temporal/tests/backfill_materialized_property/test_workflow.py
@@ -1,0 +1,221 @@
+"""Tests for backfill materialized property workflow."""
+
+import uuid
+
+import pytest
+
+import temporalio.worker
+from temporalio import activity
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from posthog.temporal.backfill_materialized_property.activities import (
+    BackfillMaterializedColumnInputs,
+    UpdateSlotStateInputs,
+)
+from posthog.temporal.backfill_materialized_property.workflows import (
+    BackfillMaterializedPropertyInputs,
+    BackfillMaterializedPropertyWorkflow,
+)
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+class TestBackfillMaterializedPropertyWorkflow:
+    """Test the backfill workflow state machine with mocked activities."""
+
+    async def test_workflow_happy_path(self, amaterialized_slot):
+        """Test successful workflow: BACKFILL → READY."""
+        slot_id = str(amaterialized_slot.id)
+        team_id = amaterialized_slot.team_id
+
+        state_updates = []
+
+        @activity.defn(name="backfill_materialized_column")
+        async def mock_backfill(inputs: BackfillMaterializedColumnInputs) -> int:
+            return 0
+
+        @activity.defn(name="update_slot_state")
+        async def mock_update_state(inputs: UpdateSlotStateInputs) -> bool:
+            state_updates.append({"state": inputs.state, "error_message": inputs.error_message})
+            return True
+
+        task_queue = str(uuid.uuid4())
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=task_queue,
+                workflows=[BackfillMaterializedPropertyWorkflow],
+                activities=[mock_backfill, mock_update_state],
+                workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+            ):
+                await env.client.execute_workflow(
+                    BackfillMaterializedPropertyWorkflow.run,
+                    BackfillMaterializedPropertyInputs(
+                        team_id=team_id,
+                        slot_id=slot_id,
+                        property_name="test_property",
+                        property_type="String",
+                        mat_column_name="dmat_string_0",
+                        cache_refresh_wait_seconds=0,
+                        state_update_retry_interval_seconds=1,
+                    ),
+                    id=str(uuid.uuid4()),
+                    task_queue=task_queue,
+                )
+
+        assert len(state_updates) == 1
+        assert state_updates[0]["state"] == "READY"
+        assert state_updates[0]["error_message"] is None
+
+    async def test_workflow_backfill_fails(self, amaterialized_slot):
+        """Test workflow failure when backfill fails: BACKFILL → ERROR."""
+        slot_id = str(amaterialized_slot.id)
+        team_id = amaterialized_slot.team_id
+
+        state_updates = []
+
+        @activity.defn(name="backfill_materialized_column")
+        async def mock_backfill(inputs: BackfillMaterializedColumnInputs) -> int:
+            raise ApplicationError("ClickHouse mutation failed", non_retryable=True)
+
+        @activity.defn(name="update_slot_state")
+        async def mock_update_state(inputs: UpdateSlotStateInputs) -> bool:
+            state_updates.append({"state": inputs.state, "error_message": inputs.error_message})
+            return True
+
+        task_queue = str(uuid.uuid4())
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=task_queue,
+                workflows=[BackfillMaterializedPropertyWorkflow],
+                activities=[mock_backfill, mock_update_state],
+                workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+            ):
+                with pytest.raises(Exception):
+                    await env.client.execute_workflow(
+                        BackfillMaterializedPropertyWorkflow.run,
+                        BackfillMaterializedPropertyInputs(
+                            team_id=team_id,
+                            slot_id=slot_id,
+                            property_name="test_property",
+                            property_type="String",
+                            mat_column_name="dmat_string_0",
+                            cache_refresh_wait_seconds=0,
+                            state_update_retry_interval_seconds=1,
+                        ),
+                        id=str(uuid.uuid4()),
+                        task_queue=task_queue,
+                    )
+
+        assert len(state_updates) == 1
+        assert state_updates[0]["state"] == "ERROR"
+        assert state_updates[0]["error_message"] is not None
+        assert "Activity task failed" in state_updates[0]["error_message"]
+
+    async def test_workflow_update_state_to_error_fails(self, amaterialized_slot):
+        """Test that workflow still raises original error if update_slot_state to ERROR fails."""
+        slot_id = str(amaterialized_slot.id)
+        team_id = amaterialized_slot.team_id
+
+        @activity.defn(name="backfill_materialized_column")
+        async def mock_backfill(inputs: BackfillMaterializedColumnInputs) -> int:
+            raise ApplicationError("Original error: backfill failed", non_retryable=True)
+
+        @activity.defn(name="update_slot_state")
+        async def mock_update_state(inputs: UpdateSlotStateInputs) -> bool:
+            # Always fail when trying to update to ERROR
+            if inputs.state == "ERROR":
+                raise ApplicationError("DB connection lost", non_retryable=True)
+            return True
+
+        task_queue = str(uuid.uuid4())
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=task_queue,
+                workflows=[BackfillMaterializedPropertyWorkflow],
+                activities=[mock_backfill, mock_update_state],
+                workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+            ):
+                with pytest.raises(Exception) as exc_info:
+                    await env.client.execute_workflow(
+                        BackfillMaterializedPropertyWorkflow.run,
+                        BackfillMaterializedPropertyInputs(
+                            team_id=team_id,
+                            slot_id=slot_id,
+                            property_name="test_property",
+                            property_type="String",
+                            mat_column_name="dmat_string_0",
+                            cache_refresh_wait_seconds=0,
+                            state_update_retry_interval_seconds=1,
+                        ),
+                        id=str(uuid.uuid4()),
+                        task_queue=task_queue,
+                    )
+
+                # Verify the workflow re-raises the ORIGINAL backfill error (not the state update error)
+                # Temporal wraps errors, so we need to check the cause chain
+                error = exc_info.value
+                error_str = str(error)
+
+                # Check if the error has a cause attribute (WorkflowFailureError)
+                if hasattr(error, "cause"):
+                    cause_str = str(error.cause) if error.cause else ""
+                    full_error = f"{error_str} | cause: {cause_str}"
+                else:
+                    full_error = error_str
+
+                # The original "backfill failed" error should be in the error chain
+                assert (
+                    "backfill failed" in full_error or "Activity task failed" in full_error
+                ), f"Expected original backfill error in chain, got: {full_error}"
+
+    async def test_workflow_update_state_to_ready_retries(self, amaterialized_slot):
+        """Test that update_slot_state to READY retries on transient failures."""
+        slot_id = str(amaterialized_slot.id)
+        team_id = amaterialized_slot.team_id
+
+        # Track how many times update_slot_state is called
+        call_count = {"count": 0}
+
+        @activity.defn(name="backfill_materialized_column")
+        async def mock_backfill(inputs: BackfillMaterializedColumnInputs) -> int:
+            return 0
+
+        @activity.defn(name="update_slot_state")
+        async def mock_update_state(inputs: UpdateSlotStateInputs) -> bool:
+            call_count["count"] += 1
+            # Fail first 2 attempts, succeed on 3rd
+            if call_count["count"] < 3:
+                raise RuntimeError("Transient database error")
+            return True
+
+        task_queue = str(uuid.uuid4())
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=task_queue,
+                workflows=[BackfillMaterializedPropertyWorkflow],
+                activities=[mock_backfill, mock_update_state],
+                workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+            ):
+                await env.client.execute_workflow(
+                    BackfillMaterializedPropertyWorkflow.run,
+                    BackfillMaterializedPropertyInputs(
+                        team_id=team_id,
+                        slot_id=slot_id,
+                        property_name="test_property",
+                        property_type="String",
+                        mat_column_name="dmat_string_0",
+                        cache_refresh_wait_seconds=0,
+                        state_update_retry_interval_seconds=1,
+                    ),
+                    id=str(uuid.uuid4()),
+                    task_queue=task_queue,
+                )
+
+        # Verify state update was retried and eventually succeeded
+        assert call_count["count"] >= 3


### PR DESCRIPTION
- Add backfill_materialized_property workflow and activities
- Implements backfill of event properties into materialized column slots
- Add workflow tests and activity tests
- Register workflow in product_analytics

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
