### PR TITLE
fix(signals): Limit video validation videos playback to 1x.

### DIFF
--- a/ee/hogai/session_summaries/constants.py
+++ b/ee/hogai/session_summaries/constants.py
@@ -38,7 +38,10 @@ MAX_SESSION_IDS_COMBINED_LOGGING_LENGTH = 150  # Maximum string of combined sess
 SECONDS_BEFORE_EVENT_FOR_VALIDATION_VIDEO = 7
 VALIDATION_VIDEO_DURATION = 12
 VALIDATION_VIDEO_RENDERING_DELAY = 2  # Don't analyze first seconds of the video, as it could include malformed frames
-VALIDATION_VIDEO_PLAYBACK_SPEED = 16  # We don't need minor details, as LLM needs 1 frame per second
+VALIDATION_VIDEO_PLAYBACK_SPEED = 8  # We don't need minor details, as LLM needs 1 frame per second
+SHORT_VALIDATION_VIDEO_PLAYBACK_SPEED = (
+    1  # For short videos (10s validation chunks), we should stick to "render fully", instead of speed
+)
 FAILED_MOMENTS_MIN_RATIO = 0.5  # If less than 50% of moments failed to generate videos, fail the analysis
 EXPIRES_AFTER_DAYS = 90  # How long to store the videos used for validation
 DEFAULT_VIDEO_EXPORT_MIME_TYPE = "video/webm"

--- a/ee/hogai/videos/session_moments.py
+++ b/ee/hogai/videos/session_moments.py
@@ -28,8 +28,8 @@ from products.llm_analytics.backend.providers.gemini import GeminiProvider
 from ee.hogai.session_summaries.constants import (
     DEFAULT_VIDEO_EXPORT_MIME_TYPE,
     DEFAULT_VIDEO_UNDERSTANDING_MODEL,
+    SHORT_VALIDATION_VIDEO_PLAYBACK_SPEED,
     VALIDATION_VIDEO_DURATION,
-    VALIDATION_VIDEO_PLAYBACK_SPEED,
     VALIDATION_VIDEO_RENDERING_DELAY,
 )
 
@@ -155,7 +155,7 @@ class SessionMomentsLLMAnalyzer:
                     "filename": moment_filename,
                     "duration": moment.duration_s,
                     # Speed up to reduce the rendering time
-                    "playback_speed": VALIDATION_VIDEO_PLAYBACK_SPEED,
+                    "playback_speed": SHORT_VALIDATION_VIDEO_PLAYBACK_SPEED,
                     # Keeping default values
                     "mode": "screenshot",
                 },


### PR DESCRIPTION
## Problem
- When exporting short videos (10s) in 16x - significant part of the video is not rendered or rendered incorrectly

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Stick to 1x playback for short videos

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
