### PR TITLE
fix: improve DOM processing for the toolbar

### DIFF
--- a/.idea/posthog.iml
+++ b/.idea/posthog.iml
@@ -53,8 +53,8 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">
-    <option name="format" value="GOOGLE" />
-    <option name="myDocStringFormat" value="Google" />
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
   </component>
   <component name="TemplatesService">
     <option name="TEMPLATE_CONFIGURATION" value="Django" />

--- a/frontend/src/toolbar/elements/domElementIndex.test.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.test.ts
@@ -1,0 +1,503 @@
+import { collectAllElementsDeep, querySelectorAllDeep } from 'query-selector-shadow-dom'
+
+import { elementToSelector } from 'lib/actionUtils'
+
+import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
+
+import { buildDOMIndex, matchEventToElementUsingIndex } from './domElementIndex'
+
+function matchEventToElementOriginal(
+    event: ElementsEventType,
+    dataAttributes: string[],
+    matchLinksByHref: boolean,
+    pageElements: HTMLElement[],
+    selectorCache: Record<string, HTMLElement[]>
+): CountedHTMLElement | null {
+    let lastSelector: string | undefined
+
+    for (let i = 0; i < event.elements.length; i++) {
+        const element = event.elements[i]
+        const selector =
+            elementToSelector(matchLinksByHref ? element : { ...element, href: undefined }, dataAttributes) || '*'
+        const combinedSelector = lastSelector ? `${selector} > ${lastSelector}` : selector
+
+        try {
+            let domElements: HTMLElement[] | undefined = selectorCache[combinedSelector]
+            if (domElements === undefined) {
+                domElements = Array.from(querySelectorAllDeep(combinedSelector, document, pageElements))
+                selectorCache[combinedSelector] = domElements
+            }
+
+            if (domElements.length === 1) {
+                const e = event.elements[i]
+                const isTooSimple =
+                    i === 0 &&
+                    e.tag_name &&
+                    !e.attr_class &&
+                    !e.attr_id &&
+                    !e.href &&
+                    !e.text &&
+                    e.nth_child === 1 &&
+                    e.nth_of_type === 1 &&
+                    !e.attributes['attr__data-attr']
+
+                if (!isTooSimple) {
+                    return {
+                        element: domElements[0],
+                        count: event.count,
+                        selector: selector,
+                        hash: event.hash,
+                        type: event.type,
+                        clickCount: 0,
+                        rageclickCount: 0,
+                        deadclickCount: 0,
+                    }
+                }
+            }
+
+            if (domElements.length === 0) {
+                if (i === event.elements.length - 1) {
+                    return null
+                } else if (i > 0 && lastSelector) {
+                    lastSelector = `* > ${lastSelector}`
+                    continue
+                }
+            }
+        } catch {
+            break
+        }
+
+        lastSelector = combinedSelector
+    }
+
+    return null
+}
+
+function createTestDOM(html: string): { container: HTMLElement; cleanup: () => void } {
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+    return {
+        container,
+        cleanup: () => {
+            document.body.removeChild(container)
+        },
+    }
+}
+
+function getAllElements(container: HTMLElement): HTMLElement[] {
+    return Array.from(container.querySelectorAll('*')) as HTMLElement[]
+}
+
+describe('domElementIndex', () => {
+    describe('buildDOMIndex', () => {
+        const indexByIdCases = [
+            {
+                name: 'indexes single element by id',
+                html: '<div id="test-id"></div>',
+                id: 'test-id',
+                expectedCount: 1,
+            },
+            {
+                name: 'indexes multiple elements with same id',
+                html: '<div id="dup"></div><span id="dup"></span>',
+                id: 'dup',
+                expectedCount: 2,
+            },
+        ]
+
+        it.each(indexByIdCases)('$name', ({ html, id, expectedCount }) => {
+            const { container, cleanup } = createTestDOM(html)
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                expect(index.byId.get(id)?.length).toBe(expectedCount)
+            } finally {
+                cleanup()
+            }
+        })
+
+        const indexByTagNameCases = [
+            {
+                name: 'indexes elements by tag name',
+                html: '<div></div><div></div><span></span>',
+                tag: 'div',
+                expectedCount: 2,
+            },
+            {
+                name: 'indexes tag names case-insensitively',
+                html: '<DIV></DIV><div></div>',
+                tag: 'div',
+                expectedCount: 2,
+            },
+        ]
+
+        it.each(indexByTagNameCases)('$name', ({ html, tag, expectedCount }) => {
+            const { container, cleanup } = createTestDOM(html)
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                expect(index.byTagName.get(tag)?.length).toBe(expectedCount)
+            } finally {
+                cleanup()
+            }
+        })
+
+        const indexByClassCases = [
+            {
+                name: 'indexes elements by class',
+                html: '<div class="foo"></div><div class="foo bar"></div>',
+                className: 'foo',
+                expectedCount: 2,
+            },
+            {
+                name: 'indexes each class separately',
+                html: '<div class="a b c"></div>',
+                className: 'b',
+                expectedCount: 1,
+            },
+        ]
+
+        it.each(indexByClassCases)('$name', ({ html, className, expectedCount }) => {
+            const { container, cleanup } = createTestDOM(html)
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                expect(index.byClass.get(className)?.length).toBe(expectedCount)
+            } finally {
+                cleanup()
+            }
+        })
+
+        const indexByDataAttrCases = [
+            {
+                name: 'indexes elements by data attribute',
+                html: '<div data-testid="button"></div>',
+                attrName: 'data-testid',
+                attrValue: 'button',
+                expectedCount: 1,
+            },
+            {
+                name: 'indexes multiple elements with same data attribute value',
+                html: '<div data-testid="item"></div><span data-testid="item"></span>',
+                attrName: 'data-testid',
+                attrValue: 'item',
+                expectedCount: 2,
+            },
+        ]
+
+        it.each(indexByDataAttrCases)('$name', ({ html, attrName, attrValue, expectedCount }) => {
+            const { container, cleanup } = createTestDOM(html)
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                expect(index.byDataAttr.get(attrName)?.get(attrValue)?.length).toBe(expectedCount)
+            } finally {
+                cleanup()
+            }
+        })
+
+        it('stores fingerprints with correct nth-child and nth-of-type', () => {
+            const { container, cleanup } = createTestDOM(
+                '<ul><li></li><li id="target"></li><span></span><li></li></ul>'
+            )
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                const target = container.querySelector('#target') as HTMLElement
+                const fingerprint = index.fingerprints.get(target)
+
+                expect(fingerprint?.nthChild).toBe(2)
+                expect(fingerprint?.nthOfType).toBe(2)
+            } finally {
+                cleanup()
+            }
+        })
+    })
+
+    describe('matchEventToElementUsingIndex', () => {
+        function createEvent(
+            elements: Partial<ElementsEventType['elements'][0]>[],
+            overrides?: Partial<ElementsEventType>
+        ): ElementsEventType {
+            return {
+                count: 1,
+                hash: 'test-hash',
+                type: '$autocapture',
+                elements: elements.map((el) => ({
+                    tag_name: 'div',
+                    attributes: {},
+                    ...el,
+                })),
+                ...overrides,
+            }
+        }
+
+        const matchByIdCases = [
+            {
+                name: 'matches element by id',
+                html: '<div id="target"></div><div></div>',
+                event: { attr_id: 'target' },
+                shouldMatch: true,
+            },
+            {
+                name: 'returns null when id not found',
+                html: '<span id="other"></span>',
+                event: { attr_id: 'nonexistent', tag_name: 'button' },
+                shouldMatch: false,
+            },
+        ]
+
+        it.each(matchByIdCases)('$name', ({ html, event, shouldMatch }) => {
+            const { container, cleanup } = createTestDOM(html)
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                const result = matchEventToElementUsingIndex(createEvent([event]), [], false, index)
+
+                if (shouldMatch) {
+                    expect(result).not.toBeNull()
+                    expect(result?.element.id).toBe(event.attr_id)
+                } else {
+                    expect(result).toBeNull()
+                }
+            } finally {
+                cleanup()
+            }
+        })
+
+        const matchByClassCases = [
+            {
+                name: 'matches element by single class',
+                html: '<div class="target"></div><div class="other"></div>',
+                event: { tag_name: 'div', attr_class: ['target'] },
+                shouldMatch: true,
+            },
+            {
+                name: 'matches element by multiple classes',
+                html: '<div class="a b c"></div><div class="a"></div>',
+                event: { tag_name: 'div', attr_class: ['a', 'b'] },
+                shouldMatch: true,
+            },
+            {
+                name: 'returns null when class combination not found',
+                html: '<div class="a"></div><div class="b"></div>',
+                event: { tag_name: 'div', attr_class: ['a', 'b'] },
+                shouldMatch: false,
+            },
+        ]
+
+        it.each(matchByClassCases)('$name', ({ html, event, shouldMatch }) => {
+            const { container, cleanup } = createTestDOM(html)
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                const result = matchEventToElementUsingIndex(createEvent([event]), [], false, index)
+
+                if (shouldMatch) {
+                    expect(result).not.toBeNull()
+                } else {
+                    expect(result).toBeNull()
+                }
+            } finally {
+                cleanup()
+            }
+        })
+
+        const nthChildCases = [
+            {
+                name: 'filters by nth-child position',
+                html: '<ul><li></li><li id="target"></li><li></li></ul>',
+                event: { tag_name: 'li', nth_child: 2 },
+                expectedId: 'target',
+            },
+            {
+                name: 'filters by nth-of-type position',
+                html: '<div><span></span><p></p><span id="target"></span></div>',
+                event: { tag_name: 'span', nth_of_type: 2 },
+                expectedId: 'target',
+            },
+        ]
+
+        it.each(nthChildCases)('$name', ({ html, event, expectedId }) => {
+            const { container, cleanup } = createTestDOM(html)
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                const result = matchEventToElementUsingIndex(createEvent([event]), [], false, index)
+
+                expect(result).not.toBeNull()
+                expect(result?.element.id).toBe(expectedId)
+            } finally {
+                cleanup()
+            }
+        })
+
+        it('uses parent chain to disambiguate multiple candidates', () => {
+            const { container, cleanup } = createTestDOM(`
+                <div class="container-a"><button class="btn"></button></div>
+                <div class="container-b"><button class="btn" id="target"></button></div>
+            `)
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                const event = createEvent([
+                    { tag_name: 'button', attr_class: ['btn'] },
+                    { tag_name: 'div', attr_class: ['container-b'] },
+                ])
+                const result = matchEventToElementUsingIndex(event, [], false, index)
+
+                expect(result).not.toBeNull()
+                expect(result?.element.id).toBe('target')
+            } finally {
+                cleanup()
+            }
+        })
+
+        it('applies isTooSimple check for generic elements', () => {
+            const { container, cleanup } = createTestDOM('<div><div></div></div>')
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                const event = createEvent([{ tag_name: 'div', nth_child: 1, nth_of_type: 1 }])
+                const result = matchEventToElementUsingIndex(event, [], false, index)
+
+                expect(result).toBeNull()
+            } finally {
+                cleanup()
+            }
+        })
+
+        it('does not apply isTooSimple check when element has class', () => {
+            const { container, cleanup } = createTestDOM('<div><div class="content"></div></div>')
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                const event = createEvent([{ tag_name: 'div', attr_class: ['content'], nth_child: 1, nth_of_type: 1 }])
+                const result = matchEventToElementUsingIndex(event, [], false, index)
+
+                expect(result).not.toBeNull()
+            } finally {
+                cleanup()
+            }
+        })
+
+        it('returns null for empty elements array', () => {
+            const { container, cleanup } = createTestDOM('<div></div>')
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                const event = createEvent([])
+                const result = matchEventToElementUsingIndex(event, [], false, index)
+
+                expect(result).toBeNull()
+            } finally {
+                cleanup()
+            }
+        })
+
+        it('preserves event count and type in result', () => {
+            const { container, cleanup } = createTestDOM('<div id="target"></div>')
+            try {
+                const index = buildDOMIndex(getAllElements(container))
+                const event = createEvent([{ attr_id: 'target' }], { count: 42, type: '$rageclick' })
+                const result = matchEventToElementUsingIndex(event, [], false, index)
+
+                expect(result?.count).toBe(42)
+                expect(result?.type).toBe('$rageclick')
+            } finally {
+                cleanup()
+            }
+        })
+    })
+
+    describe('index-based vs selector-based matching comparison', () => {
+        function createEvent(
+            elements: Partial<ElementsEventType['elements'][0]>[],
+            overrides?: Partial<ElementsEventType>
+        ): ElementsEventType {
+            return {
+                count: 1,
+                hash: 'test-hash',
+                type: '$autocapture',
+                elements: elements.map((el) => ({
+                    tag_name: 'div',
+                    attributes: {},
+                    ...el,
+                })),
+                ...overrides,
+            }
+        }
+
+        const comparisonCases = [
+            {
+                name: 'matches button by id',
+                html: '<button id="submit-btn">Submit</button>',
+                event: [{ tag_name: 'button', attr_id: 'submit-btn', text: 'Submit' }],
+            },
+            {
+                name: 'matches link by class and href',
+                html: '<a class="nav-link" href="/home">Home</a>',
+                event: [{ tag_name: 'a', attr_class: ['nav-link'], href: '/home' }],
+            },
+            {
+                name: 'matches nested element with parent chain',
+                html: `
+                    <div class="card">
+                        <div class="card-body">
+                            <button class="btn btn-primary">Click</button>
+                        </div>
+                    </div>
+                `,
+                event: [
+                    { tag_name: 'button', attr_class: ['btn', 'btn-primary'] },
+                    { tag_name: 'div', attr_class: ['card-body'] },
+                    { tag_name: 'div', attr_class: ['card'] },
+                ],
+            },
+            {
+                name: 'matches element by nth-child in list',
+                html: '<ul><li>One</li><li id="target">Two</li><li>Three</li></ul>',
+                event: [
+                    { tag_name: 'li', nth_child: 2, nth_of_type: 2 },
+                    { tag_name: 'ul', nth_child: 1, nth_of_type: 1 },
+                ],
+            },
+            {
+                name: 'matches input by type attribute',
+                html: '<input type="email" class="form-control" id="email-input">',
+                event: [{ tag_name: 'input', attr_id: 'email-input', attr_class: ['form-control'] }],
+            },
+            {
+                name: 'does not match when element missing',
+                html: '<div class="container"></div>',
+                event: [{ tag_name: 'button', attr_class: ['missing'] }],
+            },
+            {
+                name: 'matches data-testid element',
+                html: '<button data-testid="cta-button">Click me</button>',
+                event: [{ tag_name: 'button', attributes: { 'attr__data-testid': 'cta-button' } }],
+                dataAttributes: ['data-testid'],
+            },
+        ]
+
+        it.each(comparisonCases)('$name: both implementations agree', ({ html, event, dataAttributes = [] }) => {
+            const { cleanup } = createTestDOM(html)
+            try {
+                const pageElements = collectAllElementsDeep('*', document) as HTMLElement[]
+                const index = buildDOMIndex(pageElements)
+                const selectorCache: Record<string, HTMLElement[]> = {}
+
+                const eventObj = createEvent(event)
+
+                const indexResult = matchEventToElementUsingIndex(eventObj, dataAttributes, true, index)
+                const originalResult = matchEventToElementOriginal(
+                    eventObj,
+                    dataAttributes,
+                    true,
+                    pageElements,
+                    selectorCache
+                )
+
+                if (originalResult === null) {
+                    expect(indexResult).toBeNull()
+                } else {
+                    expect(indexResult).not.toBeNull()
+                    expect(indexResult?.element).toBe(originalResult.element)
+                    expect(indexResult?.count).toBe(originalResult.count)
+                    expect(indexResult?.hash).toBe(originalResult.hash)
+                }
+            } finally {
+                cleanup()
+            }
+        })
+    })
+})

