### PR TITLE
feat(customers): Filter insight by group in GroupFeedCanvas

### DIFF
--- a/products/customer_analytics/frontend/components/GroupFeedCanvas/GroupFeedCanvas.tsx
+++ b/products/customer_analytics/frontend/components/GroupFeedCanvas/GroupFeedCanvas.tsx
@@ -1,10 +1,12 @@
-import { BindLogic } from 'kea'
+import { BindLogic, useValues } from 'kea'
 
 import { uuid } from 'lib/utils'
 import { groupLogic } from 'scenes/groups/groupLogic'
 import { Notebook } from 'scenes/notebooks/Notebook/Notebook'
+import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
 
-import { Group } from '~/types'
+import { groupsModel } from '~/models/groupsModel'
+import { AnyPropertyFilter, Group, PropertyFilterType, PropertyOperator } from '~/types'
 
 interface GroupFeedCanvasProps {
     group: Group
@@ -14,69 +16,86 @@ interface GroupFeedCanvasProps {
 export const GroupFeedCanvas = ({ group, tabId }: GroupFeedCanvasProps): JSX.Element => {
     const groupKey = group.group_key
     const groupTypeIndex = group.group_type_index
+    const { aggregationLabel } = useValues(groupsModel)
+
+    const shortId = `canvas-${groupKey}-${tabId}`
+    const mode = 'canvas'
+
+    const groupFilter: AnyPropertyFilter[] = [
+        {
+            type: PropertyFilterType.EventMetadata,
+            key: `$group_${groupTypeIndex}`,
+            label: aggregationLabel(groupTypeIndex).singular,
+            value: groupKey,
+            operator: PropertyOperator.Exact,
+        },
+    ]
 
     return (
-        <BindLogic logic={groupLogic} props={{ groupKey, groupTypeIndex, tabId }}>
-            <Notebook
-                editable={false}
-                shortId={`canvas-${groupKey}-${tabId}`}
-                mode="canvas"
-                initialContent={{
-                    type: 'doc',
-                    content: [
-                        {
-                            type: 'ph-usage-metrics',
-                            attrs: {
-                                groupKey,
-                                groupTypeIndex,
-                                tabId,
-                                nodeId: uuid(),
-                                children: [
-                                    {
-                                        type: 'ph-group',
-                                        attrs: {
-                                            id: groupKey,
-                                            groupTypeIndex,
-                                            tabId,
-                                            nodeId: uuid(),
-                                            title: 'Info',
+        <BindLogic logic={notebookLogic} props={{ shortId, mode, canvasFiltersOverride: groupFilter }}>
+            <BindLogic logic={groupLogic} props={{ groupKey, groupTypeIndex, tabId }}>
+                <Notebook
+                    editable={false}
+                    shortId={`canvas-${groupKey}-${tabId}`}
+                    mode="canvas"
+                    canvasFiltersOverride={groupFilter}
+                    initialContent={{
+                        type: 'doc',
+                        content: [
+                            {
+                                type: 'ph-usage-metrics',
+                                attrs: {
+                                    groupKey,
+                                    groupTypeIndex,
+                                    tabId,
+                                    nodeId: uuid(),
+                                    children: [
+                                        {
+                                            type: 'ph-group',
+                                            attrs: {
+                                                id: groupKey,
+                                                groupTypeIndex,
+                                                tabId,
+                                                nodeId: uuid(),
+                                                title: 'Info',
+                                            },
                                         },
-                                    },
-                                    {
-                                        type: 'ph-group-properties',
-                                        attrs: {
-                                            nodeId: uuid(),
+                                        {
+                                            type: 'ph-group-properties',
+                                            attrs: {
+                                                nodeId: uuid(),
+                                            },
                                         },
-                                    },
-                                    {
-                                        type: 'ph-related-groups',
-                                        attrs: {
-                                            id: groupKey,
-                                            groupTypeIndex,
-                                            nodeId: uuid(),
-                                            title: 'Related people',
-                                            type: 'person',
+                                        {
+                                            type: 'ph-related-groups',
+                                            attrs: {
+                                                id: groupKey,
+                                                groupTypeIndex,
+                                                nodeId: uuid(),
+                                                title: 'Related people',
+                                                type: 'person',
+                                            },
                                         },
-                                    },
-                                ],
+                                    ],
+                                },
                             },
-                        },
-                        {
-                            type: 'ph-issues',
-                            attrs: { groupKey, groupTypeIndex, tabId, nodeId: uuid() },
-                        },
-                        {
-                            type: 'ph-llm-trace',
-                            attrs: {
-                                groupKey,
-                                groupTypeIndex,
-                                tabId,
-                                nodeId: uuid(),
+                            {
+                                type: 'ph-issues',
+                                attrs: { groupKey, groupTypeIndex, tabId, nodeId: uuid() },
                             },
-                        },
-                    ],
-                }}
-            />
+                            {
+                                type: 'ph-llm-trace',
+                                attrs: {
+                                    groupKey,
+                                    groupTypeIndex,
+                                    tabId,
+                                    nodeId: uuid(),
+                                },
+                            },
+                        ],
+                    }}
+                />
+            </BindLogic>
         </BindLogic>
     )
 }


### PR DESCRIPTION
## Problem

When viewing a group feed canvas, we need to automatically filter the notebook content to only show data relevant to the specific group being viewed. Currently, the canvas does not apply any group-specific filters.

## Changes

* Created a group filter based on the group type index and group key
* Used the aggregation label from the groups model to provide a human-readable label for the filter

This ensures that when users view a group's feed canvas, they only see data relevant to that specific group.

![Kapture 2025-11-28 at 11 06 52](https://github.com/user-attachments/assets/3d86892c-156c-4c96-8ffe-bded75571bdc)
Caption: adding events node to group canvas returns only events related to that group (performed by their related person). The filter is set as a `fixedProperties`, so it doesn't show up as removable.
Adding trends node shows only events related to the group too (and the counts match). The filter in this case is removable, but set as default.

## How did you test this code?

Tested by:
1. Viewing group feed canvases for different groups and group types and verifying that only data for the selected group appears
2. Checking that the filter is correctly applied with the proper group type and key
3. Confirming that the aggregation label is displayed correctly in the filter
4. Ensuring each insight type available is filtered correctly

## Changelog: Yes