### PR TITLE
feat(surveys): experiment on AI vs quickcreate for funnel surveys

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -33,3 +33,10 @@ configure({ testIdAttribute: 'data-attr' })
 
 // Mock DecompressionWorkerManager globally to avoid import.meta.url issues in tests
 jest.mock('scenes/session-recordings/player/snapshot-processing/DecompressionWorkerManager')
+
+// Mock posthog-js surveys-preview to avoid ESM import issues in tests
+jest.mock('posthog-js/dist/surveys-preview', () => ({
+    renderFeedbackWidgetPreview: jest.fn(),
+    renderSurveysPreview: jest.fn(),
+    getNextSurveyStep: jest.fn(),
+}))

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -353,6 +353,7 @@ export const FEATURE_FLAGS = {
     SURVEYS_FF_CROSS_SELL: 'surveys-ff-cross-sell', // owner: @adboio #team-surveys
     WEB_ANALYTICS_EMPTY_ONBOARDING: 'web-analytics-empty-onboarding', // owner: @jordanm-posthog #team-web-analytics
     REPLAY_WAIT_FOR_FULL_SNAPSHOT_PLAYBACK: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay
+    SURVEYS_INSIGHT_BUTTON_EXPERIMENT: 'ask-users-why-ai-vs-quickcreate', // owner: @adboio #team-surveys multivariate
 } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/frontend/src/scenes/surveys/QuickSurveyModal.tsx
+++ b/frontend/src/scenes/surveys/QuickSurveyModal.tsx
@@ -9,6 +9,7 @@ import { SurveyPopupToggle } from 'scenes/surveys/SurveySettings'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { EventSelector } from './quick-create/components/EventSelector'
+import { FunnelSequence } from './quick-create/components/FunnelSequence'
 import { URLInput } from './quick-create/components/URLInput'
 import { VariantSelector } from './quick-create/components/VariantSelector'
 import {
@@ -63,6 +64,8 @@ export function QuickSurveyForm({ context, info, onCancel }: QuickSurveyFormProp
                                 <EventSelector />
                             </>
                         )}
+
+                        {context.type === QuickSurveyType.FUNNEL && <FunnelSequence steps={context.funnel.steps} />}
 
                         <URLInput />
                     </BindLogic>

--- a/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
@@ -1,10 +1,13 @@
+import { useValues } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { IconMessage } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { formatPercentage } from 'lib/utils'
 import { addProductIntent } from 'lib/utils/product-intents'
 import { useMaxTool } from 'scenes/max/useMaxTool'
@@ -13,7 +16,9 @@ import { urls } from 'scenes/urls'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import { QueryBasedInsightModel } from '~/types'
 
+import { QuickSurveyModal } from '../QuickSurveyModal'
 import { SURVEY_CREATED_SOURCE } from '../constants'
+import { QuickSurveyType } from '../quick-create/types'
 import { captureMaxAISurveyCreationException } from '../utils'
 import { extractFunnelContext } from '../utils/opportunityDetection'
 
