### PR TITLE
feat: Print more helpful warning when permissions expire

### DIFF
--- a/infra-scripts/clitools/toolbox/user.py
+++ b/infra-scripts/clitools/toolbox/user.py
@@ -31,6 +31,12 @@ def get_current_user() -> dict:
         print(f"Command failed with return code {e.returncode}")  # noqa: T201
         print(f"Output: {e.output}")  # noqa: T201
         print(f"Stderr: {e.stderr}")  # noqa: T201
+
+        if e.returncode == 1 and "Token has expired and refresh failed" in e.stderr:
+            print(  # noqa: T201
+                "Token has expired and refresh failed, please reauthenticate with `aws sso login --profile=<your-profile>`"
+            )
+
         sys.exit(1)
     except Exception as k8s_error:
         print(f"Error: Failed to get user identity: {k8s_error}")  # noqa: T201


### PR DESCRIPTION
I got the warning that my permissions had expired but I had no idea how to regenerate them, let's make it more obvious

<img width="856" height="154" alt="image" src="https://github.com/user-attachments/assets/73ef236c-4e51-476b-88d8-071ed7f5c4a8" />