### PR TITLE
fix(replay): fix white screen issue w flex grow

### DIFF
--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -299,7 +299,7 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
                                                 ) : null}
                                             </div>
                                             <div
-                                                className="SessionRecordingPlayer__body"
+                                                className="SessionRecordingPlayer__body flex-1"
                                                 draggable={draggable}
                                                 {...elementProps}
                                             >


### PR DESCRIPTION
## Problem

Some users have a white screen that is fixed by openeing the "inspect DOM", and then closing the "inspect DOM", causing a recalculation of layout, makes everything visible as it should be--- Senor Claude thinks this alone is simple enough to fix it..... i'm dubious, but i also cant repro the initial issue locally, so figured test this "fix" in prod 🤷 

This height calculation bits also seems related to this series of "fixes/reverts" 
https://github.com/PostHog/posthog/pull/39920
https://github.com/PostHog/posthog/pull/40164

## Changes

add a flex

## How did you test this code?

renders normally locally still...

![Screenshot 2025-12-01 at 1.29.13 PM.png](https://app.graphite.com/user-attachments/assets/d4f0a05b-54f4-4648-9068-e4ecd4411fc6.png)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
