### PR TITLE
fix(surveys): timezone bug in date filters

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1270,7 +1270,7 @@ export function componentsToDayJs(
 /** Convert a string like "-30d" or "2022-02-02" or "-1mEnd" to `Dayjs().startOf('day')` */
 export function dateStringToDayJs(date: string | null, timezone: string = 'UTC'): dayjs.Dayjs | null {
     if (isDate.test(date || '')) {
-        return dayjs(date).tz(timezone)
+        return dayjs.tz(date, timezone)
     }
     const dateComponents = dateStringToComponents(date)
     if (!dateComponents) {

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -606,17 +606,13 @@ export function getResolvedSurveyDateRange(
     let fromDate = getSurveyStartDateForQuery(survey)
     let toDate = getSurveyEndDateForQuery(survey)
 
+    // date_from only is valid ("from custom date until now")
+    // date_to only is ignored to avoid impossible ranges
     if (dateRange?.date_from) {
-        const userFromDate = dateStringToDayJs(dateRange.date_from)?.startOf('day')
-        if (userFromDate && userFromDate.isAfter(fromDate)) {
-            fromDate = userFromDate.format(DATE_FORMAT)
-        }
-    }
+        fromDate = dateStringToDayJs(dateRange.date_from)?.startOf('day').format(DATE_FORMAT) ?? fromDate
 
-    if (dateRange?.date_to) {
-        const userToDate = dateStringToDayJs(dateRange.date_to)?.endOf('day')
-        if (userToDate && userToDate.isBefore(toDate)) {
-            toDate = userToDate.format(DATE_FORMAT)
+        if (dateRange.date_to) {
+            toDate = dateStringToDayJs(dateRange.date_to)?.endOf('day').format(DATE_FORMAT) ?? toDate
         }
     }
 


### PR DESCRIPTION
## Problem

when a user chooses a single date in a custom date filter, the end date incorrectly has +1 day added to it.

e.g. setting a filter on nov 20 - nov 20 produces a URL like this (correct):

```
?date_from=2025-11-20&date_to=2025-11-20T23%3A59%3A59
```

...but the generated hogql query adds a day:

```sql
AND timestamp >= '2025-11-20T00:00:00'
AND timestamp <= '2025-11-21T23:59:59' -- 🚨 bug go brrrrrrr
```

the issue is in `lib/utils:dateStringToDayJs`, it does something like this:

```javascript
dayjs(date).tz('UTC')
```

which parses as local time first, then converts to UTC. example:

```javascript
const endDate = '2025-11-20T23:59:59';

dayjs(input); // 2025-11-20T23:59:59 -08:00
dayjs(input).tz('UTC'); // 2025-11-21T07:59:59 +00:00
dayjs(input).tz('UTC').endOf('day'); // 2025-11-21T23:59:59 +00:00
```

additionally, if a user selects a date before the survey was launched, our clamping logic introduces an impossible range. e.g. i have a survey launched on nov 19, if i select october 3 as the date in my filter, the query ends up with this:

```sql
AND timestamp >= '2025-11-19T00:00:00' -- the start date of the survey
AND timestamp <= '2025-10-04T23:59:59' -- the date i selected
```

closes #41286

## Changes

- removed clamping logic; if a user selects a date outside the survey range, they just get empty results, and that is fine
    - if only `date_to` is provided without `date_from`, we ignore it and use survey defaults to avoid impossible ranges
    - `date_from` is always respected; `date_to` is applied only when `date_from` is also present​
- updated `dateStringToDayJs` to use `dayjs.tz()` instead of `dayjs().tz()`, so the date is parsed as the correct timezone, not parsed _then_ converted

## How did you test this code?

- added unit tests

### local testing cases

**using a survey that was launched on november 24**

#### valid filter range: nov 24 - nov 25

- URL: `date_from=2025-11-24&date_to=2025-11-25T23%3A59%3A59`
- hogql:

```sql
AND timestamp >= '2025-11-24T00:00:00'
AND timestamp <= '2025-11-25T23:59:59'
```

#### single day filter in-range: nov 24 - nov 24

- URL: `date_from=2025-11-24&date_to=2025-11-24T23%3A59%3A59`
- hogql:

```sql
timestamp >= '2025-11-24T00:00:00'
AND timestamp <= '2025-11-24T23:59:59'
```

#### date range out of bounds: nov 20 - nov 22

- URL: `date_from=2025-11-20&date_to=2025-11-22T23%3A59%3A59`
- hogql:

```sql
AND timestamp >= '2025-11-20T00:00:00'
AND timestamp <= '2025-11-22T23:59:59'
```

#### "from custom date til now": nov 24

- URL: `date_from=2025-11-24`
- hogql:

```sql
AND timestamp >= '2025-11-24T00:00:00'
AND timestamp <= '2025-11-25T23:59:59'
```

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->