### PR TITLE
fix: Type mismatch in persons revenue analytics join

### DIFF
--- a/posthog/hogql/database/schema/persons_revenue_analytics.py
+++ b/posthog/hogql/database/schema/persons_revenue_analytics.py
@@ -43,8 +43,11 @@ def join_with_persons_revenue_analytics_table(
         constraint=ast.JoinConstraint(
             expr=ast.CompareOperation(
                 op=ast.CompareOperationOp.Eq,
-                left=ast.Field(chain=[join_to_add.from_table, *join_to_add.lazy_join.from_field]),
-                right=ast.Field(chain=[join_to_add.to_table, "person_id"]),
+                left=ast.Call(
+                    name="toString",
+                    args=[ast.Field(chain=[join_to_add.from_table, *join_to_add.lazy_join.from_field])],
+                ),
+                right=ast.Call(name="toString", args=[ast.Field(chain=[join_to_add.to_table, "person_id"])]),
             ),
             constraint_type="ON",
         ),

--- a/posthog/hogql/database/schema/test/__snapshots__/test_groups_revenue_analytics.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_groups_revenue_analytics.ambr
@@ -543,6 +543,119 @@
                      allow_experimental_join_condition=1
   '''
 # ---
+# name: TestRevenueAnalytics.test_get_revenue_for_schema_source_for_id_join.2
+  '''
+  SELECT groups.key AS key,
+         groups__revenue_analytics.revenue AS `$virt_revenue`
+  FROM
+    (SELECT tupleElement(argMax(tuple(groups.group_key), toTimeZone(groups._timestamp, 'UTC')), 1) AS groups___key,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  LEFT JOIN
+    (SELECT 99999 AS team_id,
+            arrayJoin([revenue_analytics_customer__groups.key]) AS group_key,
+            sum(revenue_analytics_revenue_item.amount) AS revenue,
+            sumIf(revenue_analytics_revenue_item.amount, greaterOrEquals(toTimeZone(revenue_analytics_revenue_item.timestamp, 'UTC'), minus(today(), toIntervalDay(30)))) AS revenue_last_30_days
+     FROM
+       (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+               invoice.invoice_item_id AS invoice_item_id,
+               'stripe.posthog_test' AS source_label,
+               addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+               invoice.created_at AS created_at,
+               ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+               invoice.product_id AS product_id,
+               invoice.customer_id AS customer_id,
+               NULL AS group_0_key,
+               NULL AS group_1_key,
+               NULL AS group_2_key,
+               NULL AS group_3_key,
+               NULL AS group_4_key,
+               invoice.id AS invoice_id,
+               invoice.subscription_id AS subscription_id,
+               NULL AS session_id,
+               NULL AS event_name,
+               JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+               JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+               upper(invoice.currency) AS original_currency,
+               accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'GBP' AS currency,
+                 divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+        FROM
+          (SELECT posthog_test_stripe_invoice.id AS id,
+                  parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                  posthog_test_stripe_invoice.customer AS customer_id,
+                  posthog_test_stripe_invoice.subscription AS subscription_id,
+                  posthog_test_stripe_invoice.discount AS discount,
+                  arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                  JSONExtractString(data, 'id') AS invoice_item_id,
+                  JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                  coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                  greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                  JSONExtractString(data, 'currency') AS currency,
+                  JSONExtractString(data, 'price', 'product') AS product_id,
+                  fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                  fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                  greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                  arrayJoin(range(0, period_months)) AS month_index,
+                  ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+           WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+     INNER JOIN
+       (SELECT outer.id AS id,
+               'stripe.posthog_test' AS source_label,
+               parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+               outer.name AS name,
+               outer.email AS email,
+               outer.phone AS phone,
+               outer.address AS address,
+               outer.metadata AS metadata,
+               JSONExtractString(address, 'country') AS country,
+               cohort_inner.cohort AS cohort,
+               cohort_inner.initial_coupon AS initial_coupon,
+               cohort_inner.initial_coupon_id AS initial_coupon_id
+        FROM
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+        LEFT JOIN
+          (SELECT invoice.customer AS customer_id,
+                  formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                  argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                  argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+           GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)) AS revenue_analytics_customer ON equals(revenue_analytics_revenue_item.customer_id, revenue_analytics_customer.id)
+     LEFT JOIN
+       (SELECT groups.key AS key,
+               key AS revenue_analytics_customer__groups___key
+        FROM
+          (SELECT groups.group_type_index AS index,
+                  groups.group_key AS key
+           FROM groups
+           WHERE equals(groups.team_id, 99999)
+           GROUP BY groups.group_type_index,
+                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+     WHERE notEmpty(group_key)
+     GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
+  ORDER BY groups.key ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1
+  '''
+# ---
 # name: TestRevenueAnalytics.test_get_revenue_for_schema_source_for_id_join_with_managed_viewsets_ff
   '''
   SELECT groups.key AS key,

--- a/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
@@ -56,7 +56,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
         ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-     GROUP BY person_id) AS persons__revenue_analytics ON equals(persons.persons___id, persons__revenue_analytics.person_id)
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   WHERE ifNull(equals(persons.id, '00000000-0000-0000-0000-000000000000'), 0)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -127,7 +127,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
         ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-     GROUP BY person_id) AS persons__revenue_analytics ON equals(persons.persons___id, persons__revenue_analytics.person_id)
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   WHERE ifNull(equals(persons.id, '00000000-0000-0000-0000-000000000000'), 0)
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -245,7 +245,7 @@
            WHERE equals(person_distinct_id2.team_id, 99999)
            GROUP BY person_distinct_id2.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.email, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     GROUP BY person_id) AS persons__revenue_analytics ON equals(persons.persons___id, persons__revenue_analytics.person_id)
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons__revenue_analytics.revenue ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -362,7 +362,7 @@
            WHERE equals(person_distinct_id2.team_id, 99999)
            GROUP BY person_distinct_id2.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.email, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     GROUP BY person_id) AS persons__revenue_analytics ON equals(persons.persons___id, persons__revenue_analytics.person_id)
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons__revenue_analytics.revenue ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -481,7 +481,7 @@
            WHERE equals(person_distinct_id2.team_id, 99999)
            GROUP BY person_distinct_id2.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.email, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     GROUP BY person_id) AS persons__revenue_analytics ON equals(persons.persons___id, persons__revenue_analytics.person_id)
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -599,7 +599,7 @@
            WHERE equals(person_distinct_id2.team_id, 99999)
            GROUP BY person_distinct_id2.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     GROUP BY person_id) AS persons__revenue_analytics ON equals(persons.persons___id, persons__revenue_analytics.person_id)
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -717,7 +717,7 @@
            WHERE equals(person_distinct_id2.team_id, 99999)
            GROUP BY person_distinct_id2.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     GROUP BY person_id) AS persons__revenue_analytics ON equals(persons.persons___id, persons__revenue_analytics.person_id)
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -835,7 +835,7 @@
            WHERE equals(person_distinct_id2.team_id, 99999)
            GROUP BY person_distinct_id2.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     GROUP BY person_id) AS persons__revenue_analytics ON equals(persons.persons___id, persons__revenue_analytics.person_id)
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -953,7 +953,7 @@
            WHERE equals(person_distinct_id2.team_id, 99999)
            GROUP BY person_distinct_id2.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     GROUP BY person_id) AS persons__revenue_analytics ON equals(persons.persons___id, persons__revenue_analytics.person_id)
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1072,7 +1072,7 @@
            WHERE equals(person_distinct_id2.team_id, 99999)
            GROUP BY person_distinct_id2.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(JSONExtractString(revenue_analytics_customer.metadata, 'id'), revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
-     GROUP BY person_id) AS persons__revenue_analytics ON equals(persons.persons___id, persons__revenue_analytics.person_id)
+     GROUP BY person_id) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1294,7 +1294,7 @@
                     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
                  WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                  ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-              GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(e__pdi__person.e__pdi__person___id, e__pdi__person__revenue_analytics.person_id)
