### PR TITLE
feat(surveys): update messaging on FF quick-create modal

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -885,6 +885,7 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
                     flag: featureFlag,
                     initialVariantKey: quickSurveyVariantKey,
                 }}
+                info="This survey will display to all users in this feature flag, filtered by any conditions you specify below."
                 isOpen={isQuickSurveyModalOpen}
                 onCancel={() => {
                     setIsQuickSurveyModalOpen(false)

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -243,6 +243,7 @@ function FeatureFlagRowActions({ featureFlag }: { featureFlag: FeatureFlagType }
             />
             <QuickSurveyModal
                 context={{ type: QuickSurveyType.FEATURE_FLAG, flag: featureFlag }}
+                info="This survey will display to all users in this feature flag, filtered by any conditions you specify below."
                 isOpen={isQuickSurveyModalOpen}
                 onCancel={() => setIsQuickSurveyModalOpen(false)}
             />

--- a/frontend/src/scenes/surveys/QuickSurveyModal.tsx
+++ b/frontend/src/scenes/surveys/QuickSurveyModal.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { useMemo, useRef } from 'react'
 
-import { LemonButton, LemonLabel, LemonModal, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonLabel, LemonModal, LemonTextArea } from '@posthog/lemon-ui'
 
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { SurveyAppearancePreview } from 'scenes/surveys/SurveyAppearancePreview'
@@ -19,7 +19,7 @@ import {
 import { QuickSurveyFormProps, QuickSurveyType } from './quick-create/types'
 import { buildLogicProps } from './quick-create/utils'
 
-export function QuickSurveyForm({ context, onCancel }: QuickSurveyFormProps): JSX.Element {
+export function QuickSurveyForm({ context, info, onCancel }: QuickSurveyFormProps): JSX.Element {
     const logicProps: QuickSurveyFormLogicProps = useMemo(() => {
         return {
             ...buildLogicProps(context),
@@ -41,7 +41,9 @@ export function QuickSurveyForm({ context, onCancel }: QuickSurveyFormProps): JS
 
     return (
         <>
-            <div className="grid grid-cols-2 gap-6">
+            {info && <LemonBanner type="info">{info}</LemonBanner>}
+
+            <div className="grid grid-cols-2 gap-6 mt-2">
                 <div className="space-y-4">
                     <div>
                         <LemonLabel className="mb-2">Question for users</LemonLabel>
@@ -130,12 +132,13 @@ export function QuickSurveyForm({ context, onCancel }: QuickSurveyFormProps): JS
 
 export function QuickSurveyModal({
     context,
+    info,
     onCancel,
     isOpen,
 }: QuickSurveyFormProps & { isOpen: boolean }): JSX.Element {
     return (
         <LemonModal title="Quick feedback survey" isOpen={isOpen} onClose={onCancel} width={900}>
-            <QuickSurveyForm context={context} onCancel={onCancel} />
+            <QuickSurveyForm context={context} info={info} onCancel={onCancel} />
         </LemonModal>
     )
 }

--- a/frontend/src/scenes/surveys/quick-create/types.ts
+++ b/frontend/src/scenes/surveys/quick-create/types.ts
@@ -8,6 +8,7 @@ export type QuickSurveyContext = {
 
 export interface QuickSurveyFormProps {
     context: QuickSurveyContext
+    info?: string
     onCancel?: () => void
 }
 


### PR DESCRIPTION
## Problem
looking at session recordings, there appears to be some hesitation when this modal is opened. my hunch is that the targeting is unclear. adding a note to the quick-create modal to mitigate any confusion

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

![Screenshot 2025-12-01 at 10.41.02 AM.png](https://app.graphite.com/user-attachments/assets/52fa5b70-1d4c-4245-a7d7-fc9fc5caccf7.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
