### PR TITLE
fix: Drop grouptypemapping - dashboard cross-database foreign key

### DIFF
--- a/rust/persons_migrations/20251201000001_drop_dashboard_fk_constraint.sql
+++ b/rust/persons_migrations/20251201000001_drop_dashboard_fk_constraint.sql
@@ -1,0 +1,10 @@
+-- Drop foreign key constraint that shouldn't exist per Django model db_constraint=False
+-- This constraint causes issues with cross-database relationships where GroupTypeMapping
+-- (in persons_db) references Dashboard (in default db)
+--
+-- Background: Migration 0692_grouptypemapping_detail_dashboard.py created this constraint
+-- when both tables were in the same database, but GroupTypeMapping was later moved to
+-- persons_db while the constraint remained, causing FK validation failures.
+
+ALTER TABLE posthog_grouptypemapping
+    DROP CONSTRAINT IF EXISTS posthog_grouptypemapping_detail_dashboard_id_fk;


### PR DESCRIPTION
## Problem
Users are not able to create group overview dashboards due to a f[oreign key violation](https://us.posthog.com/error_tracking/019a0c54-c466-76f1-a0bc-3fa82bf821bb) between dashboards and group type mapping tables.

These tables shouldn't have a foreign key in the first place, as they live in separate database instances. The constraint existence is likely a leftover from persons db migration, so we should drop it.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Closes https://github.com/PostHog/posthog/issues/41994
Closes https://github.com/PostHog/posthog/issues/40838
## Changes
Drop `posthog_grouptypemapping_detail_dashboard_id_fk` foreign key from persons db
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Local environment doesn't have the constraint, this happens in prod only. So I needed to recreate the problematic constraint locally to replicate the behavior:
- Created a dummy `posthog_dashboard` table in my local `persons_db`
- Created the fk relationship between dashboards and group type mapping
- Tried creating the dashboard - if failed
- Wrote and ran migration to drop the constraint
- Confirmed in the GUI + query that the constraint got dropped
- Tried creating the dashboard - it worked
- 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No, not a feature
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
