### PR TITLE
fix(ai): Actually use todo examples defined on mode class

### DIFF
--- a/ee/hogai/core/agent_modes/presets/sql.py
+++ b/ee/hogai/core/agent_modes/presets/sql.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from posthog.schema import AgentMode
 
@@ -64,23 +64,21 @@ The assistant used the todo list because:
 3. This approach allows for tracking progress across the entire request
 """.strip()
 
-POSITIVE_TODO_EXAMPLES: list[TodoWriteExample] = [
-    TodoWriteExample(
-        example=POSITIVE_EXAMPLE_INSIGHT_WITH_SEGMENTATION,
-        reasoning=POSITIVE_EXAMPLE_INSIGHT_WITH_SEGMENTATION_REASONING,
-    ),
-    TodoWriteExample(
-        example=POSITIVE_EXAMPLE_COMPANY_CHURN_ANALYSIS, reasoning=POSITIVE_EXAMPLE_COMPANY_CHURN_ANALYSIS_REASONING
-    ),
-    TodoWriteExample(
-        example=POSITIVE_EXAMPLE_MULTIPLE_METRICS_ANALYSIS,
-        reasoning=POSITIVE_EXAMPLE_MULTIPLE_METRICS_ANALYSIS_REASONING,
-    ),
-]
-
 
 class SQLAgentToolkit(AgentToolkit):
-    POSITIVE_TODO_EXAMPLES = POSITIVE_TODO_EXAMPLES
+    POSITIVE_TODO_EXAMPLES: ClassVar[list[TodoWriteExample]] = [
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_INSIGHT_WITH_SEGMENTATION,
+            reasoning=POSITIVE_EXAMPLE_INSIGHT_WITH_SEGMENTATION_REASONING,
+        ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_COMPANY_CHURN_ANALYSIS, reasoning=POSITIVE_EXAMPLE_COMPANY_CHURN_ANALYSIS_REASONING
+        ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_MULTIPLE_METRICS_ANALYSIS,
+            reasoning=POSITIVE_EXAMPLE_MULTIPLE_METRICS_ANALYSIS_REASONING,
+        ),
+    ]
 
     @property
     def tools(self) -> list[type["MaxTool"]]:

--- a/ee/hogai/core/agent_modes/presets/sql.py
+++ b/ee/hogai/core/agent_modes/presets/sql.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 
 from posthog.schema import AgentMode
 
@@ -66,7 +66,7 @@ The assistant used the todo list because:
 
 
 class SQLAgentToolkit(AgentToolkit):
-    POSITIVE_TODO_EXAMPLES: ClassVar[list[TodoWriteExample]] = [
+    POSITIVE_TODO_EXAMPLES = [
         TodoWriteExample(
             example=POSITIVE_EXAMPLE_INSIGHT_WITH_SEGMENTATION,
             reasoning=POSITIVE_EXAMPLE_INSIGHT_WITH_SEGMENTATION_REASONING,

--- a/ee/hogai/core/agent_modes/test/test_toolkit.py
+++ b/ee/hogai/core/agent_modes/test/test_toolkit.py
@@ -1,0 +1,62 @@
+from posthog.test.base import BaseTest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langchain_core.runnables import RunnableConfig
+
+from ee.hogai.context import AssistantContextManager
+from ee.hogai.core.agent_modes.toolkit import AgentToolkit, AgentToolkitManager
+from ee.hogai.tools.todo_write import TodoWriteExample, TodoWriteTool
+from ee.hogai.utils.types import AssistantState
+
+
+class TestAgentToolkitManager(BaseTest):
+    async def test_accumulates_todo_examples_from_both_toolkits(self):
+        agent_positive = TodoWriteExample(example="agent positive", reasoning="agent reasoning")
+        agent_negative = TodoWriteExample(example="agent negative", reasoning="agent reasoning")
+        mode_positive = TodoWriteExample(example="mode positive", reasoning="mode reasoning")
+        mode_negative = TodoWriteExample(example="mode negative", reasoning="mode reasoning")
+
+        class AgentToolkitWithExamples(AgentToolkit):
+            POSITIVE_TODO_EXAMPLES = [agent_positive]
+            NEGATIVE_TODO_EXAMPLES = [agent_negative]
+
+            @property
+            def tools(self):
+                return [TodoWriteTool]
+
+        class ModeToolkitWithExamples(AgentToolkit):
+            POSITIVE_TODO_EXAMPLES = [mode_positive]
+            NEGATIVE_TODO_EXAMPLES = [mode_negative]
+
+            @property
+            def tools(self):
+                return []
+
+        AgentToolkitManager.configure(
+            agent_toolkit=AgentToolkitWithExamples,
+            mode_toolkit=ModeToolkitWithExamples,
+            mode_registry={},
+        )
+
+        context_manager = AssistantContextManager(
+            team=self.team, user=self.user, config=RunnableConfig(configurable={})
+        )
+        manager = AgentToolkitManager(team=self.team, user=self.user, context_manager=context_manager)
+
+        with patch.object(TodoWriteTool, "create_tool_class", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = MagicMock()
+
+            state = AssistantState(messages=[])
+            await manager.get_tools(state, RunnableConfig(configurable={}))
+
+            mock_create.assert_called_once()
+            call_kwargs = mock_create.call_args.kwargs
+
+            self.assertEqual(
+                call_kwargs["positive_examples"],
+                [agent_positive, mode_positive],
+            )
+            self.assertEqual(
+                call_kwargs["negative_examples"],
+                [agent_negative, mode_negative],
+            )

--- a/ee/hogai/core/agent_modes/toolkit.py
+++ b/ee/hogai/core/agent_modes/toolkit.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import Awaitable, Sequence
-from typing import TYPE_CHECKING, ClassVar, TypeVar, cast
+from typing import TYPE_CHECKING, TypeVar, cast
 
 import structlog
 from langchain_core.messages import BaseMessage
@@ -37,11 +37,11 @@ logger = structlog.get_logger(__name__)
 
 
 class AgentToolkit:
-    POSITIVE_TODO_EXAMPLES: ClassVar[Sequence["TodoWriteExample"] | None] = None
+    POSITIVE_TODO_EXAMPLES: Sequence["TodoWriteExample"] | None = None
     """
     Positive examples that will be injected into the `todo_write` tool. Use this field to explain the agent how it should orchestrate complex tasks using provided tools.
     """
-    NEGATIVE_TODO_EXAMPLES: ClassVar[Sequence["TodoWriteExample"] | None] = None
+    NEGATIVE_TODO_EXAMPLES: Sequence["TodoWriteExample"] | None = None
     """
     Negative examples that will be injected into the `todo_write` tool. Use this field to explain the agent how it should **NOT** orchestrate tasks using provided tools.
     """
@@ -95,12 +95,18 @@ class AgentToolkitManager:
         cls._mode_registry = mode_registry
 
     async def get_tools(self, state: AssistantState, config: RunnableConfig) -> list["MaxTool"]:
-        # Processed tools
-        available_tools: list[MaxTool] = []
+        toolkits = [self._agent_toolkit, self._mode_toolkit]
+
+        # Accumulate positive and negative examples from all toolkits
+        positive_examples: list[TodoWriteExample] = []
+        negative_examples: list[TodoWriteExample] = []
+        for toolkit_class in toolkits:
+            positive_examples.extend(toolkit_class.POSITIVE_TODO_EXAMPLES or [])
+            negative_examples.extend(toolkit_class.NEGATIVE_TODO_EXAMPLES or [])
 
         # Initialize the static toolkit
         static_tools: list[Awaitable[MaxTool]] = []
-        for toolkit_class in [self._agent_toolkit, self._mode_toolkit]:
+        for toolkit_class in toolkits:
             toolkit = toolkit_class(team=self._team, user=self._user, context_manager=self._context_manager)
             for tool_class in toolkit.tools:
                 if tool_class is TodoWriteTool:
@@ -112,8 +118,8 @@ class AgentToolkitManager:
                         state=state,
                         config=config,
                         context_manager=self._context_manager,
-                        positive_examples=toolkit.POSITIVE_TODO_EXAMPLES,
-                        negative_examples=toolkit.NEGATIVE_TODO_EXAMPLES,
+                        positive_examples=positive_examples,
+                        negative_examples=negative_examples,
                     )
                     static_tools.append(todo_future)
                 elif tool_class == SwitchModeTool:
@@ -138,6 +144,5 @@ class AgentToolkitManager:
                         context_manager=self._context_manager,
                     )
                     static_tools.append(tool_future)
-        available_tools.extend(await asyncio.gather(*static_tools))
 
-        return available_tools
+        return await asyncio.gather(*static_tools)

--- a/ee/hogai/tools/todo_write.py
+++ b/ee/hogai/tools/todo_write.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Literal, Self
+from typing import ClassVar, Literal, Self
 
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
@@ -153,19 +153,6 @@ The assistant used the todo list because:
 3. This approach allows for tracking progress across the entire request
 """.strip()
 
