### PR TITLE
feat(data-modeling): add cycle detection / dag mismatch detection into edge model directly 

### DIFF
--- a/products/data_modeling/backend/migrations/0004_drop_detect_cycles_function.py
+++ b/products/data_modeling/backend/migrations/0004_drop_detect_cycles_function.py
@@ -1,0 +1,14 @@
+# manually created by andrewjmcgehee
+
+from django.db import migrations
+
+DROP_DETECT_CYCLES = """\
+DROP FUNCTION IF EXISTS posthog_datamodelingedge_detect_cycles();
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("data_modeling", "0003_create_detect_cycles_function"),
+    ]
+    operations = [migrations.RunSQL(DROP_DETECT_CYCLES)]

--- a/products/data_modeling/backend/migrations/max_migration.txt
+++ b/products/data_modeling/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0003_create_detect_cycles_function
+0004_drop_detect_cycles_function

--- a/products/data_modeling/backend/models/edge.py
+++ b/products/data_modeling/backend/models/edge.py
@@ -1,18 +1,62 @@
-from django.db import models
+from django.db import connection, models, transaction
 
+from posthog.models import Team
 from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDModel
+
+from .node import Node
+
+DISALLOWED_UPDATE_FIELDS = ("dag_id", "source", "source_id", "target", "target_id", "team", "team_id")
+
+
+class CycleDetectionError(Exception):
+    """The exception raised when an edge would cause a cycle in a DAG"""
+
+    pass
+
+
+class DAGMismatchError(Exception):
+    """exception raised when an edge would connect two different DAGs together"""
+
+    pass
+
+
+class DataModelingEdgeQuerySet(models.QuerySet):
+    def update(self, **kwargs):
+        for key in DISALLOWED_UPDATE_FIELDS:
+            if key in kwargs:
+                raise NotImplementedError(
+                    f"QuerySet.update() is disabled for fields ({DISALLOWED_UPDATE_FIELDS}) to ensure cycle detection. "
+                    "Use individual save() calls instead."
+                )
+        return super().update(**kwargs)
+
+    def bulk_create(self, objs, *args, **kwargs):
+        del objs, args, kwargs  # unused
+        raise NotImplementedError("bulk_create() is disabled for Edge objects to ensure cycle detection.")
+
+    def bulk_update(self, objs, fields, *args, **kwargs):
+        for key in DISALLOWED_UPDATE_FIELDS:
+            if key in kwargs:
+                raise NotImplementedError(
+                    f"QuerySet.bulk_update() is disabled for fields ({DISALLOWED_UPDATE_FIELDS}) to ensure cycle detection. "
+                    "Use individual save() calls instead."
+                )
+        return super().bulk_update(objs, fields, *args, **kwargs)
+
+
+class DataModelingEdgeManager(models.Manager):
+    def get_queryset(self):
+        return DataModelingEdgeQuerySet(self.model, using=self._db)
 
 
 class Edge(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
-    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, editable=False)
+    objects = DataModelingEdgeManager()
+
+    team = models.ForeignKey(Team, on_delete=models.CASCADE, editable=False)
     # the source node of the edge (i.e. the node this edge is pointed away from)
-    source = models.ForeignKey(
-        "data_modeling.Node", related_name="outgoing_edges", on_delete=models.CASCADE, editable=False
-    )
+    source = models.ForeignKey(Node, related_name="outgoing_edges", on_delete=models.CASCADE, editable=False)
     # the target node of the edge (i.e. the node this edge is pointed toward)
-    target = models.ForeignKey(
-        "data_modeling.Node", related_name="incoming_edges", on_delete=models.CASCADE, editable=False
-    )
+    target = models.ForeignKey(Node, related_name="incoming_edges", on_delete=models.CASCADE, editable=False)
     # the name of the DAG this edge belongs to
     dag_id = models.TextField(max_length=256, default="posthog", db_index=True, editable=False)
     properties = models.JSONField(default=dict)
@@ -22,3 +66,65 @@ class Edge(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
         constraints = [
             models.UniqueConstraint(fields=["dag_id", "source", "target"], name="unique_within_dag"),
         ]
+
+    def save(self, *args, **kwargs):
+        with transaction.atomic():
+            self._detect_cycles()
+            self._detect_dag_mismatch()
+            super().save(*args, **kwargs)
+
+    def _detect_cycles(self):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_xact_lock(%s, hashtext(%s))", [self.team_id, self.dag_id])
+        # trivial case: self loop
+        if self.source_id == self.target_id:
+            raise CycleDetectionError(
+                f"Self-loop detected: team={self.team_id} dag={self.dag_id} "
+                f"source={self.source_id} target={self.target_id}"
+            )
+        # recursive case
+        if self._creates_cycle():
+            raise CycleDetectionError(
+                f"Cycle detected: team={self.team_id} dag={self.dag_id} source={self.source_id} target={self.target_id}"
+            )
+
+    def _creates_cycle(self):
+        sql = """
+            WITH RECURSIVE reachable(node_id) AS (
+                SELECT e.target_id
+                FROM posthog_datamodelingedge e
+                WHERE e.source_id = '{target_id}'
+                    AND e.team_id = '{team_id}'
+                    AND e.dag_id = '{dag_id}'
+                UNION
+                SELECT e.target_id
+                FROM posthog_datamodelingedge e
+                INNER JOIN reachable r
+                ON e.source_id = r.node_id
+                WHERE e.target_id <> '{target_id}'
+                    AND e.team_id = '{team_id}'
+                    AND e.dag_id = '{dag_id}'
+            )
+            SELECT 1 FROM reachable WHERE node_id = '{source_id}'
+        """
+        with connection.cursor() as cursor:
+            cursor.execute(
+                sql.format(team_id=self.team_id, dag_id=self.dag_id, source_id=self.source_id, target_id=self.target_id)
+            )
+            return cursor.fetchone() is not None
+
+    def _detect_dag_mismatch(self):
+        source = Node.objects.get(id=self.source_id)
+        target = Node.objects.get(id=self.target_id)
+        if source.team_id != self.team_id or target.team_id != self.team_id:
+            raise DAGMismatchError(
+                f"Edge team_id ({self.team_id}) does not match "
+                f"source node team_id ({source.team_id}) or "
+                f"target node team_id ({target.team_id})"
+            )
+        if source.dag_id != self.dag_id or target.dag_id != self.dag_id:
+            raise DAGMismatchError(
+                f"Edge dag_id ({self.dag_id}) does not match "
+                f"source node dag_id ({source.dag_id}) or "
+                f"target node dag_id ({target.dag_id})"
+            )

--- a/products/data_modeling/backend/test/test_cycle_detection.py
+++ b/products/data_modeling/backend/test/test_cycle_detection.py
@@ -1,0 +1,190 @@
+from freezegun import freeze_time
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from products.data_modeling.backend.models import CycleDetectionError, Edge, Node
+from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+
+LINKED_LIST_DAG_ID = "linked_list"
+BALANCED_TREE_DAG_ID = "balanced_tree"
+
+
+def _basic_saved_query_with_label(label: str):
+    return f"""SELECT '{label}'"""
+
+
+class LinkedListCycleDetectionTest(BaseTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        with freeze_time("2025-01-01T12:00:00.000Z"):
+            ll_queries = [
+                DataWarehouseSavedQuery.objects.create(
+                    name=f"ll_{i}",
+                    team=cls.team,
+                    query=_basic_saved_query_with_label(str(i)),
+                )
+                for i in range(25)
+            ]
+            ll_nodes = [
+                Node.objects.create(team=cls.team, dag_id=LINKED_LIST_DAG_ID, saved_query=query, name=f"ll_{i}")
+                for i, query in enumerate(ll_queries)
+            ]
+            for i in range(len(ll_nodes) - 1):
+                Edge.objects.create(
+                    team=cls.team,
+                    dag_id=LINKED_LIST_DAG_ID,
+                    source=ll_nodes[i],
+                    target=ll_nodes[i + 1],
+                )
+
+    @parameterized.expand(
+        [
+            # low index to high index is always fine
+            ("0", "24", False),
+            ("0", "5", False),
+            ("0", "2", False),  # note 0, 1 would be a duplicate edge and would fail
+            # self cycle case
+            ("0", "0", True),
+            # high index to low always causes a cycle
+            ("1", "0", True),
+            ("5", "0", True),
+            ("24", "0", True),
+        ],
+    )
+    def test_linked_list_dag(self, source_label, target_label, should_raise):
+        source = Node.objects.get(saved_query__name=f"ll_{source_label}")
+        target = Node.objects.get(saved_query__name=f"ll_{target_label}")
+        if should_raise:
+            with self.assertRaises(Exception):
+                Edge.objects.create(team=source.team, dag_id=LINKED_LIST_DAG_ID, source=source, target=target)
+        else:
+            edge = Edge.objects.create(team=source.team, dag_id=LINKED_LIST_DAG_ID, source=source, target=target)
+            edge.delete()
+
+
+class TreeCycleDetectionTest(BaseTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        with freeze_time("2025-01-01T12:00:00.000Z"):
+            bt_root = [
+                DataWarehouseSavedQuery.objects.create(
+                    name="bt_root",
+                    team=cls.team,
+                    query=_basic_saved_query_with_label("root"),
+                )
+            ]
+            bt_children = [
+                DataWarehouseSavedQuery.objects.create(
+                    name=f"bt_child_{i}",
+                    team=cls.team,
+                    query=_basic_saved_query_with_label(f"child_{i}"),
+                )
+                for i in range(5)
+            ]
+            bt_grandchildren = [
+                DataWarehouseSavedQuery.objects.create(
+                    name=f"bt_child_{i}_child_{j}",
+                    team=cls.team,
+                    query=_basic_saved_query_with_label(f"child_{i}_child_{j}"),
+                )
+                for i in range(5)
+                for j in range(5)
+            ]
+            bt_nodes = [
+                Node.objects.create(team=cls.team, dag_id=BALANCED_TREE_DAG_ID, saved_query=query, name=query.name)
+                for query in bt_root + bt_children + bt_grandchildren
+            ]
+            root = bt_nodes[0]
+            children = bt_nodes[1:6]
+            for i, child in enumerate(children):
+                Edge.objects.create(team=cls.team, dag_id=BALANCED_TREE_DAG_ID, source=root, target=child)
+                for j in range(5):
+                    grandchild = bt_nodes[6 + i * 5 + j]
+                    Edge.objects.create(
+                        team=cls.team,
+                        dag_id=BALANCED_TREE_DAG_ID,
+                        source=child,
+                        target=grandchild,
+                    )
+
+    @parameterized.expand(
+        [
+            # root to any grandchild is always fine
+            ("root", "child_0_child_0", False),
+            ("root", "child_2_child_0", False),
+            ("root", "child_4_child_0", False),
+            # child to any grandchild is always fine
+            ("child_0", "child_1_child_0", False),
+            ("child_0", "child_2_child_0", False),
+            ("child_0", "child_4_child_0", False),
+            # self cycle case
+            ("root", "root", True),
+            # child to root always causes a cycle
+            ("child_0", "root", True),
+            ("child_2", "root", True),
+            ("child_4", "root", True),
+            # grandchild to root always causes a cycle
+            ("child_0_child_0", "root", True),
+            ("child_2_child_0", "root", True),
+            ("child_4_child_0", "root", True),
+            # grandchild to any child not its parent is always fine (i.e. root -> 0 -> 0_0 -> 1 + root -> 1 = no cycle)
+            ("child_1_child_0", "child_0", False),
+            ("child_2_child_0", "child_0", False),
+            ("child_4_child_0", "child_0", False),
+            # any grandchild to its parent always causes a cycle
+            ("child_0_child_0", "child_0", True),
+            ("child_0_child_2", "child_0", True),
+            ("child_0_child_4", "child_0", True),
+            # any child to any other child is always fine
+            ("child_0", "child_1", False),
+            ("child_0", "child_2", False),
+            ("child_0", "child_4", False),
+            # any grandchild to any other grandchild is always fine
+            ("child_0_child_0", "child_1_child_1", False),
+            ("child_0_child_0", "child_2_child_2", False),
+            ("child_0_child_0", "child_4_child_4", False),
+        ],
+    )
+    def test_tree_like_dag(self, source_label, target_label, should_raise):
+        source = Node.objects.get(saved_query__name=f"bt_{source_label}")
+        target = Node.objects.get(saved_query__name=f"bt_{target_label}")
+        if should_raise:
+            with self.assertRaises(CycleDetectionError):
+                Edge.objects.create(team=source.team, dag_id=BALANCED_TREE_DAG_ID, source=source, target=target)
+        else:
+            edge = Edge.objects.create(team=source.team, dag_id=BALANCED_TREE_DAG_ID, source=source, target=target)
+            edge.delete()
+
+    def test_disallowed_object_functions(self):
+        test_team = self.team
+        test_node = Node.objects.get(name="bt_root")
+        bt_edges = Edge.objects.filter(dag_id=BALANCED_TREE_DAG_ID)
+        disallowed = ("dag_id", "source", "source_id", "target", "target_id", "team", "team_id")
+        for key in disallowed:
+            # test update disallowed for each key
+            with self.assertRaises(NotImplementedError):
+                if key.endswith("id"):
+                    bt_edges.update(**{key: "test"})
+                elif key == "source":
+                    bt_edges.update(source=test_node)
+                elif key == "target":
+                    bt_edges.update(target=test_node)
+                elif key == "team":
+                    bt_edges.update(team=test_team)
+            # test bulk_update disallowed for each key
+            mock_edges = [Edge(source=test_node, target=test_node, team=test_team, dag_id="test") for _ in range(3)]
+            for edge in mock_edges:
+                if key.endswith("id"):
+                    setattr(edge, key, "test")
+                elif key in ("source", "target"):
+                    setattr(edge, key, test_node)
+                elif key == "team":
+                    setattr(edge, key, test_team)
+            with self.assertRaises(NotImplementedError):
+                Edge.objects.bulk_update(mock_edges, [key])
+        # test bulk_create disallowed
+        with self.assertRaises(NotImplementedError):
+            Edge.objects.bulk_create(bt_edges)

--- a/products/data_modeling/backend/test/test_dag_mismatch.py
+++ b/products/data_modeling/backend/test/test_dag_mismatch.py
@@ -1,0 +1,68 @@
+from freezegun import freeze_time
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from products.data_modeling.backend.models import Edge, Node
+from products.data_modeling.backend.models.edge import DAGMismatchError
+from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+
+A_DAG_ID = "A"
+B_DAG_ID = "B"
+
+
+def _basic_saved_query_with_label(label: str):
+    return f"""SELECT '{label}'"""
+
+
+class DagMismatchTest(BaseTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        with freeze_time("2025-01-01T12:00:00.000Z"):
+            a1_query = DataWarehouseSavedQuery.objects.create(
+                name="a1",
+                team=cls.team,
+                query=_basic_saved_query_with_label("a1"),
+            )
+            a2_query = DataWarehouseSavedQuery.objects.create(
+                name="a2",
+                team=cls.team,
+                query=_basic_saved_query_with_label("a2"),
+            )
+            a3_query = DataWarehouseSavedQuery.objects.create(
+                name="a3",
+                team=cls.team,
+                query=_basic_saved_query_with_label("a3"),
+            )
+            a1_node = Node.objects.create(team=cls.team, dag_id=A_DAG_ID, saved_query=a1_query, name="a1")
+            a2_node = Node.objects.create(team=cls.team, dag_id=A_DAG_ID, saved_query=a2_query, name="a2")
+            # a3 intentionally left disconnected to test connecting two nodes with same dag id with an edge
+            # that has a different dag_id
+            Node.objects.create(team=cls.team, dag_id=A_DAG_ID, saved_query=a3_query, name="a3")
+            Edge.objects.create(team=cls.team, dag_id=A_DAG_ID, source=a1_node, target=a2_node)
+            b_query = DataWarehouseSavedQuery.objects.create(
+                name="b",
+                team=cls.team,
+                query=_basic_saved_query_with_label("b"),
+            )
+            Node.objects.create(team=cls.team, dag_id=B_DAG_ID, saved_query=b_query, name="b")
+
+    @parameterized.expand(
+        [
+            # create edge from A to B DAG should fail regardless of dag id
+            ("a1", "b", A_DAG_ID),
+            ("a2", "b", A_DAG_ID),
+            ("a1", "b", B_DAG_ID),
+            ("a2", "b", B_DAG_ID),
+            # create edge from A to A DAG should fail if edge belongs to DAG B
+            ("a1", "a3", B_DAG_ID),
+        ],
+    )
+    def test_dag_mismatch(self, source_label, target_label, dag_id):
+        # note that we don't have to test update() calls because we have it disabled
+        # to force edges to only be created or updated (when key fields are involved)
+        source = Node.objects.get(name=source_label)
+        target = Node.objects.get(name=target_label)
+        with self.assertRaises(DAGMismatchError):
+            Edge.objects.create(team=source.team, dag_id=dag_id, source=source, target=target)


### PR DESCRIPTION
## Problem

Cycles in DAGs and DAG mismatches on edges / the nodes involved.

## Changes

Detect them (but this time in app level code and not on the DB)

## How did you test this code?

Manually and via the parametrized django model tests included in the PR

## Changelog: (features only) Is this feature complete?

No