### PR TITLE
feat(marketing-analytics): add custom UTM source mappings configuration

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonMenu/index.ts
+++ b/frontend/src/lib/lemon-ui/LemonMenu/index.ts
@@ -1,2 +1,2 @@
-export type { LemonMenuItem, LemonMenuItems, LemonMenuSection } from './LemonMenu'
-export { LemonMenu } from './LemonMenu'
+export type { LemonMenuItem, LemonMenuItems, LemonMenuOverlayProps, LemonMenuSection } from './LemonMenu'
+export { LemonMenu, LemonMenuOverlay } from './LemonMenu'

--- a/frontend/src/queries/nodes/DataTable/CellActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/CellActions.tsx
@@ -1,0 +1,53 @@
+import { More } from 'lib/lemon-ui/LemonButton/More'
+
+import { DataTableNode } from '~/queries/schema/schema-general'
+import { CellActionProps, QueryContext } from '~/queries/types'
+
+interface CellActionsProps {
+    columnName: string
+    query: DataTableNode
+    record: unknown
+    recordIndex: number
+    value: unknown
+    context?: QueryContext<DataTableNode>
+    children: React.ReactNode
+}
+
+export function CellActions({
+    columnName,
+    query,
+    record,
+    recordIndex,
+    value,
+    context,
+    children,
+}: CellActionsProps): JSX.Element {
+    const cellActionsRenderer = context?.columns?.[columnName]?.cellActions
+
+    if (!cellActionsRenderer) {
+        return <>{children}</>
+    }
+
+    const actionProps: CellActionProps = {
+        columnName,
+        query,
+        record,
+        recordIndex,
+        value,
+    }
+
+    const actions = cellActionsRenderer(actionProps)
+
+    if (!actions) {
+        return <>{children}</>
+    }
+
+    return (
+        <div className="flex items-center gap-1 group/cell-actions">
+            <div className="flex-1 min-w-0">{children}</div>
+            <div className="opacity-0 group-hover/cell-actions:opacity-100 transition-opacity flex-shrink-0">
+                <More overlay={actions} size="xsmall" />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/queries/nodes/DataTable/DataTable.stories.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.stories.tsx
@@ -1,11 +1,19 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react'
 
+import { IconChevronRight, IconTrash } from '@posthog/icons'
+
+import { LemonMenuItem, LemonMenuItems, LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu'
+import { IconLink } from 'lib/lemon-ui/icons'
+
 import { mswDecorator } from '~/mocks/browser'
 import { Query } from '~/queries/Query/Query'
+import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
+import { CellActionProps, QueryContext, RowActionProps } from '~/queries/types'
 
 import events from '../DataNode/__mocks__/EventsNode.json'
 import persons from '../DataNode/__mocks__/PersonsNode.json'
 import { examples } from './DataTable.examples'
+import { QueryFeature } from './queryFeatures'
 
 type Story = StoryObj<typeof Query>
 const meta: Meta<typeof Query> = {
@@ -61,4 +69,267 @@ PinnedColumnsAtTheBeginning.args = {
 export const PinnedColumnsInTheMiddle: Story = QueryTemplate.bind({})
 PinnedColumnsInTheMiddle.args = {
     query: examples['PinnedColumnsInTheMiddle'],
+}
+
+// Static mock data for cell/row actions stories - HogQL query response format
+const mockHogQLResults = {
+    columns: ['event', 'person', 'timestamp', 'properties.$browser'],
+    hasMore: false,
+    results: [
+        ['$pageview', 'user@example.com', '2024-01-15T10:30:00Z', 'Chrome'],
+        ['button_clicked', 'alice@company.io', '2024-01-15T10:28:00Z', 'Firefox'],
+        ['form_submitted', 'bob@startup.co', '2024-01-15T10:25:00Z', 'Safari'],
+        ['$autocapture', 'carol@enterprise.com', '2024-01-15T10:22:00Z', 'Chrome'],
+        ['purchase_completed', 'dave@shop.net', '2024-01-15T10:20:00Z', 'Edge'],
+        ['$pageview', 'eve@agency.io', '2024-01-15T10:18:00Z', 'Chrome'],
+        ['signup_started', 'frank@tech.co', '2024-01-15T10:15:00Z', 'Firefox'],
+        ['feature_used', 'grace@design.com', '2024-01-15T10:12:00Z', 'Safari'],
+    ],
+    types: ['String', 'String', 'DateTime', 'String'],
+}
+
+const hogQLQuery: DataTableNode = {
+    kind: NodeKind.DataTableNode,
+    source: {
+        kind: NodeKind.HogQLQuery,
+        query: 'SELECT event, person.properties.email as person, timestamp, properties.$browser FROM events LIMIT 10',
+    },
+    columns: ['event', 'person', 'timestamp', 'properties.$browser'],
+}
+
+// Cell Actions - demonstrates custom cell action menus for specific columns
+const CellActionsContext: QueryContext = {
+    showQueryEditor: false,
+    extraDataTableQueryFeatures: [QueryFeature.cellActions],
+    columns: {
+        event: {
+            cellActions: ({ value }: CellActionProps) => {
+                const eventName = String(value || '')
+                const menuItems: LemonMenuItems = [
+                    {
+                        title: `"${eventName.length > 20 ? eventName.slice(0, 20) + '...' : eventName}"`,
+                        items: [
+                            {
+                                label: 'Actions',
+                                icon: <IconLink />,
+                                sideIcon: <IconChevronRight />,
+                                items: [
+                                    {
+                                        label: 'Filter to this event',
+                                        onClick: () => alert(`Filtering to ${eventName}`),
+                                    },
+                                    {
+                                        label: 'Exclude this event',
+                                        icon: <IconTrash />,
+                                        status: 'danger' as const,
+                                        onClick: () => alert(`Excluding ${eventName}`),
+                                    },
+                                ] as LemonMenuItem[],
+                            },
+                        ],
+                    },
+                ]
+                return <LemonMenuOverlay items={menuItems} />
+            },
+        },
+    },
+}
+
+const CellActionsTemplate: StoryFn<typeof Query> = (args) => (
+    <Query {...args} context={CellActionsContext} cachedResults={mockHogQLResults} />
+)
+
+export const WithCellActions: Story = CellActionsTemplate.bind({})
+WithCellActions.args = { query: hogQLQuery }
+WithCellActions.parameters = {
+    docs: {
+        description: {
+            story: 'DataTable with custom cell actions on the "event" column. Hover over a cell in the event column to see the action menu icon appear.',
+        },
+    },
+}
+
+// Row Actions - demonstrates custom row action menus at the end of each row
+const RowActionsContext: QueryContext = {
+    showQueryEditor: false,
+    extraDataTableQueryFeatures: [QueryFeature.rowActions],
+    rowActions: ({ record }: RowActionProps) => {
+        const eventValue = Array.isArray(record.result) ? String(record.result[0] || '') : ''
+        const personValue = Array.isArray(record.result) ? String(record.result[1] || '') : ''
+        const menuItems: LemonMenuItems = [
+            {
+                title: 'Row Actions',
+                items: [
+                    {
+                        label: `Event: "${eventValue.length > 15 ? eventValue.slice(0, 15) + '...' : eventValue}"`,
+                        icon: <IconLink />,
+                        sideIcon: <IconChevronRight />,
+                        items: [
+                            {
+                                label: 'View event details',
+                                onClick: () => alert(`Viewing details for ${eventValue}`),
+                            },
+                            {
+                                label: 'Create action from event',
+                                onClick: () => alert(`Creating action from ${eventValue}`),
+                            },
+                        ] as LemonMenuItem[],
+                    },
+                    {
+                        label: `View ${personValue}'s sessions`,
+                        onClick: () => alert(`Opening session recordings for ${personValue}`),
+                    },
+                    {
+                        label: 'Export row',
+                        onClick: () => alert('Exporting row data'),
+                    },
+                ] as LemonMenuItem[],
+            },
+        ]
+        return <LemonMenuOverlay items={menuItems} />
+    },
+}
+
+const RowActionsTemplate: StoryFn<typeof Query> = (args) => (
+    <Query {...args} context={RowActionsContext} cachedResults={mockHogQLResults} />
+)
+
+export const WithRowActions: Story = RowActionsTemplate.bind({})
+WithRowActions.args = { query: hogQLQuery }
+WithRowActions.parameters = {
+    docs: {
+        description: {
+            story: 'DataTable with custom row actions. A three-dot menu appears at the end of each row when you hover over it.',
+        },
+    },
+}
+
+// Combined Cell Actions and Row Actions
+const CombinedActionsContext: QueryContext = {
+    showQueryEditor: false,
+    extraDataTableQueryFeatures: [QueryFeature.cellActions, QueryFeature.rowActions],
+    columns: {
+        event: {
+            cellActions: ({ value }: CellActionProps) => {
+                const eventName = String(value || '')
+                const menuItems: LemonMenuItems = [
+                    {
+                        title: `"${eventName.length > 20 ? eventName.slice(0, 20) + '...' : eventName}"`,
+                        items: [
+                            {
+                                label: 'Event Actions',
+                                icon: <IconLink />,
+                                sideIcon: <IconChevronRight />,
+                                items: [
+                                    {
+                                        label: 'Filter to this event',
+                                        onClick: () => alert(`Filtering to ${eventName}`),
+                                    },
+                                    {
+                                        label: 'Exclude this event',
+                                        icon: <IconTrash />,
+                                        status: 'danger' as const,
+                                        onClick: () => alert(`Excluding ${eventName}`),
+                                    },
+                                ] as LemonMenuItem[],
+                            },
+                        ],
+                    },
+                ]
+                return <LemonMenuOverlay items={menuItems} />
+            },
+        },
+        person: {
+            cellActions: ({ value }: CellActionProps) => {
+                const personDisplay = String(value || 'Unknown')
+                const menuItems: LemonMenuItems = [
+                    {
+                        title: `"${personDisplay.length > 15 ? personDisplay.slice(0, 15) + '...' : personDisplay}"`,
+                        items: [
+                            {
+                                label: 'Person Actions',
+                                icon: <IconLink />,
+                                sideIcon: <IconChevronRight />,
+                                items: [
+                                    {
+                                        label: 'View person profile',
+                                        onClick: () => alert(`Viewing profile for ${personDisplay}`),
+                                    },
+                                    {
+                                        label: 'View recordings',
+                                        onClick: () => alert(`Viewing recordings for ${personDisplay}`),
+                                    },
+                                ] as LemonMenuItem[],
+                            },
+                        ],
+                    },
+                ]
+                return <LemonMenuOverlay items={menuItems} />
+            },
+        },
+        // Cell actions on the LAST column to test interaction with row actions
+        'properties.$browser': {
+            cellActions: ({ value }: CellActionProps) => {
+                const browser = String(value || 'Unknown')
+                const menuItems: LemonMenuItems = [
+                    {
+                        title: `Browser: "${browser}"`,
+                        items: [
+                            {
+                                label: 'Browser Actions',
+                                icon: <IconLink />,
+                                sideIcon: <IconChevronRight />,
+                                items: [
+                                    {
+                                        label: `Filter to ${browser} users`,
+                                        onClick: () => alert(`Filtering to ${browser} users`),
+                                    },
+                                    {
+                                        label: `Exclude ${browser}`,
+                                        icon: <IconTrash />,
+                                        status: 'danger' as const,
+                                        onClick: () => alert(`Excluding ${browser} users`),
+                                    },
+                                ] as LemonMenuItem[],
+                            },
+                        ],
+                    },
+                ]
+                return <LemonMenuOverlay items={menuItems} />
+            },
+        },
+    },
+    rowActions: ({ record }: RowActionProps) => {
+        const eventValue = Array.isArray(record.result) ? String(record.result[0] || '') : ''
+        const menuItems: LemonMenuItems = [
+            {
+                title: 'Row Actions',
+                items: [
+                    {
+                        label: 'View full event details',
+                        onClick: () => alert(`Viewing full details for event row`),
+                    },
+                    {
+                        label: 'Copy event JSON',
+                        onClick: () => alert(`Copying JSON for ${eventValue}`),
+                    },
+                ] as LemonMenuItem[],
+            },
+        ]
+        return <LemonMenuOverlay items={menuItems} />
+    },
+}
+
+const CombinedActionsTemplate: StoryFn<typeof Query> = (args) => (
+    <Query {...args} context={CombinedActionsContext} cachedResults={mockHogQLResults} />
+)
+
+export const WithCellAndRowActions: Story = CombinedActionsTemplate.bind({})
+WithCellAndRowActions.args = { query: hogQLQuery }
+WithCellAndRowActions.parameters = {
+    docs: {
+        description: {
+            story: 'DataTable with both cell actions (on event, person, AND the last browser column) and row actions. This demonstrates how cell actions on the last column interact with row actions.',
+        },
+    },
 }

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -9,6 +9,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonTable, LemonTableColumn } from 'lib/lemon-ui/LemonTable'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
@@ -26,6 +27,7 @@ import { Reload } from '~/queries/nodes/DataNode/Reload'
 import { TestAccountFilters } from '~/queries/nodes/DataNode/TestAccountFilters'
 import { DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { BackToSource } from '~/queries/nodes/DataTable/BackToSource'
+import { CellActions } from '~/queries/nodes/DataTable/CellActions'
 import { ColumnConfigurator } from '~/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator'
 import { DataTableExport } from '~/queries/nodes/DataTable/DataTableExport'
 import { DataTableSavedFilters } from '~/queries/nodes/DataTable/DataTableSavedFilters'
@@ -279,10 +281,43 @@ export function DataTable({
                     }
                     return { props: { colSpan: 0 } }
                 } else if (result) {
-                    if (sourceFeatures.has(QueryFeature.resultIsArrayOfArrays)) {
-                        return renderColumn(key, result[index], result, recordIndex, rowCount, query, setQuery, context)
+                    const value = sourceFeatures.has(QueryFeature.resultIsArrayOfArrays) ? result[index] : result[key]
+                    const cellContent = renderColumn(
+                        key,
+                        value,
+                        result,
+                        recordIndex,
+                        rowCount,
+                        query,
+                        setQuery,
+                        context
+                    )
+
+                    // Wrap with cell actions if the column has cellActions defined and the feature is enabled
+                    const hasCellActions =
+                        context?.columns?.[key]?.cellActions ||
+                        getContextColumn(key, context?.columns).queryContextColumn?.cellActions
+
+                    if (
+                        hasCellActions &&
+                        (sourceFeatures.has(QueryFeature.cellActions) ||
+                            context?.extraDataTableQueryFeatures?.includes(QueryFeature.cellActions))
+                    ) {
+                        return (
+                            <CellActions
+                                columnName={key}
+                                query={query}
+                                record={result}
+                                recordIndex={recordIndex}
+                                value={value}
+                                context={context}
+                            >
+                                {cellContent}
+                            </CellActions>
+                        )
                     }
-                    return renderColumn(key, result[key], result, recordIndex, rowCount, query, setQuery, context)
+
+                    return cellContent
                 }
             },
             sorter: undefined, // using custom sorting code
@@ -574,6 +609,27 @@ export function DataTable({
                               return <EventRowActions event={result[columnsInResponse.indexOf('*')]} />
                           }
                           return null
+                      },
+                      width: 0,
+                  },
+              ]
+            : []),
+        ...(context?.rowActions &&
+        (sourceFeatures.has(QueryFeature.rowActions) ||
+            context?.extraDataTableQueryFeatures?.includes(QueryFeature.rowActions))
+            ? [
+                  {
+                      dataIndex: '__row_actions' as any,
+                      title: '',
+                      render: function RenderRowActions(_: any, row: DataTableRow, recordIndex: number) {
+                          if (row.label) {
+                              return { props: { colSpan: 0 } }
+                          }
+                          const actions = context.rowActions?.({ record: row, recordIndex, query })
+                          if (!actions) {
+                              return null
+                          }
+                          return <More overlay={actions} />
                       },
                       width: 0,
                   },

--- a/frontend/src/queries/nodes/DataTable/queryFeatures.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.ts
@@ -5,6 +5,7 @@ import {
     isGroupsQuery,
     isHogQLQuery,
     isMarketingAnalyticsTableQuery,
+    isNonIntegratedConversionsTableQuery,
     isPersonsNode,
     isRevenueAnalyticsTopCustomersQuery,
     isRevenueExampleDataWarehouseTablesQuery,
@@ -38,6 +39,10 @@ export enum QueryFeature {
     hideLoadNextButton,
     testAccountFilters,
     highlightExceptionEventRows,
+    /** Enables custom row actions via QueryContext.rowActions */
+    rowActions,
+    /** Enables custom cell actions via QueryContextColumn.cellActions */
+    cellActions,
 }
 
 export function getQueryFeatures(query: Node): Set<QueryFeature> {
@@ -117,6 +122,13 @@ export function getQueryFeatures(query: Node): Set<QueryFeature> {
     }
 
     if (isMarketingAnalyticsTableQuery(query)) {
+        features.add(QueryFeature.columnsInResponse)
+        features.add(QueryFeature.resultIsArrayOfArrays)
+        features.add(QueryFeature.displayResponseError)
+        features.add(QueryFeature.selectAndOrderByColumns)
+    }
+
+    if (isNonIntegratedConversionsTableQuery(query)) {
         features.add(QueryFeature.columnsInResponse)
         features.add(QueryFeature.resultIsArrayOfArrays)
         features.add(QueryFeature.displayResponseError)

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -15,7 +15,22 @@ import { InsightLogicProps, TrendResult } from '~/types'
 import { ColumnFeature } from './nodes/DataTable/DataTable'
 import { DataTableRow } from './nodes/DataTable/dataTableLogic'
 
-/** Pass custom metadata to queries. Used for e.g. custom columns in the DataTable. */
+/** Props passed to row action render functions */
+export interface RowActionProps {
+    record: DataTableRow
+    recordIndex: number
+    query: DataTableNode
+}
+
+/** Props passed to cell action render functions */
+export interface CellActionProps {
+    columnName: string
+    query: DataTableNode
+    record: unknown
+    recordIndex: number
+    value: unknown
+}
+
 export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     /** Column templates for the DataTable */
     columns?: Record<string, QueryContextColumn>
@@ -56,6 +71,8 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     ignoreActionsInSeriesLabels?: boolean
     /** Transform dataTableRows after they are created (e.g., to add date labels) */
     dataTableRowsTransformer?: (rows: DataTableRow[]) => DataTableRow[]
+    /** Custom row actions to display in a "more" menu at the end of each row */
+    rowActions?: (props: RowActionProps) => JSX.Element | null
 }
 
 export type QueryContextColumnTitleComponent = ComponentType<{
@@ -80,4 +97,6 @@ export interface QueryContextColumn {
     width?: string
     hidden?: boolean // don't show this column in the table
     isRowFillFraction?: boolean // if true, this row will be filled with a background color based on the value (from 0 to 1)
+    /** Custom cell actions to display in a "more" menu for this column's cells */
+    cellActions?: (props: CellActionProps) => JSX.Element | null
 }


### PR DESCRIPTION
- Introduced CustomSourceMappingsConfiguration component for managing custom UTM source mappings in marketing analytics settings.
- Updated MarketingAnalyticsSettings to include the new component.
- Enhanced marketingAnalyticsSettingsLogic to handle custom source mappings.
- Added database migration for custom_source_mappings field in TeamMarketingAnalyticsConfig.
- Implemented validation for custom source mappings to ensure uniqueness across integrations.
- Updated MarketingSourceFactory to merge custom mappings with adapter defaults.
- Added integration tests for custom source mappings functionality.## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
