### PR TITLE
fix(insights): hide badge for null math

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -665,7 +665,7 @@ export function ActionFilterRow({
                                             <LemonBadge
                                                 position="top-right"
                                                 size="small"
-                                                visible={math !== undefined || isStepOptional(index + 1)}
+                                                visible={math != null || isStepOptional(index + 1)}
                                             />
                                         </div>
                                     </>


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C02E3BKC78F/p1764428482949119

We show the badge for `math === null`.

## Changes

Adapts the condition.

## How did you test this code?

Locally, with 👀 