### PR TITLE
fix: Attempt to fix bloom filter usage for property map IN clauses

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -738,7 +738,7 @@ class _Printer(Visitor[str]):
             if v.value == "" or v.value is None or not isinstance(v.value, str):
                 return None
 
-        # IN with an empty or all null set of values is always false
+        # IN with an empty set of values is always false
         if len(values) == 0:
             return "0"
 

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1991,11 +1991,6 @@ class _Printer(Visitor[str]):
             return f"SETTINGS {', '.join(pairs)}"
         return None
 
-    @staticmethod
-    def print_clickhouse_settings(s):
-        printer = _Printer(dialect="clickhouse", context=HogQLContext())
-        return printer._print_settings(s)
-
     def _create_default_window_frame(self, node: ast.WindowFunction):
         # For lag/lead functions, we need to order by the first argument by default
         order_by: list[ast.OrderExpr] | None = None

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -724,6 +724,48 @@ class _Printer(Visitor[str]):
     def visit_order_expr(self, node: ast.OrderExpr):
         return f"{self.visit(node.expr)} {node.order}"
 
+    def __optimize_in_with_string_values(
+        self, values: list[ast.Expr], property_source: PrintableMaterializedPropertyGroupItem
+    ) -> str | None:
+        """
+        Optimizes an IN comparison against a list of values for property group bloom filter usage.
+        Returns the optimized expression string, or None if optimization is not possible.
+        """
+
+        # Remove all null values, as they will always be false for IN comparisons, see
+        # https://clickhouse.com/docs/en/sql-reference/operators/in#null-processing
+        values = [v for v in values if not (isinstance(v, ast.Constant) and v.value is None)]
+
+        # Bail on the optimisation if any value is not a Constant, is the empty string, or is not a string
+        for v in values:
+            if not isinstance(v, ast.Constant):
+                return None
+            if v.value == "" or not isinstance(v.value, str):
+                return None
+
+        # IN with an empty or all null set of values is always false
+        if len(values) == 0:
+            return "0"
+
+        # A problem we run into here is that an expression like
+        # in(events.properties_group_feature_flags['$feature/onboarding-use-case-selection'], ('control', 'test'))
+        # does not hit the bloom filter on the key, so we need to modify the expression so that it does
+
+        # If only one value, switch to equality operator. Expressions like this will hit the bloom filter for both keys and values:
+        # events.properties_group_feature_flags['$feature/onboarding-use-case-selection'] = 'control'
+        if len(values) == 1:
+            return f"equals({property_source.value_expr}, {self.visit(values[0])})"
+
+        # With transform_null_in=1 in SETTINGS (which we have by default), if there are several values, we need to
+        # include a check for whether the key exists to hit the keys bloom filter.
+        # Unlike the version WITHOUT mapKeys above, the following expression WILL hit the bloom filter:
+        # and(has(mapKeys(properties_group_feature_flags), '$feature/onboarding-use-case-selection'),
+        #     in(events.properties_group_feature_flags['$feature/onboarding-use-case-selection'], ('control', 'test')))
+        # Note that we could add a mapValues to this to use the values bloom filter
+        # TODO to profile whether we should add mapValues. Probably no for flags, yes for properties.
+        values_tuple = ", ".join(self.visit(v) for v in values)
+        return f"and({property_source.has_expr}, in({property_source.value_expr}, tuple({values_tuple})))"
+
     def __get_optimized_property_group_compare_operation(self, node: ast.CompareOperation) -> str | None:
         """
         Returns a printed expression corresponding to the provided compare operation, if one of the operands is part of
@@ -821,32 +863,9 @@ class _Printer(Visitor[str]):
                     # If the RHS is the empty string, we need to disambiguate it from the default value for missing keys.
                     return f"and({property_source.has_expr}, equals({property_source.value_expr}, {self.visit(node.right)}))"
                 elif isinstance(node.right.type, ast.StringType):
-                    return f"in({property_source.value_expr}, {self.visit(node.right)})"
-            elif isinstance(node.right, ast.Tuple):
-                # If any of the values on the RHS are the empty string, we need to disambiguate it from the default
-                # value for missing keys. NULLs should also be dropped, but everything else we can directly compare
-                # (strings) can be passed through as-is
-                default_value_expr: ast.Constant | None = None
-                for expr in node.right.exprs[:]:
-                    if not isinstance(expr, ast.Constant):
-                        return None  # only optimize constants for now, see above
-                    if expr.value is None:
-                        node.right.exprs.remove(expr)
-                    elif expr.value == "":
-                        default_value_expr = expr
-                        node.right.exprs.remove(expr)
-                    elif not isinstance(expr.type, ast.StringType):
-                        return None
-                if len(node.right.exprs) > 0:
-                    # TODO: Check to see if it'd be faster to do equality comparison here instead?
-                    printed_expr = f"in({property_source.value_expr}, {self.visit(node.right)})"
-                    if default_value_expr is not None:
-                        printed_expr = f"or({printed_expr}, and({property_source.has_expr}, equals({property_source.value_expr}, {self.visit(default_value_expr)})))"
-                elif default_value_expr is not None:
-                    printed_expr = f"and({property_source.has_expr}, equals({property_source.value_expr}, {self.visit(default_value_expr)}))"
-                else:
-                    printed_expr = "0"
-                return printed_expr
+                    return f"equals({property_source.value_expr}, {self.visit(node.right)})"
+            elif isinstance(node.right, ast.Tuple) or isinstance(node.right, ast.Array):
+                return self.__optimize_in_with_string_values(node.right.exprs, property_source)
             else:
                 # TODO: Alias types are not resolved here (similarly to equality operations above) so some expressions
                 # are not optimized that possibly could be if we took that additional step to determine whether or not

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -853,8 +853,9 @@ class _Printer(Visitor[str]):
 
             if isinstance(node.right, ast.Constant):
                 if node.right.value is None:
-                    return "0"
-                elif node.right.value == "":
+                    # we can't optimize here, as the unoptimized version returns true if the key doesn't exist OR the value is null
+                    return None
+                if node.right.value == "":
                     # If the RHS is the empty string, we need to disambiguate it from the default value for missing keys.
                     return f"and({property_source.has_expr}, equals({property_source.value_expr}, {self.visit(node.right)}))"
                 elif isinstance(node.right.type, ast.StringType):
@@ -1989,6 +1990,11 @@ class _Printer(Visitor[str]):
         if len(pairs) > 0:
             return f"SETTINGS {', '.join(pairs)}"
         return None
+
+    @staticmethod
+    def print_clickhouse_settings(s):
+        printer = _Printer(dialect="clickhouse", context=HogQLContext())
+        return printer._print_settings(s)
 
     def _create_default_window_frame(self, node: ast.WindowFunction):
         # For lag/lead functions, we need to order by the first argument by default

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -731,16 +731,11 @@ class _Printer(Visitor[str]):
         Optimizes an IN comparison against a list of values for property group bloom filter usage.
         Returns the optimized expression string, or None if optimization is not possible.
         """
