### PR TITLE
fix(logs): Deduplicate logs and optimize selector lookups

### DIFF
--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -835,13 +835,12 @@ export const logsLogic = kea<logsLogicType>([
             actions.setFilterGroup({ ...values.filterGroup, values: [newGroup] }, false)
         },
         togglePinLog: ({ logId }) => {
-            const isPinned = values.pinnedLogs.some((log) => log.uuid === logId)
-            if (isPinned) {
+            if (values.pinnedLogIds.has(logId)) {
                 actions.unpinLog(logId)
             } else {
-                const logToPin = values.logs.find((log) => log.uuid === logId)
-                if (logToPin) {
-                    actions.pinLog(logToPin)
+                const index = values.logIndexByUuid.get(logId)
+                if (index !== undefined) {
+                    actions.pinLog(values.parsedLogs[index])
                 }
             }
         },


### PR DESCRIPTION
## Problem

- Duplicate logs could appear when pagination or live-tail fetches overlapping data
- `isPinned` and `highlightNextLog`/`highlightPreviousLog` used O(n) array scans
- Log Pinning was laggy when many logs were available

## Changes

- Deduplicate logs by UUID in `parsedLogs` selector using a Set
- Add `pinnedLogIds` selector (Set) so `isPinned` is O(1) instead of O(n)
- Add `logIndexByUuid` selector (Map) for O(1) keyboard navigation lookups
- Perf: Optimize `togglePinLog` to use cached lookups
- Tests: Add tests for log deduplication and pinning functionality

## How did you test this code?

Local dev + unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._