### PR TITLE
perf(logs): throttle keyboard navigation and prevent search autofocus

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -140,9 +140,12 @@ export const TaxonomicFilterSearchInput = forwardRef<
     {
         searchInputRef: React.Ref<HTMLInputElement> | null
         onClose: TaxonomicFilterProps['onClose']
-    } & Pick<LemonInputPropsText, 'onClick' | 'size' | 'prefix' | 'fullWidth' | 'onChange'> &
+    } & Pick<LemonInputPropsText, 'onClick' | 'size' | 'prefix' | 'fullWidth' | 'onChange' | 'autoFocus'> &
         Pick<TooltipProps, 'docLink'>
->(function UniversalSearchInput({ searchInputRef, onClose, onChange, docLink, ...props }, ref): JSX.Element {
+>(function UniversalSearchInput(
+    { searchInputRef, onClose, onChange, docLink, autoFocus = true, ...props },
+    ref
+): JSX.Element {
     const { searchQuery, searchPlaceholder, showNumericalPropsOnly } = useValues(taxonomicFilterLogic)
     const {
         setSearchQuery: setTaxonomicSearchQuery,
@@ -226,7 +229,7 @@ export const TaxonomicFilterSearchInput = forwardRef<
             }}
             inputRef={searchInputRef}
             onChange={_onChange}
-            autoFocus
+            autoFocus={autoFocus}
         />
     )
 })

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -1,5 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useRef } from 'react'
+import { useThrottledCallback } from 'use-debounce'
 
 import { IconFilter, IconMinusSquare, IconPin, IconPinFilled, IconPlusSquare, IconRefresh } from '@posthog/icons'
 import {
@@ -45,6 +46,8 @@ import { SeverityLevelsFilter } from './filters/SeverityLevelsFilter'
 import { logsLogic } from './logsLogic'
 import { ParsedLogMessage } from './types'
 
+const THROTTLE_TIME_MS = 150
+
 export const scene: SceneExport = {
     component: LogsScene,
     logic: logsLogic,
@@ -79,12 +82,22 @@ export function LogsScene(): JSX.Element {
         runQuery()
     }, [runQuery])
 
+    const throttledHighlightNext = useThrottledCallback(highlightNextLog, THROTTLE_TIME_MS, {
+        leading: true,
+        trailing: false,
+    })
+
+    const throttledHighlightPrev = useThrottledCallback(highlightPreviousLog, THROTTLE_TIME_MS, {
+        leading: true,
+        trailing: false,
+    })
+
     useKeyboardHotkeys(
         {
-            arrowdown: { action: highlightNextLog },
-            j: { action: highlightNextLog },
-            arrowup: { action: highlightPreviousLog },
-            k: { action: highlightPreviousLog },
+            arrowdown: { action: throttledHighlightNext },
+            j: { action: throttledHighlightNext },
+            arrowup: { action: throttledHighlightPrev },
+            k: { action: throttledHighlightPrev },
             enter: {
                 action: () => {
                     if (sceneHighlightedLogId) {
@@ -233,7 +246,7 @@ function LogsTable({
             requestAnimationFrame(() => {
                 const highlightedRow = tableRef.current?.querySelector(`[data-row-key="${highlightedLogId}"]`)
                 if (highlightedRow) {
-                    highlightedRow.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                    highlightedRow.scrollIntoView({ behavior: 'auto', block: 'center' })
                 }
             })
         }

--- a/products/logs/frontend/components/filters/LogsFilters/FilterGroup.tsx
+++ b/products/logs/frontend/components/filters/LogsFilters/FilterGroup.tsx
@@ -92,6 +92,7 @@ const UniversalSearch = (): JSX.Element => {
                     onChange={onChange}
                     size="small"
                     fullWidth
+                    autoFocus={false}
                 />
             </LemonDropdown>
         </BindLogic>


### PR DESCRIPTION
## Problem

Keyboard navigation was a bit janky & performance needed improving.
The search input was auto-focusing, preventing us from jumping straight into keyboard navigation.

## Changes

This PR improves keyboard navigation performance in the logs feature by implementing throttling and fixing the autofocus behavior of the search input.

- Throttles keyboard navigation (arrow keys and j/k) at 150ms intervals with leading execution
- Changes scroll behavior from 'smooth' to 'auto' to prevent animation stacking during rapid navigation
- Adds configurable autoFocus prop to TaxonomicFilter component and disables it for the logs filter search

## How did you test this code?

Local Dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
