### PR TITLE
fix(products): update logs category from 'Unreleased' to 'Tools'

### DIFF
--- a/frontend/src/products.json
+++ b/frontend/src/products.json
@@ -85,7 +85,7 @@
             "type": null,
             "intents": ["llm_analytics"]
         },
-        { "path": "Logs", "category": "Unreleased", "iconType": null, "type": null, "intents": ["logs"] },
+        { "path": "Logs", "category": "Tools", "iconType": null, "type": null, "intents": ["logs"] },
         {
             "path": "Product analytics",
             "category": "Analytics",

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1075,7 +1075,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     {
         path: 'Logs',
         intents: [ProductKey.LOGS],
-        category: 'Unreleased',
+        category: 'Tools',
         iconType: 'logs' as FileSystemIconType,
         iconColor: ['var(--color-product-logs-light)'] as FileSystemIconColor,
         href: urls.logs(),

--- a/products/logs/manifest.tsx
+++ b/products/logs/manifest.tsx
@@ -30,7 +30,7 @@ export const manifest: ProductManifest = {
         {
             path: 'Logs',
             intents: [ProductKey.LOGS],
-            category: 'Unreleased',
+            category: 'Tools',
             iconType: 'logs' as FileSystemIconType,
             iconColor: ['var(--color-product-logs-light)'] as FileSystemIconColor,
             href: urls.logs(),


### PR DESCRIPTION
## Problem

The logs product was still under the "unreleased" category.

## Changes

<img width="210" height="159" alt="image" src="https://github.com/user-attachments/assets/2164b4a0-aef3-4b5c-be42-e1bc0465f2fc" />

- Moves logs to "tools"

## How did you test this code?

Local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._