### PR TITLE
fix(experiments): Load experiment when logic mounted

### DIFF
--- a/frontend/src/scenes/experiments/experimentSceneLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.tsx
@@ -196,9 +196,10 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
             }
         },
     })),
-    listeners(({ sharedListeners, values }) => ({
+    listeners(({ actions, sharedListeners, values }) => ({
         setSceneState: (payload, breakpoint, action, previousState) => {
             sharedListeners.ensureExperimentLogicMounted(payload, breakpoint, action, previousState)
+            actions.loadExperimentData()
         },
         setEditMode: (payload, breakpoint, action, previousState) => {
             sharedListeners.ensureExperimentLogicMounted(payload, breakpoint, action, previousState)


### PR DESCRIPTION
## Problem
After saving an experiment as draft, the experiment view shows default values ("Unnamed", "control"/"test" variants) because the newly mounted logic doesn't load the experiment data.

The tab-aware refactor in #40296 introduced a code path that bypasses the URL-based navigation which previously triggered the data load.

## Changes
Call loadExperimentData() after mounting the new experiment logic.

## How did you test this code?
👀 