### PR TITLE
fix: pre-commit hook

### DIFF
--- a/common/hogli/core/command_types.py
+++ b/common/hogli/core/command_types.py
@@ -219,9 +219,9 @@ class DirectCommand(Command):
         if has_operators:
             # For shell commands, pass args as positional parameters using sh -c
             if args:
-                # Pass the script as first arg, script name as $0, then actual args as $1, $2, etc.
+                # Pass args as positional parameters: _ is placeholder for $0, then actual args as $1, $2, etc.
                 escaped_args = " ".join(shlex.quote(arg) for arg in args)
-                cmd_str = f"sh -c {shlex.quote(cmd_str)} -- {escaped_args}"
+                cmd_str = f"sh -c {shlex.quote(cmd_str)} _ {escaped_args}"
             _run(cmd_str, shell=True)
         else:
             # Use list format for simple commands without shell operators

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -432,14 +432,14 @@ quality:
         cmd: pnpm prettier --write
         description: Format JSON, YAML files
     format:css:
-        cmd: pnpm stylelint --fix --allow-empty-input && pnpm prettier --write
+        cmd: pnpm stylelint --fix --allow-empty-input "$@" && pnpm prettier --write "$@"
         description: Format CSS/SCSS files
     format:js:
-        cmd: pnpm oxlint --fix --fix-suggestions --quiet && pnpm prettier --write
+        cmd: pnpm oxlint --fix --fix-suggestions --quiet "$@" && pnpm prettier --write "$@"
         description: Format JavaScript/TypeScript files (frontend)
     format:plugin-server:
-        cmd: pnpm --dir plugin-server exec eslint --fix && pnpm --dir plugin-server exec
-            prettier --write
+        cmd: pnpm --dir plugin-server exec eslint --fix "$@" && pnpm --dir plugin-server exec
+            prettier --write "$@"
         description: Format plugin-server JavaScript files
     format:rust:
         cmd: rustfmt


### PR DESCRIPTION
## Changes

- Fix lint-staged pre-commit hook failing with "No parser and no file path given"
- Commands with `&&` (like `format:js`) weren't passing file args to each tool in the chain
- Changed `sh -c` to use `_` placeholder for `$0` so `$@` works correctly
- Added `"$@"` to format commands that need to pass files to multiple tools

## How did you test this code?

- Ran existing tests
- Manually
  - Made a small change in `tsx` file and tried to commit - error
  - Implemented fix, tried to commit - worked
