### PR TITLE
fix(surveys): ensure summary and data table use the same date range in query

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1338,10 +1338,10 @@ export const surveyLogic = kea<surveyLogicType>([
             },
         ],
         partialResponsesFilter: [
-            (s) => [s.survey],
-            (survey: Survey): string => {
+            (s) => [s.survey, s.dateRange],
+            (survey: Survey, dateRange: SurveyDateRange): string => {
                 if (survey.enable_partial_responses) {
-                    return buildPartialResponsesFilter(survey)
+                    return buildPartialResponsesFilter(survey, dateRange)
                 }
                 /**
                  * Return only complete responses. For pre-partial responses, we didn't have the survey_completed property.


### PR DESCRIPTION
## Problem
there is a discrepancy between the survey summary stats and the data table when partial responses are enabled. (see linked issue for more context)

![518690402-ca4698dd-3644-44a8-86a4-13401c43b245.png](https://app.graphite.com/user-attachments/assets/8d95cf30-f5a6-4793-9532-5bacc4083284.png)

![518690814-a8363ff8-54ed-4abf-9d35-b3da6906683e.png](https://app.graphite.com/user-attachments/assets/7d0bcabd-6da8-47de-b515-1176e36311e0.png)

to repro, check this survey with the date range set from nov 19 - nov 22: https://us.posthog.com/project/2/surveys/019a9dc5-745c-0000-231d-8ce32972cd72?date_from=2025-11-19&date_to=2025-11-22T23%3A59%3A59

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

closes #42063

## Changes
updated queries so the date range is always the same between stats & data table

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- added a unit test
- will test once deployed w/ real survey data
- working to find a way to add survey events to demo data so we can test with playwright (the existing surveys UI tests expect an empty state, so this will take a bit of effort)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
yes
