### PR TITLE
feat: add shift-to-interact hint and refresh clickmap on shift release

### DIFF
--- a/frontend/src/lib/components/heatmaps/useShiftKeyPressed.ts
+++ b/frontend/src/lib/components/heatmaps/useShiftKeyPressed.ts
@@ -1,9 +1,11 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 
-export function useShiftKeyPressed(): boolean {
+export function useShiftKeyPressed(onShiftReleased?: () => void): boolean {
     const [isShiftPressed, setIsShiftPressed] = useState(false)
+    const onShiftReleasedRef = useRef(onShiftReleased)
+    onShiftReleasedRef.current = onShiftReleased
 
     useOnMountEffect(() => {
         const handleKeyDown = (event: KeyboardEvent): void => {
@@ -15,6 +17,7 @@ export function useShiftKeyPressed(): boolean {
         const handleKeyUp = (event: KeyboardEvent): void => {
             if (event.key === 'Shift') {
                 setIsShiftPressed(false)
+                onShiftReleasedRef.current?.()
             }
         }
 

--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -29,10 +29,10 @@ export function Elements(): JSX.Element {
         relativePositionCompensation,
     } = useValues(elementsLogic)
     const { setHoverElement, selectElement } = useActions(elementsLogic)
-    const { highestClickCount, clickmapsEnabled } = useValues(heatmapToolbarMenuLogic)
+    const { highestClickCount } = useValues(heatmapToolbarMenuLogic)
     const { refreshClickmap } = useActions(heatmapToolbarMenuLogic)
 
-    const shiftPressed = useShiftKeyPressed(clickmapsEnabled ? refreshClickmap : undefined)
+    const shiftPressed = useShiftKeyPressed(refreshClickmap)
     const heatmapPointerEvents = shiftPressed ? 'none' : 'all'
 
     const { theme } = useValues(toolbarLogic)

--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -29,9 +29,10 @@ export function Elements(): JSX.Element {
         relativePositionCompensation,
     } = useValues(elementsLogic)
     const { setHoverElement, selectElement } = useActions(elementsLogic)
-    const { highestClickCount } = useValues(heatmapToolbarMenuLogic)
+    const { highestClickCount, clickmapsEnabled } = useValues(heatmapToolbarMenuLogic)
+    const { refreshClickmap } = useActions(heatmapToolbarMenuLogic)
 
-    const shiftPressed = useShiftKeyPressed()
+    const shiftPressed = useShiftKeyPressed(clickmapsEnabled ? refreshClickmap : undefined)
     const heatmapPointerEvents = shiftPressed ? 'none' : 'all'
 
     const { theme } = useValues(toolbarLogic)

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -131,6 +131,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         startElementObservation: true,
         stopElementObservation: true,
         processElements: true,
+        refreshClickmap: true,
         setProcessedElements: (elements: CountedHTMLElement[]) => ({ elements }),
         setElementsLoading: (loading: boolean) => ({ loading }),
         setProcessingProgress: (processed: number, total: number) => ({ processed, total }),
@@ -518,6 +519,11 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         },
 
         setMatchLinksByHref: () => {
+            actions.processElements()
+        },
+
+        refreshClickmap: () => {
+            invalidatePageElementsCache(cache as ElementProcessingCache)
             actions.processElements()
         },
 

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -523,6 +523,9 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         },
 
         refreshClickmap: () => {
+            if (!values.clickmapsEnabled) {
+                return
+            }
             invalidatePageElementsCache(cache as ElementProcessingCache)
             actions.processElements()
         },

--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -191,6 +191,10 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                                 the event can be mapped to a specific element found on the page you are viewing but less
                                 data is usually captured.
                             </p>
+                            <p className="text-xs text-secondary italic">
+                                Tip: Hold <kbd className="border rounded px-1 py-0.5 bg-surface-tertiary">shift</kbd> to
+                                interact with the page beneath the clickmap.
+                            </p>
                             <div className="flex items-center justify-between pb-2">
                                 <div className="flex items-center gap-1">
                                     <LemonLabel

--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -191,7 +191,7 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                                 the event can be mapped to a specific element found on the page you are viewing but less
                                 data is usually captured.
                             </p>
-                            <p className="text-xs text-secondary italic">
+                            <p className="text-xs italic">
                                 Tip: Hold <kbd className="border rounded px-1 py-0.5 bg-surface-tertiary">shift</kbd> to
                                 interact with the page beneath the clickmap.
                             </p>


### PR DESCRIPTION
## Problem

We already had a shift-to-interact feature with heatmaps/clickmaps, but we didn't explain this in the Toolbar UI.

Also the cache of elements doesn't get updated after a shift+click interaction if the DOM changes (even though we do invalidate the cache with the existing MutationObserver).

https://posthoghelp.zendesk.com/agent/tickets/43658 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46090)

## Changes

 * Added a tip in the clickmaps section explaining that users can hold shift to interact with the page:
<img width="495" height="119" alt="CleanShot 2025-11-28 at 16 21 53" src="https://github.com/user-attachments/assets/f80a5282-6ccc-43f3-9013-b9f6a88c0879" />

  * Extended `useShiftKeyPressed` hook to accept an optional callback when shift is released
  * Added `refreshClickmap` action that invalidates the element cache and triggers re-processing
  * When shift is released with clickmaps enabled, the clickmap now refreshes to reflect any DOM changes (e.g. after a menu is opened)

![CleanShot 2025-11-28 at 16 25 56](https://github.com/user-attachments/assets/ba5022dc-dad2-4268-b38a-bcd0b284f490)


## How did you test this code?

Tested locally to verify it works.

