### PR TITLE
chore(signals): Include distinct ID in session summarization errors

### DIFF
--- a/ee/api/test/test_session_summaries.py
+++ b/ee/api/test/test_session_summaries.py
@@ -123,7 +123,7 @@ class TestSessionSummariesAPI(APIBaseTest):
         # Verify execute_summarize_session_group was called correctly
         mock_execute.assert_called_once_with(
             session_ids=["session1", "session2"],
-            user_id=self.user.pk,
+            user=self.user,
             team=self.team,
             min_timestamp=datetime(2024, 1, 1, 10, 0, 0),
             max_timestamp=datetime(2024, 1, 1, 11, 0, 0),

--- a/ee/hogai/chat_agent/session_summaries/nodes.py
+++ b/ee/hogai/chat_agent/session_summaries/nodes.py
@@ -488,7 +488,7 @@ class _SessionSummarizer:
             nonlocal completed
             result = await execute_summarize_session(
                 session_id=session_id,
-                user_id=self._node._user.id,
+                user=self._node._user,
                 team=self._node._team,
                 model_to_use=SESSION_SUMMARIES_SYNC_MODEL,
                 video_validation_enabled=video_validation_enabled,
@@ -521,7 +521,7 @@ class _SessionSummarizer:
 
         async for update_type, data in execute_summarize_session_group(
             session_ids=session_ids,
-            user_id=self._node._user.id,
+            user=self._node._user,
             team=self._node._team,
             min_timestamp=min_timestamp,
             max_timestamp=max_timestamp,

--- a/ee/hogai/session_summaries/session/stream.py
+++ b/ee/hogai/session_summaries/session/stream.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator
 
 from posthog.models.team.team import Team
+from posthog.models.user import User
 from posthog.settings import SERVER_GATEWAY_INTERFACE
 from posthog.temporal.ai.session_summary.summarize_session import execute_summarize_session_stream
 
@@ -10,7 +11,7 @@ from ee.hogai.utils.asgi import SyncIterableToAsync
 
 def stream_recording_summary(
     session_id: str,
-    user_id: int,
+    user: User,
     team: Team,
     extra_summary_context: ExtraSummaryContext | None = None,
     local_reads_prod: bool = False,
@@ -18,14 +19,14 @@ def stream_recording_summary(
     if SERVER_GATEWAY_INTERFACE == "ASGI":
         return _astream(
             session_id=session_id,
-            user_id=user_id,
+            user=user,
             team=team,
             extra_summary_context=extra_summary_context,
             local_reads_prod=local_reads_prod,
         )
     return execute_summarize_session_stream(
         session_id=session_id,
-        user_id=user_id,
+        user=user,
         team=team,
         extra_summary_context=extra_summary_context,
         local_reads_prod=local_reads_prod,
@@ -34,7 +35,7 @@ def stream_recording_summary(
 
 def _astream(
     session_id: str,
-    user_id: int,
+    user: User,
     team: Team,
     extra_summary_context: ExtraSummaryContext | None = None,
     local_reads_prod: bool = False,
@@ -42,7 +43,7 @@ def _astream(
     return SyncIterableToAsync(
         execute_summarize_session_stream(
             session_id=session_id,
-            user_id=user_id,
+            user=user,
             team=team,
             extra_summary_context=extra_summary_context,
             local_reads_prod=local_reads_prod,

--- a/ee/hogai/session_summaries/session/summarize_session.py
+++ b/ee/hogai/session_summaries/session/summarize_session.py
@@ -63,7 +63,7 @@ class SingleSessionSummaryLlmInputs:
 
     session_id: str
     user_id: int
-    user_distinct_id: str | None = None
+    user_distinct_id_to_log: str | None = None
     summary_prompt: str
     system_prompt: str
     simplified_events_mapping: dict[str, list[str | int | None | list[str]]]

--- a/ee/hogai/session_summaries/session/summarize_session.py
+++ b/ee/hogai/session_summaries/session/summarize_session.py
@@ -63,6 +63,7 @@ class SingleSessionSummaryLlmInputs:
 
     session_id: str
     user_id: int
+    user_distinct_id: str | None = None
     summary_prompt: str
     system_prompt: str
     simplified_events_mapping: dict[str, list[str | int | None | list[str]]]
@@ -218,7 +219,12 @@ async def prepare_data_for_single_session_summary(
 
 
 def prepare_single_session_summary_input(
-    session_id: str, user_id: int, summary_data: SingleSessionSummaryData, model_to_use: str
+    session_id: str,
+    user_id: int,
+    summary_data: SingleSessionSummaryData,
+    model_to_use: str,
+    *,
+    user_distinct_id_to_log: str | None = None,
 ) -> SingleSessionSummaryLlmInputs:
     # Checking here instead of in the preparation function to keep mypy happy
     if summary_data.prompt_data is None:
@@ -241,6 +247,7 @@ def prepare_single_session_summary_input(
     input_data = SingleSessionSummaryLlmInputs(
         session_id=session_id,
         user_id=user_id,
+        user_distinct_id_to_log=user_distinct_id_to_log,
         summary_prompt=summary_data.prompt.summary_prompt,
         system_prompt=summary_data.prompt.system_prompt,
         simplified_events_mapping=summary_data.prompt_data.simplified_events_mapping,

--- a/ee/hogai/session_summaries/tests/test_summarize_session.py
+++ b/ee/hogai/session_summaries/tests/test_summarize_session.py
@@ -48,7 +48,7 @@ class TestSummarizeSession:
             # Get the generator (stream simulation)
             empty_context = ExtraSummaryContext()
             result_generator = execute_summarize_session_stream(
-                session_id=mock_session_id, user_id=mock_user.id, team=mock_team, extra_summary_context=empty_context
+                session_id=mock_session_id, user=mock_user, team=mock_team, extra_summary_context=empty_context
             )
             # Get all results from generator (consume the stream fully)
             results = list(result_generator)
@@ -124,14 +124,14 @@ class TestSummarizeSession:
                 return_value=iter([ready_summary]),
             ) as mock_execute,
         ):
-            async_gen = stream_recording_summary(session_id=mock_session_id, user_id=mock_user.id, team=mock_team)
+            async_gen = stream_recording_summary(session_id=mock_session_id, user=mock_user, team=mock_team)
             assert isinstance(async_gen, SyncIterableToAsync)
             results = [chunk async for chunk in async_gen]
             assert len(results) == 1
             assert results[0] == ready_summary
             mock_execute.assert_called_once_with(
                 session_id=mock_session_id,
-                user_id=mock_user.id,
+                user=mock_user,
                 team=mock_team,
                 extra_summary_context=None,
                 local_reads_prod=False,
@@ -155,13 +155,13 @@ class TestSummarizeSession:
                 return_value=iter([ready_summary]),
             ) as mock_execute,
         ):
-            result_gen = stream_recording_summary(session_id=mock_session_id, user_id=mock_user.id, team=mock_team)
+            result_gen = stream_recording_summary(session_id=mock_session_id, user=mock_user, team=mock_team)
             results = list(result_gen)  # type: ignore[arg-type]
             assert len(results) == 1
             assert results[0] == ready_summary
             mock_execute.assert_called_once_with(
                 session_id=mock_session_id,
-                user_id=mock_user.id,
+                user=mock_user,
                 team=mock_team,
                 extra_summary_context=None,
                 local_reads_prod=False,

--- a/ee/hogai/tools/replay/summarize_sessions.py
+++ b/ee/hogai/tools/replay/summarize_sessions.py
@@ -459,7 +459,7 @@ class SummarizeSessionsTool(MaxTool):
             nonlocal completed
             result = await execute_summarize_session(
                 session_id=session_id,
-                user_id=self._user.id,
+                user=self._user,
                 team=self._team,
                 model_to_use=SESSION_SUMMARIES_SYNC_MODEL,
                 video_validation_enabled=video_validation_enabled,
@@ -496,7 +496,7 @@ class SummarizeSessionsTool(MaxTool):
 
         async for update_type, data in execute_summarize_session_group(
             session_ids=session_ids,
-            user_id=self._user.id,
+            user=self._user,
             team=self._team,
             min_timestamp=min_timestamp,
             max_timestamp=max_timestamp,

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1258,7 +1258,7 @@ class SessionRecordingViewSet(
         # If you want to test sessions locally - override `session_id` and `self.team.pk`
         # with session/team ids of your choice and set `local_reads_prod` to True
         return StreamingHttpResponse(
-            stream_recording_summary(session_id=session_id, user_id=user.pk, team=self.team),
+            stream_recording_summary(session_id=session_id, user=user, team=self.team),
             content_type=ServerSentEventRenderer.media_type,
         )
 

--- a/posthog/temporal/ai/session_summary/summarize_session_group.py
+++ b/posthog/temporal/ai/session_summary/summarize_session_group.py
@@ -22,6 +22,7 @@ from posthog.hogql_queries.ai.session_batch_events_query_runner import (
     create_session_batch_events_query,
 )
 from posthog.models.team.team import Team
+from posthog.models.user import User
 from posthog.redis import get_async_client
 from posthog.session_recordings.constants import DEFAULT_TOTAL_EVENTS_PER_QUERY
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
@@ -200,6 +201,7 @@ async def fetch_session_batch_events_activity(
         input_data = prepare_single_session_summary_input(
             session_id=session_id,
             user_id=inputs.user_id,
+            user_distinct_id_to_log=inputs.user_distinct_id_to_log,
             summary_data=summary_data,
             model_to_use=inputs.model_to_use,
         )
@@ -309,6 +311,7 @@ class SummarizeSessionGroupWorkflow(PostHogWorkflow):
             single_session_input = SingleSessionSummaryInputs(
                 session_id=session_id,
                 user_id=inputs.user_id,
+                user_distinct_id_to_log=inputs.user_distinct_id_to_log,
                 team_id=inputs.team_id,
                 redis_key_base=inputs.redis_key_base,
                 model_to_use=inputs.model_to_use,
@@ -468,6 +471,7 @@ class SummarizeSessionGroupWorkflow(PostHogWorkflow):
                 chunk_summaries_input = SessionGroupSummaryOfSummariesInputs(
                     single_session_summaries_inputs=chunk_inputs,
                     user_id=inputs.user_id,
+                    user_distinct_id_to_log=inputs.user_distinct_id_to_log,
                     team_id=inputs.team_id,
                     summary_title=inputs.summary_title,
                     model_to_use=inputs.model_to_use,
@@ -515,6 +519,7 @@ class SummarizeSessionGroupWorkflow(PostHogWorkflow):
                 redis_keys_of_chunks_to_combine=redis_keys_of_chunks_to_combine,
                 session_ids=session_ids_with_patterns_extracted,
                 user_id=inputs.user_id,
+                user_distinct_id_to_log=inputs.user_distinct_id_to_log,
                 team_id=inputs.team_id,
                 redis_key_base=inputs.redis_key_base,
                 extra_summary_context=inputs.extra_summary_context,
@@ -539,6 +544,7 @@ class SummarizeSessionGroupWorkflow(PostHogWorkflow):
             SessionGroupSummaryOfSummariesInputs(
                 single_session_summaries_inputs=summaries_session_inputs,
                 user_id=inputs.user_id,
+                user_distinct_id_to_log=inputs.user_distinct_id_to_log,
                 team_id=inputs.team_id,
                 summary_title=inputs.summary_title,
                 model_to_use=inputs.model_to_use,
@@ -564,6 +570,7 @@ class SummarizeSessionGroupWorkflow(PostHogWorkflow):
             SessionGroupSummaryOfSummariesInputs(
                 single_session_summaries_inputs=single_session_summaries_inputs,
                 user_id=inputs.user_id,
+                user_distinct_id_to_log=inputs.user_distinct_id_to_log,
                 team_id=inputs.team_id,
                 summary_title=inputs.summary_title,
                 model_to_use=inputs.model_to_use,
@@ -675,7 +682,7 @@ def _generate_shared_id(session_ids: list[str]) -> str:
 
 async def execute_summarize_session_group(
     session_ids: list[str],
-    user_id: int,
+    user: User,
     team: Team,
     min_timestamp: datetime,
     max_timestamp: datetime,
@@ -697,10 +704,11 @@ async def execute_summarize_session_group(
     # Use shared identifier to be able to construct all the ids to check/debug.
     shared_id = _generate_shared_id(session_ids)
     # Prepare the input data
-    redis_key_base = f"session-summary:group:{user_id}-{team.id}:{shared_id}"
+    redis_key_base = f"session-summary:group:{user.id}-{team.id}:{shared_id}"
     session_group_input = SessionGroupSummaryInputs(
         session_ids=session_ids,
-        user_id=user_id,
+        user_id=user.id,
+        user_distinct_id_to_log=user.user_distinct_id_to_log,
         team_id=team.id,
         redis_key_base=redis_key_base,
         summary_title=summary_title,
@@ -712,7 +720,7 @@ async def execute_summarize_session_group(
         video_validation_enabled=video_validation_enabled,
     )
     # Connect to Temporal and execute the workflow
-    workflow_id = f"session-summary:group:{user_id}-{team.id}:{shared_id}:{uuid.uuid4()}"
+    workflow_id = f"session-summary:group:{user.id}-{team.id}:{shared_id}:{uuid.uuid4()}"
     # Yield status updates and final result
     async for update in _start_session_group_summary_workflow(inputs=session_group_input, workflow_id=workflow_id):
         yield update

--- a/posthog/temporal/ai/session_summary/summarize_session_group.py
+++ b/posthog/temporal/ai/session_summary/summarize_session_group.py
@@ -708,7 +708,7 @@ async def execute_summarize_session_group(
     session_group_input = SessionGroupSummaryInputs(
         session_ids=session_ids,
         user_id=user.id,
-        user_distinct_id_to_log=user.user_distinct_id_to_log,
+        user_distinct_id_to_log=user.distinct_id,
         team_id=team.id,
         redis_key_base=redis_key_base,
         summary_title=summary_title,

--- a/posthog/temporal/ai/session_summary/types/group.py
+++ b/posthog/temporal/ai/session_summary/types/group.py
@@ -19,6 +19,7 @@ class SessionGroupSummaryInputs:
 
     session_ids: list[str]
     user_id: int
+    user_distinct_id_to_log: str | None = None
     team_id: int
     redis_key_base: str
     summary_title: str | None
@@ -45,6 +46,7 @@ class SessionGroupSummaryOfSummariesInputs:
 
     single_session_summaries_inputs: list[SingleSessionSummaryInputs]
     user_id: int
+    user_distinct_id_to_log: str | None = None
     team_id: int
     summary_title: str | None
     redis_key_base: str
@@ -59,6 +61,7 @@ class SessionGroupSummaryPatternsExtractionChunksInputs:
     redis_keys_of_chunks_to_combine: list[str]
     session_ids: list[str]
     user_id: int
+    user_distinct_id_to_log: str | None = None
     team_id: int
     redis_key_base: str
     extra_summary_context: ExtraSummaryContext | None = None

--- a/posthog/temporal/ai/session_summary/types/single.py
+++ b/posthog/temporal/ai/session_summary/types/single.py
@@ -9,6 +9,7 @@ class SingleSessionSummaryInputs:
 
     session_id: str
     user_id: int
+    user_distinct_id_to_log: str | None = None
     team_id: int
     redis_key_base: str
     model_to_use: str

--- a/posthog/temporal/common/posthog_client.py
+++ b/posthog/temporal/common/posthog_client.py
@@ -1,5 +1,5 @@
 from dataclasses import is_dataclass
-from typing import Any, Literal, Optional
+from typing import Any, Optional
 
 import temporalio.exceptions
 from posthoganalytics import api_key, capture_exception
@@ -18,19 +18,23 @@ from posthog.temporal.common.logger import get_write_only_logger
 logger = get_write_only_logger()
 
 
-async def _add_inputs_to_properties(
-    properties: dict[str, Any],
+async def _add_inputs_to_capture_kwargs(
+    capture_kwargs: dict[str, Any],
     input: ExecuteActivityInput | ExecuteWorkflowInput,
-    execution_type: Literal["activity", "workflow"],
 ):
     try:
-        if len(input.args) == 1 and is_dataclass(input.args[0]) and hasattr(input.args[0], "properties_to_log"):
-            properties.update(input.args[0].properties_to_log)
+        if len(input.args) == 1 and is_dataclass(input.args[0]):
+            if hasattr(input.args[0], "properties_to_log"):
+                if "properties" not in capture_kwargs:
+                    capture_kwargs["properties"] = {}
+                capture_kwargs["properties"].update(input.args[0].properties_to_log)
+            if hasattr(input.args[0], "user_distinct_id_to_log"):
+                capture_kwargs["distinct_id"] = input.args[0].user_distinct_id_to_log
     except Exception as e:
         await logger.awarning(
             "Failed to add inputs to properties for class %s", type(input.args[0]).__name__, exc_info=e
         )
-        capture_exception(e, properties=properties)
+        capture_exception(e, **capture_kwargs)
 
 
 class _PostHogClientActivityInboundInterceptor(ActivityInboundInterceptor):
@@ -39,22 +43,24 @@ class _PostHogClientActivityInboundInterceptor(ActivityInboundInterceptor):
             return await super().execute_activity(input)
         except Exception as e:
             activity_info = activity.info()
-            properties = {
-                "temporal.execution_type": "activity",
-                "module": input.fn.__module__ + "." + input.fn.__qualname__,
-                "temporal.activity.attempt": activity_info.attempt,
-                "temporal.activity.id": activity_info.activity_id,
-                "temporal.activity.type": activity_info.activity_type,
-                "temporal.activity.task_queue": activity_info.task_queue,
-                "temporal.workflow.id": activity_info.workflow_id,
-                "temporal.workflow.namespace": activity_info.workflow_namespace,
-                "temporal.workflow.run_id": activity_info.workflow_run_id,
-                "temporal.workflow.type": activity_info.workflow_type,
+            capture_kwargs = {
+                "properties": {
+                    "temporal.execution_type": "activity",
+                    "module": input.fn.__module__ + "." + input.fn.__qualname__,
+                    "temporal.activity.attempt": activity_info.attempt,
+                    "temporal.activity.id": activity_info.activity_id,
+                    "temporal.activity.type": activity_info.activity_type,
+                    "temporal.activity.task_queue": activity_info.task_queue,
+                    "temporal.workflow.id": activity_info.workflow_id,
+                    "temporal.workflow.namespace": activity_info.workflow_namespace,
+                    "temporal.workflow.run_id": activity_info.workflow_run_id,
+                    "temporal.workflow.type": activity_info.workflow_type,
+                }
             }
-            await _add_inputs_to_properties(properties, input, "activity")
+            await _add_inputs_to_capture_kwargs(capture_kwargs, input)
             if api_key:
                 try:
-                    capture_exception(e, properties=properties)
+                    capture_exception(e, **capture_kwargs)
                 except Exception as capture_error:
                     await logger.awarning("Failed to capture exception", exc_info=capture_error)
             raise
@@ -75,20 +81,22 @@ class _PostHogClientWorkflowInterceptor(WorkflowInboundInterceptor):
             ):
                 raise
             workflow_info = workflow.info()
-            properties = {
-                "temporal.execution_type": "workflow",
-                "module": input.run_fn.__module__ + "." + input.run_fn.__qualname__,
-                "temporal.workflow.task_queue": workflow_info.task_queue,
-                "temporal.workflow.namespace": workflow_info.namespace,
-                "temporal.workflow.run_id": workflow_info.run_id,
-                "temporal.workflow.type": workflow_info.workflow_type,
-                "temporal.workflow.id": workflow_info.workflow_id,
+            capture_kwargs = {
+                "properties": {
+                    "temporal.execution_type": "workflow",
+                    "module": input.run_fn.__module__ + "." + input.run_fn.__qualname__,
+                    "temporal.workflow.task_queue": workflow_info.task_queue,
+                    "temporal.workflow.namespace": workflow_info.namespace,
+                    "temporal.workflow.run_id": workflow_info.run_id,
+                    "temporal.workflow.type": workflow_info.workflow_type,
+                    "temporal.workflow.id": workflow_info.workflow_id,
+                }
             }
-            await _add_inputs_to_properties(properties, input, "workflow")
+            await _add_inputs_to_capture_kwargs(capture_kwargs, input)
             if api_key and not workflow.unsafe.is_replaying():
                 with workflow.unsafe.sandbox_unrestricted():
                     try:
-                        capture_exception(e, properties=properties)
+                        capture_exception(e, **capture_kwargs)
                     except Exception as capture_error:
                         await logger.awarning("Failed to capture exception", exc_info=capture_error)
             raise

--- a/posthog/temporal/common/posthog_client.py
+++ b/posthog/temporal/common/posthog_client.py
@@ -60,7 +60,7 @@ class _PostHogClientActivityInboundInterceptor(ActivityInboundInterceptor):
             await _add_inputs_to_capture_kwargs(capture_kwargs, input)
             if api_key:
                 try:
-                    capture_exception(e, **capture_kwargs)
+                    capture_exception(e, **capture_kwargs)  # type: ignore[arg-type]
                 except Exception as capture_error:
                     await logger.awarning("Failed to capture exception", exc_info=capture_error)
             raise
@@ -96,7 +96,7 @@ class _PostHogClientWorkflowInterceptor(WorkflowInboundInterceptor):
             if api_key and not workflow.unsafe.is_replaying():
                 with workflow.unsafe.sandbox_unrestricted():
                     try:
-                        capture_exception(e, **capture_kwargs)
+                        capture_exception(e, **capture_kwargs)  # type: ignore[arg-type]
                     except Exception as capture_error:
                         await logger.awarning("Failed to capture exception", exc_info=capture_error)
             raise

--- a/posthog/temporal/tests/ai/test_summarize_session.py
+++ b/posthog/temporal/tests/ai/test_summarize_session.py
@@ -456,7 +456,7 @@ class TestSummarizeSingleSessionStreamWorkflow:
             results = []
             generator = execute_summarize_session_stream(
                 session_id=mock_session_id,
-                user_id=mock_user.id,
+                user=mock_user,
                 team=mock_team,
                 extra_summary_context=None,
                 local_reads_prod=False,
@@ -528,7 +528,7 @@ class TestSummarizeSingleSessionStreamWorkflow:
                 list(
                     execute_summarize_session_stream(
                         session_id=mock_session_id,
-                        user_id=mock_user.id,
+                        user=mock_user,
                         team=mock_team,
                         extra_summary_context=None,
                         local_reads_prod=False,
@@ -615,7 +615,7 @@ class TestSummarizeSingleSessionStreamWorkflow:
             result = list(
                 execute_summarize_session_stream(
                     session_id=mock_session_id,
-                    user_id=mock_user.id,
+                    user=mock_user,
                     team=mock_team,
                     extra_summary_context=None,
                     local_reads_prod=False,

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -1078,7 +1078,7 @@ class TestSummarizeSessionGroupWorkflow:
             results = []
             async for update in execute_summarize_session_group(
                 session_ids=session_ids,
-                user_id=mock_user.id,
+                user=mock_user,
                 team=mock_team,
                 min_timestamp=datetime.now() - timedelta(days=1),
                 max_timestamp=datetime.now(),


### PR DESCRIPTION
## Problem

Session summarization errors were not searchable by the associated user, hampering efforts to support users.

## Changes

Two changes that work together:
1. Sessions summarization workflows all get a `user_distinct_id_to_log` field as part of their input, inspired by `properties_to_log`
2. The `user_distinct_id_to_log` workflow/activity field gets special treatment - whenever it's used in _any_ Temporal workflow/activity, it attaches all errors from that workflow to that distinct ID

This way errors are attributed to users even when executed in a Temporal worker.

## How did you test this code?

Existing tests should pass.