### PR TITLE
feat(managed-proxy): add organization_id to proxy monitor events

### DIFF
--- a/posthog/temporal/proxy_service/common.py
+++ b/posthog/temporal/proxy_service/common.py
@@ -146,7 +146,7 @@ def activity_capture_event(inputs: CaptureEventInputs):
         event=f"managed reverse proxy {inputs.event_type}",
         distinct_id=f"org-{record.organization_id}",
         properties={
-            "organization_id": inputs.organization_id,
+            "organization_id": record.organization_id,
             "proxy_record_id": inputs.proxy_record_id,
             "domain": record.domain if record else None,
             "target_cname": record.target_cname if record else None,

--- a/posthog/temporal/proxy_service/common.py
+++ b/posthog/temporal/proxy_service/common.py
@@ -146,6 +146,7 @@ def activity_capture_event(inputs: CaptureEventInputs):
         event=f"managed reverse proxy {inputs.event_type}",
         distinct_id=f"org-{record.organization_id}",
         properties={
+            "organization_id": inputs.organization_id,
             "proxy_record_id": inputs.proxy_record_id,
             "domain": record.domain if record else None,
             "target_cname": record.target_cname if record else None,


### PR DESCRIPTION

## Problem

proxy's certificates can expire without us realising for active orgs
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

add org_id to our monitor events

this will make it slightly easier to correlate proxies with active orgs

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
