### PR TITLE
fix(ph-ai): ignore nulls in search output

### DIFF
--- a/ee/hogai/tools/full_text_search/test/test_tool.py
+++ b/ee/hogai/tools/full_text_search/test/test_tool.py
@@ -174,3 +174,23 @@ class TestEntitySearchToolkit(NonAtomicBaseTest):
         result = await self.toolkit.execute(query="test query", search_kind="invalid_type")  # type: ignore
 
         assert "Invalid entity kind: invalid_type. Will not perform search for it." in result
+
+    @parameterized.expand(
+        [
+            ({"a": 1, "b": None, "c": 3}, {"a": 1, "c": 3}),
+            ({"nested": {"x": 1, "y": None, "z": 2}}, {"nested": {"x": 1, "z": 2}}),
+            ({"list": [1, None, 3, None, 5]}, {"list": [1, 3, 5]}),
+            ({"tuple": (1, None, 3)}, {"tuple": (1, 3)}),
+            (
+                {"a": {"b": {"c": None, "d": 4}}, "e": [None, {"f": None, "g": 7}]},
+                {"a": {"b": {"d": 4}}, "e": [{"g": 7}]},
+            ),
+            ({"empty_dict": {}, "empty_list": []}, {"empty_dict": {}, "empty_list": []}),
+            ({"all_none": None}, {}),
+            ({}, {}),
+            ([], []),
+        ]
+    )
+    def test_omit_none_values(self, input_obj, expected_output):
+        result = self.toolkit._omit_none_values(input_obj)
+        assert result == expected_output

--- a/ee/hogai/tools/full_text_search/tool.py
+++ b/ee/hogai/tools/full_text_search/tool.py
@@ -169,10 +169,10 @@ class EntitySearchTool(MaxSubtool):
 
         result_dict = {
             "name": extra_fields.get("name", f"{entity_type.upper()} {result_id}"),
-            "id": result_id,
-            "extra_fields": extra_fields,
             "type": entity_type.title(),
+            "id": result_id,
             "url": self._build_url(entity_type, result_id),
+            "extra_fields": extra_fields,
         }
 
         cleaned_dict = self._omit_none_values(result_dict)

--- a/ee/hogai/tools/full_text_search/tool.py
+++ b/ee/hogai/tools/full_text_search/tool.py
@@ -153,6 +153,15 @@ class EntitySearchTool(MaxSubtool):
             case _:
                 raise ValueError(f"Unknown entity type: {entity_type}")
 
+    def _omit_none_values(self, obj):
+        """Recursively remove None values from dicts and sequences."""
+        if isinstance(obj, dict):
+            return {k: self._omit_none_values(v) for k, v in obj.items() if v is not None}
+        elif isinstance(obj, list | tuple):
+            return type(obj)(self._omit_none_values(item) for item in obj if item is not None)
+        else:
+            return obj
+
     def _get_formatted_entity_result(self, result: dict) -> str:
         entity_type = result["type"]
         result_id = result["result_id"]
@@ -166,7 +175,8 @@ class EntitySearchTool(MaxSubtool):
             "url": self._build_url(entity_type, result_id),
         }
 
-        return yaml.dump(result_dict, default_flow_style=False, allow_unicode=True, sort_keys=False).strip()
+        cleaned_dict = self._omit_none_values(result_dict)
+        return yaml.dump(cleaned_dict, default_flow_style=False, allow_unicode=True, sort_keys=False, indent=1).strip()
 
     def _format_results_for_display(
         self, query: str, entity_types: set[str], results: list[dict], counts: dict[str, int | None]


### PR DESCRIPTION
## Problem

Full-text search dumps the full schemas of objects, so we end up including lots of useless fields and nulls. This PR aims to shave some tokens.

## Changes

Dumping schemas will recursively filter out fields that have null values.

## How did you test this code?

Unit & manual testing
