### PR TITLE
perf(docker): optimize uv usage following Astral recommendations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,15 +129,20 @@ RUN NODE_OPTIONS="--max-old-space-size=16384" bin/turbo --filter=@posthog/plugin
 #
 # ---------------------------------------------------------
 #
+FROM ghcr.io/astral-sh/uv:0.9.9 AS uv
+
 # Same as pyproject.toml so that uv can pick it up and doesn't need to download a different Python version.
 FROM python:3.12.12-slim-bookworm AS posthog-build
+COPY --from=uv /uv /uvx /bin/
 WORKDIR /code
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
-# Compile and install Python dependencies.
-# We install those dependencies on a custom folder that we will
-# then copy to the last image.
-COPY pyproject.toml uv.lock ./
+# uv settings for Docker builds
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_PROJECT_ENVIRONMENT=/python-runtime
+
+# Install build dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     "build-essential" \
@@ -149,9 +154,13 @@ RUN apt-get update && \
     "zlib1g-dev" \
     "pkg-config" \
     && \
-    rm -rf /var/lib/apt/lists/* && \
-    pip install uv==0.9.9 --no-cache-dir && \
-    UV_PROJECT_ENVIRONMENT=/python-runtime uv sync --frozen --no-dev --no-cache --compile-bytecode --no-binary-package lxml --no-binary-package xmlsec
+    rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies using cache mount for faster rebuilds
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-dev --no-install-project --no-binary-package lxml --no-binary-package xmlsec
 
 ENV PATH=/python-runtime/bin:$PATH \
     PYTHONPATH=/python-runtime

--- a/Dockerfile.ai-evals
+++ b/Dockerfile.ai-evals
@@ -1,13 +1,20 @@
 # Same as pyproject.toml so that uv can pick it up and doesn't need to download a different Python version.
 FROM python:3.12.12-slim-bookworm AS python-base
+FROM ghcr.io/astral-sh/uv:0.9.9 AS uv
 FROM cruizba/ubuntu-dind:latest
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
-# Copy Python base
+# Copy Python base and uv
 COPY --from=python-base /usr/local /usr/local
+COPY --from=uv /uv /uvx /bin/
 
 # Set working directory
 WORKDIR /code
+
+# uv settings for Docker builds
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_PROJECT_ENVIRONMENT=/python-runtime
 
 # Copy Docker scripts
 COPY docker/ ./docker/
@@ -24,16 +31,15 @@ RUN apt-get update && \
     "zlib1g-dev" \
     "pkg-config" \
     "netcat-openbsd" \
-    "postgresql-client"
+    "postgresql-client" \
+    && \
+    rm -rf /var/lib/apt/lists/*
 
-# Copy uv dependencies
-COPY pyproject.toml uv.lock docker-compose.base.yml docker-compose.dev.yml ./
-
-# Install python deps
-RUN rm -rf /var/lib/apt/lists/* && \
-pip install uv==0.9.9 --no-cache-dir && \
-UV_PROJECT_ENVIRONMENT=/python-runtime uv sync --frozen --no-cache --compile-bytecode \
---no-binary-package lxml --no-binary-package xmlsec
+# Install Python dependencies using cache mount for faster rebuilds
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project --no-binary-package lxml --no-binary-package xmlsec
 
 # Copy project files
 COPY bin/ ./bin/
@@ -43,6 +49,7 @@ COPY common/hogvm common/hogvm/
 COPY posthog posthog/
 COPY products/ products/
 COPY ee ee/
+COPY docker-compose.base.yml docker-compose.dev.yml ./
 
 ENV PATH=/python-runtime/bin:$PATH \
     PYTHONPATH=/python-runtime


### PR DESCRIPTION
Stacked on #42122

Follows [Astral's Docker best practices](https://docs.astral.sh/uv/guides/integration/docker/):

- `COPY --from=ghcr.io/astral-sh/uv:0.9.9` instead of `pip install uv` - faster, pre-compiled binary
- Cache mounts (`--mount=type=cache,target=/root/.cache/uv`) - speeds up rebuilds
- `--locked` instead of `--frozen` - validates lockfile matches pyproject.toml
- `UV_COMPILE_BYTECODE=1` and `UV_LINK_MODE=copy` env vars
- `--no-install-project` with bind mounts for better layer caching