### PR TITLE
chore: change "health check ok" log level from info to debug

### DIFF
--- a/rust/common/health/src/lib.rs
+++ b/rust/common/health/src/lib.rs
@@ -7,7 +7,7 @@ use axum::response::{IntoResponse, Response};
 use std::time::Duration;
 use tokio::runtime;
 use tokio::sync::mpsc;
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
 /// Health reporting for components of the service.
 ///
@@ -252,7 +252,7 @@ impl HealthRegistry {
                 result
             });
         match result.healthy {
-            true => info!("{} health check ok", self.name),
+            true => debug!("{} health check ok", self.name),
             false => warn!("{} health check failed: {:?}", self.name, result.components),
         }
         result


### PR DESCRIPTION

## Problem
this log is very noisy and very low signal, it should be enough to note the absense of the "health check failed" log as implying the health check is passing


## Changes
change to debug level, we log at info level by default in production so this will hide the noise from a lot of our rust services

## How did you test this code?
ran locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
