### PR TITLE
feat(customers): Filter replay playlist by person UUID in person feed canvas

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
@@ -17,8 +17,9 @@ import {
 } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
 import { urls } from 'scenes/urls'
 
-import { FilterType, RecordingUniversalFilters, ReplayTabs } from '~/types'
+import { AnyPropertyFilter, FilterType, RecordingUniversalFilters, ReplayTabs } from '~/types'
 
+import { notebookLogic } from '../Notebook/notebookLogic'
 import { NotebookNodeAttributeProperties, NotebookNodeProps, NotebookNodeType } from '../types'
 import { notebookNodeLogic } from './notebookNodeLogic'
 
@@ -28,11 +29,14 @@ const Component = ({
 }: NotebookNodeProps<NotebookNodePlaylistAttributes>): JSX.Element => {
     const { pinned, nodeId, universalFilters } = attributes
     const playerKey = `notebook-${nodeId}`
+    const { canvasFiltersOverride } = useValues(notebookLogic)
+    const personUUID = getPersonUUIDFromOverride(canvasFiltersOverride)
 
     const recordingPlaylistLogicProps: SessionRecordingPlaylistLogicProps = useMemo(
         () => ({
             logicKey: playerKey,
             filters: universalFilters,
+            ...(personUUID ? { personUUID } : {}),
             updateSearchParams: false,
             autoPlay: false,
             onFiltersChange: (newFilters) => updateAttributes({ universalFilters: newFilters }),
@@ -163,4 +167,11 @@ export function buildPlaylistContent(filters: Partial<FilterType>): JSONContent 
         type: NotebookNodeType.RecordingPlaylist,
         attrs: { filters },
     }
+}
+
+function getPersonUUIDFromOverride(override: AnyPropertyFilter[] | null): string | null {
+    if (!override || override.length === 0) {
+        return null
+    }
+    return override.find((filter) => filter.key === 'person_id')?.value as string
 }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
@@ -17,7 +17,7 @@ import {
 } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
 import { urls } from 'scenes/urls'
 
-import { AnyPropertyFilter, FilterType, RecordingUniversalFilters, ReplayTabs } from '~/types'
+import { FilterType, RecordingUniversalFilters, ReplayTabs } from '~/types'
 
 import { notebookLogic } from '../Notebook/notebookLogic'
 import { NotebookNodeAttributeProperties, NotebookNodeProps, NotebookNodeType } from '../types'
@@ -29,14 +29,13 @@ const Component = ({
 }: NotebookNodeProps<NotebookNodePlaylistAttributes>): JSX.Element => {
     const { pinned, nodeId, universalFilters } = attributes
     const playerKey = `notebook-${nodeId}`
-    const { canvasFiltersOverride } = useValues(notebookLogic)
-    const personUUID = getPersonUUIDFromOverride(canvasFiltersOverride)
+    const { personUUIDFromCanvasOverride } = useValues(notebookLogic)
 
     const recordingPlaylistLogicProps: SessionRecordingPlaylistLogicProps = useMemo(
         () => ({
             logicKey: playerKey,
             filters: universalFilters,
-            ...(personUUID ? { personUUID } : {}),
+            ...(personUUIDFromCanvasOverride ? { personUUID: personUUIDFromCanvasOverride } : {}),
             updateSearchParams: false,
             autoPlay: false,
             onFiltersChange: (newFilters) => updateAttributes({ universalFilters: newFilters }),
@@ -167,11 +166,4 @@ export function buildPlaylistContent(filters: Partial<FilterType>): JSONContent 
         type: NotebookNodeType.RecordingPlaylist,
         attrs: { filters },
     }
-}
-
-function getPersonUUIDFromOverride(override: AnyPropertyFilter[] | null): string | null {
-    if (!override || override.length === 0) {
-        return null
-    }
-    return override.find((filter) => filter.key === 'person_id')?.value as string
 }

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -503,6 +503,17 @@ export const notebookLogic = kea<notebookLogicType>([
                 return insightNodes?.map((node) => node?.attrs?.query?.shortId)
             },
         ],
+
+        personUUIDFromCanvasOverride: [
+            () => [(_, props) => props],
+            (props: NotebookLogicProps): string | null => {
+                if (!props.canvasFiltersOverride || props.canvasFiltersOverride.length === 0) {
+                    return null
+                }
+                return props.canvasFiltersOverride.find((filter: AnyPropertyFilter) => filter.key === 'person_id')
+                    ?.value as string
+            },
+        ],
     }),
     listeners(({ values, actions, cache }) => ({
         insertAfterLastNode: async ({ content }) => {


### PR DESCRIPTION
## Problem

When viewing session recordings in a notebook, the canvas filters are not being applied to the playlist. This means if we add a playlist node to person feed canvas, it is going to show recordings from all people

## Changes

Added functionality to apply person filters from canvas to notebook playlists by:

- Importing the `notebookLogic` to access canvas filter overrides
- Creating a helper function `getPersonUUIDFromOverride` to extract person_id from canvas filters
- Passing the extracted person UUID to the recording playlist logic when available
- Ensuring the playlist displays recordings filtered by the selected person

## How did you test this code?

Tested by:

1. Adding a playlist node to person feed canvas
2. Ensuring that `/session_recordings`​ was being called with `personUUID`​ correctly set
3. Ensuring that ordinary canvases/group feed canvas were not affected

## Changelog:

No, under feature flag