### PR TITLE
fix(workflows): remove useless events filter from workflow conditional steps

### DIFF
--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -101,6 +101,9 @@ class HogFlowActionSerializer(serializers.Serializer):
             for condition in conditions:
                 filters = condition.get("filters")
                 if filters is not None:
+                    if "events" in filters:
+                        raise serializers.ValidationError("Event filters are not allowed in conditionals")
+
                     serializer = HogFunctionFiltersSerializer(data=filters, context=self.context)
                     serializer.is_valid(raise_exception=True)
                     condition["filters"] = serializer.validated_data

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -147,7 +147,7 @@ class TestHogFlowAPI(APIBaseTest):
         )
 
         action["filters"] = {
-            "properties": [{"key": "event", "type": "event_metadata", "value": ["foo_bar_event"], "operator": "exact"}]
+            "properties": [{"key": "event", "type": "event_metadata", "value": ["custom_event"], "operator": "exact"}]
         }
 
         response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
@@ -182,7 +182,7 @@ class TestHogFlowAPI(APIBaseTest):
                                 {
                                     "key": "event",
                                     "type": "event_metadata",
-                                    "value": ["note_created"],
+                                    "value": ["custom_event"],
                                     "operator": "exact",
                                 }
                             ]
@@ -277,7 +277,7 @@ class TestHogFlowAPI(APIBaseTest):
         response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
         assert response.status_code == 400, response.json()
         assert response.json() == {
-            "attr": "actions__1__config__conditions__0__filters",
+            "attr": "actions__1__non_field_errors",
             "code": "invalid_input",
             "detail": "Event filters are not allowed in conditionals",
             "type": "validation_error",

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -147,7 +147,7 @@ class TestHogFlowAPI(APIBaseTest):
         )
 
         action["filters"] = {
-            "events": [{"id": "custom_event", "name": "custom_event", "type": "events", "order": 0}],
+            "properties": [{"key": "event", "type": "event_metadata", "value": ["foo_bar_event"], "operator": "exact"}]
         }
 
         response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
@@ -178,7 +178,14 @@ class TestHogFlowAPI(APIBaseTest):
                 "conditions": [
                     {
                         "filters": {
-                            "events": [{"id": "custom_event", "name": "custom_event", "type": "events", "order": 0}]
+                            "properties": [
+                                {
+                                    "key": "event",
+                                    "type": "event_metadata",
+                                    "value": ["note_created"],
+                                    "operator": "exact",
+                                }
+                            ]
                         }
                     }
                 ],

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -231,3 +231,47 @@ class TestHogFlowAPI(APIBaseTest):
         )
         assert response.status_code == 200, response.json()
         assert response.json()["status"] == "draft"
+
+    def test_hog_flow_conditional_event_filter_rejected(self):
+        conditional_action = {
+            "id": "cond_1",
+            "name": "cond_1",
+            "type": "function",
+            "config": {
+                "template_id": "template-webhook",
+                "inputs": {"url": {"value": "https://example.com"}},
+                "conditions": [
+                    {
+                        "filters": {
+                            "events": [{"id": "custom_event", "name": "custom_event", "type": "events", "order": 0}]
+                        }
+                    }
+                ],
+            },
+        }
+
+        trigger_action = {
+            "id": "trigger_node",
+            "name": "trigger_1",
+            "type": "trigger",
+            "config": {
+                "type": "event",
+                "filters": {
+                    "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                },
+            },
+        }
+
+        hog_flow = {
+            "name": "Test Flow",
+            "actions": [trigger_action, conditional_action],
+        }
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 400, response.json()
+        assert response.json() == {
+            "attr": "actions__1__config__conditions__0__filters",
+            "code": "invalid_input",
+            "detail": "Event filters are not allowed in conditionals",
+            "type": "validation_error",
+        }

--- a/posthog/management/commands/refresh_hog_flows.py
+++ b/posthog/management/commands/refresh_hog_flows.py
@@ -12,6 +12,19 @@ from posthog.models.hog_flow.hog_flow import HogFlow
 logger = structlog.get_logger(__name__)
 
 
+def remove_event_filters_from_conditionals(actions):
+    updated_actions = []
+    for action in actions:
+        conditions = action.get("config", {}).get("conditions", [])
+        if conditions:
+            for condition in conditions:
+                filters = condition.get("filters", {})
+                if "events" in filters:
+                    del filters["events"]
+
+        updated_actions.append(action)
+
+
 class Command(BaseCommand):
     help = "Refresh HogFlows (all statuses) by re-saving them to trigger reload on workers"
 
@@ -99,6 +112,8 @@ class Command(BaseCommand):
                         "actions": hog_flow.actions,
                         "variables": hog_flow.variables,
                     }
