### PR TITLE
fix(marketing-analytics): Fix conversion goal save when there's ActionsNode 

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/ConversionGoalModal.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/ConversionGoalModal.tsx
@@ -63,7 +63,10 @@ export function ConversionGoalModal(): JSX.Element {
                     <div className="flex items-center gap-2">
                         <LemonButton
                             type="secondary"
-                            onClick={saveConversionGoal}
+                            onClick={() => {
+                                saveConversionGoal()
+                                hideConversionGoalModal()
+                            }}
                             disabledReason={
                                 !hasAppliedGoal
                                     ? 'Apply first to verify your conversion goal works correctly'
@@ -109,6 +112,7 @@ export function ConversionGoalModal(): JSX.Element {
                 <div>
                     <label className="text-sm font-medium mb-1 block">Event or table</label>
                     <ConversionGoalDropdown
+                        key={conversionGoalInput?.conversion_goal_id || 'default'}
                         value={conversionGoalInput || defaultConversionGoalFilter}
                         onChange={handleConversionGoalChange}
                         typeKey="conversion-goal-modal"

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/ConversionGoalModal.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/MarketingAnalyticsFilters/ConversionGoalModal.tsx
@@ -63,10 +63,7 @@ export function ConversionGoalModal(): JSX.Element {
                     <div className="flex items-center gap-2">
                         <LemonButton
                             type="secondary"
-                            onClick={() => {
-                                saveConversionGoal()
-                                hideConversionGoalModal()
-                            }}
+                            onClick={saveConversionGoal}
                             disabledReason={
                                 !hasAppliedGoal
                                     ? 'Apply first to verify your conversion goal works correctly'

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
@@ -109,10 +109,18 @@ export function ConversionGoalDropdown({ value, onChange, typeKey }: ConversionG
                         properties: firstSerie?.properties || [], // if we clear the filter we need the properties to be set to an empty array
                     }
 
-                    // Remove the event field from ActionsNode to prevent validation errors
-                    if (newFilter.kind === NodeKind.ActionsNode && 'event' in newFilter) {
-                        const { event, ...rest } = newFilter as any
-                        Object.assign(newFilter, rest)
+                    // Clean up ActionsNode: remove event field and ensure id is a number
+                    if (newFilter.kind === NodeKind.ActionsNode) {
+                        if ('event' in newFilter) {
+                            delete (newFilter as any).event
+                        }
+                        // Ensure id is a number for ActionsNode (actions always have numeric IDs)
+                        if ('id' in newFilter) {
+                            const numId = parseInt(String((newFilter as any).id), 10)
+                            if (!isNaN(numId)) {
+                                ;(newFilter as any).id = numId
+                            }
+                        }
                     }
 
                     // Override the schema with the schema from the data warehouse

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
@@ -641,11 +641,12 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
             actions.hideConversionGoalModal()
         },
         saveConversionGoal: () => {
-            actions.addOrUpdateConversionGoal({
-                ...values.conversionGoalInput,
-                conversion_goal_name: values.uniqueConversionGoalName,
-            })
-            // Reset input for new goal, but keep the draft applied
+            // First save the draft goal to the conversion_goals list
+            if (values.draftConversionGoal) {
+                actions.addOrUpdateConversionGoal(values.draftConversionGoal)
+            }
+            // Then clear the draft and input state (resets UI)
+            actions.setDraftConversionGoal(null)
             actions.setConversionGoalInput({
                 ...defaultConversionGoalFilter,
                 conversion_goal_id: uuid(),


### PR DESCRIPTION
## Problem

I was having this error on prod when there's an action as conversion goal: 
```
Traceback (most recent call last):
  File "/Users/javierbahamondes/Desktop/posthog/posthog/api/mixins.py", line 36, in get_model
    return model.model_validate(data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/javierbahamondes/Desktop/posthog/.flox/cache/venv/lib/python3.12/site-packages/pydantic/main.py", line 716, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 9 validation errors for QueryRequest
query.MarketingAnalyticsTableQuery.draftConversionGoal.ConversionGoalFilter1.kind
  Input should be 'EventsNode' [type=literal_error, input_value='ActionsNode', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error
query.MarketingAnalyticsTableQuery.draftConversionGoal.ConversionGoalFilter1.id
  Extra inputs are not permitted [type=extra_forbidden, input_value='2', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden
query.MarketingAnalyticsTableQuery.draftConversionGoal.ConversionGoalFilter2.event
  Extra inputs are not permitted [type=extra_forbidden, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden
query.MarketingAnalyticsTableQuery.draftConversionGoal.ConversionGoalFilter3.distinct_id_field
  Field required [type=missing, input_value={'conversion_goal_id': '5...: '2', 'properties': []}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
query.MarketingAnalyticsTableQuery.draftConversionGoal.ConversionGoalFilter3.id_field
  Field required [type=missing, input_value={'conversion_goal_id': '5...: '2', 'properties': []}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
query.MarketingAnalyticsTableQuery.draftConversionGoal.ConversionGoalFilter3.kind
  Input should be 'DataWarehouseNode' [type=literal_error, input_value='ActionsNode', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error
query.MarketingAnalyticsTableQuery.draftConversionGoal.ConversionGoalFilter3.table_name
  Field required [type=missing, input_value={'conversion_goal_id': '5...: '2', 'properties': []}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
query.MarketingAnalyticsTableQuery.draftConversionGoal.ConversionGoalFilter3.timestamp_field
  Field required [type=missing, input_value={'conversion_goal_id': '5...: '2', 'properties': []}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
query.MarketingAnalyticsTableQuery.draftConversionGoal.ConversionGoalFilter3.event
  Extra inputs are not permitted [type=extra_forbidden, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden
```

## Changes

   - Fix ActionsNode validation error by properly removing the event field using delete operator instead of Object.assign which doesn't remove props
   - Ensure ActionsNode id is converted to number safely with parseInt
   - Fix save button to properly clear UI state after saving (same as clear)
   - Add key prop to ConversionGoalDropdown to force remount on reset

## How did you test this code?
Manually