### PR TITLE
fix: Remove conditional rendering check for token reset button

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagSettings.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSettings.tsx
@@ -119,7 +119,7 @@ export function FeatureFlagSettings({ inModal = false }: FeatureFlagSettingsProp
 }
 
 export function FlagsSecureApiKeys(): JSX.Element {
-    const { currentTeam } = useValues(teamLogic)
+    const { currentTeam, isTeamTokenResetAvailable } = useValues(teamLogic)
     const { deleteSecretTokenBackup, rotateSecretToken } = useActions(teamLogic)
 
     const openResetDialog = (): void => {
@@ -184,6 +184,9 @@ export function FlagsSecureApiKeys(): JSX.Element {
                         icon={<IconRefresh />}
                         noPadding
                         onClick={openResetDialog}
+                        disabledReason={
+                            !isTeamTokenResetAvailable ? 'You do not have permission to rotate this key' : undefined
+                        }
                         tooltip={currentTeam?.secret_api_token ? 'Rotate key' : 'Generate key'}
                     />
                 }

--- a/frontend/src/scenes/feature-flags/FeatureFlagSettings.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSettings.tsx
@@ -119,7 +119,7 @@ export function FeatureFlagSettings({ inModal = false }: FeatureFlagSettingsProp
 }
 
 export function FlagsSecureApiKeys(): JSX.Element {
-    const { currentTeam, isTeamTokenResetAvailable } = useValues(teamLogic)
+    const { currentTeam } = useValues(teamLogic)
     const { deleteSecretTokenBackup, rotateSecretToken } = useActions(teamLogic)
 
     const openResetDialog = (): void => {
@@ -180,14 +180,12 @@ export function FlagsSecureApiKeys(): JSX.Element {
             </h3>
             <CodeSnippet
                 actions={
-                    isTeamTokenResetAvailable ? (
-                        <LemonButton
-                            icon={<IconRefresh />}
-                            noPadding
-                            onClick={openResetDialog}
-                            tooltip={currentTeam?.secret_api_token ? 'Rotate key' : 'Generate key'}
-                        />
-                    ) : undefined
+                    <LemonButton
+                        icon={<IconRefresh />}
+                        noPadding
+                        onClick={openResetDialog}
+                        tooltip={currentTeam?.secret_api_token ? 'Rotate key' : 'Generate key'}
+                    />
                 }
                 className={currentTeam?.secret_api_token ? '' : 'text-muted'}
                 thing="Primary Feature Flags Secure API key"


### PR DESCRIPTION
## Problem

Customer reported that the rotate button for the Feature Flags Secure API key was not visible in their UI. They didn't have permissions, but the system was displaying misleading information about clicking the hidden button.

https://posthoghelp.zendesk.com/agent/tickets/43705 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/45539)

## Changes

- The rotate button is now always visible instead of being conditionally hidden
- When the user lacks permissions, the button is disabled with a clear tooltip message: "You do not have permission to rotate this key"

<img width="1930" height="238" alt="image" src="https://github.com/user-attachments/assets/b16e33fe-663c-48d2-be4c-3e87a89703dc" />

## How did you test this code?

- Manually verified the rotate button is disabled in the Feature Flags settings when the user doesn't have permissions