### PR TITLE
fix(logs): pass tabId to attributeBreakdownLogic when connecting to logsLogic

### DIFF
--- a/products/logs/frontend/AttributeBreakdowns.tsx
+++ b/products/logs/frontend/AttributeBreakdowns.tsx
@@ -10,11 +10,13 @@ import { attributeBreakdownLogic } from './attributeBreakdownLogic'
 export const AttributeBreakdowns = ({
     attribute,
     addFilter,
+    tabId,
 }: {
     attribute: string
     addFilter: (key: string, value: string, operator?: PropertyOperator) => void
+    tabId: string
 }): JSX.Element => {
-    const logic = attributeBreakdownLogic({ attribute })
+    const logic = attributeBreakdownLogic({ attribute, tabId })
     const { attributeValues, logCount, breakdowns } = useValues(logic)
 
     const dataSource = Object.entries(breakdowns)

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -317,7 +317,7 @@ function LogsTable({
 }
 
 const ExpandedLog = ({ log }: { log: LogMessage }): JSX.Element => {
-    const { expandedAttributeBreaksdowns } = useValues(logsLogic)
+    const { expandedAttributeBreaksdowns, tabId } = useValues(logsLogic)
     const { addFilter, toggleAttributeBreakdown } = useActions(logsLogic)
 
     const attributes = log.attributes
@@ -386,7 +386,9 @@ const ExpandedLog = ({ log }: { log: LogMessage }): JSX.Element => {
                 noIndent: true,
                 showRowExpansionToggle: false,
                 isRowExpanded: (record) => expandedAttributeBreaksdowns.includes(record.key),
-                expandedRowRender: (record) => <AttributeBreakdowns attribute={record.key} addFilter={addFilter} />,
+                expandedRowRender: (record) => (
+                    <AttributeBreakdowns attribute={record.key} addFilter={addFilter} tabId={tabId} />
+                ),
             }}
         />
     )

--- a/products/logs/frontend/attributeBreakdownLogic.tsx
+++ b/products/logs/frontend/attributeBreakdownLogic.tsx
@@ -5,15 +5,16 @@ import { logsLogic } from './logsLogic'
 
 export interface AttributeBreakdownLogicProps {
     attribute: string
+    tabId: string
 }
 
 export const attributeBreakdownLogic = kea<attributeBreakdownLogicType>([
     props({} as AttributeBreakdownLogicProps),
-    key((props) => props.attribute),
+    key((props) => `${props.tabId}-${props.attribute}`),
     path((key) => ['products', 'logs', 'frontend', 'logsAttributeBreakdownsLogic', key]),
 
-    connect(() => ({
-        values: [logsLogic, ['logs']],
+    connect((props: AttributeBreakdownLogicProps) => ({
+        values: [logsLogic({ tabId: props.tabId }), ['logs']],
     })),
 
     selectors(({ props }) => ({

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -446,7 +446,8 @@ export const logsLogic = kea<logsLogicType>([
         ],
     })),
 
-    selectors(() => ({
+    selectors(({ props }) => ({
+        tabId: [() => [], () => props.tabId as string],
         utcDateRange: [
             (s) => [s.dateRange],
             (dateRange) => ({

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -1,6 +1,6 @@
 import colors from 'ansi-colors'
 import equal from 'fast-deep-equal'
-import { actions, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 
@@ -44,7 +44,12 @@ const parseLogAttributes = (logs: LogMessage[]): void => {
     })
 }
 
+export interface LogsLogicProps {
+    tabId: string
+}
+
 export const logsLogic = kea<logsLogicType>([
+    props({} as LogsLogicProps),
     path(['products', 'logs', 'frontend', 'logsLogic']),
     tabAwareScene(),
     tabAwareUrlToAction(({ actions, values }) => {
@@ -446,8 +451,8 @@ export const logsLogic = kea<logsLogicType>([
         ],
     })),
 
-    selectors(({ props }) => ({
-        tabId: [() => [], () => props.tabId as string],
+    selectors({
+        tabId: [(_, p) => [p.tabId], (tabId: string) => tabId],
         utcDateRange: [
             (s) => [s.dateRange],
             (dateRange) => ({
@@ -590,7 +595,7 @@ export const logsLogic = kea<logsLogicType>([
                 return newest
             },
         ],
-    })),
+    }),
 
     listeners(({ values, actions }) => ({
         fetchLogsFailure: ({ error }) => {


### PR DESCRIPTION
## Problem

attributeBreakdownLogic was connecting to logsLogic without tabId, causing "must have a tabId prop" error when clicking attribute breakdown.

## Changes

Passes the tab id down to the attributeBreakdownLogic connector

## How did you test this code?

Local dev & confirmed bug no longer occurs

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._