### PR TITLE
fix: Handle S3 `NoSuchKey` as cache miss instead of error

### DIFF
--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -143,7 +143,7 @@ class HyperCache:
                 return json.loads(data), "redis"
 
         try:
-            data = object_storage.read(cache_key)
+            data = object_storage.read(cache_key, missing_ok=True)
             if data:
                 response = json.loads(data)
                 HYPERCACHE_CACHE_COUNTER.labels(result="hit_s3", namespace=self.namespace, value=self.value).inc()

--- a/posthog/storage/object_storage.py
+++ b/posthog/storage/object_storage.py
@@ -193,7 +193,7 @@ class ObjectStorage(ObjectStorageClient):
                 bucket=bucket,
                 file_name=key,
                 error=e,
-                s3_response=s3_response,
+                s3_response={},
             )
             capture_exception(e)
             raise ObjectStorageError("read failed") from e

--- a/posthog/storage/object_storage.py
+++ b/posthog/storage/object_storage.py
@@ -43,11 +43,11 @@ class ObjectStorageClient(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def read(self, bucket: str, key: str) -> Optional[str]:
+    def read(self, bucket: str, key: str, *, missing_ok: bool = False) -> Optional[str]:
         pass
 
     @abc.abstractmethod
-    def read_bytes(self, bucket: str, key: str) -> Optional[bytes]:
+    def read_bytes(self, bucket: str, key: str, *, missing_ok: bool = False) -> Optional[bytes]:
         pass
 
     @abc.abstractmethod
@@ -88,10 +88,10 @@ class UnavailableStorage(ObjectStorageClient):
     def list_objects(self, bucket: str, prefix: str) -> Optional[list[str]]:
         pass
 
-    def read(self, bucket: str, key: str) -> Optional[str]:
+    def read(self, bucket: str, key: str, *, missing_ok: bool = False) -> Optional[str]:
         return None
 
-    def read_bytes(self, bucket: str, key: str) -> Optional[bytes]:
+    def read_bytes(self, bucket: str, key: str, *, missing_ok: bool = False) -> Optional[bytes]:
         return None
 
     def tag(self, bucket: str, key: str, tags: dict[str, str]) -> None:
@@ -172,21 +172,21 @@ class ObjectStorage(ObjectStorageClient):
             capture_exception(e)
             return None
 
-    def read(self, bucket: str, key: str) -> Optional[str]:
-        object_bytes = self.read_bytes(bucket, key)
+    def read(self, bucket: str, key: str, *, missing_ok: bool = False) -> Optional[str]:
+        object_bytes = self.read_bytes(bucket, key, missing_ok=missing_ok)
         if object_bytes:
             return object_bytes.decode("utf-8")
         else:
             return None
 
-    def read_bytes(self, bucket: str, key: str) -> Optional[bytes]:
+    def read_bytes(self, bucket: str, key: str, *, missing_ok: bool = False) -> Optional[bytes]:
         s3_response = {}
         try:
             s3_response = self.aws_client.get_object(Bucket=bucket, Key=key)
             return s3_response["Body"].read()
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code")
-            if error_code == "NoSuchKey":
+            if error_code == "NoSuchKey" and missing_ok:
                 return None
             logger.exception(
                 "object_storage.read_failed",
@@ -309,13 +309,15 @@ def tag(file_name: str, tags: dict[str, str]) -> None:
     return object_storage_client().tag(bucket=settings.OBJECT_STORAGE_BUCKET, key=file_name, tags=tags)
 
 
-def read(file_name: str, bucket: str | None = None) -> Optional[str]:
-    return object_storage_client().read(bucket=bucket or settings.OBJECT_STORAGE_BUCKET, key=file_name)
+def read(file_name: str, bucket: str | None = None, *, missing_ok: bool = False) -> Optional[str]:
+    return object_storage_client().read(
+        bucket=bucket or settings.OBJECT_STORAGE_BUCKET, key=file_name, missing_ok=missing_ok
+    )
 
 
-def read_bytes(file_name: str, bucket: str | None = None) -> Optional[bytes]:
+def read_bytes(file_name: str, bucket: str | None = None, *, missing_ok: bool = False) -> Optional[bytes]:
     bucket = bucket or settings.OBJECT_STORAGE_BUCKET
-    return object_storage_client().read_bytes(bucket, file_name)
+    return object_storage_client().read_bytes(bucket, file_name, missing_ok=missing_ok)
 
 
 def list_objects(prefix: str) -> Optional[list[str]]:

--- a/posthog/storage/test/test_object_storage.py
+++ b/posthog/storage/test/test_object_storage.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from boto3 import resource
 from botocore.client import Config
+from botocore.exceptions import ClientError
 
 from posthog.settings import (
     OBJECT_STORAGE_ACCESS_KEY_ID,
@@ -15,6 +16,7 @@ from posthog.settings import (
 )
 from posthog.storage.object_storage import (
     ObjectStorage,
+    ObjectStorageError,
     copy_objects,
     get_presigned_post,
     get_presigned_url,
@@ -184,3 +186,21 @@ class TestStorage(APIBaseTest):
         result = storage.read_bytes("test-bucket", "test-key")
         mock_client.get_object.assert_called_with(Bucket="test-bucket", Key="test-key")
         assert result == b"test content"
+
+    def test_read_bytes_returns_none_for_nosuchkey(self):
+        mock_client = MagicMock()
+        error_response = {"Error": {"Code": "NoSuchKey", "Message": "The specified key does not exist."}}
+        mock_client.get_object.side_effect = ClientError(error_response, "GetObject")  # type: ignore[arg-type]
+        storage = ObjectStorage(mock_client)
+
+        result = storage.read_bytes("test-bucket", "nonexistent-key")
+        assert result is None
+
+    def test_read_bytes_raises_for_other_client_errors(self):
+        mock_client = MagicMock()
+        error_response = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
+        mock_client.get_object.side_effect = ClientError(error_response, "GetObject")  # type: ignore[arg-type]
+        storage = ObjectStorage(mock_client)
+
+        with self.assertRaises(ObjectStorageError):
+            storage.read_bytes("test-bucket", "test-key")


### PR DESCRIPTION
## Problem

When reading from S3 object storage, a missing key (`NoSuchKey`) is an expected scenario for cache misses, not an error condition. Previously, this was logged as an error, causing noise when running cache verification commands against teams without warmed caches.


## Changes

Added a new `missing_ok` parameter to `read` and `read_bytes` in posthog/storage/object_storage.py. By default, they are `False` preserving existing behavior. If `True`, then `NoSuchKey` returns `None `(indicating cache miss) rather than raising an error. Other S3 errors still raise `ObjectStorageError` as before.

## How did you test this code?

Unit Tests
Manual test of `python manage.py verify_flags_cache`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
