### PR TITLE
feat(support): add 'logs' target area to support ticket options

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -275,6 +275,11 @@ export const TARGET_AREA_TO_NAME = [
                 'data-attr': `support-form-target-area-web_analytics`,
                 label: 'Web analytics',
             },
+            {
+                value: 'logs',
+                'data-attr': `support-form-target-area-logs`,
+                label: 'Logs',
+            },
         ],
     },
 ]
@@ -316,6 +321,7 @@ export type SupportTicketTargetArea =
     | 'platform_addons'
     | 'max-ai'
     | 'customer-analytics'
+    | 'logs'
 export type SupportTicketSeverityLevel = keyof typeof SEVERITY_LEVEL_TO_NAME
 export type SupportTicketKind = keyof typeof SUPPORT_KIND_TO_SUBJECT
 
@@ -359,6 +365,7 @@ export const URL_PATH_TO_TARGET_AREA: Record<string, SupportTicketTargetArea> = 
     sources: 'data_warehouse',
     workflows: 'workflows',
     billing: 'billing',
+    logs: 'logs',
 }
 
 export const SUPPORT_TICKET_TEMPLATES = {


### PR DESCRIPTION
## Problem

Logs wasn't connected to the support form

## Changes

<img width="396" height="231" alt="image" src="https://github.com/user-attachments/assets/c5277d5f-2472-4e30-8ae0-5053ed2d9612" />

- Logs topic now exists in the support form
- Logs topic chosen by default when user is on logs product

## How did you test this code?

Local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._