### PR TITLE
chore: update SDK defaults date to 2025-11-30

### DIFF
--- a/frontend/src/lib/components/JSSnippet.tsx
+++ b/frontend/src/lib/components/JSSnippet.tsx
@@ -8,6 +8,8 @@ import { apiHostOrigin } from 'lib/utils/apiHost'
 import { domainFor, proxyLogic } from 'scenes/settings/environment/proxyLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
+
 function snippetFunctions(arrayJs = '/static/array.js'): string {
     const methods: string[] = []
     const posthogPrototype = Object.getPrototypeOf(posthog)
@@ -52,7 +54,7 @@ export function useJsSnippet(indent = 0, arrayJs?: string, scriptAttributes?: st
             enabled: !!proxyRecord,
         },
         defaults: {
-            content: '2025-11-30',
+            content: SDK_DEFAULTS_DATE,
             enabled: true,
         },
         person_profiles: {

--- a/frontend/src/lib/components/JSSnippet.tsx
+++ b/frontend/src/lib/components/JSSnippet.tsx
@@ -52,7 +52,7 @@ export function useJsSnippet(indent = 0, arrayJs?: string, scriptAttributes?: st
             enabled: !!proxyRecord,
         },
         defaults: {
-            content: '2025-05-24',
+            content: '2025-11-30',
             enabled: true,
         },
         person_profiles: {

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -15,16 +15,12 @@ export function loadPostHogJS(): void {
             opt_out_useragent_filter: window.location.hostname === 'localhost', // we ARE a bot when running in localhost, so we need to enable this opt-out
             api_host: window.JS_POSTHOG_HOST,
             ui_host: window.JS_POSTHOG_UI_HOST,
-            rageclick: true,
+            defaults: '2025-11-30',
             persistence: 'localStorage+cookie',
             bootstrap: window.POSTHOG_USER_IDENTITY_WITH_FLAGS ? window.POSTHOG_USER_IDENTITY_WITH_FLAGS : {},
             opt_in_site_apps: true,
-            api_transport: 'fetch',
             disable_surveys: window.IMPERSONATED_SESSION,
             __preview_deferred_init_extensions: shouldDefer(),
-            session_recording: {
-                strictMinimumDuration: true,
-            },
             error_tracking: {
                 __capturePostHogExceptions: true,
             },
@@ -116,12 +112,10 @@ export function loadPostHogJS(): void {
             autocapture: {
                 capture_copied_text: true,
             },
-            capture_performance: { web_vitals: true },
             person_profiles: 'always',
             __preview_remote_config: true,
             __preview_flags_v2: true,
             __add_tracing_headers: ['eu.posthog.com', 'us.posthog.com'],
-            __preview_eager_load_replay: false,
             __preview_disable_xhr_credentials: true,
         })
 

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -4,6 +4,8 @@ import { sampleOnProperty } from 'posthog-js/lib/src/extensions/sampling'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils'
 
+export const SDK_DEFAULTS_DATE = '2025-11-30'
+
 const shouldDefer = (): boolean => {
     const sessionId = posthog.get_session_id()
     return sampleOnProperty(sessionId, 0.5)
@@ -15,7 +17,7 @@ export function loadPostHogJS(): void {
             opt_out_useragent_filter: window.location.hostname === 'localhost', // we ARE a bot when running in localhost, so we need to enable this opt-out
             api_host: window.JS_POSTHOG_HOST,
             ui_host: window.JS_POSTHOG_UI_HOST,
-            defaults: '2025-11-30',
+            defaults: SDK_DEFAULTS_DATE,
             persistence: 'localStorage+cookie',
             bootstrap: window.POSTHOG_USER_IDENTITY_WITH_FLAGS ? window.POSTHOG_USER_IDENTITY_WITH_FLAGS : {},
             opt_in_site_apps: true,

--- a/frontend/src/scenes/onboarding/sdks/error-tracking/nuxt.tsx
+++ b/frontend/src/scenes/onboarding/sdks/error-tracking/nuxt.tsx
@@ -9,7 +9,8 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { SDK_DEFAULTS_DATE } from '../sdk-install-instructions/constants'
+import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
+
 import { JSInstallSnippet } from '../sdk-install-instructions/js-web'
 import { JSManualCapture } from './FinalSteps'
 
@@ -170,8 +171,8 @@ const nuxtModuleConfig = (apiKey: string, host: string, teamId: string): string 
   modules: ['@posthog/nuxt'],
 
   // Enable source maps generation in both vue and nitro
-  sourcemap: { 
-    client: 'hidden' 
+  sourcemap: {
+    client: 'hidden'
   },
   nitro: {
     rollupConfig: {
@@ -217,8 +218,8 @@ export default defineEventHandler(async (event) => {
 
   const posthog = new PostHog(
     runtimeConfig.public.posthogPublicKey,
-    { 
-      host: runtimeConfig.public.posthogHost, 
+    {
+      host: runtimeConfig.public.posthogHost,
     }
   );
 

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/angular.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/angular.tsx
@@ -6,7 +6,8 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { SDK_DEFAULTS_DATE } from './constants'
+import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
+
 import { JSInstallSnippet } from './js-web'
 
 function EnvVarsSnippet(): JSX.Element {

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/constants.ts
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/constants.ts
@@ -1,1 +1,0 @@
-export const SDK_DEFAULTS_DATE = '2025-11-30'

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/constants.ts
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/constants.ts
@@ -1,1 +1,1 @@
-export const SDK_DEFAULTS_DATE = '2025-05-24'
+export const SDK_DEFAULTS_DATE = '2025-11-30'

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
@@ -10,8 +10,9 @@ import { apiHostOrigin } from 'lib/utils/apiHost'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
+
 import SetupWizardBanner from './components/SetupWizardBanner'
-import { SDK_DEFAULTS_DATE } from './constants'
 import { JSInstallSnippet } from './js-web'
 import { type NextJSRouter, nextJsInstructionsLogic } from './nextJsInstructionsLogic'
 

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/nuxt.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/nuxt.tsx
@@ -7,7 +7,8 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { SDK_DEFAULTS_DATE } from './constants'
+import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
+
 import { JSInstallSnippet } from './js-web'
 
 function NuxtEnvVarsSnippet(): JSX.Element {

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
@@ -7,8 +7,9 @@ import { apiHostOrigin } from 'lib/utils/apiHost'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
+
 import SetupWizardBanner from './components/SetupWizardBanner'
-import { SDK_DEFAULTS_DATE } from './constants'
 import { JSInstallSnippet } from './js-web'
 
 function ReactEnvVarsSnippet(): JSX.Element {

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/remix.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/remix.tsx
@@ -6,7 +6,8 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { SDK_DEFAULTS_DATE } from './constants'
+import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
+
 import { JSInstallSnippet } from './js-web'
 
 function RemixExternalImportSnippet(): JSX.Element {

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/svelte.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/svelte.tsx
@@ -9,8 +9,9 @@ import { apiHostOrigin } from 'lib/utils/apiHost'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
+
 import SetupWizardBanner from './components/SetupWizardBanner'
-import { SDK_DEFAULTS_DATE } from './constants'
 import { JSInstallSnippet } from './js-web'
 
 function SvelteAppClientCodeSnippet(): JSX.Element {

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/vue.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/vue.tsx
@@ -7,7 +7,8 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { SDK_DEFAULTS_DATE } from './constants'
+import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
+
 import { JSInstallSnippet } from './js-web'
 
 function VueCreateComposableFileSnippet(): JSX.Element {


### PR DESCRIPTION
simplify our posthog-js setup

and switch the advertised defaults to  2025-11-30  
  
this turns on skipping rage clicks on prev and next buttons, and strict minimum duration for replay