### PR TITLE
fix: Detect old versions with leading v

### DIFF
--- a/dags/sdk_doctor/github_sdk_versions.py
+++ b/dags/sdk_doctor/github_sdk_versions.py
@@ -203,7 +203,7 @@ def fetch_node_sdk_data() -> dict[str, Any]:
     # `posthog-node` was originally developed on the `posthog-js-lite` repo, but was later moved to the `posthog-js` monorepo
     # We fetch the latest version from both repos and join them together.
     posthog_js = fetch_sdk_data_from_releases("PostHog/posthog-js", tag_prefixes=["posthog-node@"])
-    posthog_js_lite = fetch_sdk_data_from_releases("PostHog/posthog-js-lite", tag_prefixes=["posthog-node-"])
+    posthog_js_lite = fetch_sdk_data_from_releases("PostHog/posthog-js-lite", tag_prefixes=["posthog-node-v"])
 
     # Shouldn't happen, but just in case
     if not posthog_js:
@@ -225,7 +225,7 @@ def fetch_react_native_sdk_data() -> dict[str, Any]:
     # `posthog-react-native` was originally developed on the `posthog-js-lite` repo, but was later moved to the `posthog-js` monorepo
     # We fetch the latest version from both repos and join them together.
     posthog_js = fetch_sdk_data_from_releases("PostHog/posthog-js", tag_prefixes=["posthog-react-native@"])
-    posthog_js_lite = fetch_sdk_data_from_releases("PostHog/posthog-js-lite", tag_prefixes=["posthog-react-native-"])
+    posthog_js_lite = fetch_sdk_data_from_releases("PostHog/posthog-js-lite", tag_prefixes=["posthog-react-native-v"])
 
     # Shouldn't happen, but just in case
     if not posthog_js:
@@ -243,7 +243,8 @@ def fetch_react_native_sdk_data() -> dict[str, Any]:
 
 def fetch_flutter_sdk_data() -> dict[str, Any]:
     """Fetch Flutter SDK data from GitHub releases API"""
-    return fetch_sdk_data_from_releases("PostHog/posthog-flutter")
+    # First attempt to cut the trailing `v` prefix and then just fallback to the full tag
+    return fetch_sdk_data_from_releases("PostHog/posthog-flutter", tag_prefixes=["v", ""])
 
 
 def fetch_ios_sdk_data() -> dict[str, Any]:

--- a/dags/tests/test_sdk_doctor.py
+++ b/dags/tests/test_sdk_doctor.py
@@ -145,6 +145,9 @@ class TestFetchNodeSdkData(TestFetchSdkDataBase):
         assert result["releaseDates"]["5.14.0"] == "2025-11-24T10:24:59Z"
         assert mock_get.call_count == 3  # Paginated to second page + 1 for `posthog-js-lite`
 
+        # `posthog-js-lite` included a leading `v` prefix on some tags, let's make sure it's removed
+        assert not any(version.startswith("v") for version in result["releaseDates"].keys())
+
 
 class TestFetchReactNativeSdkData(TestFetchSdkDataBase):
     @patch("dags.sdk_doctor.github_sdk_versions.requests.get")
@@ -161,6 +164,9 @@ class TestFetchReactNativeSdkData(TestFetchSdkDataBase):
         assert result["releaseDates"]["4.14.0"] == "2025-11-26T13:26:49Z"
         assert mock_get.call_count == 3  # Paginated to second page + 1 for `posthog-js-lite`
 
+        # `posthog-js-lite` included a leading `v` prefix on some tags, let's make sure it's removed
+        assert not any(version.startswith("v") for version in result["releaseDates"].keys())
+
 
 class TestFetchFlutterSdkData(TestFetchSdkDataBase):
     @patch("dags.sdk_doctor.github_sdk_versions.requests.get")
@@ -176,6 +182,9 @@ class TestFetchFlutterSdkData(TestFetchSdkDataBase):
         assert "5.9.0" in result["releaseDates"]
         assert result["releaseDates"]["5.9.0"] == "2025-11-05T13:22:41Z"
         assert mock_get.call_count == 2  # Paginated to second page
+
+        # `flutter` included a leading `v` prefix on some tags, let's make sure it's removed
+        assert not any(version.startswith("v") for version in result["releaseDates"].keys())
 
 
 class TestFetchIosSdkData(TestFetchSdkDataBase):

--- a/posthog/api/sdk_doctor.py
+++ b/posthog/api/sdk_doctor.py
@@ -50,7 +50,7 @@ def sdk_doctor(request: Request) -> Response:
                 {
                     **entry,
                     "is_latest": entry["lib_version"] == sdk_data_for_lib["latestVersion"],
-                    "release_date": sdk_data_for_lib["releaseDates"][entry["lib_version"]],
+                    "release_date": sdk_data_for_lib["releaseDates"].get(entry["lib_version"], None),
                 }
                 for entry in entries
             ],


### PR DESCRIPTION
Some older version for react-native, node and flutter included a leading v, let's handle that here