-POSITIVE_TODO_EXAMPLES: list[TodoWriteExample] = [
-    TodoWriteExample(
-        example=POSITIVE_EXAMPLE_INSIGHT_WITH_SEGMENTATION,
-        reasoning=POSITIVE_EXAMPLE_INSIGHT_WITH_SEGMENTATION_REASONING,
-    ),
-    TodoWriteExample(
-        example=POSITIVE_EXAMPLE_COMPANY_CHURN_ANALYSIS, reasoning=POSITIVE_EXAMPLE_COMPANY_CHURN_ANALYSIS_REASONING
-    ),
-    TodoWriteExample(
-        example=POSITIVE_EXAMPLE_MULTIPLE_METRICS_ANALYSIS,
-        reasoning=POSITIVE_EXAMPLE_MULTIPLE_METRICS_ANALYSIS_REASONING,
-    ),
-]
 
 NEGATIVE_EXAMPLE_SIMPLE_QUERY_EXPLANATION = """
 User: What does this query do?
@@ -190,15 +177,6 @@ NEGATIVE_EXAMPLE_DOCUMENTATION_REQUEST_REASONING = """
 The assistant did not use the todo list because this is an informational request. The user is simply asking for help, not for the assistant to perform multiple steps or tasks.
 """.strip()
 
-NEGATIVE_TODO_EXAMPLES: list[TodoWriteExample] = [
-    TodoWriteExample(
-        example=NEGATIVE_EXAMPLE_SIMPLE_QUERY_EXPLANATION, reasoning=NEGATIVE_EXAMPLE_SIMPLE_QUERY_EXPLANATION_REASONING
-    ),
-    TodoWriteExample(
-        example=NEGATIVE_EXAMPLE_DOCUMENTATION_REQUEST, reasoning=NEGATIVE_EXAMPLE_DOCUMENTATION_REQUEST_REASONING
-    ),
-]
-
 
 # Has its unique schema that doesn't match the Deep Research schema
 class TodoItem(BaseModel):
@@ -214,6 +192,29 @@ class TodoWriteToolArgs(BaseModel):
 class TodoWriteTool(MaxTool):
     name: Literal["todo_write"] = "todo_write"
     args_schema: type[BaseModel] = TodoWriteToolArgs
+
+    POSITIVE_TODO_EXAMPLES: ClassVar[list[TodoWriteExample]] = [
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_INSIGHT_WITH_SEGMENTATION,
+            reasoning=POSITIVE_EXAMPLE_INSIGHT_WITH_SEGMENTATION_REASONING,
+        ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_COMPANY_CHURN_ANALYSIS, reasoning=POSITIVE_EXAMPLE_COMPANY_CHURN_ANALYSIS_REASONING
+        ),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_MULTIPLE_METRICS_ANALYSIS,
+            reasoning=POSITIVE_EXAMPLE_MULTIPLE_METRICS_ANALYSIS_REASONING,
+        ),
+    ]
+    NEGATIVE_TODO_EXAMPLES: ClassVar[list[TodoWriteExample]] = [
+        TodoWriteExample(
+            example=NEGATIVE_EXAMPLE_SIMPLE_QUERY_EXPLANATION,
+            reasoning=NEGATIVE_EXAMPLE_SIMPLE_QUERY_EXPLANATION_REASONING,
+        ),
+        TodoWriteExample(
+            example=NEGATIVE_EXAMPLE_DOCUMENTATION_REQUEST, reasoning=NEGATIVE_EXAMPLE_DOCUMENTATION_REQUEST_REASONING
+        ),
+    ]
 
     async def _arun_impl(self, todos: list[TodoItem]) -> tuple[str, None]:
         return (
@@ -236,8 +237,8 @@ class TodoWriteTool(MaxTool):
     ) -> Self:
         formatted_prompt = format_prompt_string(
             TODO_WRITE_PROMPT,
-            positive_todo_examples=_format_todo_write_examples(positive_examples or POSITIVE_TODO_EXAMPLES),
-            negative_todo_examples=_format_todo_write_examples(negative_examples or NEGATIVE_TODO_EXAMPLES),
+            positive_todo_examples=_format_todo_write_examples(positive_examples or cls.POSITIVE_TODO_EXAMPLES),
+            negative_todo_examples=_format_todo_write_examples(negative_examples or cls.NEGATIVE_TODO_EXAMPLES),
         )
         return cls(
             team=team,

--- a/ee/hogai/tools/todo_write.py
+++ b/ee/hogai/tools/todo_write.py
@@ -73,11 +73,12 @@ When unsure, use this tool. Proactive task management shows attentiveness and he
 """.strip()
 
 TODO_WRITE_EXAMPLE_PROMPT = """
+<example>
 {{{example}}}
-{{#reasoning}}
-
+<reasoning>
 {{{reasoning}}}
-{{/reasoning}}
+</reasoning>
+</example>
 """.strip()
 
 


### PR DESCRIPTION
## Problem

The examples for mode-specific planning with the `todo_write` tool weren't actually being used when set as `POSITIVE_TODO_EXAMPLES`/`NEGATIVE_TODO_EXAMPLES` on the mode class! Instead of `cls.POSITIVE_TODO_EXAMPLES`, the global var `POSITIVE_TODO_EXAMPLES` was used – so only calling `create_tool_class()` would have worked, but this wasn't in use. I checked traces.

## Changes

Fixed `TodoItem`.
