### PR TITLE
feat(surveys): remove action limitation, update UX to show 'OR' between actions/events

### DIFF
--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -190,9 +190,19 @@ export function SurveyDisplaySummary({
                                     : 'once per user'}
                             </span>
                             ):
-                        </span>
+                        </span>{' '}
                         {survey.conditions?.events?.values.map((event) => (
                             <LemonTag key={event.name}>{event.name}</LemonTag>
+                        ))}
+                    </div>
+                </div>
+            )}
+            {(survey.conditions?.actions?.values?.length ?? 0) > 0 && (
+                <div className="flex flex-col font-medium gap-1">
+                    <div className="flex-row">
+                        <span>When the user sends the following actions:</span>{' '}
+                        {survey.conditions?.actions?.values.map((action) => (
+                            <LemonTag key={action.name}>{action.name}</LemonTag>
                         ))}
                     </div>
                 </div>

--- a/frontend/src/scenes/surveys/SurveyActionTrigger.tsx
+++ b/frontend/src/scenes/surveys/SurveyActionTrigger.tsx
@@ -1,0 +1,49 @@
+import { useActions, useValues } from 'kea'
+
+import { IconPlus } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { EventSelect } from 'lib/components/EventSelect/EventSelect'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { ActionType } from '~/types'
+
+import { surveyLogic } from './surveyLogic'
+
+export function SurveyActionTrigger(): JSX.Element {
+    const { survey } = useValues(surveyLogic)
+    const { setSurveyValue } = useActions(surveyLogic)
+
+    return (
+        <LemonField.Pure
+            label="User performs actions"
+            info="These actions are only observed in the current user session. Requires at least posthog-js v1.301.0, and is supported only for web surveys."
+        >
+            <EventSelect
+                filterGroupTypes={[TaxonomicFilterGroupType.Actions]}
+                onItemChange={(items: ActionType[]) => {
+                    setSurveyValue('conditions', {
+                        ...survey.conditions,
+                        actions: {
+                            values: items.map((e) => {
+                                return { id: e.id, name: e.name }
+                            }),
+                        },
+                    })
+                }}
+                selectedItems={
+                    survey.conditions?.actions?.values && survey.conditions?.actions?.values.length > 0
+                        ? survey.conditions?.actions?.values
+                        : []
+                }
+                selectedEvents={survey.conditions?.actions?.values?.map((v) => v.name) ?? []}
+                addElement={
+                    <LemonButton size="small" type="secondary" icon={<IconPlus />} sideIcon={null}>
+                        Add action
+                    </LemonButton>
+                }
+            />
+        </LemonField.Pure>
+    )
+}

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -22,7 +22,6 @@ import {
 } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { EventSelect } from 'lib/components/EventSelect/EventSelect'
 import { FlagSelector } from 'lib/components/FlagSelector'
 import { ANY_VARIANT, variantOptions } from 'lib/components/IngestionControls/triggers/FlagTrigger/VariantSelector'
 import { PropertyValue } from 'lib/components/PropertyFilters/components/PropertyValue'
@@ -37,6 +36,7 @@ import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagL
 import { formatDate } from 'lib/utils'
 import { FeatureFlagReleaseConditions } from 'scenes/feature-flags/FeatureFlagReleaseConditions'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
+import { SurveyActionTrigger } from 'scenes/surveys/SurveyActionTrigger'
 import { SurveyCancelEventTrigger, SurveyEventTrigger } from 'scenes/surveys/SurveyEventTrigger'
 import { SurveyRepeatSchedule } from 'scenes/surveys/SurveyRepeatSchedule'
 import { SurveyResponsesCollection } from 'scenes/surveys/SurveyResponsesCollection'
@@ -50,7 +50,6 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { actionsModel } from '~/models/actionsModel'
 import { getPropertyKey } from '~/taxonomy/helpers'
 import {
-    ActionType,
     LinkSurveyQuestion,
     PropertyFilterType,
     PropertyOperator,
@@ -1213,52 +1212,28 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                   )}
                                                               </BindLogic>
                                                           </LemonField.Pure>
-                                                          <SurveyEventTrigger />
+                                                          {featureFlags[FEATURE_FLAGS.SURVEYS_ACTIONS] ? (
+                                                              <LemonField.Pure
+                                                                  label="Activation triggers"
+                                                                  info="Survey will activate when any of these conditions are met"
+                                                              >
+                                                                  <div className="border rounded p-3 space-y-3">
+                                                                      <SurveyEventTrigger />
+                                                                      <div className="flex items-center gap-2">
+                                                                          <div className="flex-1 border-t border-dashed" />
+                                                                          <span className="text-xs font-semibold text-muted uppercase">
+                                                                              or
+                                                                          </span>
+                                                                          <div className="flex-1 border-t border-dashed" />
+                                                                      </div>
+                                                                      <SurveyActionTrigger />
+                                                                  </div>
+                                                              </LemonField.Pure>
+                                                          ) : (
+                                                              <SurveyEventTrigger />
+                                                          )}
                                                           {!!survey.appearance?.surveyPopupDelaySeconds && (
                                                               <SurveyCancelEventTrigger />
-                                                          )}
-                                                          {featureFlags[FEATURE_FLAGS.SURVEYS_ACTIONS] && (
-                                                              <LemonField.Pure
-                                                                  label="User performs actions"
-                                                                  info="Note that these actions are only observed, and activate this survey, in the current user session."
-                                                              >
-                                                                  <EventSelect
-                                                                      filterGroupTypes={[
-                                                                          TaxonomicFilterGroupType.Actions,
-                                                                      ]}
-                                                                      onItemChange={(items: ActionType[]) => {
-                                                                          setSurveyValue('conditions', {
-                                                                              ...survey.conditions,
-                                                                              actions: {
-                                                                                  values: items.map((e) => {
-                                                                                      return { id: e.id, name: e.name }
-                                                                                  }),
-                                                                              },
-                                                                          })
-                                                                      }}
-                                                                      selectedItems={
-                                                                          survey.conditions?.actions?.values &&
-                                                                          survey.conditions?.actions?.values.length > 0
-                                                                              ? survey.conditions?.actions?.values
-                                                                              : []
-                                                                      }
-                                                                      selectedEvents={
-                                                                          survey.conditions?.actions?.values?.map(
-                                                                              (v) => v.name
-                                                                          ) ?? []
-                                                                      }
-                                                                      addElement={
-                                                                          <LemonButton
-                                                                              size="small"
-                                                                              type="secondary"
-                                                                              icon={<IconPlus />}
-                                                                              sideIcon={null}
-                                                                          >
-                                                                              Add action
-                                                                          </LemonButton>
-                                                                      }
-                                                                  />
-                                                              </LemonField.Pure>
                                                           )}
                                                       </>
                                                   )}

