### PR TITLE
fix(flags): dont log all spans to reduce log volume

### DIFF
--- a/rust/feature-flags/src/main.rs
+++ b/rust/feature-flags/src/main.rs
@@ -98,6 +98,7 @@ async fn main() {
             // Production: JSON format (like Django's JSONRenderer())
             base_layer
                 .json()
+                .with_span_list(false)
                 .with_filter(EnvFilter::from_default_env())
                 .boxed()
         }


### PR DESCRIPTION
## Problem

feature flag logs are very noisy, we're also logging every span in every log line - these are being sampled and sent to tracing anyway so i don't _think_ we need them in the logs to
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

log without spans
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
