### PR TITLE
feat(surveys): warn on using a feature that is not supported by your SDK version

### DIFF
--- a/.github/workflows/ci-survey-sdk-check.yml
+++ b/.github/workflows/ci-survey-sdk-check.yml
@@ -1,0 +1,49 @@
+name: Survey SDK Version Check
+
+on:
+    pull_request:
+        paths:
+            - 'frontend/src/scenes/surveys/**'
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    check-sdk-requirements:
+        name: Check for SDK version requirements
+        runs-on: ubuntu-24.04
+
+        steps:
+            - name: Check for SDK-related changes
+              id: sdk-check
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  # Check added lines for SDK version patterns
+                  if gh pr diff ${{ github.event.pull_request.number }} \
+                      | grep '^+' | grep -v '^+++' \
+                      | grep -qiE 'posthog-js|posthog-react-native|posthog-ios|posthog-android|[0-9]+\.[0-9]+\.[0-9]+'; then
+                      echo "found=true" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Post reminder comment
+              if: steps.sdk-check.outputs.found == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  # Check if reminder comment already exists
+                  if gh pr view ${{ github.event.pull_request.number }} --json comments \
+                      --jq '.comments[].body' | grep -q 'SDK Version Check Reminder'; then
+                      echo "Comment already exists, skipping"
+                      exit 0
+                  fi
+
+                  gh pr comment ${{ github.event.pull_request.number }} --body '### 📦 Surveys SDK Version Check Reminder
+
+                  This PR modifies survey code and may include SDK-dependent features.
+
+                  **If adding a feature that requires a minimum SDK version**, please update:
+                  `frontend/src/scenes/surveys/surveyVersionRequirements.ts`
+
+                  This ensures users see warnings when launching surveys their SDK doesn'\''t support.'

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
@@ -126,12 +126,10 @@ export const sidePanelSdkDoctorLogic = kea<sidePanelSdkDoctorLogicType>([
         rawData: [
             null as SdkDoctorResponse | null,
             {
-                loadRawData: async ({
-                    forceRefresh,
-                }: { forceRefresh?: boolean } = {}): Promise<SdkDoctorResponse | null> => {
+                loadRawData: async (options?: { forceRefresh?: boolean }): Promise<SdkDoctorResponse | null> => {
                     try {
                         const endpoint =
-                            forceRefresh === true ? 'api/sdk_doctor/?force_refresh=true' : 'api/sdk_doctor/'
+                            options?.forceRefresh === true ? 'api/sdk_doctor/?force_refresh=true' : 'api/sdk_doctor/'
                         const response = await api.get<SdkDoctorResponse>(endpoint)
 
                         return response

--- a/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
+++ b/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react'
 import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 import { surveysLogic } from 'scenes/surveys/surveysLogic'
 import { doesSurveyHaveDisplayConditions } from 'scenes/surveys/utils'
@@ -11,7 +12,7 @@ import { doesSurveyHaveDisplayConditions } from 'scenes/surveys/utils'
 import { AccessControlLevel, AccessControlResourceType, SurveyType } from '~/types'
 
 export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNode }): JSX.Element {
-    const { survey } = useValues(surveyLogic)
+    const { survey, surveyVersionWarnings } = useValues(surveyLogic)
     const { showSurveysDisabledBanner } = useValues(surveysLogic)
     const { launchSurvey } = useActions(surveyLogic)
 
@@ -34,12 +35,15 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                     LemonDialog.open({
                         title: 'Launch this survey?',
                         content: (
-                            <div className="text-sm text-secondary">
-                                The survey will immediately start displaying to{' '}
-                                {doesSurveyHaveDisplayConditions(survey)
-                                    ? 'users matching the display conditions'
-                                    : 'all your users'}
-                                .
+                            <div>
+                                <div className="text-sm text-secondary">
+                                    The survey will immediately start displaying to{' '}
+                                    {doesSurveyHaveDisplayConditions(survey)
+                                        ? 'users matching the display conditions'
+                                        : 'all your users'}
+                                    .
+                                </div>
+                                <SdkVersionWarnings warnings={surveyVersionWarnings} />
                             </div>
                         ),
                         primaryButton: {

--- a/frontend/src/scenes/surveys/components/SdkVersionWarnings.tsx
+++ b/frontend/src/scenes/surveys/components/SdkVersionWarnings.tsx
@@ -1,0 +1,51 @@
+import { LemonBanner, Link } from '@posthog/lemon-ui'
+
+import { SurveyVersionWarning } from 'scenes/surveys/surveyVersionRequirements'
+
+export function SdkVersionWarnings({ warnings }: { warnings: SurveyVersionWarning[] }): JSX.Element | null {
+    if (warnings.length === 0) {
+        return null
+    }
+
+    const warningsByFeature = warnings.reduce(
+        (acc, warning) => {
+            if (!acc[warning.feature]) {
+                acc[warning.feature] = []
+            }
+            acc[warning.feature].push(warning)
+            return acc
+        },
+        {} as Record<string, SurveyVersionWarning[]>
+    )
+
+    return (
+        <LemonBanner type="warning" className="mt-2" hideIcon>
+            <div className="flex items-start gap-2">
+                <div>
+                    <p className="font-semibold mb-1">SDK version warning</p>
+                    <ul className="text-sm list-disc pl-4 mb-2 space-y-2">
+                        {Object.entries(warningsByFeature).map(([feature, featureWarnings]) => (
+                            <li key={feature}>
+                                <strong>{feature}</strong>
+                                <ul className="list-none pl-2 mt-0.5">
+                                    {featureWarnings.map((warning, idx) => (
+                                        <li key={idx} className="text-secondary">
+                                            {warning.sdkType} requires v{warning.minVersion}+ (you have v
+                                            {warning.currentVersion})
+                                        </li>
+                                    ))}
+                                </ul>
+                            </li>
+                        ))}
+                    </ul>
+                    <p className="text-sm text-secondary">
+                        <Link to="https://posthog.com/docs/libraries" target="_blank">
+                            Update your SDK
+                        </Link>{' '}
+                        to ensure these features work correctly.
+                    </p>
+                </div>
+            </div>
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/surveys/components/SurveysTable.tsx
+++ b/frontend/src/scenes/surveys/components/SurveysTable.tsx
@@ -12,9 +12,11 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { createdAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { cn } from 'lib/utils/css-classes'
 import stringWithWBR from 'lib/utils/stringWithWBR'
+import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings'
 import { SurveyStatusTag } from 'scenes/surveys/components/SurveyStatusTag'
 import { SurveysEmptyState } from 'scenes/surveys/components/empty-state/SurveysEmptyState'
 import { SURVEY_TYPE_LABEL_MAP, SurveyQuestionLabel } from 'scenes/surveys/constants'
+import { getSurveyVersionWarnings } from 'scenes/surveys/surveyVersionRequirements'
 import { SurveysTabs, surveysLogic } from 'scenes/surveys/surveysLogic'
 import { isSurveyRunning } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
@@ -34,6 +36,7 @@ export function SurveysTable(): JSX.Element {
         tab,
         hasNextPage,
         hasNextSearchPage,
+        teamSdkVersions,
     } = useValues(surveysLogic)
 
     const { deleteSurvey, updateSurvey, setSearchTerm, setSurveysFilters, loadNextPage, loadNextSearchPage } =
@@ -188,13 +191,22 @@ export function SurveysTable(): JSX.Element {
                                                 >
                                                     <LemonButton
                                                         fullWidth
-                                                        onClick={() =>
+                                                        onClick={() => {
+                                                            const versionWarnings = getSurveyVersionWarnings(
+                                                                survey,
+                                                                teamSdkVersions
+                                                            )
                                                             LemonDialog.open({
                                                                 title: 'Launch this survey?',
                                                                 content: (
-                                                                    <div className="text-sm text-secondary">
-                                                                        The survey will immediately start displaying to
-                                                                        users matching the display conditions.
+                                                                    <div>
+                                                                        <div className="text-sm text-secondary">
+                                                                            The survey will immediately start displaying
+                                                                            to users matching the display conditions.
+                                                                        </div>
+                                                                        <SdkVersionWarnings
+                                                                            warnings={versionWarnings}
+                                                                        />
                                                                     </div>
                                                                 ),
                                                                 primaryButton: {
@@ -218,7 +230,7 @@ export function SurveysTable(): JSX.Element {
                                                                     size: 'small',
                                                                 },
                                                             })
-                                                        }
+                                                        }}
                                                     >
                                                         Launch survey
                                                     </LemonButton>

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -84,6 +84,7 @@ import {
     defaultSurveyFieldValues,
 } from './constants'
 import type { surveyLogicType } from './surveyLogicType'
+import { SurveyVersionWarning, getSurveyVersionWarnings } from './surveyVersionRequirements'
 import { surveysLogic } from './surveysLogic'
 import {
     DATE_FORMAT,
@@ -489,7 +490,7 @@ export const surveyLogic = kea<surveyLogicType>([
             enabledFlagLogic,
             ['featureFlags as enabledFlags'],
             surveysLogic,
-            ['data'],
+            ['data', 'teamSdkVersions'],
             userLogic,
             ['user'],
             teamLogic,
@@ -1992,6 +1993,12 @@ export const surveyLogic = kea<surveyLogicType>([
                 })
 
                 return responsesByQuestion
+            },
+        ],
+        surveyVersionWarnings: [
+            (s) => [s.survey, s.teamSdkVersions],
+            (survey, teamSdkVersions): SurveyVersionWarning[] => {
+                return getSurveyVersionWarnings(survey as Survey, teamSdkVersions)
             },
         ],
     }),

--- a/frontend/src/scenes/surveys/surveyVersionRequirements.ts
+++ b/frontend/src/scenes/surveys/surveyVersionRequirements.ts
@@ -1,0 +1,154 @@
+import { compareVersion } from 'lib/utils/semver'
+
+import {
+    MultipleSurveyQuestion,
+    RatingSurveyQuestion,
+    Survey,
+    SurveyMatchType,
+    SurveyPosition,
+    SurveyQuestionType,
+    SurveySchedule,
+    SurveyTabPosition,
+    SurveyType,
+} from '~/types'
+
+export type SurveySdkType = 'posthog-js' | 'posthog-react-native' | 'posthog-ios' | 'posthog-android'
+
+export type SdkVersionRequirements = Partial<Record<SurveySdkType, string>>
+
+export type SurveyFeatureRequirement = {
+    check: (survey: Survey) => boolean
+    sdkVersions: SdkVersionRequirements
+    feature: string
+    docsUrl?: string
+}
+
+// list of survey things that require specific sdk version(s)
+// update this if you add a new feature that requires an update to the sdk!!
+export const SURVEY_SDK_REQUIREMENTS: SurveyFeatureRequirement[] = [
+    {
+        feature: 'URL targeting with regex',
+        sdkVersions: { 'posthog-js': '1.82.0' },
+        check: (s) => s.conditions?.urlMatchType === SurveyMatchType.Regex,
+    },
+    {
+        feature: 'URL targeting with exact match',
+        sdkVersions: { 'posthog-js': '1.82.0' },
+        check: (s) => s.conditions?.urlMatchType === SurveyMatchType.Exact,
+    },
+    {
+        feature: 'Custom font selection',
+        sdkVersions: { 'posthog-js': '1.223.4' },
+        check: (s) => s.appearance?.fontFamily !== undefined && s.appearance?.fontFamily !== 'inherit',
+    },
+    {
+        feature: 'Repeated survey activation (show every time)',
+        sdkVersions: { 'posthog-js': '1.234.11' },
+        check: (s) => s.schedule === SurveySchedule.Always,
+    },
+    {
+        feature: 'Survey position "next to feedback button"',
+        sdkVersions: { 'posthog-js': '1.235.2' },
+        check: (s) => s.appearance?.position === SurveyPosition.NextToTrigger,
+    },
+    {
+        feature: 'Partial response collection',
+        sdkVersions: { 'posthog-js': '1.240.0' },
+        check: (s) => s.enable_partial_responses === true,
+    },
+    {
+        feature: 'Auto-submit on selection',
+        sdkVersions: { 'posthog-js': '1.244.0' },
+        check: (s) =>
+            s.questions.some(
+                (q) =>
+                    (q.type === SurveyQuestionType.SingleChoice ||
+                        q.type === SurveyQuestionType.MultipleChoice ||
+                        q.type === SurveyQuestionType.Rating) &&
+                    (q as MultipleSurveyQuestion | RatingSurveyQuestion).skipSubmitButton === true
+            ),
+    },
+    {
+        feature: 'External link surveys',
+        sdkVersions: { 'posthog-js': '1.258.1' },
+        check: (s) => s.type === SurveyType.ExternalSurvey,
+    },
+    {
+        feature: 'Link to specific feature flag variant',
+        sdkVersions: {
+            'posthog-js': '1.259.0',
+            'posthog-react-native': '4.4.0',
+        },
+        check: (s) => !!s.conditions?.linkedFlagVariant,
+    },
+    {
+        feature: 'Event trigger property filters',
+        sdkVersions: { 'posthog-js': '1.268.0' },
+        check: (s) =>
+            (s.conditions?.events?.values?.length ?? 0) > 0 &&
+            !!s.conditions?.events?.values?.some((e) => Object.keys(e.propertyFilters ?? {}).length > 0),
+    },
+    {
+        feature: 'Feedback button position',
+        sdkVersions: { 'posthog-js': '1.294.0' },
+        check: (s) => s.appearance?.tabPosition !== undefined && s.appearance?.tabPosition !== SurveyTabPosition.Right,
+    },
+    {
+        feature: 'Cancellation events',
+        sdkVersions: { 'posthog-js': '1.299.0' },
+        check: (s) => (s.conditions?.cancelEvents?.values?.length ?? 0) > 0,
+    },
+    {
+        feature: 'Targeting with actions',
+        sdkVersions: { 'posthog-js': '1.299.0' },
+        check: (s) => (s.conditions?.actions?.values?.length ?? 0) > 0,
+    },
+]
+
+export function meetsVersionRequirement(version: string | null | undefined, minVersion: string): boolean {
+    if (!version) {
+        return true
+    }
+    try {
+        return compareVersion(version, minVersion) >= 0
+    } catch {
+        return true
+    }
+}
+
+export type TeamSdkVersions = Partial<Record<SurveySdkType, string | null>>
+
+export type SurveyVersionWarning = {
+    feature: string
+    sdkType: SurveySdkType
+    currentVersion: string
+    minVersion: string
+    docsUrl?: string
+}
+
+export function getSurveyVersionWarnings(survey: Survey, teamSdkVersions: TeamSdkVersions): SurveyVersionWarning[] {
+    const warnings: SurveyVersionWarning[] = []
+
+    for (const req of SURVEY_SDK_REQUIREMENTS) {
+        if (!req.check(survey)) {
+            continue
+        }
+
+        for (const [sdkType, minVersion] of Object.entries(req.sdkVersions) as [SurveySdkType, string][]) {
+            const teamVersion = teamSdkVersions[sdkType]
+
+            // only warn if we've seen the team use this sdk AND it's outdated
+            if (teamVersion && !meetsVersionRequirement(teamVersion, minVersion)) {
+                warnings.push({
+                    feature: req.feature,
+                    sdkType,
+                    currentVersion: teamVersion,
+                    minVersion,
+                    docsUrl: req.docsUrl,
+                })
+            }
+        }
+    }
+
+    return warnings
+}

--- a/frontend/src/scenes/surveys/surveysLogic.tsx
+++ b/frontend/src/scenes/surveys/surveysLogic.tsx
@@ -16,6 +16,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { ActivationTask, activationLogic } from '~/layout/navigation-3000/sidepanel/panels/activation/activationLogic'
+import { sidePanelSdkDoctorLogic } from '~/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic'
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { deleteFromTree } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
@@ -113,6 +114,8 @@ export const surveysLogic = kea<surveysLogicType>([
             ['currentTeam', 'currentTeamLoading'],
             enabledFlagLogic,
             ['featureFlags as enabledFlags'],
+            sidePanelSdkDoctorLogic,
+            ['augmentedData as sdkDoctorData'],
         ],
         actions: [teamLogic, ['loadCurrentTeam', 'addProductIntent']],
     })),
@@ -403,6 +406,22 @@ export const surveysLogic = kea<surveysLogicType>([
             (s) => [s.currentTeam],
             (currentTeam) => {
                 return !currentTeam?.surveys_opt_in
+            },
+        ],
+        teamSdkVersions: [
+            (s) => [s.sdkDoctorData],
+            (sdkDoctorData): Record<string, string | null> => {
+                const versions: Record<string, string | null> = {}
+
+                for (const [sdkType, sdkInfo] of Object.entries(sdkDoctorData ?? {})) {
+                    if (sdkInfo?.allReleases?.length) {
+                        // sdk doctor uses 'web' but we use 'posthog-js' in SURVEY_SDK_REQUIREMENTS...
+                        const key = sdkType === 'web' ? 'posthog-js' : sdkType
+                        versions[key] = sdkInfo.allReleases[0]?.version ?? null
+                    }
+                }
+
+                return versions
             },
         ],
         [SIDE_PANEL_CONTEXT_KEY]: [


### PR DESCRIPTION
## Problem

we have lots of survey features which are only available if you have at least version N of some SDK.

this info is available in tooltips next to feature configurations, but it's super easy to miss, and may cause confusion if something is not working as expected

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

add sdk check logic, based on the survey's features, and show a warning on launch if their survey might have unexpected behavior due to sdk version:

![Screenshot 2025-11-28 at 3.29.29 PM.png](https://app.graphite.com/user-attachments/assets/2e3fb6bf-3599-4a2e-a1d5-667be973de8b.png)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

also added a CI action that warns if you potentially added a surveys feature which might require a warning

## How did you test this code?

- manually overrode sdk version data to test
- tested the diff pieces of the new CI workflow, i have [another PR out](https://github.com/PostHog/posthog/pull/42109) that should trigger it :smiley_cat:
    - edit: this PR triggered it haha nice

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

yes

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->