### PR TITLE
fix(sessions): Should query active parts by partition and host, rather than across whole table

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -1118,7 +1118,7 @@
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
                               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-17 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('2025-11-18 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC
                      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,

--- a/posthog/clickhouse/test/__snapshots__/test_raw_sessions_v3_model.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_raw_sessions_v3_model.ambr
@@ -64,12 +64,17 @@
 # ---
 # name: TestRawSessionsModel.test_get_number_of_umerged_parts
   '''
-  
-  SELECT count()
-  FROM clusterAllReplicas('posthog', system.parts)
-  WHERE database = 'posthog_test'
-    AND table = 'sharded_raw_sessions_v3'
-    AND active = 99999
+
+  SELECT max(parts_count)
+  FROM
+    (SELECT hostName() AS host,
+            count() AS parts_count
+     FROM clusterAllReplicas('posthog', system.parts)
+     WHERE database = 'posthog_test'
+       AND table = 'sharded_raw_sessions_v3'
+       AND partition IN ('99999')
+       AND active = 99999
+     GROUP BY host)
   '''
 # ---
 # name: TestRawSessionsModel.test_handles_different_distinct_id_across_same_session

--- a/posthog/clickhouse/test/__snapshots__/test_raw_sessions_v3_model.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_raw_sessions_v3_model.ambr
@@ -64,17 +64,21 @@
 # ---
 # name: TestRawSessionsModel.test_get_number_of_umerged_parts
   '''
-
-  SELECT max(parts_count)
+  
+  SELECT coalesce(max(parts_count), 0),
+         argMax(partition, parts_count),
+         argMax(host, parts_count)
   FROM
-    (SELECT hostName() AS host,
-            count() AS parts_count
+    (SELECT hostName() as host,
+            count() as parts_count,
+            partition
      FROM clusterAllReplicas('posthog', system.parts)
      WHERE database = 'posthog_test'
        AND table = 'sharded_raw_sessions_v3'
-       AND partition IN ('99999')
+       AND partition IN ('202511')
        AND active = 99999
-     GROUP BY host)
+     GROUP BY host,
+              partition)
   '''
 # ---
 # name: TestRawSessionsModel.test_handles_different_distinct_id_across_same_session

--- a/posthog/clickhouse/test/test_raw_sessions_v3_model.py
+++ b/posthog/clickhouse/test/test_raw_sessions_v3_model.py
@@ -697,6 +697,9 @@ class TestRawSessionsModel(ClickhouseTestMixin, BaseTest):
     def test_get_number_of_umerged_parts(self):
         # Just test that the query succeeds without errors and returns an int.
         # We can't really guarantee anything about the number of parts on the test DB.
-        result = sync_execute(GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS)
+        query = GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS(["202511"])
+        result = sync_execute(query)
         self.assertEqual(len(result), 1)
         self.assertIsInstance(result[0][0], int)
+        self.assertIsInstance(result[0][1], str)
+        self.assertIsInstance(result[0][2], str)


### PR DESCRIPTION
## Problem
I was seeing 15k parts, and then waiting (forever), because I was querying ALL active parts for the table across ALL hosts, rather than getting the max active parts on a single host/partition.

See https://posthog.dagster.plus/prod-us/runs/b64f93ce-10f2-4f91-a9c8-087933dcdbb4

## Changes

Change the query to only look at the relevant partitions, and get the max for a single host/partition

## How did you test this code?

Ran the dagster job manually

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
