### PR TITLE
fix(logs): Show error toast on fetchLogsFailure for unexpected errors

### DIFF
--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -33,6 +33,7 @@ const DEFAULT_WRAP_BODY = true
 const DEFAULT_PRETTIFY_JSON = true
 const DEFAULT_TIMESTAMP_FORMAT = 'absolute' as 'absolute' | 'relative'
 const DEFAULT_LOGS_PAGE_SIZE = 100
+const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
 
 const parseLogAttributes = (logs: LogMessage[]): void => {
     logs.forEach((row) => {
@@ -553,9 +554,13 @@ export const logsLogic = kea<logsLogicType>([
 
     listeners(({ values, actions }) => ({
         fetchLogsFailure: ({ error }) => {
-            if (error !== 'new query started') {
-                // this is expected and does not need to be shown to the user
+            if (error !== NEW_QUERY_STARTED_ERROR_MESSAGE) {
                 lemonToast.error(`Failed to load logs: ${error}`)
+            }
+        },
+        loadMoreLogsFailure: ({ error }) => {
+            if (error !== NEW_QUERY_STARTED_ERROR_MESSAGE) {
+                lemonToast.error(`Failed to load more logs: ${error}`)
             }
         },
         runQuery: async ({ debounce }, breakpoint) => {
@@ -568,13 +573,13 @@ export const logsLogic = kea<logsLogicType>([
         },
         cancelInProgressLogs: ({ logsAbortController }) => {
             if (values.logsAbortController !== null) {
-                values.logsAbortController.abort('new query started')
+                values.logsAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
             }
             actions.setLogsAbortController(logsAbortController)
         },
         cancelInProgressSparkline: ({ sparklineAbortController }) => {
             if (values.sparklineAbortController !== null) {
-                values.sparklineAbortController.abort('new query started')
+                values.sparklineAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
             }
             actions.setSparklineAbortController(sparklineAbortController)
         },

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -4,6 +4,7 @@ import { actions, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 
+import { lemonToast } from '@posthog/lemon-ui'
 import { syncSearchParams, updateSearchParams } from '@posthog/products-error-tracking/frontend/utils'
 
 import api from 'lib/api'
@@ -551,6 +552,12 @@ export const logsLogic = kea<logsLogicType>([
     })),
 
     listeners(({ values, actions }) => ({
+        fetchLogsFailure: ({ error }) => {
+            if (error !== 'new query started') {
+                // this is expected and does not need to be shown to the user
+                lemonToast.error(`Failed to load logs: ${error}`)
+            }
+        },
         runQuery: async ({ debounce }, breakpoint) => {
             if (debounce) {
                 await breakpoint(debounce)


### PR DESCRIPTION
## Problem

Following [https://github.com/PostHog/posthog/pull/42197](#42197)  there was no indication in the UI of when querying logs failed.

## Changes

<img width="447" height="110" alt="image" src="https://github.com/user-attachments/assets/59c444cf-cfed-4707-9c5e-7aa802a68861" />

Adds a toast for when initial logs query or fetch more query fails, that does not show on regular breakpoint cancellation.

## How did you test this code?

Local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._