@@ -26,6 +31,11 @@ export function SurveyOpportunityButton({
     insight,
     disableAutoPromptSubmit,
 }: SurveyOpportunityButtonProps): JSX.Element | null {
+    const [modalOpen, setModalOpen] = useState(false)
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const shouldUseQuickCreate = featureFlags[FEATURE_FLAGS.SURVEYS_INSIGHT_BUTTON_EXPERIMENT] === 'test'
+
     const funnelContext = extractFunnelContext(insight)
     const initialMaxPrompt = funnelContext
         ? `${disableAutoPromptSubmit ? '' : '!'}Create a survey to help me identify and fix the root ` +
@@ -35,11 +45,15 @@ export function SurveyOpportunityButton({
         : ''
 
     useEffect(() => {
+        if (!funnelContext) {
+            return
+        }
+
         posthog.capture('survey opportunity displayed', {
             linked_insight_id: insight.id,
-            conversionRate: funnelContext?.conversionRate, // oxlint-disable-line react-hooks/exhaustive-deps
+            conversionRate: funnelContext.conversionRate,
         })
-    }, [insight.id])
+    }, [insight.id, funnelContext])
 
     const { openMax } = useMaxTool({
         identifier: 'create_survey',
@@ -73,12 +87,25 @@ export function SurveyOpportunityButton({
             linked_insight_id: insight.id,
             conversionRate: funnelContext?.conversionRate,
         })
-        openMax?.()
+        shouldUseQuickCreate ? setModalOpen(true) : openMax?.()
+    }
+
+    if (!funnelContext) {
+        return null
     }
 
     return (
-        <LemonButton size="xsmall" type="primary" sideIcon={<IconMessage />} onClick={handleClick}>
-            Ask users why
-        </LemonButton>
+        <>
+            <LemonButton size="xsmall" type="primary" sideIcon={<IconMessage />} onClick={handleClick}>
+                Ask users why
+            </LemonButton>
+            {shouldUseQuickCreate && (
+                <QuickSurveyModal
+                    context={{ type: QuickSurveyType.FUNNEL, funnel: funnelContext }}
+                    isOpen={modalOpen}
+                    onCancel={() => setModalOpen(false)}
+                />
+            )}
+        </>
     )
 }

--- a/frontend/src/scenes/surveys/quick-create/components/FunnelSequence.tsx
+++ b/frontend/src/scenes/surveys/quick-create/components/FunnelSequence.tsx
@@ -1,0 +1,62 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonInput, LemonLabel, LemonSelect } from '@posthog/lemon-ui'
+
+import { quickSurveyFormLogic } from 'scenes/surveys/quick-create/quickSurveyFormLogic'
+import { FunnelContext } from 'scenes/surveys/utils/opportunityDetection'
+
+import { EventsNode } from '~/queries/schema/schema-general'
+
+export function FunnelSequence({ steps }: { steps: FunnelContext['steps'] }): JSX.Element {
+    const { selectedEvents, cancelEvents, delaySeconds } = useValues(quickSurveyFormLogic)
+    const { setTriggerEvent, updateAppearance } = useActions(quickSurveyFormLogic)
+
+    return (
+        <div>
+            <LemonLabel className="mb-2">When should the survey appear?</LemonLabel>
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+                <span>User does</span>
+                <LemonSelect
+                    value={selectedEvents?.at(0) || null}
+                    onChange={(val) => {
+                        const step = steps.find((s) => s.name === val) as EventsNode | undefined
+                        setTriggerEvent(step ?? null, 'events')
+                    }}
+                    options={steps.map((step, idx) => ({
+                        value: step.name ?? idx.toString(),
+                        label: step.custom_name ?? step.name ?? idx.toString(),
+                    }))}
+                    placeholder="select step"
+                    size="small"
+                />
+                <span>, but not</span>
+                <LemonSelect
+                    value={cancelEvents?.at(0) || null}
+                    onChange={(val) => {
+                        const step = steps.find((s) => s.name === val) as EventsNode | undefined
+                        setTriggerEvent(step ?? null, 'cancelEvents')
+                    }}
+                    options={(() => {
+                        const triggerStepIndex = steps.findIndex((s) => s.name === selectedEvents?.at(0))
+                        return steps.map((step, idx) => ({
+                            value: step.name ?? idx.toString(),
+                            label: step.custom_name ?? step.name ?? idx.toString(),
+                            disabled: triggerStepIndex >= 0 && idx <= triggerStepIndex,
+                        }))
+                    })()}
+                    placeholder="select step"
+                    size="small"
+                />
+                <span>within</span>
+                <LemonInput
+                    type="number"
+                    min={1}
+                    value={delaySeconds}
+                    onChange={(val) => updateAppearance({ surveyPopupDelaySeconds: val })}
+                    className="w-20"
+                />
+                <span>seconds</span>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/quick-create/quickSurveyFormLogic.test.ts
+++ b/frontend/src/scenes/surveys/quick-create/quickSurveyFormLogic.test.ts
@@ -1,0 +1,144 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+import { FeatureFlagType } from '~/types'
+
+import { SURVEY_CREATED_SOURCE } from '../constants'
+import { FunnelContext, toSurveyEvent } from '../utils/opportunityDetection'
+import { quickSurveyFormLogic } from './quickSurveyFormLogic'
+import { QuickSurveyType } from './types'
+import { buildLogicProps } from './utils'
+
+const mockFlag = {
+    id: 123,
+    name: 'my-feature-flag',
+    filters: { groups: [], multivariate: null, payloads: {} },
+} as unknown as FeatureFlagType
+
+const mockFunnel: FunnelContext = {
+    insightName: 'Checkout Funnel',
+    conversionRate: 0.3,
+    steps: [
+        {
+            kind: 'EventsNode',
+            name: 'add_to_cart',
+            properties: [{ key: 'category', value: ['electronics'], operator: 'exact' }],
+        },
+        { kind: 'EventsNode', name: 'checkout_complete' },
+    ] as FunnelContext['steps'],
+}
+
+describe('buildLogicProps', () => {
+    it('builds correct props for feature flag context', () => {
+        const result = buildLogicProps({
+            type: QuickSurveyType.FEATURE_FLAG,
+            flag: mockFlag,
+        })
+
+        expect(result.key).toBe('flag-123')
+        expect(result.source).toBe(SURVEY_CREATED_SOURCE.FEATURE_FLAGS)
+        expect(result.contextType).toBe(QuickSurveyType.FEATURE_FLAG)
+        expect(result.defaults.linkedFlagId).toBe(123)
+        expect(result.defaults.name).toContain('my-feature-flag - Quick feedback')
+    })
+
+    it('includes initial variant in feature flag context when provided', () => {
+        const result = buildLogicProps({
+            type: QuickSurveyType.FEATURE_FLAG,
+            flag: mockFlag,
+            initialVariantKey: 'test-variant',
+        })
+
+        expect(result.defaults.name).toContain('my-feature-flag (test-variant) - Quick feedback')
+        expect(result.defaults.conditions?.linkedFlagVariant).toBe('test-variant')
+    })
+
+    it('builds correct props for funnel context', () => {
+        const result = buildLogicProps({
+            type: QuickSurveyType.FUNNEL,
+            funnel: mockFunnel,
+        })
+
+        expect(result.key).toBe('funnel-Checkout Funnel')
+        expect(result.source).toBe(SURVEY_CREATED_SOURCE.INSIGHT_CROSS_SELL)
+        expect(result.contextType).toBe(QuickSurveyType.FUNNEL)
+        expect(result.defaults.linkedFlagId).toBeUndefined()
+        expect(result.defaults.name).toContain('Checkout Funnel - Quick feedback')
+        expect(result.defaults.conditions?.events?.values).toEqual([
+            { name: 'add_to_cart', propertyFilters: { category: { values: ['electronics'], operator: 'exact' } } },
+        ])
+        expect(result.defaults.appearance?.surveyPopupDelaySeconds).toBe(15)
+    })
+})
+
+describe('toSurveyEvent', () => {
+    it('converts EventsNode to survey event format', () => {
+        const step = {
+            kind: 'EventsNode',
+            name: 'purchase',
+            properties: [
+                { key: 'amount', value: ['100', '200'], operator: 'exact' },
+                { key: 'currency', value: ['USD'], operator: 'exact' },
+            ],
+        } as FunnelContext['steps'][0]
+
+        const result = toSurveyEvent(step as any)
+
+        expect(result).toEqual({
+            name: 'purchase',
+            propertyFilters: {
+                amount: { values: ['100', '200'], operator: 'exact' },
+                currency: { values: ['USD'], operator: 'exact' },
+            },
+        })
+    })
+
+    it('handles step with no properties', () => {
+        const step = { kind: 'EventsNode', name: 'pageview' } as FunnelContext['steps'][0]
+
+        const result = toSurveyEvent(step as any)
+
+        expect(result).toEqual({
+            name: 'pageview',
+            propertyFilters: {},
+        })
+    })
+})
+
+describe('quickSurveyFormLogic validation', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    it('returns error when question is empty', async () => {
+        const logic = quickSurveyFormLogic({
+            key: 'test-empty',
+            source: SURVEY_CREATED_SOURCE.FEATURE_FLAGS,
+            contextType: QuickSurveyType.FEATURE_FLAG,
+            defaults: { question: '' },
+        })
+        logic.mount()
+
+        await expectLogic(logic).toMatchValues({
+            surveyFormValidationErrors: expect.objectContaining({
+                question: 'Please enter a question',
+            }),
+        })
+    })
+
+    it('returns no error when question is provided', async () => {
+        const logic = quickSurveyFormLogic({
+            key: 'test-valid',
+            source: SURVEY_CREATED_SOURCE.FEATURE_FLAGS,
+            contextType: QuickSurveyType.FEATURE_FLAG,
+            defaults: { question: 'What do you think?' },
+        })
+        logic.mount()
+
+        await expectLogic(logic).toMatchValues({
+            surveyFormValidationErrors: expect.objectContaining({
+                question: undefined,
+            }),
+        })
+    })
+})

--- a/frontend/src/scenes/surveys/quick-create/types.ts
+++ b/frontend/src/scenes/surveys/quick-create/types.ts
@@ -1,10 +1,10 @@
 import { FeatureFlagType } from '~/types'
 
-export type QuickSurveyContext = {
-    type: QuickSurveyType.FEATURE_FLAG
-    flag: FeatureFlagType
-    initialVariantKey?: string | null
-}
+import { FunnelContext } from '../utils/opportunityDetection'
+
+export type QuickSurveyContext =
+    | { type: QuickSurveyType.FEATURE_FLAG; flag: FeatureFlagType; initialVariantKey?: string | null }
+    | { type: QuickSurveyType.FUNNEL; funnel: FunnelContext }
 
 export interface QuickSurveyFormProps {
     context: QuickSurveyContext
@@ -14,4 +14,5 @@ export interface QuickSurveyFormProps {
 
 export enum QuickSurveyType {
     FEATURE_FLAG = 'feature_flag',
+    FUNNEL = 'funnel',
 }

--- a/frontend/src/scenes/surveys/quick-create/utils.ts
+++ b/frontend/src/scenes/surveys/quick-create/utils.ts
@@ -1,4 +1,7 @@
-import { SURVEY_CREATED_SOURCE } from '../constants'
+import { EventsNode } from '~/queries/schema/schema-general'
+
+import { SURVEY_CREATED_SOURCE, defaultSurveyAppearance } from '../constants'
+import { toSurveyEvent } from '../utils/opportunityDetection'
 import { QuickSurveyFormLogicProps } from './quickSurveyFormLogic'
 import { QuickSurveyContext, QuickSurveyType } from './types'
 
@@ -19,6 +22,30 @@ export const buildLogicProps = (context: QuickSurveyContext): Omit<QuickSurveyFo
                         actions: null,
                         events: { values: [] },
                         ...(context.initialVariantKey ? { linkedFlagVariant: context.initialVariantKey } : {}),
+                    },
+                },
+            }
+
+        case QuickSurveyType.FUNNEL:
+            return {
+                key: `funnel-${context.funnel.insightName}`,
+                contextType: context.type,
+                source: SURVEY_CREATED_SOURCE.INSIGHT_CROSS_SELL,
+                defaults: {
+                    name: `${context.funnel.insightName} - Quick feedback ${randomId}`,
+                    question: `We noticed you started but didn't complete this action. What stopped you?`,
+                    conditions: {
+                        actions: null,
+                        events: {
+                            values: [toSurveyEvent(context.funnel.steps[0] as EventsNode)],
+                        },
+                        cancelEvents: {
+                            values: [toSurveyEvent(context.funnel.steps[1] as EventsNode)],
+                        },
+                    },
+                    appearance: {
+                        ...defaultSurveyAppearance,
+                        surveyPopupDelaySeconds: 15,
                     },
                 },
             }

