### PR TITLE
fix(data-modeling): Get the table from the hogql db

### DIFF
--- a/products/data_warehouse/backend/models/modeling.py
+++ b/products/data_warehouse/backend/models/modeling.py
@@ -477,7 +477,7 @@ class DataWarehouseModelPathManager(models.Manager["DataWarehouseModelPath"]):
                                         .filter(team=team, name=table.name)
                                         .get()
                                     )
-                            except ObjectDoesNotExist:
+                            except (ObjectDoesNotExist, QueryError):
                                 raise UnknownParentError(parent, query)
                             else:
                                 parent_id = parent_table.id.hex

--- a/products/data_warehouse/backend/models/modeling.py
+++ b/products/data_warehouse/backend/models/modeling.py
@@ -461,11 +461,22 @@ class DataWarehouseModelPathManager(models.Manager["DataWarehouseModelPath"]):
                             )
                         except ObjectDoesNotExist:
                             try:
-                                parent_table = (
-                                    DataWarehouseTable.objects.exclude(deleted=True)
-                                    .filter(team=team, name=parent)
-                                    .get()
-                                )
+                                table = self.get_hogql_database(team).get_table(parent)
+                                if not isinstance(table, HogQLDataWarehouseTable):
+                                    raise ObjectDoesNotExist()
+
+                                if table.table_id:
+                                    parent_table = (
+                                        DataWarehouseTable.objects.exclude(deleted=True)
+                                        .filter(team=team, id=table.table_id)
+                                        .get()
+                                    )
+                                else:
+                                    parent_table = (
+                                        DataWarehouseTable.objects.exclude(deleted=True)
+                                        .filter(team=team, name=table.name)
+                                        .get()
+                                    )
                             except ObjectDoesNotExist:
                                 raise UnknownParentError(parent, query)
                             else:


### PR DESCRIPTION
## Problem
- In some cases, we were looking up table names in the DB by their hogql name - causing the table to not be found 
- https://posthoghelp.zendesk.com/agent/tickets/43596 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46185)

## Changes
- Look up the table via hogql instead - the same as we do in other places 