### PR TITLE
fix: Create propdefs for properties added in the UI

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -23,13 +23,14 @@ from posthog.api.utils import action
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
 from posthog.helpers.dashboard_templates import create_group_type_mapping_detail_dashboard
-from posthog.models import GroupUsageMetric
+from posthog.models import GroupUsageMetric, PropertyDefinition
 from posthog.models.activity_logging.activity_log import Change, Detail, load_activity, log_activity
 from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.filters.utils import GroupTypeIndex
 from posthog.models.group import Group
 from posthog.models.group.util import create_group, raw_create_group_ch
 from posthog.models.group_type_mapping import GROUP_TYPE_MAPPING_SERIALIZER_FIELDS, GroupTypeMapping
+from posthog.models.property_definition import PropertyType
 from posthog.models.user import User
 
 from products.notebooks.backend.models import Notebook, ResourceNotebook
@@ -44,6 +45,37 @@ from ee.clickhouse.queries.related_actors_query import RelatedActorsQuery
 from ee.clickhouse.views.exceptions import TriggerGroupIdentifyException
 
 logger = structlog.get_logger(__name__)
+
+
+def detect_group_property_type(value):
+    if value is None:
+        return PropertyType.String
+    elif isinstance(value, bool):
+        return PropertyType.Boolean
+    elif isinstance(value, int | float):
+        return PropertyType.Numeric
+    elif isinstance(value, str):
+        if value.lower() in ("true", "false"):
+            return PropertyType.Boolean
+        return PropertyType.String
+    return PropertyType.String
+
+
+def create_property_definition(team_id: int, group_type_index: int, property_name: str, property_value):
+    """Create or update PostgreSQL PropertyDefinition for group property"""
+    property_type = detect_group_property_type(property_value)
+    is_numerical = property_type == PropertyType.Numeric
+
+    PropertyDefinition.objects.update_or_create(
+        team_id=team_id,
+        name=property_name,
+        type=PropertyDefinition.Type.GROUP,
+        group_type_index=group_type_index,
+        defaults={
+            "property_type": property_type.value,
+            "is_numerical": is_numerical,
+        },
+    )
 
 
 class GroupTypeSerializer(serializers.ModelSerializer):
@@ -280,6 +312,14 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
         except TriggerGroupIdentifyException as exc:
             return response.Response(data=exc.exception_data, status=exc.status_code)
 
+        for prop_name, prop_value in group.group_properties.items():
+            create_property_definition(
+                team_id=self.team.pk,
+                group_type_index=group.group_type_index,
+                property_name=prop_name,
+                property_value=prop_value,
+            )
+
         details = [
             Detail(
                 name=str(name),
@@ -379,9 +419,17 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
                         },
                         status=400,
                     )
+            create_or_update = "update" if request.data["key"] in group.group_properties.keys() else "create"
             original_value = group.group_properties.get(request.data["key"], None)
             group.group_properties[request.data["key"]] = request.data["value"]
             group.save()
+
+            create_property_definition(
+                team_id=self.team.pk,
+                group_type_index=group.group_type_index,
+                property_name=request.data["key"],
+                property_value=request.data["value"],
+            )
 
             # Need to update ClickHouse too
             timestamp = timezone.now()
@@ -394,11 +442,10 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
                 timestamp=timestamp,
             )
 
-            # another internal event submission where we best-effort and don't handle failures...
             try:
                 self.trigger_group_identify(
                     group=group,
-                    operation="group property update",
+                    operation=f"group property {create_or_update}",
                     group_properties={request.data["key"]: request.data["value"]},
                 )
             except TriggerGroupIdentifyException as exc:
@@ -411,13 +458,13 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
                 was_impersonated=is_impersonated_session(request),
                 item_id=group.pk,
                 scope="Group",
