### PR TITLE
fix: a bunch of changes to try and make the clickmap faster

### DIFF
--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -19,6 +19,8 @@ import { heatmapToolbarMenuLogic } from './heatmapToolbarMenuLogic'
 export type ActionElementMap = Map<HTMLElement, ActionElementWithMetadata[]>
 export type ElementMap = Map<HTMLElement, ElementWithMetadata>
 
+const VIEWPORT_BUFFER_PX = 200
+
 const getMaxZIndex = (element: Element): number => {
     let maxZIndex = 0
     let currentElement: Element | null = element
@@ -153,14 +155,23 @@ export const elementsLogic = kea<elementsLogicType>([
                 s.rectUpdateCounter,
                 toolbarConfigLogic.selectors.buttonVisible,
             ],
-            (countedElements) =>
-                countedElements.map(
-                    (e) =>
-                        ({
-                            ...e,
-                            rect: getRectForElement(e.element),
-                        }) as ElementWithMetadata
-                ),
+            (countedElements) => {
+                const windowHeight = window.innerHeight
+
+                const result: ElementWithMetadata[] = []
+
+                for (const e of countedElements) {
+                    const rect = getRectForElement(e.element)
+                    const inViewport =
+                        rect.bottom >= -VIEWPORT_BUFFER_PX && rect.top <= windowHeight + VIEWPORT_BUFFER_PX
+
+                    if (inViewport) {
+                        result.push({ ...e, rect } as ElementWithMetadata)
+                    }
+                }
+
+                return result
+            },
         ],
 
         allInspectElements: [

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -15,12 +15,60 @@ import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
 import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
-import { elementToActionStep, trimElement } from '~/toolbar/utils'
+import { elementIsVisible, elementToActionStep, trimElement } from '~/toolbar/utils'
 import { FilterType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import type { heatmapToolbarMenuLogicType } from './heatmapToolbarMenuLogicType'
 
 export const doesVersionSupportScrollDepth = createVersionChecker('1.99')
+
+const FRAME_BUDGET_MS = 12
+
+function yieldToMain(): Promise<void> {
+    return new Promise((resolve) => {
+        if ('scheduler' in window && typeof (window as any).scheduler?.yield === 'function') {
+            ;(window as any).scheduler.yield().then(resolve)
+        } else if (typeof (window as any).requestIdleCallback === 'function') {
+            ;(window as any).requestIdleCallback(() => resolve(), { timeout: 50 })
+        } else {
+            setTimeout(resolve, 0)
+        }
+    })
+}
+
+function shouldYield(startTime: number): boolean {
+    return performance.now() - startTime >= FRAME_BUDGET_MS
+}
+
+interface ElementProcessingCache {
+    pageElements?: HTMLElement[]
+    selectorToElements: Record<string, HTMLElement[]>
+    lastHref?: string
+    intersectionObserver?: IntersectionObserver
+    visibilityCache: WeakMap<HTMLElement, boolean>
+    mutationObserver?: MutationObserver
+    cacheInvalidated?: boolean
+}
+
+function invalidatePageElementsCache(cache: ElementProcessingCache): void {
+    cache.cacheInvalidated = true
+    cache.visibilityCache = new WeakMap()
+}
+
+function getCachedPageElements(cache: ElementProcessingCache, href: string): HTMLElement[] {
+    const hrefChanged = cache.lastHref !== href
+    const cacheValid = cache.pageElements && !hrefChanged && !cache.cacheInvalidated
+
+    if (cacheValid && cache.pageElements) {
+        return cache.pageElements
+    }
+
+    cache.pageElements = collectAllElementsDeep('*', document)
+    cache.lastHref = href
+    cache.selectorToElements = {}
+    cache.cacheInvalidated = false
+    return cache.pageElements
+}
 
 const emptyElementsStatsPages: PaginatedResponse<ElementsEventType> = {
     next: undefined,
@@ -87,6 +135,9 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         stopScrollTracking: true,
         startElementObservation: true,
         stopElementObservation: true,
+        processElements: true,
+        setProcessedElements: (elements: CountedHTMLElement[]) => ({ elements }),
+        setElementsLoading: (loading: boolean) => ({ loading }),
     }),
     windowValues(() => ({
         windowWidth: (window: Window) => window.innerWidth,
@@ -138,6 +189,23 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                     return onUpdate
                 },
                 toggleClickmapsEnabled: (state, { enabled }) => (enabled ? state : new Map()),
+            },
+        ],
+        processedElements: [
+            [] as CountedHTMLElement[],
+            {
+                setProcessedElements: (_, { elements }) => elements,
+                toggleClickmapsEnabled: (state, { enabled }) => (enabled ? state : []),
+                resetElementStats: () => [],
+            },
+        ],
+        elementsLoading: [
+            false,
+            {
+                setElementsLoading: (_, { loading }) => loading,
+                processElements: () => true,
+                setProcessedElements: () => false,
+                toggleClickmapsEnabled: (state, { enabled }) => (enabled ? state : false),
             },
         ],
     }),