--- a/frontend/src/toolbar/elements/domElementIndex.ts
+++ b/frontend/src/toolbar/elements/domElementIndex.ts
@@ -1,0 +1,240 @@
+import { matchesDataAttribute } from 'lib/actionUtils'
+
+import { CountedHTMLElement, ElementsEventType } from '~/toolbar/types'
+import { ElementType } from '~/types'
+
+interface ElementFingerprint {
+    tagName: string
+    id: string | null
+    classes: Set<string>
+    dataAttrs: Map<string, string>
+    nthChild: number
+    nthOfType: number
+}
+
+export interface DOMIndex {
+    byId: Map<string, HTMLElement[]>
+    byTagName: Map<string, HTMLElement[]>
+    byClass: Map<string, HTMLElement[]>
+    byDataAttr: Map<string, Map<string, HTMLElement[]>>
+    byHref: Map<string, HTMLElement[]>
+    fingerprints: WeakMap<HTMLElement, ElementFingerprint>
+}
+
+function addToIndex(map: Map<string, HTMLElement[]>, key: string, element: HTMLElement): void {
+    const existing = map.get(key)
+    if (existing) {
+        existing.push(element)
+    } else {
+        map.set(key, [element])
+    }
+}
+
+function createFingerprint(element: HTMLElement): ElementFingerprint {
+    const parent = element.parentElement
+    let nthChild = 1
+    let nthOfType = 1
+
+    if (parent) {
+        const siblings = Array.from(parent.children)
+        const elementIndex = siblings.indexOf(element)
+        nthChild = elementIndex + 1
+        nthOfType = siblings.filter((s, idx) => s.tagName === element.tagName && idx < elementIndex).length + 1
+    }
+
+    const dataAttrs = new Map<string, string>()
+    for (let i = 0; i < element.attributes.length; i++) {
+        const attr = element.attributes[i]
+        if (attr.name.startsWith('data-')) {
+            dataAttrs.set(attr.name, attr.value)
+        }
+    }
+
+    return {
+        tagName: element.tagName.toLowerCase(),
+        id: element.id || null,
+        classes: new Set(Array.from(element.classList)),
+        dataAttrs,
+        nthChild,
+        nthOfType,
+    }
+}
+
+export function buildDOMIndex(pageElements: HTMLElement[]): DOMIndex {
+    const index: DOMIndex = {
+        byId: new Map(),
+        byTagName: new Map(),
+        byClass: new Map(),
+        byDataAttr: new Map(),
+        byHref: new Map(),
+        fingerprints: new WeakMap(),
+    }
+
+    for (const element of pageElements) {
+        const fingerprint = createFingerprint(element)
+        index.fingerprints.set(element, fingerprint)
+
+        if (fingerprint.id) {
+            addToIndex(index.byId, fingerprint.id, element)
+        }
+
+        addToIndex(index.byTagName, fingerprint.tagName, element)
+
+        for (const cls of fingerprint.classes) {
+            addToIndex(index.byClass, cls, element)
+        }
+
+        for (const [name, value] of fingerprint.dataAttrs) {
+            if (!index.byDataAttr.has(name)) {
+                index.byDataAttr.set(name, new Map())
+            }
+            addToIndex(index.byDataAttr.get(name)!, value, element)
+        }
+
+        const href = element.getAttribute('href')
+        if (href) {
+            addToIndex(index.byHref, href, element)
+        }
+    }
+
+    return index
+}
+
+function matchesPosition(fingerprint: ElementFingerprint, eventElement: ElementType): boolean {
+    if (eventElement.nth_child && fingerprint.nthChild !== eventElement.nth_child) {
+        return false
+    }
+    if (eventElement.nth_of_type && fingerprint.nthOfType !== eventElement.nth_of_type) {
+        return false
+    }
+    return true
+}
+
+function getCandidatesFromIndex(
+    eventElement: ElementType,
+    dataAttributes: string[],
+    matchLinksByHref: boolean,
+    index: DOMIndex
+): HTMLElement[] {
+    const matchedAttr = matchesDataAttribute(eventElement, dataAttributes)
+    if (matchedAttr && eventElement.attributes) {
+        const value = eventElement.attributes[`attr__${matchedAttr}`]
+        if (value !== undefined) {
+            const candidates = index.byDataAttr.get(matchedAttr)?.get(value) || []
+            if (candidates.length) {
+                return candidates.filter((el) => {
+                    const fp = index.fingerprints.get(el)
+                    return fp && matchesPosition(fp, eventElement)
+                })
+            }
+        }
+    }
+
+    if (eventElement.attr_id) {
+        const candidates = index.byId.get(eventElement.attr_id) || []
+        if (candidates.length) {
+            return candidates.filter((el) => {
+                const fp = index.fingerprints.get(el)
+                return fp && matchesPosition(fp, eventElement)
+            })
+        }
+    }
+
+    let candidates = eventElement.tag_name ? [...(index.byTagName.get(eventElement.tag_name.toLowerCase()) || [])] : []
+
+    if (eventElement.attr_class?.length) {
+        for (const cls of eventElement.attr_class) {
+            if (cls) {
+                const classMatches = new Set(index.byClass.get(cls) || [])
+                candidates = candidates.filter((el) => classMatches.has(el))
+            }
+        }
+    }
+
+    if (matchLinksByHref && eventElement.href) {
+        const hrefMatches = new Set(index.byHref.get(eventElement.href) || [])
+        candidates = candidates.filter((el) => hrefMatches.has(el))
+    }
+
+    return candidates.filter((el) => {
+        const fp = index.fingerprints.get(el)
+        return fp && matchesPosition(fp, eventElement)
+    })
+}
+
+function matchesParent(candidate: HTMLElement, parentEvent: ElementType, index: DOMIndex): boolean {
+    const parent = candidate.parentElement
+    if (!parent) {
+        return false
+    }
+
+    const fp = index.fingerprints.get(parent)
+    if (!fp) {
+        return false
+    }
+
+    if (parentEvent.tag_name && fp.tagName !== parentEvent.tag_name.toLowerCase()) {
+        return false
+    }
+    if (parentEvent.attr_id && fp.id !== parentEvent.attr_id) {
+        return false
+    }
+    if (parentEvent.attr_class?.length) {
+        for (const cls of parentEvent.attr_class) {
+            if (cls && !fp.classes.has(cls)) {
+                return false
+            }
+        }
+    }
+    return true
+}
+
+function isTooSimple(element: ElementType): boolean {
+    return !!(
+        element.tag_name &&
+        !element.attr_class &&
+        !element.attr_id &&
+        !element.href &&
+        !element.text &&
+        element.nth_child === 1 &&
+        element.nth_of_type === 1 &&
+        !element.attributes?.['attr__data-attr']
+    )
+}
+
+export function matchEventToElementUsingIndex(
+    event: ElementsEventType,
+    dataAttributes: string[],
+    matchLinksByHref: boolean,
+    index: DOMIndex
+): CountedHTMLElement | null {
+    const targetElement = event.elements[0]
+    if (!targetElement) {
+        return null
+    }
+
+    let candidates = getCandidatesFromIndex(targetElement, dataAttributes, matchLinksByHref, index)
+
+    if (candidates.length === 0) {
+        return null
+    }
+
+    for (let i = 1; i < event.elements.length && candidates.length > 1; i++) {
+        candidates = candidates.filter((c) => matchesParent(c, event.elements[i], index))
+    }
+
+    if (candidates.length === 1 && !isTooSimple(targetElement)) {
+        return {
+            element: candidates[0],
+            count: event.count,
+            selector: '',
+            hash: event.hash,
+            type: event.type,
+            clickCount: 0,
+            rageclickCount: 0,
+            deadclickCount: 0,
+        }
+    }
+
+    return null
+}

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -11,6 +11,7 @@ import { PaginatedResponse } from 'lib/api'
 import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
 import { createVersionChecker } from 'lib/utils/semver'
 