-
-        # Remove all null values, as they will always be false for IN comparisons, see
-        # https://clickhouse.com/docs/en/sql-reference/operators/in#null-processing
-        values = [v for v in values if not (isinstance(v, ast.Constant) and v.value is None)]
-
-        # Bail on the optimisation if any value is not a Constant, is the empty string, or is not a string
+        # Bail on the optimisation if any value is not a Constant, is the empty string, is NULL, or is not a string
         for v in values:
             if not isinstance(v, ast.Constant):
                 return None
-            if v.value == "" or not isinstance(v.value, str):
+            if v.value == "" or v.value is None or not isinstance(v.value, str):
                 return None
 
         # IN with an empty or all null set of values is always false

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -616,7 +616,7 @@ class TestPrinter(BaseTest):
                 f"EXPLAIN indexes = 1, json = 1 SELECT count() FROM events WHERE {printed_expr}",
                 context.values,
                 settings={
-                    "1" if v is True else "0" if v is False else str(v): v
+                    k: "1" if v is True else "0" if v is False else str(v)
                     for k, v in HogQLGlobalSettings().model_dump().items()
                     if v is not None
                 },

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -783,13 +783,15 @@ class TestPrinter(BaseTest):
             "properties.key IN ('a', 'b')",
             "and(has(events.properties_group_custom, %(hogql_val_0)s), in(events.properties_group_custom[%(hogql_val_0)s], tuple(%(hogql_val_1)s, %(hogql_val_2)s)))",
             {"hogql_val_0": "key", "hogql_val_1": "a", "hogql_val_2": "b"},
