### PR TITLE
fix: prevent email field from clearing in SAML auth

### DIFF
--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -83,14 +83,18 @@ export function Login(): JSX.Element {
     const preventPasswordError = useRef(false)
     const isPasswordHidden = precheckResponse.status === 'pending' || precheckResponse.sso_enforcement
     const isEmailVerificationSent = generalError?.code === 'email_verification_sent'
+    const wasPasswordHiddenRef = useRef(isPasswordHidden)
 
     const lastLoginMethod = getCookie(LAST_LOGIN_METHOD_COOKIE) as LoginMethod
 
     useEffect(() => {
+        const wasPasswordHidden = wasPasswordHiddenRef.current
+        wasPasswordHiddenRef.current = isPasswordHidden
+
         if (!isPasswordHidden) {
             passwordInputRef.current?.focus()
-        } else {
-            // clear form when password field becomes hidden
+        } else if (!wasPasswordHidden) {
+            // clear form when transitioning from visible to hidden
             resetLogin()
         }
     }, [isPasswordHidden, resetLogin])


### PR DESCRIPTION
## Problem

PR [#41642](https://github.com/PostHog/posthog/pull/41642) added `resetLogin` to the `useEffect` deps. Now when `resetLogin` changes identity during kea updates, the effect re-runs and clears the email if `isPasswordHidden` is true. This breaks SAML flow, users must enter email twice.

https://github.com/user-attachments/assets/dc2c8fde-9354-4bad-b154-ce76da101ed1

## Changes
- Track previous` isPasswordHidden` value with a ref. Only call `resetLogin()` on transition from false to true


https://github.com/user-attachments/assets/959f5a6c-d9b5-484c-bec0-a3e5fae2a74e


## How did you test this code?
- Set up SAML with OneLogin locally, logged out and back in. 