+
+                    data.actions = remove_event_filters_from_conditionals(hog_flow.actions)
 
                     # Process through serializer to regenerate bytecode
                     serializer = HogFlowSerializer(

--- a/posthog/management/commands/refresh_hog_flows.py
+++ b/posthog/management/commands/refresh_hog_flows.py
@@ -23,6 +23,7 @@ def remove_event_filters_from_conditionals(actions):
                     del filters["events"]
 
         updated_actions.append(action)
+    return updated_actions
 
 
 class Command(BaseCommand):

--- a/posthog/management/commands/refresh_hog_flows.py
+++ b/posthog/management/commands/refresh_hog_flows.py
@@ -23,6 +23,7 @@ def remove_event_filters_from_conditionals(actions):
                     del filters["events"]
 
         updated_actions.append(action)
+
     return updated_actions
 
 

--- a/posthog/management/commands/refresh_hog_flows.py
+++ b/posthog/management/commands/refresh_hog_flows.py
@@ -114,7 +114,7 @@ class Command(BaseCommand):
                         "variables": hog_flow.variables,
                     }
 
-                    data.actions = remove_event_filters_from_conditionals(hog_flow.actions)
+                    data["actions"] = remove_event_filters_from_conditionals(hog_flow.actions)
 
                     # Process through serializer to regenerate bytecode
                     serializer = HogFlowSerializer(

--- a/posthog/management/commands/test/test_refresh_hog_flows.py
+++ b/posthog/management/commands/test/test_refresh_hog_flows.py
@@ -337,7 +337,7 @@ class TestRefreshHogFlows(BaseTest):
         filters = updated[0]["config"]["conditions"][0]["filters"]
         self.assertNotIn("events", filters)
         self.assertEqual(filters["source"], "events")
-        self.assertJSONEqual(
+        self.assertEqual(
             filters["properties"], [{"key": "$browser", "type": "event", "value": "is_set", "operator": "is_set"}]
         )
 
@@ -365,7 +365,7 @@ class TestRefreshHogFlows(BaseTest):
         filters = updated[0]["config"]["conditions"][0]["filters"]
         self.assertNotIn("events", filters)
         self.assertEqual(filters["source"], "events")
-        self.assertJSONEqual(
+        self.assertEqual(
             filters["properties"], [{"key": "$browser", "type": "event", "value": "is_set", "operator": "is_set"}]
         )
 
@@ -394,5 +394,5 @@ class TestRefreshHogFlows(BaseTest):
         cond2 = updated[0]["config"]["conditions"][1]["filters"]
         self.assertNotIn("events", cond1)
         self.assertNotIn("events", cond2)
-        self.assertJSONEqual(cond1, {"source": "events"})
-        self.assertJSONEqual(cond2, {"source": "events"})
+        self.assertEqual(cond1, {"source": "events"})
+        self.assertEqual(cond2, {"source": "events"})

--- a/posthog/management/commands/test/test_refresh_hog_flows.py
+++ b/posthog/management/commands/test/test_refresh_hog_flows.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 
+from posthog.management.commands.refresh_hog_flows import remove_event_filters_from_conditionals
 from posthog.models import Team
 from posthog.models.hog_flow.hog_flow import HogFlow
 
@@ -310,3 +311,88 @@ class TestRefreshHogFlows(BaseTest):
         self.assertIn("Found 1 HogFlows to process", output)
         self.assertIn("Updated: 1", output)
         self.assertIn("Errors: 0", output)
+
+    def test_remove_event_filters_from_single_condition(self):
+        actions = [
+            {
+                "id": "action_conditional_branch_test",
+                "name": "Conditional branch",
+                "type": "conditional_branch",
+                "config": {
+                    "conditions": [
+                        {
+                            "filters": {
+                                "events": [{"id": "$pageview", "name": "$pageview", "type": "events"}],
+                                "source": "events",
+                                "properties": [
+                                    {"key": "$browser", "type": "event", "value": "is_set", "operator": "is_set"}
+                                ],
+                            }
+                        }
+                    ]
+                },
+            }
+        ]
+        updated = remove_event_filters_from_conditionals(actions)
+        filters = updated[0]["config"]["conditions"][0]["filters"]
+        self.assertNotIn("events", filters)
+        self.assertEqual(filters["source"], "events")
+        self.assertJSONEqual(
+            filters["properties"], [{"key": "$browser", "type": "event", "value": "is_set", "operator": "is_set"}]
+        )
+
+    def test_remove_event_filters_does_not_fail_if_no_events(self):
+        actions = [
+            {
+                "id": "action_conditional_branch_test",
+                "name": "Conditional branch",
+                "type": "conditional_branch",
+                "config": {
+                    "conditions": [
+                        {
+                            "filters": {
+                                "source": "events",
+                                "properties": [
+                                    {"key": "$browser", "type": "event", "value": "is_set", "operator": "is_set"}
+                                ],
+                            }
+                        }
+                    ]
+                },
+            }
+        ]
+        updated = remove_event_filters_from_conditionals(actions)
+        filters = updated[0]["config"]["conditions"][0]["filters"]
+        self.assertNotIn("events", filters)
+        self.assertEqual(filters["source"], "events")
+        self.assertJSONEqual(
+            filters["properties"], [{"key": "$browser", "type": "event", "value": "is_set", "operator": "is_set"}]
+        )
+
+    def test_remove_event_filters_multiple_conditions_and_actions(self):
+        actions = [
+            {
+                "id": "action_conditional_branch_test",
+                "name": "Conditional branch",
+                "type": "conditional_branch",
+                "config": {
+                    "conditions": [
+                        {"filters": {"events": [{"id": "a"}], "source": "events"}},
+                        {"filters": {"source": "events"}},
+                    ]
+                },
+            },
+            {
+                "id": "other_action",
+                "name": "Other",
+                "type": "exit",
+                "config": {},
+            },
+        ]
+        updated = remove_event_filters_from_conditionals(actions)
+        cond1 = updated[0]["config"]["conditions"][0]["filters"]
+        cond2 = updated[0]["config"]["conditions"][1]["filters"]
+        self.assertNotIn("events", cond1)
+        self.assertNotIn("events", cond2)
+        self.assertJSONEqual(cond1, {"source": "events"})
+        self.assertJSONEqual(cond2, {"source": "events"})

--- a/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
@@ -54,11 +54,6 @@ export function HogFlowEventFilters({ filters, setFilters, typeKey, buttonCopy }
             actionsTaxonomicGroupTypes={actionsTaxonomicGroupTypes}
             propertiesTaxonomicGroupTypes={propertyTaxonomicGroupTypes}
             propertyFiltersPopover
-            addFilterDefaultOptions={{
-                id: '$pageview',
-                name: '$pageview',
-                type: 'events',
-            }}
             buttonProps={{
                 type: 'secondary',
             }}

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuild.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuild.tsx
@@ -79,15 +79,7 @@ export const LOGIC_NODES_TO_SHOW: CreateActionType[] = [
         config: {
             conditions: [
                 {
-                    filters: {
-                        events: [
-                            {
-                                id: '$pageview',
-                                name: '$pageview',
-                                type: 'events',
-                            },
-                        ],
-                    },
+                    filters: {},
                 },
             ],
         },

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -59,10 +59,7 @@ export function StepConditionalBranchConfiguration({
             throw new Error('Continue edge not found')
         }
 
-        setConditions([
-            ...conditions,
-            { filters: { events: [{ id: '$pageview', name: '$pageview', type: 'events' }] } },
-        ])
+        setConditions([...conditions, { filters: {} }])
         setWorkflowActionEdges(action.id, [
             ...branchEdges,
             {


### PR DESCRIPTION
## Problem

Context: https://posthoghelp.zendesk.com/agent/tickets/43570 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/45538)
TLDR the newly added event metadata filters seem to be borked due to a default filter value for conditionals. This default filter value includes an events filter which is more appropriate for the trigger filters, but not post-trigger conditionals

## Changes

Fix the bug for new conditionals, add logic to existing hog flow migration script to fix this for existing ones.

## How did you test this code?

Added test, 