### PR TITLE
feat(llma): multimodal display

### DIFF
--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -320,7 +320,13 @@ describe('eventDefinitionsTableLogic', () => {
             await expectLogic(logic, () => {
                 logic.actions.loadPropertiesForEvent(eventDefinition)
             })
-                .toDispatchActions(['loadPropertiesForEvent', 'loadPropertiesForEventSuccess'])
+                .toDispatchActionsInAnyOrder([
+                    router.actionCreators.push(url),
+                    'loadEventDefinitions',
+                    'loadEventDefinitionsSuccess',
+                    'loadPropertiesForEvent',
+                    'loadPropertiesForEventSuccess',
+                ])
                 .toMatchValues({
                     eventPropertiesCacheMap: partial({
                         [eventDefinition.id]: partial({
@@ -329,7 +335,7 @@ describe('eventDefinitionsTableLogic', () => {
                         }),
                     }),
                 })
-            expect(api.get).toHaveBeenCalledTimes(2)
+            expect(api.get).toHaveBeenCalledTimes(3)
             // Forwards
             await expectLogic(logic, () => {
                 logic.actions.loadPropertiesForEvent(
@@ -347,7 +353,7 @@ describe('eventDefinitionsTableLogic', () => {
                         }),
                     }),
                 })
-            expect(api.get).toHaveBeenCalledTimes(3)
+            expect(api.get).toHaveBeenCalledTimes(4)
             // Backwards
             await expectLogic(logic, () => {
                 logic.actions.loadPropertiesForEvent(eventDefinition, propertiesStartingUrl)
@@ -361,7 +367,7 @@ describe('eventDefinitionsTableLogic', () => {
                         }),
                     }),
                 })
-            expect(api.get).toHaveBeenCalledTimes(3)
+            expect(api.get).toHaveBeenCalledTimes(4)
         })
     })
 })

--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -16,7 +16,15 @@ import { SearchHighlight } from '../SearchHighlight'
 import { llmAnalyticsTraceLogic } from '../llmAnalyticsTraceLogic'
 import { containsSearchQuery } from '../searchUtils'
 import { CompatMessage, VercelSDKImageMessage } from '../types'
-import { looksLikeXml } from '../utils'
+import {
+    isAnthropicImageMessage,
+    isGeminiAudioMessage,
+    isGeminiImageMessage,
+    isOpenAIAudioMessage,
+    isOpenAIFileMessage,
+    isOpenAIImageURLMessage,
+    looksLikeXml,
+} from '../utils'
 import { HighlightedLemonMarkdown } from './HighlightedLemonMarkdown'
 import { HighlightedXMLViewer } from './HighlightedXMLViewer'
 import { XMLViewer } from './XMLViewer'
