### PR TITLE
perf(logs): improve logs keyboard navigation performance

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -140,9 +140,12 @@ export const TaxonomicFilterSearchInput = forwardRef<
     {
         searchInputRef: React.Ref<HTMLInputElement> | null
         onClose: TaxonomicFilterProps['onClose']
-    } & Pick<LemonInputPropsText, 'onClick' | 'size' | 'prefix' | 'fullWidth' | 'onChange'> &
+    } & Pick<LemonInputPropsText, 'onClick' | 'size' | 'prefix' | 'fullWidth' | 'onChange' | 'autoFocus'> &
         Pick<TooltipProps, 'docLink'>
->(function UniversalSearchInput({ searchInputRef, onClose, onChange, docLink, ...props }, ref): JSX.Element {
+>(function UniversalSearchInput(
+    { searchInputRef, onClose, onChange, docLink, autoFocus = true, ...props },
+    ref
+): JSX.Element {
     const { searchQuery, searchPlaceholder, showNumericalPropsOnly } = useValues(taxonomicFilterLogic)
     const {
         setSearchQuery: setTaxonomicSearchQuery,
@@ -226,7 +229,7 @@ export const TaxonomicFilterSearchInput = forwardRef<
             }}
             inputRef={searchInputRef}
             onChange={_onChange}
-            autoFocus
+            autoFocus={autoFocus}
         />
     )
 })

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -242,10 +242,12 @@ function LogsTable({
 
     useEffect(() => {
         if (!loading && highlightedLogId && tableRef.current) {
-            const highlightedRow = tableRef.current?.querySelector(`[data-row-key="${highlightedLogId}"]`)
-            if (highlightedRow) {
-                highlightedRow.scrollIntoView({ behavior: 'instant', block: 'center' })
-            }
+            requestAnimationFrame(() => {
+                const highlightedRow = tableRef.current?.querySelector(`[data-row-key="${highlightedLogId}"]`)
+                if (highlightedRow) {
+                    highlightedRow.scrollIntoView({ behavior: 'instant', block: 'center' })
+                }
+            })
         }
     }, [loading, highlightedLogId])
 

--- a/products/logs/frontend/components/filters/LogsFilters/FilterGroup.tsx
+++ b/products/logs/frontend/components/filters/LogsFilters/FilterGroup.tsx
@@ -92,6 +92,7 @@ const UniversalSearch = (): JSX.Element => {
                     onChange={onChange}
                     size="small"
                     fullWidth
+                    autoFocus={false}
                 />
             </LemonDropdown>
         </BindLogic>

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -589,7 +589,13 @@ export const logsLogic = kea<logsLogicType>([
         parsedLogs: [
             (s) => [s.logs],
             (logs: LogMessage[]): ParsedLogMessage[] => {
-                return logs.map((log: LogMessage) => {
+                const seen = new Set<string>() // de-dupe
+                const result: ParsedLogMessage[] = []
+                for (const log of logs) {
+                    if (seen.has(log.uuid)) {
+                        continue
+                    }
+                    seen.add(log.uuid)
                     const cleanBody = colors.unstyle(log.body)
                     let parsedBody: JsonType | null = null
                     try {
@@ -597,8 +603,9 @@ export const logsLogic = kea<logsLogicType>([
                     } catch {
                         // Not JSON, that's fine
                     }
-                    return { ...log, cleanBody, parsedBody }
-                })
+                    result.push({ ...log, cleanBody, parsedBody })
+                }
+                return result
             },
         ],
         pinnedParsedLogs: [
@@ -616,10 +623,11 @@ export const logsLogic = kea<logsLogicType>([
                 })
             },
         ],
-        isPinned: [
+        pinnedLogIds: [
             (s) => [s.pinnedLogs],
-            (pinnedLogs: LogMessage[]) => (logId: string) => pinnedLogs.some((log) => log.uuid === logId),
+            (pinnedLogs: LogMessage[]): Set<string> => new Set(pinnedLogs.map((log) => log.uuid)),
         ],
+        isPinned: [(s) => [s.pinnedLogIds], (pinnedLogIds: Set<string>) => (logId: string) => pinnedLogIds.has(logId)],
         visibleLogsTimeRange: [
             (s) => [s.parsedLogs, s.orderBy],
             (
@@ -723,6 +731,16 @@ export const logsLogic = kea<logsLogicType>([
         logsRemainingToLoad: [
             (s) => [s.totalLogsMatchingFilters, s.logs],
             (totalLogsMatchingFilters, logs): number => totalLogsMatchingFilters - logs.length,
+        ],
+        logIndexByUuid: [
+            (s) => [s.parsedLogs],
+            (parsedLogs: ParsedLogMessage[]): Map<string, number> => {
+                const map = new Map<string, number>()
+                for (let i = 0; i < parsedLogs.length; i++) {
+                    map.set(parsedLogs[i].uuid, i)
+                }
+                return map
+            },
         ],
     }),
 
@@ -847,7 +865,7 @@ export const logsLogic = kea<logsLogicType>([
             }
 
             const currentIndex = values.highlightedLogId
-                ? logs.findIndex((log) => log.uuid === values.highlightedLogId)
+                ? (values.logIndexByUuid.get(values.highlightedLogId) ?? -1)
                 : -1
 
             if (currentIndex === -1) {
@@ -865,7 +883,7 @@ export const logsLogic = kea<logsLogicType>([
             }
 
             const currentIndex = values.highlightedLogId
-                ? logs.findIndex((log) => log.uuid === values.highlightedLogId)
+                ? (values.logIndexByUuid.get(values.highlightedLogId) ?? -1)
                 : -1
 
             if (currentIndex === -1) {


### PR DESCRIPTION
## Problem

- Keyboard navigation was a bit janky & performance needed improving. 
- The search input was auto-focusing, preventing us from jumping straight into keyboard navigation.
- Duplicate logs were occasionally appearing and breaking keyboard nav

## Changes

- Optimized log lookups by replacing O(n) operations with O(1) Map/Set-based lookups
- Added throttling to keyboard navigation to prevent rapid repeated calls
- Implemented log de-duplication based on UUID in the parsed logs selector

## How did you test this code?

Local dev + unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._