### PR TITLE
chore(web-analytics): Populate $prev_pageview_duration and $prev_pageview_path properties in the Matrix

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -479,7 +479,6 @@
      (SELECT persons.id AS id
       FROM
         (SELECT tupleElement(argMax(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '')), person.version), 1) AS properties___name,
-        (SELECT tupleElement(argMax(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '')), person.version), 1) AS properties___name,
                 person.id AS id
          FROM person
          WHERE and(equals(person.team_id, 99999), in(id,
@@ -487,7 +486,6 @@
                                                         FROM person AS where_optimization
                                                         WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
          GROUP BY person.id
-         HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
          HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
       WHERE ifNull(equals(persons.properties___name, 'test'), 0)
       ORDER BY persons.id ASC
@@ -507,7 +505,6 @@
                                   e.distinct_id AS distinct_id
                            FROM events AS e
                            LEFT OUTER JOIN
-                             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
                              (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
                                      person_distinct_id_overrides.distinct_id AS distinct_id
                               FROM person_distinct_id_overrides
@@ -576,7 +573,6 @@
      (SELECT persons.id AS id
       FROM
         (SELECT tupleElement(argMax(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '')), person.version), 1) AS properties___name,
-        (SELECT tupleElement(argMax(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '')), person.version), 1) AS properties___name,
                 person.id AS id
          FROM person
          WHERE and(equals(person.team_id, 99999), in(id,
@@ -584,7 +580,6 @@
                                                         FROM person AS where_optimization
                                                         WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
          GROUP BY person.id
-         HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
          HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
       WHERE ifNull(equals(persons.properties___name, 'test'), 0)
       ORDER BY persons.id ASC
@@ -604,7 +599,6 @@
                                   e.distinct_id AS distinct_id
                            FROM events AS e
                            LEFT OUTER JOIN
-                             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
                              (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
                                      person_distinct_id_overrides.distinct_id AS distinct_id
                               FROM person_distinct_id_overrides

--- a/posthog/demo/matrix/models.py
+++ b/posthog/demo/matrix/models.py
@@ -285,6 +285,7 @@ class SimBrowserClient(SimClient):
     def __exit__(self, exc_type, exc_value, exc_traceback):
         """End session within client. Handles `$pageleave` event."""
         if self.current_url is not None:
+            assert self.current_url_timestamp is not None
             prev_pageview_duration = (self.person.cluster.simulation_time - self.current_url_timestamp).total_seconds()
             prev_pageview_path = urlparse(self.current_url).path
             self.capture(
@@ -362,6 +363,7 @@ class SimBrowserClient(SimClient):
         prev_pageview_duration: Optional[float] = None
         prev_pageview_path: Optional[str] = None
         if self.current_url is not None:
+            assert self.current_url_timestamp is not None
             prev_pageview_duration = (self.person.cluster.simulation_time - self.current_url_timestamp).total_seconds()
             prev_pageview_path = urlparse(self.current_url).path
             self.capture(


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
When generating demo data, the `$prev_pageview_duration` and `$prev_pageview_path properties` aren’t populated. As a result, features related to https://github.com/PostHog/posthog/issues/24555 don’t display correctly in demos and make local development harder for anything that relies on these properties.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
Set the `$prev_pageview_duration` and `$prev_pageview_path properties` during page leave and page view events in the Matrix.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Manually ran HogQL queries in the dashboard to confirm presence of the new properties.

<img width="1239" height="616" alt="Screenshot 2025-11-30 at 12 59 08 PM" src="https://github.com/user-attachments/assets/d345adee-73b1-453c-a4fa-610876eb4953" />

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
