### PR TITLE
chore: Assign security team ownership for .github directory due to untrusted GitHub Actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,3 +21,7 @@ posthog/hogql/** @PostHog/hogql
 # Being open source brings us unwanted problems because Github Actions are untrusted and inherently unsafe
 # so we have to be extra careful with changes here. Let's have the security team own this.
 .github/** @PostHog/team-security
+
+# And of course modifying this file can bring us problems so let's have the security team own it.
+# This does not affect CODEOWNERS-soft which is used for assigning non-required reviewers and it's much safer to change.
+CODEOWNERS @PostHog/team-security

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,11 @@
 # to manage the risk you're thinking about, do not add an entry.
 
 # ClickHouse team owns Clickhouse migrations
-
 posthog/clickhouse/migrations/** @PostHog/clickhouse
 
 # HogQL team owns HogQL changes
-
 posthog/hogql/** @PostHog/hogql
+
+# Being open source brings us unwanted problems because Github Actions are untrusted and inherently unsafe
+# so we have to be extra careful with changes here. Let's have the security team own this.
+.github/** @PostHog/team-security


### PR DESCRIPTION
A lot of problems can arise from having people modify `.github` files - one of the causes of the sha1-hulud affecting us.

We hate adding stuff to CODEOWNERS, but this one seems warranted. Let's do it