### PR TITLE
fix: removing id as well from custom events

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
@@ -123,6 +123,13 @@ export function ConversionGoalDropdown({ value, onChange, typeKey }: ConversionG
                         }
                     }
 
+                    // Clean up EventsNode: remove id field (EventsNode uses event, not id)
+                    if (newFilter.kind === NodeKind.EventsNode) {
+                        if ('id' in newFilter) {
+                            delete (newFilter as any).id
+                        }
+                    }
+
                     // Override the schema with the schema from the data warehouse
                     if (data_warehouse?.[0]?.type === EntityTypes.DATA_WAREHOUSE) {
                         const dwNode = data_warehouse[0] as DataWarehouseFilter & Record<ConversionGoalSchema, string>


### PR DESCRIPTION
## Problem

Same as the other problem when a custom event is defined we cannot send the id . So when it's an action -> remove event (done) and now if it's event -> remove id.

## Changes
Removing the id from events


I will probably revisit all this code if I get new errors because probably could be done in a better way 😅 