@@ -231,6 +239,88 @@ export const ImageMessageDisplay = ({
     return <span>{content}</span>
 }
 
+function renderContentItem(item: any, searchQuery?: string): JSX.Element | null {
+    if (typeof item === 'string') {
+        return searchQuery?.trim() ? (
+            <SearchHighlight string={item} substring={searchQuery} className="whitespace-pre-wrap" />
+        ) : (
+            <span className="whitespace-pre-wrap">{item}</span>
+        )
+    }
+
+    if (!item || typeof item !== 'object' || !('type' in item)) {
+        return <HighlightedJSONViewer src={item} name={null} collapsed={5} searchQuery={searchQuery} />
+    }
+
+    if (item.type === 'text' && 'text' in item) {
+        return searchQuery?.trim() && typeof item.text === 'string' ? (
+            <SearchHighlight string={item.text} substring={searchQuery} className="whitespace-pre-wrap" />
+        ) : (
+            <span className="whitespace-pre-wrap">{item.text}</span>
+        )
+    }
+
+    if (item.type === 'image' && 'image' in item && typeof item.image === 'string') {
+        return <ImageMessageDisplay message={{ content: { type: 'image', image: item.image } }} />
+    }
+
+    if (isOpenAIImageURLMessage(item)) {
+        return <img src={item.image_url.url} alt="Message content" className="max-w-full max-h-[400px] rounded" />
+    }
+
+    if (isAnthropicImageMessage(item)) {
+        return (
+            <img
+                src={`data:${item.source.media_type};base64,${item.source.data}`}
+                alt="Message content"
+                className="max-w-full max-h-[400px] rounded"
+            />
+        )
+    }
+
+    if (isGeminiImageMessage(item)) {
+        return (
+            <img
+                src={`data:${item.inline_data.mime_type};base64,${item.inline_data.data}`}
+                alt="Message content"
+                className="max-w-full max-h-[400px] rounded"
+            />
+        )
+    }
+
+    if (isOpenAIFileMessage(item)) {
+        return (
+            // eslint-disable-next-line react/forbid-elements
+            <a href={item.file.file_data} download={item.file.filename} className="text-link hover:underline">
+                {item.file.filename}
+            </a>
+        )
+    }
+
+    if (isOpenAIAudioMessage(item) || isGeminiAudioMessage(item)) {
+        const mimeType = 'mime_type' in item ? item.mime_type : undefined
+        const transcript = 'transcript' in item ? item.transcript : undefined
+
+        return (
+            <div className="space-y-2">
+                <audio
+                    controls
+                    className="w-[500px]"
+                    src={mimeType ? `data:${mimeType};base64,${item.data}` : `data:audio/wav;base64,${item.data}`}
+                />
+                {transcript && typeof transcript === 'string' && (
+                    <div className="text-xs text-muted p-2 bg-bg-light rounded border">
+                        <div className="font-semibold mb-1">Transcript:</div>
+                        <div className="whitespace-pre-wrap">{transcript}</div>
+                    </div>
+                )}
+            </div>
+        )
+    }
+
+    return <HighlightedJSONViewer src={item} name={null} collapsed={5} searchQuery={searchQuery} />
+}
+
 export const LLMMessageDisplay = React.memo(
     ({
         message,
@@ -296,52 +386,7 @@ export const LLMMessageDisplay = React.memo(
                     <>
                         {content.map((item, index) => (
                             <React.Fragment key={index}>
-                                {typeof item === 'string' ? (
-                                    searchQuery?.trim() ? (
-                                        <SearchHighlight
-                                            string={item}
-                                            substring={searchQuery}
-                                            className="whitespace-pre-wrap"
-                                        />
-                                    ) : (
-                                        <span className="whitespace-pre-wrap">{item}</span>
-                                    )
-                                ) : item &&
-                                  typeof item === 'object' &&
-                                  'type' in item &&
-                                  item.type === 'text' &&
-                                  'text' in item ? (
-                                    searchQuery?.trim() && typeof item.text === 'string' ? (
-                                        <SearchHighlight
-                                            string={item.text}
-                                            substring={searchQuery}
-                                            className="whitespace-pre-wrap"
-                                        />
-                                    ) : (
-                                        <span className="whitespace-pre-wrap">{item.text}</span>
-                                    )
-                                ) : item &&
-                                  typeof item === 'object' &&
-                                  'type' in item &&
-                                  item.type === 'image' &&
-                                  'image' in item &&
-                                  typeof item.image === 'string' ? (
-                                    <ImageMessageDisplay
-                                        message={{
-                                            content: {
-                                                type: 'image',
-                                                image: item.image,
-                                            },
-                                        }}
-                                    />
-                                ) : (
-                                    <HighlightedJSONViewer
-                                        src={item}
-                                        name={null}
-                                        collapsed={5}
-                                        searchQuery={searchQuery}
-                                    />
-                                )}
+                                {renderContentItem(item, searchQuery)}
                                 {index < content.length - 1 && <div className="border-t my-2" />}
                             </React.Fragment>
                         ))}

--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -17,8 +17,10 @@ import { llmAnalyticsTraceLogic } from '../llmAnalyticsTraceLogic'
 import { containsSearchQuery } from '../searchUtils'
 import { CompatMessage, VercelSDKImageMessage } from '../types'
 import {
+    isAnthropicDocumentMessage,
     isAnthropicImageMessage,
     isGeminiAudioMessage,
+    isGeminiDocumentMessage,
     isGeminiImageMessage,
     isOpenAIAudioMessage,
     isOpenAIFileMessage,
@@ -293,6 +295,34 @@ function renderContentItem(item: any, searchQuery?: string): JSX.Element | null 
             // eslint-disable-next-line react/forbid-elements
             <a href={item.file.file_data} download={item.file.filename} className="text-link hover:underline">
                 {item.file.filename}
+            </a>
+        )
+    }
+
+    if (isAnthropicDocumentMessage(item)) {
+        const fileName = `document.${item.source.media_type.split('/')[1] || 'bin'}`
+        return (
+            // eslint-disable-next-line react/forbid-elements
+            <a
+                href={`data:${item.source.media_type};base64,${item.source.data}`}
+                download={fileName}
+                className="text-link hover:underline"
+            >
+                {fileName}
+            </a>
+        )
+    }
+
+    if (isGeminiDocumentMessage(item)) {
+        const fileName = `document.${item.inline_data.mime_type.split('/')[1] || 'bin'}`
+        return (
+            // eslint-disable-next-line react/forbid-elements
+            <a
+                href={`data:${item.inline_data.mime_type};base64,${item.inline_data.data}`}
+                download={fileName}
+                className="text-link hover:underline"
+            >
+                {fileName}
             </a>
         )
     }

--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -17,6 +17,7 @@ import { llmAnalyticsTraceLogic } from '../llmAnalyticsTraceLogic'
 import { containsSearchQuery } from '../searchUtils'
 import { CompatMessage, VercelSDKImageMessage } from '../types'
 import {
+    getGeminiInlineData,
     isAnthropicDocumentMessage,
     isAnthropicImageMessage,
     isGeminiAudioMessage,
@@ -281,9 +282,13 @@ function renderContentItem(item: any, searchQuery?: string): JSX.Element | null 
     }
 
     if (isGeminiImageMessage(item)) {
+        const inlineData = getGeminiInlineData(item)
+        if (!inlineData) {
+            return null
+        }
         return (
             <img
-                src={`data:${item.inline_data.mime_type};base64,${item.inline_data.data}`}
+                src={`data:${inlineData.mime_type};base64,${inlineData.data}`}
                 alt="Message content"
                 className="max-w-full max-h-[400px] rounded"
             />
@@ -314,11 +319,15 @@ function renderContentItem(item: any, searchQuery?: string): JSX.Element | null 
     }
 
     if (isGeminiDocumentMessage(item)) {
-        const fileName = `document.${item.inline_data.mime_type.split('/')[1] || 'bin'}`
+        const inlineData = getGeminiInlineData(item)
+        if (!inlineData) {
+            return null
+        }
+        const fileName = `document.${inlineData.mime_type.split('/')[1] || 'bin'}`
         return (
             // eslint-disable-next-line react/forbid-elements
             <a
-                href={`data:${item.inline_data.mime_type};base64,${item.inline_data.data}`}
+                href={`data:${inlineData.mime_type};base64,${inlineData.data}`}
                 download={fileName}
                 className="text-link hover:underline"
             >

--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -15,7 +15,7 @@ import { LLMInputOutput } from '../LLMInputOutput'
 import { SearchHighlight } from '../SearchHighlight'
 import { llmAnalyticsTraceLogic } from '../llmAnalyticsTraceLogic'
 import { containsSearchQuery } from '../searchUtils'
-import { CompatMessage, VercelSDKImageMessage } from '../types'
+import { CompatMessage, MultiModalContentItem, VercelSDKImageMessage } from '../types'
 import {
     getGeminiInlineData,
     isAnthropicDocumentMessage,
@@ -242,7 +242,7 @@ export const ImageMessageDisplay = ({
     return <span>{content}</span>
 }
 
-function renderContentItem(item: any, searchQuery?: string): JSX.Element | null {
+function renderContentItem(item: MultiModalContentItem, searchQuery?: string): JSX.Element | null {
     if (typeof item === 'string') {
         return searchQuery?.trim() ? (
             <SearchHighlight string={item} substring={searchQuery} className="whitespace-pre-wrap" />
@@ -296,6 +296,9 @@ function renderContentItem(item: any, searchQuery?: string): JSX.Element | null 
     }
 
     if (isOpenAIFileMessage(item)) {
+        if (!item.file.file_data.startsWith('data:')) {
+            return <span className="text-muted">{item.file.filename}</span>
+        }
         return (
             // eslint-disable-next-line react/forbid-elements
             <a href={item.file.file_data} download={item.file.filename} className="text-link hover:underline">
@@ -412,7 +415,7 @@ export const LLMMessageDisplay = React.memo(
             : Object.fromEntries(Object.entries(additionalKwargs).filter(([, value]) => value !== undefined))
 
         const renderMessageContent = (
-            content: string | { type: string; content: string } | VercelSDKImageMessage | object[],
+            content: string | { type: string; content: string } | VercelSDKImageMessage | MultiModalContentItem[],
             searchQuery?: string
         ): JSX.Element | null => {
             if (!content) {

--- a/products/llm_analytics/frontend/types.ts
+++ b/products/llm_analytics/frontend/types.ts
@@ -37,6 +37,52 @@ export interface VercelSDKInputImageMessage {
     image_url: string
 }
 
+export interface OpenAIImageURLMessage {
+    type: 'image_url'
+    image_url: {
+        url: string
+    }
+}
+
+export interface OpenAIFileMessage {
+    type: 'file'
+    file: {
+        file_data: string
+        filename: string
+    }
+}
+
+export interface OpenAIAudioMessage {
+    type: 'audio'
+    data: string
+    transcript: string
+    id: string
+    expires_at: number
+}
+
+export interface AnthropicImageMessage {
+    type: 'image'
+    source: {
+        type: 'base64'
+        media_type: string
+        data: string
+    }
+}
+
+export interface GeminiAudioMessage {
+    type: 'audio'
+    data: string
+    mime_type: string
+}
+
+export interface GeminiImageMessage {
+    type: 'image'
+    inline_data: {
+        data: string
+        mime_type: string
+    }
+}
+
 export interface VercelSDKInputTextMessage {
     type: 'input_text'
     text: string

--- a/products/llm_analytics/frontend/types.ts
+++ b/products/llm_analytics/frontend/types.ts
@@ -86,17 +86,29 @@ export interface GeminiAudioMessage {
 
 export interface GeminiImageMessage {
     type: 'image'
-    inline_data: {
+    // snake_case (Python SDK)
+    inline_data?: {
         data: string
         mime_type: string
+    }
+    // camelCase (Node SDK)
+    inlineData?: {
+        data: string
+        mimeType: string
     }
 }
 
 export interface GeminiDocumentMessage {
-    type: 'document'
-    inline_data: {
+    type: 'document' | 'image' // 'image' when SDK misdetects PDF by MIME type
+    // snake_case (Python SDK)
+    inline_data?: {
         data: string
         mime_type: string
+    }
+    // camelCase (Node SDK)
+    inlineData?: {
+        data: string
+        mimeType: string
     }
 }
 

--- a/products/llm_analytics/frontend/types.ts
+++ b/products/llm_analytics/frontend/types.ts
@@ -1,6 +1,6 @@
 export interface RoleBasedMessage {
     role: string
-    content: string | { type: string; content: string } | object[]
+    content: string | { type: string; content: string } | MultiModalContentItem[]
 }
 
 export interface OpenAIToolCall {
@@ -178,3 +178,26 @@ export interface LiteLLMResponse {
     choices?: LiteLLMChoice[]
     [additionalKey: string]: any
 }
+
+export interface TextContentItem {
+    type: 'text'
+    text: string
+}
+
+export interface ImageContentItem {
+    type: 'image'
+    image: string
+}
+
+export type MultiModalContentItem =
+    | string
+    | TextContentItem
+    | ImageContentItem
+    | OpenAIImageURLMessage
+    | OpenAIFileMessage
+    | OpenAIAudioMessage
+    | AnthropicImageMessage
+    | AnthropicDocumentMessage
+    | GeminiImageMessage
+    | GeminiDocumentMessage
+    | GeminiAudioMessage

--- a/products/llm_analytics/frontend/types.ts
+++ b/products/llm_analytics/frontend/types.ts
@@ -69,6 +69,15 @@ export interface AnthropicImageMessage {
     }
 }
 
+export interface AnthropicDocumentMessage {
+    type: 'document'
+    source: {
+        type: 'base64'
+        media_type: string
+        data: string
+    }
+}
+
 export interface GeminiAudioMessage {
     type: 'audio'
     data: string
@@ -77,6 +86,14 @@ export interface GeminiAudioMessage {
 
 export interface GeminiImageMessage {
     type: 'image'
+    inline_data: {
+        data: string
+        mime_type: string
+    }
+}
+
+export interface GeminiDocumentMessage {
+    type: 'document'
     inline_data: {
         data: string
         mime_type: string

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -329,12 +329,46 @@ export function isAnthropicImageMessage(input: unknown): boolean {
     )
 }
 
+export function isAnthropicDocumentMessage(input: unknown): boolean {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'type' in input &&
+        input.type === 'document' &&
+        'source' in input &&
+        typeof input.source === 'object' &&
+        input.source !== null &&
+        'type' in input.source &&
+        input.source.type === 'base64' &&
+        'data' in input.source &&
+        'media_type' in input.source &&
+        typeof input.source.data === 'string' &&
+        typeof input.source.media_type === 'string'
+    )
+}
+
 export function isGeminiImageMessage(input: unknown): boolean {
     return (
         !!input &&
         typeof input === 'object' &&
         'type' in input &&
         input.type === 'image' &&
+        'inline_data' in input &&
+        typeof input.inline_data === 'object' &&
+        input.inline_data !== null &&
+        'data' in input.inline_data &&
+        'mime_type' in input.inline_data &&
+        typeof input.inline_data.data === 'string' &&
+        typeof input.inline_data.mime_type === 'string'
+    )
+}
+
+export function isGeminiDocumentMessage(input: unknown): boolean {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'type' in input &&
+        input.type === 'document' &&
         'inline_data' in input &&
         typeof input.inline_data === 'object' &&
         input.inline_data !== null &&
@@ -418,7 +452,7 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
 
     // Handle new array-based content format (unified format with structured objects)
     // Only apply this if the array contains objects with 'type' field (not Anthropic-specific formats)
-    // Supported types include: text, output_text, input_text, function, image, input_image
+    // Supported types include: text, output_text, input_text, function, image, input_image, document
     if (
         rawMessage &&
         typeof rawMessage === 'object' &&
@@ -440,7 +474,8 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
                     item.type === 'input_image' ||
                     item.type === 'image_url' ||
                     item.type === 'file' ||
-                    item.type === 'audio')
+                    item.type === 'audio' ||
+                    item.type === 'document')
         )
     ) {
         return [

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -7,6 +7,8 @@ import { hogql } from '~/queries/utils'
 import type { EvaluationRun } from './evaluations/types'
 import type { SpanAggregation } from './llmAnalyticsTraceDataLogic'
 import {
+    AnthropicDocumentMessage,
+    AnthropicImageMessage,
     AnthropicInputMessage,
     AnthropicTextMessage,
     AnthropicThinkingMessage,
@@ -14,9 +16,15 @@ import {
     AnthropicToolResultMessage,
     CompatMessage,
     CompatToolCall,
+    GeminiAudioMessage,
+    GeminiDocumentMessage,
+    GeminiImageMessage,
     LiteLLMChoice,
     LiteLLMResponse,
+    OpenAIAudioMessage,
     OpenAICompletionMessage,
+    OpenAIFileMessage,
+    OpenAIImageURLMessage,
     OpenAIToolCall,
     VercelSDKImageMessage,
     VercelSDKInputImageMessage,
@@ -270,7 +278,7 @@ export function isVercelSDKInputTextMessage(input: unknown): input is VercelSDKI
     )
 }
 
-export function isOpenAIImageURLMessage(input: unknown): boolean {
+export function isOpenAIImageURLMessage(input: unknown): input is OpenAIImageURLMessage {
     return (
         !!input &&
         typeof input === 'object' &&
@@ -284,7 +292,7 @@ export function isOpenAIImageURLMessage(input: unknown): boolean {
     )
 }
 
-export function isOpenAIFileMessage(input: unknown): boolean {
+export function isOpenAIFileMessage(input: unknown): input is OpenAIFileMessage {
     return (
         !!input &&
         typeof input === 'object' &&
@@ -300,7 +308,7 @@ export function isOpenAIFileMessage(input: unknown): boolean {
     )
 }
 
-export function isOpenAIAudioMessage(input: unknown): boolean {
+export function isOpenAIAudioMessage(input: unknown): input is OpenAIAudioMessage {
     return (
         !!input &&
         typeof input === 'object' &&
@@ -311,7 +319,7 @@ export function isOpenAIAudioMessage(input: unknown): boolean {
     )
 }
 
-export function isAnthropicImageMessage(input: unknown): boolean {
+export function isAnthropicImageMessage(input: unknown): input is AnthropicImageMessage {
     return (
         !!input &&
         typeof input === 'object' &&
@@ -329,7 +337,7 @@ export function isAnthropicImageMessage(input: unknown): boolean {
     )
 }
 
-export function isAnthropicDocumentMessage(input: unknown): boolean {
+export function isAnthropicDocumentMessage(input: unknown): input is AnthropicDocumentMessage {
     return (
         !!input &&
         typeof input === 'object' &&
@@ -379,7 +387,7 @@ export function getGeminiInlineData(input: unknown): { data: string; mime_type: 
     return null
 }
 
-export function isGeminiImageMessage(input: unknown): boolean {
+export function isGeminiImageMessage(input: unknown): input is GeminiImageMessage {
     if (!input || typeof input !== 'object' || !('type' in input) || input.type !== 'image') {
         return false
     }
@@ -387,7 +395,7 @@ export function isGeminiImageMessage(input: unknown): boolean {
     return inlineData !== null && inlineData.mime_type.startsWith('image/')
 }
 
-export function isGeminiDocumentMessage(input: unknown): boolean {
+export function isGeminiDocumentMessage(input: unknown): input is GeminiDocumentMessage {
     if (!input || typeof input !== 'object' || !('type' in input)) {
         return false
     }
@@ -406,7 +414,7 @@ export function isGeminiDocumentMessage(input: unknown): boolean {
     return false
 }
 
-export function isGeminiAudioMessage(input: unknown): boolean {
+export function isGeminiAudioMessage(input: unknown): input is GeminiAudioMessage {
     return (
         !!input &&
         typeof input === 'object' &&

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -270,6 +270,94 @@ export function isVercelSDKInputTextMessage(input: unknown): input is VercelSDKI
     )
 }
 
+export function isOpenAIImageURLMessage(input: unknown): boolean {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'type' in input &&
+        input.type === 'image_url' &&
+        'image_url' in input &&
+        typeof input.image_url === 'object' &&
+        input.image_url !== null &&
+        'url' in input.image_url &&
+        typeof input.image_url.url === 'string'
+    )
+}
+
+export function isOpenAIFileMessage(input: unknown): boolean {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'type' in input &&
+        input.type === 'file' &&
+        'file' in input &&
+        typeof input.file === 'object' &&
+        input.file !== null &&
+        'file_data' in input.file &&
+        'filename' in input.file &&
+        typeof input.file.file_data === 'string' &&
+        typeof input.file.filename === 'string'
+    )
+}
+
+export function isOpenAIAudioMessage(input: unknown): boolean {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'type' in input &&
+        input.type === 'audio' &&
+        'data' in input &&
+        typeof input.data === 'string'
+    )
+}
+
+export function isAnthropicImageMessage(input: unknown): boolean {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'type' in input &&
+        input.type === 'image' &&
+        'source' in input &&
+        typeof input.source === 'object' &&
+        input.source !== null &&
+        'type' in input.source &&
+        input.source.type === 'base64' &&
+        'data' in input.source &&
+        'media_type' in input.source &&
+        typeof input.source.data === 'string' &&
+        typeof input.source.media_type === 'string'
+    )
+}
+
+export function isGeminiImageMessage(input: unknown): boolean {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'type' in input &&
+        input.type === 'image' &&
+        'inline_data' in input &&
+        typeof input.inline_data === 'object' &&
+        input.inline_data !== null &&
+        'data' in input.inline_data &&
+        'mime_type' in input.inline_data &&
+        typeof input.inline_data.data === 'string' &&
+        typeof input.inline_data.mime_type === 'string'
+    )
+}
+
+export function isGeminiAudioMessage(input: unknown): boolean {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'type' in input &&
+        input.type === 'audio' &&
+        'data' in input &&
+        'mime_type' in input &&
+        typeof input.data === 'string' &&
+        typeof input.mime_type === 'string'
+    )
+}
+
 export function isLiteLLMChoice(input: unknown): input is LiteLLMChoice {
     return (
         !!input &&
@@ -349,7 +437,10 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
                     item.type === 'input_text' ||
                     item.type === 'function' ||
                     item.type === 'image' ||
-                    item.type === 'input_image')
+                    item.type === 'input_image' ||
+                    item.type === 'image_url' ||
+                    item.type === 'file' ||
+                    item.type === 'audio')
         )
     ) {
         return [


### PR DESCRIPTION
Properly displays multimodal content. Note that right now files are stripped by default by the SDK to avoid hitting size limits, this will become useful once we switch over to the new ingestion pipeline.

<img width="859" height="773" alt="Screenshot 2025-11-28 at 16 06 15" src="https://github.com/user-attachments/assets/74781c1e-d193-4c2c-94b4-50a48a3a69c3" />
<img width="746" height="418" alt="Screenshot 2025-11-28 at 16 10 35" src="https://github.com/user-attachments/assets/9b4a2be1-7cc4-4b3d-ae04-c1871cd127bc" />
<img width="891" height="660" alt="Screenshot 2025-11-28 at 16 38 48" src="https://github.com/user-attachments/assets/57c7b0d4-8d95-4eb0-9025-2fb97a059c43" />