+              GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(toString(e__pdi__person.e__pdi__person___id), toString(e__pdi__person__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
                     breakdown_value_1)
@@ -1392,7 +1392,7 @@
                  FROM events
                  WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                  ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-              GROUP BY person_id) AS e__poe__revenue_analytics ON equals(e.person_id, e__poe__revenue_analytics.person_id)
+              GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(e.person_id), toString(e__poe__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
                     breakdown_value_1)
@@ -1504,7 +1504,7 @@
                     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
                  WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                  ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-              GROUP BY person_id) AS e__poe__revenue_analytics ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__poe__revenue_analytics.person_id)
+              GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), toString(e__poe__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
                     breakdown_value_1)
@@ -1623,7 +1623,7 @@
                     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
                  WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                  ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-              GROUP BY person_id) AS e__person__revenue_analytics ON equals(e__person.e__person___id, e__person__revenue_analytics.person_id)
+              GROUP BY person_id) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
                     breakdown_value_1)
@@ -1764,7 +1764,7 @@
                                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
                                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                 ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                             GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(e__pdi__person.e__pdi__person___id, e__pdi__person__revenue_analytics.person_id)
+                             GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(toString(e__pdi__person.e__pdi__person___id), toString(e__pdi__person__revenue_analytics.person_id))
                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                           GROUP BY day_start,
                                    breakdown_value_1)
