### PR TITLE
fix: notebook node query scrolling

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from 'react'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
@@ -104,21 +105,23 @@ const Component = ({
     return (
         <div className="flex flex-1 flex-col h-full" data-attr="notebook-node-query">
             <BindLogic logic={insightLogic} props={insightLogicProps}>
-                <Query
-                    // use separate keys for the settings and visualization to avoid conflicts with insightProps
-                    uniqueKey={nodeId + '-component'}
-                    query={modifiedQuery}
-                    setQuery={(t) => {
-                        updateAttributes({
-                            query: {
-                                ...attributes.query,
-                                source: (t as DataTableNode | InsightVizNode).source,
-                            } as QuerySchema,
-                        })
-                    }}
-                    embedded
-                    readOnly
-                />
+                <ScrollableShadows direction="vertical" className="flex-1">
+                    <Query
+                        // use separate keys for the settings and visualization to avoid conflicts with insightProps
+                        uniqueKey={nodeId + '-component'}
+                        query={modifiedQuery}
+                        setQuery={(t) => {
+                            updateAttributes({
+                                query: {
+                                    ...attributes.query,
+                                    source: (t as DataTableNode | InsightVizNode).source,
+                                } as QuerySchema,
+                            })
+                        }}
+                        embedded
+                        readOnly
+                    />
+                </ScrollableShadows>
             </BindLogic>
         </div>
     )


### PR DESCRIPTION
## Problem
Notebook node queries weren't scrolling
<img width="2000" height="1170" alt="image" src="https://github.com/user-attachments/assets/f00c98de-b05e-4b97-a0d6-a1a039a2178f" />

## Changes
Add `<ScrollableShadows>` (to match Events in notebooks)  around the `<Query>` and voila, she scrolls.

![2025-11-27 10 28 44](https://github.com/user-attachments/assets/445c94f4-6a7f-4b04-b311-4f669397eb73)


## How did you test this code?
was able to reproduce locally, and fix works