--- a/frontend/src/scenes/surveys/utils/opportunityDetection.ts
+++ b/frontend/src/scenes/surveys/utils/opportunityDetection.ts
@@ -1,98 +1,126 @@
-import { FunnelsQuery, InsightVizNode } from '~/queries/schema/schema-general'
-import { DashboardTile, QueryBasedInsightModel } from '~/types'
+import { AnyEntityNode, EventsNode, FunnelsQuery, InsightVizNode } from '~/queries/schema/schema-general'
+import { DashboardTile, QueryBasedInsightModel, SurveyEventsWithProperties } from '~/types'
 
 export interface FunnelContext {
     insightName: string
     conversionRate: number
-    steps: string[]
+    steps: AnyEntityNode[]
+}
+
+interface FunnelStepResult {
+    count: number
+    type: string
+}
+
+export interface SurveyableFunnelInsight {
+    id?: number
+    name?: string
+    query: InsightVizNode<FunnelsQuery>
+    result: FunnelStepResult[]
 }
 
 /**
- * Given a list of dashboard tiles, find the funnel with the best
- * opportunity to create a survey. See {@link getBestSurveyOpportunityFromDashboard}
- * for logic details
+ * Find the funnel with the best opportunity to create a survey, given a list
+ * of dashboard tiles.
  *
- * @param tiles list of dashboard tiles
- * @param linkedInsightIds list of surveys with linked insights
- * @returns
+ * Returns the funnel with the lowest conversion rate (<50%) that:
+ * - Is a valid funnel insight
+ * - Has only event/action steps (survey targeting limitation)
+ * - Doesn't already have a linked survey
  */
 export function getBestSurveyOpportunityFunnel(
     tiles: DashboardTile<QueryBasedInsightModel>[],
     linkedInsightIds: Set<number> = new Set()
 ): DashboardTile<QueryBasedInsightModel> | null {
-    return getBestSurveyOpportunityFromDashboard(
-        tiles.filter((tile) => isFunnelInsight(tile.insight?.query)),
-        linkedInsightIds
+    const candidates = tiles
+        .filter(
+            (tile) =>
+                isSurveyableFunnelInsight(tile.insight) && tile.insight?.id && !linkedInsightIds.has(tile.insight.id)
+        )
+        .map((tile) => ({
+            tile,
+            conversionRate: funnelConversionRate(tile.insight!.result as FunnelStepResult[]),
+        }))
+        .filter(({ conversionRate }) => conversionRate < 0.5)
+        .sort((a, b) => a.conversionRate - b.conversionRate)
+
+    return candidates[0]?.tile ?? null
+}
+
+/**
+ * Type guard to check if an insight has all required data for survey targeting.
+ * Returns true only if we have a valid funnel query with results.
+ */
+export function isSurveyableFunnelInsight(
+    insight: Partial<QueryBasedInsightModel> | undefined
+): insight is SurveyableFunnelInsight {
+    const query = insight?.query as InsightVizNode<FunnelsQuery> | undefined
+    const result = insight?.result
+
+    return (
+        isValidFunnelQuery(query) &&
+        Array.isArray(result) &&
+        result.length >= 2 &&
+        result.every((step: FunnelStepResult) => step.type === 'events' || step.type === 'actions')
     )
 }
 
 /**
- * Get some useful "context" data from a funnel insight
+ * Get some useful "context" data from a funnel insight.
+ * Returns null if the insight doesn't have valid funnel data.
  *
- * @param insight funnel insight
- * @returns funnel "context" object with name, conversion rate (0-1), list of step names
+ * @param insight funnel insight to extract context from
+ * @returns funnel "context" object, or null if invalid
  */
-export function extractFunnelContext(insight: Partial<QueryBasedInsightModel>): FunnelContext | null {
-    if (!isFunnelInsight(insight.query)) {
+export function extractFunnelContext(insight: Partial<QueryBasedInsightModel> | undefined): FunnelContext | null {
+    if (!isSurveyableFunnelInsight(insight)) {
         return null
     }
-
-    const result = insight.result
-    if (!result || !Array.isArray(result) || result.length === 0) {
-        return null
-    }
-
-    const conversionRate = conversionRateFromInsight(result)
-    const steps = result.map((step: any) => step.name || 'Unknown step')
 
     return {
         insightName: insight.name || 'Funnel',
-        conversionRate,
-        steps,
+        conversionRate: funnelConversionRate(insight.result),
+        steps: insight.query.source.series,
     }
 }
 
 /**
- * Given a list of dashboard tiles (insights), find the best opportunity to
- * create a survey.
+ * Convert an event step (EventsNode) to the type expected by survey targeting conditions
  *
- * Logic:
- * - Filter insights with existing linked surveys
- * - Calculate overall conversion rate
- * - Filter conversion rate < 50%
- * - Return lowest conversion rate funnel
- *
- * @param tiles list of dashboard tiles
- * @param linkedInsightIds list of surveys with linked insights
+ * @param step step from funnel query source, e.g. `InsightVizNode<FunnelsQuery>.source.series[n]`
  * @returns
  */
-function getBestSurveyOpportunityFromDashboard(
-    tiles: DashboardTile<QueryBasedInsightModel>[],
-    linkedInsightIds: Set<number> = new Set()
-): DashboardTile<QueryBasedInsightModel> | null {
-    const funnelTiles = tiles
-        .filter((tile) => tile.insight?.id && !linkedInsightIds.has(tile.insight.id))
-        .map((tile) => {
-            const result = tile.insight?.result
-            if (!result || !Array.isArray(result) || result.length === 0) {
-                return { tile, conversionRate: 1 }
-            }
-
-            const conversionRate = conversionRateFromInsight(result)
-            return { tile, conversionRate }
-        })
-        .filter(({ conversionRate }) => conversionRate < 0.5)
-        .sort((a, b) => a.conversionRate - b.conversionRate)
-
-    return funnelTiles[0]?.tile || null
+export function toSurveyEvent(step: EventsNode): SurveyEventsWithProperties {
+    const properties = (step as any).properties || []
+    return {
+        name: step.name || '',
+        propertyFilters: Object.fromEntries(
+            properties.map((p: any) => [
+                p.key,
+                {
+                    values: Array.isArray(p.value) ? p.value.map(String) : [],
+                    operator: p.operator,
+                },
+            ])
+        ),
+    }
 }
 
-function conversionRateFromInsight(result: QueryBasedInsightModel['result']): number {
+export function isValidFunnelQuery(query: InsightVizNode | undefined): boolean {
+    return (
+        query?.kind === 'InsightVizNode' &&
+        query?.source?.kind === 'FunnelsQuery' &&
+        (query?.source?.series?.length ?? 0) >= 2
+    )
+}
+
+/**
+ * Get overall conversion rate from a given funnel insight result
+ * @param result validated funnel step results
+ * @returns conversion rate, expressed as a number 0-1
+ */
+function funnelConversionRate(result: FunnelStepResult[]): number {
     const first = result[0]?.count || 1
     const last = result[result.length - 1]?.count || 0
     return last / first
-}
-
-function isFunnelInsight(query: any): query is InsightVizNode<FunnelsQuery> {
-    return query?.kind === 'InsightVizNode' && query?.source?.kind === 'FunnelsQuery'
 }


### PR DESCRIPTION
## Problem

"ask users why" button on funnel opens AI panel by default, and this experience is not very good right now. it's still early, but we have low conversion on this button right now

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

depends on

- [MERGED] ~~PRs~~ [~~42109~~](https://github.com/PostHog/posthog/pull/42109) ~~and~~ [~~2641~~](https://github.com/PostHog/posthog-js/pull/2641) ~~to add 'cancellation events' to survey display conditions~~
- PRs to fix action matching in SDK
    - [MERGED] ~~pass regex from api:~~ [~~https://github.com/PostHog/posthog/pull/42530~~](https://github.com/PostHog/posthog/pull/42530)
    - SDK PR https://github.com/PostHog/posthog-js/pull/2676
- PR https://github.com/PostHog/posthog/pull/42327 to add support for actions with event filters

**safe to merge now, as the** [**experiment** **feature** **flag**](https://us.posthog.com/project/2/feature_flags/252911) **is** **disabled!**

add new funnel sequence input to the modal, and add experiment logic on "ask users why" button to A/B test the AI panel vs. quick create

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## ![Screenshot 2025-11-26 at 11.37.08 AM.png](https://app.graphite.com/user-attachments/assets/8677b9da-43aa-43a3-bf8a-3cb8bcf43e82.png)

the input there is basically doing this:

> User does [trigger event], but not [cancellation event] within [survey popup delay seconds]

## How did you test this code?

lots of manual testing 😺

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->

no