### PR TITLE
feat(capture): facet Rust deploy OTEL service namespaces

### DIFF
--- a/rust/capture/src/main.rs
+++ b/rust/capture/src/main.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
-use capture::config::Config;
+use capture::config::{CaptureMode, Config};
 use capture::server::serve;
 
 common_alloc::used!();
@@ -61,10 +61,23 @@ fn init_tracer(sink_url: &str, sampling_rate: f64, service_name: &str) -> Tracer
 async fn main() {
     let config = Config::init_from_env().expect("Invalid configuration:");
 
+    // Determine service name based on mirror deploy flag
+    let otel_service_name = match (&config.capture_mode, config.is_mirror_deploy) {
+        (&CaptureMode::Events, true) => format!("{}-mirrored", config.otel_service_name),
+        (&CaptureMode::Events, false) => config.otel_service_name.clone(),
+        (&CaptureMode::Recordings, true) => format!("{}-replay-mirrored", config.otel_service_name),
+        (&CaptureMode::Recordings, false) => format!("{}-replay", config.otel_service_name),
+    };
+
     // Instantiate tracing outputs:
     //   - stdout with a level configured by the RUST_LOG envvar (default=ERROR)
     //   - OpenTelemetry if enabled, for levels INFO and higher
-    let log_layer = tracing_subscriber::fmt::layer().with_filter(EnvFilter::from_default_env());
+    // Use JSON formatting to include service name field for mirror deploy distinction
+    let log_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_current_span(false)
+        .with_span_list(false)
+        .with_filter(EnvFilter::from_default_env());
     let otel_layer = config
         .otel_url
         .clone()
@@ -72,7 +85,7 @@ async fn main() {
             OpenTelemetryLayer::new(init_tracer(
                 &url,
                 config.otel_sampling_rate,
-                &config.otel_service_name,
+                &otel_service_name,
             ))
         })
         .with_filter(LevelFilter::from_level(config.log_level));
@@ -80,6 +93,13 @@ async fn main() {
         .with(log_layer)
         .with(otel_layer)
         .init();
+
+    // Log service name for mirror deploy distinction
+    if config.is_mirror_deploy {
+        tracing::info!(service_name = %otel_service_name, "Starting capture service (mirror deploy)");
+    } else {
+        tracing::info!(service_name = %otel_service_name, "Starting capture service");
+    }
 
     // Open the TCP port and start the server
     let listener = tokio::net::TcpListener::bind(config.address)

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -973,7 +973,7 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
     // simple defaults - payload validation isn't the focus of these tests
     let enable_historical_rerouting = false;
     let historical_rerouting_threshold_days = 1_i64;
-    let is_mirror_deploy = false; // TODO: remove after migration to 100% capture-rs backend
+    let is_mirror_deploy = false;
     let verbose_sample_percent = 0.0_f32;
 
     (


### PR DESCRIPTION
## Problem
`capture`, `capture-replay`, `capture-mirrored` deployments share a common codebase and do not correctly split their OTEL `service.name` so we can facet logs by deployment in observability tools/UI.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add namespace faceting based on `CaptureMode` (covers analytics vs. replay) and `is_mirror_deploy` config flag (covers `capture-mirrored` when in use)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required ✅ 
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