@@ -1852,7 +1852,7 @@
                                          HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
                                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                       ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                                   GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(e__pdi__person.e__pdi__person___id, e__pdi__person__revenue_analytics.person_id)
+                                   GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(toString(e__pdi__person.e__pdi__person___id), toString(e__pdi__person__revenue_analytics.person_id))
                                 WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                                 GROUP BY day_start,
                                          breakdown_value_1)
@@ -1945,7 +1945,7 @@
                                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
                                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                 ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                             GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(e__pdi__person.e__pdi__person___id, e__pdi__person__revenue_analytics.person_id)
+                             GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(toString(e__pdi__person.e__pdi__person___id), toString(e__pdi__person__revenue_analytics.person_id))
                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                           GROUP BY day_start,
                                    breakdown_value_1)
@@ -2033,7 +2033,7 @@
                                          HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
                                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                       ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                                   GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(e__pdi__person.e__pdi__person___id, e__pdi__person__revenue_analytics.person_id)
+                                   GROUP BY person_id) AS e__pdi__person__revenue_analytics ON equals(toString(e__pdi__person.e__pdi__person___id), toString(e__pdi__person__revenue_analytics.person_id))
                                 WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                                 GROUP BY day_start,
                                          breakdown_value_1)
@@ -2154,7 +2154,7 @@
                                 FROM events
                                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                 ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                             GROUP BY person_id) AS e__poe__revenue_analytics ON equals(e.person_id, e__poe__revenue_analytics.person_id)
+                             GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(e.person_id), toString(e__poe__revenue_analytics.person_id))
                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                           GROUP BY day_start,
                                    breakdown_value_1)
@@ -2220,7 +2220,7 @@
                                       FROM events
                                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                       ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                                   GROUP BY person_id) AS e__poe__revenue_analytics ON equals(e.person_id, e__poe__revenue_analytics.person_id)
+                                   GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(e.person_id), toString(e__poe__revenue_analytics.person_id))
                                 WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                                 GROUP BY day_start,
                                          breakdown_value_1)
@@ -2291,7 +2291,7 @@
                                 FROM events
                                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                 ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                             GROUP BY person_id) AS e__poe__revenue_analytics ON equals(e.person_id, e__poe__revenue_analytics.person_id)
+                             GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(e.person_id), toString(e__poe__revenue_analytics.person_id))
                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                           GROUP BY day_start,
                                    breakdown_value_1)
@@ -2357,7 +2357,7 @@
                                       FROM events
                                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                       ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                                   GROUP BY person_id) AS e__poe__revenue_analytics ON equals(e.person_id, e__poe__revenue_analytics.person_id)
+                                   GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(e.person_id), toString(e__poe__revenue_analytics.person_id))
                                 WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                                 GROUP BY day_start,
                                          breakdown_value_1)
@@ -2492,7 +2492,7 @@
                                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
                                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                 ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                             GROUP BY person_id) AS e__poe__revenue_analytics ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__poe__revenue_analytics.person_id)
