### PR TITLE
fix: Restrict alog subscriptions with existing visibility rules

### DIFF
--- a/posthog/api/advanced_activity_logs/viewset.py
+++ b/posthog/api/advanced_activity_logs/viewset.py
@@ -248,6 +248,8 @@ class AdvancedActivityLogsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSe
         if lookback_date:
             queryset = queryset.filter(created_at__gte=lookback_date)
 
+        queryset = apply_activity_visibility_restrictions(queryset, self.request.user)
+
         return queryset.order_by("-created_at")
 
     def get_serializer_class(self):

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -867,10 +867,10 @@ def apply_activity_visibility_restrictions(queryset: QuerySet, user: Union["User
     """
     Apply visibility restrictions to activity log queryset based on user permissions.
     """
-    from posthog.models.activity_logging.utils import activity_visibility_restrictions
+    from posthog.models.activity_logging.utils import activity_visibility_manager
 
     is_staff = bool(user and not isinstance(user, AnonymousUser) and hasattr(user, "is_staff") and user.is_staff)
-    return activity_visibility_restrictions.apply_to_queryset(queryset, is_staff)
+    return activity_visibility_manager.apply_to_queryset(queryset, is_staff)
 
 
 def load_activity(
@@ -905,13 +905,13 @@ def activity_log_created(sender, instance: "ActivityLog", created, **kwargs):
     from posthog.api.advanced_activity_logs import ActivityLogSerializer
     from posthog.api.shared import UserBasicSerializer
     from posthog.cdp.internal_events import InternalEventEvent, InternalEventPerson, produce_internal_event
-    from posthog.models.activity_logging.utils import activity_visibility_restrictions
+    from posthog.models.activity_logging.utils import activity_visibility_manager
 
     if not created:
         return
 
     try:
-        if activity_visibility_restrictions.is_restricted(instance, restrict_for_staff=True):
+        if activity_visibility_manager.is_restricted(instance, restrict_for_staff=True):
             logger.info(
                 "Skipping restricted activity log event",
                 scope=instance.scope,

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -9,7 +9,7 @@ from django.contrib.postgres.indexes import GinIndex
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.core.paginator import Paginator
 from django.db import models, transaction
-from django.db.models import Q, QuerySet
+from django.db.models import QuerySet
 from django.db.models.signals import post_save
 from django.dispatch.dispatcher import receiver
 from django.utils import timezone
@@ -867,30 +867,10 @@ def apply_activity_visibility_restrictions(queryset: QuerySet, user: Union["User
     """
     Apply visibility restrictions to activity log queryset based on user permissions.
     """
-    exclusion_queries = []
-    for scope, restrictions in activity_visibility_restrictions.items():
-        if restrictions.get("allow_staff"):
-            if user and not isinstance(user, AnonymousUser) and hasattr(user, "is_staff") and user.is_staff:
-                continue
+    from posthog.models.activity_logging.utils import activity_visibility_restrictions
 
-        activities = restrictions.get("activities", [])
-        exclude_conditions = restrictions.get("exclude_when", {})
-
-        # Build the query: scope AND activity IN [...] AND exclude_conditions
-        query = Q(scope=scope) & Q(activity__in=activities)
-        for field, value in exclude_conditions.items():
-            query &= Q(**{field: value})
-
-        exclusion_queries.append(query)
-
-    # Apply all exclusions with OR logic
-    if exclusion_queries:
-        combined_exclusion = exclusion_queries[0]
-        for q in exclusion_queries[1:]:
-            combined_exclusion |= q
-        queryset = queryset.exclude(combined_exclusion)
-
-    return queryset
+    is_staff = bool(user and not isinstance(user, AnonymousUser) and hasattr(user, "is_staff") and user.is_staff)
+    return activity_visibility_restrictions.apply_to_queryset(queryset, is_staff)
 
 
 def load_activity(
@@ -925,40 +905,53 @@ def activity_log_created(sender, instance: "ActivityLog", created, **kwargs):
     from posthog.api.advanced_activity_logs import ActivityLogSerializer
     from posthog.api.shared import UserBasicSerializer
     from posthog.cdp.internal_events import InternalEventEvent, InternalEventPerson, produce_internal_event
+    from posthog.models.activity_logging.utils import activity_visibility_restrictions
+
+    if not created:
+        return
 
     try:
+        if activity_visibility_restrictions.is_restricted(instance, restrict_for_staff=True):
+            logger.info(
+                "Skipping restricted activity log event",
+                scope=instance.scope,
+                activity=instance.activity,
+                team_id=instance.team_id,
+                organization_id=instance.organization_id,
+            )
+            return
+
         serialized_data = ActivityLogSerializer(instance).data
         # We need to serialize the detail object using the encoder to avoid unsupported types like timedelta
         serialized_data["detail"] = json.loads(json.dumps(serialized_data["detail"], cls=ActivityDetailEncoder))
         # TODO: Move this into the producer to support dataclasses
         user_data = UserBasicSerializer(instance.user).data if instance.user else None
 
-        if created:
-            if instance.team_id is not None:
-                produce_internal_event(
-                    team_id=instance.team_id,
-                    event=InternalEventEvent(
-                        event="$activity_log_entry_created",
-                        distinct_id=user_data["distinct_id"] if user_data else f"team_{instance.team_id}",
-                        properties=serialized_data,
-                    ),
-                    person=(
-                        InternalEventPerson(
-                            id=user_data["id"],
-                            properties=user_data,
-                        )
-                        if user_data
-                        else None
-                    ),
-                )
-            elif instance.organization_id is not None:
-                from posthog.tasks.activity_log import broadcast_activity_log_to_organization
+        if instance.team_id is not None:
+            produce_internal_event(
+                team_id=instance.team_id,
+                event=InternalEventEvent(
+                    event="$activity_log_entry_created",
+                    distinct_id=user_data["distinct_id"] if user_data else f"team_{instance.team_id}",
+                    properties=serialized_data,
+                ),
+                person=(
+                    InternalEventPerson(
+                        id=user_data["id"],
+                        properties=user_data,
+                    )
+                    if user_data
+                    else None
+                ),
+            )
+        elif instance.organization_id is not None:
+            from posthog.tasks.activity_log import broadcast_activity_log_to_organization
 
-                broadcast_activity_log_to_organization.delay(
-                    organization_id=instance.organization_id,
-                    serialized_data=serialized_data,
-                    user_data=user_data,
-                )
+            broadcast_activity_log_to_organization.delay(
+                organization_id=instance.organization_id,
+                serialized_data=serialized_data,
+                user_data=user_data,
+            )
     except Exception as e:
         # We don't want to hard fail here.
         logger.exception("Failed to produce internal event", data=serialized_data, error=e)

--- a/posthog/models/activity_logging/utils.py
+++ b/posthog/models/activity_logging/utils.py
@@ -49,7 +49,7 @@ class ActivityLoggingStorage:
 activity_storage = ActivityLoggingStorage()
 
 
-class ActivityVisibilityRestrictions:
+class ActivityLogVisibilityManager:
     """
     Manages visibility restrictions for activity logs.
 
@@ -116,7 +116,7 @@ class ActivityVisibilityRestrictions:
         return queryset
 
 
-activity_visibility_restrictions = ActivityVisibilityRestrictions()
+activity_visibility_manager = ActivityLogVisibilityManager()
 
 
 def get_changed_fields_local(before_update: models.Model, after_update: models.Model) -> list[str]:

--- a/posthog/models/activity_logging/utils.py
+++ b/posthog/models/activity_logging/utils.py
@@ -1,10 +1,14 @@
 import traceback
-from typing import Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from django.db import models
+from django.db.models import Q, QuerySet
 
 import structlog
 from asgiref.local import Local
+
+if TYPE_CHECKING:
+    from posthog.models.activity_logging.activity_log import ActivityLog, ActivityScope
 
 logger = structlog.get_logger(__name__)
 
@@ -43,6 +47,76 @@ class ActivityLoggingStorage:
 
 
 activity_storage = ActivityLoggingStorage()
+
+
+class ActivityVisibilityRestrictions:
+    """
+    Manages visibility restrictions for activity logs.
+
+    Controls which activity logs can be seen by users and which should be
+    filtered out from external destinations and user-facing interfaces.
+
+    Configuration is defined in activity_log.py as `activity_visibility_restrictions`.
+    """
+
+    @classmethod
+    def _get_restrictions(cls) -> dict["ActivityScope", dict[str, Any]]:
+        from posthog.models.activity_logging.activity_log import activity_visibility_restrictions
+
+        return activity_visibility_restrictions
+
+    @classmethod
+    def is_restricted(cls, instance: "ActivityLog", restrict_for_staff: bool = False) -> bool:
+        for restriction_scope, config in cls._get_restrictions().items():
+            if not restrict_for_staff and config.get("allow_staff"):
+                continue
+            if instance.scope != restriction_scope:
+                continue
+            if instance.activity not in config.get("activities", []):
+                continue
+            exclude_conditions = config.get("exclude_when", {})
+            if all(getattr(instance, field, None) == value for field, value in exclude_conditions.items()):
+                return True
+        return False
+
+    @classmethod
+    def build_exclusion_query(cls, is_staff: bool = False) -> Q | None:
+        """
+        Build a Q object that excludes restricted activity logs.
+
+        Returns None if no exclusions apply (e.g., staff user with allow_staff restrictions).
+        """
+        exclusion_queries: list[Q] = []
+
+        for scope, config in cls._get_restrictions().items():
+            if config.get("allow_staff") and is_staff:
+                continue
+
+            activities = config.get("activities", [])
+            exclude_conditions = config.get("exclude_when", {})
+
+            query = Q(scope=scope) & Q(activity__in=activities)
+            for field, value in exclude_conditions.items():
+                query &= Q(**{field: value})
+            exclusion_queries.append(query)
+
+        if not exclusion_queries:
+            return None
+
+        combined = exclusion_queries[0]
+        for q in exclusion_queries[1:]:
+            combined |= q
+        return combined
+
+    @classmethod
+    def apply_to_queryset(cls, queryset: QuerySet, is_staff: bool = False) -> QuerySet:
+        exclusion_query = cls.build_exclusion_query(is_staff)
+        if exclusion_query is not None:
+            return queryset.exclude(exclusion_query)
+        return queryset
+
+
+activity_visibility_restrictions = ActivityVisibilityRestrictions()
 
 
 def get_changed_fields_local(before_update: models.Model, after_update: models.Model) -> list[str]:

--- a/posthog/test/activity_logging/test_activity_logging.py
+++ b/posthog/test/activity_logging/test_activity_logging.py
@@ -3,8 +3,11 @@ from posthog.test.base import BaseTest
 
 from django.db.utils import IntegrityError
 
+from parameterized import parameterized
+
 from posthog.models import User
 from posthog.models.activity_logging.activity_log import ActivityLog, Change, Detail, log_activity
+from posthog.models.activity_logging.utils import ActivityVisibilityRestrictions
 from posthog.models.utils import UUIDT
 
 
@@ -107,3 +110,91 @@ class TestActivityLogModel(BaseTest):
             self.assertEqual(logged_warning["msg"]["team"], 1)
             self.assertEqual(logged_warning["msg"]["activity"], "does not explode")
             self.assertIsInstance(logged_warning["msg"]["exception"], ValueError)
+
+
+class TestActivityVisibilityRestrictions(BaseTest):
+    @parameterized.expand(
+        [
+            # Restricted: impersonated login/logout should be hidden from external destinations
+            ("impersonated_login", "User", "logged_in", True, True),
+            ("impersonated_logout", "User", "logged_out", True, True),
+            # Not restricted: normal (non-impersonated) login/logout are fine to show
+            ("normal_login", "User", "logged_in", False, False),
+            ("normal_logout", "User", "logged_out", False, False),
+            # Not restricted: other User activities don't match the restriction
+            ("user_updated", "User", "updated", True, False),
+            ("user_changed_password", "User", "changed_password", False, False),
+            # Not restricted: other scopes are unaffected
+            ("feature_flag_created", "FeatureFlag", "created", False, False),
+            ("feature_flag_updated", "FeatureFlag", "updated", True, False),
+            ("insight_created", "Insight", "created", False, False),
+            ("dashboard_deleted", "Dashboard", "deleted", False, False),
+            ("experiment_launched", "Experiment", "launched", True, False),
+        ]
+    )
+    def test_is_restricted_for_external_destinations(
+        self, _name: str, scope: str, activity: str, was_impersonated: bool, expected_restricted: bool
+    ) -> None:
+        log = ActivityLog(
+            team_id=self.team.id,
+            scope=scope,
+            activity=activity,
+            was_impersonated=was_impersonated,
+        )
+        self.assertEqual(
+            ActivityVisibilityRestrictions.is_restricted(log, restrict_for_staff=True), expected_restricted
+        )
+
+    @parameterized.expand(
+        [
+            # Staff bypass: impersonated login/logout visible to staff via allow_staff=True
+            ("impersonated_login_staff_bypass", "User", "logged_in", True, False),
+            ("impersonated_logout_staff_bypass", "User", "logged_out", True, False),
+            # Normal activities still not restricted
+            ("normal_login", "User", "logged_in", False, False),
+            ("feature_flag_created", "FeatureFlag", "created", False, False),
+        ]
+    )
+    def test_staff_can_see_restricted_logs_when_allowed(
+        self, _name: str, scope: str, activity: str, was_impersonated: bool, expected_restricted: bool
+    ) -> None:
+        log = ActivityLog(
+            team_id=self.team.id,
+            scope=scope,
+            activity=activity,
+            was_impersonated=was_impersonated,
+        )
+        self.assertEqual(
+            ActivityVisibilityRestrictions.is_restricted(log, restrict_for_staff=False), expected_restricted
+        )
+
+    def test_queryset_excludes_restricted_logs_for_non_staff(self) -> None:
+        # Create a mix of activity logs
+        ActivityLog.objects.create(team_id=self.team.id, scope="User", activity="logged_in", was_impersonated=True)
+        ActivityLog.objects.create(team_id=self.team.id, scope="User", activity="logged_out", was_impersonated=True)
+        ActivityLog.objects.create(team_id=self.team.id, scope="User", activity="logged_in", was_impersonated=False)
+        ActivityLog.objects.create(
+            team_id=self.team.id, scope="FeatureFlag", activity="created", was_impersonated=False
+        )
+
+        queryset = ActivityLog.objects.filter(team_id=self.team.id)
+        filtered = ActivityVisibilityRestrictions.apply_to_queryset(queryset, is_staff=False)
+
+        self.assertEqual(queryset.count(), 4)
+        self.assertEqual(filtered.count(), 2)
+        self.assertFalse(filtered.filter(scope="User", activity="logged_in", was_impersonated=True).exists())
+        self.assertFalse(filtered.filter(scope="User", activity="logged_out", was_impersonated=True).exists())
+        self.assertTrue(filtered.filter(scope="User", activity="logged_in", was_impersonated=False).exists())
+        self.assertTrue(filtered.filter(scope="FeatureFlag", activity="created").exists())
+
+    def test_queryset_includes_all_logs_for_staff(self) -> None:
+        ActivityLog.objects.create(team_id=self.team.id, scope="User", activity="logged_in", was_impersonated=True)
+        ActivityLog.objects.create(team_id=self.team.id, scope="User", activity="logged_out", was_impersonated=True)
+        ActivityLog.objects.create(
+            team_id=self.team.id, scope="FeatureFlag", activity="created", was_impersonated=False
+        )
+
+        queryset = ActivityLog.objects.filter(team_id=self.team.id)
+        filtered = ActivityVisibilityRestrictions.apply_to_queryset(queryset, is_staff=True)
+
+        self.assertEqual(filtered.count(), 3)


### PR DESCRIPTION
Apply same restrictions as on the advanced activity logs endpoints and exports, to when dispatching the internal activity log events which are used for subscriptions

## Problem

- Currently there are some activity logs which are not supposed to be seen by non-staff users (i.e. any clients on Cloud). These are defined in `posthog/models/activity_logging/activity_log.py::activity_visibility_restrictions`.
- Although activity log API calls and exports take these restrictions into account filters the activity logs out, currently activity log subscriptions (e.g. pushing activity log create/update events to Slack via a Destination) do not exclude these.
- This is especially important in sensitive situations, such as impersonated login activity logs (e.g. a support person impersonated someone) - we don't want to share these with the client as these are in practice internal events.

## Changes

- Refactor the restriction logic to abstract it a bit better.
- Apply it when dispatching the kafka events which trigger activity log subscriptions

## How did you test this code?

- Unit