-            expected_skip_indexes_used={"properties_group_custom_keys_bf", "properties_group_custom_values_bf"},
+            expected_skip_indexes_used={"properties_group_custom_keys_bf"},
+            expected_skip_indexes_not_used={"properties_group_custom_values_bf"},
         )
         self._test_property_group_comparison(
             "properties.key IN ['a', 'b']",
             "and(has(events.properties_group_custom, %(hogql_val_0)s), in(events.properties_group_custom[%(hogql_val_0)s], tuple(%(hogql_val_1)s, %(hogql_val_2)s)))",
             {"hogql_val_0": "key", "hogql_val_1": "a", "hogql_val_2": "b"},
-            expected_skip_indexes_used={"properties_group_custom_keys_bf", "properties_group_custom_values_bf"},
+            expected_skip_indexes_used={"properties_group_custom_keys_bf"},
+            expected_skip_indexes_not_used={"properties_group_custom_values_bf"},
         )
 
         # Single string value converts to equality comparison

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -813,18 +813,7 @@ class TestPrinter(BaseTest):
         # Tuples with empty string or NULL - bail out of tuple optimization (use default behavior)
         self._test_property_group_comparison("properties.key IN ('a', 'b', '')", None)
         self._test_property_group_comparison("properties.key IN ('', NULL)", None)
-
-        # Tuples with NULL values should have the NULL value removed
-        self._test_property_group_comparison(
-            "properties.key IN ('a', 'b', NULL)",
-            "and(has(events.properties_group_custom, %(hogql_val_0)s), in(events.properties_group_custom[%(hogql_val_0)s], tuple(%(hogql_val_1)s, %(hogql_val_2)s)))",
-            {
-                "hogql_val_0": "key",
-                "hogql_val_1": "a",
-                "hogql_val_2": "b",
-            },
-            expected_skip_indexes_used={"properties_group_custom_keys_bf", "properties_group_custom_values_bf"},
-        )
+        self._test_property_group_comparison("properties.key IN ('a', 'b', NULL)", None)
 
         # NULL values are never equal. While this differs from the behavior of the equality operator above, it is
         # consistent with how ClickHouse treats these values:

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -953,6 +953,8 @@ class TestPrinter(BaseTest):
         assert_result_is_equal("[NULL, NULL, NULL]", {"null", "not_set"})
         assert_result_is_equal("('s', 1)", {"string", "int"})
         assert_result_is_equal("('s', '')", {"string", "empty_string"})
+        assert_result_is_equal("'null'", set())
+        assert_result_is_equal("'NULL'", set())
 
     def test_property_groups_select_with_aliases(self):
         def build_context(property_groups_mode: PropertyGroupsMode) -> HogQLContext:

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -822,9 +822,12 @@ class TestPrinter(BaseTest):
         self._test_property_group_comparison("properties.key IN ('', NULL)", None)
         self._test_property_group_comparison("properties.key IN ('a', 'b', NULL)", None)
 
-        # NULL values are never equal. While this differs from the behavior of the equality operator above, it is
-        # consistent with how ClickHouse treats these values:
+        # NULL values are can be equal if using transform_null_in = 1, which we do by default
+        # https://clickhouse.com/docs/operations/settings/settings#transform_null_in
         # https://clickhouse.com/docs/en/sql-reference/operators/in#null-processing
+        self.assertTrue(
+            HogQLGlobalSettings().transform_null_in
+        )  # if changing this assumption, you'll need to change the printer too
         self._test_property_group_comparison(
             "properties.key in NULL",
             "in(has(events.properties_group_custom, %(hogql_val_1)s) ? events.properties_group_custom[%(hogql_val_1)s] : null, NULL)",

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -882,6 +882,13 @@ class TestPrinter(BaseTest):
             properties={"label": "int", "value": 1},
         )
 
+        # update this test if we add more modes
+        assert {e.value for e in PropertyGroupsMode} == {
+            PropertyGroupsMode.DISABLED,
+            PropertyGroupsMode.ENABLED,
+            PropertyGroupsMode.OPTIMIZED,
+        }
+
         def assert_result_is_equal(expr: str, labels):
             hogql_expr = parse_expr(expr)
 

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -941,7 +941,8 @@ class TestPrinter(BaseTest):
             assert {row[0] for row in optimized_response.results} == labels
 
         assert_result_is_equal("1", {"int"})
-        assert_result_is_equal("s", {"string"})
+        assert_result_is_equal("'1'", {"int"})  # this feels wrong, but at least it's consistent
+        assert_result_is_equal("'s'", {"string"})
         assert_result_is_equal("''", {"empty_string"})
         assert_result_is_equal("NULL", {"null", "not_set"})
         assert_result_is_equal("('s')", {"string"})

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -955,6 +955,7 @@ class TestPrinter(BaseTest):
         assert_result_is_equal("('s', '')", {"string", "empty_string"})
         assert_result_is_equal("'null'", set())
         assert_result_is_equal("'NULL'", set())