+                             GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), toString(e__poe__revenue_analytics.person_id))
                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                           GROUP BY day_start,
                                    breakdown_value_1)
@@ -2572,7 +2572,7 @@
                                          HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
                                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                       ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                                   GROUP BY person_id) AS e__poe__revenue_analytics ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__poe__revenue_analytics.person_id)
+                                   GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), toString(e__poe__revenue_analytics.person_id))
                                 WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                                 GROUP BY day_start,
                                          breakdown_value_1)
@@ -2657,7 +2657,7 @@
                                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
                                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                 ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                             GROUP BY person_id) AS e__poe__revenue_analytics ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__poe__revenue_analytics.person_id)
+                             GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), toString(e__poe__revenue_analytics.person_id))
                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                           GROUP BY day_start,
                                    breakdown_value_1)
@@ -2737,7 +2737,7 @@
                                          HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
                                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                       ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                                   GROUP BY person_id) AS e__poe__revenue_analytics ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__poe__revenue_analytics.person_id)
+                                   GROUP BY person_id) AS e__poe__revenue_analytics ON equals(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), toString(e__poe__revenue_analytics.person_id))
                                 WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                                 GROUP BY day_start,
                                          breakdown_value_1)
@@ -2879,7 +2879,7 @@
                                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
                                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                 ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                             GROUP BY person_id) AS e__person__revenue_analytics ON equals(e__person.e__person___id, e__person__revenue_analytics.person_id)
+                             GROUP BY person_id) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                           GROUP BY day_start,
                                    breakdown_value_1)
@@ -2966,7 +2966,7 @@
                                          HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
                                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                       ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                                   GROUP BY person_id) AS e__person__revenue_analytics ON equals(e__person.e__person___id, e__person__revenue_analytics.person_id)
+                                   GROUP BY person_id) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
                                 WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                                 GROUP BY day_start,
                                          breakdown_value_1)
@@ -3058,7 +3058,7 @@
                                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
                                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                 ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                             GROUP BY person_id) AS e__person__revenue_analytics ON equals(e__person.e__person___id, e__person__revenue_analytics.person_id)
+                             GROUP BY person_id) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                           GROUP BY day_start,
                                    breakdown_value_1)
@@ -3145,7 +3145,7 @@
                                          HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
                                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
                                       ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-                                   GROUP BY person_id) AS e__person__revenue_analytics ON equals(e__person.e__person___id, e__person__revenue_analytics.person_id)
+                                   GROUP BY person_id) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
                                 WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
                                 GROUP BY day_start,
                                          breakdown_value_1)

--- a/posthog/hogql/database/schema/test/test_groups_revenue_analytics.py
+++ b/posthog/hogql/database/schema/test/test_groups_revenue_analytics.py
@@ -268,6 +268,7 @@ class TestRevenueAnalytics(ClickhouseTestMixin, APIBaseTest):
             queries = [
                 "SELECT key, revenue_analytics.revenue FROM groups ORDER BY key ASC",
                 "SELECT key, $virt_revenue FROM groups ORDER BY key ASC",
+                "SELECT key, properties.$virt_revenue FROM groups ORDER BY key ASC",
             ]
 
             for query in queries:

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -38,6 +38,7 @@ from posthog.hogql.base import AST
 from posthog.hogql.errors import NotImplementedError, QueryError
 from posthog.hogql.functions import find_hogql_aggregation
 from posthog.hogql.parser import parse_expr
+from posthog.hogql.utils import map_virtual_properties
 from posthog.hogql.visitor import TraversingVisitor, clone_expr
 
 from posthog.constants import AUTOCAPTURE_EVENT, TREND_FILTER_TYPE_ACTIONS, PropertyOperatorType
