### PR TITLE
refactor(logs): make logs tab aware

### DIFF
--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -57,6 +57,7 @@ export type SettingSectionId =
     | 'user-danger-zone'
     | 'user-feature-previews'
     | 'mcp-server'
+    | 'product-logs'
 
 export type SettingId =
     | 'replay-triggers'

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -49,6 +49,8 @@ import { ParsedLogMessage } from './types'
 
 export const scene: SceneExport = {
     component: LogsScene,
+    logic: logsLogic,
+    settingSectionId: 'product-logs',
 }
 
 export function LogsScene(): JSX.Element {

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -2,13 +2,16 @@ import colors from 'ansi-colors'
 import equal from 'fast-deep-equal'
 import { actions, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { actionToUrl, router, urlToAction } from 'kea-router'
+import { router } from 'kea-router'
 
 import { syncSearchParams, updateSearchParams } from '@posthog/products-error-tracking/frontend/utils'
 
 import api from 'lib/api'
 import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { dayjs } from 'lib/dayjs'
+import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
+import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
+import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import { Params } from 'scenes/sceneTypes'
 
@@ -31,8 +34,8 @@ const DEFAULT_TIMESTAMP_FORMAT = 'absolute' as 'absolute' | 'relative'
 
 export const logsLogic = kea<logsLogicType>([
     path(['products', 'logs', 'frontend', 'logsLogic']),
-
-    urlToAction(({ actions, values }) => {
+    tabAwareScene(),
+    tabAwareUrlToAction(({ actions, values }) => {
         const urlToAction = (_: any, params: Params): void => {
             if (params.dateRange && !equal(params.dateRange, values.dateRange)) {
                 actions.setDateRange(params.dateRange)
@@ -70,7 +73,7 @@ export const logsLogic = kea<logsLogicType>([
         }
     }),
 
-    actionToUrl(({ actions, values }) => {
+    tabAwareActionToUrl(({ actions, values }) => {
         const buildURL = (): [
             string,
             Params,


### PR DESCRIPTION
## Problem

Logs scene was not tab aware and not playing nicely with other tabs.

## Changes

- Introduced 'product-logs' setting section ID in types.
- Updated logsLogic to utilize tab-aware URL and action handling.

## How did you test this code?

Local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._