### PR TITLE
feat(customers): Add B2B mode to customer analytics dashboard

### DIFF
--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -68,6 +68,12 @@ function MathTag({ math, mathProperty, mathHogQL, mathGroupTypeIndex }: MathTagP
     if (math === 'unique_group' && mathGroupTypeIndex != undefined) {
         return <LemonTag>Unique {aggregationLabel(mathGroupTypeIndex).plural}</LemonTag>
     }
+    if (math === 'weekly_active' && mathGroupTypeIndex != undefined) {
+        return <LemonTag>Weekly active {aggregationLabel(mathGroupTypeIndex).plural}</LemonTag>
+    }
+    if (math === 'monthly_active' && mathGroupTypeIndex != undefined) {
+        return <LemonTag>Monthly active {aggregationLabel(mathGroupTypeIndex).plural}</LemonTag>
+    }
     if (math && ['sum', 'avg', 'min', 'max', 'median', 'p75', 'p90', 'p95', 'p99'].includes(math)) {
         return (
             <>

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -787,6 +787,7 @@ export function LineGraph_({
                                         })
                                     }
                                     hideInspectActorsSection={!onClick || !showPersonsModal}
+                                    {...tooltipConfig}
                                     groupTypeLabel={
                                         labelGroupType === 'people'
                                             ? 'people'
@@ -794,7 +795,6 @@ export function LineGraph_({
                                               ? ''
                                               : aggregationLabel(labelGroupType).plural
                                     }
-                                    {...tooltipConfig}
                                 />
                             )
                         }

--- a/products/customer_analytics/frontend/CustomerAnalyticsFilters.tsx
+++ b/products/customer_analytics/frontend/CustomerAnalyticsFilters.tsx
@@ -107,11 +107,6 @@ export function CustomerAnalyticsFilters(): JSX.Element {
                     {businessType === 'b2b' && (
                         <LemonSelect
                             size="small"
-                            // options={[
-                            //     { label: 'Group 0', value: 0 },
-                            //     { label: 'Group 1', value: 1 },
-                            //     { label: 'Group 2', value: 2 },
-                            // ]}
                             options={groupOptions}
                             value={selectedGroupType}
                             onChange={setSelectedGroupType}

--- a/products/customer_analytics/frontend/CustomerAnalyticsFilters.tsx
+++ b/products/customer_analytics/frontend/CustomerAnalyticsFilters.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { Tooltip } from '@posthog/lemon-ui'
+import { LemonSegmentedButton, LemonSelect, Tooltip } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { CUSTOM_OPTION_KEY } from 'lib/components/DateFilter/types'
@@ -73,21 +73,51 @@ const DATE_FILTER_DATE_OPTIONS: DateMappingOption[] = [
 
 export function CustomerAnalyticsFilters(): JSX.Element {
     const {
+        businessType,
         dateFilter: { dateTo, dateFrom },
+        groupsEnabled,
+        groupOptions,
+        selectedGroupType,
     } = useValues(customerAnalyticsSceneLogic)
 
-    const { setDates } = useActions(customerAnalyticsSceneLogic)
+    const { setBusinessType, setDates, setSelectedGroupType } = useActions(customerAnalyticsSceneLogic)
+    // TODO: Add CTA for cross sell
+    const b2bDisabledReason = groupsEnabled ? '' : 'Group analytics add-on is not enabled'
 
     return (
         <FilterBar
             left={
-                <DateFilter
-                    dateFrom={dateFrom}
-                    dateTo={dateTo}
-                    onChange={setDates}
-                    dateOptions={DATE_FILTER_DATE_OPTIONS}
-                    size="small"
-                />
+                <div className="flex flex-row items-center gap-2">
+                    <DateFilter
+                        dateFrom={dateFrom}
+                        dateTo={dateTo}
+                        onChange={setDates}
+                        dateOptions={DATE_FILTER_DATE_OPTIONS}
+                        size="small"
+                    />
+                    <LemonSegmentedButton
+                        size="small"
+                        options={[
+                            { label: 'B2C', value: 'b2c' },
+                            { label: 'B2B', value: 'b2b', disabledReason: b2bDisabledReason },
+                        ]}
+                        value={businessType}
+                        onChange={(value) => setBusinessType(value)}
+                    />
+                    {businessType === 'b2b' && (
+                        <LemonSelect
+                            size="small"
+                            // options={[
+                            //     { label: 'Group 0', value: 0 },
+                            //     { label: 'Group 1', value: 1 },
+                            //     { label: 'Group 2', value: 2 },
+                            // ]}
+                            options={groupOptions}
+                            value={selectedGroupType}
+                            onChange={setSelectedGroupType}
+                        />
+                    )}
+                </div>
             }
             right={
                 <Tooltip title="Refresh data">

--- a/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
+++ b/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
@@ -34,11 +34,16 @@ function getEmptySeriesNames(requiredSeries: object): string[] {
         .map(([key]) => key)
 }
 
+function generateUniqueKey(name: string, tabId: string, businessType: string, groupType?: number): string {
+    const suffix = businessType === 'b2b' ? groupType : 'users'
+    return `${name}-${tabId}-${businessType}-${suffix}`
+}
+
 export function CustomerAnalyticsQueryCard({ insight, tabId }: CustomerAnalyticsQueryCardProps): JSX.Element {
     const { businessType, selectedGroupType } = useValues(customerAnalyticsSceneLogic)
     const { addEventToHighlight, toggleModalOpen } = useActions(eventConfigModalLogic)
     const needsConfig = insight?.requiredSeries ? anyValueIsNull(insight.requiredSeries) : false
-    const uniqueKey = `${insight.name}-${tabId}-${businessType}-${businessType === 'b2b' ? selectedGroupType : 'users'}`
+    const uniqueKey = generateUniqueKey(insight.name, tabId || '', businessType, selectedGroupType)
     const insightProps: InsightLogicProps<QuerySchema> = {
         dataNodeCollectionId: CUSTOMER_ANALYTICS_DATA_COLLECTION_NODE_ID,
         dashboardItemId: buildDashboardItemId(uniqueKey),

--- a/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
+++ b/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
@@ -1,4 +1,4 @@
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 
 import { LemonBanner, LemonButton, LemonCard } from '@posthog/lemon-ui'
 
@@ -35,9 +35,10 @@ function getEmptySeriesNames(requiredSeries: object): string[] {
 }
 
 export function CustomerAnalyticsQueryCard({ insight, tabId }: CustomerAnalyticsQueryCardProps): JSX.Element {
+    const { businessType, selectedGroupType } = useValues(customerAnalyticsSceneLogic)
     const { addEventToHighlight, toggleModalOpen } = useActions(eventConfigModalLogic)
     const needsConfig = insight?.requiredSeries ? anyValueIsNull(insight.requiredSeries) : false
-    const uniqueKey = `${insight.name}-${tabId}`
+    const uniqueKey = `${insight.name}-${tabId}-${businessType}-${businessType === 'b2b' ? selectedGroupType : 'users'}`
     const insightProps: InsightLogicProps<QuerySchema> = {
         dataNodeCollectionId: CUSTOMER_ANALYTICS_DATA_COLLECTION_NODE_ID,
         dashboardItemId: buildDashboardItemId(uniqueKey),

--- a/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
@@ -16,7 +16,7 @@ import { CustomerAnalyticsQueryCard } from '../CustomerAnalyticsQueryCard'
 import { eventConfigModalLogic } from './eventConfigModalLogic'
 
 export function ActiveUsersInsights(): JSX.Element {
-    const { activityEvent, activeUsersInsights, tabId } = useValues(customerAnalyticsSceneLogic)
+    const { activityEvent, activeUsersInsights, customerLabel, tabId } = useValues(customerAnalyticsSceneLogic)
     const { toggleModalOpen } = useActions(eventConfigModalLogic)
 
     // Check if using pageview as default, with no properties filter
@@ -38,7 +38,7 @@ export function ActiveUsersInsights(): JSX.Element {
                     </div>
                 </LemonBanner>
             )}
-            <h2 className="ml-1">Active users</h2>
+            <h2 className="ml-1">Active {customerLabel.plural}</h2>
             <div className="grid grid-cols-[3fr_1fr] gap-2">
                 {activeUsersInsights.map((insight, index) => {
                     return (
@@ -52,13 +52,14 @@ export function ActiveUsersInsights(): JSX.Element {
 }
 
 function PowerUsersTable(): JSX.Element {
-    const { dauSeries, tabId } = useValues(customerAnalyticsSceneLogic)
+    const { businessType, customerLabel, dauSeries, selectedGroupType, tabId } = useValues(customerAnalyticsSceneLogic)
     const uniqueKey = `power-users-${tabId}`
     const insightProps: InsightLogicProps<InsightVizNode> = {
         dataNodeCollectionId: CUSTOMER_ANALYTICS_DATA_COLLECTION_NODE_ID,
         dashboardItemId: buildDashboardItemId(uniqueKey),
     }
 
+    // TODO: Fix query for b2b
     const query = {
         kind: NodeKind.DataTableNode,
         hiddenColumns: ['id', 'person.$delete', 'event_distinct_ids'],
@@ -85,12 +86,14 @@ function PowerUsersTable(): JSX.Element {
             limit: 10,
         },
     }
+    const buttonTo = businessType === 'b2c' ? urls.persons() : urls.groups(selectedGroupType)
+    const tooltip = businessType === 'b2c' ? 'Open people list' : 'Open groups list'
 
     return (
         <>
             <div className="flex items-center gap-2 -mb-2">
-                <h2 className="mb-0 ml-1">Power users</h2>
-                <LemonButton size="small" noPadding targetBlank to={urls.persons()} tooltip="Open people list" />
+                <h2 className="mb-0 ml-1">Power {customerLabel.plural}</h2>
+                <LemonButton size="small" noPadding targetBlank to={buttonTo} tooltip={tooltip} />
             </div>
             <Query
                 uniqueKey={uniqueKey}

--- a/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
@@ -59,14 +59,17 @@ function PowerUsersTable(): JSX.Element {
         dashboardItemId: buildDashboardItemId(uniqueKey),
     }
 
-    // TODO: Fix query for b2b
+    const isB2c = businessType === 'b2c'
+    const buttonTo = isB2c ? urls.persons() : urls.groups(selectedGroupType)
+    const tooltip = isB2c ? 'Open people list' : `Open ${customerLabel.plural} list`
+
     const query = {
         kind: NodeKind.DataTableNode,
         hiddenColumns: ['id', 'person.$delete', 'event_distinct_ids'],
         showSourceQueryOptions: false,
         source: {
             kind: NodeKind.ActorsQuery,
-            select: ['person', 'event_count'],
+            select: isB2c ? ['person', 'event_count'] : ['group', 'event_count'],
             source: {
                 kind: NodeKind.InsightActorsQuery,
                 source: {
@@ -79,6 +82,7 @@ function PowerUsersTable(): JSX.Element {
                     trendsFilter: {
                         display: ChartDisplayType.ActionsTable,
                     },
+                    ...(isB2c ? {} : { aggregation_group_type_index: selectedGroupType }),
                 },
                 series: 0,
             },
@@ -86,8 +90,6 @@ function PowerUsersTable(): JSX.Element {
             limit: 10,
         },
     }
-    const buttonTo = businessType === 'b2c' ? urls.persons() : urls.groups(selectedGroupType)
-    const tooltip = businessType === 'b2c' ? 'Open people list' : 'Open groups list'
 
     return (
         <>
@@ -102,6 +104,7 @@ function PowerUsersTable(): JSX.Element {
                 context={{
                     columns: {
                         event_count: { title: 'Event count' },
+                        group: { title: customerLabel.singular },
                     },
                     insightProps,
                 }}

--- a/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
+++ b/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
@@ -20,6 +20,8 @@ import {
     FunnelConversionWindowTimeUnit,
     FunnelStepReference,
     FunnelVizType,
+    GroupMathType,
+    GroupTypeIndex,
     PropertyMathType,
     SimpleIntervalType,
     StepOrderValue,
@@ -157,86 +159,141 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
             },
         ],
         dauSeries: [
-            (s) => [s.activityEvent],
-            (activityEvent: EventsNode | ActionsNode | null): AnyEntityNode | null => {
+            (s) => [s.activityEvent, s.businessType, s.selectedGroupType],
+            (
+                activityEvent: EventsNode | ActionsNode | null,
+                businessType: string,
+                selectedGroupType: GroupTypeIndex
+            ): AnyEntityNode | null => {
                 if (!activityEvent) {
                     return null
                 }
+                if (businessType === 'b2c') {
+                    return {
+                        ...activityEvent,
+                        math: BaseMathType.UniqueUsers,
+                    }
+                }
                 return {
                     ...activityEvent,
-                    math: BaseMathType.UniqueUsers,
+                    math: GroupMathType.UniqueGroup,
+                    math_group_type_index: selectedGroupType,
                 }
             },
         ],
         wauSeries: [
-            (s) => [s.activityEvent],
-            (activityEvent: EventsNode | ActionsNode | null): AnyEntityNode | null => {
+            (s) => [s.activityEvent, s.businessType, s.selectedGroupType],
+            (
+                activityEvent: EventsNode | ActionsNode | null,
+                businessType: string,
+                selectedGroupType: GroupTypeIndex
+            ): AnyEntityNode | null => {
                 if (!activityEvent) {
                     return null
                 }
-                return {
+                const series = {
                     ...activityEvent,
                     math: BaseMathType.WeeklyActiveUsers,
                 }
+                if (businessType === 'b2b') {
+                    series['math_group_type_index'] = selectedGroupType
+                }
+                return series
             },
         ],
         mauSeries: [
-            (s) => [s.activityEvent],
-            (activityEvent: EventsNode | ActionsNode | null): AnyEntityNode | null => {
+            (s) => [s.activityEvent, s.businessType, s.selectedGroupType],
+            (
+                activityEvent: EventsNode | ActionsNode | null,
+                businessType: string,
+                selectedGroupType: GroupTypeIndex
+            ): AnyEntityNode | null => {
                 if (!activityEvent) {
                     return null
                 }
-                return {
+                const series = {
                     ...activityEvent,
                     math: BaseMathType.MonthlyActiveUsers,
                 }
+                if (businessType === 'b2b') {
+                    series['math_group_type_index'] = selectedGroupType
+                }
+                return series
             },
         ],
         signupSeries: [
-            (s) => [s.signupEvent],
-            (signupEvent): AnyEntityNode | null => {
+            (s) => [s.businessType, s.selectedGroupType, s.signupEvent],
+            (businessType: string, selectedGroupType: GroupTypeIndex, signupEvent): AnyEntityNode | null => {
                 if (Object.keys(signupEvent).length === 0) {
                     return null
                 }
+                if (businessType === 'b2c') {
+                    return {
+                        ...signupEvent,
+                        math: BaseMathType.UniqueUsers,
+                    }
+                }
                 return {
                     ...signupEvent,
-                    math: BaseMathType.UniqueUsers,
+                    math: GroupMathType.UniqueGroup,
+                    math_group_type_index: selectedGroupType,
                 }
             },
         ],
         signupPageviewSeries: [
-            (s) => [s.signupPageviewEvent],
-            (signupPageviewEvent): AnyEntityNode | null => {
+            (s) => [s.businessType, s.selectedGroupType, s.signupPageviewEvent],
+            (businessType: string, selectedGroupType: GroupTypeIndex, signupPageviewEvent): AnyEntityNode | null => {
                 if (Object.keys(signupPageviewEvent).length === 0) {
                     return null
                 }
+                if (businessType === 'b2c') {
+                    return {
+                        ...signupPageviewEvent,
+                        math: BaseMathType.UniqueUsers,
+                    }
+                }
                 return {
                     ...signupPageviewEvent,
-                    math: BaseMathType.UniqueUsers,
+                    math: GroupMathType.UniqueGroup,
+                    math_group_type_index: selectedGroupType,
                 }
             },
         ],
         subscriptionSeries: [
-            (s) => [s.subscriptionEvent],
-            (subscriptionEvent): AnyEntityNode | null => {
+            (s) => [s.businessType, s.selectedGroupType, s.subscriptionEvent],
+            (businessType: string, selectedGroupType: GroupTypeIndex, subscriptionEvent): AnyEntityNode | null => {
                 if (Object.keys(subscriptionEvent).length === 0) {
                     return null
                 }
+                if (businessType === 'b2c') {
+                    return {
+                        ...subscriptionEvent,
+                        math: BaseMathType.UniqueUsers,
+                    }
+                }
                 return {
                     ...subscriptionEvent,
-                    math: BaseMathType.UniqueUsers,
+                    math: GroupMathType.UniqueGroup,
+                    math_group_type_index: selectedGroupType,
                 }
             },
         ],
         paymentSeries: [
-            (s) => [s.paymentEvent],
-            (paymentEvent): AnyEntityNode | null => {
+            (s) => [s.businessType, s.selectedGroupType, s.paymentEvent],
+            (businessType: string, selectedGroupType: GroupTypeIndex, paymentEvent): AnyEntityNode | null => {
                 if (Object.keys(paymentEvent).length === 0) {
                     return null
                 }
+                if (businessType === 'b2c') {
+                    return {
+                        ...paymentEvent,
+                        math: BaseMathType.UniqueUsers,
+                    }
+                }
                 return {
                     ...paymentEvent,
-                    math: BaseMathType.UniqueUsers,
+                    math: GroupMathType.UniqueGroup,
+                    math_group_type_index: selectedGroupType,
                 }
             },
         ],
@@ -488,18 +545,22 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
         ],
         signupInsights: [
             (s) => [
+                s.businessType,
                 s.customerLabel,
                 s.signupSeries,
                 s.paymentSeries,
+                s.selectedGroupType,
                 s.subscriptionSeries,
                 s.signupPageviewSeries,
                 s.dauSeries,
                 s.dateRange,
             ],
             (
+                businessType,
                 customerLabel,
                 signupSeries,
                 paymentSeries,
+                selectedGroupType,
                 subscriptionSeries,
                 signupPageviewSeries,
                 dauSeries,
@@ -675,6 +736,7 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
                         kind: NodeKind.InsightVizNode,
                         source: {
                             kind: NodeKind.FunnelsQuery,
+                            ...(businessType === 'b2c' ? {} : { aggregation_group_type_index: selectedGroupType }),
                             series: [signupPageviewSeries as AnyEntityNode, signupSeries as AnyEntityNode],
                             interval: 'week',
                             dateRange: {
@@ -707,6 +769,7 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
                         kind: NodeKind.InsightVizNode,
                         source: {
                             kind: NodeKind.LifecycleQuery,
+                            ...(businessType === 'b2c' ? {} : { aggregation_group_type_index: selectedGroupType }),
                             series: [dauSeries as AnyEntityNode],
                             interval: 'week',
                             dateRange: {
@@ -719,7 +782,6 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
                                 showLegend: false,
                             },
                             filterTestAccounts: true,
-                            aggregation_group_type_index: 0,
                         },
                     },
                 },
@@ -730,6 +792,7 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
                         kind: NodeKind.InsightVizNode,
                         source: {
                             kind: NodeKind.FunnelsQuery,
+                            ...(businessType === 'b2c' ? {} : { aggregation_group_type_index: selectedGroupType }),
                             series: [signupSeries as AnyEntityNode, paymentSeries as AnyEntityNode],
                             dateRange: {
                                 date_from: dateRange.date_from,

--- a/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
+++ b/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
@@ -123,7 +123,10 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
         ],
     })),
     selectors({
-        tabId: [() => [(_, props: CustomerAnalyticsSceneLogicProps) => props.tabId], (tabIdProp): string => tabIdProp],
+        tabId: [
+            () => [(_, props: CustomerAnalyticsSceneLogicProps) => props.tabId],
+            (tabIdProp: string): string => tabIdProp,
+        ],
         breadcrumbs: [
             () => [],
             (): Breadcrumb[] => [
@@ -137,7 +140,11 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
         ],
         customerLabel: [
             (s) => [s.aggregationLabel, s.businessType, s.selectedGroupType],
-            (aggregationLabel, businessType, selectedGroupType) => {
+            (
+                aggregationLabel: any,
+                businessType: BusinessType,
+                selectedGroupType: number
+            ): { singular: string; plural: string } => {
                 if (!aggregationLabel || typeof aggregationLabel !== 'function') {
                     return { singular: 'user', plural: 'users' }
                 }
@@ -149,14 +156,17 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
         ],
         dateRange: [
             (s) => [s.dateFilter],
-            (dateFilter) => ({
+            (dateFilter: {
+                dateFrom: string | null
+                dateTo: string | null
+            }): { date_from: string | null; date_to: string | null } => ({
                 date_from: dateFilter.dateFrom,
                 date_to: dateFilter.dateTo,
             }),
         ],
         groupOptions: [
             (s) => [s.groupTypesRaw],
-            (groupTypesRaw) => {
+            (groupTypesRaw: any[]): { label: string; value: number }[] => {
                 return groupTypesRaw.map((groupType) => ({
                     label: capitalizeFirstLetter(groupType.name_plural || wordPluralize(groupType.group_type)),
                     value: groupType.group_type_index,
@@ -436,7 +446,7 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
         ],
         sessionInsights: [
             (s) => [s.customerLabel],
-            (customerLabel) => [
+            (customerLabel: { singular: string; plural: string }): InsightDefinition[] => [
                 {
                     name: 'Unique sessions',
                     description: 'Events without session IDs are excluded.',
@@ -575,15 +585,15 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
                 s.dateRange,
             ],
             (
-                businessType,
-                customerLabel,
-                signupSeries,
-                paymentSeries,
-                selectedGroupType,
-                subscriptionSeries,
-                signupPageviewSeries,
-                dauSeries,
-                dateRange
+                businessType: BusinessType,
+                customerLabel: { singular: string; plural: string },
+                signupSeries: AnyEntityNode | null,
+                paymentSeries: AnyEntityNode | null,
+                selectedGroupType: number,
+                subscriptionSeries: AnyEntityNode | null,
+                signupPageviewSeries: AnyEntityNode | null,
+                dauSeries: AnyEntityNode | null,
+                dateRange: { date_from: string | null; date_to: string | null }
             ): InsightDefinition[] => [
                 {
                     name: `${capitalizeFirstLetter(customerLabel.singular)} signups`,


### PR DESCRIPTION
## Problem

Customer Analytics currently only supports B2C analytics. Let's enable B2B analytics too.

Closes https://github.com/PostHog/posthog/issues/41545
## Changes

- Added B2B/B2C toggle in the Customer Analytics filters
- Implemented group type selection dropdown for B2B mode
- Updated all insights to support both B2C (person-based) and B2B (group-based) analytics
- Added support for weekly and monthly active groups in the MathTag component
- Dynamically updated labels throughout the UI to reflect the selected business type (users vs. groups)
- Fixed tooltip configuration in LineGraph component

### B2C selected
<img width="1624" height="979" alt="image" src="https://github.com/user-attachments/assets/a669cc77-c52b-40df-8273-f548aeec8a59" />

### B2B selected
Insights reflect the selected group type
<img width="1624" height="979" alt="image" src="https://github.com/user-attachments/assets/db0aabf1-bd40-46f9-ac9d-8235d6af2d7b" />

### Group selector
<img width="1624" height="979" alt="image" src="https://github.com/user-attachments/assets/41c90b5e-ddf2-4c36-bf47-b4101b795a7a" />


## How did you test this code?

- Tested switching between B2C and B2B modes and verified all insights update correctly
- Verified group selection dropdown works and updates all insights
- Confirmed that labels dynamically update based on the selected business type
- Tested with various group types to ensure proper display of metrics
- Verified that the B2B option is disabled when group analytics is not enabled

## Changelog: (features only) Is this feature complete?
No, under feature flag