### PR TITLE
feat: Preload custom sidebar products from app context

### DIFF
--- a/frontend/src/layout/panel-layout/PinnedFolder/pinnedFolderLogic.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/pinnedFolderLogic.tsx
@@ -7,6 +7,8 @@ import { splitProtocolPath } from '~/layout/panel-layout/ProjectTree/utils'
 
 import type { pinnedFolderLogicType } from './pinnedFolderLogicType'
 
+const LOCAL_STORAGE_PINNED_FOLDER_KEY = 'layout.panel-layout.PinnedFolder.pinnedFolderLogic.lazyLoaders.pinnedFolder'
+
 export const pinnedFolderLogic = kea<pinnedFolderLogicType>([
     path(['layout', 'panel-layout', 'PinnedFolder', 'pinnedFolderLogic']),
     actions({
@@ -14,20 +16,25 @@ export const pinnedFolderLogic = kea<pinnedFolderLogicType>([
     }),
     lazyLoaders(() => ({
         pinnedFolder: [
-            'loading://',
+            localStorage.getItem(LOCAL_STORAGE_PINNED_FOLDER_KEY) || 'loading://',
             {
                 loadPinnedFolder: async () => {
                     const folders = await api.persistedFolder.list()
                     const pinned = folders.results.find((folder) => folder.type === 'pinned')
+
+                    let pinnedFolder = 'products://'
                     if (pinned) {
-                        return `${pinned.protocol || 'products://'}${pinned.path}`
+                        pinnedFolder = `${pinned.protocol || 'products://'}${pinned.path}`
                     }
-                    return 'products://'
+
+                    localStorage.setItem(LOCAL_STORAGE_PINNED_FOLDER_KEY, pinnedFolder)
+                    return pinnedFolder
                 },
                 setPinnedFolder: async (id: string) => {
                     const [protocol, path] = splitProtocolPath(id)
                     await api.persistedFolder.create({ protocol, path, type: 'pinned' })
 
+                    localStorage.setItem(LOCAL_STORAGE_PINNED_FOLDER_KEY, id)
                     return id
                 },
             },

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -165,7 +165,7 @@ export function ProjectTree({
         if (root === 'custom-products://' && (fullFileSystemFiltered.length === 0 || !customProductHelperDismissed)) {
             treeData.push({
                 id: 'products/custom-products-helper-category',
-                name: 'Example apps',
+                name: 'Example custom products',
                 type: 'category',
                 displayName: (
                     <div

--- a/frontend/src/layout/panel-layout/ProjectTree/customProductsLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/customProductsLogic.tsx
@@ -1,7 +1,8 @@
-import { kea, path, selectors } from 'kea'
-import { lazyLoaders } from 'kea-loaders'
+import { kea, path } from 'kea'
+import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
+import { getAppContext } from 'lib/utils/getAppContext'
 
 import type { UserProductListItem } from '~/queries/schema/schema-general'
 
@@ -9,23 +10,16 @@ import type { customProductsLogicType } from './customProductsLogicType'
 
 export const customProductsLogic = kea<customProductsLogicType>([
     path(['layout', 'panel-layout', 'ProjectTree', 'customProductsLogic']),
-    lazyLoaders({
+    loaders(() => ({
         customProducts: [
-            [] as UserProductListItem[],
+            getAppContext()?.custom_products ?? [],
             {
                 loadCustomProducts: async (): Promise<UserProductListItem[]> => {
                     const response = await api.userProductList.list()
-                    return response.results
+
+                    return response.results ?? []
                 },
             },
         ],
-    }),
-    selectors({
-        customProductPaths: [
-            (s) => [s.customProducts],
-            (customProducts: UserProductListItem[]): Set<string> => {
-                return new Set(customProducts.map((item) => item.product_path))
-            },
-        ],
-    }),
+    })),
 ])

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -140,7 +140,7 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
             groupsModel,
             ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus'],
             customProductsLogic,
-            ['customProducts', 'customProductPaths'],
+            ['customProducts'],
         ],
         actions: [panelLayoutLogic, ['setActivePanelIdentifier']],
     })),

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -60,7 +60,7 @@ const FOLDER_LOADING = [
         name: 'Loading...',
         icon: <Spinner />,
         type: 'loading-indicator',
-    },
+    } as TreeDataItem,
 ]
 
 export const projectTreeLogic = kea<projectTreeLogicType>([
@@ -565,15 +565,9 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                     return recentTreeItems
                 }
                 if (loadingPaths[''] && projectTree.length === 0) {
-                    return [
-                        {
-                            id: `folder-loading/`,
-                            name: 'Loading...',
-                            icon: <Spinner />,
-                            type: 'loading-indicator',
-                        },
-                    ]
+                    return FOLDER_LOADING
                 }
+
                 return projectTree
             },
         ],

--- a/frontend/src/lib/components/NavPanelAdvertisement/navPanelAdvertisementRecommendedLogic.ts
+++ b/frontend/src/lib/components/NavPanelAdvertisement/navPanelAdvertisementRecommendedLogic.ts
@@ -15,7 +15,6 @@ export const navPanelAdvertisementRecommendedLogic = kea<navPanelAdvertisementRe
     path(['lib', 'components', 'NavPanelAdvertisement', 'navPanelAdvertisementRecommendedLogic']),
     connect(() => ({
         values: [customProductsLogic, ['customProducts']],
-        actions: [customProductsLogic, ['loadCustomProducts']],
     })),
     selectors({
         recommendedProducts: [

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -74,6 +74,7 @@ import type {
     RevenueAnalyticsConfig,
     SharingConfigurationSettings,
     TileFilters,
+    UserProductListItem,
 } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
@@ -4033,6 +4034,7 @@ export interface AppContext {
     frontend_apps?: Record<number, FrontendAppConfig>
     effective_resource_access_control: Record<AccessControlResourceType, AccessControlLevel>
     resource_access_control: Record<AccessControlResourceType, AccessControlLevel>
+    custom_products: UserProductListItem[]
     commit_sha?: string
     /** Whether the user was autoswitched to the current item's team. */
     switched_team: TeamType['id'] | null

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -134,7 +134,7 @@ class TestAutoProjectMiddleware(APIBaseTest):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.base_app_num_queries = 51
+        cls.base_app_num_queries = 52
         # Create another team that the user does have access to
         cls.second_team = create_team(organization=cls.organization, name="Second Life")
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -26,6 +26,7 @@ from django.apps import apps
 from django.conf import settings
 from django.core.cache import cache
 from django.db import ProgrammingError
+from django.db.models.functions import Lower
 from django.db.utils import DatabaseError
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import get_template
@@ -407,10 +408,12 @@ def get_context_for_template(
 
     # Set the frontend app context
     if not request.GET.get("no-preloaded-app-context"):
+        from posthog.api.file_system.user_product_list import UserProductListSerializer
         from posthog.api.project import ProjectSerializer
         from posthog.api.shared import TeamPublicSerializer
         from posthog.api.team import TeamSerializer
         from posthog.api.user import UserSerializer
+        from posthog.models.file_system.user_product_list import UserProductList
         from posthog.rbac.user_access_control import ACCESS_CONTROL_RESOURCES, UserAccessControl
         from posthog.user_permissions import UserPermissions
         from posthog.views import preflight_check
@@ -421,6 +424,7 @@ def get_context_for_template(
             "current_team": None,
             "preflight": json.loads(preflight_check(request).getvalue()),
             "default_event_name": "$pageview",
+            "custom_products": [],
             "switched_team": getattr(request, "switched_team", None),
             "suggested_users_with_access": getattr(request, "suggested_users_with_access", None),
             "commit_sha": context["git_rev"],
@@ -435,6 +439,7 @@ def get_context_for_template(
             ).data
         elif request.user.pk:
             user = cast("User", request.user)
+
             user_permissions = UserPermissions(user=user, team=user.team)
             user_access_control = UserAccessControl(user=user, team=user.team)
             posthog_app_context["effective_resource_access_control"] = {
@@ -445,6 +450,7 @@ def get_context_for_template(
                 resource: user_access_control.access_level_for_resource(resource)
                 for resource in ACCESS_CONTROL_RESOURCES
             }
+
             user_serialized = UserSerializer(
                 request.user,
                 context={
@@ -456,6 +462,7 @@ def get_context_for_template(
             )
             posthog_app_context["current_user"] = user_serialized.data
             posthog_distinct_id = user_serialized.data.get("distinct_id")
+
             if user.team:
                 team_serialized = TeamSerializer(
                     user.team,
@@ -467,6 +474,7 @@ def get_context_for_template(
                     many=False,
                 )
                 posthog_app_context["current_team"] = team_serialized.data
+
                 project_serialized = ProjectSerializer(
                     user.team.project,
                     context={"request": request, "user_permissions": user_permissions},
@@ -475,6 +483,14 @@ def get_context_for_template(
                 posthog_app_context["current_project"] = project_serialized.data
                 posthog_app_context["frontend_apps"] = get_frontend_apps(user.team.pk)
                 posthog_app_context["default_event_name"] = get_default_event_name(user.team)
+
+                user_product_list = UserProductListSerializer(
+                    UserProductList.objects.filter(team=user.team, user=user, enabled=True).order_by(
+                        Lower("product_path")
+                    ),
+                    many=True,
+                )
+                posthog_app_context["custom_products"] = user_product_list.data
 
     # JSON dumps here since there may be objects like Queries
     # that are not serializable by Django's JSON serializer


### PR DESCRIPTION
Rather than querying the custom products from the backend everytime we mount let's just send it along to the context!
This avoids a "loading" state on the sidebar.

We've also updated the pinned folder code slightly to just use the cached value from local storage since it doesn't change that often
and it's ok to have it blink once when we fix the cache rather than everytime