### PR TITLE
fix: Address issues in Snowflake batch export

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -356,7 +356,7 @@ class SnowflakeField(Field):
         return cls(field.name, snowflake_type, snowflake_type_to_data_type(snowflake_type), field.is_nullable)
 
     @property
-    def snowflake_type_name(self) -> str:
+    def snowflake_type_name(self) -> SnowflakeTypeName:
         if self.snowflake_type.repeated is True:
             return "ARRAY"
         else:

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -957,7 +957,7 @@ class SnowflakeClient:
         """
         select_fields = ", ".join(
             f'PARSE_JSON($1:"{field.name}")'
-            if field.data_type == JsonType() and field.name != "elements"
+            if field.data_type == JsonType() and field.name.lower() != "elements"
             else f'$1:"{field.name}"'
             for field in table
         )

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -355,8 +355,15 @@ class SnowflakeField(Field):
 
         return cls(field.name, snowflake_type, snowflake_type_to_data_type(snowflake_type), field.is_nullable)
 
+    @property
+    def snowflake_type_name(self) -> str:
+        if self.snowflake_type.repeated is True:
+            return "ARRAY"
+        else:
+            return self.snowflake_type.name
+
     def to_destination_field(self) -> SnowflakeDestinationField:
-        return SnowflakeDestinationField(name=self.name, type=self.snowflake_type.name, is_nullable=self.nullable)
+        return SnowflakeDestinationField(name=self.name, type=self.snowflake_type_name, is_nullable=self.nullable)
 
 
 class SnowflakeTable(Table):
@@ -818,7 +825,7 @@ class SnowflakeClient:
                 Whether to include an 'IF NOT EXISTS' clause in the query such that it
                 won't fail if the table already exists.
         """
-        field_ddl = ", ".join(f'"{field.name}" {field.snowflake_type.name}' for field in table)
+        field_ddl = ", ".join(f'"{field.name}" {field.snowflake_type_name}' for field in table)
 
         if_not_exists = ""
         if exists_ok:


### PR DESCRIPTION
## Problem

* There is an issue with ARRAY columns. I accidentally was passing the array's internal type (i.e. "STRING") rather than the type "ARRAY" when creating a table in snowflake.
    * I've now added a test to verify the array value inserted in sessions, this was not caught by our tests before.
* Users having UPPERCASE column names were passing the check for `field.name != "elements"` which caused errors when parsing "ELEMENTS" which is not really a JSON field although it is exported as one for historical reasons.
    * I've made the check case insensitive.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

See above.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran test suite, extended unit test as described.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
