### PR TITLE
chore(logs): tidy up log text to reduce clutter and improve ui

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -68,7 +68,6 @@ export function LogsScene(): JSX.Element {
         isPinned,
         hasMoreLogsToLoad,
         logsPageSize,
-        totalLogsMatchingFilters,
         logsRemainingToLoad,
     } = useValues(logsLogic)
     const { runQuery, setDateRangeFromSparkline, loadMoreLogs } = useActions(logsLogic)
@@ -177,7 +176,7 @@ export function LogsScene(): JSX.Element {
                                 {logsLoading
                                     ? 'Loading more logs...'
                                     : hasMoreLogsToLoad
-                                      ? `Showing ${humanFriendlyNumber(parsedLogs.length)} of ${humanFriendlyNumber(totalLogsMatchingFilters)} logs – load ${humanFriendlyNumber(Math.min(logsPageSize, logsRemainingToLoad))} more`
+                                      ? `Click to load ${humanFriendlyNumber(Math.min(logsPageSize, logsRemainingToLoad))} more`
                                       : `Showing all ${humanFriendlyNumber(parsedLogs.length)} logs`}
                             </LemonButton>
                         </div>
@@ -461,6 +460,7 @@ const DisplayOptions = (): JSX.Element => {
         timestampFormat,
         logsPageSize,
         totalLogsMatchingFilters,
+        parsedLogs,
         sparklineLoading,
     } = useValues(logsLogic)
     const { setOrderBy, setWrapBody, setPrettifyJson, setTimestampFormat, setLogsPageSize } = useActions(logsLogic)
@@ -505,7 +505,10 @@ const DisplayOptions = (): JSX.Element => {
             </div>
             <div className="flex items-center gap-4">
                 {!sparklineLoading && totalLogsMatchingFilters > 0 && (
-                    <span className="text-muted text-xs">{humanFriendlyNumber(totalLogsMatchingFilters)} logs</span>
+                    <span className="text-muted text-xs">
+                        Showing {humanFriendlyNumber(parsedLogs.length)} of{' '}
+                        {humanFriendlyNumber(totalLogsMatchingFilters)} logs
+                    </span>
                 )}
                 <LemonField.Pure label="Page size" inline className="items-center gap-2">
                     <LemonSelect


### PR DESCRIPTION
## Problem

Total logs text & load more button were too cluttered

## Changes

<img width="366" height="62" alt="image" src="https://github.com/user-attachments/assets/65aaada4-186c-45a9-82d6-ff72f2872c92" />
<img width="290" height="83" alt="image" src="https://github.com/user-attachments/assets/ffd5fc4c-bff8-488d-a865-084adfaef4e3" />

Reduces length of text on the load more button & displays the total logs in the sticky bar.

## How did you test this code?

Local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._