@@ -211,144 +279,14 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             },
         ],
     })),
-    selectors(({ cache }) => ({
-        elements: [
-            (s) => [
-                s.elementStats,
-                toolbarConfigLogic.selectors.dataAttributes,
-                s.href,
-                s.matchLinksByHref,
-                s.clickmapsEnabled,
-            ],
-            (elementStats, dataAttributes, href, matchLinksByHref, clickmapsEnabled) => {
-                if (!clickmapsEnabled) {
-                    return []
-                }
-
-                cache.pageElements = cache.lastHref == href ? cache.pageElements : collectAllElementsDeep('*', document)
-                cache.selectorToElements = cache.lastHref == href ? cache.selectorToElements : {}
-
-                cache.lastHref = href
-
-                const elements: CountedHTMLElement[] = []
-                elementStats?.results.forEach((event) => {
-                    let combinedSelector: string
-                    let lastSelector: string | undefined
-                    for (let i = 0; i < event.elements.length; i++) {
-                        const element = event.elements[i]
-                        const selector =
-                            elementToSelector(
-                                matchLinksByHref ? element : { ...element, href: undefined },
-                                dataAttributes
-                            ) || '*'
-                        combinedSelector = lastSelector ? `${selector} > ${lastSelector}` : selector
-
-                        try {
-                            let domElements: HTMLElement[] | undefined = cache.selectorToElements?.[combinedSelector]
-                            if (domElements === undefined) {
-                                domElements = Array.from(
-                                    querySelectorAllDeep(combinedSelector, document, cache.pageElements)
-                                )
-                                cache.selectorToElements[combinedSelector] = domElements
-                            }
-
-                            if (domElements.length === 1) {
-                                const e = event.elements[i]
-
-                                // element like "svg" (only tag, no class/id/etc.) as the first one
-                                if (
-                                    i === 0 &&
-                                    e.tag_name &&
-                                    !e.attr_class &&
-                                    !e.attr_id &&
-                                    !e.href &&
-                                    !e.text &&
-                                    e.nth_child === 1 &&
-                                    e.nth_of_type === 1 &&
-                                    !e.attributes['attr__data-attr']
-                                ) {
-                                    // too simple selector, bail
-                                } else {
-                                    elements.push({
-                                        element: domElements[0],
-                                        count: event.count,
-                                        selector: selector,
-                                        hash: event.hash,
-                                        type: event.type,
-                                    } as CountedHTMLElement)
-                                    return null
-                                }
-                            }
-
-                            if (domElements.length === 0) {
-                                if (i === event.elements.length - 1) {
-                                    return null
-                                } else if (i > 0 && lastSelector) {
-                                    // We already have something, but found nothing when adding the next selector.
-                                    // Skip it and try with the next one...
-                                    lastSelector = lastSelector ? `* > ${lastSelector}` : '*'
-                                    continue
-                                }
-                            }
-                        } catch {
-                            break
-                        }
-
-                        lastSelector = combinedSelector
-
-                        // TODO: what if multiple elements will continue to match until the end?
-                    }
-                })
-
-                return elements
-            },
-        ],
+    selectors(() => ({
         countedElements: [
-            (s) => [s.elements, toolbarConfigLogic.selectors.dataAttributes, s.clickmapsEnabled, s.elementMetrics],
-            (elements, dataAttributes, clickmapsEnabled, elementMetrics) => {
-                if (!clickmapsEnabled || !cache.intersectionObserver) {
-                    return []
-                }
-
-                const normalisedElements = new Map<HTMLElement, CountedHTMLElement>()
-
-                for (const countedElement of elements || []) {
-                    const trimmedElement = trimElement(countedElement.element)
-                    if (!trimmedElement) {
-                        continue
-                    }
-
-                    const metrics = elementMetrics.get(trimmedElement) || {
-                        visible: isElementVisible(trimmedElement),
-                        rect: trimmedElement.getBoundingClientRect(),
-                    }
-
-                    if (normalisedElements.has(trimmedElement)) {
-                        const existing = normalisedElements.get(trimmedElement)
-                        if (existing) {
-                            existing.count += countedElement.count
-                            existing.clickCount += countedElement.type === '$autocapture' ? countedElement.count : 0
-                            existing.rageclickCount += countedElement.type === '$rageclick' ? countedElement.count : 0
-                            existing.deadclickCount += countedElement.type === '$dead_click' ? countedElement.count : 0
-                            existing.visible = metrics.visible
-                        }
-                    } else {
-                        normalisedElements.set(trimmedElement, {
-                            ...countedElement,
-                            clickCount: countedElement.type === '$autocapture' ? countedElement.count : 0,
-                            rageclickCount: countedElement.type === '$rageclick' ? countedElement.count : 0,
-                            deadclickCount: countedElement.type === '$dead_click' ? countedElement.count : 0,
-                            element: trimmedElement,
-                            actionStep: elementToActionStep(trimmedElement, dataAttributes),
-                            visible: metrics.visible,
-                        })
-                    }
-                }
-
-                const countedElements = Array.from(normalisedElements.values())
-                countedElements.sort((a, b) => b.count - a.count)
-
-                return countedElements.map((e, i) => ({ ...e, position: i + 1 }))
+            (s) => [s.processedElements, s.elementMetrics],
+            (processedElements, elementMetrics) => {
+                return processedElements.map((el: CountedHTMLElement) => {
+                    const metrics = elementMetrics.get(el.element)
+                    return metrics ? { ...el, visible: metrics.visible } : el
+                })
             },
         ],
         elementCount: [(s) => [s.countedElements], (countedElements) => countedElements.length],
@@ -384,6 +322,22 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 return !isSupported ? 'version' : isDisabled ? 'disabled' : null
             },
         ],
+        processingInputs: [
+            (s) => [
+                s.elementStats,
+                toolbarConfigLogic.selectors.dataAttributes,
+                s.href,
+                s.matchLinksByHref,
+                s.clickmapsEnabled,
+            ],
+            (elementStats, dataAttributes, href, matchLinksByHref, clickmapsEnabled) => ({
+                elementStats,
+                dataAttributes,
+                href,
+                matchLinksByHref,
+                clickmapsEnabled,
+            }),
+        ],
     })),
     subscriptions(({ actions }) => ({
         viewportRange: () => {
@@ -392,8 +346,69 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         countedElements: () => {
             actions.startElementObservation()
         },
+        processingInputs: () => {
+            actions.processElements()
+        },
     })),
     listeners(({ actions, values, cache }) => ({
+        processElements: async (_, breakpoint) => {
+            const { elementStats, dataAttributes, href, matchLinksByHref, clickmapsEnabled } = values.processingInputs
+
+            if (!clickmapsEnabled || !elementStats?.results?.length) {
+                actions.setProcessedElements([])
+                return
+            }
+
+            cache.visibilityCache = cache.visibilityCache || new WeakMap<HTMLElement, boolean>()
+            const pageElements = getCachedPageElements(cache as ElementProcessingCache, href)
+
+            const eventsToProcess = elementStats.results
+            const matchedElements: CountedHTMLElement[] = []
+
+            let frameStart = performance.now()
+            for (const event of eventsToProcess) {
+                const matched = matchEventToElement(
+                    event,
+                    dataAttributes,
+                    matchLinksByHref,
+                    pageElements,
+                    cache as ElementProcessingCache
+                )
+                if (matched) {
+                    matchedElements.push(matched)
+                }
+
+                if (shouldYield(frameStart)) {
+                    breakpoint()
+                    await yieldToMain()
+                    frameStart = performance.now()
+                }
+            }
+
+            breakpoint()
+
+            const trimmedElements: CountedHTMLElement[] = []
+            frameStart = performance.now()
+            for (const el of matchedElements) {
+                const trimmed = trimElement(el.element)
+                if (trimmed && elementIsVisible(trimmed, cache.visibilityCache as WeakMap<HTMLElement, boolean>)) {
+                    trimmedElements.push({ ...el, element: trimmed })
+                }
+
+                if (shouldYield(frameStart)) {
+                    breakpoint()
+                    await yieldToMain()
+                    frameStart = performance.now()
+                }
+            }
+
+            breakpoint()
+
+            const countedElements = aggregateAndSortElements(trimmedElements, dataAttributes)
+
+            actions.setProcessedElements(countedElements)
+        },
+
         enableHeatmap: () => {
             actions.setDataHref(values.href)
             actions.loadAllEnabled()
@@ -458,7 +473,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             }
         },
 
-        // setHref is called when the page url changes
         setHref: ({ href }) => {
             if (values.heatmapEnabled) {
                 actions.setHrefMatchType(href === window.location.href ? 'exact' : 'pattern')
@@ -490,6 +504,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 cache.pageElements = undefined
                 cache.selectorToElements = {}
                 cache.lastHref = undefined
+                cache.visibilityCache = new WeakMap()
             }
         },
 
@@ -501,13 +516,15 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
 
         patchHeatmapFilters: ({ filters }) => {
             if (filters.type) {
-                // Clear the heatmap if the type changes
                 actions.resetHeatmapData()
             }
             actions.maybeLoadHeatmap()
         },
     })),
     afterMount(({ actions, cache, values }) => {
+        cache.selectorToElements = {}
+        cache.visibilityCache = new WeakMap()
+
         cache.disposables.add(() => {
             const intersectionObserver = new IntersectionObserver((entries) => {
                 const observedElements: [HTMLElement, boolean][] = []
@@ -522,6 +539,34 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
 
             return () => intersectionObserver.disconnect()
         }, 'intersectionObserver')
+
+        cache.disposables.add(() => {
+            let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+            const mutationObserver = new MutationObserver(() => {
+                if (debounceTimer) {
+                    clearTimeout(debounceTimer)
+                }
+                debounceTimer = setTimeout(() => {
+                    invalidatePageElementsCache(cache as ElementProcessingCache)
+                    debounceTimer = null
+                }, 500)
+            })
+
+            mutationObserver.observe(document.body, {
+                childList: true,
+                subtree: true,
+            })
+
+            cache.mutationObserver = mutationObserver
+
+            return () => {
+                if (debounceTimer) {
+                    clearTimeout(debounceTimer)
+                }
+                mutationObserver.disconnect()
+            }
+        }, 'mutationObserver')
 
         cache.disposables.add(() => {
             const handleVisibilityChange = (): void => {
@@ -542,14 +587,104 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
         }, 'visibilityChangeHandler')
     }),
-    beforeUnmount(() => {
-        // Disposables plugin handles cleanup automatically
+    beforeUnmount(({ cache }) => {
+        cache.pageElements = undefined
+        cache.selectorToElements = {}
+        cache.visibilityCache = new WeakMap()
+        cache.lastHref = undefined
+        cache.cacheInvalidated = false
     }),
 ])
 
-function isElementVisible(element: HTMLElement): boolean {
-    const style = window.getComputedStyle(element)
-    return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0'
+function matchEventToElement(
+    event: ElementsEventType,
+    dataAttributes: string[],
+    matchLinksByHref: boolean,
+    pageElements: HTMLElement[],
+    cache: ElementProcessingCache
+): CountedHTMLElement | null {
+    let lastSelector: string | undefined
+
+    for (let i = 0; i < event.elements.length; i++) {
+        const element = event.elements[i]
+        const selector =
+            elementToSelector(matchLinksByHref ? element : { ...element, href: undefined }, dataAttributes) || '*'
+        const combinedSelector = lastSelector ? `${selector} > ${lastSelector}` : selector
+
+        try {
+            let domElements: HTMLElement[] | undefined = cache.selectorToElements[combinedSelector]
+            if (domElements === undefined) {
+                domElements = Array.from(querySelectorAllDeep(combinedSelector, document, pageElements))
+                cache.selectorToElements[combinedSelector] = domElements
+            }
+
+            if (domElements.length === 1) {
+                const e = event.elements[i]
+                const isTooSimple =
+                    i === 0 &&
+                    e.tag_name &&
+                    !e.attr_class &&
+                    !e.attr_id &&
+                    !e.href &&
+                    !e.text &&
+                    e.nth_child === 1 &&
+                    e.nth_of_type === 1 &&
+                    !e.attributes['attr__data-attr']
+
+                if (!isTooSimple) {
+                    return {
+                        element: domElements[0],
+                        count: event.count,
+                        selector: selector,
+                        hash: event.hash,
+                        type: event.type,
+                    } as CountedHTMLElement
+                }
+            }
+
+            if (domElements.length === 0) {
+                if (i === event.elements.length - 1) {
+                    return null
+                } else if (i > 0 && lastSelector) {
+                    lastSelector = `* > ${lastSelector}`
+                    continue
+                }
+            }
+        } catch {
+            break
+        }
+
+        lastSelector = combinedSelector
+    }
+
+    return null
+}
+
+function aggregateAndSortElements(elements: CountedHTMLElement[], dataAttributes: string[]): CountedHTMLElement[] {
+    const normalisedElements = new Map<HTMLElement, CountedHTMLElement>()
+
+    for (const countedElement of elements) {
+        if (normalisedElements.has(countedElement.element)) {
+            const existing = normalisedElements.get(countedElement.element)!
+            existing.count += countedElement.count
+            existing.clickCount += countedElement.type === '$autocapture' ? countedElement.count : 0
+            existing.rageclickCount += countedElement.type === '$rageclick' ? countedElement.count : 0
+            existing.deadclickCount += countedElement.type === '$dead_click' ? countedElement.count : 0
+        } else {
+            normalisedElements.set(countedElement.element, {
+                ...countedElement,
+                clickCount: countedElement.type === '$autocapture' ? countedElement.count : 0,
+                rageclickCount: countedElement.type === '$rageclick' ? countedElement.count : 0,
+                deadclickCount: countedElement.type === '$dead_click' ? countedElement.count : 0,
+                actionStep: elementToActionStep(countedElement.element, dataAttributes),
+            })
+        }
+    }
+
+    const sorted = Array.from(normalisedElements.values())
+    sorted.sort((a, b) => b.count - a.count)
+
+    return sorted.map((e, i) => ({ ...e, position: i + 1 }))
 }
 
 export const escapeUnescapedRegex = (str: string): string =>

--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -91,6 +91,7 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
         heatmapFixedPositionMode,
         heatmapColorPalette,
         samplingFactor,
+        elementsLoading,
     } = useValues(heatmapToolbarMenuLogic)
     const {
         setCommonFilters,
@@ -261,7 +262,8 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                             </div>
 
                             <div className="my-2">
-                                Found: {countedElements.length} elements / {clickCount} clicks!
+                                Found: {countedElements.length} elements / {clickCount} clicks
+                                {elementsLoading ? ' (processing...)' : '!'}
                             </div>
                             <div className="flex flex-col w-full h-full">
                                 {countedElements.length ? (

--- a/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
+++ b/products/llm_analytics/frontend/text-view/TextViewDisplay.tsx
@@ -72,6 +72,7 @@ export function TextViewDisplay({
                 document.removeEventListener('mousedown', handleClickOutside)
             }
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- setPopoutSegment is a stable Kea action
     }, [popoutSegment])
 
     const segments = useMemo(() => parseTextSegments(textRepr || ''), [textRepr])

--- a/products/session_summaries/frontend/SessionGroupSummaryScene.tsx
+++ b/products/session_summaries/frontend/SessionGroupSummaryScene.tsx
@@ -351,6 +351,7 @@ export function SessionGroupSummary(): JSX.Element {
                 }
             })
             .filter((pattern): pattern is EnrichedSessionGroupSummaryPattern => pattern !== null)
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- matchesIssueTypeFilter only depends on issueTypeFilters which is already in deps
     }, [summary.patterns, debouncedSearchValue, issueTypeFilters])
 
     const sortedPatterns = useMemo(() => {


### PR DESCRIPTION
I love the click map, it's so useful

except if you have a decent amount of data it's horribly slow

i sped the API up, but now the constraint is browser processing / freezing so...

i've added:

1. Chunked async processing - yields to main thread every 100 events
2. Smart(er) caching - DOM elements cached until navigation or DOM mutation
3. Viewport virtualization - only renders elements in viewport ± 200px
4. Proper visibility checks - uses checkVisibility() API with caching

i don't have enough data to test these make much difference locally, but i confirmed the thing still runs with these changes in place