### PR TITLE
fix(ph-ai): memory back button to main chat fix

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSettings.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSettings.tsx
@@ -34,7 +34,9 @@ export const SidePanelSettings = (): JSX.Element => {
         })
     }, [selectedSectionId, selectedLevel, setSettings])
 
-    const cameFromMax = previousTab === SidePanelTab.Max && selectedSectionId === 'environment-max'
+    const cameFromMax =
+        previousTab === SidePanelTab.Max &&
+        (selectedSectionId === 'environment-max' || selectedSectionId === ('project-max' as typeof selectedSectionId))
 
     return (
         <div className="flex flex-col overflow-hidden">


### PR DESCRIPTION
## Problem

The back button from memory was actually working only locally

<img width="511" height="349" alt="image" src="https://github.com/user-attachments/assets/cb88eaeb-746a-4f1f-8941-919eff59079a" />

and not in `prod`

<img width="634" height="164" alt="image" src="https://github.com/user-attachments/assets/1e72f5da-b780-4cb6-ae8c-78b1592dbb5f" />

This was due to some dynamic naming logic we have in `settingsLogic.ts` that I missed, this fixed this.

## Changes

* show back to PostHog AI button for all envs.

## How did you test this code?

![me](https://media1.tenor.com/m/iCqG_iT-h48AAAAC/bills-ugh.gif)