--- a/frontend/src/scenes/surveys/surveyVersionRequirements.ts
+++ b/frontend/src/scenes/surveys/surveyVersionRequirements.ts
@@ -110,7 +110,7 @@ export const SURVEY_SDK_REQUIREMENTS: SurveyFeatureRequirement[] = [
     },
     {
         feature: 'Targeting with actions',
-        sdkVersions: { 'posthog-js': '1.299.0' },
+        sdkVersions: { 'posthog-js': '1.301.0' },
         unsupportedSdks: ['posthog-ios', 'posthog-android', 'posthog-react-native'],
         check: (s) => (s.conditions?.actions?.values?.length ?? 0) > 0,
     },

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -215,7 +215,6 @@ posthog/api/shared.py:0: error: Incompatible return value type (got "int | None"
 posthog/api/signup.py:0: error: Argument 1 to "create_user" of "UserManager" has incompatible type "str | None"; expected "str"  [arg-type]
 posthog/api/survey.py:0: error: Item "list[_ErrorFullDetails]" of "_FullDetailDict | list[_ErrorFullDetails] | dict[str, _ErrorFullDetails]" has no attribute "get"  [union-attr]
 posthog/api/survey.py:0: error: Item "object" of "object | Any" has no attribute "__iter__" (not iterable)  [union-attr]
-posthog/api/survey.py:0: error: Unsupported target for indexed assignment ("Any | None")  [index]
 posthog/api/test/dashboards/test_dashboard.py:0: error: Value of type variable "_S" of "assertAlmostEqual" of "TestCase" cannot be "datetime | None"  [type-var]
 posthog/api/test/dashboards/test_dashboard_duplication.py:0: error: List comprehension has incompatible type List[Any | None]; expected List[int]  [misc]
 posthog/api/test/test_feature_flag.py:0: error: Value of type "Any | None" is not indexable  [index]

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -135,6 +135,22 @@ SurveyStats = TypedDict(
 )
 
 
+def get_survey_conditions_with_actions(
+    survey: "Survey", action_serializer_class: type[serializers.Serializer] | None = None
+) -> dict | None:
+    if action_serializer_class is None:
+        action_serializer_class = ActionSerializer
+    conditions = survey.conditions
+    actions = survey.actions.all()
+    if len(actions) > 0:
+        if conditions is None:
+            conditions = {}
+        else:
+            conditions = dict(conditions)
+        conditions["actions"] = {"values": action_serializer_class(actions, many=True).data}
+    return conditions
+
+
 class SurveySerializer(UserAccessControlSerializerMixin, serializers.ModelSerializer):
     linked_flag_id = serializers.IntegerField(required=False, allow_null=True, source="linked_flag.id")
     linked_flag = MinimalFeatureFlagSerializer(read_only=True)
@@ -204,13 +220,7 @@ class SurveySerializer(UserAccessControlSerializerMixin, serializers.ModelSerial
         read_only_fields = ["id", "created_at", "created_by"]
 
     def get_conditions(self, survey: Survey):
-        actions = survey.actions.all()
-        if len(actions) > 0:
-            # actionNames can change between when the survey is created and when its retrieved.
-            # update the actionNames in the response from the real names of the actions as defined
-            # in data management.
-            survey.conditions["actions"] = {"values": ActionSerializer(actions, many=True).data}
-        return survey.conditions
+        return get_survey_conditions_with_actions(survey)
 
 
 class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
@@ -271,6 +281,11 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "linked_flag", "targeting_flag", "created_at"]
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data["conditions"] = get_survey_conditions_with_actions(instance)
+        return data
+
     def validate_appearance(self, value):
         if value is None:
             return value
@@ -314,29 +329,6 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
 
         if not isinstance(value, dict):
             raise serializers.ValidationError("Conditions must be an object")
-
-        actions = value.get("actions", None)
-
-        if actions is None:
-            return value
-
-        values = actions.get("values", None)
-        if values is None or len(values) == 0:
-            return value
-
-        action_ids = [value.get("id") for value in values if isinstance(value, dict) and "id" in value]
-
-        if len(action_ids) == 0:
-            return value
-
-        project_actions = Action.objects.filter(team__project_id=self.context["project_id"], id__in=action_ids)
-
-        for project_action in project_actions:
-            for step in project_action.steps:
-                if step.properties is not None and len(step.properties) > 0:
-                    raise serializers.ValidationError(
-                        "Survey cannot be activated by an Action with property filters defined on it."
-                    )
 
         return value
 
@@ -1932,16 +1924,7 @@ class SurveyAPISerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_conditions(self, survey: Survey):
-        actions = survey.actions.all()
-        if len(actions) > 0:
-            # action names can change between when the survey is created and when its retrieved.
-            # update the actionNames in the response from the real names of the actions as defined
-            # in data management.
-            if survey.conditions is None:
-                survey.conditions = {}
-
-            survey.conditions["actions"] = {"values": SurveyAPIActionSerializer(actions, many=True).data}
-        return survey.conditions
+        return get_survey_conditions_with_actions(survey, SurveyAPIActionSerializer)
 
 
 def get_surveys_opt_in(team: Team) -> bool:

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -2774,7 +2774,7 @@ class TestSurveyQuestionValidationWithEnterpriseFeatures(APIBaseTest):
 
 
 class TestSurveyWithActions(APIBaseTest):
-    def test_cannot_use_actions_with_properties(self):
+    def test_can_use_actions_with_properties(self):
         action = Action.objects.create(
             team=self.team,
             name="person subscribed",
@@ -2783,7 +2783,7 @@ class TestSurveyWithActions(APIBaseTest):
                     "event": "$pageview",
                     "url": "docs",
                     "url_matching": "contains",
-                    "properties": {"type": "person", "key": "val"},
+                    "properties": [{"key": "plan", "value": "pro", "operator": "exact"}],
                 }
             ],
         )