+import { buildDOMIndex, matchEventToElementUsingIndex } from '~/toolbar/elements/domElementIndex'
 import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
 import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
@@ -22,8 +23,6 @@ import type { heatmapToolbarMenuLogicType } from './heatmapToolbarMenuLogicType'
 
 export const doesVersionSupportScrollDepth = createVersionChecker('1.99')
 
-const FRAME_BUDGET_MS = 12
-
 function yieldToMain(): Promise<void> {
     return new Promise((resolve) => {
         if ('scheduler' in window && typeof (window as any).scheduler?.yield === 'function') {
@@ -34,10 +33,6 @@ function yieldToMain(): Promise<void> {
             setTimeout(resolve, 0)
         }
     })
-}
-
-function shouldYield(startTime: number): boolean {
-    return performance.now() - startTime >= FRAME_BUDGET_MS
 }
 
 interface ElementProcessingCache {
@@ -138,6 +133,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         processElements: true,
         setProcessedElements: (elements: CountedHTMLElement[]) => ({ elements }),
         setElementsLoading: (loading: boolean) => ({ loading }),
+        setProcessingProgress: (processed: number, total: number) => ({ processed, total }),
     }),
     windowValues(() => ({
         windowWidth: (window: Window) => window.innerWidth,
@@ -206,6 +202,14 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 processElements: () => true,
                 setProcessedElements: () => false,
                 toggleClickmapsEnabled: (state, { enabled }) => (enabled ? state : false),
+            },
+        ],
+        processingProgress: [
+            null as { processed: number; total: number } | null,
+            {
+                setProcessingProgress: (_, { processed, total }) => (processed >= total ? null : { processed, total }),
+                setProcessedElements: () => null,
+                toggleClickmapsEnabled: () => null,
             },
         ],
     }),
