### PR TITLE
fix: capture our own frontend errors

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -25,6 +25,9 @@ export function loadPostHogJS(): void {
             session_recording: {
                 strictMinimumDuration: true,
             },
+            error_tracking: {
+                __capturePostHogExceptions: true,
+            },
             loaded: (loadedInstance) => {
                 if (loadedInstance.sessionRecording) {
                     loadedInstance.sessionRecording._forceAllowLocalhostNetworkCapture = true


### PR DESCRIPTION
Since my changes in https://github.com/PostHog/posthog-js/pull/2430 we have stopped capturing our own exceptions 🙈 Caught by @luke-belton in https://posthog.slack.com/archives/C07AA937K9A/p1764068312177629