### PR TITLE
feat: Add all filters

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -524,7 +524,8 @@
                                                                                 max_bytes_before_external_group_by=0,
                                                                                 transform_null_in=1,
                                                                                 optimize_min_equality_disjunction_chain_length=4294967295,
-                                                                                allow_experimental_join_condition=1
+                                                                                allow_experimental_join_condition=1,
+                                                                                use_hive_partitioning=0
   '''
 # ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.11
@@ -617,7 +618,8 @@
                                                                                 max_bytes_before_external_group_by=0,
                                                                                 transform_null_in=1,
                                                                                 optimize_min_equality_disjunction_chain_length=4294967295,
-                                                                                allow_experimental_join_condition=1
+                                                                                allow_experimental_join_condition=1,
+                                                                                use_hive_partitioning=0
   '''
 # ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.13

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -677,6 +677,9 @@
                     "$ref": "#/definitions/PersonPropertyFilter"
                 },
                 {
+                    "$ref": "#/definitions/PersonOnEventPropertyFilter"
+                },
+                {
                     "$ref": "#/definitions/ElementPropertyFilter"
                 },
                 {
@@ -19452,6 +19455,29 @@
             "required": ["id", "type", "protocol", "path", "created_at", "updated_at"],
             "type": "object"
         },
+        "PersonOnEventPropertyFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "operator": {
+                    "$ref": "#/definitions/PropertyOperator"
+                },
+                "type": {
+                    "const": "person_on_event",
+                    "type": "string"
+                },
+                "value": {
+                    "$ref": "#/definitions/PropertyFilterValue"
+                }
+            },
+            "required": ["key", "operator", "type"],
+            "type": "object"
+        },
         "PersonPropertyFilter": {
             "additionalProperties": false,
             "description": "Sync with plugin-server/src/types.ts",
@@ -19807,6 +19833,7 @@
             "enum": [
                 "meta",
                 "event",
+                "person_on_event",
                 "internal_event",
                 "event_metadata",
                 "person",

--- a/frontend/src/queries/validators.js
+++ b/frontend/src/queries/validators.js
@@ -5,6 +5,7 @@ const schema12 = {
     anyOf: [
         { $ref: '#/definitions/EventPropertyFilter' },
         { $ref: '#/definitions/PersonPropertyFilter' },
+        { $ref: '#/definitions/PersonOnEventPropertyFilter' },
         { $ref: '#/definitions/ElementPropertyFilter' },
         { $ref: '#/definitions/EventMetadataPropertyFilter' },
         { $ref: '#/definitions/SessionPropertyFilter' },
@@ -23,7 +24,7 @@ const schema12 = {
         { $ref: '#/definitions/RevenueAnalyticsPropertyFilter' },
     ],
 }
-const schema37 = {
+const schema39 = {
     additionalProperties: false,
     properties: {
         key: { description: 'The key should be the flag ID', type: 'string' },
@@ -39,7 +40,7 @@ const schema37 = {
     required: ['key', 'operator', 'type', 'value'],
     type: 'object',
 }
-const schema39 = { additionalProperties: false, type: 'object' }
+const schema41 = { additionalProperties: false, type: 'object' }
 const schema13 = {
     additionalProperties: false,
     description: 'Sync with plugin-server/src/types.ts',
@@ -659,12 +660,11 @@ function validate16(data, { instancePath = '', parentData, parentDataProperty, r
 }
 const schema20 = {
     additionalProperties: false,
-    description: 'Sync with plugin-server/src/types.ts',
     properties: {
-        key: { enum: ['tag_name', 'text', 'href', 'selector'], type: 'string' },
+        key: { type: 'string' },
         label: { type: 'string' },
         operator: { $ref: '#/definitions/PropertyOperator' },
-        type: { const: 'element', type: 'string' },
+        type: { const: 'person_on_event', type: 'string' },
         value: { $ref: '#/definitions/PropertyFilterValue' },
     },
     required: ['key', 'operator', 'type'],
@@ -718,9 +718,8 @@ function validate19(data, { instancePath = '', parentData, parentDataProperty, r
                 }
                 if (_errs1 === errors) {
                     if (data.key !== undefined) {
-                        let data0 = data.key
                         const _errs2 = errors
-                        if (typeof data0 !== 'string') {
+                        if (typeof data.key !== 'string') {
                             validate19.errors = [
                                 {
                                     instancePath: instancePath + '/key',
@@ -728,18 +727,6 @@ function validate19(data, { instancePath = '', parentData, parentDataProperty, r
                                     keyword: 'type',
                                     params: { type: 'string' },
                                     message: 'must be string',
-                                },
-                            ]
-                            return false
-                        }
-                        if (!(data0 === 'tag_name' || data0 === 'text' || data0 === 'href' || data0 === 'selector')) {
-                            validate19.errors = [
-                                {
-                                    instancePath: instancePath + '/key',
-                                    schemaPath: '#/properties/key/enum',
-                                    keyword: 'enum',
-                                    params: { allowedValues: schema20.properties.key.enum },
-                                    message: 'must be equal to one of the allowed values',
                                 },
                             ]
                             return false
@@ -841,13 +828,13 @@ function validate19(data, { instancePath = '', parentData, parentDataProperty, r
                                         ]
                                         return false
                                     }
-                                    if ('element' !== data3) {
+                                    if ('person_on_event' !== data3) {
                                         validate19.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/const',
                                                 keyword: 'const',
-                                                params: { allowedValue: 'element' },
+                                                params: { allowedValue: 'person_on_event' },
                                                 message: 'must be equal to constant',
                                             },
                                         ]
@@ -900,11 +887,12 @@ function validate19(data, { instancePath = '', parentData, parentDataProperty, r
 }
 const schema22 = {
     additionalProperties: false,
+    description: 'Sync with plugin-server/src/types.ts',
     properties: {
-        key: { type: 'string' },
+        key: { enum: ['tag_name', 'text', 'href', 'selector'], type: 'string' },
         label: { type: 'string' },
         operator: { $ref: '#/definitions/PropertyOperator' },
-        type: { const: 'event_metadata', type: 'string' },
+        type: { const: 'element', type: 'string' },
         value: { $ref: '#/definitions/PropertyFilterValue' },
     },
     required: ['key', 'operator', 'type'],
@@ -958,8 +946,9 @@ function validate22(data, { instancePath = '', parentData, parentDataProperty, r
                 }
                 if (_errs1 === errors) {
                     if (data.key !== undefined) {
+                        let data0 = data.key
                         const _errs2 = errors
-                        if (typeof data.key !== 'string') {
+                        if (typeof data0 !== 'string') {
                             validate22.errors = [
                                 {
                                     instancePath: instancePath + '/key',
@@ -967,6 +956,18 @@ function validate22(data, { instancePath = '', parentData, parentDataProperty, r
                                     keyword: 'type',
                                     params: { type: 'string' },
                                     message: 'must be string',
+                                },
+                            ]
+                            return false
+                        }
+                        if (!(data0 === 'tag_name' || data0 === 'text' || data0 === 'href' || data0 === 'selector')) {
+                            validate22.errors = [
+                                {
+                                    instancePath: instancePath + '/key',
+                                    schemaPath: '#/properties/key/enum',
+                                    keyword: 'enum',
+                                    params: { allowedValues: schema22.properties.key.enum },
+                                    message: 'must be equal to one of the allowed values',
                                 },
                             ]
                             return false
@@ -1068,13 +1069,13 @@ function validate22(data, { instancePath = '', parentData, parentDataProperty, r
                                         ]
                                         return false
                                     }
-                                    if ('event_metadata' !== data3) {
+                                    if ('element' !== data3) {
                                         validate22.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/const',
                                                 keyword: 'const',
-                                                params: { allowedValue: 'event_metadata' },
+                                                params: { allowedValue: 'element' },
                                                 message: 'must be equal to constant',
                                             },
                                         ]
@@ -1131,7 +1132,7 @@ const schema24 = {
         key: { type: 'string' },
         label: { type: 'string' },
         operator: { $ref: '#/definitions/PropertyOperator' },
-        type: { const: 'session', type: 'string' },
+        type: { const: 'event_metadata', type: 'string' },
         value: { $ref: '#/definitions/PropertyFilterValue' },
     },
     required: ['key', 'operator', 'type'],
@@ -1295,13 +1296,13 @@ function validate25(data, { instancePath = '', parentData, parentDataProperty, r
                                         ]
                                         return false
                                     }
-                                    if ('session' !== data3) {
+                                    if ('event_metadata' !== data3) {
                                         validate25.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/const',
                                                 keyword: 'const',
-                                                params: { allowedValue: 'session' },
+                                                params: { allowedValue: 'event_metadata' },
                                                 message: 'must be equal to constant',
                                             },
                                         ]
@@ -1354,6 +1355,233 @@ function validate25(data, { instancePath = '', parentData, parentDataProperty, r
 }
 const schema26 = {
     additionalProperties: false,
+    properties: {
+        key: { type: 'string' },
+        label: { type: 'string' },
+        operator: { $ref: '#/definitions/PropertyOperator' },
+        type: { const: 'session', type: 'string' },
+        value: { $ref: '#/definitions/PropertyFilterValue' },
+    },
+    required: ['key', 'operator', 'type'],
+    type: 'object',
+}
+function validate28(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+    let vErrors = null
+    let errors = 0
+    if (errors === 0) {
+        if (data && typeof data == 'object' && !Array.isArray(data)) {
+            let missing0
+            if (
+                (data.key === undefined && (missing0 = 'key')) ||
+                (data.operator === undefined && (missing0 = 'operator')) ||
+                (data.type === undefined && (missing0 = 'type'))
+            ) {
+                validate28.errors = [
+                    {
+                        instancePath,
+                        schemaPath: '#/required',
+                        keyword: 'required',
+                        params: { missingProperty: missing0 },
+                        message: "must have required property '" + missing0 + "'",
+                    },
+                ]
+                return false
+            } else {
+                const _errs1 = errors
+                for (const key0 in data) {
+                    if (
+                        !(
+                            key0 === 'key' ||
+                            key0 === 'label' ||
+                            key0 === 'operator' ||
+                            key0 === 'type' ||
+                            key0 === 'value'
+                        )
+                    ) {
+                        validate28.errors = [
+                            {
+                                instancePath,
+                                schemaPath: '#/additionalProperties',
+                                keyword: 'additionalProperties',
+                                params: { additionalProperty: key0 },
+                                message: 'must NOT have additional properties',
+                            },
+                        ]
+                        return false
+                        break
+                    }
+                }
+                if (_errs1 === errors) {
+                    if (data.key !== undefined) {
+                        const _errs2 = errors
+                        if (typeof data.key !== 'string') {
+                            validate28.errors = [
+                                {
+                                    instancePath: instancePath + '/key',
+                                    schemaPath: '#/properties/key/type',
+                                    keyword: 'type',
+                                    params: { type: 'string' },
+                                    message: 'must be string',
+                                },
+                            ]
+                            return false
+                        }
+                        var valid0 = _errs2 === errors
+                    } else {
+                        var valid0 = true
+                    }
+                    if (valid0) {
+                        if (data.label !== undefined) {
+                            const _errs4 = errors
+                            if (typeof data.label !== 'string') {
+                                validate28.errors = [
+                                    {
+                                        instancePath: instancePath + '/label',
+                                        schemaPath: '#/properties/label/type',
+                                        keyword: 'type',
+                                        params: { type: 'string' },
+                                        message: 'must be string',
+                                    },
+                                ]
+                                return false
+                            }
+                            var valid0 = _errs4 === errors
+                        } else {
+                            var valid0 = true
+                        }
+                        if (valid0) {
+                            if (data.operator !== undefined) {
+                                let data2 = data.operator
+                                const _errs6 = errors
+                                if (typeof data2 !== 'string') {
+                                    validate28.errors = [
+                                        {
+                                            instancePath: instancePath + '/operator',
+                                            schemaPath: '#/definitions/PropertyOperator/type',
+                                            keyword: 'type',
+                                            params: { type: 'string' },
+                                            message: 'must be string',
+                                        },
+                                    ]
+                                    return false
+                                }
+                                if (
+                                    !(
+                                        data2 === 'exact' ||
+                                        data2 === 'is_not' ||
+                                        data2 === 'icontains' ||
+                                        data2 === 'not_icontains' ||
+                                        data2 === 'regex' ||
+                                        data2 === 'not_regex' ||
+                                        data2 === 'gt' ||
+                                        data2 === 'gte' ||
+                                        data2 === 'lt' ||
+                                        data2 === 'lte' ||
+                                        data2 === 'is_set' ||
+                                        data2 === 'is_not_set' ||
+                                        data2 === 'is_date_exact' ||
+                                        data2 === 'is_date_before' ||
+                                        data2 === 'is_date_after' ||
+                                        data2 === 'between' ||
+                                        data2 === 'not_between' ||
+                                        data2 === 'min' ||
+                                        data2 === 'max' ||
+                                        data2 === 'in' ||
+                                        data2 === 'not_in' ||
+                                        data2 === 'is_cleaned_path_exact' ||
+                                        data2 === 'flag_evaluates_to'
+                                    )
+                                ) {
+                                    validate28.errors = [
+                                        {
+                                            instancePath: instancePath + '/operator',
+                                            schemaPath: '#/definitions/PropertyOperator/enum',
+                                            keyword: 'enum',
+                                            params: { allowedValues: schema14.enum },
+                                            message: 'must be equal to one of the allowed values',
+                                        },
+                                    ]
+                                    return false
+                                }
+                                var valid0 = _errs6 === errors
+                            } else {
+                                var valid0 = true
+                            }
+                            if (valid0) {
+                                if (data.type !== undefined) {
+                                    let data3 = data.type
+                                    const _errs9 = errors
+                                    if (typeof data3 !== 'string') {
+                                        validate28.errors = [
+                                            {
+                                                instancePath: instancePath + '/type',
+                                                schemaPath: '#/properties/type/type',
+                                                keyword: 'type',
+                                                params: { type: 'string' },
+                                                message: 'must be string',
+                                            },
+                                        ]
+                                        return false
+                                    }
+                                    if ('session' !== data3) {
+                                        validate28.errors = [
+                                            {
+                                                instancePath: instancePath + '/type',
+                                                schemaPath: '#/properties/type/const',
+                                                keyword: 'const',
+                                                params: { allowedValue: 'session' },
+                                                message: 'must be equal to constant',
+                                            },
+                                        ]
+                                        return false
+                                    }
+                                    var valid0 = _errs9 === errors
+                                } else {
+                                    var valid0 = true
+                                }
+                                if (valid0) {
+                                    if (data.value !== undefined) {
+                                        const _errs11 = errors
+                                        if (
+                                            !validate13(data.value, {
+                                                instancePath: instancePath + '/value',
+                                                parentData: data,
+                                                parentDataProperty: 'value',
+                                                rootData,
+                                            })
+                                        ) {
+                                            vErrors =
+                                                vErrors === null ? validate13.errors : vErrors.concat(validate13.errors)
+                                            errors = vErrors.length
+                                        }
+                                        var valid0 = _errs11 === errors
+                                    } else {
+                                        var valid0 = true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            validate28.errors = [
+                {
+                    instancePath,
+                    schemaPath: '#/type',
+                    keyword: 'type',
+                    params: { type: 'object' },
+                    message: 'must be object',
+                },
+            ]
+            return false
+        }
+    }
+    validate28.errors = vErrors
+    return errors === 0
+}
+const schema28 = {
+    additionalProperties: false,
     description: 'Sync with plugin-server/src/types.ts',
     properties: {
         cohort_name: { type: 'string' },
@@ -1366,7 +1594,7 @@ const schema26 = {
     required: ['key', 'operator', 'type', 'value'],
     type: 'object',
 }
-function validate28(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate31(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -1378,7 +1606,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                 (data.type === undefined && (missing0 = 'type')) ||
                 (data.value === undefined && (missing0 = 'value'))
             ) {
-                validate28.errors = [
+                validate31.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -1401,7 +1629,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                             key0 === 'value'
                         )
                     ) {
-                        validate28.errors = [
+                        validate31.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -1418,7 +1646,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                     if (data.cohort_name !== undefined) {
                         const _errs2 = errors
                         if (typeof data.cohort_name !== 'string') {
-                            validate28.errors = [
+                            validate31.errors = [
                                 {
                                     instancePath: instancePath + '/cohort_name',
                                     schemaPath: '#/properties/cohort_name/type',
@@ -1438,7 +1666,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                             let data1 = data.key
                             const _errs4 = errors
                             if (typeof data1 !== 'string') {
-                                validate28.errors = [
+                                validate31.errors = [
                                     {
                                         instancePath: instancePath + '/key',
                                         schemaPath: '#/properties/key/type',
@@ -1450,7 +1678,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                                 return false
                             }
                             if ('id' !== data1) {
-                                validate28.errors = [
+                                validate31.errors = [
                                     {
                                         instancePath: instancePath + '/key',
                                         schemaPath: '#/properties/key/const',
@@ -1469,7 +1697,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                             if (data.label !== undefined) {
                                 const _errs6 = errors
                                 if (typeof data.label !== 'string') {
-                                    validate28.errors = [
+                                    validate31.errors = [
                                         {
                                             instancePath: instancePath + '/label',
                                             schemaPath: '#/properties/label/type',
@@ -1489,7 +1717,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                                     let data3 = data.operator
                                     const _errs8 = errors
                                     if (typeof data3 !== 'string') {
-                                        validate28.errors = [
+                                        validate31.errors = [
                                             {
                                                 instancePath: instancePath + '/operator',
                                                 schemaPath: '#/definitions/PropertyOperator/type',
@@ -1527,7 +1755,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                                             data3 === 'flag_evaluates_to'
                                         )
                                     ) {
-                                        validate28.errors = [
+                                        validate31.errors = [
                                             {
                                                 instancePath: instancePath + '/operator',
                                                 schemaPath: '#/definitions/PropertyOperator/enum',
@@ -1547,7 +1775,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                                         let data4 = data.type
                                         const _errs11 = errors
                                         if (typeof data4 !== 'string') {
-                                            validate28.errors = [
+                                            validate31.errors = [
                                                 {
                                                     instancePath: instancePath + '/type',
                                                     schemaPath: '#/properties/type/type',
@@ -1559,7 +1787,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                                             return false
                                         }
                                         if ('cohort' !== data4) {
-                                            validate28.errors = [
+                                            validate31.errors = [
                                                 {
                                                     instancePath: instancePath + '/type',
                                                     schemaPath: '#/properties/type/const',
@@ -1586,7 +1814,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                                                     isFinite(data5)
                                                 )
                                             ) {
-                                                validate28.errors = [
+                                                validate31.errors = [
                                                     {
                                                         instancePath: instancePath + '/value',
                                                         schemaPath: '#/properties/value/type',
@@ -1609,7 +1837,7 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate28.errors = [
+            validate31.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -1621,10 +1849,10 @@ function validate28(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate28.errors = vErrors
+    validate31.errors = vErrors
     return errors === 0
 }
-const schema28 = {
+const schema30 = {
     additionalProperties: false,
     properties: {
         key: {
@@ -1643,8 +1871,8 @@ const schema28 = {
     required: ['key', 'operator', 'type'],
     type: 'object',
 }
-const schema29 = { enum: ['duration', 'active_seconds', 'inactive_seconds'], type: 'string' }
-function validate30(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+const schema31 = { enum: ['duration', 'active_seconds', 'inactive_seconds'], type: 'string' }
+function validate33(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -1655,7 +1883,7 @@ function validate30(data, { instancePath = '', parentData, parentDataProperty, r
                 (data.operator === undefined && (missing0 = 'operator')) ||
                 (data.type === undefined && (missing0 = 'type'))
             ) {
-                validate30.errors = [
+                validate33.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -1677,7 +1905,7 @@ function validate30(data, { instancePath = '', parentData, parentDataProperty, r
                             key0 === 'value'
                         )
                     ) {
-                        validate30.errors = [
+                        validate33.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -1717,7 +1945,7 @@ function validate30(data, { instancePath = '', parentData, parentDataProperty, r
                                 instancePath: instancePath + '/key',
                                 schemaPath: '#/definitions/DurationType/enum',
                                 keyword: 'enum',
-                                params: { allowedValues: schema29.enum },
+                                params: { allowedValues: schema31.enum },
                                 message: 'must be equal to one of the allowed values',
                             }
                             if (vErrors === null) {
@@ -1848,7 +2076,7 @@ function validate30(data, { instancePath = '', parentData, parentDataProperty, r
                                 vErrors.push(err8)
                             }
                             errors++
-                            validate30.errors = vErrors
+                            validate33.errors = vErrors
                             return false
                         } else {
                             errors = _errs3
@@ -1868,7 +2096,7 @@ function validate30(data, { instancePath = '', parentData, parentDataProperty, r
                         if (data.label !== undefined) {
                             const _errs13 = errors
                             if (typeof data.label !== 'string') {
-                                validate30.errors = [
+                                validate33.errors = [
                                     {
                                         instancePath: instancePath + '/label',
                                         schemaPath: '#/properties/label/type',
@@ -1888,7 +2116,7 @@ function validate30(data, { instancePath = '', parentData, parentDataProperty, r
                                 let data2 = data.operator
                                 const _errs15 = errors
                                 if (typeof data2 !== 'string') {
-                                    validate30.errors = [
+                                    validate33.errors = [
                                         {
                                             instancePath: instancePath + '/operator',
                                             schemaPath: '#/definitions/PropertyOperator/type',
@@ -1926,7 +2154,7 @@ function validate30(data, { instancePath = '', parentData, parentDataProperty, r
                                         data2 === 'flag_evaluates_to'
                                     )
                                 ) {
-                                    validate30.errors = [
+                                    validate33.errors = [
                                         {
                                             instancePath: instancePath + '/operator',
                                             schemaPath: '#/definitions/PropertyOperator/enum',
@@ -1946,7 +2174,7 @@ function validate30(data, { instancePath = '', parentData, parentDataProperty, r
                                     let data3 = data.type
                                     const _errs18 = errors
                                     if (typeof data3 !== 'string') {
-                                        validate30.errors = [
+                                        validate33.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/type',
@@ -1958,7 +2186,7 @@ function validate30(data, { instancePath = '', parentData, parentDataProperty, r
                                         return false
                                     }
                                     if ('recording' !== data3) {
-                                        validate30.errors = [
+                                        validate33.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/const',
@@ -1999,7 +2227,7 @@ function validate30(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate30.errors = [
+            validate33.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -2011,10 +2239,10 @@ function validate30(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate30.errors = vErrors
+    validate33.errors = vErrors
     return errors === 0
 }
-const schema31 = {
+const schema33 = {
     additionalProperties: false,
     properties: {
         key: { type: 'string' },
@@ -2026,7 +2254,7 @@ const schema31 = {
     required: ['key', 'operator', 'type'],
     type: 'object',
 }
-function validate33(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate36(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -2037,7 +2265,7 @@ function validate33(data, { instancePath = '', parentData, parentDataProperty, r
                 (data.operator === undefined && (missing0 = 'operator')) ||
                 (data.type === undefined && (missing0 = 'type'))
             ) {
-                validate33.errors = [
+                validate36.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -2059,7 +2287,7 @@ function validate33(data, { instancePath = '', parentData, parentDataProperty, r
                             key0 === 'value'
                         )
                     ) {
-                        validate33.errors = [
+                        validate36.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -2076,7 +2304,7 @@ function validate33(data, { instancePath = '', parentData, parentDataProperty, r
                     if (data.key !== undefined) {
                         const _errs2 = errors
                         if (typeof data.key !== 'string') {
-                            validate33.errors = [
+                            validate36.errors = [
                                 {
                                     instancePath: instancePath + '/key',
                                     schemaPath: '#/properties/key/type',
@@ -2095,7 +2323,7 @@ function validate33(data, { instancePath = '', parentData, parentDataProperty, r
                         if (data.label !== undefined) {
                             const _errs4 = errors
                             if (typeof data.label !== 'string') {
-                                validate33.errors = [
+                                validate36.errors = [
                                     {
                                         instancePath: instancePath + '/label',
                                         schemaPath: '#/properties/label/type',
@@ -2115,7 +2343,7 @@ function validate33(data, { instancePath = '', parentData, parentDataProperty, r
                                 let data2 = data.operator
                                 const _errs6 = errors
                                 if (typeof data2 !== 'string') {
-                                    validate33.errors = [
+                                    validate36.errors = [
                                         {
                                             instancePath: instancePath + '/operator',
                                             schemaPath: '#/definitions/PropertyOperator/type',
@@ -2153,7 +2381,7 @@ function validate33(data, { instancePath = '', parentData, parentDataProperty, r
                                         data2 === 'flag_evaluates_to'
                                     )
                                 ) {
-                                    validate33.errors = [
+                                    validate36.errors = [
                                         {
                                             instancePath: instancePath + '/operator',
                                             schemaPath: '#/definitions/PropertyOperator/enum',
@@ -2173,7 +2401,7 @@ function validate33(data, { instancePath = '', parentData, parentDataProperty, r
                                     let data3 = data.type
                                     const _errs9 = errors
                                     if (typeof data3 !== 'string') {
-                                        validate33.errors = [
+                                        validate36.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/type',
@@ -2185,7 +2413,7 @@ function validate33(data, { instancePath = '', parentData, parentDataProperty, r
                                         return false
                                     }
                                     if ('log_entry' !== data3) {
-                                        validate33.errors = [
+                                        validate36.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/const',
@@ -2226,7 +2454,7 @@ function validate33(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate33.errors = [
+            validate36.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -2238,10 +2466,10 @@ function validate33(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate33.errors = vErrors
+    validate36.errors = vErrors
     return errors === 0
 }
-const schema33 = {
+const schema35 = {
     additionalProperties: false,
     properties: {
         group_type_index: { anyOf: [{ type: 'integer' }, { type: 'null' }] },
@@ -2254,7 +2482,7 @@ const schema33 = {
     required: ['key', 'operator', 'type'],
     type: 'object',
 }
-function validate36(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate39(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -2265,7 +2493,7 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                 (data.operator === undefined && (missing0 = 'operator')) ||
                 (data.type === undefined && (missing0 = 'type'))
             ) {
-                validate36.errors = [
+                validate39.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -2288,7 +2516,7 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                             key0 === 'value'
                         )
                     ) {
-                        validate36.errors = [
+                        validate39.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -2359,7 +2587,7 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                                 vErrors.push(err2)
                             }
                             errors++
-                            validate36.errors = vErrors
+                            validate39.errors = vErrors
                             return false
                         } else {
                             errors = _errs3
@@ -2379,7 +2607,7 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                         if (data.key !== undefined) {
                             const _errs8 = errors
                             if (typeof data.key !== 'string') {
-                                validate36.errors = [
+                                validate39.errors = [
                                     {
                                         instancePath: instancePath + '/key',
                                         schemaPath: '#/properties/key/type',
@@ -2398,7 +2626,7 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                             if (data.label !== undefined) {
                                 const _errs10 = errors
                                 if (typeof data.label !== 'string') {
-                                    validate36.errors = [
+                                    validate39.errors = [
                                         {
                                             instancePath: instancePath + '/label',
                                             schemaPath: '#/properties/label/type',
@@ -2418,7 +2646,7 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                                     let data3 = data.operator
                                     const _errs12 = errors
                                     if (typeof data3 !== 'string') {
-                                        validate36.errors = [
+                                        validate39.errors = [
                                             {
                                                 instancePath: instancePath + '/operator',
                                                 schemaPath: '#/definitions/PropertyOperator/type',
@@ -2456,7 +2684,7 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                                             data3 === 'flag_evaluates_to'
                                         )
                                     ) {
-                                        validate36.errors = [
+                                        validate39.errors = [
                                             {
                                                 instancePath: instancePath + '/operator',
                                                 schemaPath: '#/definitions/PropertyOperator/enum',
@@ -2476,7 +2704,7 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                                         let data4 = data.type
                                         const _errs15 = errors
                                         if (typeof data4 !== 'string') {
-                                            validate36.errors = [
+                                            validate39.errors = [
                                                 {
                                                     instancePath: instancePath + '/type',
                                                     schemaPath: '#/properties/type/type',
@@ -2488,7 +2716,7 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                                             return false
                                         }
                                         if ('group' !== data4) {
-                                            validate36.errors = [
+                                            validate39.errors = [
                                                 {
                                                     instancePath: instancePath + '/type',
                                                     schemaPath: '#/properties/type/const',
@@ -2532,7 +2760,7 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate36.errors = [
+            validate39.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -2544,10 +2772,10 @@ function validate36(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate36.errors = vErrors
+    validate39.errors = vErrors
     return errors === 0
 }
-const schema35 = {
+const schema37 = {
     additionalProperties: false,
     properties: {
         key: { type: 'string' },
@@ -2559,7 +2787,7 @@ const schema35 = {
     required: ['key', 'operator', 'type'],
     type: 'object',
 }
-function validate39(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate42(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -2570,7 +2798,7 @@ function validate39(data, { instancePath = '', parentData, parentDataProperty, r
                 (data.operator === undefined && (missing0 = 'operator')) ||
                 (data.type === undefined && (missing0 = 'type'))
             ) {
-                validate39.errors = [
+                validate42.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -2592,220 +2820,6 @@ function validate39(data, { instancePath = '', parentData, parentDataProperty, r
                             key0 === 'value'
                         )
                     ) {
-                        validate39.errors = [
-                            {
-                                instancePath,
-                                schemaPath: '#/additionalProperties',
-                                keyword: 'additionalProperties',
-                                params: { additionalProperty: key0 },
-                                message: 'must NOT have additional properties',
-                            },
-                        ]
-                        return false
-                        break
-                    }
-                }
-                if (_errs1 === errors) {
-                    if (data.key !== undefined) {
-                        const _errs2 = errors
-                        if (typeof data.key !== 'string') {
-                            validate39.errors = [
-                                {
-                                    instancePath: instancePath + '/key',
-                                    schemaPath: '#/properties/key/type',
-                                    keyword: 'type',
-                                    params: { type: 'string' },
-                                    message: 'must be string',
-                                },
-                            ]
-                            return false
-                        }
-                        var valid0 = _errs2 === errors
-                    } else {
-                        var valid0 = true
-                    }
-                    if (valid0) {
-                        if (data.label !== undefined) {
-                            const _errs4 = errors
-                            if (typeof data.label !== 'string') {
-                                validate39.errors = [
-                                    {
-                                        instancePath: instancePath + '/label',
-                                        schemaPath: '#/properties/label/type',
-                                        keyword: 'type',
-                                        params: { type: 'string' },
-                                        message: 'must be string',
-                                    },
-                                ]
-                                return false
-                            }
-                            var valid0 = _errs4 === errors
-                        } else {
-                            var valid0 = true
-                        }
-                        if (valid0) {
-                            if (data.operator !== undefined) {
-                                let data2 = data.operator
-                                const _errs6 = errors
-                                if (typeof data2 !== 'string') {
-                                    validate39.errors = [
-                                        {
-                                            instancePath: instancePath + '/operator',
-                                            schemaPath: '#/definitions/PropertyOperator/type',
-                                            keyword: 'type',
-                                            params: { type: 'string' },
-                                            message: 'must be string',
-                                        },
-                                    ]
-                                    return false
-                                }
-                                if (
-                                    !(
-                                        data2 === 'exact' ||
-                                        data2 === 'is_not' ||
-                                        data2 === 'icontains' ||
-                                        data2 === 'not_icontains' ||
-                                        data2 === 'regex' ||
-                                        data2 === 'not_regex' ||
-                                        data2 === 'gt' ||
-                                        data2 === 'gte' ||
-                                        data2 === 'lt' ||
-                                        data2 === 'lte' ||
-                                        data2 === 'is_set' ||
-                                        data2 === 'is_not_set' ||
-                                        data2 === 'is_date_exact' ||
-                                        data2 === 'is_date_before' ||
-                                        data2 === 'is_date_after' ||
-                                        data2 === 'between' ||
-                                        data2 === 'not_between' ||
-                                        data2 === 'min' ||
-                                        data2 === 'max' ||
-                                        data2 === 'in' ||
-                                        data2 === 'not_in' ||
-                                        data2 === 'is_cleaned_path_exact' ||
-                                        data2 === 'flag_evaluates_to'
-                                    )
-                                ) {
-                                    validate39.errors = [
-                                        {
-                                            instancePath: instancePath + '/operator',
-                                            schemaPath: '#/definitions/PropertyOperator/enum',
-                                            keyword: 'enum',
-                                            params: { allowedValues: schema14.enum },
-                                            message: 'must be equal to one of the allowed values',
-                                        },
-                                    ]
-                                    return false
-                                }
-                                var valid0 = _errs6 === errors
-                            } else {
-                                var valid0 = true
-                            }
-                            if (valid0) {
-                                if (data.type !== undefined) {
-                                    let data3 = data.type
-                                    const _errs9 = errors
-                                    if (typeof data3 !== 'string') {
-                                        validate39.errors = [
-                                            {
-                                                instancePath: instancePath + '/type',
-                                                schemaPath: '#/properties/type/type',
-                                                keyword: 'type',
-                                                params: { type: 'string' },
-                                                message: 'must be string',
-                                            },
-                                        ]
-                                        return false
-                                    }
-                                    if ('feature' !== data3) {
-                                        validate39.errors = [
-                                            {
-                                                instancePath: instancePath + '/type',
-                                                schemaPath: '#/properties/type/const',
-                                                keyword: 'const',
-                                                params: { allowedValue: 'feature' },
-                                                message: 'must be equal to constant',
-                                            },
-                                        ]
-                                        return false
-                                    }
-                                    var valid0 = _errs9 === errors
-                                } else {
-                                    var valid0 = true
-                                }
-                                if (valid0) {
-                                    if (data.value !== undefined) {
-                                        const _errs11 = errors
-                                        if (
-                                            !validate13(data.value, {
-                                                instancePath: instancePath + '/value',
-                                                parentData: data,
-                                                parentDataProperty: 'value',
-                                                rootData,
-                                            })
-                                        ) {
-                                            vErrors =
-                                                vErrors === null ? validate13.errors : vErrors.concat(validate13.errors)
-                                            errors = vErrors.length
-                                        }
-                                        var valid0 = _errs11 === errors
-                                    } else {
-                                        var valid0 = true
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        } else {
-            validate39.errors = [
-                {
-                    instancePath,
-                    schemaPath: '#/type',
-                    keyword: 'type',
-                    params: { type: 'object' },
-                    message: 'must be object',
-                },
-            ]
-            return false
-        }
-    }
-    validate39.errors = vErrors
-    return errors === 0
-}
-const schema38 = {
-    additionalProperties: false,
-    properties: {
-        key: { type: 'string' },
-        label: { type: 'string' },
-        type: { const: 'hogql', type: 'string' },
-        value: { $ref: '#/definitions/PropertyFilterValue' },
-    },
-    required: ['key', 'type'],
-    type: 'object',
-}
-function validate42(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
-    let vErrors = null
-    let errors = 0
-    if (errors === 0) {
-        if (data && typeof data == 'object' && !Array.isArray(data)) {
-            let missing0
-            if ((data.key === undefined && (missing0 = 'key')) || (data.type === undefined && (missing0 = 'type'))) {
-                validate42.errors = [
-                    {
-                        instancePath,
-                        schemaPath: '#/required',
-                        keyword: 'required',
-                        params: { missingProperty: missing0 },
-                        message: "must have required property '" + missing0 + "'",
-                    },
-                ]
-                return false
-            } else {
-                const _errs1 = errors
-                for (const key0 in data) {
-                    if (!(key0 === 'key' || key0 === 'label' || key0 === 'type' || key0 === 'value')) {
                         validate42.errors = [
                             {
                                 instancePath,
@@ -2858,14 +2872,14 @@ function validate42(data, { instancePath = '', parentData, parentDataProperty, r
                             var valid0 = true
                         }
                         if (valid0) {
-                            if (data.type !== undefined) {
-                                let data2 = data.type
+                            if (data.operator !== undefined) {
+                                let data2 = data.operator
                                 const _errs6 = errors
                                 if (typeof data2 !== 'string') {
                                     validate42.errors = [
                                         {
-                                            instancePath: instancePath + '/type',
-                                            schemaPath: '#/properties/type/type',
+                                            instancePath: instancePath + '/operator',
+                                            schemaPath: '#/definitions/PropertyOperator/type',
                                             keyword: 'type',
                                             params: { type: 'string' },
                                             message: 'must be string',
@@ -2873,14 +2887,40 @@ function validate42(data, { instancePath = '', parentData, parentDataProperty, r
                                     ]
                                     return false
                                 }
-                                if ('hogql' !== data2) {
+                                if (
+                                    !(
+                                        data2 === 'exact' ||
+                                        data2 === 'is_not' ||
+                                        data2 === 'icontains' ||
+                                        data2 === 'not_icontains' ||
+                                        data2 === 'regex' ||
+                                        data2 === 'not_regex' ||
+                                        data2 === 'gt' ||
+                                        data2 === 'gte' ||
+                                        data2 === 'lt' ||
+                                        data2 === 'lte' ||
+                                        data2 === 'is_set' ||
+                                        data2 === 'is_not_set' ||
+                                        data2 === 'is_date_exact' ||
+                                        data2 === 'is_date_before' ||
+                                        data2 === 'is_date_after' ||
+                                        data2 === 'between' ||
+                                        data2 === 'not_between' ||
+                                        data2 === 'min' ||
+                                        data2 === 'max' ||
+                                        data2 === 'in' ||
+                                        data2 === 'not_in' ||
+                                        data2 === 'is_cleaned_path_exact' ||
+                                        data2 === 'flag_evaluates_to'
+                                    )
+                                ) {
                                     validate42.errors = [
                                         {
-                                            instancePath: instancePath + '/type',
-                                            schemaPath: '#/properties/type/const',
-                                            keyword: 'const',
-                                            params: { allowedValue: 'hogql' },
-                                            message: 'must be equal to constant',
+                                            instancePath: instancePath + '/operator',
+                                            schemaPath: '#/definitions/PropertyOperator/enum',
+                                            keyword: 'enum',
+                                            params: { allowedValues: schema14.enum },
+                                            message: 'must be equal to one of the allowed values',
                                         },
                                     ]
                                     return false
@@ -2890,23 +2930,56 @@ function validate42(data, { instancePath = '', parentData, parentDataProperty, r
                                 var valid0 = true
                             }
                             if (valid0) {
-                                if (data.value !== undefined) {
-                                    const _errs8 = errors
-                                    if (
-                                        !validate13(data.value, {
-                                            instancePath: instancePath + '/value',
-                                            parentData: data,
-                                            parentDataProperty: 'value',
-                                            rootData,
-                                        })
-                                    ) {
-                                        vErrors =
-                                            vErrors === null ? validate13.errors : vErrors.concat(validate13.errors)
-                                        errors = vErrors.length
+                                if (data.type !== undefined) {
+                                    let data3 = data.type
+                                    const _errs9 = errors
+                                    if (typeof data3 !== 'string') {
+                                        validate42.errors = [
+                                            {
+                                                instancePath: instancePath + '/type',
+                                                schemaPath: '#/properties/type/type',
+                                                keyword: 'type',
+                                                params: { type: 'string' },
+                                                message: 'must be string',
+                                            },
+                                        ]
+                                        return false
                                     }
-                                    var valid0 = _errs8 === errors
+                                    if ('feature' !== data3) {
+                                        validate42.errors = [
+                                            {
+                                                instancePath: instancePath + '/type',
+                                                schemaPath: '#/properties/type/const',
+                                                keyword: 'const',
+                                                params: { allowedValue: 'feature' },
+                                                message: 'must be equal to constant',
+                                            },
+                                        ]
+                                        return false
+                                    }
+                                    var valid0 = _errs9 === errors
                                 } else {
                                     var valid0 = true
+                                }
+                                if (valid0) {
+                                    if (data.value !== undefined) {
+                                        const _errs11 = errors
+                                        if (
+                                            !validate13(data.value, {
+                                                instancePath: instancePath + '/value',
+                                                parentData: data,
+                                                parentDataProperty: 'value',
+                                                rootData,
+                                            })
+                                        ) {
+                                            vErrors =
+                                                vErrors === null ? validate13.errors : vErrors.concat(validate13.errors)
+                                            errors = vErrors.length
+                                        }
+                                        var valid0 = _errs11 === errors
+                                    } else {
+                                        var valid0 = true
+                                    }
                                 }
                             }
                         }
@@ -2934,11 +3007,10 @@ const schema40 = {
     properties: {
         key: { type: 'string' },
         label: { type: 'string' },
-        operator: { $ref: '#/definitions/PropertyOperator' },
-        type: { const: 'data_warehouse', type: 'string' },
+        type: { const: 'hogql', type: 'string' },
         value: { $ref: '#/definitions/PropertyFilterValue' },
     },
-    required: ['key', 'operator', 'type'],
+    required: ['key', 'type'],
     type: 'object',
 }
 function validate45(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
@@ -2947,11 +3019,7 @@ function validate45(data, { instancePath = '', parentData, parentDataProperty, r
     if (errors === 0) {
         if (data && typeof data == 'object' && !Array.isArray(data)) {
             let missing0
-            if (
-                (data.key === undefined && (missing0 = 'key')) ||
-                (data.operator === undefined && (missing0 = 'operator')) ||
-                (data.type === undefined && (missing0 = 'type'))
-            ) {
+            if ((data.key === undefined && (missing0 = 'key')) || (data.type === undefined && (missing0 = 'type'))) {
                 validate45.errors = [
                     {
                         instancePath,
@@ -2965,15 +3033,7 @@ function validate45(data, { instancePath = '', parentData, parentDataProperty, r
             } else {
                 const _errs1 = errors
                 for (const key0 in data) {
-                    if (
-                        !(
-                            key0 === 'key' ||
-                            key0 === 'label' ||
-                            key0 === 'operator' ||
-                            key0 === 'type' ||
-                            key0 === 'value'
-                        )
-                    ) {
+                    if (!(key0 === 'key' || key0 === 'label' || key0 === 'type' || key0 === 'value')) {
                         validate45.errors = [
                             {
                                 instancePath,
@@ -3026,14 +3086,14 @@ function validate45(data, { instancePath = '', parentData, parentDataProperty, r
                             var valid0 = true
                         }
                         if (valid0) {
-                            if (data.operator !== undefined) {
-                                let data2 = data.operator
+                            if (data.type !== undefined) {
+                                let data2 = data.type
                                 const _errs6 = errors
                                 if (typeof data2 !== 'string') {
                                     validate45.errors = [
                                         {
-                                            instancePath: instancePath + '/operator',
-                                            schemaPath: '#/definitions/PropertyOperator/type',
+                                            instancePath: instancePath + '/type',
+                                            schemaPath: '#/properties/type/type',
                                             keyword: 'type',
                                             params: { type: 'string' },
                                             message: 'must be string',
@@ -3041,40 +3101,14 @@ function validate45(data, { instancePath = '', parentData, parentDataProperty, r
                                     ]
                                     return false
                                 }
-                                if (
-                                    !(
-                                        data2 === 'exact' ||
-                                        data2 === 'is_not' ||
-                                        data2 === 'icontains' ||
-                                        data2 === 'not_icontains' ||
-                                        data2 === 'regex' ||
-                                        data2 === 'not_regex' ||
-                                        data2 === 'gt' ||
-                                        data2 === 'gte' ||
-                                        data2 === 'lt' ||
-                                        data2 === 'lte' ||
-                                        data2 === 'is_set' ||
-                                        data2 === 'is_not_set' ||
-                                        data2 === 'is_date_exact' ||
-                                        data2 === 'is_date_before' ||
-                                        data2 === 'is_date_after' ||
-                                        data2 === 'between' ||
-                                        data2 === 'not_between' ||
-                                        data2 === 'min' ||
-                                        data2 === 'max' ||
-                                        data2 === 'in' ||
-                                        data2 === 'not_in' ||
-                                        data2 === 'is_cleaned_path_exact' ||
-                                        data2 === 'flag_evaluates_to'
-                                    )
-                                ) {
+                                if ('hogql' !== data2) {
                                     validate45.errors = [
                                         {
-                                            instancePath: instancePath + '/operator',
-                                            schemaPath: '#/definitions/PropertyOperator/enum',
-                                            keyword: 'enum',
-                                            params: { allowedValues: schema14.enum },
-                                            message: 'must be equal to one of the allowed values',
+                                            instancePath: instancePath + '/type',
+                                            schemaPath: '#/properties/type/const',
+                                            keyword: 'const',
+                                            params: { allowedValue: 'hogql' },
+                                            message: 'must be equal to constant',
                                         },
                                     ]
                                     return false
@@ -3084,56 +3118,23 @@ function validate45(data, { instancePath = '', parentData, parentDataProperty, r
                                 var valid0 = true
                             }
                             if (valid0) {
-                                if (data.type !== undefined) {
-                                    let data3 = data.type
-                                    const _errs9 = errors
-                                    if (typeof data3 !== 'string') {
-                                        validate45.errors = [
-                                            {
-                                                instancePath: instancePath + '/type',
-                                                schemaPath: '#/properties/type/type',
-                                                keyword: 'type',
-                                                params: { type: 'string' },
-                                                message: 'must be string',
-                                            },
-                                        ]
-                                        return false
+                                if (data.value !== undefined) {
+                                    const _errs8 = errors
+                                    if (
+                                        !validate13(data.value, {
+                                            instancePath: instancePath + '/value',
+                                            parentData: data,
+                                            parentDataProperty: 'value',
+                                            rootData,
+                                        })
+                                    ) {
+                                        vErrors =
+                                            vErrors === null ? validate13.errors : vErrors.concat(validate13.errors)
+                                        errors = vErrors.length
                                     }
-                                    if ('data_warehouse' !== data3) {
-                                        validate45.errors = [
-                                            {
-                                                instancePath: instancePath + '/type',
-                                                schemaPath: '#/properties/type/const',
-                                                keyword: 'const',
-                                                params: { allowedValue: 'data_warehouse' },
-                                                message: 'must be equal to constant',
-                                            },
-                                        ]
-                                        return false
-                                    }
-                                    var valid0 = _errs9 === errors
+                                    var valid0 = _errs8 === errors
                                 } else {
                                     var valid0 = true
-                                }
-                                if (valid0) {
-                                    if (data.value !== undefined) {
-                                        const _errs11 = errors
-                                        if (
-                                            !validate13(data.value, {
-                                                instancePath: instancePath + '/value',
-                                                parentData: data,
-                                                parentDataProperty: 'value',
-                                                rootData,
-                                            })
-                                        ) {
-                                            vErrors =
-                                                vErrors === null ? validate13.errors : vErrors.concat(validate13.errors)
-                                            errors = vErrors.length
-                                        }
-                                        var valid0 = _errs11 === errors
-                                    } else {
-                                        var valid0 = true
-                                    }
                                 }
                             }
                         }
@@ -3162,7 +3163,7 @@ const schema42 = {
         key: { type: 'string' },
         label: { type: 'string' },
         operator: { $ref: '#/definitions/PropertyOperator' },
-        type: { const: 'data_warehouse_person_property', type: 'string' },
+        type: { const: 'data_warehouse', type: 'string' },
         value: { $ref: '#/definitions/PropertyFilterValue' },
     },
     required: ['key', 'operator', 'type'],
@@ -3326,13 +3327,13 @@ function validate48(data, { instancePath = '', parentData, parentDataProperty, r
                                         ]
                                         return false
                                     }
-                                    if ('data_warehouse_person_property' !== data3) {
+                                    if ('data_warehouse' !== data3) {
                                         validate48.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/const',
                                                 keyword: 'const',
-                                                params: { allowedValue: 'data_warehouse_person_property' },
+                                                params: { allowedValue: 'data_warehouse' },
                                                 message: 'must be equal to constant',
                                             },
                                         ]
@@ -3389,7 +3390,7 @@ const schema44 = {
         key: { type: 'string' },
         label: { type: 'string' },
         operator: { $ref: '#/definitions/PropertyOperator' },
-        type: { const: 'error_tracking_issue', type: 'string' },
+        type: { const: 'data_warehouse_person_property', type: 'string' },
         value: { $ref: '#/definitions/PropertyFilterValue' },
     },
     required: ['key', 'operator', 'type'],
@@ -3553,13 +3554,13 @@ function validate51(data, { instancePath = '', parentData, parentDataProperty, r
                                         ]
                                         return false
                                     }
-                                    if ('error_tracking_issue' !== data3) {
+                                    if ('data_warehouse_person_property' !== data3) {
                                         validate51.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/const',
                                                 keyword: 'const',
-                                                params: { allowedValue: 'error_tracking_issue' },
+                                                params: { allowedValue: 'data_warehouse_person_property' },
                                                 message: 'must be equal to constant',
                                             },
                                         ]
@@ -3616,7 +3617,7 @@ const schema46 = {
         key: { type: 'string' },
         label: { type: 'string' },
         operator: { $ref: '#/definitions/PropertyOperator' },
-        type: { const: 'log', type: 'string' },
+        type: { const: 'error_tracking_issue', type: 'string' },
         value: { $ref: '#/definitions/PropertyFilterValue' },
     },
     required: ['key', 'operator', 'type'],
@@ -3780,13 +3781,13 @@ function validate54(data, { instancePath = '', parentData, parentDataProperty, r
                                         ]
                                         return false
                                     }
-                                    if ('log' !== data3) {
+                                    if ('error_tracking_issue' !== data3) {
                                         validate54.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/const',
                                                 keyword: 'const',
-                                                params: { allowedValue: 'log' },
+                                                params: { allowedValue: 'error_tracking_issue' },
                                                 message: 'must be equal to constant',
                                             },
                                         ]
@@ -3843,7 +3844,7 @@ const schema48 = {
         key: { type: 'string' },
         label: { type: 'string' },
         operator: { $ref: '#/definitions/PropertyOperator' },
-        type: { const: 'revenue_analytics', type: 'string' },
+        type: { const: 'log', type: 'string' },
         value: { $ref: '#/definitions/PropertyFilterValue' },
     },
     required: ['key', 'operator', 'type'],
@@ -4007,13 +4008,13 @@ function validate57(data, { instancePath = '', parentData, parentDataProperty, r
                                         ]
                                         return false
                                     }
-                                    if ('revenue_analytics' !== data3) {
+                                    if ('log' !== data3) {
                                         validate57.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/const',
                                                 keyword: 'const',
-                                                params: { allowedValue: 'revenue_analytics' },
+                                                params: { allowedValue: 'log' },
                                                 message: 'must be equal to constant',
                                             },
                                         ]
@@ -4062,6 +4063,233 @@ function validate57(data, { instancePath = '', parentData, parentDataProperty, r
         }
     }
     validate57.errors = vErrors
+    return errors === 0
+}
+const schema50 = {
+    additionalProperties: false,
+    properties: {
+        key: { type: 'string' },
+        label: { type: 'string' },
+        operator: { $ref: '#/definitions/PropertyOperator' },
+        type: { const: 'revenue_analytics', type: 'string' },
+        value: { $ref: '#/definitions/PropertyFilterValue' },
+    },
+    required: ['key', 'operator', 'type'],
+    type: 'object',
+}
+function validate60(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+    let vErrors = null
+    let errors = 0
+    if (errors === 0) {
+        if (data && typeof data == 'object' && !Array.isArray(data)) {
+            let missing0
+            if (
+                (data.key === undefined && (missing0 = 'key')) ||
+                (data.operator === undefined && (missing0 = 'operator')) ||
+                (data.type === undefined && (missing0 = 'type'))
+            ) {
+                validate60.errors = [
+                    {
+                        instancePath,
+                        schemaPath: '#/required',
+                        keyword: 'required',
+                        params: { missingProperty: missing0 },
+                        message: "must have required property '" + missing0 + "'",
+                    },
+                ]
+                return false
+            } else {
+                const _errs1 = errors
+                for (const key0 in data) {
+                    if (
+                        !(
+                            key0 === 'key' ||
+                            key0 === 'label' ||
+                            key0 === 'operator' ||
+                            key0 === 'type' ||
+                            key0 === 'value'
+                        )
+                    ) {
+                        validate60.errors = [
+                            {
+                                instancePath,
+                                schemaPath: '#/additionalProperties',
+                                keyword: 'additionalProperties',
+                                params: { additionalProperty: key0 },
+                                message: 'must NOT have additional properties',
+                            },
+                        ]
+                        return false
+                        break
+                    }
+                }
+                if (_errs1 === errors) {
+                    if (data.key !== undefined) {
+                        const _errs2 = errors
+                        if (typeof data.key !== 'string') {
+                            validate60.errors = [
+                                {
+                                    instancePath: instancePath + '/key',
+                                    schemaPath: '#/properties/key/type',
+                                    keyword: 'type',
+                                    params: { type: 'string' },
+                                    message: 'must be string',
+                                },
+                            ]
+                            return false
+                        }
+                        var valid0 = _errs2 === errors
+                    } else {
+                        var valid0 = true
+                    }
+                    if (valid0) {
+                        if (data.label !== undefined) {
+                            const _errs4 = errors
+                            if (typeof data.label !== 'string') {
+                                validate60.errors = [
+                                    {
+                                        instancePath: instancePath + '/label',
+                                        schemaPath: '#/properties/label/type',
+                                        keyword: 'type',
+                                        params: { type: 'string' },
+                                        message: 'must be string',
+                                    },
+                                ]
+                                return false
+                            }
+                            var valid0 = _errs4 === errors
+                        } else {
+                            var valid0 = true
+                        }
+                        if (valid0) {
+                            if (data.operator !== undefined) {
+                                let data2 = data.operator
+                                const _errs6 = errors
+                                if (typeof data2 !== 'string') {
+                                    validate60.errors = [
+                                        {
+                                            instancePath: instancePath + '/operator',
+                                            schemaPath: '#/definitions/PropertyOperator/type',
+                                            keyword: 'type',
+                                            params: { type: 'string' },
+                                            message: 'must be string',
+                                        },
+                                    ]
+                                    return false
+                                }
+                                if (
+                                    !(
+                                        data2 === 'exact' ||
+                                        data2 === 'is_not' ||
+                                        data2 === 'icontains' ||
+                                        data2 === 'not_icontains' ||
+                                        data2 === 'regex' ||
+                                        data2 === 'not_regex' ||
+                                        data2 === 'gt' ||
+                                        data2 === 'gte' ||
+                                        data2 === 'lt' ||
+                                        data2 === 'lte' ||
+                                        data2 === 'is_set' ||
+                                        data2 === 'is_not_set' ||
+                                        data2 === 'is_date_exact' ||
+                                        data2 === 'is_date_before' ||
+                                        data2 === 'is_date_after' ||
+                                        data2 === 'between' ||
+                                        data2 === 'not_between' ||
+                                        data2 === 'min' ||
+                                        data2 === 'max' ||
+                                        data2 === 'in' ||
+                                        data2 === 'not_in' ||
+                                        data2 === 'is_cleaned_path_exact' ||
+                                        data2 === 'flag_evaluates_to'
+                                    )
+                                ) {
+                                    validate60.errors = [
+                                        {
+                                            instancePath: instancePath + '/operator',
+                                            schemaPath: '#/definitions/PropertyOperator/enum',
+                                            keyword: 'enum',
+                                            params: { allowedValues: schema14.enum },
+                                            message: 'must be equal to one of the allowed values',
+                                        },
+                                    ]
+                                    return false
+                                }
+                                var valid0 = _errs6 === errors
+                            } else {
+                                var valid0 = true
+                            }
+                            if (valid0) {
+                                if (data.type !== undefined) {
+                                    let data3 = data.type
+                                    const _errs9 = errors
+                                    if (typeof data3 !== 'string') {
+                                        validate60.errors = [
+                                            {
+                                                instancePath: instancePath + '/type',
+                                                schemaPath: '#/properties/type/type',
+                                                keyword: 'type',
+                                                params: { type: 'string' },
+                                                message: 'must be string',
+                                            },
+                                        ]
+                                        return false
+                                    }
+                                    if ('revenue_analytics' !== data3) {
+                                        validate60.errors = [
+                                            {
+                                                instancePath: instancePath + '/type',
+                                                schemaPath: '#/properties/type/const',
+                                                keyword: 'const',
+                                                params: { allowedValue: 'revenue_analytics' },
+                                                message: 'must be equal to constant',
+                                            },
+                                        ]
+                                        return false
+                                    }
+                                    var valid0 = _errs9 === errors
+                                } else {
+                                    var valid0 = true
+                                }
+                                if (valid0) {
+                                    if (data.value !== undefined) {
+                                        const _errs11 = errors
+                                        if (
+                                            !validate13(data.value, {
+                                                instancePath: instancePath + '/value',
+                                                parentData: data,
+                                                parentDataProperty: 'value',
+                                                rootData,
+                                            })
+                                        ) {
+                                            vErrors =
+                                                vErrors === null ? validate13.errors : vErrors.concat(validate13.errors)
+                                            errors = vErrors.length
+                                        }
+                                        var valid0 = _errs11 === errors
+                                    } else {
+                                        var valid0 = true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            validate60.errors = [
+                {
+                    instancePath,
+                    schemaPath: '#/type',
+                    keyword: 'type',
+                    params: { type: 'object' },
+                    message: 'must be object',
+                },
+            ]
+            return false
+        }
+    }
+    validate60.errors = vErrors
     return errors === 0
 }
 function validate11(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
@@ -4118,8 +4346,8 @@ function validate11(data, { instancePath = '', parentData, parentDataProperty, r
                         valid0 = valid0 || _valid0
                         if (!valid0) {
                             const _errs7 = errors
-                            if (!validate30(data, { instancePath, parentData, parentDataProperty, rootData })) {
-                                vErrors = vErrors === null ? validate30.errors : vErrors.concat(validate30.errors)
+                            if (!validate31(data, { instancePath, parentData, parentDataProperty, rootData })) {
+                                vErrors = vErrors === null ? validate31.errors : vErrors.concat(validate31.errors)
                                 errors = vErrors.length
                             }
                             var _valid0 = _errs7 === errors
@@ -4159,322 +4387,333 @@ function validate11(data, { instancePath = '', parentData, parentDataProperty, r
                                         valid0 = valid0 || _valid0
                                         if (!valid0) {
                                             const _errs11 = errors
-                                            const _errs12 = errors
-                                            if (errors === _errs12) {
-                                                if (data && typeof data == 'object' && !Array.isArray(data)) {
-                                                    let missing0
-                                                    if (
-                                                        (data.key === undefined && (missing0 = 'key')) ||
-                                                        (data.operator === undefined && (missing0 = 'operator')) ||
-                                                        (data.type === undefined && (missing0 = 'type')) ||
-                                                        (data.value === undefined && (missing0 = 'value'))
-                                                    ) {
-                                                        const err0 = {
-                                                            instancePath,
-                                                            schemaPath: '#/definitions/FlagPropertyFilter/required',
-                                                            keyword: 'required',
-                                                            params: { missingProperty: missing0 },
-                                                            message: "must have required property '" + missing0 + "'",
-                                                        }
-                                                        if (vErrors === null) {
-                                                            vErrors = [err0]
-                                                        } else {
-                                                            vErrors.push(err0)
-                                                        }
-                                                        errors++
-                                                    } else {
-                                                        const _errs14 = errors
-                                                        for (const key0 in data) {
-                                                            if (
-                                                                !(
-                                                                    key0 === 'key' ||
-                                                                    key0 === 'label' ||
-                                                                    key0 === 'operator' ||
-                                                                    key0 === 'type' ||
-                                                                    key0 === 'value'
-                                                                )
-                                                            ) {
-                                                                const err1 = {
-                                                                    instancePath,
-                                                                    schemaPath:
-                                                                        '#/definitions/FlagPropertyFilter/additionalProperties',
-                                                                    keyword: 'additionalProperties',
-                                                                    params: { additionalProperty: key0 },
-                                                                    message: 'must NOT have additional properties',
-                                                                }
-                                                                if (vErrors === null) {
-                                                                    vErrors = [err1]
-                                                                } else {
-                                                                    vErrors.push(err1)
-                                                                }
-                                                                errors++
-                                                                break
+                                            if (
+                                                !validate42(data, {
+                                                    instancePath,
+                                                    parentData,
+                                                    parentDataProperty,
+                                                    rootData,
+                                                })
+                                            ) {
+                                                vErrors =
+                                                    vErrors === null
+                                                        ? validate42.errors
+                                                        : vErrors.concat(validate42.errors)
+                                                errors = vErrors.length
+                                            }
+                                            var _valid0 = _errs11 === errors
+                                            valid0 = valid0 || _valid0
+                                            if (!valid0) {
+                                                const _errs12 = errors
+                                                const _errs13 = errors
+                                                if (errors === _errs13) {
+                                                    if (data && typeof data == 'object' && !Array.isArray(data)) {
+                                                        let missing0
+                                                        if (
+                                                            (data.key === undefined && (missing0 = 'key')) ||
+                                                            (data.operator === undefined && (missing0 = 'operator')) ||
+                                                            (data.type === undefined && (missing0 = 'type')) ||
+                                                            (data.value === undefined && (missing0 = 'value'))
+                                                        ) {
+                                                            const err0 = {
+                                                                instancePath,
+                                                                schemaPath: '#/definitions/FlagPropertyFilter/required',
+                                                                keyword: 'required',
+                                                                params: { missingProperty: missing0 },
+                                                                message:
+                                                                    "must have required property '" + missing0 + "'",
                                                             }
-                                                        }
-                                                        if (_errs14 === errors) {
-                                                            if (data.key !== undefined) {
-                                                                const _errs15 = errors
-                                                                if (typeof data.key !== 'string') {
-                                                                    const err2 = {
-                                                                        instancePath: instancePath + '/key',
+                                                            if (vErrors === null) {
+                                                                vErrors = [err0]
+                                                            } else {
+                                                                vErrors.push(err0)
+                                                            }
+                                                            errors++
+                                                        } else {
+                                                            const _errs15 = errors
+                                                            for (const key0 in data) {
+                                                                if (
+                                                                    !(
+                                                                        key0 === 'key' ||
+                                                                        key0 === 'label' ||
+                                                                        key0 === 'operator' ||
+                                                                        key0 === 'type' ||
+                                                                        key0 === 'value'
+                                                                    )
+                                                                ) {
+                                                                    const err1 = {
+                                                                        instancePath,
                                                                         schemaPath:
-                                                                            '#/definitions/FlagPropertyFilter/properties/key/type',
-                                                                        keyword: 'type',
-                                                                        params: { type: 'string' },
-                                                                        message: 'must be string',
+                                                                            '#/definitions/FlagPropertyFilter/additionalProperties',
+                                                                        keyword: 'additionalProperties',
+                                                                        params: { additionalProperty: key0 },
+                                                                        message: 'must NOT have additional properties',
                                                                     }
                                                                     if (vErrors === null) {
-                                                                        vErrors = [err2]
+                                                                        vErrors = [err1]
                                                                     } else {
-                                                                        vErrors.push(err2)
+                                                                        vErrors.push(err1)
                                                                     }
                                                                     errors++
+                                                                    break
                                                                 }
-                                                                var valid2 = _errs15 === errors
-                                                            } else {
-                                                                var valid2 = true
                                                             }
-                                                            if (valid2) {
-                                                                if (data.label !== undefined) {
-                                                                    const _errs17 = errors
-                                                                    if (typeof data.label !== 'string') {
-                                                                        const err3 = {
-                                                                            instancePath: instancePath + '/label',
+                                                            if (_errs15 === errors) {
+                                                                if (data.key !== undefined) {
+                                                                    const _errs16 = errors
+                                                                    if (typeof data.key !== 'string') {
+                                                                        const err2 = {
+                                                                            instancePath: instancePath + '/key',
                                                                             schemaPath:
-                                                                                '#/definitions/FlagPropertyFilter/properties/label/type',
+                                                                                '#/definitions/FlagPropertyFilter/properties/key/type',
                                                                             keyword: 'type',
                                                                             params: { type: 'string' },
                                                                             message: 'must be string',
                                                                         }
                                                                         if (vErrors === null) {
-                                                                            vErrors = [err3]
+                                                                            vErrors = [err2]
                                                                         } else {
-                                                                            vErrors.push(err3)
+                                                                            vErrors.push(err2)
                                                                         }
                                                                         errors++
                                                                     }
-                                                                    var valid2 = _errs17 === errors
+                                                                    var valid2 = _errs16 === errors
                                                                 } else {
                                                                     var valid2 = true
                                                                 }
                                                                 if (valid2) {
-                                                                    if (data.operator !== undefined) {
-                                                                        let data2 = data.operator
-                                                                        const _errs19 = errors
-                                                                        if (typeof data2 !== 'string') {
-                                                                            const err4 = {
-                                                                                instancePath:
-                                                                                    instancePath + '/operator',
+                                                                    if (data.label !== undefined) {
+                                                                        const _errs18 = errors
+                                                                        if (typeof data.label !== 'string') {
+                                                                            const err3 = {
+                                                                                instancePath: instancePath + '/label',
                                                                                 schemaPath:
-                                                                                    '#/definitions/FlagPropertyFilter/properties/operator/type',
+                                                                                    '#/definitions/FlagPropertyFilter/properties/label/type',
                                                                                 keyword: 'type',
                                                                                 params: { type: 'string' },
                                                                                 message: 'must be string',
                                                                             }
                                                                             if (vErrors === null) {
-                                                                                vErrors = [err4]
+                                                                                vErrors = [err3]
                                                                             } else {
-                                                                                vErrors.push(err4)
+                                                                                vErrors.push(err3)
                                                                             }
                                                                             errors++
                                                                         }
-                                                                        if ('flag_evaluates_to' !== data2) {
-                                                                            const err5 = {
-                                                                                instancePath:
-                                                                                    instancePath + '/operator',
-                                                                                schemaPath:
-                                                                                    '#/definitions/FlagPropertyFilter/properties/operator/const',
-                                                                                keyword: 'const',
-                                                                                params: {
-                                                                                    allowedValue: 'flag_evaluates_to',
-                                                                                },
-                                                                                message: 'must be equal to constant',
-                                                                            }
-                                                                            if (vErrors === null) {
-                                                                                vErrors = [err5]
-                                                                            } else {
-                                                                                vErrors.push(err5)
-                                                                            }
-                                                                            errors++
-                                                                        }
-                                                                        var valid2 = _errs19 === errors
+                                                                        var valid2 = _errs18 === errors
                                                                     } else {
                                                                         var valid2 = true
                                                                     }
                                                                     if (valid2) {
-                                                                        if (data.type !== undefined) {
-                                                                            let data3 = data.type
-                                                                            const _errs21 = errors
-                                                                            if (typeof data3 !== 'string') {
-                                                                                const err6 = {
+                                                                        if (data.operator !== undefined) {
+                                                                            let data2 = data.operator
+                                                                            const _errs20 = errors
+                                                                            if (typeof data2 !== 'string') {
+                                                                                const err4 = {
                                                                                     instancePath:
-                                                                                        instancePath + '/type',
+                                                                                        instancePath + '/operator',
                                                                                     schemaPath:
-                                                                                        '#/definitions/FlagPropertyFilter/properties/type/type',
+                                                                                        '#/definitions/FlagPropertyFilter/properties/operator/type',
                                                                                     keyword: 'type',
                                                                                     params: { type: 'string' },
                                                                                     message: 'must be string',
                                                                                 }
                                                                                 if (vErrors === null) {
-                                                                                    vErrors = [err6]
+                                                                                    vErrors = [err4]
                                                                                 } else {
-                                                                                    vErrors.push(err6)
+                                                                                    vErrors.push(err4)
                                                                                 }
                                                                                 errors++
                                                                             }
-                                                                            if ('flag' !== data3) {
-                                                                                const err7 = {
+                                                                            if ('flag_evaluates_to' !== data2) {
+                                                                                const err5 = {
                                                                                     instancePath:
-                                                                                        instancePath + '/type',
+                                                                                        instancePath + '/operator',
                                                                                     schemaPath:
-                                                                                        '#/definitions/FlagPropertyFilter/properties/type/const',
+                                                                                        '#/definitions/FlagPropertyFilter/properties/operator/const',
                                                                                     keyword: 'const',
-                                                                                    params: { allowedValue: 'flag' },
+                                                                                    params: {
+                                                                                        allowedValue:
+                                                                                            'flag_evaluates_to',
+                                                                                    },
                                                                                     message:
                                                                                         'must be equal to constant',
                                                                                 }
                                                                                 if (vErrors === null) {
-                                                                                    vErrors = [err7]
+                                                                                    vErrors = [err5]
                                                                                 } else {
-                                                                                    vErrors.push(err7)
+                                                                                    vErrors.push(err5)
                                                                                 }
                                                                                 errors++
                                                                             }
-                                                                            var valid2 = _errs21 === errors
+                                                                            var valid2 = _errs20 === errors
                                                                         } else {
                                                                             var valid2 = true
                                                                         }
                                                                         if (valid2) {
-                                                                            if (data.value !== undefined) {
-                                                                                let data4 = data.value
-                                                                                const _errs23 = errors
-                                                                                if (
-                                                                                    typeof data4 !== 'boolean' &&
-                                                                                    typeof data4 !== 'string'
-                                                                                ) {
-                                                                                    const err8 = {
+                                                                            if (data.type !== undefined) {
+                                                                                let data3 = data.type
+                                                                                const _errs22 = errors
+                                                                                if (typeof data3 !== 'string') {
+                                                                                    const err6 = {
                                                                                         instancePath:
-                                                                                            instancePath + '/value',
+                                                                                            instancePath + '/type',
                                                                                         schemaPath:
-                                                                                            '#/definitions/FlagPropertyFilter/properties/value/type',
+                                                                                            '#/definitions/FlagPropertyFilter/properties/type/type',
                                                                                         keyword: 'type',
-                                                                                        params: {
-                                                                                            type: schema37.properties
-                                                                                                .value.type,
-                                                                                        },
-                                                                                        message:
-                                                                                            'must be boolean,string',
+                                                                                        params: { type: 'string' },
+                                                                                        message: 'must be string',
                                                                                     }
                                                                                     if (vErrors === null) {
-                                                                                        vErrors = [err8]
+                                                                                        vErrors = [err6]
                                                                                     } else {
-                                                                                        vErrors.push(err8)
+                                                                                        vErrors.push(err6)
                                                                                     }
                                                                                     errors++
                                                                                 }
-                                                                                var valid2 = _errs23 === errors
+                                                                                if ('flag' !== data3) {
+                                                                                    const err7 = {
+                                                                                        instancePath:
+                                                                                            instancePath + '/type',
+                                                                                        schemaPath:
+                                                                                            '#/definitions/FlagPropertyFilter/properties/type/const',
+                                                                                        keyword: 'const',
+                                                                                        params: {
+                                                                                            allowedValue: 'flag',
+                                                                                        },
+                                                                                        message:
+                                                                                            'must be equal to constant',
+                                                                                    }
+                                                                                    if (vErrors === null) {
+                                                                                        vErrors = [err7]
+                                                                                    } else {
+                                                                                        vErrors.push(err7)
+                                                                                    }
+                                                                                    errors++
+                                                                                }
+                                                                                var valid2 = _errs22 === errors
                                                                             } else {
                                                                                 var valid2 = true
+                                                                            }
+                                                                            if (valid2) {
+                                                                                if (data.value !== undefined) {
+                                                                                    let data4 = data.value
+                                                                                    const _errs24 = errors
+                                                                                    if (
+                                                                                        typeof data4 !== 'boolean' &&
+                                                                                        typeof data4 !== 'string'
+                                                                                    ) {
+                                                                                        const err8 = {
+                                                                                            instancePath:
+                                                                                                instancePath + '/value',
+                                                                                            schemaPath:
+                                                                                                '#/definitions/FlagPropertyFilter/properties/value/type',
+                                                                                            keyword: 'type',
+                                                                                            params: {
+                                                                                                type: schema39
+                                                                                                    .properties.value
+                                                                                                    .type,
+                                                                                            },
+                                                                                            message:
+                                                                                                'must be boolean,string',
+                                                                                        }
+                                                                                        if (vErrors === null) {
+                                                                                            vErrors = [err8]
+                                                                                        } else {
+                                                                                            vErrors.push(err8)
+                                                                                        }
+                                                                                        errors++
+                                                                                    }
+                                                                                    var valid2 = _errs24 === errors
+                                                                                } else {
+                                                                                    var valid2 = true
+                                                                                }
                                                                             }
                                                                         }
                                                                     }
                                                                 }
                                                             }
                                                         }
-                                                    }
-                                                } else {
-                                                    const err9 = {
-                                                        instancePath,
-                                                        schemaPath: '#/definitions/FlagPropertyFilter/type',
-                                                        keyword: 'type',
-                                                        params: { type: 'object' },
-                                                        message: 'must be object',
-                                                    }
-                                                    if (vErrors === null) {
-                                                        vErrors = [err9]
                                                     } else {
-                                                        vErrors.push(err9)
+                                                        const err9 = {
+                                                            instancePath,
+                                                            schemaPath: '#/definitions/FlagPropertyFilter/type',
+                                                            keyword: 'type',
+                                                            params: { type: 'object' },
+                                                            message: 'must be object',
+                                                        }
+                                                        if (vErrors === null) {
+                                                            vErrors = [err9]
+                                                        } else {
+                                                            vErrors.push(err9)
+                                                        }
+                                                        errors++
                                                     }
-                                                    errors++
                                                 }
-                                            }
-                                            var _valid0 = _errs11 === errors
-                                            valid0 = valid0 || _valid0
-                                            if (!valid0) {
-                                                const _errs25 = errors
-                                                if (
-                                                    !validate42(data, {
-                                                        instancePath,
-                                                        parentData,
-                                                        parentDataProperty,
-                                                        rootData,
-                                                    })
-                                                ) {
-                                                    vErrors =
-                                                        vErrors === null
-                                                            ? validate42.errors
-                                                            : vErrors.concat(validate42.errors)
-                                                    errors = vErrors.length
-                                                }
-                                                var _valid0 = _errs25 === errors
+                                                var _valid0 = _errs12 === errors
                                                 valid0 = valid0 || _valid0
                                                 if (!valid0) {
                                                     const _errs26 = errors
-                                                    const _errs27 = errors
-                                                    if (errors === _errs27) {
-                                                        if (data && typeof data == 'object' && !Array.isArray(data)) {
-                                                            for (const key1 in data) {
-                                                                const err10 = {
-                                                                    instancePath,
-                                                                    schemaPath:
-                                                                        '#/definitions/EmptyPropertyFilter/additionalProperties',
-                                                                    keyword: 'additionalProperties',
-                                                                    params: { additionalProperty: key1 },
-                                                                    message: 'must NOT have additional properties',
-                                                                }
-                                                                if (vErrors === null) {
-                                                                    vErrors = [err10]
-                                                                } else {
-                                                                    vErrors.push(err10)
-                                                                }
-                                                                errors++
-                                                                break
-                                                            }
-                                                        } else {
-                                                            const err11 = {
-                                                                instancePath,
-                                                                schemaPath: '#/definitions/EmptyPropertyFilter/type',
-                                                                keyword: 'type',
-                                                                params: { type: 'object' },
-                                                                message: 'must be object',
-                                                            }
-                                                            if (vErrors === null) {
-                                                                vErrors = [err11]
-                                                            } else {
-                                                                vErrors.push(err11)
-                                                            }
-                                                            errors++
-                                                        }
+                                                    if (
+                                                        !validate45(data, {
+                                                            instancePath,
+                                                            parentData,
+                                                            parentDataProperty,
+                                                            rootData,
+                                                        })
+                                                    ) {
+                                                        vErrors =
+                                                            vErrors === null
+                                                                ? validate45.errors
+                                                                : vErrors.concat(validate45.errors)
+                                                        errors = vErrors.length
                                                     }
                                                     var _valid0 = _errs26 === errors
                                                     valid0 = valid0 || _valid0
                                                     if (!valid0) {
-                                                        const _errs30 = errors
-                                                        if (
-                                                            !validate45(data, {
-                                                                instancePath,
-                                                                parentData,
-                                                                parentDataProperty,
-                                                                rootData,
-                                                            })
-                                                        ) {
-                                                            vErrors =
-                                                                vErrors === null
-                                                                    ? validate45.errors
-                                                                    : vErrors.concat(validate45.errors)
-                                                            errors = vErrors.length
+                                                        const _errs27 = errors
+                                                        const _errs28 = errors
+                                                        if (errors === _errs28) {
+                                                            if (
+                                                                data &&
+                                                                typeof data == 'object' &&
+                                                                !Array.isArray(data)
+                                                            ) {
+                                                                for (const key1 in data) {
+                                                                    const err10 = {
+                                                                        instancePath,
+                                                                        schemaPath:
+                                                                            '#/definitions/EmptyPropertyFilter/additionalProperties',
+                                                                        keyword: 'additionalProperties',
+                                                                        params: { additionalProperty: key1 },
+                                                                        message: 'must NOT have additional properties',
+                                                                    }
+                                                                    if (vErrors === null) {
+                                                                        vErrors = [err10]
+                                                                    } else {
+                                                                        vErrors.push(err10)
+                                                                    }
+                                                                    errors++
+                                                                    break
+                                                                }
+                                                            } else {
+                                                                const err11 = {
+                                                                    instancePath,
+                                                                    schemaPath:
+                                                                        '#/definitions/EmptyPropertyFilter/type',
+                                                                    keyword: 'type',
+                                                                    params: { type: 'object' },
+                                                                    message: 'must be object',
+                                                                }
+                                                                if (vErrors === null) {
+                                                                    vErrors = [err11]
+                                                                } else {
+                                                                    vErrors.push(err11)
+                                                                }
+                                                                errors++
+                                                            }
                                                         }
-                                                        var _valid0 = _errs30 === errors
+                                                        var _valid0 = _errs27 === errors
                                                         valid0 = valid0 || _valid0
                                                         if (!valid0) {
                                                             const _errs31 = errors
@@ -4548,6 +4787,27 @@ function validate11(data, { instancePath = '', parentData, parentDataProperty, r
                                                                         }
                                                                         var _valid0 = _errs34 === errors
                                                                         valid0 = valid0 || _valid0
+                                                                        if (!valid0) {
+                                                                            const _errs35 = errors
+                                                                            if (
+                                                                                !validate60(data, {
+                                                                                    instancePath,
+                                                                                    parentData,
+                                                                                    parentDataProperty,
+                                                                                    rootData,
+                                                                                })
+                                                                            ) {
+                                                                                vErrors =
+                                                                                    vErrors === null
+                                                                                        ? validate60.errors
+                                                                                        : vErrors.concat(
+                                                                                              validate60.errors
+                                                                                          )
+                                                                                errors = vErrors.length
+                                                                            }
+                                                                            var _valid0 = _errs35 === errors
+                                                                            valid0 = valid0 || _valid0
+                                                                        }
                                                                     }
                                                                 }
                                                             }
@@ -4594,16 +4854,16 @@ function validate11(data, { instancePath = '', parentData, parentDataProperty, r
     validate11.errors = vErrors
     return errors === 0
 }
-export const WebAnalyticsPropertyFilters = validate60
-const schema50 = { items: { $ref: '#/definitions/WebAnalyticsPropertyFilter' }, type: 'array' }
-const schema51 = {
+export const WebAnalyticsPropertyFilters = validate63
+const schema52 = { items: { $ref: '#/definitions/WebAnalyticsPropertyFilter' }, type: 'array' }
+const schema53 = {
     anyOf: [
         { $ref: '#/definitions/EventPropertyFilter' },
         { $ref: '#/definitions/PersonPropertyFilter' },
         { $ref: '#/definitions/SessionPropertyFilter' },
     ],
 }
-function validate61(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate64(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     const _errs0 = errors
@@ -4625,8 +4885,8 @@ function validate61(data, { instancePath = '', parentData, parentDataProperty, r
         valid0 = valid0 || _valid0
         if (!valid0) {
             const _errs3 = errors
-            if (!validate25(data, { instancePath, parentData, parentDataProperty, rootData })) {
-                vErrors = vErrors === null ? validate25.errors : vErrors.concat(validate25.errors)
+            if (!validate28(data, { instancePath, parentData, parentDataProperty, rootData })) {
+                vErrors = vErrors === null ? validate28.errors : vErrors.concat(validate28.errors)
                 errors = vErrors.length
             }
             var _valid0 = _errs3 === errors
@@ -4647,7 +4907,7 @@ function validate61(data, { instancePath = '', parentData, parentDataProperty, r
             vErrors.push(err0)
         }
         errors++
-        validate61.errors = vErrors
+        validate64.errors = vErrors
         return false
     } else {
         errors = _errs0
@@ -4659,10 +4919,10 @@ function validate61(data, { instancePath = '', parentData, parentDataProperty, r
             }
         }
     }
-    validate61.errors = vErrors
+    validate64.errors = vErrors
     return errors === 0
 }
-function validate60(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate63(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -4672,14 +4932,14 @@ function validate60(data, { instancePath = '', parentData, parentDataProperty, r
             for (let i0 = 0; i0 < len0; i0++) {
                 const _errs1 = errors
                 if (
-                    !validate61(data[i0], {
+                    !validate64(data[i0], {
                         instancePath: instancePath + '/' + i0,
                         parentData: data,
                         parentDataProperty: i0,
                         rootData,
                     })
                 ) {
-                    vErrors = vErrors === null ? validate61.errors : vErrors.concat(validate61.errors)
+                    vErrors = vErrors === null ? validate64.errors : vErrors.concat(validate64.errors)
                     errors = vErrors.length
                 }
                 var valid0 = _errs1 === errors
@@ -4688,7 +4948,7 @@ function validate60(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate60.errors = [
+            validate63.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -4700,12 +4960,12 @@ function validate60(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate60.errors = vErrors
+    validate63.errors = vErrors
     return errors === 0
 }
-export const RevenueAnalyticsPropertyFilters = validate66
-const schema52 = { items: { $ref: '#/definitions/RevenueAnalyticsPropertyFilter' }, type: 'array' }
-function validate66(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+export const RevenueAnalyticsPropertyFilters = validate69
+const schema54 = { items: { $ref: '#/definitions/RevenueAnalyticsPropertyFilter' }, type: 'array' }
+function validate69(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -4715,14 +4975,14 @@ function validate66(data, { instancePath = '', parentData, parentDataProperty, r
             for (let i0 = 0; i0 < len0; i0++) {
                 const _errs1 = errors
                 if (
-                    !validate57(data[i0], {
+                    !validate60(data[i0], {
                         instancePath: instancePath + '/' + i0,
                         parentData: data,
                         parentDataProperty: i0,
                         rootData,
                     })
                 ) {
-                    vErrors = vErrors === null ? validate57.errors : vErrors.concat(validate57.errors)
+                    vErrors = vErrors === null ? validate60.errors : vErrors.concat(validate60.errors)
                     errors = vErrors.length
                 }
                 var valid0 = _errs1 === errors
@@ -4731,7 +4991,7 @@ function validate66(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate66.errors = [
+            validate69.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -4743,11 +5003,11 @@ function validate66(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate66.errors = vErrors
+    validate69.errors = vErrors
     return errors === 0
 }
-export const SessionPropertyFilter = validate68
-function validate68(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+export const SessionPropertyFilter = validate71
+function validate71(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -4758,7 +5018,7 @@ function validate68(data, { instancePath = '', parentData, parentDataProperty, r
                 (data.operator === undefined && (missing0 = 'operator')) ||
                 (data.type === undefined && (missing0 = 'type'))
             ) {
-                validate68.errors = [
+                validate71.errors = [
                     {
                         instancePath,
                         schemaPath: '#/required',
@@ -4780,7 +5040,7 @@ function validate68(data, { instancePath = '', parentData, parentDataProperty, r
                             key0 === 'value'
                         )
                     ) {
-                        validate68.errors = [
+                        validate71.errors = [
                             {
                                 instancePath,
                                 schemaPath: '#/additionalProperties',
@@ -4797,7 +5057,7 @@ function validate68(data, { instancePath = '', parentData, parentDataProperty, r
                     if (data.key !== undefined) {
                         const _errs2 = errors
                         if (typeof data.key !== 'string') {
-                            validate68.errors = [
+                            validate71.errors = [
                                 {
                                     instancePath: instancePath + '/key',
                                     schemaPath: '#/properties/key/type',
@@ -4816,7 +5076,7 @@ function validate68(data, { instancePath = '', parentData, parentDataProperty, r
                         if (data.label !== undefined) {
                             const _errs4 = errors
                             if (typeof data.label !== 'string') {
-                                validate68.errors = [
+                                validate71.errors = [
                                     {
                                         instancePath: instancePath + '/label',
                                         schemaPath: '#/properties/label/type',
@@ -4836,7 +5096,7 @@ function validate68(data, { instancePath = '', parentData, parentDataProperty, r
                                 let data2 = data.operator
                                 const _errs6 = errors
                                 if (typeof data2 !== 'string') {
-                                    validate68.errors = [
+                                    validate71.errors = [
                                         {
                                             instancePath: instancePath + '/operator',
                                             schemaPath: '#/definitions/PropertyOperator/type',
@@ -4874,7 +5134,7 @@ function validate68(data, { instancePath = '', parentData, parentDataProperty, r
                                         data2 === 'flag_evaluates_to'
                                     )
                                 ) {
-                                    validate68.errors = [
+                                    validate71.errors = [
                                         {
                                             instancePath: instancePath + '/operator',
                                             schemaPath: '#/definitions/PropertyOperator/enum',
@@ -4894,7 +5154,7 @@ function validate68(data, { instancePath = '', parentData, parentDataProperty, r
                                     let data3 = data.type
                                     const _errs9 = errors
                                     if (typeof data3 !== 'string') {
-                                        validate68.errors = [
+                                        validate71.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/type',
@@ -4906,7 +5166,7 @@ function validate68(data, { instancePath = '', parentData, parentDataProperty, r
                                         return false
                                     }
                                     if ('session' !== data3) {
-                                        validate68.errors = [
+                                        validate71.errors = [
                                             {
                                                 instancePath: instancePath + '/type',
                                                 schemaPath: '#/properties/type/const',
@@ -4947,7 +5207,7 @@ function validate68(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate68.errors = [
+            validate71.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -4959,11 +5219,11 @@ function validate68(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate68.errors = vErrors
+    validate71.errors = vErrors
     return errors === 0
 }
-export const CompareFilter = validate70
-const schema55 = {
+export const CompareFilter = validate73
+const schema57 = {
     additionalProperties: false,
     properties: {
         compare: {
@@ -4979,7 +5239,7 @@ const schema55 = {
     },
     type: 'object',
 }
-function validate70(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
+function validate73(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
     let vErrors = null
     let errors = 0
     if (errors === 0) {
@@ -4987,7 +5247,7 @@ function validate70(data, { instancePath = '', parentData, parentDataProperty, r
             const _errs1 = errors
             for (const key0 in data) {
                 if (!(key0 === 'compare' || key0 === 'compare_to')) {
-                    validate70.errors = [
+                    validate73.errors = [
                         {
                             instancePath,
                             schemaPath: '#/additionalProperties',
@@ -5004,7 +5264,7 @@ function validate70(data, { instancePath = '', parentData, parentDataProperty, r
                 if (data.compare !== undefined) {
                     const _errs2 = errors
                     if (typeof data.compare !== 'boolean') {
-                        validate70.errors = [
+                        validate73.errors = [
                             {
                                 instancePath: instancePath + '/compare',
                                 schemaPath: '#/properties/compare/type',
@@ -5023,7 +5283,7 @@ function validate70(data, { instancePath = '', parentData, parentDataProperty, r
                     if (data.compare_to !== undefined) {
                         const _errs4 = errors
                         if (typeof data.compare_to !== 'string') {
-                            validate70.errors = [
+                            validate73.errors = [
                                 {
                                     instancePath: instancePath + '/compare_to',
                                     schemaPath: '#/properties/compare_to/type',
@@ -5041,7 +5301,7 @@ function validate70(data, { instancePath = '', parentData, parentDataProperty, r
                 }
             }
         } else {
-            validate70.errors = [
+            validate73.errors = [
                 {
                     instancePath,
                     schemaPath: '#/type',
@@ -5053,6 +5313,6 @@ function validate70(data, { instancePath = '', parentData, parentDataProperty, r
             return false
         }
     }
-    validate70.errors = vErrors
+    validate73.errors = vErrors
     return errors === 0
 }

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
@@ -219,11 +219,11 @@ export function BatchExportConfiguration(): JSX.Element {
                                                     taxonomicGroupTypes={
                                                         selectedModel === 'events'
                                                             ? [
-                                                                TaxonomicFilterGroupType.EventProperties,
-                                                                TaxonomicFilterGroupType.EventFeatureFlags,
-                                                                TaxonomicFilterGroupType.PersonProperties,
-                                                                TaxonomicFilterGroupType.HogQLExpression,
-                                                            ]
+                                                                  TaxonomicFilterGroupType.EventProperties,
+                                                                  TaxonomicFilterGroupType.EventFeatureFlags,
+                                                                  TaxonomicFilterGroupType.PersonProperties,
+                                                                  TaxonomicFilterGroupType.HogQLExpression,
+                                                              ]
                                                             : []
                                                     }
                                                     onChange={(filters: AnyPropertyFilter[]) => {

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
@@ -222,7 +222,6 @@ export function BatchExportConfiguration(): JSX.Element {
                                                                 TaxonomicFilterGroupType.EventProperties,
                                                                 TaxonomicFilterGroupType.EventFeatureFlags,
                                                                 TaxonomicFilterGroupType.PersonProperties,
-                                                                TaxonomicFilterGroupType.Cohorts,
                                                                 TaxonomicFilterGroupType.HogQLExpression,
                                                             ]
                                                             : []

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
@@ -218,8 +218,14 @@ export function BatchExportConfiguration(): JSX.Element {
                                                     }
                                                     taxonomicGroupTypes={
                                                         selectedModel === 'events'
-                                                            ? [TaxonomicFilterGroupType.EventProperties]
-                                                            : [TaxonomicFilterGroupType.PersonProperties]
+                                                            ? [
+                                                                TaxonomicFilterGroupType.EventProperties,
+                                                                TaxonomicFilterGroupType.EventFeatureFlags,
+                                                                TaxonomicFilterGroupType.PersonProperties,
+                                                                TaxonomicFilterGroupType.Cohorts,
+                                                                TaxonomicFilterGroupType.HogQLExpression,
+                                                            ]
+                                                            : []
                                                     }
                                                     onChange={(filters: AnyPropertyFilter[]) => {
                                                         setConfigurationValue('filters', filters)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -835,6 +835,7 @@ export enum PropertyFilterType {
     Meta = 'meta',
     /** Event properties */
     Event = 'event',
+    PersonOnEvent = 'person_on_event',
     InternalEvent = 'internal_event',
     EventMetadata = 'event_metadata',
     /** Person properties */
@@ -885,6 +886,11 @@ export interface RevenueAnalyticsPropertyFilter extends BasePropertyFilter {
 /** Sync with plugin-server/src/types.ts */
 export interface PersonPropertyFilter extends BasePropertyFilter {
     type: PropertyFilterType.Person
+    operator: PropertyOperator
+}
+
+export interface PersonOnEventPropertyFilter extends BasePropertyFilter {
+    type: PropertyFilterType.PersonOnEvent
     operator: PropertyOperator
 }
 
@@ -967,6 +973,7 @@ export interface EmptyPropertyFilter {
 export type AnyPropertyFilter =
     | EventPropertyFilter
     | PersonPropertyFilter
+    | PersonOnEventPropertyFilter
     | ElementPropertyFilter
     | EventMetadataPropertyFilter
     | SessionPropertyFilter

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1179,6 +1179,10 @@ export interface PersonPropertyFilter extends PropertyFilterWithOperator {
     type: 'person'
 }
 
+export interface PersonOnEventPropertyFilter extends PropertyFilterWithOperator {
+    type: 'person_on_event'
+}
+
 export interface DataWarehousePropertyFilter extends PropertyFilterWithOperator {
     type: 'data_warehouse'
 }
@@ -1205,6 +1209,7 @@ export interface CohortPropertyFilter extends PropertyFilterBase {
 export type PropertyFilter =
     | EventPropertyFilter
     | PersonPropertyFilter
+    | PersonOnEventPropertyFilter
     | ElementPropertyFilter
     | CohortPropertyFilter
     | DataWarehousePropertyFilter

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -23,6 +23,7 @@ from posthog.schema import (
     HogQLPropertyFilter,
     LogEntryPropertyFilter,
     LogPropertyFilter,
+    PersonOnEventPropertyFilter,
     PersonPropertyFilter,
     PropertyGroupFilter,
     PropertyGroupFilterValue,
@@ -316,6 +317,7 @@ def property_to_expr(
         | ast.Expr
         | EventPropertyFilter
         | PersonPropertyFilter
+        | PersonOnEventPropertyFilter
         | ElementPropertyFilter
         | SessionPropertyFilter
         | EventMetadataPropertyFilter
@@ -442,6 +444,7 @@ def property_to_expr(
         or property.type == "event_metadata"
         or property.type == "feature"
         or property.type == "person"
+        or property.type == "person_on_event"
         or property.type == "group"
         or property.type == "behavioral"
         or property.type == "data_warehouse"
@@ -466,6 +469,8 @@ def property_to_expr(
 
         if property.type == "person" and scope != "person":
             chain = ["person", "properties"]
+        elif property.type == "person_on_event":
+            chain = ["events", "poe", "properties"]
         elif property.type == "event" and scope == "replay_entity":
             chain = ["events", "properties"]
         elif property.type == "session" and scope == "replay_entity":

--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -89,6 +89,7 @@ VALIDATE_PROP_TYPES = {
     "event": ["key", "value"],
     "event_metadata": ["key", "value"],
     "person": ["key", "value"],
+    "person_on_event": ["key", "value"],
     "data_warehouse": ["key", "value"],
     "data_warehouse_person_property": ["key", "value"],
     "error_tracking_issue": ["key", "value"],

--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -25,6 +25,7 @@ PropertyType = Literal[
     "event_metadata",
     "feature",
     "person",
+    "person_on_event",
     "cohort",
     "element",
     "static-cohort",

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4752,10 +4752,10 @@ class PersonOnEventPropertyFilter(BaseModel):
         extra="forbid",
     )
     key: str
-    label: Optional[str] = None
+    label: str | None = None
     operator: PropertyOperator
     type: Literal["person_on_event"] = Field(default="person_on_event", description="Person properties on the event")
-    value: Optional[Union[list[Union[str, float, bool]], Union[str, float, bool]]] = None
+    value: list[str | float | bool] | str | float | bool | None = None
 
 
 class PlanningStep(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5,18 +5,17 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel
 
 
 class SchemaRoot(RootModel[Any]):
     root: Any
 
 
-class AIEventType(str, Enum):
+class AIEventType(StrEnum):
     FIELD_AI_GENERATION = "$ai_generation"
     FIELD_AI_EMBEDDING = "$ai_embedding"
     FIELD_AI_SPAN = "$ai_span"
@@ -34,13 +33,13 @@ class MathGroupTypeIndex(float, Enum):
     NUMBER_4 = 4
 
 
-class AgentMode(str, Enum):
+class AgentMode(StrEnum):
     PRODUCT_ANALYTICS = "product_analytics"
     SQL = "sql"
     SESSION_REPLAY = "session_replay"
 
 
-class AggregationAxisFormat(str, Enum):
+class AggregationAxisFormat(StrEnum):
     NUMERIC = "numeric"
     DURATION = "duration"
     DURATION_MS = "duration_ms"
@@ -49,27 +48,27 @@ class AggregationAxisFormat(str, Enum):
     CURRENCY = "currency"
 
 
-class AlertCalculationInterval(str, Enum):
+class AlertCalculationInterval(StrEnum):
     HOURLY = "hourly"
     DAILY = "daily"
     WEEKLY = "weekly"
     MONTHLY = "monthly"
 
 
-class AlertConditionType(str, Enum):
+class AlertConditionType(StrEnum):
     ABSOLUTE_VALUE = "absolute_value"
     RELATIVE_INCREASE = "relative_increase"
     RELATIVE_DECREASE = "relative_decrease"
 
 
-class AlertState(str, Enum):
+class AlertState(StrEnum):
     FIRING = "Firing"
     NOT_FIRING = "Not firing"
     ERRORED = "Errored"
     SNOOZED = "Snoozed"
 
 
-class AssistantArrayPropertyFilterOperator(str, Enum):
+class AssistantArrayPropertyFilterOperator(StrEnum):
     EXACT = "exact"
     IS_NOT = "is_not"
 
@@ -89,7 +88,7 @@ class AssistantDateRange(BaseModel):
     date_to: str | None = Field(default=None, description="ISO8601 date string.")
 
 
-class AssistantDateTimePropertyFilterOperator(str, Enum):
+class AssistantDateTimePropertyFilterOperator(StrEnum):
     IS_DATE_EXACT = "is_date_exact"
     IS_DATE_BEFORE = "is_date_before"
     IS_DATE_AFTER = "is_date_after"
@@ -109,7 +108,7 @@ class AssistantDurationRange(BaseModel):
     )
 
 
-class AssistantEventMultipleBreakdownFilterType(str, Enum):
+class AssistantEventMultipleBreakdownFilterType(StrEnum):
     COHORT = "cohort"
     PERSON = "person"
     EVENT = "event"
@@ -119,7 +118,7 @@ class AssistantEventMultipleBreakdownFilterType(str, Enum):
     REVENUE_ANALYTICS = "revenue_analytics"
 
 
-class AssistantEventType(str, Enum):
+class AssistantEventType(StrEnum):
     STATUS = "status"
     MESSAGE = "message"
     CONVERSATION = "conversation"
@@ -138,7 +137,7 @@ class AssistantFormOption(BaseModel):
     variant: str | None = Field(default=None, description="'primary', 'secondary', or 'tertiary' - default 'secondary'")
 
 
-class AssistantFunnelsBreakdownType(str, Enum):
+class AssistantFunnelsBreakdownType(StrEnum):
     PERSON = "person"
     EVENT = "event"
     GROUP = "group"
@@ -150,12 +149,12 @@ class FunnelAggregateByHogQL(Enum):
     NONE_TYPE_NONE = None
 
 
-class AssistantFunnelsMath(str, Enum):
+class AssistantFunnelsMath(StrEnum):
     FIRST_TIME_FOR_USER = "first_time_for_user"
     FIRST_TIME_FOR_USER_WITH_FILTERS = "first_time_for_user_with_filters"
 
 
-class AssistantGenerationStatusType(str, Enum):
+class AssistantGenerationStatusType(StrEnum):
     ACK = "ack"
     GENERATION_ERROR = "generation_error"
 
@@ -168,7 +167,7 @@ class AssistantGenericMultipleBreakdownFilter(BaseModel):
     type: AssistantEventMultipleBreakdownFilterType
 
 
-class AssistantGenericPropertyFilterType(str, Enum):
+class AssistantGenericPropertyFilterType(StrEnum):
     EVENT = "event"
     PERSON = "person"
     SESSION = "session"
@@ -186,7 +185,7 @@ class AssistantHogQLQuery(BaseModel):
     )
 
 
-class AssistantMessageType(str, Enum):
+class AssistantMessageType(StrEnum):
     HUMAN = "human"
     TOOL = "tool"
     CONTEXT = "context"
@@ -200,7 +199,7 @@ class AssistantMessageType(str, Enum):
     AI_TASK_EXECUTION = "ai/task_execution"
 
 
-class AssistantNavigateUrl(str, Enum):
+class AssistantNavigateUrl(StrEnum):
     ACTIONS = "actions"
     ACTIVITY = "activity"
     ALERTS = "alerts"
@@ -238,29 +237,29 @@ class AssistantNavigateUrl(str, Enum):
     PERSONS = "persons"
 
 
-class AssistantNumericValuePropertyFilterOperator(str, Enum):
+class AssistantNumericValuePropertyFilterOperator(StrEnum):
     EXACT = "exact"
     GT = "gt"
     LT = "lt"
 
 
-class MeanRetentionCalculation(str, Enum):
+class MeanRetentionCalculation(StrEnum):
     SIMPLE = "simple"
     WEIGHTED = "weighted"
     NONE = "none"
 
 
-class RetentionReference(str, Enum):
+class RetentionReference(StrEnum):
     TOTAL = "total"
     PREVIOUS = "previous"
 
 
-class AssistantSetPropertyFilterOperator(str, Enum):
+class AssistantSetPropertyFilterOperator(StrEnum):
     IS_SET = "is_set"
     IS_NOT_SET = "is_not_set"
 
 
-class AssistantStringOrBooleanValuePropertyFilterOperator(str, Enum):
+class AssistantStringOrBooleanValuePropertyFilterOperator(StrEnum):
     EXACT = "exact"
     IS_NOT = "is_not"
     ICONTAINS = "icontains"
@@ -269,7 +268,7 @@ class AssistantStringOrBooleanValuePropertyFilterOperator(str, Enum):
     NOT_REGEX = "not_regex"
 
 
-class AssistantTool(str, Enum):
+class AssistantTool(StrEnum):
     SEARCH_SESSION_RECORDINGS = "search_session_recordings"
     GENERATE_HOGQL_QUERY = "generate_hogql_query"
     FIX_HOGQL_QUERY = "fix_hogql_query"
@@ -336,7 +335,7 @@ class AssistantTrendsDisplayType(RootModel[str | Any]):
     root: str | Any
 
 
-class Display(str, Enum):
+class Display(StrEnum):
     ACTIONS_LINE_GRAPH = "ActionsLineGraph"
     ACTIONS_BAR = "ActionsBar"
     ACTIONS_UNSTACKED_BAR = "ActionsUnstackedBar"
@@ -350,7 +349,7 @@ class Display(str, Enum):
     CALENDAR_HEATMAP = "CalendarHeatmap"
 
 
-class YAxisScaleType(str, Enum):
+class YAxisScaleType(StrEnum):
     LOG10 = "log10"
     LINEAR = "linear"
 
@@ -444,12 +443,12 @@ class AssistantUpdateEvent(BaseModel):
     tool_call_id: str
 
 
-class AttributionMode(str, Enum):
+class AttributionMode(StrEnum):
     FIRST_TOUCH = "first_touch"
     LAST_TOUCH = "last_touch"
 
 
-class AutocompleteCompletionItemKind(str, Enum):
+class AutocompleteCompletionItemKind(StrEnum):
     METHOD = "Method"
     FUNCTION = "Function"
     CONSTRUCTOR = "Constructor"
@@ -488,7 +487,7 @@ class BaseAssistantMessage(BaseModel):
     parent_tool_call_id: str | None = None
 
 
-class BaseMathType(str, Enum):
+class BaseMathType(StrEnum):
     TOTAL = "total"
     DAU = "dau"
     WEEKLY_ACTIVE = "weekly_active"
@@ -498,26 +497,26 @@ class BaseMathType(str, Enum):
     FIRST_MATCHING_EVENT_FOR_USER = "first_matching_event_for_user"
 
 
-class BillingSpendResponseBreakdownType(str, Enum):
+class BillingSpendResponseBreakdownType(StrEnum):
     TYPE = "type"
     TEAM = "team"
     MULTIPLE = "multiple"
 
 
-class BillingUsageResponseBreakdownType(str, Enum):
+class BillingUsageResponseBreakdownType(StrEnum):
     TYPE = "type"
     TEAM = "team"
     MULTIPLE = "multiple"
 
 
-class BreakdownAttributionType(str, Enum):
+class BreakdownAttributionType(StrEnum):
     FIRST_TOUCH = "first_touch"
     LAST_TOUCH = "last_touch"
     ALL_EVENTS = "all_events"
     STEP = "step"
 
 
-class BreakdownType(str, Enum):
+class BreakdownType(StrEnum):
     COHORT = "cohort"
     PERSON = "person"
     EVENT = "event"
@@ -569,12 +568,12 @@ class CalendarHeatmapFilter(BaseModel):
     dummy: str | None = None
 
 
-class CalendarHeatmapMathType(str, Enum):
+class CalendarHeatmapMathType(StrEnum):
     TOTAL = "total"
     DAU = "dau"
 
 
-class MatchField(str, Enum):
+class MatchField(StrEnum):
     CAMPAIGN_NAME = "campaign_name"
     CAMPAIGN_ID = "campaign_id"
 
@@ -586,13 +585,13 @@ class CampaignFieldPreference(BaseModel):
     match_field: MatchField
 
 
-class ChartDisplayCategory(str, Enum):
+class ChartDisplayCategory(StrEnum):
     TIME_SERIES = "TimeSeries"
     CUMULATIVE_TIME_SERIES = "CumulativeTimeSeries"
     TOTAL_VALUE = "TotalValue"
 
 
-class ChartDisplayType(str, Enum):
+class ChartDisplayType(StrEnum):
     ACTIONS_LINE_GRAPH = "ActionsLineGraph"
     ACTIONS_BAR = "ActionsBar"
     ACTIONS_UNSTACKED_BAR = "ActionsUnstackedBar"
@@ -607,13 +606,13 @@ class ChartDisplayType(str, Enum):
     CALENDAR_HEATMAP = "CalendarHeatmap"
 
 
-class DisplayType(str, Enum):
+class DisplayType(StrEnum):
     AUTO = "auto"
     LINE = "line"
     BAR = "bar"
 
 
-class YAxisPosition(str, Enum):
+class YAxisPosition(StrEnum):
     LEFT = "left"
     RIGHT = "right"
 
@@ -629,7 +628,7 @@ class ChartSettingsDisplay(BaseModel):
     yAxisPosition: YAxisPosition | None = None
 
 
-class Style(str, Enum):
+class Style(StrEnum):
     NONE = "none"
     NUMBER = "number"
     PERCENT = "percent"
@@ -662,7 +661,7 @@ class CompareFilter(BaseModel):
     )
 
 
-class ColorMode(str, Enum):
+class ColorMode(StrEnum):
     LIGHT = "light"
     DARK = "dark"
 
@@ -690,7 +689,7 @@ class ContextMessage(BaseModel):
     type: Literal["context"] = "context"
 
 
-class CountPerActorMathType(str, Enum):
+class CountPerActorMathType(StrEnum):
     AVG_COUNT_PER_ACTOR = "avg_count_per_actor"
     MIN_COUNT_PER_ACTOR = "min_count_per_actor"
     MAX_COUNT_PER_ACTOR = "max_count_per_actor"
@@ -701,7 +700,7 @@ class CountPerActorMathType(str, Enum):
     P99_COUNT_PER_ACTOR = "p99_count_per_actor"
 
 
-class CurrencyCode(str, Enum):
+class CurrencyCode(StrEnum):
     AED = "AED"
     AFN = "AFN"
     ALL = "ALL"
@@ -856,7 +855,7 @@ class CurrencyCode(str, Enum):
     ZMW = "ZMW"
 
 
-class CustomChannelField(str, Enum):
+class CustomChannelField(StrEnum):
     UTM_SOURCE = "utm_source"
     UTM_MEDIUM = "utm_medium"
     UTM_CAMPAIGN = "utm_campaign"
@@ -866,7 +865,7 @@ class CustomChannelField(str, Enum):
     HOSTNAME = "hostname"
 
 
-class CustomChannelOperator(str, Enum):
+class CustomChannelOperator(StrEnum):
     EXACT = "exact"
     IS_NOT = "is_not"
     IS_SET = "is_set"
@@ -884,7 +883,7 @@ class CustomEventConversionGoal(BaseModel):
     customEventName: str
 
 
-class DataColorToken(str, Enum):
+class DataColorToken(StrEnum):
     PRESET_1 = "preset-1"
     PRESET_2 = "preset-2"
     PRESET_3 = "preset-3"
@@ -902,7 +901,7 @@ class DataColorToken(str, Enum):
     PRESET_15 = "preset-15"
 
 
-class DataTableNodeViewPropsContextType(str, Enum):
+class DataTableNodeViewPropsContextType(StrEnum):
     EVENT_DEFINITION = "event_definition"
     TEAM_COLUMNS = "team_columns"
 
@@ -921,7 +920,7 @@ class DataWarehouseManagedViewsetKind(RootModel[Literal["revenue_analytics"]]):
     root: Literal["revenue_analytics"] = "revenue_analytics"
 
 
-class DataWarehouseSyncInterval(str, Enum):
+class DataWarehouseSyncInterval(StrEnum):
     FIELD_5MIN = "5min"
     FIELD_30MIN = "30min"
     FIELD_1HOUR = "1hour"
@@ -940,7 +939,7 @@ class DataWarehouseViewLinkConfiguration(BaseModel):
     experiments_timestamp_key: str | None = None
 
 
-class DatabaseSchemaManagedViewTableKind(str, Enum):
+class DatabaseSchemaManagedViewTableKind(StrEnum):
     REVENUE_ANALYTICS_CHARGE = "revenue_analytics_charge"
     REVENUE_ANALYTICS_CUSTOMER = "revenue_analytics_customer"
     REVENUE_ANALYTICS_PRODUCT = "revenue_analytics_product"
@@ -971,7 +970,7 @@ class DatabaseSchemaSource(BaseModel):
     status: str
 
 
-class DatabaseSchemaTableType(str, Enum):
+class DatabaseSchemaTableType(StrEnum):
     POSTHOG = "posthog"
     SYSTEM = "system"
     DATA_WAREHOUSE = "data_warehouse"
@@ -982,7 +981,7 @@ class DatabaseSchemaTableType(str, Enum):
     ENDPOINT = "endpoint"
 
 
-class DatabaseSerializedFieldType(str, Enum):
+class DatabaseSerializedFieldType(StrEnum):
     INTEGER = "integer"
     FLOAT = "float"
     DECIMAL = "decimal"
@@ -1016,16 +1015,16 @@ class DateRange(BaseModel):
     )
 
 
-class DatetimeDay(RootModel[datetime]):
-    root: datetime
+class DatetimeDay(RootModel[AwareDatetime]):
+    root: AwareDatetime
 
 
-class DeepResearchType(str, Enum):
+class DeepResearchType(StrEnum):
     PLANNING = "planning"
     REPORT = "report"
 
 
-class DefaultChannelTypes(str, Enum):
+class DefaultChannelTypes(StrEnum):
     CROSS_NETWORK = "Cross Network"
     PAID_SEARCH = "Paid Search"
     PAID_SOCIAL = "Paid Social"
@@ -1046,29 +1045,29 @@ class DefaultChannelTypes(str, Enum):
     UNKNOWN = "Unknown"
 
 
-class DistanceFunc(str, Enum):
+class DistanceFunc(StrEnum):
     L1_DISTANCE = "L1Distance"
     L2_DISTANCE = "L2Distance"
     COSINE_DISTANCE = "cosineDistance"
 
 
-class OrderBy(str, Enum):
+class OrderBy(StrEnum):
     DISTANCE = "distance"
     TIMESTAMP = "timestamp"
 
 
-class OrderDirection(str, Enum):
+class OrderDirection(StrEnum):
     ASC = "asc"
     DESC = "desc"
 
 
-class DurationType(str, Enum):
+class DurationType(StrEnum):
     DURATION = "duration"
     ACTIVE_SECONDS = "active_seconds"
     INACTIVE_SECONDS = "inactive_seconds"
 
 
-class Key(str, Enum):
+class Key(StrEnum):
     TAG_NAME = "tag_name"
     TEXT = "text"
     HREF = "href"
@@ -1097,10 +1096,10 @@ class EmbeddedDocument(BaseModel):
     document_id: str
     document_type: str
     product: str
-    timestamp: datetime
+    timestamp: AwareDatetime
 
 
-class EmbeddingModelName(str, Enum):
+class EmbeddingModelName(StrEnum):
     TEXT_EMBEDDING_3_SMALL_1536 = "text-embedding-3-small-1536"
     TEXT_EMBEDDING_3_LARGE_3072 = "text-embedding-3-large-3072"
 
@@ -1114,7 +1113,7 @@ class EmbeddingRecord(BaseModel):
     model_name: EmbeddingModelName
     product: str
     rendering: str
-    timestamp: datetime
+    timestamp: AwareDatetime
 
 
 class EmptyPropertyFilter(BaseModel):
@@ -1131,7 +1130,7 @@ class EndpointLastExecutionTimesRequest(BaseModel):
     names: list[str]
 
 
-class EntityType(str, Enum):
+class EntityType(StrEnum):
     ACTIONS = "actions"
     EVENTS = "events"
     DATA_WAREHOUSE = "data_warehouse"
@@ -1148,7 +1147,7 @@ class Population(BaseModel):
     success_only: float
 
 
-class Status(str, Enum):
+class Status(StrEnum):
     ARCHIVED = "archived"
     ACTIVE = "active"
     RESOLVED = "resolved"
@@ -1203,7 +1202,7 @@ class ErrorTrackingIssueAggregations(BaseModel):
     volume_buckets: list[VolumeBucket]
 
 
-class ErrorTrackingIssueAssigneeType(str, Enum):
+class ErrorTrackingIssueAssigneeType(StrEnum):
     USER = "user"
     ROLE = "role"
 
@@ -1216,7 +1215,7 @@ class ErrorTrackingIssueCohort(BaseModel):
     name: str
 
 
-class OrderBy1(str, Enum):
+class OrderBy1(StrEnum):
     LAST_SEEN = "last_seen"
     FIRST_SEEN = "first_seen"
     OCCURRENCES = "occurrences"
@@ -1225,12 +1224,12 @@ class OrderBy1(str, Enum):
     REVENUE = "revenue"
 
 
-class OrderDirection1(str, Enum):
+class OrderDirection1(StrEnum):
     ASC = "ASC"
     DESC = "DESC"
 
 
-class Status2(str, Enum):
+class Status2(StrEnum):
     ARCHIVED = "archived"
     ACTIVE = "active"
     RESOLVED = "resolved"
@@ -1246,7 +1245,7 @@ class ErrorTrackingIssueImpactToolOutput(BaseModel):
     events: list[str]
 
 
-class RevenueEntity(str, Enum):
+class RevenueEntity(StrEnum):
     PERSON = "person"
     GROUP_0 = "group_0"
     GROUP_1 = "group_1"
@@ -1255,12 +1254,12 @@ class RevenueEntity(str, Enum):
     GROUP_4 = "group_4"
 
 
-class RevenuePeriod(str, Enum):
+class RevenuePeriod(StrEnum):
     ALL_TIME = "all_time"
     LAST_30_DAYS = "last_30_days"
 
 
-class Status4(str, Enum):
+class Status4(StrEnum):
     ARCHIVED = "archived"
     ACTIVE = "active"
     RESOLVED = "resolved"
@@ -1277,7 +1276,7 @@ class EventDefinition(BaseModel):
     properties: dict[str, Any]
 
 
-class CorrelationType(str, Enum):
+class CorrelationType(StrEnum):
     SUCCESS = "success"
     FAILURE = "failure"
 
@@ -1326,7 +1325,7 @@ class EventsQueryPersonColumn(BaseModel):
     uuid: str
 
 
-class MultipleVariantHandling(str, Enum):
+class MultipleVariantHandling(StrEnum):
     EXCLUDE = "exclude"
     FIRST_SEEN = "first_seen"
 
@@ -1360,12 +1359,12 @@ class ExperimentMaxFrequentistContext(BaseModel):
     significant: bool
 
 
-class ExperimentMetricGoal(str, Enum):
+class ExperimentMetricGoal(StrEnum):
     INCREASE = "increase"
     DECREASE = "decrease"
 
 
-class ExperimentMetricMathType(str, Enum):
+class ExperimentMetricMathType(StrEnum):
     TOTAL = "total"
     SUM = "sum"
     UNIQUE_SESSION = "unique_session"
@@ -1386,26 +1385,26 @@ class ExperimentMetricOutlierHandling(BaseModel):
     upper_bound_percentile: float | None = None
 
 
-class Status5(str, Enum):
+class Status5(StrEnum):
     PENDING = "pending"
     COMPLETED = "completed"
     PARTIAL = "partial"
     FAILED = "failed"
 
 
-class ExperimentMetricType(str, Enum):
+class ExperimentMetricType(StrEnum):
     FUNNEL = "funnel"
     MEAN = "mean"
     RATIO = "ratio"
     RETENTION = "retention"
 
 
-class StartHandling(str, Enum):
+class StartHandling(StrEnum):
     FIRST_SEEN = "first_seen"
     LAST_SEEN = "last_seen"
 
 
-class ExperimentSignificanceCode(str, Enum):
+class ExperimentSignificanceCode(StrEnum):
     SIGNIFICANT = "significant"
     NOT_ENOUGH_EXPOSURE = "not_enough_exposure"
     LOW_WIN_PROBABILITY = "low_win_probability"
@@ -1413,12 +1412,12 @@ class ExperimentSignificanceCode(str, Enum):
     HIGH_P_VALUE = "high_p_value"
 
 
-class ExperimentStatsMethod(str, Enum):
+class ExperimentStatsMethod(StrEnum):
     BAYESIAN = "bayesian"
     FREQUENTIST = "frequentist"
 
 
-class ExperimentStatsValidationFailure(str, Enum):
+class ExperimentStatsValidationFailure(StrEnum):
     NOT_ENOUGH_EXPOSURES = "not-enough-exposures"
     BASELINE_MEAN_IS_ZERO = "baseline-mean-is-zero"
     NOT_ENOUGH_METRIC_DATA = "not-enough-metric-data"
@@ -1443,7 +1442,7 @@ class ExperimentVariantTrendsBaseStats(BaseModel):
     key: str
 
 
-class ExternalDataSourceType(str, Enum):
+class ExternalDataSourceType(StrEnum):
     CUSTOMER_IO = "CustomerIO"
     GITHUB = "Github"
     STRIPE = "Stripe"
@@ -1477,12 +1476,12 @@ class ExternalDataSourceType(str, Enum):
     SHOPIFY = "Shopify"
 
 
-class ExternalQueryErrorCode(str, Enum):
+class ExternalQueryErrorCode(StrEnum):
     PLATFORM_ACCESS_REQUIRED = "platform_access_required"
     QUERY_EXECUTION_FAILED = "query_execution_failed"
 
 
-class ExternalQueryStatus(str, Enum):
+class ExternalQueryStatus(StrEnum):
     SUCCESS = "success"
     ERROR = "error"
 
@@ -1497,7 +1496,7 @@ class FailureMessage(BaseModel):
     type: Literal["ai/failure"] = "ai/failure"
 
 
-class Tag(str, Enum):
+class Tag(StrEnum):
     ALPHA = "alpha"
     BETA = "beta"
 
@@ -1522,7 +1521,7 @@ class FileSystemEntry(BaseModel):
     visualOrder: float | None = Field(default=None, description="Order of object in tree")
 
 
-class FileSystemIconType(str, Enum):
+class FileSystemIconType(StrEnum):
     DEFAULT_ICON_TYPE = "default_icon_type"
     DASHBOARD = "dashboard"
     LLM_ANALYTICS = "llm_analytics"
@@ -1588,7 +1587,7 @@ class FileSystemViewLogEntry(BaseModel):
     viewed_at: str
 
 
-class FilterLogicalOperator(str, Enum):
+class FilterLogicalOperator(StrEnum):
     AND_ = "AND"
     OR_ = "OR"
 
@@ -1606,7 +1605,7 @@ class FlagPropertyFilter(BaseModel):
     value: bool | str = Field(..., description="The value can be true, false, or a variant name")
 
 
-class FunnelConversionWindowTimeUnit(str, Enum):
+class FunnelConversionWindowTimeUnit(StrEnum):
     SECOND = "second"
     MINUTE = "minute"
     HOUR = "hour"
@@ -1615,7 +1614,7 @@ class FunnelConversionWindowTimeUnit(str, Enum):
     MONTH = "month"
 
 
-class FunnelCorrelationResultsType(str, Enum):
+class FunnelCorrelationResultsType(StrEnum):
     EVENTS = "events"
     PROPERTIES = "properties"
     EVENT_WITH_PROPERTIES = "event_with_properties"
@@ -1636,24 +1635,24 @@ class FunnelExclusionLegacy(BaseModel):
     type: EntityType | None = None
 
 
-class FunnelLayout(str, Enum):
+class FunnelLayout(StrEnum):
     HORIZONTAL = "horizontal"
     VERTICAL = "vertical"
 
 
-class FunnelMathType(str, Enum):
+class FunnelMathType(StrEnum):
     TOTAL = "total"
     FIRST_TIME_FOR_USER = "first_time_for_user"
     FIRST_TIME_FOR_USER_WITH_FILTERS = "first_time_for_user_with_filters"
 
 
-class FunnelPathType(str, Enum):
+class FunnelPathType(StrEnum):
     FUNNEL_PATH_BEFORE_STEP = "funnel_path_before_step"
     FUNNEL_PATH_BETWEEN_STEPS = "funnel_path_between_steps"
     FUNNEL_PATH_AFTER_STEP = "funnel_path_after_step"
 
 
-class FunnelStepReference(str, Enum):
+class FunnelStepReference(StrEnum):
     TOTAL = "total"
     PREVIOUS = "previous"
 
@@ -1678,13 +1677,13 @@ class FunnelTrendsResults(RootModel[list[dict[str, Any]]]):
     root: list[dict[str, Any]]
 
 
-class FunnelVizType(str, Enum):
+class FunnelVizType(StrEnum):
     STEPS = "steps"
     TIME_TO_CONVERT = "time_to_convert"
     TRENDS = "trends"
 
 
-class Position(str, Enum):
+class Position(StrEnum):
     START = "start"
     END = "end"
 
@@ -1701,7 +1700,7 @@ class GoalLine(BaseModel):
     value: float
 
 
-class HedgehogColorOptions(str, Enum):
+class HedgehogColorOptions(StrEnum):
     GREEN = "green"
     RED = "red"
     BLUE = "blue"
@@ -1722,7 +1721,7 @@ class HogCompileResponse(BaseModel):
     locals: list
 
 
-class HogLanguage(str, Enum):
+class HogLanguage(StrEnum):
     HOG = "hog"
     HOG_JSON = "hogJson"
     HOG_QL = "hogQL"
@@ -1731,58 +1730,58 @@ class HogLanguage(str, Enum):
     LIQUID = "liquid"
 
 
-class BounceRatePageViewMode(str, Enum):
+class BounceRatePageViewMode(StrEnum):
     COUNT_PAGEVIEWS = "count_pageviews"
     UNIQ_URLS = "uniq_urls"
     UNIQ_PAGE_SCREEN_AUTOCAPTURES = "uniq_page_screen_autocaptures"
 
 
-class InCohortVia(str, Enum):
+class InCohortVia(StrEnum):
     AUTO = "auto"
     LEFTJOIN = "leftjoin"
     SUBQUERY = "subquery"
     LEFTJOIN_CONJOINED = "leftjoin_conjoined"
 
 
-class MaterializationMode(str, Enum):
+class MaterializationMode(StrEnum):
     AUTO = "auto"
     LEGACY_NULL_AS_STRING = "legacy_null_as_string"
     LEGACY_NULL_AS_NULL = "legacy_null_as_null"
     DISABLED = "disabled"
 
 
-class PersonsArgMaxVersion(str, Enum):
+class PersonsArgMaxVersion(StrEnum):
     AUTO = "auto"
     V1 = "v1"
     V2 = "v2"
 
 
-class PersonsJoinMode(str, Enum):
+class PersonsJoinMode(StrEnum):
     INNER = "inner"
     LEFT = "left"
 
 
-class PersonsOnEventsMode(str, Enum):
+class PersonsOnEventsMode(StrEnum):
     DISABLED = "disabled"
     PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS = "person_id_no_override_properties_on_events"
     PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS = "person_id_override_properties_on_events"
     PERSON_ID_OVERRIDE_PROPERTIES_JOINED = "person_id_override_properties_joined"
 
 
-class PropertyGroupsMode(str, Enum):
+class PropertyGroupsMode(StrEnum):
     ENABLED = "enabled"
     DISABLED = "disabled"
     OPTIMIZED = "optimized"
 
 
-class SessionTableVersion(str, Enum):
+class SessionTableVersion(StrEnum):
     AUTO = "auto"
     V1 = "v1"
     V2 = "v2"
     V3 = "v3"
 
 
-class SessionsV2JoinMode(str, Enum):
+class SessionsV2JoinMode(StrEnum):
     STRING = "string"
     UUID = "uuid"
 
@@ -1812,12 +1811,12 @@ class InfinityValue(float, Enum):
     NUMBER__999999 = -999999
 
 
-class Compare(str, Enum):
+class Compare(StrEnum):
     CURRENT = "current"
     PREVIOUS = "previous"
 
 
-class InsightFilterProperty(str, Enum):
+class InsightFilterProperty(StrEnum):
     TRENDS_FILTER = "trendsFilter"
     FUNNELS_FILTER = "funnelsFilter"
     RETENTION_FILTER = "retentionFilter"
@@ -1827,7 +1826,7 @@ class InsightFilterProperty(str, Enum):
     LIFECYCLE_FILTER = "lifecycleFilter"
 
 
-class InsightNodeKind(str, Enum):
+class InsightNodeKind(StrEnum):
     TRENDS_QUERY = "TrendsQuery"
     FUNNELS_QUERY = "FunnelsQuery"
     RETENTION_QUERY = "RetentionQuery"
@@ -1836,7 +1835,7 @@ class InsightNodeKind(str, Enum):
     LIFECYCLE_QUERY = "LifecycleQuery"
 
 
-class InsightThresholdType(str, Enum):
+class InsightThresholdType(StrEnum):
     ABSOLUTE = "absolute"
     PERCENTAGE = "percentage"
 
@@ -1858,7 +1857,7 @@ class IntegrationFilter(BaseModel):
     )
 
 
-class IntegrationKind(str, Enum):
+class IntegrationKind(StrEnum):
     SLACK = "slack"
     SALESFORCE = "salesforce"
     HUBSPOT = "hubspot"
@@ -1882,7 +1881,7 @@ class IntegrationKind(str, Enum):
     BING_ADS = "bing-ads"
 
 
-class IntervalType(str, Enum):
+class IntervalType(StrEnum):
     SECOND = "second"
     MINUTE = "minute"
     HOUR = "hour"
@@ -1911,14 +1910,14 @@ class LLMTracePerson(BaseModel):
     uuid: str
 
 
-class LifecycleToggle(str, Enum):
+class LifecycleToggle(StrEnum):
     NEW = "new"
     RESURRECTING = "resurrecting"
     RETURNING = "returning"
     DORMANT = "dormant"
 
 
-class LogSeverityLevel(str, Enum):
+class LogSeverityLevel(StrEnum):
     TRACE = "trace"
     DEBUG = "debug"
     INFO = "info"
@@ -1927,7 +1926,7 @@ class LogSeverityLevel(str, Enum):
     FATAL = "fatal"
 
 
-class OrderBy3(str, Enum):
+class OrderBy3(StrEnum):
     LATEST = "latest"
     EARLIEST = "earliest"
 
@@ -1940,7 +1939,7 @@ class MarkdownBlock(BaseModel):
     type: Literal["markdown"] = "markdown"
 
 
-class MarketingAnalyticsBaseColumns(str, Enum):
+class MarketingAnalyticsBaseColumns(StrEnum):
     ID = "ID"
     CAMPAIGN = "Campaign"
     SOURCE = "Source"
@@ -1952,7 +1951,7 @@ class MarketingAnalyticsBaseColumns(str, Enum):
     REPORTED_CONVERSION = "Reported Conversion"
 
 
-class MarketingAnalyticsColumnsSchemaNames(str, Enum):
+class MarketingAnalyticsColumnsSchemaNames(StrEnum):
     ID = "id"
     CAMPAIGN = "campaign"
     CLICKS = "clicks"
@@ -1964,17 +1963,17 @@ class MarketingAnalyticsColumnsSchemaNames(str, Enum):
     REPORTED_CONVERSION = "reported_conversion"
 
 
-class MarketingAnalyticsHelperForColumnNames(str, Enum):
+class MarketingAnalyticsHelperForColumnNames(StrEnum):
     GOAL = "Goal"
     COST_PER = "Cost per"
 
 
-class MarketingAnalyticsOrderByEnum(str, Enum):
+class MarketingAnalyticsOrderByEnum(StrEnum):
     ASC = "ASC"
     DESC = "DESC"
 
 
-class MarketingAnalyticsSchemaFieldTypes(str, Enum):
+class MarketingAnalyticsSchemaFieldTypes(StrEnum):
     STRING = "string"
     INTEGER = "integer"
     NUMBER = "number"
@@ -2050,7 +2049,7 @@ class UsageHistoryItem(BaseModel):
     label: str
 
 
-class MaxBillingContextBillingPeriodInterval(str, Enum):
+class MaxBillingContextBillingPeriodInterval(StrEnum):
     MONTH = "month"
     YEAR = "year"
 
@@ -2063,7 +2062,7 @@ class MaxBillingContextSettings(BaseModel):
     autocapture_on: bool
 
 
-class MaxBillingContextSubscriptionLevel(str, Enum):
+class MaxBillingContextSubscriptionLevel(StrEnum):
     FREE = "free"
     PAID = "paid"
     CUSTOM = "custom"
@@ -2137,7 +2136,7 @@ class MinimalHedgehogConfig(BaseModel):
     use_as_profile: bool
 
 
-class MultipleBreakdownType(str, Enum):
+class MultipleBreakdownType(StrEnum):
     COHORT = "cohort"
     PERSON = "person"
     EVENT = "event"
@@ -2148,7 +2147,7 @@ class MultipleBreakdownType(str, Enum):
     REVENUE_ANALYTICS = "revenue_analytics"
 
 
-class NodeKind(str, Enum):
+class NodeKind(StrEnum):
     EVENTS_NODE = "EventsNode"
     ACTIONS_NODE = "ActionsNode"
     DATA_WAREHOUSE_NODE = "DataWarehouseNode"
@@ -2242,7 +2241,7 @@ class PathCleaningFilter(BaseModel):
     regex: str | None = None
 
 
-class PathType(str, Enum):
+class PathType(StrEnum):
     FIELD_PAGEVIEW = "$pageview"
     FIELD_SCREEN = "$screen"
     CUSTOM_EVENT = "custom_event"
@@ -2305,7 +2304,7 @@ class PersonType(BaseModel):
     uuid: str | None = None
 
 
-class PlanningStepStatus(str, Enum):
+class PlanningStepStatus(StrEnum):
     PENDING = "pending"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
@@ -2331,7 +2330,7 @@ class PlaywrightWorkspaceSetupResult(BaseModel):
     user_id: str
 
 
-class ProductIntentContext(str, Enum):
+class ProductIntentContext(StrEnum):
     ONBOARDING_PRODUCT_SELECTED___PRIMARY = "onboarding product selected - primary"
     ONBOARDING_PRODUCT_SELECTED___SECONDARY = "onboarding product selected - secondary"
     QUICK_START_PRODUCT_SELECTED = "quick start product selected"
@@ -2384,7 +2383,7 @@ class ProductIntentContext(str, Enum):
     VERCEL_INTEGRATION = "vercel_integration"
 
 
-class ProductKey(str, Enum):
+class ProductKey(StrEnum):
     ACTIONS = "actions"
     ALERTS = "alerts"
     ANNOTATIONS = "annotations"
@@ -2425,10 +2424,9 @@ class ProductKey(str, Enum):
     WORKFLOWS = "workflows"
 
 
-class PropertyFilterType(str, Enum):
+class PropertyFilterType(StrEnum):
     META = "meta"
     EVENT = "event"
-    PERSON_ON_EVENT = "person_on_event"
     INTERNAL_EVENT = "internal_event"
     EVENT_METADATA = "event_metadata"
     PERSON = "person"
@@ -2448,7 +2446,7 @@ class PropertyFilterType(str, Enum):
     LOG = "log"
 
 
-class PropertyMathType(str, Enum):
+class PropertyMathType(StrEnum):
     AVG = "avg"
     SUM = "sum"
     MIN = "min"
@@ -2460,7 +2458,7 @@ class PropertyMathType(str, Enum):
     P99 = "p99"
 
 
-class PropertyOperator(str, Enum):
+class PropertyOperator(StrEnum):
     EXACT = "exact"
     IS_NOT = "is_not"
     ICONTAINS = "icontains"
@@ -2499,7 +2497,7 @@ class ProsemirrorJSONContent(BaseModel):
     type: str | None = None
 
 
-class QueryIndexUsage(str, Enum):
+class QueryIndexUsage(StrEnum):
     UNDECISIVE = "undecisive"
     NO = "no"
     PARTIAL = "partial"
@@ -2561,12 +2559,12 @@ class QueryTiming(BaseModel):
     t: float = Field(..., description="Time in seconds. Shortened to 't' to save on data.")
 
 
-class QuickFilterContext(str, Enum):
+class QuickFilterContext(StrEnum):
     ERROR_TRACKING_ISSUE_FILTERS = "error-tracking-issue-filters"
     LOGS_FILTERS = "logs-filters"
 
 
-class QuickFilterType(str, Enum):
+class QuickFilterType(StrEnum):
     MANUAL_OPTIONS = "manual-options"
     AUTO_DISCOVERY = "auto-discovery"
 
@@ -2593,7 +2591,7 @@ class RecordingDurationFilter(BaseModel):
     value: float
 
 
-class RecordingOrder(str, Enum):
+class RecordingOrder(StrEnum):
     DURATION = "duration"
     RECORDING_DURATION = "recording_duration"
     INACTIVE_SECONDS = "inactive_seconds"
@@ -2607,7 +2605,7 @@ class RecordingOrder(str, Enum):
     RECORDING_TTL = "recording_ttl"
 
 
-class RecordingOrderDirection(str, Enum):
+class RecordingOrderDirection(StrEnum):
     ASC = "ASC"
     DESC = "DESC"
 
@@ -2623,7 +2621,7 @@ class RecordingPropertyFilter(BaseModel):
     value: list[str | float | bool] | str | float | bool | None = None
 
 
-class RefreshType(str, Enum):
+class RefreshType(StrEnum):
     ASYNC_ = "async"
     ASYNC_EXCEPT_ON_CACHE_MISS = "async_except_on_cache_miss"
     BLOCKING = "blocking"
@@ -2637,8 +2635,8 @@ class ResolvedDateRangeResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    date_from: datetime
-    date_to: datetime
+    date_from: AwareDatetime
+    date_to: AwareDatetime
 
 
 class ResultCustomizationBase(BaseModel):
@@ -2649,7 +2647,7 @@ class ResultCustomizationBase(BaseModel):
     hidden: bool | None = None
 
 
-class ResultCustomizationBy(str, Enum):
+class ResultCustomizationBy(StrEnum):
     VALUE = "value"
     POSITION = "position"
 
@@ -2672,30 +2670,30 @@ class ResultCustomizationByValue(BaseModel):
     hidden: bool | None = None
 
 
-class RetentionDashboardDisplayType(str, Enum):
+class RetentionDashboardDisplayType(StrEnum):
     TABLE_ONLY = "table_only"
     GRAPH_ONLY = "graph_only"
     ALL = "all"
 
 
-class RetentionEntityKind(str, Enum):
+class RetentionEntityKind(StrEnum):
     ACTIONS_NODE = "ActionsNode"
     EVENTS_NODE = "EventsNode"
 
 
-class TimeWindowMode(str, Enum):
+class TimeWindowMode(StrEnum):
     STRICT_CALENDAR_DATES = "strict_calendar_dates"
     FIELD_24_HOUR_WINDOWS = "24_hour_windows"
 
 
-class RetentionPeriod(str, Enum):
+class RetentionPeriod(StrEnum):
     HOUR = "Hour"
     DAY = "Day"
     WEEK = "Week"
     MONTH = "Month"
 
 
-class RetentionType(str, Enum):
+class RetentionType(StrEnum):
     RETENTION_RECURRING = "retention_recurring"
     RETENTION_FIRST_TIME = "retention_first_time"
     RETENTION_FIRST_EVER_OCCURRENCE = "retention_first_ever_occurrence"
@@ -2709,7 +2707,7 @@ class RevenueAnalyticsBreakdown(BaseModel):
     type: Literal["revenue_analytics"] = "revenue_analytics"
 
 
-class MrrOrGross(str, Enum):
+class MrrOrGross(StrEnum):
     MRR = "mrr"
     GROSS = "gross"
 
@@ -2735,7 +2733,7 @@ class RevenueAnalyticsMRRQueryResultItem(BaseModel):
     total: Any
 
 
-class RevenueAnalyticsOverviewItemKey(str, Enum):
+class RevenueAnalyticsOverviewItemKey(StrEnum):
     REVENUE = "revenue"
     PAYING_CUSTOMER_COUNT = "paying_customer_count"
     AVG_REVENUE_PER_CUSTOMER = "avg_revenue_per_customer"
@@ -2752,7 +2750,7 @@ class RevenueAnalyticsPropertyFilter(BaseModel):
     value: list[str | float | bool] | str | float | bool | None = None
 
 
-class RevenueAnalyticsTopCustomersGroupBy(str, Enum):
+class RevenueAnalyticsTopCustomersGroupBy(StrEnum):
     MONTH = "month"
     ALL = "all"
 
@@ -2773,7 +2771,7 @@ class SamplingRate(BaseModel):
     numerator: float
 
 
-class SessionAttributionGroupBy(str, Enum):
+class SessionAttributionGroupBy(StrEnum):
     CHANNEL_TYPE = "ChannelType"
     MEDIUM = "Medium"
     SOURCE = "Source"
@@ -2815,13 +2813,13 @@ class SessionPropertyFilter(BaseModel):
     value: list[str | float | bool] | str | float | bool | None = None
 
 
-class SnapshotSource(str, Enum):
+class SnapshotSource(StrEnum):
     WEB = "web"
     MOBILE = "mobile"
     UNKNOWN = "unknown"
 
 
-class Storage(str, Enum):
+class Storage(StrEnum):
     OBJECT_STORAGE_LTS = "object_storage_lts"
     OBJECT_STORAGE = "object_storage"
 
@@ -2861,7 +2859,7 @@ class SimilarIssue(BaseModel):
     status: str
 
 
-class SimpleIntervalType(str, Enum):
+class SimpleIntervalType(StrEnum):
     DAY = "day"
     MONTH = "month"
 
@@ -2874,7 +2872,7 @@ class SourceFieldFileUploadJsonFormatConfig(BaseModel):
     keys: str | list[str]
 
 
-class SourceFieldInputConfigType(str, Enum):
+class SourceFieldInputConfigType(StrEnum):
     TEXT = "text"
     EMAIL = "email"
     SEARCH = "search"
@@ -2905,7 +2903,7 @@ class SourceFieldSSHTunnelConfig(BaseModel):
     type: Literal["ssh-tunnel"] = "ssh-tunnel"
 
 
-class SourceFieldSelectConfigConverter(str, Enum):
+class SourceFieldSelectConfigConverter(StrEnum):
     STR_TO_INT = "str_to_int"
     STR_TO_BOOL = "str_to_bool"
     STR_TO_OPTIONAL_INT = "str_to_optional_int"
@@ -2926,13 +2924,13 @@ class SourceMap(BaseModel):
     source: str | None = None
 
 
-class StepOrderValue(str, Enum):
+class StepOrderValue(StrEnum):
     STRICT = "strict"
     UNORDERED = "unordered"
     ORDERED = "ordered"
 
 
-class StickinessComputationMode(str, Enum):
+class StickinessComputationMode(StrEnum):
     NON_CUMULATIVE = "non_cumulative"
     CUMULATIVE = "cumulative"
 
@@ -2950,13 +2948,13 @@ class StickinessFilterLegacy(BaseModel):
     show_values_on_series: bool | None = None
 
 
-class StickinessOperator(str, Enum):
+class StickinessOperator(StrEnum):
     GTE = "gte"
     LTE = "lte"
     EXACT = "exact"
 
 
-class SubscriptionDropoffMode(str, Enum):
+class SubscriptionDropoffMode(StrEnum):
     LAST_EVENT = "last_event"
     AFTER_DROPOFF_PERIOD = "after_dropoff_period"
 
@@ -3000,7 +2998,7 @@ class Actions(BaseModel):
     values: list[Value]
 
 
-class SurveyMatchType(str, Enum):
+class SurveyMatchType(StrEnum):
     EXACT = "exact"
     IS_NOT = "is_not"
     ICONTAINS = "icontains"
@@ -3009,7 +3007,7 @@ class SurveyMatchType(str, Enum):
     NOT_REGEX = "not_regex"
 
 
-class SurveyPosition(str, Enum):
+class SurveyPosition(StrEnum):
     TOP_LEFT = "top_left"
     TOP_CENTER = "top_center"
     TOP_RIGHT = "top_right"
@@ -3022,14 +3020,14 @@ class SurveyPosition(str, Enum):
     NEXT_TO_TRIGGER = "next_to_trigger"
 
 
-class SurveyQuestionBranchingType(str, Enum):
+class SurveyQuestionBranchingType(StrEnum):
     NEXT_QUESTION = "next_question"
     END = "end"
     RESPONSE_BASED = "response_based"
     SPECIFIC_QUESTION = "specific_question"
 
 
-class SurveyQuestionDescriptionContentType(str, Enum):
+class SurveyQuestionDescriptionContentType(StrEnum):
     HTML = "html"
     TEXT = "text"
 
@@ -3043,12 +3041,12 @@ class Branching(BaseModel):
     type: SurveyQuestionBranchingType
 
 
-class Display1(str, Enum):
+class Display1(StrEnum):
     NUMBER = "number"
     EMOJI = "emoji"
 
 
-class SurveyQuestionType(str, Enum):
+class SurveyQuestionType(StrEnum):
     OPEN = "open"
     MULTIPLE_CHOICE = "multiple_choice"
     SINGLE_CHOICE = "single_choice"
@@ -3056,14 +3054,14 @@ class SurveyQuestionType(str, Enum):
     LINK = "link"
 
 
-class SurveyTabPosition(str, Enum):
+class SurveyTabPosition(StrEnum):
     TOP = "top"
     LEFT = "left"
     RIGHT = "right"
     BOTTOM = "bottom"
 
 
-class SurveyType(str, Enum):
+class SurveyType(StrEnum):
     POPOVER = "popover"
     WIDGET = "widget"
     FULL_SCREEN = "full_screen"
@@ -3071,20 +3069,20 @@ class SurveyType(str, Enum):
     EXTERNAL_SURVEY = "external_survey"
 
 
-class SurveyWidgetType(str, Enum):
+class SurveyWidgetType(StrEnum):
     BUTTON = "button"
     TAB = "tab"
     SELECTOR = "selector"
 
 
-class TaskExecutionStatus(str, Enum):
+class TaskExecutionStatus(StrEnum):
     PENDING = "pending"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
     FAILED = "failed"
 
 
-class TaxonomicFilterGroupType(str, Enum):
+class TaxonomicFilterGroupType(StrEnum):
     METADATA = "metadata"
     ACTIONS = "actions"
     COHORTS = "cohorts"
@@ -3154,7 +3152,7 @@ class TimelineEntry(BaseModel):
     sessionId: str | None = Field(default=None, description="Session ID. None means out-of-session events")
 
 
-class DetailedResultsAggregationType(str, Enum):
+class DetailedResultsAggregationType(StrEnum):
     TOTAL = "total"
     AVERAGE = "average"
     MEDIAN = "median"
@@ -3193,12 +3191,12 @@ class TrendsFormulaNode(BaseModel):
     formula: str
 
 
-class UsageMetricDisplay(str, Enum):
+class UsageMetricDisplay(StrEnum):
     NUMBER = "number"
     SPARKLINE = "sparkline"
 
 
-class UsageMetricFormat(str, Enum):
+class UsageMetricFormat(StrEnum):
     NUMERIC = "numeric"
     CURRENCY = "currency"
 
@@ -3218,7 +3216,7 @@ class UserBasicType(BaseModel):
     uuid: str
 
 
-class UserProductListReason(str, Enum):
+class UserProductListReason(StrEnum):
     ONBOARDING = "onboarding"
     PRODUCT_INTENT = "product_intent"
     USED_BY_COLLEAGUES = "used_by_colleagues"
@@ -3278,19 +3276,19 @@ class WebAnalyticsExternalSummaryRequest(BaseModel):
     explicit_date: bool | None = None
 
 
-class WebAnalyticsItemKind(str, Enum):
+class WebAnalyticsItemKind(StrEnum):
     UNIT = "unit"
     DURATION_S = "duration_s"
     PERCENTAGE = "percentage"
     CURRENCY = "currency"
 
 
-class WebAnalyticsOrderByDirection(str, Enum):
+class WebAnalyticsOrderByDirection(StrEnum):
     ASC = "ASC"
     DESC = "DESC"
 
 
-class WebAnalyticsOrderByFields(str, Enum):
+class WebAnalyticsOrderByFields(StrEnum):
     VISITORS = "Visitors"
     VIEWS = "Views"
     CLICKS = "Clicks"
@@ -3327,7 +3325,7 @@ class WebOverviewItem(BaseModel):
     value: float | None = None
 
 
-class WebStatsBreakdown(str, Enum):
+class WebStatsBreakdown(StrEnum):
     PAGE = "Page"
     INITIAL_PAGE = "InitialPage"
     EXIT_PAGE = "ExitPage"
@@ -3374,7 +3372,7 @@ class WebTrendsItem(BaseModel):
     metrics: Metrics
 
 
-class WebTrendsMetric(str, Enum):
+class WebTrendsMetric(StrEnum):
     UNIQUE_USERS = "UniqueUsers"
     PAGE_VIEWS = "PageViews"
     SESSIONS = "Sessions"
@@ -3383,14 +3381,14 @@ class WebTrendsMetric(str, Enum):
     TOTAL_SESSIONS = "TotalSessions"
 
 
-class WebVitalsMetric(str, Enum):
+class WebVitalsMetric(StrEnum):
     INP = "INP"
     LCP = "LCP"
     CLS = "CLS"
     FCP = "FCP"
 
 
-class WebVitalsMetricBand(str, Enum):
+class WebVitalsMetricBand(StrEnum):
     GOOD = "good"
     NEEDS_IMPROVEMENTS = "needs_improvements"
     POOR = "poor"
@@ -3404,13 +3402,13 @@ class WebVitalsPathBreakdownResultItem(BaseModel):
     value: float
 
 
-class WebVitalsPercentile(str, Enum):
+class WebVitalsPercentile(StrEnum):
     P75 = "p75"
     P90 = "p90"
     P99 = "p99"
 
 
-class Scale(str, Enum):
+class Scale(StrEnum):
     LINEAR = "linear"
     LOGARITHMIC = "logarithmic"
 
@@ -4542,7 +4540,7 @@ class DayItem(BaseModel):
         extra="forbid",
     )
     label: str
-    value: str | datetime | int
+    value: str | AwareDatetime | int
 
 
 class InsightThreshold(BaseModel):
@@ -4613,14 +4611,14 @@ class LogMessage(BaseModel):
     event_name: str
     instrumentation_scope: str
     level: LogSeverityLevel
-    live_logs_checkpoint: datetime | None = None
+    live_logs_checkpoint: AwareDatetime | None = None
     new: bool | None = None
-    observed_timestamp: datetime
+    observed_timestamp: AwareDatetime
     resource_attributes: Any
     severity_number: float
     severity_text: LogSeverityLevel
     span_id: str
-    timestamp: datetime
+    timestamp: AwareDatetime
     trace_id: str
     uuid: str
 
@@ -4697,13 +4695,17 @@ class MaxExperimentSummaryContext(BaseModel):
     variants: list[str]
 
 
+class NotebookInfo(RootModel[DeepResearchNotebook]):
+    root: DeepResearchNotebook
+
+
 class NotebookUpdateMessage(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     content: ProsemirrorJSONContent
-    conversation_notebooks: list[DeepResearchNotebook] | None = None
-    current_run_notebooks: list[DeepResearchNotebook] | None = None
+    conversation_notebooks: list[NotebookInfo] | None = None
+    current_run_notebooks: list[NotebookInfo] | None = None
     id: str | None = None
     notebook_id: str
     notebook_type: Literal["deep_research"] = "deep_research"
@@ -4830,7 +4832,7 @@ class QueryStatus(BaseModel):
         ),
     )
     dashboard_id: int | None = None
-    end_time: datetime | None = Field(
+    end_time: AwareDatetime | None = Field(
         default=None, description="When did the query execution task finish (whether successfully or not)."
     )
     error: bool | None = Field(
@@ -4840,17 +4842,17 @@ class QueryStatus(BaseModel):
         ),
     )
     error_message: str | None = None
-    expiration_time: datetime | None = None
+    expiration_time: AwareDatetime | None = None
     id: str
     insight_id: int | None = None
     labels: list[str] | None = None
-    pickup_time: datetime | None = Field(
+    pickup_time: AwareDatetime | None = Field(
         default=None, description="When was the query execution task picked up by a worker."
     )
     query_async: Literal[True] = Field(default=True, description="ONLY async queries use QueryStatus.")
     query_progress: ClickhouseQueryProgress | None = None
     results: Any | None = None
-    start_time: datetime | None = Field(default=None, description="When was query execution task enqueued.")
+    start_time: AwareDatetime | None = Field(default=None, description="When was query execution task enqueued.")
     task_id: str | None = None
     team_id: int
 
@@ -5580,7 +5582,7 @@ class TestCachedBasicQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -5590,9 +5592,9 @@ class TestCachedBasicQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6486,7 +6488,7 @@ class CachedActorsPropertyTaxonomyQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6496,9 +6498,9 @@ class CachedActorsPropertyTaxonomyQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6518,7 +6520,7 @@ class CachedActorsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6530,11 +6532,11 @@ class CachedActorsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str = Field(..., description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int
     missing_actors_count: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6556,7 +6558,7 @@ class CachedCalendarHeatmapQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6567,9 +6569,9 @@ class CachedCalendarHeatmapQueryResponse(BaseModel):
     hasMore: bool | None = Field(default=None, description="Wether more breakdown values are available.")
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6589,7 +6591,7 @@ class CachedDocumentSimilarityQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6600,10 +6602,10 @@ class CachedDocumentSimilarityQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6624,7 +6626,7 @@ class CachedErrorTrackingBreakdownsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6634,9 +6636,9 @@ class CachedErrorTrackingBreakdownsQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6656,7 +6658,7 @@ class CachedErrorTrackingSimilarIssuesQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6667,10 +6669,10 @@ class CachedErrorTrackingSimilarIssuesQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6691,7 +6693,7 @@ class CachedEventTaxonomyQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6701,9 +6703,9 @@ class CachedEventTaxonomyQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6723,7 +6725,7 @@ class CachedEventsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6735,10 +6737,10 @@ class CachedEventsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str = Field(..., description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6760,15 +6762,15 @@ class CachedExperimentExposureQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
     date_range: DateRange
     is_cached: bool
     kind: Literal["ExperimentExposureQuery"] = "ExperimentExposureQuery"
-    last_refresh: datetime
-    next_allowed_client_refresh: datetime
+    last_refresh: AwareDatetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6783,7 +6785,7 @@ class CachedFunnelCorrelationResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6795,10 +6797,10 @@ class CachedFunnelCorrelationResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6820,7 +6822,7 @@ class CachedFunnelsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6831,9 +6833,9 @@ class CachedFunnelsQueryResponse(BaseModel):
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     isUdf: bool | None = None
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6853,7 +6855,7 @@ class CachedGroupsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6866,10 +6868,10 @@ class CachedGroupsQueryResponse(BaseModel):
     hogql: str = Field(..., description="Generated HogQL query.")
     is_cached: bool
     kind: Literal["GroupsQuery"] = "GroupsQuery"
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6891,7 +6893,7 @@ class CachedLifecycleQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6901,9 +6903,9 @@ class CachedLifecycleQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6923,7 +6925,7 @@ class CachedLogsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6935,10 +6937,10 @@ class CachedLogsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6959,7 +6961,7 @@ class CachedMarketingAnalyticsAggregatedQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6969,9 +6971,9 @@ class CachedMarketingAnalyticsAggregatedQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6992,7 +6994,7 @@ class CachedMarketingAnalyticsTableQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7004,10 +7006,10 @@ class CachedMarketingAnalyticsTableQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7030,7 +7032,7 @@ class CachedPathsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7040,9 +7042,9 @@ class CachedPathsQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7062,7 +7064,7 @@ class CachedRevenueAnalyticsGrossRevenueQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7073,9 +7075,9 @@ class CachedRevenueAnalyticsGrossRevenueQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7095,7 +7097,7 @@ class CachedRevenueAnalyticsMRRQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7106,9 +7108,9 @@ class CachedRevenueAnalyticsMRRQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7128,7 +7130,7 @@ class CachedRevenueAnalyticsMetricsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7139,9 +7141,9 @@ class CachedRevenueAnalyticsMetricsQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7161,7 +7163,7 @@ class CachedRevenueAnalyticsOverviewQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7171,9 +7173,9 @@ class CachedRevenueAnalyticsOverviewQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7193,7 +7195,7 @@ class CachedRevenueAnalyticsTopCustomersQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7204,9 +7206,9 @@ class CachedRevenueAnalyticsTopCustomersQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7226,7 +7228,7 @@ class CachedRevenueExampleDataWarehouseTablesQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7238,10 +7240,10 @@ class CachedRevenueExampleDataWarehouseTablesQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7263,7 +7265,7 @@ class CachedRevenueExampleEventsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7275,10 +7277,10 @@ class CachedRevenueExampleEventsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7300,7 +7302,7 @@ class CachedSessionAttributionExplorerQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7312,10 +7314,10 @@ class CachedSessionAttributionExplorerQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7337,7 +7339,7 @@ class CachedSessionBatchEventsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7349,10 +7351,10 @@ class CachedSessionBatchEventsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str = Field(..., description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7380,7 +7382,7 @@ class CachedSessionsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7392,10 +7394,10 @@ class CachedSessionsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str = Field(..., description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7417,7 +7419,7 @@ class CachedSessionsTimelineQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7428,9 +7430,9 @@ class CachedSessionsTimelineQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7450,7 +7452,7 @@ class CachedStickinessQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7460,9 +7462,9 @@ class CachedStickinessQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7482,13 +7484,13 @@ class CachedSuggestedQuestionsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
     is_cached: bool
-    last_refresh: datetime
-    next_allowed_client_refresh: datetime
+    last_refresh: AwareDatetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7502,7 +7504,7 @@ class CachedTeamTaxonomyQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7512,9 +7514,9 @@ class CachedTeamTaxonomyQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7534,7 +7536,7 @@ class CachedTraceQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7546,10 +7548,10 @@ class CachedTraceQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7570,7 +7572,7 @@ class CachedTracesQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7582,10 +7584,10 @@ class CachedTracesQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7606,7 +7608,7 @@ class CachedTrendsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7617,9 +7619,9 @@ class CachedTrendsQueryResponse(BaseModel):
     hasMore: bool | None = Field(default=None, description="Wether more breakdown values are available.")
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7639,7 +7641,7 @@ class CachedUsageMetricsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7649,9 +7651,9 @@ class CachedUsageMetricsQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7671,7 +7673,7 @@ class CachedVectorSearchQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7681,9 +7683,9 @@ class CachedVectorSearchQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7703,7 +7705,7 @@ class CachedWebExternalClicksTableQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7715,10 +7717,10 @@ class CachedWebExternalClicksTableQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7741,7 +7743,7 @@ class CachedWebGoalsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7753,10 +7755,10 @@ class CachedWebGoalsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7779,7 +7781,7 @@ class CachedWebOverviewQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7791,9 +7793,9 @@ class CachedWebOverviewQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7815,7 +7817,7 @@ class CachedWebPageURLSearchQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7826,10 +7828,10 @@ class CachedWebPageURLSearchQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7849,7 +7851,7 @@ class CachedWebStatsTableQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7861,10 +7863,10 @@ class CachedWebStatsTableQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7888,7 +7890,7 @@ class CachedWebVitalsPathBreakdownQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7898,9 +7900,9 @@ class CachedWebVitalsPathBreakdownQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -8997,11 +8999,11 @@ class ErrorTrackingIssue(BaseModel):
     description: str | None = None
     external_issues: list[ErrorTrackingExternalReference] | None = None
     first_event: FirstEvent | None = None
-    first_seen: datetime
+    first_seen: AwareDatetime
     function: str | None = None
     id: str
     last_event: LastEvent | None = None
-    last_seen: datetime
+    last_seen: AwareDatetime
     library: str | None = None
     name: str | None = None
     revenue: float | None = None
@@ -9080,7 +9082,7 @@ class ErrorTrackingRelationalIssue(BaseModel):
     cohort: ErrorTrackingIssueCohort | None = None
     description: str | None = None
     external_issues: list[ErrorTrackingExternalReference] | None = None
-    first_seen: datetime
+    first_seen: AwareDatetime
     id: str
     name: str | None = None
     status: Status4
@@ -9632,13 +9634,13 @@ class FunnelsQueryResponse(BaseModel):
 
 class GenericCachedQueryResponse(BaseModel):
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
     is_cached: bool
-    last_refresh: datetime
-    next_allowed_client_refresh: datetime
+    last_refresh: AwareDatetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -11518,7 +11520,7 @@ class RetentionResult(BaseModel):
     breakdown_value: str | float | None = Field(
         default=None, description="Optional breakdown value for retention cohorts"
     )
-    date: datetime
+    date: AwareDatetime
     label: str
     values: list[RetentionValue]
 
@@ -12311,7 +12313,7 @@ class CachedErrorTrackingQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12323,10 +12325,10 @@ class CachedErrorTrackingQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -12347,7 +12349,7 @@ class CachedHogQLQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12361,11 +12363,11 @@ class CachedHogQLQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     metadata: HogQLMetadataResponse | None = Field(default=None, description="Query metadata output")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query: str | None = Field(default=None, description="Input query string")
     query_metadata: dict[str, Any] | None = None
@@ -12390,7 +12392,7 @@ class CachedInsightActorsQueryOptionsResponse(BaseModel):
     breakdown: list[BreakdownItem] | None = None
     breakdowns: list[MultipleBreakdownOptions] | None = None
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12398,8 +12400,8 @@ class CachedInsightActorsQueryOptionsResponse(BaseModel):
     day: list[DayItem] | None = None
     interval: list[IntervalItem] | None = None
     is_cached: bool
-    last_refresh: datetime
-    next_allowed_client_refresh: datetime
+    last_refresh: AwareDatetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -12416,15 +12418,15 @@ class CachedNewExperimentQueryResponse(BaseModel):
     baseline: ExperimentStatsBaseValidated
     breakdown_results: list[ExperimentBreakdownResult] | None = None
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
     clickhouse_sql: str | None = None
     hogql: str | None = None
     is_cached: bool
-    last_refresh: datetime
-    next_allowed_client_refresh: datetime
+    last_refresh: AwareDatetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -12438,7 +12440,7 @@ class CachedRetentionQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12448,9 +12450,9 @@ class CachedRetentionQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -12470,7 +12472,7 @@ class CachedWebTrendsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12484,11 +12486,11 @@ class CachedWebTrendsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     metadata: HogQLMetadataResponse | None = Field(default=None, description="Query metadata output")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query: str | None = Field(default=None, description="Input query string")
     query_metadata: dict[str, Any] | None = None
@@ -12513,7 +12515,7 @@ class CachedWebVitalsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12523,9 +12525,9 @@ class CachedWebVitalsQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -12656,9 +12658,9 @@ class ErrorTrackingCorrelatedIssue(BaseModel):
     description: str | None = None
     event: str
     external_issues: list[ErrorTrackingExternalReference] | None = None
-    first_seen: datetime
+    first_seen: AwareDatetime
     id: str
-    last_seen: datetime
+    last_seen: AwareDatetime
     library: str | None = None
     name: str | None = None
     odds_ratio: float
@@ -13417,7 +13419,7 @@ class CachedErrorTrackingIssueCorrelationQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -13429,10 +13431,10 @@ class CachedErrorTrackingIssueCorrelationQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -13453,7 +13455,7 @@ class CachedExperimentTrendsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -13463,8 +13465,8 @@ class CachedExperimentTrendsQueryResponse(BaseModel):
     insight: list[dict[str, Any]]
     is_cached: bool
     kind: Literal["ExperimentTrendsQuery"] = "ExperimentTrendsQuery"
-    last_refresh: datetime
-    next_allowed_client_refresh: datetime
+    last_refresh: AwareDatetime
+    next_allowed_client_refresh: AwareDatetime
     p_value: float
     probability: dict[str, float]
     query_metadata: dict[str, Any] | None = None
@@ -14504,7 +14506,7 @@ class CachedExperimentFunnelsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -14514,8 +14516,8 @@ class CachedExperimentFunnelsQueryResponse(BaseModel):
     insight: list[list[dict[str, Any]]]
     is_cached: bool
     kind: Literal["ExperimentFunnelsQuery"] = "ExperimentFunnelsQuery"
-    last_refresh: datetime
-    next_allowed_client_refresh: datetime
+    last_refresh: AwareDatetime
+    next_allowed_client_refresh: AwareDatetime
     probability: dict[str, float]
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -14540,7 +14542,7 @@ class CachedExperimentQueryResponse(BaseModel):
         ),
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -14550,11 +14552,11 @@ class CachedExperimentQueryResponse(BaseModel):
     insight: list[dict[str, Any]] | None = None
     is_cached: bool
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric | None = (
         None
     )
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     p_value: float | None = None
     probability: dict[str, float] | None = None
     query_metadata: dict[str, Any] | None = None
@@ -14574,7 +14576,7 @@ class CachedLegacyExperimentQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: datetime | None = None
+    cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -14582,9 +14584,9 @@ class CachedLegacyExperimentQueryResponse(BaseModel):
     insight: list[dict[str, Any]]
     is_cached: bool
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
-    last_refresh: datetime
+    last_refresh: AwareDatetime
     metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric
-    next_allowed_client_refresh: datetime
+    next_allowed_client_refresh: AwareDatetime
     p_value: float
     probability: dict[str, float]
     query_metadata: dict[str, Any] | None = None

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5,17 +5,18 @@
 
 from __future__ import annotations
 
-from enum import Enum, StrEnum
+from datetime import datetime
+from enum import Enum
 from typing import Any, Literal
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class SchemaRoot(RootModel[Any]):
     root: Any
 
 
-class AIEventType(StrEnum):
+class AIEventType(str, Enum):
     FIELD_AI_GENERATION = "$ai_generation"
     FIELD_AI_EMBEDDING = "$ai_embedding"
     FIELD_AI_SPAN = "$ai_span"
@@ -33,13 +34,13 @@ class MathGroupTypeIndex(float, Enum):
     NUMBER_4 = 4
 
 
-class AgentMode(StrEnum):
+class AgentMode(str, Enum):
     PRODUCT_ANALYTICS = "product_analytics"
     SQL = "sql"
     SESSION_REPLAY = "session_replay"
 
 
-class AggregationAxisFormat(StrEnum):
+class AggregationAxisFormat(str, Enum):
     NUMERIC = "numeric"
     DURATION = "duration"
     DURATION_MS = "duration_ms"
@@ -48,27 +49,27 @@ class AggregationAxisFormat(StrEnum):
     CURRENCY = "currency"
 
 
-class AlertCalculationInterval(StrEnum):
+class AlertCalculationInterval(str, Enum):
     HOURLY = "hourly"
     DAILY = "daily"
     WEEKLY = "weekly"
     MONTHLY = "monthly"
 
 
-class AlertConditionType(StrEnum):
+class AlertConditionType(str, Enum):
     ABSOLUTE_VALUE = "absolute_value"
     RELATIVE_INCREASE = "relative_increase"
     RELATIVE_DECREASE = "relative_decrease"
 
 
-class AlertState(StrEnum):
+class AlertState(str, Enum):
     FIRING = "Firing"
     NOT_FIRING = "Not firing"
     ERRORED = "Errored"
     SNOOZED = "Snoozed"
 
 
-class AssistantArrayPropertyFilterOperator(StrEnum):
+class AssistantArrayPropertyFilterOperator(str, Enum):
     EXACT = "exact"
     IS_NOT = "is_not"
 
@@ -88,7 +89,7 @@ class AssistantDateRange(BaseModel):
     date_to: str | None = Field(default=None, description="ISO8601 date string.")
 
 
-class AssistantDateTimePropertyFilterOperator(StrEnum):
+class AssistantDateTimePropertyFilterOperator(str, Enum):
     IS_DATE_EXACT = "is_date_exact"
     IS_DATE_BEFORE = "is_date_before"
     IS_DATE_AFTER = "is_date_after"
@@ -108,7 +109,7 @@ class AssistantDurationRange(BaseModel):
     )
 
 
-class AssistantEventMultipleBreakdownFilterType(StrEnum):
+class AssistantEventMultipleBreakdownFilterType(str, Enum):
     COHORT = "cohort"
     PERSON = "person"
     EVENT = "event"
@@ -118,7 +119,7 @@ class AssistantEventMultipleBreakdownFilterType(StrEnum):
     REVENUE_ANALYTICS = "revenue_analytics"
 
 
-class AssistantEventType(StrEnum):
+class AssistantEventType(str, Enum):
     STATUS = "status"
     MESSAGE = "message"
     CONVERSATION = "conversation"
@@ -137,7 +138,7 @@ class AssistantFormOption(BaseModel):
     variant: str | None = Field(default=None, description="'primary', 'secondary', or 'tertiary' - default 'secondary'")
 
 
-class AssistantFunnelsBreakdownType(StrEnum):
+class AssistantFunnelsBreakdownType(str, Enum):
     PERSON = "person"
     EVENT = "event"
     GROUP = "group"
@@ -149,12 +150,12 @@ class FunnelAggregateByHogQL(Enum):
     NONE_TYPE_NONE = None
 
 
-class AssistantFunnelsMath(StrEnum):
+class AssistantFunnelsMath(str, Enum):
     FIRST_TIME_FOR_USER = "first_time_for_user"
     FIRST_TIME_FOR_USER_WITH_FILTERS = "first_time_for_user_with_filters"
 
 
-class AssistantGenerationStatusType(StrEnum):
+class AssistantGenerationStatusType(str, Enum):
     ACK = "ack"
     GENERATION_ERROR = "generation_error"
 
@@ -167,7 +168,7 @@ class AssistantGenericMultipleBreakdownFilter(BaseModel):
     type: AssistantEventMultipleBreakdownFilterType
 
 
-class AssistantGenericPropertyFilterType(StrEnum):
+class AssistantGenericPropertyFilterType(str, Enum):
     EVENT = "event"
     PERSON = "person"
     SESSION = "session"
@@ -185,7 +186,7 @@ class AssistantHogQLQuery(BaseModel):
     )
 
 
-class AssistantMessageType(StrEnum):
+class AssistantMessageType(str, Enum):
     HUMAN = "human"
     TOOL = "tool"
     CONTEXT = "context"
@@ -199,7 +200,7 @@ class AssistantMessageType(StrEnum):
     AI_TASK_EXECUTION = "ai/task_execution"
 
 
-class AssistantNavigateUrl(StrEnum):
+class AssistantNavigateUrl(str, Enum):
     ACTIONS = "actions"
     ACTIVITY = "activity"
     ALERTS = "alerts"
@@ -237,29 +238,29 @@ class AssistantNavigateUrl(StrEnum):
     PERSONS = "persons"
 
 
-class AssistantNumericValuePropertyFilterOperator(StrEnum):
+class AssistantNumericValuePropertyFilterOperator(str, Enum):
     EXACT = "exact"
     GT = "gt"
     LT = "lt"
 
 
-class MeanRetentionCalculation(StrEnum):
+class MeanRetentionCalculation(str, Enum):
     SIMPLE = "simple"
     WEIGHTED = "weighted"
     NONE = "none"
 
 
-class RetentionReference(StrEnum):
+class RetentionReference(str, Enum):
     TOTAL = "total"
     PREVIOUS = "previous"
 
 
-class AssistantSetPropertyFilterOperator(StrEnum):
+class AssistantSetPropertyFilterOperator(str, Enum):
     IS_SET = "is_set"
     IS_NOT_SET = "is_not_set"
 
 
-class AssistantStringOrBooleanValuePropertyFilterOperator(StrEnum):
+class AssistantStringOrBooleanValuePropertyFilterOperator(str, Enum):
     EXACT = "exact"
     IS_NOT = "is_not"
     ICONTAINS = "icontains"
@@ -268,7 +269,7 @@ class AssistantStringOrBooleanValuePropertyFilterOperator(StrEnum):
     NOT_REGEX = "not_regex"
 
 
-class AssistantTool(StrEnum):
+class AssistantTool(str, Enum):
     SEARCH_SESSION_RECORDINGS = "search_session_recordings"
     GENERATE_HOGQL_QUERY = "generate_hogql_query"
     FIX_HOGQL_QUERY = "fix_hogql_query"
@@ -335,7 +336,7 @@ class AssistantTrendsDisplayType(RootModel[str | Any]):
     root: str | Any
 
 
-class Display(StrEnum):
+class Display(str, Enum):
     ACTIONS_LINE_GRAPH = "ActionsLineGraph"
     ACTIONS_BAR = "ActionsBar"
     ACTIONS_UNSTACKED_BAR = "ActionsUnstackedBar"
@@ -349,7 +350,7 @@ class Display(StrEnum):
     CALENDAR_HEATMAP = "CalendarHeatmap"
 
 
-class YAxisScaleType(StrEnum):
+class YAxisScaleType(str, Enum):
     LOG10 = "log10"
     LINEAR = "linear"
 
@@ -443,12 +444,12 @@ class AssistantUpdateEvent(BaseModel):
     tool_call_id: str
 
 
-class AttributionMode(StrEnum):
+class AttributionMode(str, Enum):
     FIRST_TOUCH = "first_touch"
     LAST_TOUCH = "last_touch"
 
 
-class AutocompleteCompletionItemKind(StrEnum):
+class AutocompleteCompletionItemKind(str, Enum):
     METHOD = "Method"
     FUNCTION = "Function"
     CONSTRUCTOR = "Constructor"
@@ -487,7 +488,7 @@ class BaseAssistantMessage(BaseModel):
     parent_tool_call_id: str | None = None
 
 
-class BaseMathType(StrEnum):
+class BaseMathType(str, Enum):
     TOTAL = "total"
     DAU = "dau"
     WEEKLY_ACTIVE = "weekly_active"
@@ -497,26 +498,26 @@ class BaseMathType(StrEnum):
     FIRST_MATCHING_EVENT_FOR_USER = "first_matching_event_for_user"
 
 
-class BillingSpendResponseBreakdownType(StrEnum):
+class BillingSpendResponseBreakdownType(str, Enum):
     TYPE = "type"
     TEAM = "team"
     MULTIPLE = "multiple"
 
 
-class BillingUsageResponseBreakdownType(StrEnum):
+class BillingUsageResponseBreakdownType(str, Enum):
     TYPE = "type"
     TEAM = "team"
     MULTIPLE = "multiple"
 
 
-class BreakdownAttributionType(StrEnum):
+class BreakdownAttributionType(str, Enum):
     FIRST_TOUCH = "first_touch"
     LAST_TOUCH = "last_touch"
     ALL_EVENTS = "all_events"
     STEP = "step"
 
 
-class BreakdownType(StrEnum):
+class BreakdownType(str, Enum):
     COHORT = "cohort"
     PERSON = "person"
     EVENT = "event"
@@ -568,12 +569,12 @@ class CalendarHeatmapFilter(BaseModel):
     dummy: str | None = None
 
 
-class CalendarHeatmapMathType(StrEnum):
+class CalendarHeatmapMathType(str, Enum):
     TOTAL = "total"
     DAU = "dau"
 
 
-class MatchField(StrEnum):
+class MatchField(str, Enum):
     CAMPAIGN_NAME = "campaign_name"
     CAMPAIGN_ID = "campaign_id"
 
@@ -585,13 +586,13 @@ class CampaignFieldPreference(BaseModel):
     match_field: MatchField
 
 
-class ChartDisplayCategory(StrEnum):
+class ChartDisplayCategory(str, Enum):
     TIME_SERIES = "TimeSeries"
     CUMULATIVE_TIME_SERIES = "CumulativeTimeSeries"
     TOTAL_VALUE = "TotalValue"
 
 
-class ChartDisplayType(StrEnum):
+class ChartDisplayType(str, Enum):
     ACTIONS_LINE_GRAPH = "ActionsLineGraph"
     ACTIONS_BAR = "ActionsBar"
     ACTIONS_UNSTACKED_BAR = "ActionsUnstackedBar"
@@ -606,13 +607,13 @@ class ChartDisplayType(StrEnum):
     CALENDAR_HEATMAP = "CalendarHeatmap"
 
 
-class DisplayType(StrEnum):
+class DisplayType(str, Enum):
     AUTO = "auto"
     LINE = "line"
     BAR = "bar"
 
 
-class YAxisPosition(StrEnum):
+class YAxisPosition(str, Enum):
     LEFT = "left"
     RIGHT = "right"
 
@@ -628,7 +629,7 @@ class ChartSettingsDisplay(BaseModel):
     yAxisPosition: YAxisPosition | None = None
 
 
-class Style(StrEnum):
+class Style(str, Enum):
     NONE = "none"
     NUMBER = "number"
     PERCENT = "percent"
@@ -661,7 +662,7 @@ class CompareFilter(BaseModel):
     )
 
 
-class ColorMode(StrEnum):
+class ColorMode(str, Enum):
     LIGHT = "light"
     DARK = "dark"
 
@@ -689,7 +690,7 @@ class ContextMessage(BaseModel):
     type: Literal["context"] = "context"
 
 
-class CountPerActorMathType(StrEnum):
+class CountPerActorMathType(str, Enum):
     AVG_COUNT_PER_ACTOR = "avg_count_per_actor"
     MIN_COUNT_PER_ACTOR = "min_count_per_actor"
     MAX_COUNT_PER_ACTOR = "max_count_per_actor"
@@ -700,7 +701,7 @@ class CountPerActorMathType(StrEnum):
     P99_COUNT_PER_ACTOR = "p99_count_per_actor"
 
 
-class CurrencyCode(StrEnum):
+class CurrencyCode(str, Enum):
     AED = "AED"
     AFN = "AFN"
     ALL = "ALL"
@@ -855,7 +856,7 @@ class CurrencyCode(StrEnum):
     ZMW = "ZMW"
 
 
-class CustomChannelField(StrEnum):
+class CustomChannelField(str, Enum):
     UTM_SOURCE = "utm_source"
     UTM_MEDIUM = "utm_medium"
     UTM_CAMPAIGN = "utm_campaign"
@@ -865,7 +866,7 @@ class CustomChannelField(StrEnum):
     HOSTNAME = "hostname"
 
 
-class CustomChannelOperator(StrEnum):
+class CustomChannelOperator(str, Enum):
     EXACT = "exact"
     IS_NOT = "is_not"
     IS_SET = "is_set"
@@ -883,7 +884,7 @@ class CustomEventConversionGoal(BaseModel):
     customEventName: str
 
 
-class DataColorToken(StrEnum):
+class DataColorToken(str, Enum):
     PRESET_1 = "preset-1"
     PRESET_2 = "preset-2"
     PRESET_3 = "preset-3"
@@ -901,7 +902,7 @@ class DataColorToken(StrEnum):
     PRESET_15 = "preset-15"
 
 
-class DataTableNodeViewPropsContextType(StrEnum):
+class DataTableNodeViewPropsContextType(str, Enum):
     EVENT_DEFINITION = "event_definition"
     TEAM_COLUMNS = "team_columns"
 
@@ -920,7 +921,7 @@ class DataWarehouseManagedViewsetKind(RootModel[Literal["revenue_analytics"]]):
     root: Literal["revenue_analytics"] = "revenue_analytics"
 
 
-class DataWarehouseSyncInterval(StrEnum):
+class DataWarehouseSyncInterval(str, Enum):
     FIELD_5MIN = "5min"
     FIELD_30MIN = "30min"
     FIELD_1HOUR = "1hour"
@@ -939,7 +940,7 @@ class DataWarehouseViewLinkConfiguration(BaseModel):
     experiments_timestamp_key: str | None = None
 
 
-class DatabaseSchemaManagedViewTableKind(StrEnum):
+class DatabaseSchemaManagedViewTableKind(str, Enum):
     REVENUE_ANALYTICS_CHARGE = "revenue_analytics_charge"
     REVENUE_ANALYTICS_CUSTOMER = "revenue_analytics_customer"
     REVENUE_ANALYTICS_PRODUCT = "revenue_analytics_product"
@@ -970,7 +971,7 @@ class DatabaseSchemaSource(BaseModel):
     status: str
 
 
-class DatabaseSchemaTableType(StrEnum):
+class DatabaseSchemaTableType(str, Enum):
     POSTHOG = "posthog"
     SYSTEM = "system"
     DATA_WAREHOUSE = "data_warehouse"
@@ -981,7 +982,7 @@ class DatabaseSchemaTableType(StrEnum):
     ENDPOINT = "endpoint"
 
 
-class DatabaseSerializedFieldType(StrEnum):
+class DatabaseSerializedFieldType(str, Enum):
     INTEGER = "integer"
     FLOAT = "float"
     DECIMAL = "decimal"
@@ -1015,16 +1016,16 @@ class DateRange(BaseModel):
     )
 
 
-class DatetimeDay(RootModel[AwareDatetime]):
-    root: AwareDatetime
+class DatetimeDay(RootModel[datetime]):
+    root: datetime
 
 
-class DeepResearchType(StrEnum):
+class DeepResearchType(str, Enum):
     PLANNING = "planning"
     REPORT = "report"
 
 
-class DefaultChannelTypes(StrEnum):
+class DefaultChannelTypes(str, Enum):
     CROSS_NETWORK = "Cross Network"
     PAID_SEARCH = "Paid Search"
     PAID_SOCIAL = "Paid Social"
@@ -1045,29 +1046,29 @@ class DefaultChannelTypes(StrEnum):
     UNKNOWN = "Unknown"
 
 
-class DistanceFunc(StrEnum):
+class DistanceFunc(str, Enum):
     L1_DISTANCE = "L1Distance"
     L2_DISTANCE = "L2Distance"
     COSINE_DISTANCE = "cosineDistance"
 
 
-class OrderBy(StrEnum):
+class OrderBy(str, Enum):
     DISTANCE = "distance"
     TIMESTAMP = "timestamp"
 
 
-class OrderDirection(StrEnum):
+class OrderDirection(str, Enum):
     ASC = "asc"
     DESC = "desc"
 
 
-class DurationType(StrEnum):
+class DurationType(str, Enum):
     DURATION = "duration"
     ACTIVE_SECONDS = "active_seconds"
     INACTIVE_SECONDS = "inactive_seconds"
 
 
-class Key(StrEnum):
+class Key(str, Enum):
     TAG_NAME = "tag_name"
     TEXT = "text"
     HREF = "href"
@@ -1096,10 +1097,10 @@ class EmbeddedDocument(BaseModel):
     document_id: str
     document_type: str
     product: str
-    timestamp: AwareDatetime
+    timestamp: datetime
 
 
-class EmbeddingModelName(StrEnum):
+class EmbeddingModelName(str, Enum):
     TEXT_EMBEDDING_3_SMALL_1536 = "text-embedding-3-small-1536"
     TEXT_EMBEDDING_3_LARGE_3072 = "text-embedding-3-large-3072"
 
@@ -1113,7 +1114,7 @@ class EmbeddingRecord(BaseModel):
     model_name: EmbeddingModelName
     product: str
     rendering: str
-    timestamp: AwareDatetime
+    timestamp: datetime
 
 
 class EmptyPropertyFilter(BaseModel):
@@ -1130,7 +1131,7 @@ class EndpointLastExecutionTimesRequest(BaseModel):
     names: list[str]
 
 
-class EntityType(StrEnum):
+class EntityType(str, Enum):
     ACTIONS = "actions"
     EVENTS = "events"
     DATA_WAREHOUSE = "data_warehouse"
@@ -1147,7 +1148,7 @@ class Population(BaseModel):
     success_only: float
 
 
-class Status(StrEnum):
+class Status(str, Enum):
     ARCHIVED = "archived"
     ACTIVE = "active"
     RESOLVED = "resolved"
@@ -1202,7 +1203,7 @@ class ErrorTrackingIssueAggregations(BaseModel):
     volume_buckets: list[VolumeBucket]
 
 
-class ErrorTrackingIssueAssigneeType(StrEnum):
+class ErrorTrackingIssueAssigneeType(str, Enum):
     USER = "user"
     ROLE = "role"
 
@@ -1215,7 +1216,7 @@ class ErrorTrackingIssueCohort(BaseModel):
     name: str
 
 
-class OrderBy1(StrEnum):
+class OrderBy1(str, Enum):
     LAST_SEEN = "last_seen"
     FIRST_SEEN = "first_seen"
     OCCURRENCES = "occurrences"
@@ -1224,12 +1225,12 @@ class OrderBy1(StrEnum):
     REVENUE = "revenue"
 
 
-class OrderDirection1(StrEnum):
+class OrderDirection1(str, Enum):
     ASC = "ASC"
     DESC = "DESC"
 
 
-class Status2(StrEnum):
+class Status2(str, Enum):
     ARCHIVED = "archived"
     ACTIVE = "active"
     RESOLVED = "resolved"
@@ -1245,7 +1246,7 @@ class ErrorTrackingIssueImpactToolOutput(BaseModel):
     events: list[str]
 
 
-class RevenueEntity(StrEnum):
+class RevenueEntity(str, Enum):
     PERSON = "person"
     GROUP_0 = "group_0"
     GROUP_1 = "group_1"
@@ -1254,12 +1255,12 @@ class RevenueEntity(StrEnum):
     GROUP_4 = "group_4"
 
 
-class RevenuePeriod(StrEnum):
+class RevenuePeriod(str, Enum):
     ALL_TIME = "all_time"
     LAST_30_DAYS = "last_30_days"
 
 
-class Status4(StrEnum):
+class Status4(str, Enum):
     ARCHIVED = "archived"
     ACTIVE = "active"
     RESOLVED = "resolved"
@@ -1276,7 +1277,7 @@ class EventDefinition(BaseModel):
     properties: dict[str, Any]
 
 
-class CorrelationType(StrEnum):
+class CorrelationType(str, Enum):
     SUCCESS = "success"
     FAILURE = "failure"
 
@@ -1325,7 +1326,7 @@ class EventsQueryPersonColumn(BaseModel):
     uuid: str
 
 
-class MultipleVariantHandling(StrEnum):
+class MultipleVariantHandling(str, Enum):
     EXCLUDE = "exclude"
     FIRST_SEEN = "first_seen"
 
@@ -1359,12 +1360,12 @@ class ExperimentMaxFrequentistContext(BaseModel):
     significant: bool
 
 
-class ExperimentMetricGoal(StrEnum):
+class ExperimentMetricGoal(str, Enum):
     INCREASE = "increase"
     DECREASE = "decrease"
 
 
-class ExperimentMetricMathType(StrEnum):
+class ExperimentMetricMathType(str, Enum):
     TOTAL = "total"
     SUM = "sum"
     UNIQUE_SESSION = "unique_session"
@@ -1385,26 +1386,26 @@ class ExperimentMetricOutlierHandling(BaseModel):
     upper_bound_percentile: float | None = None
 
 
-class Status5(StrEnum):
+class Status5(str, Enum):
     PENDING = "pending"
     COMPLETED = "completed"
     PARTIAL = "partial"
     FAILED = "failed"
 
 
-class ExperimentMetricType(StrEnum):
+class ExperimentMetricType(str, Enum):
     FUNNEL = "funnel"
     MEAN = "mean"
     RATIO = "ratio"
     RETENTION = "retention"
 
 
-class StartHandling(StrEnum):
+class StartHandling(str, Enum):
     FIRST_SEEN = "first_seen"
     LAST_SEEN = "last_seen"
 
 
-class ExperimentSignificanceCode(StrEnum):
+class ExperimentSignificanceCode(str, Enum):
     SIGNIFICANT = "significant"
     NOT_ENOUGH_EXPOSURE = "not_enough_exposure"
     LOW_WIN_PROBABILITY = "low_win_probability"
@@ -1412,12 +1413,12 @@ class ExperimentSignificanceCode(StrEnum):
     HIGH_P_VALUE = "high_p_value"
 
 
-class ExperimentStatsMethod(StrEnum):
+class ExperimentStatsMethod(str, Enum):
     BAYESIAN = "bayesian"
     FREQUENTIST = "frequentist"
 
 
-class ExperimentStatsValidationFailure(StrEnum):
+class ExperimentStatsValidationFailure(str, Enum):
     NOT_ENOUGH_EXPOSURES = "not-enough-exposures"
     BASELINE_MEAN_IS_ZERO = "baseline-mean-is-zero"
     NOT_ENOUGH_METRIC_DATA = "not-enough-metric-data"
@@ -1442,7 +1443,7 @@ class ExperimentVariantTrendsBaseStats(BaseModel):
     key: str
 
 
-class ExternalDataSourceType(StrEnum):
+class ExternalDataSourceType(str, Enum):
     CUSTOMER_IO = "CustomerIO"
     GITHUB = "Github"
     STRIPE = "Stripe"
@@ -1476,12 +1477,12 @@ class ExternalDataSourceType(StrEnum):
     SHOPIFY = "Shopify"
 
 
-class ExternalQueryErrorCode(StrEnum):
+class ExternalQueryErrorCode(str, Enum):
     PLATFORM_ACCESS_REQUIRED = "platform_access_required"
     QUERY_EXECUTION_FAILED = "query_execution_failed"
 
 
-class ExternalQueryStatus(StrEnum):
+class ExternalQueryStatus(str, Enum):
     SUCCESS = "success"
     ERROR = "error"
 
@@ -1496,7 +1497,7 @@ class FailureMessage(BaseModel):
     type: Literal["ai/failure"] = "ai/failure"
 
 
-class Tag(StrEnum):
+class Tag(str, Enum):
     ALPHA = "alpha"
     BETA = "beta"
 
@@ -1521,7 +1522,7 @@ class FileSystemEntry(BaseModel):
     visualOrder: float | None = Field(default=None, description="Order of object in tree")
 
 
-class FileSystemIconType(StrEnum):
+class FileSystemIconType(str, Enum):
     DEFAULT_ICON_TYPE = "default_icon_type"
     DASHBOARD = "dashboard"
     LLM_ANALYTICS = "llm_analytics"
@@ -1587,7 +1588,7 @@ class FileSystemViewLogEntry(BaseModel):
     viewed_at: str
 
 
-class FilterLogicalOperator(StrEnum):
+class FilterLogicalOperator(str, Enum):
     AND_ = "AND"
     OR_ = "OR"
 
@@ -1605,7 +1606,7 @@ class FlagPropertyFilter(BaseModel):
     value: bool | str = Field(..., description="The value can be true, false, or a variant name")
 
 
-class FunnelConversionWindowTimeUnit(StrEnum):
+class FunnelConversionWindowTimeUnit(str, Enum):
     SECOND = "second"
     MINUTE = "minute"
     HOUR = "hour"
@@ -1614,7 +1615,7 @@ class FunnelConversionWindowTimeUnit(StrEnum):
     MONTH = "month"
 
 
-class FunnelCorrelationResultsType(StrEnum):
+class FunnelCorrelationResultsType(str, Enum):
     EVENTS = "events"
     PROPERTIES = "properties"
     EVENT_WITH_PROPERTIES = "event_with_properties"
@@ -1635,24 +1636,24 @@ class FunnelExclusionLegacy(BaseModel):
     type: EntityType | None = None
 
 
-class FunnelLayout(StrEnum):
+class FunnelLayout(str, Enum):
     HORIZONTAL = "horizontal"
     VERTICAL = "vertical"
 
 
-class FunnelMathType(StrEnum):
+class FunnelMathType(str, Enum):
     TOTAL = "total"
     FIRST_TIME_FOR_USER = "first_time_for_user"
     FIRST_TIME_FOR_USER_WITH_FILTERS = "first_time_for_user_with_filters"
 
 
-class FunnelPathType(StrEnum):
+class FunnelPathType(str, Enum):
     FUNNEL_PATH_BEFORE_STEP = "funnel_path_before_step"
     FUNNEL_PATH_BETWEEN_STEPS = "funnel_path_between_steps"
     FUNNEL_PATH_AFTER_STEP = "funnel_path_after_step"
 
 
-class FunnelStepReference(StrEnum):
+class FunnelStepReference(str, Enum):
     TOTAL = "total"
     PREVIOUS = "previous"
 
@@ -1677,13 +1678,13 @@ class FunnelTrendsResults(RootModel[list[dict[str, Any]]]):
     root: list[dict[str, Any]]
 
 
-class FunnelVizType(StrEnum):
+class FunnelVizType(str, Enum):
     STEPS = "steps"
     TIME_TO_CONVERT = "time_to_convert"
     TRENDS = "trends"
 
 
-class Position(StrEnum):
+class Position(str, Enum):
     START = "start"
     END = "end"
 
@@ -1700,7 +1701,7 @@ class GoalLine(BaseModel):
     value: float
 
 
-class HedgehogColorOptions(StrEnum):
+class HedgehogColorOptions(str, Enum):
     GREEN = "green"
     RED = "red"
     BLUE = "blue"
@@ -1721,7 +1722,7 @@ class HogCompileResponse(BaseModel):
     locals: list
 
 
-class HogLanguage(StrEnum):
+class HogLanguage(str, Enum):
     HOG = "hog"
     HOG_JSON = "hogJson"
     HOG_QL = "hogQL"
@@ -1730,58 +1731,58 @@ class HogLanguage(StrEnum):
     LIQUID = "liquid"
 
 
-class BounceRatePageViewMode(StrEnum):
+class BounceRatePageViewMode(str, Enum):
     COUNT_PAGEVIEWS = "count_pageviews"
     UNIQ_URLS = "uniq_urls"
     UNIQ_PAGE_SCREEN_AUTOCAPTURES = "uniq_page_screen_autocaptures"
 
 
-class InCohortVia(StrEnum):
+class InCohortVia(str, Enum):
     AUTO = "auto"
     LEFTJOIN = "leftjoin"
     SUBQUERY = "subquery"
     LEFTJOIN_CONJOINED = "leftjoin_conjoined"
 
 
-class MaterializationMode(StrEnum):
+class MaterializationMode(str, Enum):
     AUTO = "auto"
     LEGACY_NULL_AS_STRING = "legacy_null_as_string"
     LEGACY_NULL_AS_NULL = "legacy_null_as_null"
     DISABLED = "disabled"
 
 
-class PersonsArgMaxVersion(StrEnum):
+class PersonsArgMaxVersion(str, Enum):
     AUTO = "auto"
     V1 = "v1"
     V2 = "v2"
 
 
-class PersonsJoinMode(StrEnum):
+class PersonsJoinMode(str, Enum):
     INNER = "inner"
     LEFT = "left"
 
 
-class PersonsOnEventsMode(StrEnum):
+class PersonsOnEventsMode(str, Enum):
     DISABLED = "disabled"
     PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS = "person_id_no_override_properties_on_events"
     PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS = "person_id_override_properties_on_events"
     PERSON_ID_OVERRIDE_PROPERTIES_JOINED = "person_id_override_properties_joined"
 
 
-class PropertyGroupsMode(StrEnum):
+class PropertyGroupsMode(str, Enum):
     ENABLED = "enabled"
     DISABLED = "disabled"
     OPTIMIZED = "optimized"
 
 
-class SessionTableVersion(StrEnum):
+class SessionTableVersion(str, Enum):
     AUTO = "auto"
     V1 = "v1"
     V2 = "v2"
     V3 = "v3"
 
 
-class SessionsV2JoinMode(StrEnum):
+class SessionsV2JoinMode(str, Enum):
     STRING = "string"
     UUID = "uuid"
 
@@ -1811,12 +1812,12 @@ class InfinityValue(float, Enum):
     NUMBER__999999 = -999999
 
 
-class Compare(StrEnum):
+class Compare(str, Enum):
     CURRENT = "current"
     PREVIOUS = "previous"
 
 
-class InsightFilterProperty(StrEnum):
+class InsightFilterProperty(str, Enum):
     TRENDS_FILTER = "trendsFilter"
     FUNNELS_FILTER = "funnelsFilter"
     RETENTION_FILTER = "retentionFilter"
@@ -1826,7 +1827,7 @@ class InsightFilterProperty(StrEnum):
     LIFECYCLE_FILTER = "lifecycleFilter"
 
 
-class InsightNodeKind(StrEnum):
+class InsightNodeKind(str, Enum):
     TRENDS_QUERY = "TrendsQuery"
     FUNNELS_QUERY = "FunnelsQuery"
     RETENTION_QUERY = "RetentionQuery"
@@ -1835,7 +1836,7 @@ class InsightNodeKind(StrEnum):
     LIFECYCLE_QUERY = "LifecycleQuery"
 
 
-class InsightThresholdType(StrEnum):
+class InsightThresholdType(str, Enum):
     ABSOLUTE = "absolute"
     PERCENTAGE = "percentage"
 
@@ -1857,7 +1858,7 @@ class IntegrationFilter(BaseModel):
     )
 
 
-class IntegrationKind(StrEnum):
+class IntegrationKind(str, Enum):
     SLACK = "slack"
     SALESFORCE = "salesforce"
     HUBSPOT = "hubspot"
@@ -1881,7 +1882,7 @@ class IntegrationKind(StrEnum):
     BING_ADS = "bing-ads"
 
 
-class IntervalType(StrEnum):
+class IntervalType(str, Enum):
     SECOND = "second"
     MINUTE = "minute"
     HOUR = "hour"
@@ -1910,14 +1911,14 @@ class LLMTracePerson(BaseModel):
     uuid: str
 
 
-class LifecycleToggle(StrEnum):
+class LifecycleToggle(str, Enum):
     NEW = "new"
     RESURRECTING = "resurrecting"
     RETURNING = "returning"
     DORMANT = "dormant"
 
 
-class LogSeverityLevel(StrEnum):
+class LogSeverityLevel(str, Enum):
     TRACE = "trace"
     DEBUG = "debug"
     INFO = "info"
@@ -1926,7 +1927,7 @@ class LogSeverityLevel(StrEnum):
     FATAL = "fatal"
 
 
-class OrderBy3(StrEnum):
+class OrderBy3(str, Enum):
     LATEST = "latest"
     EARLIEST = "earliest"
 
@@ -1939,7 +1940,7 @@ class MarkdownBlock(BaseModel):
     type: Literal["markdown"] = "markdown"
 
 
-class MarketingAnalyticsBaseColumns(StrEnum):
+class MarketingAnalyticsBaseColumns(str, Enum):
     ID = "ID"
     CAMPAIGN = "Campaign"
     SOURCE = "Source"
@@ -1951,7 +1952,7 @@ class MarketingAnalyticsBaseColumns(StrEnum):
     REPORTED_CONVERSION = "Reported Conversion"
 
 
-class MarketingAnalyticsColumnsSchemaNames(StrEnum):
+class MarketingAnalyticsColumnsSchemaNames(str, Enum):
     ID = "id"
     CAMPAIGN = "campaign"
     CLICKS = "clicks"
@@ -1963,17 +1964,17 @@ class MarketingAnalyticsColumnsSchemaNames(StrEnum):
     REPORTED_CONVERSION = "reported_conversion"
 
 
-class MarketingAnalyticsHelperForColumnNames(StrEnum):
+class MarketingAnalyticsHelperForColumnNames(str, Enum):
     GOAL = "Goal"
     COST_PER = "Cost per"
 
 
-class MarketingAnalyticsOrderByEnum(StrEnum):
+class MarketingAnalyticsOrderByEnum(str, Enum):
     ASC = "ASC"
     DESC = "DESC"
 
 
-class MarketingAnalyticsSchemaFieldTypes(StrEnum):
+class MarketingAnalyticsSchemaFieldTypes(str, Enum):
     STRING = "string"
     INTEGER = "integer"
     NUMBER = "number"
@@ -2049,7 +2050,7 @@ class UsageHistoryItem(BaseModel):
     label: str
 
 
-class MaxBillingContextBillingPeriodInterval(StrEnum):
+class MaxBillingContextBillingPeriodInterval(str, Enum):
     MONTH = "month"
     YEAR = "year"
 
@@ -2062,7 +2063,7 @@ class MaxBillingContextSettings(BaseModel):
     autocapture_on: bool
 
 
-class MaxBillingContextSubscriptionLevel(StrEnum):
+class MaxBillingContextSubscriptionLevel(str, Enum):
     FREE = "free"
     PAID = "paid"
     CUSTOM = "custom"
@@ -2136,7 +2137,7 @@ class MinimalHedgehogConfig(BaseModel):
     use_as_profile: bool
 
 
-class MultipleBreakdownType(StrEnum):
+class MultipleBreakdownType(str, Enum):
     COHORT = "cohort"
     PERSON = "person"
     EVENT = "event"
@@ -2147,7 +2148,7 @@ class MultipleBreakdownType(StrEnum):
     REVENUE_ANALYTICS = "revenue_analytics"
 
 
-class NodeKind(StrEnum):
+class NodeKind(str, Enum):
     EVENTS_NODE = "EventsNode"
     ACTIONS_NODE = "ActionsNode"
     DATA_WAREHOUSE_NODE = "DataWarehouseNode"
@@ -2241,7 +2242,7 @@ class PathCleaningFilter(BaseModel):
     regex: str | None = None
 
 
-class PathType(StrEnum):
+class PathType(str, Enum):
     FIELD_PAGEVIEW = "$pageview"
     FIELD_SCREEN = "$screen"
     CUSTOM_EVENT = "custom_event"
@@ -2304,7 +2305,7 @@ class PersonType(BaseModel):
     uuid: str | None = None
 
 
-class PlanningStepStatus(StrEnum):
+class PlanningStepStatus(str, Enum):
     PENDING = "pending"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
@@ -2330,7 +2331,7 @@ class PlaywrightWorkspaceSetupResult(BaseModel):
     user_id: str
 
 
-class ProductIntentContext(StrEnum):
+class ProductIntentContext(str, Enum):
     ONBOARDING_PRODUCT_SELECTED___PRIMARY = "onboarding product selected - primary"
     ONBOARDING_PRODUCT_SELECTED___SECONDARY = "onboarding product selected - secondary"
     QUICK_START_PRODUCT_SELECTED = "quick start product selected"
@@ -2383,7 +2384,7 @@ class ProductIntentContext(StrEnum):
     VERCEL_INTEGRATION = "vercel_integration"
 
 
-class ProductKey(StrEnum):
+class ProductKey(str, Enum):
     ACTIONS = "actions"
     ALERTS = "alerts"
     ANNOTATIONS = "annotations"
@@ -2424,9 +2425,10 @@ class ProductKey(StrEnum):
     WORKFLOWS = "workflows"
 
 
-class PropertyFilterType(StrEnum):
+class PropertyFilterType(str, Enum):
     META = "meta"
     EVENT = "event"
+    PERSON_ON_EVENT = "person_on_event"
     INTERNAL_EVENT = "internal_event"
     EVENT_METADATA = "event_metadata"
     PERSON = "person"
@@ -2446,7 +2448,7 @@ class PropertyFilterType(StrEnum):
     LOG = "log"
 
 
-class PropertyMathType(StrEnum):
+class PropertyMathType(str, Enum):
     AVG = "avg"
     SUM = "sum"
     MIN = "min"
@@ -2458,7 +2460,7 @@ class PropertyMathType(StrEnum):
     P99 = "p99"
 
 
-class PropertyOperator(StrEnum):
+class PropertyOperator(str, Enum):
     EXACT = "exact"
     IS_NOT = "is_not"
     ICONTAINS = "icontains"
@@ -2497,7 +2499,7 @@ class ProsemirrorJSONContent(BaseModel):
     type: str | None = None
 
 
-class QueryIndexUsage(StrEnum):
+class QueryIndexUsage(str, Enum):
     UNDECISIVE = "undecisive"
     NO = "no"
     PARTIAL = "partial"
@@ -2559,12 +2561,12 @@ class QueryTiming(BaseModel):
     t: float = Field(..., description="Time in seconds. Shortened to 't' to save on data.")
 
 
-class QuickFilterContext(StrEnum):
+class QuickFilterContext(str, Enum):
     ERROR_TRACKING_ISSUE_FILTERS = "error-tracking-issue-filters"
     LOGS_FILTERS = "logs-filters"
 
 
-class QuickFilterType(StrEnum):
+class QuickFilterType(str, Enum):
     MANUAL_OPTIONS = "manual-options"
     AUTO_DISCOVERY = "auto-discovery"
 
@@ -2591,7 +2593,7 @@ class RecordingDurationFilter(BaseModel):
     value: float
 
 
-class RecordingOrder(StrEnum):
+class RecordingOrder(str, Enum):
     DURATION = "duration"
     RECORDING_DURATION = "recording_duration"
     INACTIVE_SECONDS = "inactive_seconds"
@@ -2605,7 +2607,7 @@ class RecordingOrder(StrEnum):
     RECORDING_TTL = "recording_ttl"
 
 
-class RecordingOrderDirection(StrEnum):
+class RecordingOrderDirection(str, Enum):
     ASC = "ASC"
     DESC = "DESC"
 
@@ -2621,7 +2623,7 @@ class RecordingPropertyFilter(BaseModel):
     value: list[str | float | bool] | str | float | bool | None = None
 
 
-class RefreshType(StrEnum):
+class RefreshType(str, Enum):
     ASYNC_ = "async"
     ASYNC_EXCEPT_ON_CACHE_MISS = "async_except_on_cache_miss"
     BLOCKING = "blocking"
@@ -2635,8 +2637,8 @@ class ResolvedDateRangeResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    date_from: AwareDatetime
-    date_to: AwareDatetime
+    date_from: datetime
+    date_to: datetime
 
 
 class ResultCustomizationBase(BaseModel):
@@ -2647,7 +2649,7 @@ class ResultCustomizationBase(BaseModel):
     hidden: bool | None = None
 
 
-class ResultCustomizationBy(StrEnum):
+class ResultCustomizationBy(str, Enum):
     VALUE = "value"
     POSITION = "position"
 
@@ -2670,30 +2672,30 @@ class ResultCustomizationByValue(BaseModel):
     hidden: bool | None = None
 
 
-class RetentionDashboardDisplayType(StrEnum):
+class RetentionDashboardDisplayType(str, Enum):
     TABLE_ONLY = "table_only"
     GRAPH_ONLY = "graph_only"
     ALL = "all"
 
 
-class RetentionEntityKind(StrEnum):
+class RetentionEntityKind(str, Enum):
     ACTIONS_NODE = "ActionsNode"
     EVENTS_NODE = "EventsNode"
 
 
-class TimeWindowMode(StrEnum):
+class TimeWindowMode(str, Enum):
     STRICT_CALENDAR_DATES = "strict_calendar_dates"
     FIELD_24_HOUR_WINDOWS = "24_hour_windows"
 
 
-class RetentionPeriod(StrEnum):
+class RetentionPeriod(str, Enum):
     HOUR = "Hour"
     DAY = "Day"
     WEEK = "Week"
     MONTH = "Month"
 
 
-class RetentionType(StrEnum):
+class RetentionType(str, Enum):
     RETENTION_RECURRING = "retention_recurring"
     RETENTION_FIRST_TIME = "retention_first_time"
     RETENTION_FIRST_EVER_OCCURRENCE = "retention_first_ever_occurrence"
@@ -2707,7 +2709,7 @@ class RevenueAnalyticsBreakdown(BaseModel):
     type: Literal["revenue_analytics"] = "revenue_analytics"
 
 
-class MrrOrGross(StrEnum):
+class MrrOrGross(str, Enum):
     MRR = "mrr"
     GROSS = "gross"
 
@@ -2733,7 +2735,7 @@ class RevenueAnalyticsMRRQueryResultItem(BaseModel):
     total: Any
 
 
-class RevenueAnalyticsOverviewItemKey(StrEnum):
+class RevenueAnalyticsOverviewItemKey(str, Enum):
     REVENUE = "revenue"
     PAYING_CUSTOMER_COUNT = "paying_customer_count"
     AVG_REVENUE_PER_CUSTOMER = "avg_revenue_per_customer"
@@ -2750,7 +2752,7 @@ class RevenueAnalyticsPropertyFilter(BaseModel):
     value: list[str | float | bool] | str | float | bool | None = None
 
 
-class RevenueAnalyticsTopCustomersGroupBy(StrEnum):
+class RevenueAnalyticsTopCustomersGroupBy(str, Enum):
     MONTH = "month"
     ALL = "all"
 
@@ -2771,7 +2773,7 @@ class SamplingRate(BaseModel):
     numerator: float
 
 
-class SessionAttributionGroupBy(StrEnum):
+class SessionAttributionGroupBy(str, Enum):
     CHANNEL_TYPE = "ChannelType"
     MEDIUM = "Medium"
     SOURCE = "Source"
@@ -2813,13 +2815,13 @@ class SessionPropertyFilter(BaseModel):
     value: list[str | float | bool] | str | float | bool | None = None
 
 
-class SnapshotSource(StrEnum):
+class SnapshotSource(str, Enum):
     WEB = "web"
     MOBILE = "mobile"
     UNKNOWN = "unknown"
 
 
-class Storage(StrEnum):
+class Storage(str, Enum):
     OBJECT_STORAGE_LTS = "object_storage_lts"
     OBJECT_STORAGE = "object_storage"
 
@@ -2859,7 +2861,7 @@ class SimilarIssue(BaseModel):
     status: str
 
 
-class SimpleIntervalType(StrEnum):
+class SimpleIntervalType(str, Enum):
     DAY = "day"
     MONTH = "month"
 
@@ -2872,7 +2874,7 @@ class SourceFieldFileUploadJsonFormatConfig(BaseModel):
     keys: str | list[str]
 
 
-class SourceFieldInputConfigType(StrEnum):
+class SourceFieldInputConfigType(str, Enum):
     TEXT = "text"
     EMAIL = "email"
     SEARCH = "search"
@@ -2903,7 +2905,7 @@ class SourceFieldSSHTunnelConfig(BaseModel):
     type: Literal["ssh-tunnel"] = "ssh-tunnel"
 
 
-class SourceFieldSelectConfigConverter(StrEnum):
+class SourceFieldSelectConfigConverter(str, Enum):
     STR_TO_INT = "str_to_int"
     STR_TO_BOOL = "str_to_bool"
     STR_TO_OPTIONAL_INT = "str_to_optional_int"
@@ -2924,13 +2926,13 @@ class SourceMap(BaseModel):
     source: str | None = None
 
 
-class StepOrderValue(StrEnum):
+class StepOrderValue(str, Enum):
     STRICT = "strict"
     UNORDERED = "unordered"
     ORDERED = "ordered"
 
 
-class StickinessComputationMode(StrEnum):
+class StickinessComputationMode(str, Enum):
     NON_CUMULATIVE = "non_cumulative"
     CUMULATIVE = "cumulative"
 
@@ -2948,13 +2950,13 @@ class StickinessFilterLegacy(BaseModel):
     show_values_on_series: bool | None = None
 
 
-class StickinessOperator(StrEnum):
+class StickinessOperator(str, Enum):
     GTE = "gte"
     LTE = "lte"
     EXACT = "exact"
 
 
-class SubscriptionDropoffMode(StrEnum):
+class SubscriptionDropoffMode(str, Enum):
     LAST_EVENT = "last_event"
     AFTER_DROPOFF_PERIOD = "after_dropoff_period"
 
@@ -2998,7 +3000,7 @@ class Actions(BaseModel):
     values: list[Value]
 
 
-class SurveyMatchType(StrEnum):
+class SurveyMatchType(str, Enum):
     EXACT = "exact"
     IS_NOT = "is_not"
     ICONTAINS = "icontains"
@@ -3007,7 +3009,7 @@ class SurveyMatchType(StrEnum):
     NOT_REGEX = "not_regex"
 
 
-class SurveyPosition(StrEnum):
+class SurveyPosition(str, Enum):
     TOP_LEFT = "top_left"
     TOP_CENTER = "top_center"
     TOP_RIGHT = "top_right"
@@ -3020,14 +3022,14 @@ class SurveyPosition(StrEnum):
     NEXT_TO_TRIGGER = "next_to_trigger"
 
 
-class SurveyQuestionBranchingType(StrEnum):
+class SurveyQuestionBranchingType(str, Enum):
     NEXT_QUESTION = "next_question"
     END = "end"
     RESPONSE_BASED = "response_based"
     SPECIFIC_QUESTION = "specific_question"
 
 
-class SurveyQuestionDescriptionContentType(StrEnum):
+class SurveyQuestionDescriptionContentType(str, Enum):
     HTML = "html"
     TEXT = "text"
 
@@ -3041,12 +3043,12 @@ class Branching(BaseModel):
     type: SurveyQuestionBranchingType
 
 
-class Display1(StrEnum):
+class Display1(str, Enum):
     NUMBER = "number"
     EMOJI = "emoji"
 
 
-class SurveyQuestionType(StrEnum):
+class SurveyQuestionType(str, Enum):
     OPEN = "open"
     MULTIPLE_CHOICE = "multiple_choice"
     SINGLE_CHOICE = "single_choice"
@@ -3054,14 +3056,14 @@ class SurveyQuestionType(StrEnum):
     LINK = "link"
 
 
-class SurveyTabPosition(StrEnum):
+class SurveyTabPosition(str, Enum):
     TOP = "top"
     LEFT = "left"
     RIGHT = "right"
     BOTTOM = "bottom"
 
 
-class SurveyType(StrEnum):
+class SurveyType(str, Enum):
     POPOVER = "popover"
     WIDGET = "widget"
     FULL_SCREEN = "full_screen"
@@ -3069,20 +3071,20 @@ class SurveyType(StrEnum):
     EXTERNAL_SURVEY = "external_survey"
 
 
-class SurveyWidgetType(StrEnum):
+class SurveyWidgetType(str, Enum):
     BUTTON = "button"
     TAB = "tab"
     SELECTOR = "selector"
 
 
-class TaskExecutionStatus(StrEnum):
+class TaskExecutionStatus(str, Enum):
     PENDING = "pending"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
     FAILED = "failed"
 
 
-class TaxonomicFilterGroupType(StrEnum):
+class TaxonomicFilterGroupType(str, Enum):
     METADATA = "metadata"
     ACTIONS = "actions"
     COHORTS = "cohorts"
@@ -3152,7 +3154,7 @@ class TimelineEntry(BaseModel):
     sessionId: str | None = Field(default=None, description="Session ID. None means out-of-session events")
 
 
-class DetailedResultsAggregationType(StrEnum):
+class DetailedResultsAggregationType(str, Enum):
     TOTAL = "total"
     AVERAGE = "average"
     MEDIAN = "median"
@@ -3191,12 +3193,12 @@ class TrendsFormulaNode(BaseModel):
     formula: str
 
 
-class UsageMetricDisplay(StrEnum):
+class UsageMetricDisplay(str, Enum):
     NUMBER = "number"
     SPARKLINE = "sparkline"
 
 
-class UsageMetricFormat(StrEnum):
+class UsageMetricFormat(str, Enum):
     NUMERIC = "numeric"
     CURRENCY = "currency"
 
@@ -3216,7 +3218,7 @@ class UserBasicType(BaseModel):
     uuid: str
 
 
-class UserProductListReason(StrEnum):
+class UserProductListReason(str, Enum):
     ONBOARDING = "onboarding"
     PRODUCT_INTENT = "product_intent"
     USED_BY_COLLEAGUES = "used_by_colleagues"
@@ -3276,19 +3278,19 @@ class WebAnalyticsExternalSummaryRequest(BaseModel):
     explicit_date: bool | None = None
 
 
-class WebAnalyticsItemKind(StrEnum):
+class WebAnalyticsItemKind(str, Enum):
     UNIT = "unit"
     DURATION_S = "duration_s"
     PERCENTAGE = "percentage"
     CURRENCY = "currency"
 
 
-class WebAnalyticsOrderByDirection(StrEnum):
+class WebAnalyticsOrderByDirection(str, Enum):
     ASC = "ASC"
     DESC = "DESC"
 
 
-class WebAnalyticsOrderByFields(StrEnum):
+class WebAnalyticsOrderByFields(str, Enum):
     VISITORS = "Visitors"
     VIEWS = "Views"
     CLICKS = "Clicks"
@@ -3325,7 +3327,7 @@ class WebOverviewItem(BaseModel):
     value: float | None = None
 
 
-class WebStatsBreakdown(StrEnum):
+class WebStatsBreakdown(str, Enum):
     PAGE = "Page"
     INITIAL_PAGE = "InitialPage"
     EXIT_PAGE = "ExitPage"
@@ -3372,7 +3374,7 @@ class WebTrendsItem(BaseModel):
     metrics: Metrics
 
 
-class WebTrendsMetric(StrEnum):
+class WebTrendsMetric(str, Enum):
     UNIQUE_USERS = "UniqueUsers"
     PAGE_VIEWS = "PageViews"
     SESSIONS = "Sessions"
@@ -3381,14 +3383,14 @@ class WebTrendsMetric(StrEnum):
     TOTAL_SESSIONS = "TotalSessions"
 
 
-class WebVitalsMetric(StrEnum):
+class WebVitalsMetric(str, Enum):
     INP = "INP"
     LCP = "LCP"
     CLS = "CLS"
     FCP = "FCP"
 
 
-class WebVitalsMetricBand(StrEnum):
+class WebVitalsMetricBand(str, Enum):
     GOOD = "good"
     NEEDS_IMPROVEMENTS = "needs_improvements"
     POOR = "poor"
@@ -3402,13 +3404,13 @@ class WebVitalsPathBreakdownResultItem(BaseModel):
     value: float
 
 
-class WebVitalsPercentile(StrEnum):
+class WebVitalsPercentile(str, Enum):
     P75 = "p75"
     P90 = "p90"
     P99 = "p99"
 
 
-class Scale(StrEnum):
+class Scale(str, Enum):
     LINEAR = "linear"
     LOGARITHMIC = "logarithmic"
 
@@ -4540,7 +4542,7 @@ class DayItem(BaseModel):
         extra="forbid",
     )
     label: str
-    value: str | AwareDatetime | int
+    value: str | datetime | int
 
 
 class InsightThreshold(BaseModel):
@@ -4611,14 +4613,14 @@ class LogMessage(BaseModel):
     event_name: str
     instrumentation_scope: str
     level: LogSeverityLevel
-    live_logs_checkpoint: AwareDatetime | None = None
+    live_logs_checkpoint: datetime | None = None
     new: bool | None = None
-    observed_timestamp: AwareDatetime
+    observed_timestamp: datetime
     resource_attributes: Any
     severity_number: float
     severity_text: LogSeverityLevel
     span_id: str
-    timestamp: AwareDatetime
+    timestamp: datetime
     trace_id: str
     uuid: str
 
@@ -4695,17 +4697,13 @@ class MaxExperimentSummaryContext(BaseModel):
     variants: list[str]
 
 
-class NotebookInfo(RootModel[DeepResearchNotebook]):
-    root: DeepResearchNotebook
-
-
 class NotebookUpdateMessage(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     content: ProsemirrorJSONContent
-    conversation_notebooks: list[NotebookInfo] | None = None
-    current_run_notebooks: list[NotebookInfo] | None = None
+    conversation_notebooks: list[DeepResearchNotebook] | None = None
+    current_run_notebooks: list[DeepResearchNotebook] | None = None
     id: str | None = None
     notebook_id: str
     notebook_type: Literal["deep_research"] = "deep_research"
@@ -4736,6 +4734,17 @@ class PathsFilter(BaseModel):
     stepLimit: int | None = 5
 
 
+class PersonOnEventPropertyFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: str
+    label: str | None = None
+    operator: PropertyOperator
+    type: Literal["person_on_event"] = "person_on_event"
+    value: list[str | float | bool] | str | float | bool | None = None
+
+
 class PersonPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4744,17 +4753,6 @@ class PersonPropertyFilter(BaseModel):
     label: str | None = None
     operator: PropertyOperator
     type: Literal["person"] = Field(default="person", description="Person properties")
-    value: list[str | float | bool] | str | float | bool | None = None
-
-
-class PersonOnEventPropertyFilter(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    key: str
-    label: str | None = None
-    operator: PropertyOperator
-    type: Literal["person_on_event"] = Field(default="person_on_event", description="Person properties on the event")
     value: list[str | float | bool] | str | float | bool | None = None
 
 
@@ -4832,7 +4830,7 @@ class QueryStatus(BaseModel):
         ),
     )
     dashboard_id: int | None = None
-    end_time: AwareDatetime | None = Field(
+    end_time: datetime | None = Field(
         default=None, description="When did the query execution task finish (whether successfully or not)."
     )
     error: bool | None = Field(
@@ -4842,17 +4840,17 @@ class QueryStatus(BaseModel):
         ),
     )
     error_message: str | None = None
-    expiration_time: AwareDatetime | None = None
+    expiration_time: datetime | None = None
     id: str
     insight_id: int | None = None
     labels: list[str] | None = None
-    pickup_time: AwareDatetime | None = Field(
+    pickup_time: datetime | None = Field(
         default=None, description="When was the query execution task picked up by a worker."
     )
     query_async: Literal[True] = Field(default=True, description="ONLY async queries use QueryStatus.")
     query_progress: ClickhouseQueryProgress | None = None
     results: Any | None = None
-    start_time: AwareDatetime | None = Field(default=None, description="When was query execution task enqueued.")
+    start_time: datetime | None = Field(default=None, description="When was query execution task enqueued.")
     task_id: str | None = None
     team_id: int
 
@@ -5582,7 +5580,7 @@ class TestCachedBasicQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -5592,9 +5590,9 @@ class TestCachedBasicQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6488,7 +6486,7 @@ class CachedActorsPropertyTaxonomyQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6498,9 +6496,9 @@ class CachedActorsPropertyTaxonomyQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6520,7 +6518,7 @@ class CachedActorsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6532,11 +6530,11 @@ class CachedActorsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str = Field(..., description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int
     missing_actors_count: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6558,7 +6556,7 @@ class CachedCalendarHeatmapQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6569,9 +6567,9 @@ class CachedCalendarHeatmapQueryResponse(BaseModel):
     hasMore: bool | None = Field(default=None, description="Wether more breakdown values are available.")
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6591,7 +6589,7 @@ class CachedDocumentSimilarityQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6602,10 +6600,10 @@ class CachedDocumentSimilarityQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6626,7 +6624,7 @@ class CachedErrorTrackingBreakdownsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6636,9 +6634,9 @@ class CachedErrorTrackingBreakdownsQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6658,7 +6656,7 @@ class CachedErrorTrackingSimilarIssuesQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6669,10 +6667,10 @@ class CachedErrorTrackingSimilarIssuesQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6693,7 +6691,7 @@ class CachedEventTaxonomyQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6703,9 +6701,9 @@ class CachedEventTaxonomyQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6725,7 +6723,7 @@ class CachedEventsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6737,10 +6735,10 @@ class CachedEventsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str = Field(..., description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6762,15 +6760,15 @@ class CachedExperimentExposureQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
     date_range: DateRange
     is_cached: bool
     kind: Literal["ExperimentExposureQuery"] = "ExperimentExposureQuery"
-    last_refresh: AwareDatetime
-    next_allowed_client_refresh: AwareDatetime
+    last_refresh: datetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6785,7 +6783,7 @@ class CachedFunnelCorrelationResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6797,10 +6795,10 @@ class CachedFunnelCorrelationResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6822,7 +6820,7 @@ class CachedFunnelsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6833,9 +6831,9 @@ class CachedFunnelsQueryResponse(BaseModel):
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     isUdf: bool | None = None
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6855,7 +6853,7 @@ class CachedGroupsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6868,10 +6866,10 @@ class CachedGroupsQueryResponse(BaseModel):
     hogql: str = Field(..., description="Generated HogQL query.")
     is_cached: bool
     kind: Literal["GroupsQuery"] = "GroupsQuery"
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6893,7 +6891,7 @@ class CachedLifecycleQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6903,9 +6901,9 @@ class CachedLifecycleQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6925,7 +6923,7 @@ class CachedLogsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6937,10 +6935,10 @@ class CachedLogsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -6961,7 +6959,7 @@ class CachedMarketingAnalyticsAggregatedQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -6971,9 +6969,9 @@ class CachedMarketingAnalyticsAggregatedQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -6994,7 +6992,7 @@ class CachedMarketingAnalyticsTableQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7006,10 +7004,10 @@ class CachedMarketingAnalyticsTableQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7032,7 +7030,7 @@ class CachedPathsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7042,9 +7040,9 @@ class CachedPathsQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7064,7 +7062,7 @@ class CachedRevenueAnalyticsGrossRevenueQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7075,9 +7073,9 @@ class CachedRevenueAnalyticsGrossRevenueQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7097,7 +7095,7 @@ class CachedRevenueAnalyticsMRRQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7108,9 +7106,9 @@ class CachedRevenueAnalyticsMRRQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7130,7 +7128,7 @@ class CachedRevenueAnalyticsMetricsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7141,9 +7139,9 @@ class CachedRevenueAnalyticsMetricsQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7163,7 +7161,7 @@ class CachedRevenueAnalyticsOverviewQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7173,9 +7171,9 @@ class CachedRevenueAnalyticsOverviewQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7195,7 +7193,7 @@ class CachedRevenueAnalyticsTopCustomersQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7206,9 +7204,9 @@ class CachedRevenueAnalyticsTopCustomersQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7228,7 +7226,7 @@ class CachedRevenueExampleDataWarehouseTablesQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7240,10 +7238,10 @@ class CachedRevenueExampleDataWarehouseTablesQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7265,7 +7263,7 @@ class CachedRevenueExampleEventsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7277,10 +7275,10 @@ class CachedRevenueExampleEventsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7302,7 +7300,7 @@ class CachedSessionAttributionExplorerQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7314,10 +7312,10 @@ class CachedSessionAttributionExplorerQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7339,7 +7337,7 @@ class CachedSessionBatchEventsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7351,10 +7349,10 @@ class CachedSessionBatchEventsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str = Field(..., description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7382,7 +7380,7 @@ class CachedSessionsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7394,10 +7392,10 @@ class CachedSessionsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str = Field(..., description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7419,7 +7417,7 @@ class CachedSessionsTimelineQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7430,9 +7428,9 @@ class CachedSessionsTimelineQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7452,7 +7450,7 @@ class CachedStickinessQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7462,9 +7460,9 @@ class CachedStickinessQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7484,13 +7482,13 @@ class CachedSuggestedQuestionsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
     is_cached: bool
-    last_refresh: AwareDatetime
-    next_allowed_client_refresh: AwareDatetime
+    last_refresh: datetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7504,7 +7502,7 @@ class CachedTeamTaxonomyQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7514,9 +7512,9 @@ class CachedTeamTaxonomyQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7536,7 +7534,7 @@ class CachedTraceQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7548,10 +7546,10 @@ class CachedTraceQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7572,7 +7570,7 @@ class CachedTracesQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7584,10 +7582,10 @@ class CachedTracesQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7608,7 +7606,7 @@ class CachedTrendsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7619,9 +7617,9 @@ class CachedTrendsQueryResponse(BaseModel):
     hasMore: bool | None = Field(default=None, description="Wether more breakdown values are available.")
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7641,7 +7639,7 @@ class CachedUsageMetricsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7651,9 +7649,9 @@ class CachedUsageMetricsQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7673,7 +7671,7 @@ class CachedVectorSearchQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7683,9 +7681,9 @@ class CachedVectorSearchQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7705,7 +7703,7 @@ class CachedWebExternalClicksTableQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7717,10 +7715,10 @@ class CachedWebExternalClicksTableQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7743,7 +7741,7 @@ class CachedWebGoalsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7755,10 +7753,10 @@ class CachedWebGoalsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7781,7 +7779,7 @@ class CachedWebOverviewQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7793,9 +7791,9 @@ class CachedWebOverviewQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7817,7 +7815,7 @@ class CachedWebPageURLSearchQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7828,10 +7826,10 @@ class CachedWebPageURLSearchQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7851,7 +7849,7 @@ class CachedWebStatsTableQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7863,10 +7861,10 @@ class CachedWebStatsTableQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -7890,7 +7888,7 @@ class CachedWebVitalsPathBreakdownQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -7900,9 +7898,9 @@ class CachedWebVitalsPathBreakdownQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -7952,6 +7950,7 @@ class ConversionGoalFilter1(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -8000,6 +7999,7 @@ class ConversionGoalFilter1(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -8035,6 +8035,7 @@ class ConversionGoalFilter2(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -8082,6 +8083,7 @@ class ConversionGoalFilter2(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -8119,6 +8121,7 @@ class ConversionGoalFilter3(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -8167,6 +8170,7 @@ class ConversionGoalFilter3(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -8205,6 +8209,7 @@ class DashboardFilter(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -8697,6 +8702,7 @@ class DataWarehouseNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -8745,6 +8751,7 @@ class DataWarehouseNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -8878,6 +8885,7 @@ class EntityNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -8924,6 +8932,7 @@ class EntityNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -8988,11 +8997,11 @@ class ErrorTrackingIssue(BaseModel):
     description: str | None = None
     external_issues: list[ErrorTrackingExternalReference] | None = None
     first_event: FirstEvent | None = None
-    first_seen: AwareDatetime
+    first_seen: datetime
     function: str | None = None
     id: str
     last_event: LastEvent | None = None
-    last_seen: AwareDatetime
+    last_seen: datetime
     library: str | None = None
     name: str | None = None
     revenue: float | None = None
@@ -9010,6 +9019,7 @@ class ErrorTrackingIssueFilteringToolOutput(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9070,7 +9080,7 @@ class ErrorTrackingRelationalIssue(BaseModel):
     cohort: ErrorTrackingIssueCohort | None = None
     description: str | None = None
     external_issues: list[ErrorTrackingExternalReference] | None = None
-    first_seen: AwareDatetime
+    first_seen: datetime
     id: str
     name: str | None = None
     status: Status4
@@ -9133,6 +9143,7 @@ class EventsNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9181,6 +9192,7 @@ class EventsNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9261,6 +9273,7 @@ class ExperimentDataWarehouseNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9307,6 +9320,7 @@ class ExperimentDataWarehouseNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9341,6 +9355,7 @@ class ExperimentEventExposureConfig(BaseModel):
     properties: list[
         EventPropertyFilter
         | PersonPropertyFilter
+        | PersonOnEventPropertyFilter
         | ElementPropertyFilter
         | EventMetadataPropertyFilter
         | SessionPropertyFilter
@@ -9371,6 +9386,7 @@ class FeatureFlagGroupType(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9432,6 +9448,7 @@ class FunnelExclusionActionsNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9481,6 +9498,7 @@ class FunnelExclusionActionsNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9514,6 +9532,7 @@ class FunnelExclusionEventsNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9564,6 +9583,7 @@ class FunnelExclusionEventsNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9612,13 +9632,13 @@ class FunnelsQueryResponse(BaseModel):
 
 class GenericCachedQueryResponse(BaseModel):
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
     is_cached: bool
-    last_refresh: AwareDatetime
-    next_allowed_client_refresh: AwareDatetime
+    last_refresh: datetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -9668,6 +9688,7 @@ class HogQLFilters(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9931,6 +9952,7 @@ class PersonsNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -9961,6 +9983,7 @@ class PersonsNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -10005,6 +10028,7 @@ class PropertyGroupFilterValue(BaseModel):
         PropertyGroupFilterValue
         | EventPropertyFilter
         | PersonPropertyFilter
+        | PersonOnEventPropertyFilter
         | ElementPropertyFilter
         | EventMetadataPropertyFilter
         | SessionPropertyFilter
@@ -11414,6 +11438,7 @@ class RetentionEntity(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -11493,7 +11518,7 @@ class RetentionResult(BaseModel):
     breakdown_value: str | float | None = Field(
         default=None, description="Optional breakdown value for retention cohorts"
     )
-    date: AwareDatetime
+    date: datetime
     label: str
     values: list[RetentionValue]
 
@@ -11759,6 +11784,7 @@ class TileFilters(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -11791,6 +11817,7 @@ class TraceQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -11833,6 +11860,7 @@ class TracesQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -12142,6 +12170,7 @@ class ActionsNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -12189,6 +12218,7 @@ class ActionsNode(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -12281,7 +12311,7 @@ class CachedErrorTrackingQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12293,10 +12323,10 @@ class CachedErrorTrackingQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -12317,7 +12347,7 @@ class CachedHogQLQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12331,11 +12361,11 @@ class CachedHogQLQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     metadata: HogQLMetadataResponse | None = Field(default=None, description="Query metadata output")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query: str | None = Field(default=None, description="Input query string")
     query_metadata: dict[str, Any] | None = None
@@ -12360,7 +12390,7 @@ class CachedInsightActorsQueryOptionsResponse(BaseModel):
     breakdown: list[BreakdownItem] | None = None
     breakdowns: list[MultipleBreakdownOptions] | None = None
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12368,8 +12398,8 @@ class CachedInsightActorsQueryOptionsResponse(BaseModel):
     day: list[DayItem] | None = None
     interval: list[IntervalItem] | None = None
     is_cached: bool
-    last_refresh: AwareDatetime
-    next_allowed_client_refresh: AwareDatetime
+    last_refresh: datetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -12386,15 +12416,15 @@ class CachedNewExperimentQueryResponse(BaseModel):
     baseline: ExperimentStatsBaseValidated
     breakdown_results: list[ExperimentBreakdownResult] | None = None
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
     clickhouse_sql: str | None = None
     hogql: str | None = None
     is_cached: bool
-    last_refresh: AwareDatetime
-    next_allowed_client_refresh: AwareDatetime
+    last_refresh: datetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -12408,7 +12438,7 @@ class CachedRetentionQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12418,9 +12448,9 @@ class CachedRetentionQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -12440,7 +12470,7 @@ class CachedWebTrendsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12454,11 +12484,11 @@ class CachedWebTrendsQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     metadata: HogQLMetadataResponse | None = Field(default=None, description="Query metadata output")
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query: str | None = Field(default=None, description="Input query string")
     query_metadata: dict[str, Any] | None = None
@@ -12483,7 +12513,7 @@ class CachedWebVitalsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -12493,9 +12523,9 @@ class CachedWebVitalsQueryResponse(BaseModel):
     )
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -12626,9 +12656,9 @@ class ErrorTrackingCorrelatedIssue(BaseModel):
     description: str | None = None
     event: str
     external_issues: list[ErrorTrackingExternalReference] | None = None
-    first_seen: AwareDatetime
+    first_seen: datetime
     id: str
-    last_seen: AwareDatetime
+    last_seen: datetime
     library: str | None = None
     name: str | None = None
     odds_ratio: float
@@ -13105,6 +13135,7 @@ class RecordingsQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -13144,6 +13175,7 @@ class RecordingsQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -13222,6 +13254,7 @@ class StickinessQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -13288,6 +13321,7 @@ class TrendsQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -13383,7 +13417,7 @@ class CachedErrorTrackingIssueCorrelationQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -13395,10 +13429,10 @@ class CachedErrorTrackingIssueCorrelationQueryResponse(BaseModel):
     hasMore: bool | None = None
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     is_cached: bool
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -13419,7 +13453,7 @@ class CachedExperimentTrendsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -13429,8 +13463,8 @@ class CachedExperimentTrendsQueryResponse(BaseModel):
     insight: list[dict[str, Any]]
     is_cached: bool
     kind: Literal["ExperimentTrendsQuery"] = "ExperimentTrendsQuery"
-    last_refresh: AwareDatetime
-    next_allowed_client_refresh: AwareDatetime
+    last_refresh: datetime
+    next_allowed_client_refresh: datetime
     p_value: float
     probability: dict[str, float]
     query_metadata: dict[str, Any] | None = None
@@ -13470,6 +13504,7 @@ class CalendarHeatmapQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -13809,6 +13844,7 @@ class FunnelsQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -13852,6 +13888,7 @@ class InsightsQueryBaseCalendarHeatmapResponse(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -13894,6 +13931,7 @@ class InsightsQueryBaseFunnelsQueryResponse(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -13936,6 +13974,7 @@ class InsightsQueryBaseLifecycleQueryResponse(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -13978,6 +14017,7 @@ class InsightsQueryBasePathsQueryResponse(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -14020,6 +14060,7 @@ class InsightsQueryBaseRetentionQueryResponse(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -14062,6 +14103,7 @@ class InsightsQueryBaseTrendsQueryResponse(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -14127,6 +14169,7 @@ class LifecycleQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -14285,6 +14328,7 @@ class RetentionQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -14328,6 +14372,7 @@ class SessionsQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -14354,6 +14399,7 @@ class SessionsQuery(BaseModel):
             | PropertyGroupFilterValue
             | EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -14386,6 +14432,7 @@ class SessionsQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -14457,7 +14504,7 @@ class CachedExperimentFunnelsQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -14467,8 +14514,8 @@ class CachedExperimentFunnelsQueryResponse(BaseModel):
     insight: list[list[dict[str, Any]]]
     is_cached: bool
     kind: Literal["ExperimentFunnelsQuery"] = "ExperimentFunnelsQuery"
-    last_refresh: AwareDatetime
-    next_allowed_client_refresh: AwareDatetime
+    last_refresh: datetime
+    next_allowed_client_refresh: datetime
     probability: dict[str, float]
     query_metadata: dict[str, Any] | None = None
     query_status: QueryStatus | None = Field(
@@ -14493,7 +14540,7 @@ class CachedExperimentQueryResponse(BaseModel):
         ),
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -14503,11 +14550,11 @@ class CachedExperimentQueryResponse(BaseModel):
     insight: list[dict[str, Any]] | None = None
     is_cached: bool
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric | None = (
         None
     )
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     p_value: float | None = None
     probability: dict[str, float] | None = None
     query_metadata: dict[str, Any] | None = None
@@ -14527,7 +14574,7 @@ class CachedLegacyExperimentQueryResponse(BaseModel):
         extra="forbid",
     )
     cache_key: str
-    cache_target_age: AwareDatetime | None = None
+    cache_target_age: datetime | None = None
     calculation_trigger: str | None = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
@@ -14535,9 +14582,9 @@ class CachedLegacyExperimentQueryResponse(BaseModel):
     insight: list[dict[str, Any]]
     is_cached: bool
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
-    last_refresh: AwareDatetime
+    last_refresh: datetime
     metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric
-    next_allowed_client_refresh: AwareDatetime
+    next_allowed_client_refresh: datetime
     p_value: float
     probability: dict[str, float]
     query_metadata: dict[str, Any] | None = None
@@ -14691,6 +14738,7 @@ class PathsQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -15085,6 +15133,7 @@ class FunnelCorrelationActorsQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -15161,6 +15210,7 @@ class SessionBatchEventsQuery(BaseModel):
             | PropertyGroupFilterValue
             | EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -15196,6 +15246,7 @@ class SessionBatchEventsQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -15285,6 +15336,7 @@ class EventsQuery(BaseModel):
             | PropertyGroupFilterValue
             | EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter
@@ -15317,6 +15369,7 @@ class EventsQuery(BaseModel):
         list[
             EventPropertyFilter
             | PersonPropertyFilter
+            | PersonOnEventPropertyFilter
             | ElementPropertyFilter
             | EventMetadataPropertyFilter
             | SessionPropertyFilter

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4747,6 +4747,17 @@ class PersonPropertyFilter(BaseModel):
     value: list[str | float | bool] | str | float | bool | None = None
 
 
+class PersonOnEventPropertyFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: str
+    label: Optional[str] = None
+    operator: PropertyOperator
+    type: Literal["person_on_event"] = Field(default="person_on_event", description="Person properties on the event")
+    value: Optional[Union[list[Union[str, float, bool]], Union[str, float, bool]]] = None
+
+
 class PlanningStep(BaseModel):
     model_config = ConfigDict(
         extra="forbid",

--- a/posthog/types.py
+++ b/posthog/types.py
@@ -26,6 +26,7 @@ from posthog.schema import (
     LogEntryPropertyFilter,
     LogPropertyFilter,
     PathsQuery,
+    PersonOnEventPropertyFilter,
     PersonPropertyFilter,
     RecordingPropertyFilter,
     RetentionQuery,
@@ -52,6 +53,7 @@ type InsightActorsQueryNode = Union[
 
 type AnyPropertyFilter = Union[
     EventPropertyFilter,
+    PersonOnEventPropertyFilter,
     PersonPropertyFilter,
     ElementPropertyFilter,
     EventMetadataPropertyFilter,

--- a/products/batch_exports/backend/tests/temporal/test_spmc.py
+++ b/products/batch_exports/backend/tests/temporal/test_spmc.py
@@ -269,6 +269,7 @@ def test_use_distributed_events_recent_table(test_data: dict[str, typing.Any]):
 @pytest.mark.parametrize(
     "filters,expected_clause,expected_values",
     [
+        # Events
         (
             [
                 {"key": "$browser", "operator": "exact", "type": "event", "value": ["Firefox"]},
@@ -291,10 +292,45 @@ def test_use_distributed_events_recent_table(test_data: dict[str, typing.Any]):
             """and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_2)s), ''), 'null'), '^"|"$', ''), %(hogql_val_3)s), 0))""",
             {"hogql_val_0": "$browser", "hogql_val_1": "Firefox", "hogql_val_2": "test", "hogql_val_3": "Test"},
         ),
+        # Feature (subset of event)
+        (
+            [
+                {"key": "$feature/some-feature", "type": "event", "operator": "exact", "value": ["true"]},
+            ],
+            """ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), \'\'), \'null\'), \'^"|"$\', \'\'), %(hogql_val_1)s), 0)""",
+            {"hogql_val_0": "$feature/some-feature", "hogql_val_1": "true"},
+        ),
+        # Person
+        (
+            [
+                {"key": "$initial_current_url", "type": "person", "operator": "exact", "value": ["http://localhost"]},
+            ],
+            """ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s), 0)""",
+            {"hogql_val_0": "$initial_current_url", "hogql_val_1": "http://localhost"},
+        ),
+        # HogQL
+        (
+            [
+                {"key": "toInt(properties.$browser_version) * 10 = 1", "type": "hogql", "value": None},
+            ],
+            """ifNull(equals(multiply(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), \'\'), \'null\'), \'^"|"$\', \'\'), %(hogql_val_1)s), 10), 1), 0)""",
+            {"hogql_val_0": "$browser_version", "hogql_val_1": "Int64"},
+        ),
+    ],
+    ids=[
+        "events0",
+        "events1",
+        "events2",
+        "feature0",
+        "person0",
+        "hogql0",
     ],
 )
 def test_compose_filters_clause(
-    filters: list[dict[str, typing.Any]], expected_clause: str, expected_values: dict[str, str], ateam
+    filters: list[dict[str, typing.Any]],
+    expected_clause: str,
+    expected_values: dict[str, str],
+    ateam,
 ):
     result_clause, result_values = compose_filters_clause(filters, team_id=ateam.id)
     assert result_clause == expected_clause


### PR DESCRIPTION
## Problem

Add support for all the filters we support in workflows to batch exports. At the moment, we only did event property filters in batch exports. This adds feature flag, hogql, and person property filters in batch exports.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Adds a new property type so we can resolve to `person_properties` on the event rather than doing a join with persons table. This should mimic the behavior of workflows which resolves person filters with the person properties in the event.
* Adds all filter types to frontend so they can be selected.
* Update all the hogql stuff.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a unit test to verify we generate a sql that more or less looks ok.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
