### PR TITLE
feat(llma): add `duration_seconds` to some reporting events

### DIFF
--- a/products/llm_analytics/backend/api/summarization.py
+++ b/products/llm_analytics/backend/api/summarization.py
@@ -8,6 +8,7 @@ Endpoint:
 - POST /api/projects/:id/llm_analytics/summarize/ - Summarize trace or event
 """
 
+import time
 from typing import cast
 
 from django.conf import settings
@@ -339,12 +340,15 @@ The response includes the summary text and optional metadata.
 
             text_repr = self._generate_text_repr(summarize_type, entity_data)
 
+            start_time = time.time()
             summary = async_to_sync(summarize)(
                 text_repr=text_repr,
                 team_id=self.team_id,
                 trace_id=entity_id,
                 mode=mode,
             )
+
+            duration_seconds = time.time() - start_time
 
             result = self._build_summary_response(summary, text_repr, summarize_type)
 
@@ -368,6 +372,7 @@ The response includes the summary text and optional metadata.
                     "mode": mode,
                     "text_repr_length": len(text_repr),
                     "force_refresh": force_refresh,
+                    "duration_seconds": duration_seconds,
                 },
                 self.team,
             )

--- a/products/llm_analytics/backend/api/text_repr.py
+++ b/products/llm_analytics/backend/api/text_repr.py
@@ -13,6 +13,7 @@ Endpoint:
 """
 
 import json
+import time
 import hashlib
 from typing import cast
 
@@ -306,6 +307,7 @@ The response includes the formatted text and metadata about the rendering.
                 return Response(cached_result, status=status.HTTP_200_OK)
 
             # Cache miss - generate text representation
+            start_time = time.time()
             if event_type == "$ai_trace":
                 # For traces, expect data to have trace and hierarchy
                 text = format_trace_text_repr(
@@ -316,6 +318,7 @@ The response includes the formatted text and metadata about the rendering.
             else:
                 # For $ai_generation and $ai_span
                 text = format_event_text_repr(event=data, options=options)
+            duration_seconds = time.time() - start_time
 
             # Apply max_length cap if output exceeds limit
             max_len = options.get("max_length", 4000000)
@@ -365,6 +368,7 @@ The response includes the formatted text and metadata about the rendering.
                     "entity_id": entity_id,
                     "char_count": len(text),
                     "truncated": truncated_by_max_length,
+                    "duration_seconds": duration_seconds,
                 },
                 self.team,
             )


### PR DESCRIPTION
## Problem

LLM analytics reporting events for summarization and text repr generation don't include timing information, making it harder to track performance metrics.

## Changes

- Add `duration_seconds` to the `llma summarization generated` user action event
- Add `duration_seconds` to the `llma text repr generated` user action event

Both measure the time taken by the core processing (LLM call for summarization, text formatting for text repr).

## How did you test this code?

Tested locally.

## Changelog: (features only) Is this feature complete?

No - internal analytics improvement only.