### PR TITLE
fix: project tree products custom menus padding

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/menus/DashboardsMenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/DashboardsMenuItems.tsx
@@ -6,6 +6,7 @@ import { IconChevronRight } from '@posthog/icons'
 import { Link } from 'lib/lemon-ui/Link'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import {
+    DropdownMenuGroup,
     DropdownMenuItem,
     DropdownMenuSub,
     DropdownMenuSubContent,
@@ -22,6 +23,7 @@ export function DashboardsMenuItems({
     MenuSub = DropdownMenuSub,
     MenuSubTrigger = DropdownMenuSubTrigger,
     MenuSubContent = DropdownMenuSubContent,
+    MenuGroup = DropdownMenuGroup,
     onLinkClick,
 }: CustomMenuProps): JSX.Element {
     const { pinnedDashboards, dashboardsLoading } = useValues(dashboardsModel)
@@ -38,28 +40,30 @@ export function DashboardsMenuItems({
                     </MenuSubTrigger>
 
                     <MenuSubContent>
-                        {pinnedDashboards.map((dashboard) => (
-                            <MenuItem asChild key={dashboard.id}>
-                                <Link
-                                    buttonProps={{
-                                        menuItem: true,
-                                    }}
-                                    to={urls.dashboard(dashboard.id)}
-                                    onClick={(e) => {
-                                        e.stopPropagation()
-                                        onLinkClick?.(false)
-                                        router.actions.push(urls.dashboard(dashboard.id))
-                                    }}
-                                    onKeyDown={(e) => {
-                                        if (e.key === 'Enter' || e.key === ' ') {
-                                            onLinkClick?.(true)
-                                        }
-                                    }}
-                                >
-                                    <span className="truncate">{dashboard.name}</span>
-                                </Link>
-                            </MenuItem>
-                        ))}
+                        <MenuGroup>
+                            {pinnedDashboards.map((dashboard) => (
+                                <MenuItem asChild key={dashboard.id}>
+                                    <Link
+                                        buttonProps={{
+                                            menuItem: true,
+                                        }}
+                                        to={urls.dashboard(dashboard.id)}
+                                        onClick={(e) => {
+                                            e.stopPropagation()
+                                            onLinkClick?.(false)
+                                            router.actions.push(urls.dashboard(dashboard.id))
+                                        }}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter' || e.key === ' ') {
+                                                onLinkClick?.(true)
+                                            }
+                                        }}
+                                    >
+                                        <span className="truncate">{dashboard.name}</span>
+                                    </Link>
+                                </MenuItem>
+                            ))}
+                        </MenuGroup>
                     </MenuSubContent>
                 </MenuSub>
             ) : dashboardsLoading ? (

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/MenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/MenuItems.tsx
@@ -8,6 +8,7 @@ import { moveToLogic } from 'lib/components/FileSystem/MoveTo/moveToLogic'
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import {
+    ContextMenuGroup,
     ContextMenuItem,
     ContextMenuSeparator,
     ContextMenuSub,
@@ -15,6 +16,7 @@ import {
     ContextMenuSubTrigger,
 } from 'lib/ui/ContextMenu/ContextMenu'
 import {
+    DropdownMenuGroup,
     DropdownMenuItem,
     DropdownMenuSeparator,
     DropdownMenuSub,
@@ -86,7 +88,7 @@ export function MenuItems({
     const MenuSub = type === 'context' ? ContextMenuSub : DropdownMenuSub
     const MenuSubTrigger = type === 'context' ? ContextMenuSubTrigger : DropdownMenuSubTrigger
     const MenuSubContent = type === 'context' ? ContextMenuSubContent : DropdownMenuSubContent
-
+    const MenuGroup = type === 'context' ? ContextMenuGroup : DropdownMenuGroup
     const showSelectMenuItems =
         root === 'project://' && item.record?.path && !item.disableSelect && !onlyTree && showSelectMenuOption
 
@@ -101,6 +103,7 @@ export function MenuItems({
             <>
                 <ProductAnalyticsMenuItems
                     MenuItem={MenuItem}
+                    MenuGroup={MenuGroup}
                     MenuSeparator={MenuSeparator}
                     onLinkClick={(keyboardAction) => resetPanelLayout(keyboardAction ?? false)}
                 />
@@ -113,6 +116,7 @@ export function MenuItems({
                     MenuSub={MenuSub}
                     MenuSubTrigger={MenuSubTrigger}
                     MenuSubContent={MenuSubContent}
+                    MenuGroup={MenuGroup}
                     MenuSeparator={MenuSeparator}
                     onLinkClick={(keyboardAction) => resetPanelLayout(keyboardAction ?? false)}
                 />
@@ -125,6 +129,7 @@ export function MenuItems({
                     MenuSub={MenuSub}
                     MenuSubTrigger={MenuSubTrigger}
                     MenuSubContent={MenuSubContent}
+                    MenuGroup={MenuGroup}
                     MenuSeparator={MenuSeparator}
                     onLinkClick={(keyboardAction) => resetPanelLayout(keyboardAction ?? false)}
                 />

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/SessionReplayMenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/SessionReplayMenuItems.tsx
@@ -6,6 +6,7 @@ import { IconChevronRight } from '@posthog/icons'
 import { Link } from 'lib/lemon-ui/Link'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import {
+    DropdownMenuGroup,
     DropdownMenuItem,
     DropdownMenuSeparator,
     DropdownMenuSub,
@@ -25,6 +26,7 @@ export function SessionReplayMenuItems({
     MenuSub = DropdownMenuSub,
     MenuSubTrigger = DropdownMenuSubTrigger,
     MenuSubContent = DropdownMenuSubContent,
+    MenuGroup = DropdownMenuGroup,
     MenuSeparator = DropdownMenuSeparator,
     onLinkClick,
 }: CustomMenuProps): JSX.Element {
@@ -55,43 +57,45 @@ export function SessionReplayMenuItems({
                     </MenuSubTrigger>
 
                     <MenuSubContent>
-                        {savedFilters.results.map((savedFilter) => (
-                            <MenuItem asChild key={savedFilter.short_id}>
-                                <Link
-                                    buttonProps={{
-                                        menuItem: true,
-                                    }}
-                                    to={urls.absolute(
-                                        combineUrl(urls.replay(ReplayTabs.Home), {
-                                            savedFilterId: savedFilter.short_id,
-                                        }).url
-                                    )}
-                                    onKeyDown={handleKeyDown}
-                                    onClick={() => onLinkClick?.(false)}
-                                >
-                                    <span className="truncate">
-                                        {savedFilter.name || savedFilter.derived_name || 'Unnamed'}
-                                    </span>
-                                </Link>
-                            </MenuItem>
-                        ))}
-                        {savedFilters.next ? (
-                            <>
-                                <MenuSeparator />
-                                <MenuItem asChild key="all-saved-filters">
+                        <MenuGroup>
+                            {savedFilters.results.map((savedFilter) => (
+                                <MenuItem asChild key={savedFilter.short_id}>
                                     <Link
                                         buttonProps={{
                                             menuItem: true,
                                         }}
-                                        to={`${urls.replay(ReplayTabs.Home)}?showFilters=true&filtersTab=saved`}
+                                        to={urls.absolute(
+                                            combineUrl(urls.replay(ReplayTabs.Home), {
+                                                savedFilterId: savedFilter.short_id,
+                                            }).url
+                                        )}
                                         onKeyDown={handleKeyDown}
                                         onClick={() => onLinkClick?.(false)}
                                     >
-                                        <span className="truncate">All saved filters</span>
+                                        <span className="truncate">
+                                            {savedFilter.name || savedFilter.derived_name || 'Unnamed'}
+                                        </span>
                                     </Link>
                                 </MenuItem>
-                            </>
-                        ) : null}
+                            ))}
+                            {savedFilters.next ? (
+                                <>
+                                    <MenuSeparator />
+                                    <MenuItem asChild key="all-saved-filters">
+                                        <Link
+                                            buttonProps={{
+                                                menuItem: true,
+                                            }}
+                                            to={`${urls.replay(ReplayTabs.Home)}?showFilters=true&filtersTab=saved`}
+                                            onKeyDown={handleKeyDown}
+                                            onClick={() => onLinkClick?.(false)}
+                                        >
+                                            <span className="truncate">All saved filters</span>
+                                        </Link>
+                                    </MenuItem>
+                                </>
+                            ) : null}
+                        </MenuGroup>
                     </MenuSubContent>
                 </MenuSub>
             ) : null}
@@ -110,39 +114,41 @@ export function SessionReplayMenuItems({
                     </MenuSubTrigger>
 
                     <MenuSubContent>
-                        {playlists.results.map((playlist) => (
-                            <MenuItem asChild key={playlist.short_id}>
-                                <Link
-                                    buttonProps={{
-                                        menuItem: true,
-                                    }}
-                                    to={urls.replayPlaylist(playlist.short_id)}
-                                    onKeyDown={handleKeyDown}
-                                    onClick={() => onLinkClick?.(false)}
-                                >
-                                    <span className="truncate">
-                                        {playlist.name || playlist.derived_name || 'Unnamed'}
-                                    </span>
-                                </Link>
-                            </MenuItem>
-                        ))}
-                        {playlists.next ? (
-                            <>
-                                <DropdownMenuSeparator />
-                                <MenuItem asChild key="all-collections">
+                        <MenuGroup>
+                            {playlists.results.map((playlist) => (
+                                <MenuItem asChild key={playlist.short_id}>
                                     <Link
                                         buttonProps={{
                                             menuItem: true,
                                         }}
-                                        to={`${urls.replay(ReplayTabs.Playlists)}`}
+                                        to={urls.replayPlaylist(playlist.short_id)}
                                         onKeyDown={handleKeyDown}
                                         onClick={() => onLinkClick?.(false)}
                                     >
-                                        <span className="truncate">All collections</span>
+                                        <span className="truncate">
+                                            {playlist.name || playlist.derived_name || 'Unnamed'}
+                                        </span>
                                     </Link>
                                 </MenuItem>
-                            </>
-                        ) : null}
+                            ))}
+                            {playlists.next ? (
+                                <>
+                                    <DropdownMenuSeparator />
+                                    <MenuItem asChild key="all-collections">
+                                        <Link
+                                            buttonProps={{
+                                                menuItem: true,
+                                            }}
+                                            to={`${urls.replay(ReplayTabs.Playlists)}`}
+                                            onKeyDown={handleKeyDown}
+                                            onClick={() => onLinkClick?.(false)}
+                                        >
+                                            <span className="truncate">All collections</span>
+                                        </Link>
+                                    </MenuItem>
+                                </>
+                            ) : null}
+                        </MenuGroup>
                     </MenuSubContent>
                 </MenuSub>
             ) : null}

--- a/frontend/src/layout/panel-layout/ProjectTree/types.ts
+++ b/frontend/src/layout/panel-layout/ProjectTree/types.ts
@@ -1,4 +1,5 @@
 import {
+    ContextMenuGroup,
     ContextMenuItem,
     ContextMenuSeparator,
     ContextMenuSub,
@@ -6,6 +7,7 @@ import {
     ContextMenuSubTrigger,
 } from 'lib/ui/ContextMenu/ContextMenu'
 import {
+    DropdownMenuGroup,
     DropdownMenuItem,
     DropdownMenuSeparator,
     DropdownMenuSub,
@@ -26,6 +28,7 @@ export type FolderState = 'loading' | 'loaded' | 'has-more' | 'error'
 
 export interface CustomMenuProps {
     MenuItem?: typeof ContextMenuItem | typeof DropdownMenuItem
+    MenuGroup?: typeof ContextMenuGroup | typeof DropdownMenuGroup
     MenuSeparator?: typeof ContextMenuSeparator | typeof DropdownMenuSeparator
     MenuSub?: typeof ContextMenuSub | typeof DropdownMenuSub
     MenuSubTrigger?: typeof ContextMenuSubTrigger | typeof DropdownMenuSubTrigger


### PR DESCRIPTION
## Problem
Some product context/dropdown menus were lacking padding

![2025-11-27 14 37 54](https://github.com/user-attachments/assets/61b6999b-6782-4150-9e85-8caf85497415)

## Changes
Add appropriate `<Group>` component to these menus

![2025-11-27 14 38 38](https://github.com/user-attachments/assets/36816583-5cb6-4c6c-8a3c-9fc341ae5840)



## How did you test this code?
locally