@@ -708,19 +709,6 @@ def property_to_expr(
     raise NotImplementedError(
         f"property_to_expr not implemented for filter type {type(property).__name__} and {property.type}"
     )
-
-
-def map_virtual_properties(e: ast.Expr):
-    if (
-        isinstance(e, ast.Field)
-        and len(e.chain) >= 2
-        and e.chain[-2] == "properties"
-        and isinstance(e.chain[-1], str)
-        and e.chain[-1].startswith("$virt")
-    ):
-        # we pretend virtual properties are regular properties, but they should map to the same field directly on the parent table
-        return ast.Field(chain=e.chain[:-2] + [e.chain[-1]])
-    return e
 
 
 def action_to_expr(action: Action, events_alias: Optional[str] = None) -> ast.Expr:

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -606,6 +606,11 @@ class Resolver(CloningVisitor):
         if len(node.chain) == 0:
             raise ResolutionError("Invalid field access with empty chain")
 
+        # Apply virtual property mapping before field resolution
+        from posthog.hogql.property import map_virtual_properties
+
+        node = map_virtual_properties(node)
+
         node = super().visit_field(node)
 
         # Only look for fields in the last SELECT scope, instead of all previous select queries.

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -30,6 +30,7 @@ from posthog.hogql.resolver_utils import (
     lookup_field_by_name,
     lookup_table_by_name,
 )
+from posthog.hogql.utils import map_virtual_properties
 from posthog.hogql.visitor import CloningVisitor, TraversingVisitor, clone_expr
 
 from posthog.models.utils import UUIDT
@@ -607,8 +608,6 @@ class Resolver(CloningVisitor):
             raise ResolutionError("Invalid field access with empty chain")
 
         # Apply virtual property mapping before field resolution
-        from posthog.hogql.property import map_virtual_properties
-
         node = map_virtual_properties(node)
 
         node = super().visit_field(node)

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -852,5 +852,6 @@ class TestResolver(BaseTest):
 
                 revenue_field = resolved_expr.select[0]
                 assert isinstance(revenue_field, ast.Alias)
+                assert isinstance(revenue_field.expr, ast.Field)
                 chain = revenue_field.expr.chain
                 assert chain == expected_chain

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -826,3 +826,31 @@ class TestResolver(BaseTest):
         query = "SELECT arrayMap(a -> concat(a, e.event), ['str']) FROM events e"
         resolve_types(self._select(query), self.context, dialect="hogql")
         resolve_types(self._select(query), self.context, dialect="clickhouse")
+
+    def test_virtual_property_mapping(self):
+        queries = [
+            (
+                "groups virtual prop",
+                "SELECT properties.$virt_revenue FROM groups ORDER BY key ASC",
+                ["$virt_revenue"],
+            ),
+            (
+                "persons virtual prop from events",
+                "SELECT person.properties.$virt_revenue FROM events",
+                ["person", "$virt_revenue"],
+            ),
+            (
+                "regular props are not affected",
+                "SELECT properties.regular_prop FROM events",
+                ["properties", "regular_prop"],
+            ),
+        ]
+        for msg, query, expected_chain in queries:
+            with self.subTest(msg):
+                expr = self._select(query)
+                resolved_expr = cast(ast.SelectQuery, resolve_types(expr, self.context, dialect="clickhouse"))
+
+                revenue_field = resolved_expr.select[0]
+                assert isinstance(revenue_field, ast.Alias)
+                chain = revenue_field.expr.chain
+                assert chain == expected_chain

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -1077,7 +1077,7 @@
               HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
            WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
            ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-        GROUP BY person_id) AS e__person__revenue_analytics ON equals(e__person.e__person___id, e__person__revenue_analytics.person_id)
+        GROUP BY person_id) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
      LEFT OUTER JOIN
        (SELECT tupleElement(argMax(tuple(error_tracking_issue_fingerprint_overrides.issue_id), error_tracking_issue_fingerprint_overrides.version), 1) AS issue_id,
                error_tracking_issue_fingerprint_overrides.fingerprint AS fingerprint


### PR DESCRIPTION
## Problem
Two problems:
1. There is a potential type mismatch when joining revenue analytics tables to persons table, depending on the types being used as `person_id`.
2. When adding a filter/data table column, we're mapping revenue analytics virtual fields to `properties.$virt_revenue` e.g. This is not being parsed correctly in the backend and we always return an empty string (as people don't have a $virt_revenue prop set). 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Make sure person_id has the same type as revenue analytics person before joining the tables
- Map virtual properties when visiting node 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Unit tests
Manually adding filters/columns for the revenue virtual fields in the UI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
