### PR TITLE
feat(migrations): add migration metrics to pushgateway

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -87,7 +87,11 @@ while [ $MIGRATE_ATTEMPT -le $MIGRATE_MAX_RETRIES ]; do
     MIGRATE_ATTEMPT=$((MIGRATE_ATTEMPT + 1))
 done
 
-if [ "$MIGRATE_SUCCESS" != "true" ]; then
+# Report migration metrics to pushgateway (if configured)
+if [ "$MIGRATE_SUCCESS" = "true" ]; then
+    python manage.py report_migration_metric --attempts=$MIGRATE_ATTEMPT --success || true
+else
+    python manage.py report_migration_metric --attempts=$MIGRATE_ATTEMPT || true
     echo "Error in postgres migrations, killing background process and exiting."
     kill $CLICKHOUSE_PID 2>/dev/null || true
     rm $CLICKHOUSE_STATUS

--- a/bin/migrate
+++ b/bin/migrate
@@ -63,6 +63,7 @@ MIGRATE_LOCK_TIMEOUT=${MIGRATE_LOCK_TIMEOUT:-2000}  # 2 seconds
 
 MIGRATE_ATTEMPT=1
 MIGRATE_SUCCESS=false
+MIGRATE_START_TIME=$(date +%s.%N)
 
 while [ $MIGRATE_ATTEMPT -le $MIGRATE_MAX_RETRIES ]; do
     echo "[migrate] Django migration attempt $MIGRATE_ATTEMPT/$MIGRATE_MAX_RETRIES (lock_timeout=${MIGRATE_LOCK_TIMEOUT}ms)"
@@ -87,11 +88,14 @@ while [ $MIGRATE_ATTEMPT -le $MIGRATE_MAX_RETRIES ]; do
     MIGRATE_ATTEMPT=$((MIGRATE_ATTEMPT + 1))
 done
 
+MIGRATE_END_TIME=$(date +%s.%N)
+MIGRATE_DURATION=$(python3 -c "print($MIGRATE_END_TIME - $MIGRATE_START_TIME)")
+
 # Report migration metrics to pushgateway (if configured)
 if [ "$MIGRATE_SUCCESS" = "true" ]; then
-    python manage.py report_migration_metric --attempts=$MIGRATE_ATTEMPT --success || true
+    python manage.py report_migration_metric --attempts=$MIGRATE_ATTEMPT --duration=$MIGRATE_DURATION --success || true
 else
-    python manage.py report_migration_metric --attempts=$MIGRATE_ATTEMPT || true
+    python manage.py report_migration_metric --attempts=$MIGRATE_ATTEMPT --duration=$MIGRATE_DURATION || true
     echo "Error in postgres migrations, killing background process and exiting."
     kill $CLICKHOUSE_PID 2>/dev/null || true
     rm $CLICKHOUSE_STATUS

--- a/posthog/management/commands/report_migration_metric.py
+++ b/posthog/management/commands/report_migration_metric.py
@@ -1,0 +1,62 @@
+import logging
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Report Django migration metrics to Prometheus pushgateway"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--attempts",
+            type=int,
+            required=True,
+            help="Number of migration attempts made",
+        )
+        parser.add_argument(
+            "--success",
+            action="store_true",
+            help="Whether migration ultimately succeeded",
+        )
+
+    def handle(self, *args, **options):
+        attempts = options["attempts"]
+        success = options["success"]
+
+        if not settings.PROM_PUSHGATEWAY_ADDRESS:
+            logger.info("PROM_PUSHGATEWAY_ADDRESS not set, skipping metric push")
+            return
+
+        registry = CollectorRegistry()
+
+        attempts_gauge = Gauge(
+            "django_migration_attempts",
+            "Number of attempts for the last Django migration run",
+            registry=registry,
+        )
+        attempts_gauge.set(attempts)
+
+        success_gauge = Gauge(
+            "django_migration_success",
+            "Whether the last Django migration succeeded (1) or failed (0)",
+            registry=registry,
+        )
+        success_gauge.set(1 if success else 0)
+
+        try:
+            push_to_gateway(
+                settings.PROM_PUSHGATEWAY_ADDRESS,
+                job="django_migrate",
+                registry=registry,
+            )
+            logger.info(
+                "Pushed migration metrics",
+                extra={"attempts": attempts, "success": success},
+            )
+        except Exception as e:
+            logger.exception("Failed to push migration metrics", extra={"error": str(e)})


### PR DESCRIPTION
Stacked on #42361

**Adds metrics pushed to Prometheus pushgateway after Django migrations:**
- `django_migration_attempts` - number of attempts made (1-10)
- `django_migration_success` - whether it succeeded (1) or failed (0)
- `django_migration_duration_seconds` - total migration time including retries

Uses `grouping_key` to ensure each deploy completely replaces previous metrics (so alerts auto-resolve on successful deploy).

**Charts PR:** PostHog/charts#7208 (adds env var + alert rules)