### PR TITLE
feat(sessions): Add session properties to activity screen

### DIFF
--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -136,7 +136,9 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                 TaxonomicFilterGroupType.EventProperties,
                 TaxonomicFilterGroupType.EventFeatureFlags,
                 TaxonomicFilterGroupType.PersonProperties,
-                ...(isEventsQuery(query.source) ? [TaxonomicFilterGroupType.HogQLExpression] : []),
+                ...(isEventsQuery(query.source)
+                    ? [TaxonomicFilterGroupType.SessionProperties, TaxonomicFilterGroupType.HogQLExpression]
+                    : []),
             ]
 
     const showPersistedColumnReorder =
@@ -270,6 +272,11 @@ const SelectedColumn = ({
     if (column.startsWith('properties.')) {
         columnType = PropertyFilterType.Event
         columnKey = column.substring(11)
+    }
+    if (column.startsWith('session.')) {
+        columnType = PropertyFilterType.Session
+        filterGroupType = TaxonomicFilterGroupType.SessionProperties
+        columnKey = column.substring(8)
     }
 
     columnKey = trimQuotes(extractExpressionComment(columnKey))

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -603,6 +603,9 @@ export function taxonomicEventFilterToHogQL(
     if (groupType === TaxonomicFilterGroupType.EventFeatureFlags) {
         return `properties.${escapePropertyAsHogQLIdentifier(String(value))}`
     }
+    if (groupType === TaxonomicFilterGroupType.SessionProperties) {
+        return `session.${escapePropertyAsHogQLIdentifier(String(value))}`
+    }
     if (groupType === TaxonomicFilterGroupType.HogQLExpression && value) {
         return String(value)
     }


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C09BDQLM8KA/p1763984587371299

## Changes

Add support for sessions columns

## How did you test this code?
<img width="771" height="642" alt="Screenshot 2025-11-25 at 11 38 51" src="https://github.com/user-attachments/assets/994a115c-f851-47ab-8130-1137f595bdd8" />


## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
