### PR TITLE
chore: Retrigger build for temporal workers

### DIFF
--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -21,7 +21,7 @@ from ee.tasks.subscriptions import deliver_subscription_report_async, team_use_t
 
 LOGGER = get_logger(__name__)
 
-# Changed 21-Nov-2025
+# Changed 28-Nov-2025
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Since the beginning of this week, we started to receive quite a few reports surrounding the subscription functionality where it would show "There are no matching events for this query" for exported insights. See this issue which tracks all of the reports: https://github.com/PostHog/posthog/issues/42127. 

After a thorough investigation through the codebase, we found out that we recently changed our hashing logic (PR: https://github.com/PostHog/posthog/pull/41871) however due to how our conditional image building works, new images for the workers were not deployed. This meant that our "cache warming" for subscriptions no longer worked, and as a result that the subscription exports intermittently showed empty insight screenshots due to a cache key mismatch.

When exporting insights for subscriptions, two services generate cache keys:
1. Temporal worker (image_exporter.py): Pre-calculates the query with `force_blocking` and caches results
2. Web Django (sharing.py → InsightSerializer): Loads the `/exporter` page and fetches results using `lazy_async` mode

These services were running different code versions:
  - Temporal worker (old): cache_<md5_hash> (e.g., `cache_85875d5fbbbb44fba24c30059434f111`)
  - Web Django (new): cache_{team_id}_{sha256_hash} (e.g., `cache_2_5d9797e550043c1ea24704b123452a1079e59aa4f28eaaaa4b3548f6946c52c`)

Why This Caused Empty Screenshots

1. Temporal worker calculates query and caches with MD5-based key (this still had the old code, but this is to "warm" the cache for the export)
2. Selenium opens `/exporter` page, Django serializes the insight via `InsightSerializer.to_representation()`
3. Because `is_shared=True`, the execution mode becomes lazy_async (via `shared_insights_execution_mode()`) => This does a cache refresh in the background but does not block.
4. Django looks for cache with SHA256-based key → cache miss, as in step 1, we warmed it with the "old" cache key.
5. Page renders with InsightEmptyState, screenshot captures empty state as it did not find any cached data. This as `lazy_async` returns immediatly without waiting for the data, thus if there is no cached data, there is nothing to show. 

This problem was spotted by digging thoroughly through the events that we emitted, and at some point it stood out that the 2 failing insights from my test example both had `cache_hit: false`. This then triggered the above investigation and led to this conclusion:

<img width="2870" height="521" alt="CleanShot 2025-11-28 at 17 43 34" src="https://github.com/user-attachments/assets/15371edb-7ef9-489e-9ac6-f6cd14128462" />

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

I'm changing a comment so that it will trigger a rebuild and redeploy of the workers, including the new hashing logic. Outside this "fix" I will spend some time next week to see what we can do to improve our visibility around this type of errors. This has been done before in: https://github.com/PostHog/posthog/pull/41900.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

The CI is passing.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->

N/A this is not relevant for the changelog as this is a bugfix.