+        assert_result_is_equal("[]", set())
 
     def test_property_groups_select_with_aliases(self):
         def build_context(property_groups_mode: PropertyGroupsMode) -> HogQLContext:

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -870,7 +870,7 @@ class TestPrinter(BaseTest):
             properties={"label": "c", "is_string": "s", "is_null_and_string": "s"},
         )
 
-        def assert_expressions_are_equal(expr: str):
+        def assert_result_is_equal(expr: str):
             hogql_expr = parse_expr(expr)
 
             query = parse_select(
@@ -921,25 +921,28 @@ class TestPrinter(BaseTest):
             assert enabled_response.results == disabled_response.results
             assert optimized_response.results == disabled_response.results
 
-        assert_expressions_are_equal("properties.is_string in ('s')")
-        assert_expressions_are_equal("properties.is_string in ('not_exist')")
-        assert_expressions_are_equal("properties.is_string in ('not_exist', 's')")
-        assert_expressions_are_equal("properties.is_string in ('not_exist', 's', NULL)")
+        assert_result_is_equal("properties.is_string in ('s')")
+        assert_result_is_equal("properties.is_string in ('not_exist')")
+        assert_result_is_equal("properties.is_string in ('not_exist', 's')")
+        assert_result_is_equal("properties.is_string in ('not_exist', 's', NULL)")
+        assert_result_is_equal("properties.is_string in NULL")
 
-        assert_expressions_are_equal("properties.is_null in NULL")
-        assert_expressions_are_equal("properties.is_null in (NULL)")
-        assert_expressions_are_equal("properties.is_null in (NULL, NULL, NULL)")
-        assert_expressions_are_equal("properties.is_null in [NULL, NULL, NULL]")
-        assert_expressions_are_equal("properties.is_null in ('not_exist', 's', NULL)")
+        assert_result_is_equal("properties.is_null in NULL")
+        assert_result_is_equal("properties.is_null in (NULL)")
+        assert_result_is_equal("properties.is_null in (NULL, NULL, NULL)")
+        assert_result_is_equal("properties.is_null in [NULL, NULL, NULL]")
+        assert_result_is_equal("properties.is_null in ('not_exist', 's', NULL)")
 
-        assert_expressions_are_equal("properties.is_null_and_string in ('s')")
-        assert_expressions_are_equal("properties.is_null_and_string in (NULL)")
-        assert_expressions_are_equal("properties.is_null_and_string in ('not_exist')")
-        assert_expressions_are_equal("properties.is_null_and_string in ('not_exist', 's')")
-        assert_expressions_are_equal("properties.is_null_and_string in ('not_exist', 's', NULL)")
+        assert_result_is_equal("properties.is_null_and_string in ('s')")
+        assert_result_is_equal("properties.is_null_and_string in (NULL)")
+        assert_result_is_equal("properties.is_null_and_string in ('not_exist')")
+        assert_result_is_equal("properties.is_null_and_string in ('not_exist', 's')")
+        assert_result_is_equal("properties.is_null_and_string in ('not_exist', 's', NULL)")
 
-        assert_expressions_are_equal("properties.not_exist in (NULL)")
-        assert_expressions_are_equal("properties.not_exist in ('not_exist', NULL)")
+        assert_result_is_equal("properties.not_exist in (NULL)")
+        assert_result_is_equal("properties.not_exist in (NULL, NULL, NULL)")
+        assert_result_is_equal("properties.not_exist in [NULL, NULL, NULL]")
+        assert_result_is_equal("properties.not_exist in ('not_exist', NULL)")
 
     def test_property_groups_select_with_aliases(self):
         def build_context(property_groups_mode: PropertyGroupsMode) -> HogQLContext:


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/42278

A while ago, we added `transform_null_in = 1` to settings, which prevents us from using the bloom filter index on the feature flag properties map on the events table.

The bloom filter doesn't support `map['key'] in ('foo', 'bar')` when `transform_null_in = 1` so change it to `has(map, 'key') and map['key'] in ('foo', 'bar')` so that it does.

I also found some correctness problems where queries can have different values depending on the optimisation mode.

The tests that should have covered this never caught it, as they didn't use the same query settings that we use for production queries.

## Changes

* I changed some code that assumed that `properties.foo in [NULL]` would always be false, with `transform_null_in = 1` this is no longer true
* I changed the value equality check to `and(key_presence_check, value_equality_check)` in some cases so that we could actually hit the bloom filter correctly, as this broke with the introduction of `transform_null_in = 1`
* I updated the relevant tests to apply the default HogQL settings, as this would have caught this regression


## How did you test this code?
I added a new set of tests to make sure that we get the same result for all values of `PropertyGroupsMode`

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
