### PR TITLE
fix: Run less doctor instances at the same time

### DIFF
--- a/dags/sdk_doctor/team_sdk_versions.py
+++ b/dags/sdk_doctor/team_sdk_versions.py
@@ -209,8 +209,8 @@ def aggregate_results_op(context: dagster.OpExecutionContext, results: list[list
 
 @dagster.job(
     description="Queries ClickHouse for recent SDK versions and caches them in Redis",
-    # Do this slowly, 10 batches at a time at most, more than this will cause the pod to OOM
-    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 10}),
+    # Do this slowly, 5 batches at a time at most, more than this will cause the pod to OOM
+    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 5}),
     tags={"owner": JobOwners.TEAM_GROWTH.value},
 )
 def cache_all_team_sdk_versions_job():


### PR DESCRIPTION
We're OOMing, so let's run less instances at the same time. Thsi runs every 24 hours so it's fine if it takes long to finish running