### PR TITLE
fix(db): groupTypeMapping routing

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -121,6 +121,7 @@ from posthog.hogql.timings import HogQLTimings
 from posthog.exceptions_capture import capture_exception
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.team.team import WeekStartDay
+from posthog.person_db_router import PERSONS_DB_FOR_READ
 
 from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
 from products.data_warehouse.backend.models.table import DataWarehouseTable, DataWarehouseTableColumns
@@ -699,7 +700,7 @@ class Database(BaseModel):
         with timings.measure("group_type_mapping"):
             _setup_group_key_fields(database, team)
             events_table = database.get_table("events")
-            for mapping in GroupTypeMapping.objects.using("persons_db_writer").filter(project_id=team.project_id):
+            for mapping in GroupTypeMapping.objects.using(PERSONS_DB_FOR_READ).filter(project_id=team.project_id):
                 if events_table.fields.get(mapping.group_type) is None:
                     events_table.fields[mapping.group_type] = FieldTraverser(
                         chain=[f"group_{mapping.group_type_index}"]
@@ -1110,7 +1111,7 @@ def _setup_group_key_fields(database: Database, team: "Team") -> None:
     """
     group_mappings = {
         mapping.group_type_index: mapping
-        for mapping in GroupTypeMapping.objects.using("persons_db_writer").filter(team=team)
+        for mapping in GroupTypeMapping.objects.using(PERSONS_DB_FOR_READ).filter(team=team)
     }
     table = database.get_table("events")
 


### PR DESCRIPTION
## Problem

We shouldn't hardcode the connection string, instead we should fetch from the variable that handles the connection hanlding

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
