### PR TITLE
feat(managed-proxy): Add a new proxy monitor task to check the _actual_ certificate for expiry

### DIFF
--- a/posthog/temporal/proxy_service/monitor.py
+++ b/posthog/temporal/proxy_service/monitor.py
@@ -1,5 +1,7 @@
+import ssl
 import json
 import uuid
+import socket
 import typing as t
 import datetime as dt
 import ipaddress
@@ -210,6 +212,24 @@ async def check_proxy_is_live(inputs: CheckActivityInput) -> CheckActivityOutput
         )
 
         response.raise_for_status()
+
+        # fetch the cert info to see how far away the expiry is - if less than 2 weeks we have a problem
+        ctx = ssl.create_default_context()
+        with ctx.wrap_socket(socket.socket(), server_hostname=proxy_record.domain) as s:
+            s.connect((proxy_record.domain, 443))
+            cert = s.getpeercert()
+            if cert is None:
+                # How can cert be none if we sent an event over https?
+                raise Exception(
+                    "Certificate not found while monitoring proxy endpoint (but we sent an event successfully)"
+                )
+            assert isinstance(cert["notAfter"], str)
+            expires_at = dt.datetime.strptime(cert["notAfter"], "%b %d %H:%M:%S %Y %Z")
+            if expires_at - dt.datetime.now() < dt.timedelta(days=14):
+                return CheckActivityOutput(
+                    errors=["Live proxy certificate is expiring soon"],
+                    warnings=[],
+                )
     except requests.exceptions.SSLError:
         return CheckActivityOutput(
             errors=["Failed to connect to proxy: invalid SSL certificate"],

--- a/posthog/temporal/proxy_service/monitor.py
+++ b/posthog/temporal/proxy_service/monitor.py
@@ -215,6 +215,7 @@ async def check_proxy_is_live(inputs: CheckActivityInput) -> CheckActivityOutput
 
         # fetch the cert info to see how far away the expiry is - if less than 2 weeks we have a problem
         ctx = ssl.create_default_context()
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
         with ctx.wrap_socket(socket.socket(), server_hostname=proxy_record.domain) as s:
             s.connect((proxy_record.domain, 443))
             cert = s.getpeercert()

--- a/posthog/temporal/proxy_service/monitor.py
+++ b/posthog/temporal/proxy_service/monitor.py
@@ -225,7 +225,7 @@ async def check_proxy_is_live(inputs: CheckActivityInput) -> CheckActivityOutput
                 )
             assert isinstance(cert["notAfter"], str)
             expires_at = dt.datetime.strptime(cert["notAfter"], "%b %d %H:%M:%S %Y %Z")
