### PR TITLE
fix: ensure consistent ordering when querying teams and orgs for digest

### DIFF
--- a/posthog/temporal/weekly_digest/queries.py
+++ b/posthog/temporal/weekly_digest/queries.py
@@ -29,15 +29,16 @@ def query_teams_for_digest() -> QuerySet:
             "organization__created_at",
             "organization__available_product_features",
         )
+        .order_by("id")
     )
 
 
 def query_orgs_for_digest() -> QuerySet:
-    return Organization.objects.exclude(Q(for_internal_metrics=True)).only("id", "name", "created_at")
+    return Organization.objects.exclude(Q(for_internal_metrics=True)).only("id", "name", "created_at").order_by("id")
 
 
 def query_org_teams(organization: Organization) -> QuerySet:
-    return Team.objects.only("id", "name").filter(organization=organization).exclude(is_demo=True)
+    return Team.objects.only("id", "name").filter(organization=organization).exclude(is_demo=True).order_by("id")
 
 
 def query_org_members(organization: Organization) -> QuerySet:
@@ -45,7 +46,7 @@ def query_org_members(organization: Organization) -> QuerySet:
         OrganizationMembership.objects.filter(organization_id=organization.id)
         .select_related("user")
         .only("id", "user__distinct_id", "user__first_name", "user__email")
-    )
+    ).order_by("id")
 
 
 def query_new_dashboards(period_start: datetime, period_end: datetime) -> QuerySet:


### PR DESCRIPTION
Avoids skipping rows when splitting up the workload across activities.