### PR TITLE
feat(logs): support compression in logs capture

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -87,6 +87,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +279,19 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1400,6 +1428,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "brownstone"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1626,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tonic 0.12.3",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2003,6 +2053,26 @@ dependencies = [
  "time",
  "uuid",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
 
 [[package]]
 name = "concurrent-queue"
@@ -8508,12 +8578,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
+ "async-compression",
  "bitflags 2.9.1",
  "bytes",
+ "futures-core",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -105,7 +105,7 @@ time = { version = "0.3.36", features = [
 thiserror = { version = "2.0" }
 tokio = { version = "1.34.0", features = ["full"] }
 tower = { version = "0.4.13", features = ["default", "limit"] }
-tower-http = { version = "0.5.2", features = ["cors", "limit", "trace"] }
+tower-http = { version = "0.5.2", features = ["cors", "decompression-br", "decompression-deflate", "decompression-gzip", "decompression-zstd", "limit", "trace"] }
 tracing = "0.1.40"
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/rust/capture-logs/Cargo.toml
+++ b/rust/capture-logs/Cargo.toml
@@ -32,6 +32,7 @@ chrono = { workspace = true }
 apache-avro = { version = "0.18.0", features = ["zstandard"] }
 prost = "0.13.5"
 bytes = { workspace = true }
+tower-http = { workspace = true }
 
 [dev-dependencies]
 

--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -14,6 +14,7 @@ use health::HealthRegistry;
 use tokio::signal;
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
+use tower_http::decompression::RequestDecompressionLayer;
 
 use limiters::token_dropper::TokenDropper;
 
@@ -101,7 +102,8 @@ async fn main() {
         .route("/v1/logs", post(export_logs_http))
         .route("/i/v1/logs", post(export_logs_http))
         .with_state(logs_service)
-        .layer(axum::middleware::from_fn(track_metrics));
+        .layer(axum::middleware::from_fn(track_metrics))
+        .layer(RequestDecompressionLayer::new());
 
     let http_server = tokio::spawn(async move {
         if let Err(e) = axum::serve(

--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -12,9 +12,9 @@ use std::net::SocketAddr;
 
 use health::HealthRegistry;
 use tokio::signal;
+use tower_http::decompression::RequestDecompressionLayer;
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
-use tower_http::decompression::RequestDecompressionLayer;
 
 use limiters::token_dropper::TokenDropper;
 


### PR DESCRIPTION


## Problem
lots of otel exporters compress by default - we need to support this!

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

sent logs locally with and without compression, and again after the fix

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