-                activity="update_property",
+                activity=f"{create_or_update}_property",
                 detail=Detail(
                     name=str(request.data["key"]),
                     changes=[
                         Change(
                             type="Group",
-                            action="created" if original_value is None else "changed",
+                            action=f"created" if create_or_update == "create" else "changed",
                             before=original_value,
                             after=request.data["value"],
                         )

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -17,7 +17,8 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.helpers.dashboard_templates import create_group_type_mapping_detail_dashboard
-from posthog.models import GroupTypeMapping, GroupUsageMetric, Person
+from posthog.models import GroupTypeMapping, GroupUsageMetric, Person, PropertyDefinition
+from posthog.models.filters.utils import GroupTypeIndex
 from posthog.models.group.util import create_group
 from posthog.models.organization import Organization
 from posthog.models.sharing_configuration import SharingConfiguration
@@ -385,6 +386,18 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertEqual(response.status_code, 200)
+        property_definitions = PropertyDefinition.objects.filter(
+            team=self.team, type=PropertyDefinition.Type.GROUP, group_type_index=0
+        )
+        self.assertEqual(len(property_definitions), 2)
+        name_prop = property_definitions.get(name="name")
+        self.assertEqual(name_prop.property_type, "String")
+        self.assertFalse(name_prop.is_numerical)
+
+        industry_prop = property_definitions.get(name="industry")
+        self.assertEqual(industry_prop.property_type, "String")
+        self.assertFalse(industry_prop.is_numerical)
+
         results = response.json()["results"]
         self.assertEqual(len(results), 2)
         for result in results:
@@ -530,7 +543,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
                 select properties
                 from groups
                 where index = {index}
-                and key = {key}
+                  and key = {key}
                 """,
                 placeholders={
                     "index": ast.Constant(value=group.group_type_index),
@@ -562,7 +575,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 200)
         self.assertIn("results", response.json())
         self.assertEqual(len(response.json()["results"]), 1)
-        self.assertEqual(response.json()["results"][0]["activity"], "update_property")
+        self.assertEqual(response.json()["results"][0]["activity"], "create_property")
         self.assertEqual(response.json()["results"][0]["scope"], "Group")
         self.assertEqual(response.json()["results"][0]["item_id"], str(group.pk))
         self.assertEqual(response.json()["results"][0]["detail"]["changes"][0]["type"], "Group")
@@ -609,7 +622,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
                 select properties
                 from groups
                 where index = {index}
-                and key = {key}
+                  and key = {key}
                 """,
                 placeholders={
                     "index": ast.Constant(value=group.group_type_index),
@@ -733,7 +746,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
                 select properties
                 from groups
                 where index = {index}
-                and key = {key}
+                  and key = {key}
                 """,
                 placeholders={
                     "index": ast.Constant(value=group.group_type_index),
@@ -1691,3 +1704,165 @@ class GroupUsageMetricViewSetTestCase(APIBaseTest):
         self.assertEqual(response.json(), self.permission_denied_response("You don't have access to the project."))
 
         self.assertTrue(GroupUsageMetric.objects.filter(id=other_metric.id).exists())
+
+
+class GroupPropertyDefinitionsTestCase(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.group_type_index: GroupTypeIndex = 0
+        self.group_type_mapping = create_group_type_mapping_without_created_at(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=self.group_type_index,
+            group_type="organization",
+        )
+        self.group_key = "test_company"
+        self.base_url = f"/api/projects/{self.team.id}/groups/"
+
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    def test_create_group_creates_property_definitions(self, mock_capture):
+        data = {
+            "group_type_index": self.group_type_index,
+            "group_key": self.group_key,
+            "group_properties": {"name": "Test Company", "employees": 100, "is_active": True, "revenue": 50000.50},
+        }
+
+        response = self.client.post(self.base_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        mock_capture.assert_called_once()
+
+        property_definitions = PropertyDefinition.objects.filter(
+            team=self.team, type=PropertyDefinition.Type.GROUP, group_type_index=self.group_type_index
+        )
+
+        self.assertEqual(property_definitions.count(), 4)
+
+        name_prop = property_definitions.get(name="name")
+        self.assertEqual(name_prop.property_type, "String")
+        self.assertFalse(name_prop.is_numerical)
+
+        employees_prop = property_definitions.get(name="employees")
+        self.assertEqual(employees_prop.property_type, "Numeric")
+        self.assertTrue(employees_prop.is_numerical)
+
+        is_active_prop = property_definitions.get(name="is_active")
+        self.assertEqual(is_active_prop.property_type, "Boolean")
+        self.assertFalse(is_active_prop.is_numerical)
+
+        revenue_prop = property_definitions.get(name="revenue")
+        self.assertEqual(revenue_prop.property_type, "Numeric")
+        self.assertTrue(revenue_prop.is_numerical)
+
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    def test_update_property_creates_property_definition(self, mock_capture):
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=self.group_type_index,
+            group_key=self.group_key,
+            properties={"existing": "value"},
+        )
+
+        data = {"key": "new_property", "value": "test_value"}
+        response = self.client.post(
+            f"{self.base_url}update_property?group_key={self.group_key}&group_type_index={self.group_type_index}",
+            data,
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_capture.assert_called_once()
+
+        prop_def = PropertyDefinition.objects.filter(
+            team=self.team,
+            name="new_property",
+            type=PropertyDefinition.Type.GROUP,
+            group_type_index=self.group_type_index,
+        ).first()
+
+        assert prop_def is not None
+        self.assertEqual(prop_def.property_type, "String")
+        self.assertFalse(prop_def.is_numerical)
+
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    def test_update_property_with_different_types(self, mock_capture):
+        create_group(
+            team_id=self.team.pk, group_type_index=self.group_type_index, group_key=self.group_key, properties={}
+        )
+
+        test_cases = [
+            ("string_prop", "test", "String", False),
+            ("number_prop", 42, "Numeric", True),
+            ("float_prop", 3.14, "Numeric", True),
+            ("bool_prop", True, "Boolean", False),
+            ("bool_string_true", "true", "Boolean", False),
+            ("bool_string_false", "false", "Boolean", False),
+        ]
+        for prop_name, prop_value, expected_type, expected_numerical in test_cases:
+            with self.subTest(prop_name):
+                mock_capture.reset_mock()
+                data = {"key": prop_name, "value": prop_value}
+                response = self.client.post(
+                    f"{self.base_url}update_property?group_key={self.group_key}&group_type_index={self.group_type_index}",
+                    data,
+                    format="json",
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                mock_capture.assert_called_once()
+
+                prop_def = PropertyDefinition.objects.get(
+                    team=self.team,
+                    name=prop_name,
+                    type=PropertyDefinition.Type.GROUP,
+                    group_type_index=self.group_type_index,
+                )
+
+                self.assertEqual(prop_def.property_type, expected_type)
+                self.assertEqual(prop_def.is_numerical, expected_numerical)
+
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    def test_update_existing_property_definition(self, mock_capture):
+        create_group(
+            team_id=self.team.pk, group_type_index=self.group_type_index, group_key=self.group_key, properties={}
+        )
+
+        string_prop_data = {"key": "test_prop", "value": "string_value"}
+        self.client.post(
+            f"{self.base_url}update_property?group_key={self.group_key}&group_type_index={self.group_type_index}",
+            string_prop_data,
+            format="json",
+        )
+
+        numerical_prop_data = {"key": "test_prop", "value": 123}
+        self.client.post(
+            f"{self.base_url}update_property?group_key={self.group_key}&group_type_index={self.group_type_index}",
+            numerical_prop_data,
+            format="json",
+        )
+
+        prop_def = PropertyDefinition.objects.filter(
+            team=self.team, name="test_prop", type=PropertyDefinition.Type.GROUP, group_type_index=self.group_type_index
+        ).first()
+
+        assert prop_def is not None
+        self.assertEqual(prop_def.property_type, "Numeric")
+        self.assertTrue(prop_def.is_numerical)
+
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    def test_property_definitions_have_correct_group_type_index(self, mock_capture):
+        self.group_type_mapping = create_group_type_mapping_without_created_at(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=1,
+            group_type="team",
+        )
+        data = {"group_type_index": 1, "group_key": "test_key", "group_properties": {"test_prop": "value"}}
+
+        response = self.client.post(self.base_url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        mock_capture.assert_called_once()
+        prop_def = PropertyDefinition.objects.get(
+            team=self.team, name="test_prop", type=PropertyDefinition.Type.GROUP, group_type_index=1
+        )
+        self.assertEqual(prop_def.group_type_index, 1)


### PR DESCRIPTION
## Problem

When manually creating group props via the UI, we are not generating propdefs, causing the properties to never show up in the filters.

For some reason, the dag is not picking up these properties and they end up never being synced (even after months, so it is not a matter of delays).

[Zendesk ticket](https://posthoghelp.zendesk.com/agent/tickets/36054)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

Create property definitions in postgres synchronously when creating/updating groups properties.

Note: this is not syncing with clickhouse, but it seems that the filters pull propdefs from postgres.
Feels like the right thing to do is to fix the dag to pick up these props, but I couldn't get it to work.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests for the row creation
In the UI by creating a group property and seeing it show up in filters (and successfully filtering by them)

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->