-            if expires_at - dt.datetime.now() < dt.timedelta(days=14):
+            if expires_at - dt.datetime.utcnow() < dt.timedelta(days=14):
                 return CheckActivityOutput(
                     errors=["Live proxy certificate is expiring soon"],
                     warnings=[],

--- a/posthog/temporal/proxy_service/test/monitor_test.py
+++ b/posthog/temporal/proxy_service/test/monitor_test.py
@@ -1,0 +1,144 @@
+import json
+
+import pytest
+from freezegun import freeze_time
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+import requests
+
+from posthog.models import Organization, ProxyRecord
+from posthog.temporal.proxy_service.monitor import CheckActivityInput, check_proxy_is_live
+
+
+class TestCheckProxyIsLive(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.proxy_record = ProxyRecord.objects.create(
+            organization=self.organization, domain="us.i.posthog.com", status="active"
+        )
+        self.input = CheckActivityInput(proxy_record_id=self.proxy_record.id)
+
+    @pytest.mark.asyncio
+    @patch("posthog.temporal.proxy_service.monitor.get_record")
+    async def test_check_proxy_is_live_success_live(self, mock_get_record):
+        """Live test against us.i.posthog.com"""
+        mock_get_record.return_value = self.proxy_record
+
+        result = await check_proxy_is_live(self.input)
+
+        # Should succeed without errors or warnings
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.warnings, [])
+
+    @pytest.mark.asyncio
+    @freeze_time("2024-01-16 10:00:00")  # Frozen at Jan 16, cert expires Feb 15 (30 days later)
+    @patch("posthog.temporal.proxy_service.monitor.ssl.create_default_context")
+    @patch("posthog.temporal.proxy_service.monitor.requests.post")
+    @patch("posthog.temporal.proxy_service.monitor.get_record")
+    async def test_check_proxy_is_live_success_mocked(self, mock_get_record, mock_post, mock_ssl_context):
+        """Test successful proxy check with mocked dependencies"""
+        mock_get_record.return_value = self.proxy_record
+
+        # Mock successful HTTP response
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        # Mock SSL certificate check with fixed future date (20 days from frozen time)
+        mock_cert = {"notAfter": "Feb  5 10:00:00 2024 GMT"}
+        mock_socket = Mock()
+        mock_socket.getpeercert.return_value = mock_cert
+
+        mock_context = Mock()
+        mock_wrapped_socket = Mock()
+        mock_wrapped_socket.__enter__ = Mock(return_value=mock_socket)
+        mock_wrapped_socket.__exit__ = Mock(return_value=None)
+        mock_context.wrap_socket.return_value = mock_wrapped_socket
+        mock_ssl_context.return_value = mock_context
+
+        result = await check_proxy_is_live(self.input)
+
+        # Verify the request was made correctly
+        mock_post.assert_called_once_with(
+            f"https://{self.proxy_record.domain}/i/v0/e/",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps({"event": "test", "api_key": "test", "distinct_id": "test"}),
+        )
+
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.warnings, [])
+
+    @pytest.mark.asyncio
+    @patch("posthog.temporal.proxy_service.monitor.requests.post")
+    @patch("posthog.temporal.proxy_service.monitor.get_record")
+    async def test_check_proxy_is_live_ssl_error(self, mock_get_record, mock_post):
+        """Test SSL error handling"""
+        mock_get_record.return_value = self.proxy_record
+        mock_post.side_effect = requests.exceptions.SSLError("SSL certificate problem")
+
+        result = await check_proxy_is_live(self.input)
+
+        self.assertEqual(result.errors, ["Failed to connect to proxy: invalid SSL certificate"])
+        self.assertEqual(result.warnings, [])
+
+    @pytest.mark.asyncio
+    @patch("posthog.temporal.proxy_service.monitor.requests.post")
+    @patch("posthog.temporal.proxy_service.monitor.get_record")
+    async def test_check_proxy_is_live_connection_error(self, mock_get_record, mock_post):
+        """Test connection error handling"""
+        mock_get_record.return_value = self.proxy_record
+        mock_post.side_effect = requests.exceptions.ConnectionError("Connection refused")
+
+        result = await check_proxy_is_live(self.input)
+
+        self.assertEqual(result.errors, ["Failed to connect to proxy"])
+        self.assertEqual(result.warnings, [])
+
+    @pytest.mark.asyncio
+    @patch("posthog.temporal.proxy_service.monitor.requests.post")
+    @patch("posthog.temporal.proxy_service.monitor.get_record")
+    async def test_check_proxy_is_live_http_error(self, mock_get_record, mock_post):
+        """Test HTTP error handling"""
+        mock_get_record.return_value = self.proxy_record
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_post.side_effect = requests.exceptions.HTTPError(response=mock_response)
+
+        result = await check_proxy_is_live(self.input)
+
+        self.assertEqual(result.errors, ["Failed to send event to proxy, expected 200 but got 500"])
+        self.assertEqual(result.warnings, [])
+
+    @pytest.mark.asyncio
+    @freeze_time("2024-01-16 10:00:00")  # Frozen at Jan 16, cert expires Jan 25 (9 days later, < 14 day threshold)
+    @patch("posthog.temporal.proxy_service.monitor.ssl.create_default_context")
+    @patch("posthog.temporal.proxy_service.monitor.requests.post")
+    @patch("posthog.temporal.proxy_service.monitor.get_record")
+    async def test_check_proxy_is_live_cert_expiring_soon(self, mock_get_record, mock_post, mock_ssl_context):
+        """Test certificate expiring soon warning"""
+        mock_get_record.return_value = self.proxy_record
+
+        # Mock successful HTTP response
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        # Mock SSL certificate that expires in 9 days (less than 14 day threshold)
+        mock_cert = {"notAfter": "Jan 25 10:00:00 2024 GMT"}
+        mock_socket = Mock()
+        mock_socket.getpeercert.return_value = mock_cert
+
+        mock_context = Mock()
+        mock_wrapped_socket = Mock()
+        mock_wrapped_socket.__enter__ = Mock(return_value=mock_socket)
+        mock_wrapped_socket.__exit__ = Mock(return_value=None)
+        mock_context.wrap_socket.return_value = mock_wrapped_socket
+        mock_ssl_context.return_value = mock_context
+
+        result = await check_proxy_is_live(self.input)
+
+        self.assertEqual(result.errors, ["Live proxy certificate is expiring soon"])
+        self.assertEqual(result.warnings, [])


### PR DESCRIPTION
## Problem

We currently check _our_ certificate for expiry, but this is noisy as a
bunch of users have wrapped the proxy in e.g. cloudflare, and are
happily using an expired certificate (and showing end-users a cloudflare
generating certificate)

Check the _actual_ certificate that we send events to and alert on this

we'll correlate this with proxies which are receiving traffic/events and
alert accordingly
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

add a new check for the actual ssl certificate we see on the URL, not our managed one
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
