### PR TITLE
fix(replay): fix recording button in error tracking

### DIFF
--- a/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
+++ b/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
@@ -158,6 +158,7 @@ export function useRecordingButton({
         userClickedThrough()
         if (inModal) {
             const fiveSecondsBeforeEvent = timestamp ? dayjs(timestamp).valueOf() - 5000 : 0
+
             openSessionPlayer(
                 { id: sessionId ?? '', matching_events: matchingEvents ?? undefined },
                 Math.max(fiveSecondsBeforeEvent, 0)

--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 
 import { IconAI } from '@posthog/icons'
-import { Link } from '@posthog/lemon-ui'
+import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { ErrorEventType } from 'lib/components/Errors/types'
 import { getExceptionAttributes, getRecordingStatus, getSessionId } from 'lib/components/Errors/utils'
@@ -9,8 +9,6 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { useRecordingButton } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { IconLink, IconPlayCircle } from 'lib/lemon-ui/icons'
-import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import { isString } from 'lib/utils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { PersonDisplay, PersonIcon } from 'scenes/persons/PersonDisplay'
 import { asDisplay } from 'scenes/persons/person-utils'
@@ -110,20 +108,21 @@ const Actions = (record: ErrorEventType): JSX.Element => {
     })
 
     return (
-        <div className="flex justify-end">
-            <ButtonPrimitive
-                disabledReasons={isString(disabledReason) ? { [disabledReason]: true } : {}}
+        <div className="flex justify-end gap-1">
+            <LemonButton
+                size="small"
+                icon={<IconPlayCircle />}
                 onClick={(event) => {
                     cancelEvent(event)
                     onClickRecordingButton()
                 }}
-                tooltip="View recording"
-            >
-                <IconPlayCircle />
-            </ButtonPrimitive>
+                disabledReason={disabledReason || undefined}
+                tooltip={!disabledReason ? 'View recording' : undefined}
+            />
             {record.properties.$ai_trace_id && (
-                <ButtonPrimitive
-                    fullWidth
+                <LemonButton
+                    size="small"
+                    icon={<IconAI />}
                     onClick={(event) => {
                         cancelEvent(event)
                         urls.llmAnalyticsTrace(record.properties.$ai_trace_id, {
@@ -131,13 +130,15 @@ const Actions = (record: ErrorEventType): JSX.Element => {
                             timestamp: record.timestamp,
                         })
                     }}
-                    disabledReasons={{ ['There is no LLM Trace ID on this event']: !record.properties.$ai_trace_id }}
-                    tooltip="View LLM Trace"
-                >
-                    <IconAI />
-                </ButtonPrimitive>
+                    disabledReason={
+                        !record.properties.$ai_trace_id ? 'There is no LLM Trace ID on this event' : undefined
+                    }
+                    tooltip={record.properties.$ai_trace_id ? 'View LLM Trace' : undefined}
+                />
             )}
-            <ButtonPrimitive
+            <LemonButton
+                size="small"
+                icon={<IconLink />}
                 data-attr="events-table-event-link"
                 onClick={(event) => {
                     cancelEvent(event)
@@ -147,9 +148,7 @@ const Actions = (record: ErrorEventType): JSX.Element => {
                     )
                 }}
                 tooltip="Copy link to exception event"
-            >
-                <IconLink />
-            </ButtonPrimitive>
+            />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

this was definitely broken, it always showed as clickable, and just kind of displayed a blank gray overlay of the whole page

there are still improvements to be made: (ie we show the modal popup with "no recording found", which still maybe is unexpected) but at least this isnt a gray blurry overlay anymore

## Changes

Basically convert to a lemonButton so we could properly check the "isDisabled" field / tooltip field, the primitive was not prepared to get JSX elements which was messing with everything
### before: what?

![Screenshot 2025-11-26 at 11.49.09 AM.png](https://app.graphite.com/user-attachments/assets/3d55aa37-d4c7-45dd-a2f2-13d190495502.png)

![Screenshot 2025-11-26 at 11.49.13 AM.png](https://app.graphite.com/user-attachments/assets/2ecb43dc-0a0b-4de4-9db7-09896df6b78b.png)


### after: wow so clear

![Screenshot 2025-11-26 at 11.48.29 AM.png](https://app.graphite.com/user-attachments/assets/a07fcec5-4b71-4c84-a321-6c14fb7f282b.png)

![Screenshot 2025-11-26 at 12.00.21 PM.png](https://app.graphite.com/user-attachments/assets/ea180b68-77cd-4e48-8eb8-023db4aa524f.png)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
