### PR TITLE
chore: Make Dagster jobs required

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -6,6 +6,9 @@ on:
             - master
     pull_request:
 
+permissions:
+    contents: read
+
 env:
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -50,8 +50,10 @@ jobs:
                   filters: |
                       dagster:
                         - 'dags/**'
-                        # Dagster depends on code from the posthog package, so ensure we run on changes to it
+                        # Dagster depends on Python, so ensure we run on possible changes to it
                         - 'posthog/**/*'
+                        - 'ee/**/*'
+                        - 'products/**/*'
                         # Make sure we run if someone is explicitly change the workflow
                         - .github/workflows/ci-dagster.yml
                         # We use docker compose for tests, make sure we rerun on

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -145,3 +145,21 @@ jobs:
             - name: Run Dagster tests
               run: |
                   pytest dags
+
+    # Job just to collate the status of the matrix jobs for requiring passing status
+    dagster_tests:
+        needs: [dagster]
+        name: Dagster Tests Pass
+        runs-on: ubuntu-latest
+        if: always()
+        steps:
+            - name: Check matrix outcome
+              run: |
+                  # The `needs.dagster.result` will be 'success' only if all jobs in the matrix succeeded.
+                  # Otherwise, it will be 'failure'.
+                  if [[ "${{ needs.dagster.result }}" != "success" && "${{ needs.dagster.result }}" != "skipped" ]]; then
+                    echo "One or more jobs in the Dagster test matrix failed."
+                    exit 1
+                  fi
+
+                  echo "All checks passed."

--- a/dags/tests/test_sdk_doctor.py
+++ b/dags/tests/test_sdk_doctor.py
@@ -99,7 +99,7 @@ class TestFetchWebSdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "1.298.1" in result["releaseDates"]
         assert result["releaseDates"]["1.298.1"] == "2025-11-26T13:26:47Z"
-        assert mock_get.call_count == 2  # Paginated to second page
+        assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
     @patch("dags.sdk_doctor.github_sdk_versions.requests.get")
     def test_fetch_web_sdk_data_request_failure(self, mock_get):
@@ -127,7 +127,7 @@ class TestFetchPythonSdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "7.0.1" in result["releaseDates"]
         assert result["releaseDates"]["7.0.1"] == "2025-11-15T12:43:55Z"
-        assert mock_get.call_count == 2  # Paginated to second page
+        assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
 
 class TestFetchNodeSdkData(TestFetchSdkDataBase):
@@ -143,7 +143,7 @@ class TestFetchNodeSdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "5.14.0" in result["releaseDates"]
         assert result["releaseDates"]["5.14.0"] == "2025-11-24T10:24:59Z"
-        assert mock_get.call_count == 3  # Paginated to second page + 1 for `posthog-js-lite`
+        assert mock_get.call_count == 3  # Assert that it attempted to paginate + 1 for `posthog-js-lite`
 
 
 class TestFetchReactNativeSdkData(TestFetchSdkDataBase):
@@ -159,7 +159,7 @@ class TestFetchReactNativeSdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "4.14.0" in result["releaseDates"]
         assert result["releaseDates"]["4.14.0"] == "2025-11-26T13:26:49Z"
-        assert mock_get.call_count == 3  # Paginated to second page + 1 for `posthog-js-lite`
+        assert mock_get.call_count == 3  # Assert that it attempted to paginate + 1 for `posthog-js-lite`
 
 
 class TestFetchFlutterSdkData(TestFetchSdkDataBase):
@@ -175,7 +175,7 @@ class TestFetchFlutterSdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "5.9.0" in result["releaseDates"]
         assert result["releaseDates"]["5.9.0"] == "2025-11-05T13:22:41Z"
-        assert mock_get.call_count == 2  # Paginated to second page
+        assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
 
 class TestFetchIosSdkData(TestFetchSdkDataBase):
@@ -191,7 +191,7 @@ class TestFetchIosSdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "3.35.0" in result["releaseDates"]
         assert result["releaseDates"]["3.35.0"] == "2025-11-07T16:22:45Z"
-        assert mock_get.call_count == 2  # Paginated to second page
+        assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
 
 class TestFetchAndroidSdkData(TestFetchSdkDataBase):
@@ -207,7 +207,7 @@ class TestFetchAndroidSdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "3.26.0" in result["releaseDates"]
         assert result["releaseDates"]["3.26.0"] == "2025-11-05T20:29:02Z"
-        assert mock_get.call_count == 2  # Paginated to second page
+        assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
 
 class TestFetchGoSdkData(TestFetchSdkDataBase):
@@ -223,7 +223,7 @@ class TestFetchGoSdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "1.6.13" in result["releaseDates"]
         assert result["releaseDates"]["1.6.13"] == "2025-11-21T21:58:29Z"
-        assert mock_get.call_count == 2  # Paginated to second page
+        assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
 
 class TestFetchPhpSdkData(TestFetchSdkDataBase):
@@ -239,7 +239,7 @@ class TestFetchPhpSdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "3.7.2" in result["releaseDates"]
         assert result["releaseDates"]["3.7.2"] == "2025-10-23T00:40:34Z"
-        assert mock_get.call_count == 2  # Paginated to second page
+        assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
 
 class TestFetchRubySdkData(TestFetchSdkDataBase):
@@ -255,7 +255,7 @@ class TestFetchRubySdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "3.3.3" in result["releaseDates"]
         assert result["releaseDates"]["3.3.3"] == "2025-10-22T17:40:15Z"
-        assert mock_get.call_count == 2  # Paginated to second page
+        assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
 
 class TestFetchElixirSdkData(TestFetchSdkDataBase):
@@ -271,7 +271,7 @@ class TestFetchElixirSdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "2.1.0" in result["releaseDates"]
         assert result["releaseDates"]["2.1.0"] == "2025-11-25T18:54:57Z"
-        assert mock_get.call_count == 2  # Paginated to second page
+        assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
 
 class TestFetchDotnetSdkData(TestFetchSdkDataBase):
@@ -287,4 +287,4 @@ class TestFetchDotnetSdkData(TestFetchSdkDataBase):
         assert len(result["releaseDates"]) > 0
         assert "2.2.2" in result["releaseDates"]
         assert result["releaseDates"]["2.2.2"] == "2025-11-21T17:27:02Z"
-        assert mock_get.call_count == 2  # Paginated to second page
+        assert mock_get.call_count == 2  # Assert that it attempted to paginate


### PR DESCRIPTION
We merged a broken change to dagster because these weren't required and we merged before they finished running, let's make this required now

Let's first get this merged - and seeing that it works - and then we can add it to the list of required checks.
