### PR TITLE
fix: re-enable auto assign reviews on pull requests

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,9 +1,11 @@
 name: Auto Assign Reviewers
 
 on:
-    pull_request: # Don't use `pull_request_target` for security reasons (see https://posthog.slack.com/archives/C09V86BQT5X/p1763989103518279)
+    pull_request_target:
         # Only opened or when clicking ready otherwise you can never remove the reviewers
         types: [opened, ready_for_review]
+        branches:
+            - master
 
 permissions:
     contents: read


### PR DESCRIPTION

## Problem

we now only run code on the master branch so this is safe to run as a pull_request_target action again


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
