### PR TITLE
chore: [Experiments] link to person page instead of generic activity page from funnel conversion modal

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -31,6 +31,7 @@ import {
     InsightSceneSource,
     InsightShortId,
     InsightType,
+    PersonsTabType,
     RecordingUniversalFilters,
     ReplayTabs,
 } from './types'
@@ -524,10 +525,14 @@ export const productUrls = {
     notebooks: (): string => '/notebooks',
     notebook: (shortId: string): string => `/notebooks/${shortId}`,
     canvas: (): string => `/canvas`,
-    personByDistinctId: (id: string, encode: boolean = true): string =>
-        encode ? `/person/${encodeURIComponent(id)}` : `/person/${id}`,
-    personByUUID: (uuid: string, encode: boolean = true): string =>
-        encode ? `/persons/${encodeURIComponent(uuid)}` : `/persons/${uuid}`,
+    personByDistinctId: (id: string, encode: boolean = true, activeTab?: PersonsTabType): string => {
+        const path = encode ? `/person/${encodeURIComponent(id)}` : `/person/${id}`
+        return activeTab ? `${path}#activeTab=${activeTab}` : path
+    },
+    personByUUID: (uuid: string, encode: boolean = true, activeTab?: PersonsTabType): string => {
+        const path = encode ? `/persons/${encodeURIComponent(uuid)}` : `/persons/${uuid}`
+        return activeTab ? `${path}#activeTab=${activeTab}` : path
+    },
     persons: (): string => '/persons',
     insights: (): string => '/insights',
     insightNew: ({

--- a/frontend/src/scenes/experiments/charts/funnel/SampledSessionsModal.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/SampledSessionsModal.tsx
@@ -12,7 +12,7 @@ import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/
 import { urls } from 'scenes/urls'
 
 import { SessionData } from '~/queries/schema/schema-general'
-import { ActivityTab, PropertyFilterType, PropertyOperator } from '~/types'
+import { ActivityTab, PersonsTabType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { sampledSessionsModalLogic } from './sampledSessionsModalLogic'
 
@@ -41,7 +41,7 @@ const getLinkTextAndUrl = (session: SessionData): { text: string; url: string } 
     } else if (session.person_id) {
         return {
             text: session.person_id,
-            url: getEventsUrl('person_id', session.person_id),
+            url: urls.personByUUID(session.person_id, true, PersonsTabType.EVENTS),
         }
     }
     return {

--- a/frontend/src/scenes/experiments/charts/funnel/SampledSessionsModal.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/SampledSessionsModal.tsx
@@ -7,6 +7,7 @@ import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { IconOpenInNew, IconPlayCircle } from 'lib/lemon-ui/icons'
 import { getDefaultEventsSceneQuery } from 'scenes/activity/explore/defaults'
+import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { urls } from 'scenes/urls'
@@ -37,11 +38,6 @@ const getLinkTextAndUrl = (session: SessionData): { text: string; url: string } 
         return {
             text: session.session_id,
             url: getEventsUrl('$session_id', session.session_id),
-        }
-    } else if (session.person_id) {
-        return {
-            text: session.person_id,
-            url: urls.personByUUID(session.person_id, true, PersonsTabType.EVENTS),
         }
     }
     return {
@@ -79,6 +75,17 @@ export function SampledSessionsModal(): JSX.Element {
             title: 'Person',
             key: 'personId',
             render: (_, session) => {
+                if (session.person_id) {
+                    return (
+                        <PersonDisplay
+                            person={{ id: session.person_id }}
+                            displayName={session.person_id}
+                            withIcon={true}
+                            href={urls.personByUUID(session.person_id, true, PersonsTabType.EVENTS)}
+                        />
+                    )
+                }
+
                 const { text, url } = getLinkTextAndUrl(session)
                 return (
                     <div className="flex items-center gap-1">

--- a/frontend/src/scenes/experiments/charts/funnel/SampledSessionsModal.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/SampledSessionsModal.tsx
@@ -1,50 +1,18 @@
 import { useActions, useValues } from 'kea'
-import { combineUrl } from 'kea-router'
 
-import { LemonButton, LemonModal, LemonTable, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonModal, LemonTable } from '@posthog/lemon-ui'
 
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
-import { IconOpenInNew, IconPlayCircle } from 'lib/lemon-ui/icons'
-import { getDefaultEventsSceneQuery } from 'scenes/activity/explore/defaults'
+import { IconPlayCircle } from 'lib/lemon-ui/icons'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
-import { sceneLogic } from 'scenes/sceneLogic'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { urls } from 'scenes/urls'
 
 import { SessionData } from '~/queries/schema/schema-general'
-import { ActivityTab, PersonsTabType, PropertyFilterType, PropertyOperator } from '~/types'
+import { PersonsTabType } from '~/types'
 
 import { sampledSessionsModalLogic } from './sampledSessionsModalLogic'
-
-const getEventsUrl = (key: string, value: string): string => {
-    const eventsQuery = getDefaultEventsSceneQuery([
-        {
-            type: PropertyFilterType.EventMetadata,
-            key: key,
-            value: [value],
-            operator: PropertyOperator.Exact,
-        },
-    ])
-    // Override the default time range to 90 days
-    if ('after' in eventsQuery.source) {
-        eventsQuery.source.after = '-90d'
-    }
-    return combineUrl(urls.activity(ActivityTab.ExploreEvents), {}, { q: eventsQuery }).url
-}
-
-const getLinkTextAndUrl = (session: SessionData): { text: string; url: string } => {
-    if (session.session_id) {
-        return {
-            text: session.session_id,
-            url: getEventsUrl('$session_id', session.session_id),
-        }
-    }
-    return {
-        text: session.event_uuid,
-        url: getEventsUrl('uuid', session.event_uuid),
-    }
-}
 
 export function SampledSessionsModal(): JSX.Element {
     const { isOpen, modalData, recordingAvailability, recordingAvailabilityLoading } =
@@ -74,36 +42,14 @@ export function SampledSessionsModal(): JSX.Element {
         {
             title: 'Person',
             key: 'personId',
-            render: (_, session) => {
-                if (session.person_id) {
-                    return (
-                        <PersonDisplay
-                            person={{ id: session.person_id }}
-                            displayName={session.person_id}
-                            withIcon={true}
-                            href={urls.personByUUID(session.person_id, true, PersonsTabType.EVENTS)}
-                        />
-                    )
-                }
-
-                const { text, url } = getLinkTextAndUrl(session)
-                return (
-                    <div className="flex items-center gap-1">
-                        <Link
-                            to={url}
-                            onClick={(e) => {
-                                e.preventDefault()
-                                sceneLogic.actions.newTab(url)
-                            }}
-                            className="font-mono text-xs whitespace-nowrap"
-                            title={`View events for ${text}`}
-                        >
-                            {text}
-                            <IconOpenInNew style={{ fontSize: 14 }} />
-                        </Link>
-                    </div>
-                )
-            },
+            render: (_, session) => (
+                <PersonDisplay
+                    person={{ id: session.person_id }}
+                    displayName={session.person_id}
+                    withIcon={true}
+                    href={urls.personByUUID(session.person_id, true, PersonsTabType.EVENTS)}
+                />
+            ),
             width: '40%',
         },
         {

--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -47,15 +47,21 @@ export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
 
     // NOTE: This can happen if the Person was deleted or the events associated with the distinct_id had person processing disabled
     if (!person) {
-        const eventsQuery = getDefaultEventsSceneQuery([
-            {
-                type: PropertyFilterType.EventMetadata,
-                key: 'distinct_id',
-                value: props.distinctId,
-                operator: PropertyOperator.Exact,
-            },
-        ])
-        const eventsUrl = combineUrl(urls.activity(ActivityTab.ExploreEvents), {}, { q: eventsQuery }).url
+        const identifier = props.distinctId || props.personId
+        const identifierKey = props.distinctId ? 'distinct_id' : 'person_id'
+        const eventsQuery = identifier
+            ? getDefaultEventsSceneQuery([
+                  {
+                      type: PropertyFilterType.EventMetadata,
+                      key: identifierKey,
+                      value: identifier,
+                      operator: PropertyOperator.Exact,
+                  },
+              ])
+            : null
+        const eventsUrl = eventsQuery
+            ? combineUrl(urls.activity(ActivityTab.ExploreEvents), {}, { q: eventsQuery }).url
+            : null
         return (
             <div className="p-2 max-w-160">
                 <h4>No profile associated with this ID</h4>
@@ -64,16 +70,18 @@ export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
                     devices, and more. To create person profiles, see{' '}
                     <Link to="https://posthog.com/docs/data/persons#capturing-person-profiles">here.</Link>
                 </p>
-                <div className="flex justify-center mt-2 w-fit">
-                    <LemonButton
-                        type="secondary"
-                        size="small"
-                        to={eventsUrl}
-                        tooltip={`View events matching distinct_id=${props.distinctId}`}
-                    >
-                        View events
-                    </LemonButton>
-                </div>
+                {eventsUrl && (
+                    <div className="flex justify-center mt-2 w-fit">
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            to={eventsUrl}
+                            tooltip={`View events matching ${identifierKey}=${identifier}`}
+                        >
+                            View events
+                        </LemonButton>
+                    </div>
+                )}
             </div>
         )
     }

--- a/products/persons/manifest.tsx
+++ b/products/persons/manifest.tsx
@@ -1,12 +1,16 @@
-import { ProductManifest } from '../../frontend/src/types'
+import { PersonsTabType, ProductManifest } from '../../frontend/src/types'
 
 export const manifest: ProductManifest = {
     name: 'Persons',
     urls: {
-        personByDistinctId: (id: string, encode: boolean = true): string =>
-            encode ? `/person/${encodeURIComponent(id)}` : `/person/${id}`,
-        personByUUID: (uuid: string, encode: boolean = true): string =>
-            encode ? `/persons/${encodeURIComponent(uuid)}` : `/persons/${uuid}`,
+        personByDistinctId: (id: string, encode: boolean = true, activeTab?: PersonsTabType): string => {
+            const path = encode ? `/person/${encodeURIComponent(id)}` : `/person/${id}`
+            return activeTab ? `${path}#activeTab=${activeTab}` : path
+        },
+        personByUUID: (uuid: string, encode: boolean = true, activeTab?: PersonsTabType): string => {
+            const path = encode ? `/persons/${encodeURIComponent(uuid)}` : `/persons/${uuid}`
+            return activeTab ? `${path}#activeTab=${activeTab}` : path
+        },
         persons: (): string => '/persons',
     },
     fileSystemTypes: {},


### PR DESCRIPTION
## Problem

I think it makes more sense to link to the person rather than the activity page from the experiment modal with either the `session_id` or `person_id` as a filter. This is more consistent with the experience in product analytics funnels.

More often than not in support I need to look outside the session where the user converted/dropped off the experiment funnel to work out what happened.

## Changes

Link to persons page activity tab instead of searching for events by person ID on the activity page:

https://github.com/user-attachments/assets/1f54f67e-e160-4e79-8e43-15a2d4e92286

## How did you test this code?

Tested locally