### PR TITLE
test(batch-exports): Fix commented-out assertions in tests

### DIFF
--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -59,28 +59,26 @@ def test_create_batch_export_with_interval_schedule(client: HttpClient, interval
     with mock.patch(
         "posthog.batch_exports.http.posthoganalytics.feature_enabled",
         return_value=True,
-    ):
+    ) as feature_enabled:
         response = create_batch_export(
             client,
             team.pk,
             batch_export_data,
         )
 
-    # TODO: Removed while `managed-viewsets` feature flag is active since this messes up this check
-    # This can be uncommented once the `managed-viewsets` feature flag is fully rolled out
-    # if interval == "every 5 minutes":
-    #     feature_enabled.assert_called_once_with(
-    #         "high-frequency-batch-exports",
-    #         str(team.uuid),
-    #         groups={"organization": str(team.organization.id)},
-    #         group_properties={
-    #             "organization": {
-    #                 "id": str(team.organization.id),
-    #                 "created_at": team.organization.created_at,
-    #             }
-    #         },
-    #         send_feature_flag_events=False,
-    #     )
+    if interval == "every 5 minutes":
+        feature_enabled.assert_any_call(
+            "high-frequency-batch-exports",
+            str(team.uuid),
+            groups={"organization": str(team.organization.id)},
+            group_properties={
+                "organization": {
+                    "id": str(team.organization.id),
+                    "created_at": team.organization.created_at,
+                }
+            },
+            send_feature_flag_events=False,
+        )
 
     assert response.status_code == status.HTTP_201_CREATED, response.json()
 
@@ -799,23 +797,22 @@ def databricks_integration(team, user):
 
 @pytest.fixture
 def enable_databricks(team):
-    with mock.patch("posthog.batch_exports.http.posthoganalytics.feature_enabled", return_value=True):
+    with mock.patch(
+        "posthog.batch_exports.http.posthoganalytics.feature_enabled", return_value=True
+    ) as feature_enabled:
         yield
-
-        # TODO: Removed while `managed-viewsets` feature flag is active since this messes up this check
-        # This can be uncommented once the `managed-viewsets` feature flag is fully rolled out
-        # feature_enabled.assert_called_once_with(
-        #     "databricks-batch-exports",
-        #     str(team.uuid),
-        #     groups={"organization": str(team.organization.id)},
-        #     group_properties={
-        #         "organization": {
-        #             "id": str(team.organization.id),
-        #             "created_at": team.organization.created_at,
-        #         }
-        #     },
-        #     send_feature_flag_events=False,
-        # )
+        feature_enabled.assert_any_call(
+            "databricks-batch-exports",
+            str(team.uuid),
+            groups={"organization": str(team.organization.id)},
+            group_properties={
+                "organization": {
+                    "id": str(team.organization.id),
+                    "created_at": team.organization.created_at,
+                }
+            },
+            send_feature_flag_events=False,
+        )
 
 
 def test_creating_databricks_batch_export_using_integration(


### PR DESCRIPTION
## Problem

A couple of the assertions in our tests were commented out by an [unrelated PR](https://github.com/PostHog/posthog/pull/40352/files#diff-6554599614c681cc6f01556cf68e8798a76bcb993feff82f9982eb1dfea4e208R69)

## Changes

Uncomment these assertions.

We can use [`assert_any_call`](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.assert_any_call) rather than `assert_called_once_with`.

## How did you test this code?

These are tests ;)
