### PR TITLE
feat(logs): copy link to log includes time range and initial limit

### DIFF
--- a/products/logs/frontend/components/LogsTable/LogsTableRowActions.tsx
+++ b/products/logs/frontend/components/LogsTable/LogsTableRowActions.tsx
@@ -1,3 +1,5 @@
+import { useActions } from 'kea'
+
 import { IconCopy } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -7,25 +9,21 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import { LogMessage } from '~/queries/schema/schema-general'
 
+import { logsLogic } from '../../logsLogic'
+
 interface LogsTableRowActionsProps {
     log: LogMessage
 }
 
 export function LogsTableRowActions({ log }: LogsTableRowActionsProps): JSX.Element {
-    const handleCopyLink = (): void => {
-        const url = new URL(window.location.href)
-        url.searchParams.set('highlightedLogId', log.uuid)
-        void copyToClipboard(url.toString(), 'link to log')
-    }
+    const { copyLinkToLog } = useActions(logsLogic)
 
     return (
         <More
             overlay={
                 <>
                     <LemonButton
-                        onClick={() => {
-                            void copyToClipboard(log.body, 'log message')
-                        }}
+                        onClick={() => copyToClipboard(log.body, 'log message')}
                         fullWidth
                         sideIcon={<IconCopy />}
                         data-attr="logs-table-copy-message"
@@ -33,7 +31,7 @@ export function LogsTableRowActions({ log }: LogsTableRowActionsProps): JSX.Elem
                         Copy log message
                     </LemonButton>
                     <LemonButton
-                        onClick={handleCopyLink}
+                        onClick={() => copyLinkToLog(log.uuid)}
                         fullWidth
                         sideIcon={<IconLink />}
                         data-attr="logs-table-copy-link"

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -14,6 +14,7 @@ import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { humanFriendlyDetailedTime } from 'lib/utils'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { Params } from 'scenes/sceneTypes'
 
 import { DateRange, LogMessage, LogsQuery } from '~/queries/schema/schema-general'
@@ -32,6 +33,7 @@ const DEFAULT_ORDER_BY = 'latest' as LogsQuery['orderBy']
 const DEFAULT_WRAP_BODY = true
 const DEFAULT_PRETTIFY_JSON = true
 const DEFAULT_LOGS_PAGE_SIZE: number = 100
+const DEFAULT_INITIAL_LOGS_LIMIT = null as number | null
 const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
 const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS = 1000
 const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MAX_MS = 5000
@@ -55,8 +57,11 @@ export const logsLogic = kea<logsLogicType>([
     tabAwareScene(),
     tabAwareUrlToAction(({ actions, values }) => {
         const urlToAction = (_: any, params: Params): void => {
-            if (params.dateRange && !equal(params.dateRange, values.dateRange)) {
-                actions.setDateRange(params.dateRange)
+            if (params.dateRange) {
+                const dateRange = typeof params.dateRange === 'string' ? JSON.parse(params.dateRange) : params.dateRange
+                if (!equal(dateRange, values.dateRange)) {
+                    actions.setDateRange(dateRange)
+                }
             }
             if (params.filterGroup && !equal(params.filterGroup, values.filterGroup)) {
                 actions.setFilterGroup(params.filterGroup, false)
@@ -84,6 +89,9 @@ export const logsLogic = kea<logsLogicType>([
             }
             if (+params.logsPageSize && +params.logsPageSize !== values.logsPageSize) {
                 actions.setLogsPageSize(+params.logsPageSize)
+            }
+            if (+params.initialLogsLimit && +params.initialLogsLimit !== values.initialLogsLimit) {
+                actions.setInitialLogsLimit(+params.initialLogsLimit)
             }
         }
         return {
@@ -217,6 +225,8 @@ export const logsLogic = kea<logsLogicType>([
         setHighlightedLogId: (highlightedLogId: string | null) => ({ highlightedLogId }),
         setHasMoreLogsToLoad: (hasMoreLogsToLoad: boolean) => ({ hasMoreLogsToLoad }),
         setLogsPageSize: (logsPageSize: number) => ({ logsPageSize }),
+        setInitialLogsLimit: (initialLogsLimit: number | null) => ({ initialLogsLimit }),
+        copyLinkToLog: (logId: string) => ({ logId }),
         highlightNextLog: true,
         highlightPreviousLog: true,
         toggleExpandLog: (logId: string) => ({ logId }),
@@ -235,6 +245,13 @@ export const logsLogic = kea<logsLogicType>([
             DEFAULT_LOGS_PAGE_SIZE,
             {
                 setLogsPageSize: (_, { logsPageSize }) => logsPageSize,
+            },
+        ],
+        initialLogsLimit: [
+            DEFAULT_INITIAL_LOGS_LIMIT as number | null,
+            {
+                setInitialLogsLimit: (_, { initialLogsLimit }) => initialLogsLimit,
+                fetchLogsSuccess: () => null,
             },
         ],
         dateRange: [
@@ -421,7 +438,7 @@ export const logsLogic = kea<logsLogicType>([
 
                     const response = await api.logs.query({
                         query: {
-                            limit: values.logsPageSize,
+                            limit: values.initialLogsLimit ?? values.logsPageSize,
                             orderBy: values.orderBy,
                             dateRange: values.utcDateRange,
                             searchTerm: values.searchTerm,
@@ -977,6 +994,24 @@ export const logsLogic = kea<logsLogicType>([
             if (values.sparklineAbortController) {
                 values.sparklineAbortController.abort('unmounting component')
             }
+        },
+        copyLinkToLog: ({ logId }) => {
+            const url = new URL(window.location.href)
+            url.searchParams.set('highlightedLogId', logId)
+            if (values.visibleLogsTimeRange) {
+                url.searchParams.set(
+                    'dateRange',
+                    JSON.stringify({
+                        date_from: values.visibleLogsTimeRange.date_from,
+                        date_to: values.visibleLogsTimeRange.date_to,
+                        explicitDate: true,
+                    })
+                )
+            }
+            if (values.logs.length > 0) {
+                url.searchParams.set('initialLogsLimit', String(values.logs.length))
+            }
+            void copyToClipboard(url.toString(), 'link to log')
         },
     })),
 ])

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -95,7 +95,7 @@ export const logsLogic = kea<logsLogicType>([
             if (+params.logsPageSize && +params.logsPageSize !== values.logsPageSize) {
                 actions.setLogsPageSize(+params.logsPageSize)
             }
-            if (+params.initialLogsLimit && +params.initialLogsLimit !== values.initialLogsLimit) {
+            if (params.initialLogsLimit != null && +params.initialLogsLimit !== values.initialLogsLimit) {
                 actions.setInitialLogsLimit(+params.initialLogsLimit)
             }
         }

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -1002,20 +1002,7 @@ export const logsLogic = kea<logsLogicType>([
                     .filter((item) => latest_time_bucket.diff(dayjs(item.time), 'seconds') <= sparklineTimeWindow)
             )
         },
-    })),
-
-    events(({ values, actions }) => ({
-        beforeUnmount: () => {
-            actions.setLiveTailRunning(false)
-            actions.cancelInProgressLiveTail(null)
-            if (values.logsAbortController) {
-                values.logsAbortController.abort('unmounting component')
-            }
-            if (values.sparklineAbortController) {
-                values.sparklineAbortController.abort('unmounting component')
-            }
-        },
-        copyLinkToLog: ({ logId }) => {
+        copyLinkToLog: ({ logId }: { logId: string }) => {
             const url = new URL(window.location.href)
             url.searchParams.set('highlightedLogId', logId)
             if (values.visibleLogsTimeRange) {
@@ -1032,6 +1019,19 @@ export const logsLogic = kea<logsLogicType>([
                 url.searchParams.set('initialLogsLimit', String(values.logs.length))
             }
             void copyToClipboard(url.toString(), 'link to log')
+        },
+    })),
+
+    events(({ values, actions }) => ({
+        beforeUnmount: () => {
+            actions.setLiveTailRunning(false)
+            actions.cancelInProgressLiveTail(null)
+            if (values.logsAbortController) {
+                values.logsAbortController.abort('unmounting component')
+            }
+            if (values.sparklineAbortController) {
+                values.sparklineAbortController.abort('unmounting component')
+            }
         },
     })),
 ])

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -58,9 +58,14 @@ export const logsLogic = kea<logsLogicType>([
     tabAwareUrlToAction(({ actions, values }) => {
         const urlToAction = (_: any, params: Params): void => {
             if (params.dateRange) {
-                const dateRange = typeof params.dateRange === 'string' ? JSON.parse(params.dateRange) : params.dateRange
-                if (!equal(dateRange, values.dateRange)) {
-                    actions.setDateRange(dateRange)
+                try {
+                    const dateRange =
+                        typeof params.dateRange === 'string' ? JSON.parse(params.dateRange) : params.dateRange
+                    if (!equal(dateRange, values.dateRange)) {
+                        actions.setDateRange(dateRange)
+                    }
+                } catch {
+                    // Ignore malformed dateRange JSON in URL
                 }
             }
             if (params.filterGroup && !equal(params.filterGroup, values.filterGroup)) {

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -166,7 +166,22 @@ export const logsLogic = kea<logsLogicType>([
             })
         }
 
+        const clearInitialLogsLimit = (): [
+            string,
+            Params,
+            Record<string, any>,
+            {
+                replace: boolean
+            },
+        ] => {
+            return syncSearchParams(router, (params: Params) => {
+                updateSearchParams(params, 'initialLogsLimit', null, DEFAULT_INITIAL_LOGS_LIMIT)
+                return params
+            })
+        }
+
         return {
+            fetchLogsSuccess: () => clearInitialLogsLimit(),
             setDateRange: () => buildUrlAndRunQuery(),
             setFilterGroup: () => buildUrlAndRunQuery(),
             setSearchTerm: () => buildUrlAndRunQuery(),


### PR DESCRIPTION
## Problem

When copying a link to a log on page 2+, clicking the link only loads the first page of results. The highlighted log isn't visible because it exists in a later page that hasn't been fetched yet.

## Changes

When copying a link to a log on page 2+, the URL now includes:
- dateRange with visible logs time range (explicitDate: true)
- initialLogsLimit set to current logs count (one-time, cleared after first fetch)
- highlightedLogId to scroll to the specific log

This ensures recipients land on the same visible range with the highlighted log visible, rather than page 1.

Moved URL building logic from LogsTableRowActions component into logsLogic as copyLinkToLog action.

## How did you test this code?

Local Dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._