### PR TITLE
feat: Extend quick start section to 3 months after onboarding

### DIFF
--- a/dags/user_product_list.py
+++ b/dags/user_product_list.py
@@ -92,7 +92,7 @@ def populate_user_product_list(context: dagster.OpExecutionContext, config: Popu
     context.log.info(f"Starting populate for {len(config.product_paths)} products: {config.product_paths}")
 
     # Build user queryset with filters
-    users = User.objects.all()
+    users = User.objects.all().order_by("created_at")
 
     # Filter by creation date if specified
     if config.user_created_before is not None:

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activation/SidePanelActivation.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activation/SidePanelActivation.tsx
@@ -296,7 +296,7 @@ const ActivationTask = ({
                             className="h-6 font-semibold text-muted-alt activation-task-skip"
                             onClick={handleUnskip}
                         >
-                            Unskip?
+                            Unskip
                         </LemonButton>
                     ) : (
                         <LemonButton

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activation/SidePanelActivation.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activation/SidePanelActivation.tsx
@@ -67,7 +67,7 @@ export const SidePanelActivation = (): JSX.Element | null => {
                             role="button"
                             aria-expanded={showHiddenSections}
                         >
-                            <h4 className="font-semibold text-[16px]">All products</h4>
+                            <h4 className="font-semibold text-[16px]">Onboard to more products?</h4>
                             {showHiddenSections ? (
                                 <IconCollapse className="h-5 w-5" />
                             ) : (
@@ -176,7 +176,7 @@ const ActivationSectionComponent = ({
                             size="xsmall"
                             type="secondary"
                         >
-                            Add
+                            Add to list
                         </LemonButton>
                     )}
                 </div>
@@ -202,10 +202,11 @@ const ActivationTask = ({
     url,
     buttonText,
 }: ActivationTaskType): JSX.Element => {
-    const { runTask, markTaskAsSkipped, setExpandedTaskId, setTaskContentHeight } = useActions(activationLogic)
+    const { runTask, markTaskAsSkipped, unmarkTaskAsSkipped, setExpandedTaskId, setTaskContentHeight } =
+        useActions(activationLogic)
     const { reportActivationSideBarTaskClicked } = useActions(eventUsageLogic)
     const { expandedTaskId, taskContentHeights } = useValues(activationLogic)
-    const isActive = !completed && !skipped && !lockedReason
+    const isActive = !completed && !lockedReason
     const hasContent = Boolean(activationTaskContentMap[id])
     const expanded = expandedTaskId === id
     const ContentComponent = hasContent ? activationTaskContentMap[id] : undefined
@@ -223,9 +224,10 @@ const ActivationTask = ({
     }
 
     const handleRowClick = (): void => {
-        if (!isActive) {
+        if (completed || lockedReason) {
             return
         }
+
         if (hasContent) {
             setExpandedTaskId(expanded ? null : id)
         } else {
@@ -243,6 +245,11 @@ const ActivationTask = ({
         markTaskAsSkipped(id)
     }
 
+    const handleUnskip = (e: React.MouseEvent): void => {
+        e.stopPropagation()
+        unmarkTaskAsSkipped(id)
+    }
+
     const handleGetStarted = (e: React.MouseEvent): void => {
         e.stopPropagation()
         reportActivationSideBarTaskClicked(id)
@@ -257,7 +264,7 @@ const ActivationTask = ({
         <li
             className={clsx(
                 'p-2 border bg-primary-alt-highlight flex flex-col',
-                completed || skipped ? 'line-through opacity-70' : '',
+
                 lockedReason && 'opacity-70'
             )}
         >
@@ -268,7 +275,7 @@ const ActivationTask = ({
                 )}
                 onClick={handleRowClick}
             >
-                <div className="flex items-center gap-2">
+                <div className={clsx('flex items-center gap-2', completed || skipped ? 'line-through opacity-70' : '')}>
                     {completed ? (
                         <IconCheckCircle className="h-6 w-6 text-success" />
                     ) : lockedReason ? (
@@ -280,16 +287,27 @@ const ActivationTask = ({
                     )}
                     <p className="m-0 font-semibold">{title}</p>
                 </div>
-                {isActive && canSkip && (
-                    <LemonButton
-                        size="xsmall"
-                        type="secondary"
-                        className="h-6 font-semibold text-muted-alt activation-task-skip"
-                        onClick={handleSkip}
-                    >
-                        Skip
-                    </LemonButton>
-                )}
+                {isActive &&
+                    canSkip &&
+                    (skipped ? (
+                        <LemonButton
+                            size="xsmall"
+                            type="secondary"
+                            className="h-6 font-semibold text-muted-alt activation-task-skip"
+                            onClick={handleUnskip}
+                        >
+                            Unskip?
+                        </LemonButton>
+                    ) : (
+                        <LemonButton
+                            size="xsmall"
+                            type="secondary"
+                            className="h-6 font-semibold text-muted-alt activation-task-skip"
+                            onClick={handleSkip}
+                        >
+                            Skip
+                        </LemonButton>
+                    ))}
             </div>
             {isActive && hasContent && (
                 <div

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activation/activationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activation/activationLogic.tsx
@@ -96,6 +96,7 @@ export const activationLogic = kea<activationLogicType>([
         runTask: (id: ActivationTask) => ({ id }),
         markTaskAsCompleted: (id: ActivationTask) => ({ id }),
         markTaskAsSkipped: (id: ActivationTask) => ({ id }),
+        unmarkTaskAsSkipped: (id: ActivationTask) => ({ id }),
         toggleShowHiddenSections: () => ({}),
         addIntentForSection: (section: ActivationSection) => ({ section }),
         toggleSectionOpen: (section: ActivationSection) => ({ section }),
@@ -356,6 +357,22 @@ export const activationLogic = kea<activationLogicType>([
                     [id]: ActivationTaskStatus.SKIPPED,
                 },
             })
+        },
+        unmarkTaskAsSkipped: ({ id }) => {
+            const skipped = values.currentTeam?.onboarding_tasks?.[id] === ActivationTaskStatus.SKIPPED
+
+            if (!skipped) {
+                return
+            }
+
+            posthog.capture('activation sidebar task unskipped', {
+                task: id,
+            })
+
+            const onboardingTasks = { ...values.currentTeam?.onboarding_tasks }
+            delete onboardingTasks[id]
+
+            actions.updateCurrentTeam({ onboarding_tasks: onboardingTasks })
         },
         markTaskAsCompleted: ({ id }) => {
             const completed = values.currentTeam?.onboarding_tasks?.[id] === ActivationTaskStatus.COMPLETED

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -82,33 +82,37 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
             (selectedTab, sidePanelOpen, isCloudOrDev, featureFlags, sceneSidePanelContext, currentTeam) => {
                 const tabs: SidePanelTab[] = []
 
+                // Show Max if user is already enrolled into beta OR they got a link to Max (even if they haven't enrolled)
                 if (featureFlags[FEATURE_FLAGS.ARTIFICIAL_HOG] || (sidePanelOpen && selectedTab === SidePanelTab.Max)) {
-                    // Show Max if user is already enrolled into beta OR they got a link to Max (even if they haven't enrolled)
                     tabs.push(SidePanelTab.Max)
                 }
+
                 if (isCloudOrDev) {
                     tabs.push(SidePanelTab.Status)
                 }
+
+                // Quick start is shown in the sidebar for the first 90 days of a team's existence
+                if (currentTeam?.created_at) {
+                    const teamCreatedAt = dayjs(currentTeam.created_at)
+
+                    if (dayjs().diff(teamCreatedAt, 'day') < 90) {
+                        tabs.push(SidePanelTab.Activation)
+                    }
+                }
+
                 tabs.push(SidePanelTab.Notebooks)
                 tabs.push(SidePanelTab.Docs)
                 if (isCloudOrDev) {
                     tabs.push(SidePanelTab.Support)
                 }
+
                 tabs.push(SidePanelTab.Activity)
-
-                if (currentTeam?.created_at) {
-                    const teamCreatedAt = dayjs(currentTeam.created_at)
-
-                    if (dayjs().diff(teamCreatedAt, 'day') < 30) {
-                        tabs.push(SidePanelTab.Activation)
-                    }
-                }
-
                 tabs.push(SidePanelTab.Discussion)
 
                 if (sceneSidePanelContext.access_control_resource && sceneSidePanelContext.access_control_resource_id) {
                     tabs.push(SidePanelTab.AccessControl)
                 }
+
                 tabs.push(SidePanelTab.Exports)
                 tabs.push(SidePanelTab.Settings)
                 tabs.push(SidePanelTab.SdkDoctor)
@@ -116,6 +120,7 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                 if (!currentTeam) {
                     return tabs.filter((tab) => !TABS_REQUIRING_A_TEAM.includes(tab))
                 }
+
                 return tabs
             },
         ],


### PR DESCRIPTION
This goes away too quickly and then people can't find it anymore hurting onboarding.
Also moving it slightly higher in the sidebar and allowing people to unskip allowing people to read the contents of what they've skipped.  
  
![image.png](https://app.graphite.com/user-attachments/assets/854ef941-fbc5-44cd-b687-7f9b951780a7.png)

