### PR TITLE
chore(data-warehouse): Use 95th percentile for calculating row chunk size

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -325,7 +325,9 @@ def _has_duplicate_primary_keys(
 def _get_table_chunk_size(cursor: psycopg.Cursor, inner_query: sql.Composed, logger: FilteringBoundLogger) -> int:
     try:
         query = sql.SQL("""
-            SELECT percentile_cont(0.95) within group (order by row_size) FROM (SELECT pg_column_size(t) as row_size FROM ({}) as t)
+            SELECT percentile_cont(0.95) within group (order by subquery.row_size) FROM (
+                SELECT pg_column_size(t) as row_size FROM ({}) as t
+            ) as subquery
         """).format(inner_query)
 
         _explain_query(cursor, query, logger)

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -325,7 +325,7 @@ def _has_duplicate_primary_keys(
 def _get_table_chunk_size(cursor: psycopg.Cursor, inner_query: sql.Composed, logger: FilteringBoundLogger) -> int:
     try:
         query = sql.SQL("""
-            SELECT SUM(pg_column_size(t)) / COUNT(*) FROM ({}) as t
+            SELECT percentile_cont(0.95) within group (order by row_size) FROM (SELECT pg_column_size(t) as row_size FROM ({}) as t)
         """).format(inner_query)
 
         _explain_query(cursor, query, logger)


### PR DESCRIPTION
## Problem
- We've been using the average row size in postgres for calculating the dynamic chunk size - meaning if a table has a handful of very big rows, then we're likely not catering for them and causing OOMs

## Changes
- Use the 95th percentile for row size instead

## How did you test this code?
- Tested the query extensively and tests pass