### PR TITLE
feat(logs): support multiple search tokens with AND semantics

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -35,7 +35,7 @@ def parse_search_tokens(search_term: str) -> list[tuple[Literal["positive", "neg
     results: list[tuple[Literal["positive", "negative"], str]] = []
     for token in tokens:
         if token.startswith("!"):
-            value = token[1:]
+            value = token.lstrip("!")
             if value:
                 results.append(("negative", value))
         else:

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -201,7 +201,11 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
 
         if self.query.searchTerm:
             # shlex.split preserves quoted strings as single tokens: "hello world" → ["hello world"]
-            for token in shlex.split(self.query.searchTerm):
+            try:
+                tokens = shlex.split(self.query.searchTerm)
+            except ValueError:
+                tokens = self.query.searchTerm.split()
+            for token in tokens:
                 if token == "!":
                     continue
                 if token.startswith("!"):

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -218,6 +218,8 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
             )
 
         if self.query.searchTerm:
+            # NOTE: each token adds a separate LIKE '%value%' condition which will be expensive for the logs table
+            # Future optimisation: consider ClickHouse multiSearchAny or better ngram index usage if performance becomes an issue with many tokens.
             for token_type, value in parse_search_tokens(self.query.searchTerm):
                 if token_type == "negative":
                     exprs.append(

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -34,10 +34,10 @@ def parse_search_tokens(search_term: str) -> list[tuple[Literal["positive", "neg
 
     results: list[tuple[Literal["positive", "negative"], str]] = []
     for token in tokens:
-        if token == "!":
-            continue
         if token.startswith("!"):
-            results.append(("negative", token[1:]))
+            value = token[1:]
+            if value:
+                results.append(("negative", value))
         else:
             results.append(("positive", token))
     return results

--- a/products/logs/backend/test_logs_query_runner.py
+++ b/products/logs/backend/test_logs_query_runner.py
@@ -16,6 +16,7 @@ class TestParseSearchTokens(BaseTest):
             ("quoted phrase", '"hello world"', [("positive", "hello world")]),
             ("negative quoted phrase", '!"hello world"', [("negative", "hello world")]),
             ("standalone bang ignored", "!", []),
+            ("double bang ignored", "!!", []),
             ("standalone bang with tokens", "error ! warning", [("positive", "error"), ("positive", "warning")]),
             ("multiple spaces", "error    warning", [("positive", "error"), ("positive", "warning")]),
             ("malformed quotes fallback", '"unclosed quote', [("positive", '"unclosed'), ("positive", "quote")]),

--- a/products/logs/backend/test_logs_query_runner.py
+++ b/products/logs/backend/test_logs_query_runner.py
@@ -1,0 +1,26 @@
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from products.logs.backend.logs_query_runner import parse_search_tokens
+
+
+class TestParseSearchTokens(BaseTest):
+    @parameterized.expand(
+        [
+            ("single positive", "error", [("positive", "error")]),
+            ("single negative", "!error", [("negative", "error")]),
+            ("multiple positive AND", "error warning", [("positive", "error"), ("positive", "warning")]),
+            ("multiple negative", "!error !warning", [("negative", "error"), ("negative", "warning")]),
+            ("mixed positive and negative", "error !warning", [("positive", "error"), ("negative", "warning")]),
+            ("quoted phrase", '"hello world"', [("positive", "hello world")]),
+            ("negative quoted phrase", '!"hello world"', [("negative", "hello world")]),
+            ("standalone bang ignored", "!", []),
+            ("standalone bang with tokens", "error ! warning", [("positive", "error"), ("positive", "warning")]),
+            ("multiple spaces", "error    warning", [("positive", "error"), ("positive", "warning")]),
+            ("malformed quotes fallback", '"unclosed quote', [("positive", '"unclosed'), ("positive", "quote")]),
+        ]
+    )
+    def test_parse_search_tokens(self, _name: str, search_term: str, expected: list[tuple[str, str]]):
+        result = parse_search_tokens(search_term)
+        self.assertEqual(result, expected)


### PR DESCRIPTION
## Problem

Text search was slightly limited & could only use basic tokens

## Changes

<img width="339" height="90" alt="image" src="https://github.com/user-attachments/assets/958e3e05-8ce9-47a2-8668-4233db390f09" />

- Multiple negative tokens: `!foo !bar` excludes logs containing either
- Multiple positive tokens: `foo bar` matches logs containing both (AND)
- Quoted phrases: `"hello world"` matches exact substring
- Uses shlex.split to handle quoted strings properly
- Ignores standalone `!` tokens"

## How did you test this code?

Local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._