@@ -2808,10 +2808,11 @@ class TestSurveyWithActions(APIBaseTest):
             format="json",
         )
         response_data = response.json()
-        assert response.status_code == status.HTTP_400_BAD_REQUEST, response_data
-        assert (
-            response.json()["detail"] == "Survey cannot be activated by an Action with property filters defined on it."
-        )
+        assert response.status_code == status.HTTP_201_CREATED, response_data
+        assert response_data["conditions"]["actions"]["values"][0]["name"] == "person subscribed"
+        assert response_data["conditions"]["actions"]["values"][0]["steps"][0]["properties"] == [
+            {"key": "plan", "value": "pro", "operator": "exact"}
+        ]
 
     def test_can_set_associated_actions(self):
         user_subscribed_action = Action.objects.create(


### PR DESCRIPTION
## 🚨 action targeting is broken, but safe to merge bc feature flag

## Problem

we don't support triggering surveys based on actions with event property filters

![Screenshot 2025-11-28 at 11.22.14 AM.png](https://app.graphite.com/user-attachments/assets/a0638e0e-544a-472c-8b26-8e0a0355635f.png)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- removed validation for actions with event property filters
- updated UX to make it clearer that it's an "OR" between actions and events

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## ![Screenshot 2025-11-28 at 11.50.08 AM.png](https://app.graphite.com/user-attachments/assets/99377f0b-cf4c-454e-baba-3de31b09d6c9.png)

## How did you test this code?

### test notes

- old SDK, survey with actions, no event filters
    - posthog-js@1.294.0 (release from ~6 months ago)
    - created survey with action trigger, no event filter
    - survey successfully triggers
- old SDK, survey with action and event trigger, no event filters
    - posthog-js@1.294.0 (release from ~6 months ago)
    - created survey with two triggers:
        - action, no filters
        - event, no filters
    - survey successfully triggers on either event or action
- old SDK, survey with action + filters
    - posthog-js@1.294.0 (release from ~6 months ago)
    - created survey with two triggers:
        - action, WITH filters
        - event, no filters
    - action does _not_ trigger survey
    - event _does_ trigger survey
- newest SDK, survey with action + filters
    - posthog-js@1.299.0
    - created survey with three triggers:
        - action, with filters
            - survey triggers successfully
        - action, without filters
            - survey triggers successfully
        - event, no filters
            - survey triggers successfully

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->