### PR TITLE
fix(logs): fix bad margin on pretty json text

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -302,7 +302,7 @@ function LogsTable({
                         render: (_, { cleanBody, parsedBody }) => {
                             if (parsedBody && prettifyJson) {
                                 return (
-                                    <pre className={cn('text-xs', wrapBody ? '' : 'whitespace-nowrap')}>
+                                    <pre className={cn('text-xs m-0', wrapBody ? '' : 'whitespace-nowrap')}>
                                         {JSON.stringify(parsedBody, null, 2)}
                                     </pre>
                                 )


### PR DESCRIPTION
## Problem

margin was off on pretty formatted json

<img width="338" height="644" alt="image" src="https://github.com/user-attachments/assets/a09a5758-b030-4e59-9756-a2979538ccff" />

## Changes

remove the bad margin on pre element

<img width="358" height="828" alt="image" src="https://github.com/user-attachments/assets/a305038f-f87b-48b7-b5bc-487f79c4374c" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
