### PR TITLE
fix(funnels): replace deprecated rust group_by

### DIFF
--- a/funnel-udf/src/steps.rs
+++ b/funnel-udf/src/steps.rs
@@ -122,7 +122,7 @@ impl AggregateFunnelRow {
                     true
                 }
             })
-            .group_by(|e| e.timestamp);
+            .chunk_by(|e| e.timestamp);
 
         for (timestamp, events_with_same_timestamp) in &filtered_events {
             let events_with_same_timestamp: Vec<_> = events_with_same_timestamp.collect();

--- a/funnel-udf/src/trends.rs
+++ b/funnel-udf/src/trends.rs
@@ -134,7 +134,7 @@ impl AggregateFunnelRow {
                     true
                 }
             })
-            .group_by(|e| e.timestamp);
+            .chunk_by(|e| e.timestamp);
 
         for (_timestamp, events_with_same_timestamp) in &filtered_events {
             let events_with_same_timestamp: Vec<_> = events_with_same_timestamp.collect();


### PR DESCRIPTION
## Problem

"group by" was renamed to "chunk by" https://github.com/rust-lang/rust/pull/117678

```
warning: use of deprecated method itertools::Itertools::group_by: Use .chunk_by() instead
--> src/steps.rs:125:14
|
125 | .group_by(|e| e.timestamp);
| ^^^^^^^^
|
= note: #[warn(deprecated)] on by default

warning: use of deprecated method itertools::Itertools::group_by: Use .chunk_by() instead
--> src/trends.rs:137:14
|
137 | .group_by(|e| e.timestamp);
| ^^^^^^^^
```

## Changes

Updates code usages.

## How did you test this code?

CI run