### PR TITLE
fix(search): slash in search page

### DIFF
--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -34,7 +34,7 @@ import {
     iconForType,
 } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { SearchResults } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
-import { splitPath } from '~/layout/panel-layout/ProjectTree/utils'
+import { splitPath, unescapePath } from '~/layout/panel-layout/ProjectTree/utils'
 import { TreeDataItem } from '~/lib/lemon-ui/LemonTree/LemonTree'
 import { groupsModel } from '~/models/groupsModel'
 import {
@@ -710,7 +710,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                     const name = splitPath(item.path).pop()
                     return {
                         id: item.path,
-                        name: name || item.path,
+                        name: name ? unescapePath(name) : item.path,
                         category: 'recents',
                         href: item.href || '#',
                         lastViewedAt: item.last_viewed_at ?? null,


### PR DESCRIPTION
## Problem

Recent items with a slash in them would show like this:

<img width="343" height="210" alt="image" src="https://github.com/user-attachments/assets/f9342372-5dc0-43a7-8dac-4eeb83e967b8" />

## Changes

<img width="363" height="271" alt="image" src="https://github.com/user-attachments/assets/6999a59e-1515-4763-8c2e-26348232bde6" />


## How did you test this code?

👀 