### PR TITLE
feat(logs): improve timestamp formatting

### DIFF
--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -32,6 +32,8 @@ export type TZLabelProps = Omit<LemonDropdownProps, 'overlay' | 'trigger' | 'chi
     className?: string
     title?: string
     children?: JSX.Element
+    showNow?: boolean
+    showToday?: boolean
 }
 
 const TZLabelPopoverContent = React.memo(function TZLabelPopoverContent({
@@ -139,6 +141,8 @@ const TZLabelRaw = forwardRef<HTMLElement, TZLabelProps>(function TZLabelRaw(
     {
         time,
         showSeconds,
+        showNow = true,
+        showToday = true,
         formatDate,
         formatTime,
         showPopover = true,
@@ -154,7 +158,7 @@ const TZLabelRaw = forwardRef<HTMLElement, TZLabelProps>(function TZLabelRaw(
 
     const format = useCallback(() => {
         return formatDate || formatTime
-            ? humanFriendlyDetailedTime(parsedTime, formatDate, formatTime)
+            ? humanFriendlyDetailedTime(parsedTime, formatDate, formatTime, { showNow, showToday })
             : parsedTime.fromNow()
     }, [formatDate, formatTime, parsedTime])
 

--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -160,7 +160,7 @@ const TZLabelRaw = forwardRef<HTMLElement, TZLabelProps>(function TZLabelRaw(
         return formatDate || formatTime
             ? humanFriendlyDetailedTime(parsedTime, formatDate, formatTime, { showNow, showToday })
             : parsedTime.fromNow()
-    }, [formatDate, formatTime, parsedTime])
+    }, [formatDate, formatTime, parsedTime, showNow, showToday])
 
     const [formattedContent, setFormattedContent] = useState(format())
 

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -702,7 +702,7 @@ export function humanFriendlyDetailedTime(
     date: dayjs.Dayjs | string | null | undefined,
     formatDate = 'MMMM DD, YYYY',
     formatTime = 'h:mm:ss A',
-    options = {}
+    options: { showNow?: boolean; showToday?: boolean } = {}
 ): string {
     const defaultOptions = {
         showNow: true,

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -701,20 +701,30 @@ export function humanFriendlyDiff(from: dayjs.Dayjs | string, to: dayjs.Dayjs | 
 export function humanFriendlyDetailedTime(
     date: dayjs.Dayjs | string | null | undefined,
     formatDate = 'MMMM DD, YYYY',
-    formatTime = 'h:mm:ss A'
+    formatTime = 'h:mm:ss A',
+    options = {}
 ): string {
+    const defaultOptions = {
+        showNow: true,
+        showToday: true,
+    }
+    const { showNow, showToday } = { ...defaultOptions, ...options }
     if (!date) {
         return 'Never'
     }
     const parsedDate = dayjs(date)
     const today = dayjs().startOf('day')
     const yesterday = today.clone().subtract(1, 'days').startOf('day')
-    if (parsedDate.isSame(dayjs(), 'm')) {
+    if (showNow && parsedDate.isSame(dayjs(), 'm')) {
         return 'Just now'
     }
     let formatString: string
     if (parsedDate.isSame(today, 'd')) {
-        formatString = `[Today] ${formatTime}`
+        if (showToday) {
+            formatString = `[Today] ${formatTime}`
+        } else {
+            formatString = formatTime
+        }
     } else if (parsedDate.isSame(yesterday, 'd')) {
         formatString = `[Yesterday] ${formatTime}`
     } else {

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -79,7 +79,7 @@ export function LogsScene(): JSX.Element {
         timestampFormat === 'absolute'
             ? {
                   formatDate: 'YYYY-MM-DD',
-                  formatTime: 'HH:mm:ss',
+                  formatTime: 'HH:mm:ss.SSS',
               }
             : {}
 
@@ -247,7 +247,9 @@ function LogsTable({
                         key: 'timestamp',
                         dataIndex: 'timestamp',
                         width: 180,
-                        render: (_, { timestamp }) => <TZLabel time={timestamp} {...tzLabelFormat} />,
+                        render: (_, { timestamp }) => (
+                            <TZLabel time={timestamp} {...tzLabelFormat} showNow={false} showToday={false} />
+                        ),
                     },
                     {
                         title: 'Level',

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -434,7 +434,11 @@ export const logsLogic = kea<logsLogicType>([
                 const data = Object.entries(
                     sparkline.reduce((accumulator, currentItem) => {
                         if (currentItem.time !== lastTime) {
-                            labels.push(humanFriendlyDetailedTime(currentItem.time))
+                            labels.push(
+                                humanFriendlyDetailedTime(currentItem.time, 'YYYY-MM-DD', 'HH:mm:ss', {
+                                    showNow: false,
+                                })
+                            )
                             dates.push(currentItem.time)
                             lastTime = currentItem.time
                             i++


### PR DESCRIPTION
## Problem

timestamps are using our generic timestamp formatter which at the moment is not really suitable, e.g. recent logs the time shows as "Just Now" which is very unhelpful. We also don't have millisecond precision which is useful for logs.

## Changes

No more "Just Now", show full timestamp with milliseconds

<img width="517" height="503" alt="image" src="https://github.com/user-attachments/assets/431d1239-05a6-48a3-b9a6-74631d7267be" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