@@ -346,12 +350,12 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         countedElements: () => {
             actions.startElementObservation()
         },
-        processingInputs: () => {
-            actions.processElements()
-        },
     })),
     listeners(({ actions, values, cache }) => ({
         processElements: async (_, breakpoint) => {
+            const BATCH_SIZE = 200
+            const INITIAL_BATCH_SIZE = 50
+
             const { elementStats, dataAttributes, href, matchLinksByHref, clickmapsEnabled } = values.processingInputs
 
             if (!clickmapsEnabled || !elementStats?.results?.length) {
@@ -361,52 +365,47 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
 
             cache.visibilityCache = cache.visibilityCache || new WeakMap<HTMLElement, boolean>()
             const pageElements = getCachedPageElements(cache as ElementProcessingCache, href)
-
+            const domIndex = buildDOMIndex(pageElements)
             const eventsToProcess = elementStats.results
-            const matchedElements: CountedHTMLElement[] = []
+            const totalEvents = eventsToProcess.length
 
-            let frameStart = performance.now()
-            for (const event of eventsToProcess) {
-                const matched = matchEventToElement(
-                    event,
-                    dataAttributes,
-                    matchLinksByHref,
-                    pageElements,
-                    cache as ElementProcessingCache
-                )
-                if (matched) {
-                    matchedElements.push(matched)
+            const allTrimmedElements: CountedHTMLElement[] = []
+            let processedCount = 0
+
+            while (processedCount < totalEvents) {
+                const batchSize = processedCount === 0 ? INITIAL_BATCH_SIZE : BATCH_SIZE
+                const batchEnd = Math.min(processedCount + batchSize, totalEvents)
+
+                for (let i = processedCount; i < batchEnd; i++) {
+                    const event = eventsToProcess[i]
+                    const matched =
+                        matchEventToElementUsingIndex(event, dataAttributes, matchLinksByHref, domIndex) ||
+                        matchEventToElement(
+                            event,
+                            dataAttributes,
+                            matchLinksByHref,
+                            pageElements,
+                            cache as ElementProcessingCache
+                        )
+
+                    if (matched) {
+                        const trimmed = trimElement(matched.element)
+                        if (
+                            trimmed &&
+                            elementIsVisible(trimmed, cache.visibilityCache as WeakMap<HTMLElement, boolean>)
+                        ) {
+                            allTrimmedElements.push({ ...matched, element: trimmed })
+                        }
+                    }
                 }
 
-                if (shouldYield(frameStart)) {
-                    breakpoint()
-                    await yieldToMain()
-                    frameStart = performance.now()
-                }
+                processedCount = batchEnd
+                actions.setProcessedElements(aggregateAndSortElements(allTrimmedElements))
+                actions.setProcessingProgress(processedCount, totalEvents)
+
+                breakpoint()
+                await yieldToMain()
             }
-
-            breakpoint()
-
-            const trimmedElements: CountedHTMLElement[] = []
-            frameStart = performance.now()
-            for (const el of matchedElements) {
-                const trimmed = trimElement(el.element)
-                if (trimmed && elementIsVisible(trimmed, cache.visibilityCache as WeakMap<HTMLElement, boolean>)) {
-                    trimmedElements.push({ ...el, element: trimmed })
-                }
-
-                if (shouldYield(frameStart)) {
-                    breakpoint()
-                    await yieldToMain()
-                    frameStart = performance.now()
-                }
-            }
-
-            breakpoint()
-
-            const countedElements = aggregateAndSortElements(trimmedElements)
-
-            actions.setProcessedElements(countedElements)
         },
 
         enableHeatmap: () => {
@@ -512,6 +511,14 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             if (values.elementStats?.next) {
                 actions.getElementStats(values.elementStats.next)
             }
+        },
+
+        getElementStatsSuccess: () => {
+            actions.processElements()
+        },
+
+        setMatchLinksByHref: () => {
+            actions.processElements()
         },
 
         patchHeatmapFilters: ({ filters }) => {

--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -92,6 +92,7 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
         heatmapColorPalette,
         samplingFactor,
         elementsLoading,
+        processingProgress,
     } = useValues(heatmapToolbarMenuLogic)
     const {
         setCommonFilters,
@@ -177,7 +178,7 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                 <div className="p-2">
                     <SectionButton
                         onChange={(e) => toggleClickmapsEnabled(e)}
-                        loading={elementStatsLoading}
+                        loading={elementStatsLoading || elementsLoading || !!processingProgress}
                         checked={!!clickmapsEnabled}
                     >
                         Clickmaps (autocapture)
@@ -263,7 +264,17 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
 
                             <div className="my-2">
                                 Found: {countedElements.length} elements / {clickCount} clicks
-                                {elementsLoading ? ' (processing...)' : '!'}
+                                {processingProgress ? (
+                                    <span className="text-muted">
+                                        {' '}
+                                        (Processing: {processingProgress.processed.toLocaleString()}/
+                                        {processingProgress.total.toLocaleString()})
+                                    </span>
+                                ) : elementsLoading ? (
+                                    ' (processing...)'
+                                ) : (
+                                    '!'
+                                )}
                             </div>
                             <div className="flex flex-col w-full h-full">
                                 {countedElements.length ? (


### PR DESCRIPTION
with recent changes the toolbar went from freezing my browser with the clickmap to taking 20 seconds to process events against the DOM

![Screenshot 2025-11-27 at 14.06.59.png](https://app.graphite.com/user-attachments/assets/4675ca0a-c073-4603-8e5b-2c84c0f2dc06.png)

there is multiple repeated calls to matchEventToElement which traverses the DOM to find a selector

let's introduce a bunch of optimisations since a lot of look-ups could be O(1) against a map

we also show progress as we go, so the user knows what is a-happening

![Screenshot 2025-11-27 at 14.30.58.png](https://app.graphite.com/user-attachments/assets/a5eea207-5deb-4d21-99b6-2e85b48a25da.png)

