### PR TITLE
feat(capture-logs): use json logging and add more context

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -108,7 +108,7 @@ tower = { version = "0.4.13", features = ["default", "limit"] }
 tower-http = { version = "0.5.2", features = ["cors", "limit", "trace"] }
 tracing = "0.1.40"
 tracing-opentelemetry = "0.23.0"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 url = "2.5.0"
 uuid = { version = "1.6.1", features = ["v4", "v7", "serde"] }
 neon = "1"

--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -35,11 +35,9 @@ async fn shutdown() {
 }
 
 fn setup_tracing() {
-    let log_layer: tracing_subscriber::filter::Filtered<
-        tracing_subscriber::fmt::Layer<tracing_subscriber::Registry>,
-        EnvFilter,
-        tracing_subscriber::Registry,
-    > = tracing_subscriber::fmt::layer().with_filter(EnvFilter::from_default_env());
+    let log_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_filter(EnvFilter::from_default_env());
     tracing_subscriber::registry().with(log_layer).init();
 }
 

--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -36,7 +36,8 @@ async fn shutdown() {
 
 fn setup_tracing() {
     let log_layer = tracing_subscriber::fmt::layer()
-        .json().with_span_list(false)
+        .json()
+        .with_span_list(false)
         .with_filter(EnvFilter::from_default_env());
     tracing_subscriber::registry().with(log_layer).init();
 }

--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -36,7 +36,7 @@ async fn shutdown() {
 
 fn setup_tracing() {
     let log_layer = tracing_subscriber::fmt::layer()
-        .json()
+        .json().with_span_list(false)
         .with_filter(EnvFilter::from_default_env());
     tracing_subscriber::registry().with(log_layer).init();
 }


### PR DESCRIPTION
## Problem

we get a handful of capture errors from logs but we don't know the cause - add structured logging with more context to help us debug things

## Changes

New example log line:

> `{"timestamp":"2025-11-27T10:17:45.577089Z","level":"ERROR","fields":{"message":"Failed to decode JSON: invalid length 0, expected struct ExportLogsServiceRequest with 1 element at line 1 column 2 or Protobuf: failed to decode Protobuf message: buffer underflow"},"target":"capture_logs::service","span":{"content_encoding":"","content_length":"2","content_type":"application/x-www-form-urlencoded","token":"blah","user_agent":"curl/8.7.1","name":"export_logs_http"}}`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
