### PR TITLE
feat(signals): Fix string timestamps cases (coming from cache)

### DIFF
--- a/ee/hogai/session_summaries/session/prompt_data.py
+++ b/ee/hogai/session_summaries/session/prompt_data.py
@@ -69,6 +69,10 @@ class SessionSummaryPromptData:
             # Stringify timestamp to avoid datetime objects in the prompt
             if timestamp_index is not None:
                 event_timestamp = simplified_event[timestamp_index]
+                if isinstance(event_timestamp, str):
+                    # Sometimes timestamps are stringified (when cache is hit), so it's safe to convert back to datetime.
+                    # It will be converted back to ISO next, but the conversion is required to confirm it's a valid datetime.
+                    event_timestamp = prepare_datetime(event_timestamp)
                 if not isinstance(event_timestamp, datetime):
                     raise ValueError(f"Timestamp is not a datetime: {event_timestamp}")
                 # All timestamps are stringified, so no datetime in the output type

--- a/ee/hogai/session_summaries/tests/test_prompt_data.py
+++ b/ee/hogai/session_summaries/tests/test_prompt_data.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -120,6 +120,67 @@ def test_load_session_data(
     assert first_event[get_column_index(mock_events_columns, "$current_url")] == "url_1"  # url mapped
     assert isinstance(first_event[get_column_index(mock_events_columns, "event_id")], str)  # event_id is hex string
     assert first_event[get_column_index(mock_events_columns, "event_index")] == 0  # event_index is 0 for first event
+
+
+@pytest.mark.parametrize(
+    "timestamp_value",
+    [
+        datetime(2025, 3, 31, 18, 40, 39, 302000, tzinfo=UTC),  # datetime object (direct from DB)
+        "2025-03-31T18:40:39.302000+00:00",  # ISO string (from cache)
+    ],
+    ids=["datetime_object", "iso_string_from_cache"],
+)
+def test_load_session_data_handles_timestamp_formats(
+    timestamp_value: datetime | str,
+    mock_raw_metadata: dict[str, Any],
+    mock_session_id: str,
+) -> None:
+    """Timestamps can be datetime objects (direct from DB) or ISO strings (from cache deserialization)."""
+    prompt_data = SessionSummaryPromptData()
+    raw_columns = ["event", "timestamp", "$window_id", "$current_url", "uuid"]
+    raw_events = [
+        ("$pageview", timestamp_value, "window-1", "http://example.com", "uuid-1"),
+    ]
+    events_mapping, _ = prompt_data.load_session_data(
+        raw_session_events=raw_events,
+        raw_session_metadata=mock_raw_metadata,
+        raw_session_columns=raw_columns,
+        session_id=mock_session_id,
+    )
+    assert len(events_mapping) == 1
+    event = next(events_mapping.values())[0]
+    timestamp_index = prompt_data.columns.index("timestamp")
+    assert event[timestamp_index] == "2025-03-31T18:40:39.302000+00:00"
+
+
+@pytest.mark.parametrize(
+    "invalid_timestamp,error_match",
+    [
+        ("not-a-datetime", "Invalid isoformat string"),  # malformed string
+        (12345, "Timestamp is not a datetime"),  # integer
+        (["2025-03-31"], "Timestamp is not a datetime"),  # list
+    ],
+    ids=["malformed_string", "integer", "list"],
+)
+def test_load_session_data_rejects_invalid_timestamps(
+    invalid_timestamp: Any,
+    error_match: str,
+    mock_raw_metadata: dict[str, Any],
+    mock_session_id: str,
+) -> None:
+    prompt_data = SessionSummaryPromptData()
+    raw_columns = ["event", "timestamp", "$window_id", "$current_url", "uuid"]
+    raw_events = [
+        ("$pageview", invalid_timestamp, "window-1", "http://example.com", "uuid-1"),
+    ]
+
+    with pytest.raises(ValueError, match=error_match):
+        prompt_data.load_session_data(
+            raw_session_events=raw_events,
+            raw_session_metadata=mock_raw_metadata,
+            raw_session_columns=raw_columns,
+            session_id=mock_session_id,
+        )
 
 
 def test_prepare_metadata_missing_required_fields() -> None:

--- a/ee/hogai/session_summaries/tests/test_prompt_data.py
+++ b/ee/hogai/session_summaries/tests/test_prompt_data.py
@@ -148,7 +148,7 @@ def test_load_session_data_handles_timestamp_formats(
         session_id=mock_session_id,
     )
     assert len(events_mapping) == 1
-    event = next(events_mapping.values())[0]
+    event = next(iter(events_mapping.values()))
     timestamp_index = prompt_data.columns.index("timestamp")
     assert event[timestamp_index] == "2025-03-31T18:40:39.302000+00:00"
 

--- a/ee/hogai/session_summaries/tests/test_prompt_data.py
+++ b/ee/hogai/session_summaries/tests/test_prompt_data.py
@@ -138,7 +138,7 @@ def test_load_session_data_handles_timestamp_formats(
     """Timestamps can be datetime objects (direct from DB) or ISO strings (from cache deserialization)."""
     prompt_data = SessionSummaryPromptData()
     raw_columns = ["event", "timestamp", "$window_id", "$current_url", "uuid"]
-    raw_events = [
+    raw_events: list[tuple[str | datetime | list[str] | None, ...]] = [
         ("$pageview", timestamp_value, "window-1", "http://example.com", "uuid-1"),
     ]
     events_mapping, _ = prompt_data.load_session_data(
@@ -170,7 +170,7 @@ def test_load_session_data_rejects_invalid_timestamps(
 ) -> None:
     prompt_data = SessionSummaryPromptData()
     raw_columns = ["event", "timestamp", "$window_id", "$current_url", "uuid"]
-    raw_events = [
+    raw_events: list[tuple[str | datetime | list[str] | None, ...]] = [
         ("$pageview", invalid_timestamp, "window-1", "http://example.com", "uuid-1"),
     ]
 


### PR DESCRIPTION
## Problem
- When datetimes come from cache - they are stringified, so force the workflow to fail

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Check if the valid datetime, and convert to datetime, instead of failing

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
