### PR TITLE
fix: fix assign reviews to not run untrusted code

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -17,19 +17,16 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
-              with:
-                  # fetch enough commits to include the BASE_SHA, without fetching the full repo history.
-                  # note: it's possible a PR will have more than 1000 commits, but extremely unlikely.
-                  fetch-depth: 1000
-                  ref: ${{ github.event.pull_request.head.sha }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
                   node-version: '20'
 
-            - name: Fetch master branch
-              run: git fetch origin master
+            - name: Fetch head and base commits
+              run: |
+                  git fetch origin ${{ github.event.pull_request.base.sha }}
+                  git fetch origin ${{ github.event.pull_request.head.sha }}
 
             - name: Run reviewer assignment script
               env:


### PR DESCRIPTION
## Problem

re ran a pull_request_target action on the PR head, this is BAD and runs untrusted code by untrusted actors

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
