### PR TITLE
fix: fixing 'or' error in join clause

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_adapters.ambr
+++ b/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_adapters.ambr
@@ -2,7 +2,7 @@
 # name: TestMarketingAnalyticsAdapters.test_azure_adapter_query_generation
   '''
   
-  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'Azure'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('\'USD\'', 'USD', toFloat(coalesce(spend, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion 
+  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'Azure'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('\'USD\'', 'USD', toFloat(coalesce(spend, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion, toString(campaign_name) AS match_key 
   FROM azure_table 
   WHERE and(greaterOrEquals(toDateTime(report_date), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(report_date), toDateTime('2024-12-31 23:59:59')))
   '''
@@ -10,7 +10,7 @@
 # name: TestMarketingAnalyticsAdapters.test_bing_ads_native_query_generation
   '''
   
-  SELECT toString(bing_campaigns.name) AS campaign, toString(bing_campaigns.id) AS id, toString('bing') AS source, toFloat(SUM(toFloatOrZero(bing_campaign_performance_report.impressions))) AS impressions, toFloat(SUM(toFloatOrZero(bing_campaign_performance_report.clicks))) AS clicks, SUM(toFloatOrZero(bing_campaign_performance_report.spend)) AS cost, toFloat(SUM(toFloatOrZero(bing_campaign_performance_report.conversions))) AS reported_conversion 
+  SELECT toString(bing_campaigns.name) AS campaign, toString(bing_campaigns.id) AS id, toString('bing') AS source, toFloat(SUM(toFloatOrZero(bing_campaign_performance_report.impressions))) AS impressions, toFloat(SUM(toFloatOrZero(bing_campaign_performance_report.clicks))) AS clicks, SUM(toFloatOrZero(bing_campaign_performance_report.spend)) AS cost, toFloat(SUM(toFloatOrZero(bing_campaign_performance_report.conversions))) AS reported_conversion, toString(bing_campaigns.name) AS match_key 
   FROM bing_campaigns LEFT JOIN bing_campaign_performance_report ON equals(toString(bing_campaigns.id), toString(bing_campaign_performance_report.campaign_id)) 
   WHERE and(greaterOrEquals(toDateTime(bing_campaign_performance_report.time_period), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(bing_campaign_performance_report.time_period), toDateTime('2024-12-31 23:59:59'))) 
   GROUP BY toString(bing_campaigns.name), toString(bing_campaigns.id)
@@ -19,7 +19,7 @@
 # name: TestMarketingAnalyticsAdapters.test_cloudflare_r2_adapter_query_generation
   '''
   
-  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'Cloudflare'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('\'USD\'', 'USD', toFloat(coalesce(spend, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion 
+  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'Cloudflare'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('\'USD\'', 'USD', toFloat(coalesce(spend, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion, toString(campaign_name) AS match_key 
   FROM cloudflare_table 
   WHERE and(greaterOrEquals(toDateTime(report_date), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(report_date), toDateTime('2024-12-31 23:59:59')))
   '''
@@ -27,7 +27,7 @@
 # name: TestMarketingAnalyticsAdapters.test_currency_conversion_handling
   '''
   
-  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'Facebook'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('spend_currency', 'USD', toFloat(coalesce(spend_amount, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion 
+  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'Facebook'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('spend_currency', 'USD', toFloat(coalesce(spend_amount, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion, toString(campaign_name) AS match_key 
   FROM currency_test_table 
   WHERE and(greaterOrEquals(toDateTime(date), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(date), toDateTime('2024-12-31 23:59:59')))
   '''
@@ -35,7 +35,7 @@
 # name: TestMarketingAnalyticsAdapters.test_facebook_ads_query_generation
   '''
   
-  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'Facebook'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('\'USD\'', 'USD', toFloat(coalesce(spend_usd, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion 
+  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'Facebook'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('\'USD\'', 'USD', toFloat(coalesce(spend_usd, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion, toString(campaign_name) AS match_key 
   FROM facebook_table 
   WHERE and(greaterOrEquals(toDateTime(report_date), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(report_date), toDateTime('2024-12-31 23:59:59')))
   '''
@@ -43,7 +43,7 @@
 # name: TestMarketingAnalyticsAdapters.test_google_ads_query_generation
   '''
   
-  SELECT toString(google_campaign.campaign_name) AS campaign, toString(google_campaign.campaign_id) AS id, toString('google') AS source, toFloat(SUM(google_stats.metrics_impressions)) AS impressions, toFloat(SUM(google_stats.metrics_clicks)) AS clicks, toFloat(convertCurrency('USD', 'USD', SUM(toFloat(divide(google_stats.metrics_cost_micros, 1000000))))) AS cost, toFloat(SUM(google_stats.metrics_conversions)) AS reported_conversion 
+  SELECT toString(google_campaign.campaign_name) AS campaign, toString(google_campaign.campaign_id) AS id, toString('google') AS source, toFloat(SUM(google_stats.metrics_impressions)) AS impressions, toFloat(SUM(google_stats.metrics_clicks)) AS clicks, toFloat(convertCurrency('USD', 'USD', SUM(toFloat(divide(google_stats.metrics_cost_micros, 1000000))))) AS cost, toFloat(SUM(google_stats.metrics_conversions)) AS reported_conversion, toString(google_campaign.campaign_name) AS match_key 
   FROM google_campaign LEFT JOIN google_stats ON equals(google_campaign.campaign_id, google_stats.campaign_id) 
   WHERE and(greaterOrEquals(toDateTime(google_stats.segments_date), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(google_stats.segments_date), toDateTime('2024-12-31 23:59:59'))) 
   GROUP BY toString(google_campaign.campaign_name), toString(google_campaign.campaign_id)
@@ -52,16 +52,34 @@
 # name: TestMarketingAnalyticsAdapters.test_linkedin_ads_query_generation
   '''
   
-  SELECT toString(linkedin_campaigns.name) AS campaign, toString(linkedin_campaigns.id) AS id, toString('linkedin') AS source, toFloat(SUM(linkedin_stats.impressions)) AS impressions, toFloat(SUM(linkedin_stats.clicks)) AS clicks, toFloat(SUM(toFloat(linkedin_stats.cost_in_usd))) AS cost, toFloat(SUM(linkedin_stats.external_website_conversions)) AS reported_conversion 
+  SELECT toString(linkedin_campaigns.name) AS campaign, toString(linkedin_campaigns.id) AS id, toString('linkedin') AS source, toFloat(SUM(linkedin_stats.impressions)) AS impressions, toFloat(SUM(linkedin_stats.clicks)) AS clicks, toFloat(SUM(toFloat(linkedin_stats.cost_in_usd))) AS cost, toFloat(SUM(linkedin_stats.external_website_conversions)) AS reported_conversion, toString(linkedin_campaigns.name) AS match_key 
   FROM linkedin_campaigns LEFT JOIN linkedin_stats ON equals(linkedin_campaigns.id, linkedin_stats.campaign_id) 
   WHERE and(greaterOrEquals(toDateTime(linkedin_stats.date_start), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(linkedin_stats.date_start), toDateTime('2024-12-31 23:59:59'))) 
   GROUP BY toString(linkedin_campaigns.name), toString(linkedin_campaigns.id)
   '''
 # ---
+# name: TestMarketingAnalyticsAdapters.test_match_key_uses_campaign_id_when_configured
+  '''
+  
+  SELECT toString(metaads_campaigns.name) AS campaign, toString(metaads_campaigns.id) AS id, toString('meta') AS source, toFloat(SUM(toFloat(metaads_campaign_stats.impressions))) AS impressions, toFloat(SUM(toFloat(metaads_campaign_stats.clicks))) AS clicks, SUM(toFloat(metaads_campaign_stats.spend)) AS cost, 0 AS reported_conversion, toString(metaads_campaigns.id) AS match_key 
+  FROM metaads_campaigns LEFT JOIN metaads_campaign_stats ON equals(metaads_campaigns.id, metaads_campaign_stats.campaign_id) 
+  WHERE and(greaterOrEquals(toDateTime(metaads_campaign_stats.date_stop), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(metaads_campaign_stats.date_stop), toDateTime('2024-12-31 23:59:59'))) 
+  GROUP BY toString(metaads_campaigns.name), toString(metaads_campaigns.id)
+  '''
+# ---
+# name: TestMarketingAnalyticsAdapters.test_match_key_uses_campaign_name_by_default
+  '''
+  
+  SELECT toString(metaads_campaigns.name) AS campaign, toString(metaads_campaigns.id) AS id, toString('meta') AS source, toFloat(SUM(toFloat(metaads_campaign_stats.impressions))) AS impressions, toFloat(SUM(toFloat(metaads_campaign_stats.clicks))) AS clicks, SUM(toFloat(metaads_campaign_stats.spend)) AS cost, 0 AS reported_conversion, toString(metaads_campaigns.name) AS match_key 
+  FROM metaads_campaigns LEFT JOIN metaads_campaign_stats ON equals(metaads_campaigns.id, metaads_campaign_stats.campaign_id) 
+  WHERE and(greaterOrEquals(toDateTime(metaads_campaign_stats.date_stop), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(metaads_campaign_stats.date_stop), toDateTime('2024-12-31 23:59:59'))) 
+  GROUP BY toString(metaads_campaigns.name), toString(metaads_campaigns.id)
+  '''
+# ---
 # name: TestMarketingAnalyticsAdapters.test_meta_ads_query_generation
   '''
   
-  SELECT toString(meta_campaigns.name) AS campaign, toString(meta_campaigns.id) AS id, toString('meta') AS source, toFloat(SUM(toFloat(meta_campaign_stats.impressions))) AS impressions, toFloat(SUM(toFloat(meta_campaign_stats.clicks))) AS clicks, SUM(toFloat(meta_campaign_stats.spend)) AS cost, 0 AS reported_conversion 
+  SELECT toString(meta_campaigns.name) AS campaign, toString(meta_campaigns.id) AS id, toString('meta') AS source, toFloat(SUM(toFloat(meta_campaign_stats.impressions))) AS impressions, toFloat(SUM(toFloat(meta_campaign_stats.clicks))) AS clicks, SUM(toFloat(meta_campaign_stats.spend)) AS cost, 0 AS reported_conversion, toString(meta_campaigns.name) AS match_key 
   FROM meta_campaigns LEFT JOIN meta_campaign_stats ON equals(meta_campaigns.id, meta_campaign_stats.campaign_id) 
   WHERE and(greaterOrEquals(toDateTime(meta_campaign_stats.date_stop), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(meta_campaign_stats.date_stop), toDateTime('2024-12-31 23:59:59'))) 
   GROUP BY toString(meta_campaigns.name), toString(meta_campaigns.id)
@@ -70,7 +88,7 @@
 # name: TestMarketingAnalyticsAdapters.test_reddit_ads_query_generation
   '''
   
-  SELECT toString(reddit_campaign.name) AS campaign, toString(reddit_campaign.id) AS id, toString('reddit') AS source, toFloat(SUM(reddit_stats.impressions)) AS impressions, toFloat(SUM(reddit_stats.clicks)) AS clicks, SUM(toFloat(divide(reddit_stats.spend, 1000000))) AS cost, toFloat(plus(SUM(reddit_stats.conversion_signup_total_value), SUM(reddit_stats.conversion_purchase_total_items))) AS reported_conversion 
+  SELECT toString(reddit_campaign.name) AS campaign, toString(reddit_campaign.id) AS id, toString('reddit') AS source, toFloat(SUM(reddit_stats.impressions)) AS impressions, toFloat(SUM(reddit_stats.clicks)) AS clicks, SUM(toFloat(divide(reddit_stats.spend, 1000000))) AS cost, toFloat(plus(SUM(reddit_stats.conversion_signup_total_value), SUM(reddit_stats.conversion_purchase_total_items))) AS reported_conversion, toString(reddit_campaign.name) AS match_key 
   FROM reddit_campaign LEFT JOIN reddit_stats ON equals(reddit_campaign.id, reddit_stats.campaign_id) 
   WHERE and(greaterOrEquals(toDateTime(reddit_stats.date), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(reddit_stats.date), toDateTime('2024-12-31 23:59:59'))) 
   GROUP BY toString(reddit_campaign.name), toString(reddit_campaign.id)
@@ -79,7 +97,7 @@
 # name: TestMarketingAnalyticsAdapters.test_tiktok_ads_native_query_generation
   '''
   
-  SELECT toString(tiktok_campaigns.campaign_name) AS campaign, toString(tiktok_campaigns.campaign_id) AS id, toString('tiktok') AS source, toFloat(SUM(toFloatOrZero(tiktok_campaign_report.impressions))) AS impressions, toFloat(SUM(toFloatOrZero(tiktok_campaign_report.clicks))) AS clicks, SUM(toFloatOrZero(tiktok_campaign_report.spend)) AS cost, toFloat(SUM(toFloatOrZero(tiktok_campaign_report.conversion))) AS reported_conversion 
+  SELECT toString(tiktok_campaigns.campaign_name) AS campaign, toString(tiktok_campaigns.campaign_id) AS id, toString('tiktok') AS source, toFloat(SUM(toFloatOrZero(tiktok_campaign_report.impressions))) AS impressions, toFloat(SUM(toFloatOrZero(tiktok_campaign_report.clicks))) AS clicks, SUM(toFloatOrZero(tiktok_campaign_report.spend)) AS cost, toFloat(SUM(toFloatOrZero(tiktok_campaign_report.conversion))) AS reported_conversion, toString(tiktok_campaigns.campaign_name) AS match_key 
   FROM tiktok_campaigns LEFT JOIN tiktok_campaign_report ON equals(tiktok_campaigns.campaign_id, tiktok_campaign_report.campaign_id) 
   WHERE and(greaterOrEquals(toDateTime(tiktok_campaign_report.stat_time_day), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(tiktok_campaign_report.stat_time_day), toDateTime('2024-12-31 23:59:59'))) 
   GROUP BY toString(tiktok_campaigns.campaign_name), toString(tiktok_campaigns.campaign_id)
@@ -88,7 +106,7 @@
 # name: TestMarketingAnalyticsAdapters.test_tiktok_ads_query_generation
   '''
   
-  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'TikTok'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('\'USD\'', 'USD', toFloat(coalesce(spend, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion 
+  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'TikTok'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('\'USD\'', 'USD', toFloat(coalesce(spend, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion, toString(campaign_name) AS match_key 
   FROM tiktok_table 
   WHERE and(greaterOrEquals(toDateTime(report_date), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(report_date), toDateTime('2024-12-31 23:59:59')))
   '''
@@ -98,10 +116,10 @@
   
   SELECT campaign AS campaign, source AS source, impressions AS impressions, clicks AS clicks, cost AS cost 
   FROM (
-  SELECT toString(campaign_id) AS campaign, toString(campaign_id) AS id, toString(`'Facebook'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('currency', 'USD', toFloat(coalesce(spend, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion 
+  SELECT toString(campaign_id) AS campaign, toString(campaign_id) AS id, toString(`'Facebook'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('currency', 'USD', toFloat(coalesce(spend, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion, toString(campaign_id) AS match_key 
   FROM facebook_table 
   WHERE and(greaterOrEquals(toDateTime(date), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(date), toDateTime('2024-12-31 23:59:59'))) UNION ALL 
-  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'TikTok'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('currency', 'USD', toFloat(coalesce(spend, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion 
+  SELECT toString(campaign_name) AS campaign, toString(campaign_name) AS id, toString(`'TikTok'`) AS source, toFloat(coalesce(impressions, 0)) AS impressions, toFloat(coalesce(clicks, 0)) AS clicks, toFloat(convertCurrency('currency', 'USD', toFloat(coalesce(spend, 0)))) AS cost, toFloat(coalesce(conversions, 0)) AS reported_conversion, toString(campaign_name) AS match_key 
   FROM tiktok_table 
   WHERE and(greaterOrEquals(toDateTime(date), toDateTime('2024-01-01 00:00:00')), lessOrEquals(toDateTime(date), toDateTime('2024-12-31 23:59:59')))) AS all_marketing_data
   '''

--- a/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_conversion_goal_processor.ambr
+++ b/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_conversion_goal_processor.ambr
@@ -6,6 +6,7 @@
       if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
       if(notEmpty(campaign_id), campaign_id, '-') AS id,
       if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
+      if(notEmpty(campaign_name), campaign_name, 'organic') AS match_key,
       count() AS conversion_0
   
   FROM
@@ -69,6 +70,7 @@
       if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
       if(notEmpty(campaign_id), campaign_id, '-') AS id,
       if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
+      if(notEmpty(campaign_name), campaign_name, 'organic') AS match_key,
       count() AS conversion_0
   
   FROM
@@ -132,6 +134,7 @@
       if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
       if(notEmpty(campaign_id), campaign_id, '-') AS id,
       if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
+      if(notEmpty(campaign_name), campaign_name, 'organic') AS match_key,
       count() AS conversion_0
   
   FROM
@@ -195,6 +198,7 @@
       if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
       if(notEmpty(campaign_id), campaign_id, '-') AS id,
       if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
+      if(notEmpty(campaign_name), campaign_name, 'organic') AS match_key,
       count() AS conversion_0
   
   FROM
@@ -258,6 +262,7 @@
       if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
       if(notEmpty(campaign_id), campaign_id, '-') AS id,
       if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
+      if(notEmpty(campaign_name), campaign_name, 'organic') AS match_key,
       count() AS conversion_0
   
   FROM
@@ -321,6 +326,7 @@
       if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
       if(notEmpty(campaign_id), campaign_id, '-') AS id,
       if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
+      if(notEmpty(campaign_name), campaign_name, 'organic') AS match_key,
       count() AS conversion_1
   
   FROM
@@ -384,6 +390,7 @@
       if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
       if(notEmpty(campaign_id), campaign_id, '-') AS id,
       if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
+      if(notEmpty(campaign_name), campaign_name, 'organic') AS match_key,
       coalesce(sum(conversion_value), 0) AS conversion_0
   
   FROM
@@ -447,6 +454,7 @@
       if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
       if(notEmpty(campaign_id), campaign_id, '-') AS id,
       if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
+      if(notEmpty(campaign_name), campaign_name, 'organic') AS match_key,
       count() AS conversion_0
   
   FROM

--- a/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_conversion_goals_aggregator.ambr
+++ b/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_conversion_goals_aggregator.ambr
@@ -6,6 +6,7 @@
       multiIf(and(in(lower(conv.source), ['google', 'adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), in(lower(conv.campaign), ['spring_sale_2024', 'spring-sale-2024'])), 'Spring Sale 2024', and(in(lower(conv.source), ['google', 'adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), in(lower(conv.campaign), ['holiday_campaign', 'holiday_promo'])), 'Holiday Promo', conv.campaign) AS campaign,
       conv.id AS id,
       conv.source AS source,
+      multiIf(and(in(lower(conv.source), ['google', 'adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), in(lower(conv.campaign), ['spring_sale_2024', 'spring-sale-2024'])), 'Spring Sale 2024', and(in(lower(conv.source), ['google', 'adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), in(lower(conv.campaign), ['holiday_campaign', 'holiday_promo'])), 'Holiday Promo', conv.campaign) AS match_key,
       sum(conv.conversion_0) AS conversion_0
   
   FROM
@@ -82,6 +83,7 @@
       conv.campaign AS campaign,
       conv.id AS id,
       conv.source AS source,
+      conv.campaign AS match_key,
       sum(conv.conversion_0) AS conversion_0
   
   FROM
@@ -158,6 +160,7 @@
       multiIf(and(in(lower(conv.source), ['google', 'adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), in(lower(conv.campaign), ['messy_campaign_1', 'messy_campaign_2', 'messy_campaign_3'])), 'Clean Campaign Name', conv.campaign) AS campaign,
       conv.id AS id,
       conv.source AS source,
+      multiIf(and(in(lower(conv.source), ['google', 'adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), in(lower(conv.campaign), ['messy_campaign_1', 'messy_campaign_2', 'messy_campaign_3'])), 'Clean Campaign Name', conv.campaign) AS match_key,
       sum(conv.conversion_0) AS conversion_0
   
   FROM
@@ -234,6 +237,7 @@
       multiIf(and(in(lower(conv.source), ['google', 'adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), in(lower(conv.campaign), ['spring_sale_2024', 'spring-sale-2024', 'spring_sale'])), 'Spring Sale 2024', and(in(lower(conv.source), ['google', 'adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), in(lower(conv.campaign), ['bf_2024', 'blackfriday', 'bf-promo'])), 'Black Friday', and(in(lower(conv.source), ['meta', 'facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), in(lower(conv.campaign), ['spring_sale_fb', 'springsalefb'])), 'Spring Sale 2024', and(in(lower(conv.source), ['meta', 'facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), in(lower(conv.campaign), ['summer_2024', 'summer_promo'])), 'Summer Campaign', conv.campaign) AS campaign,
       conv.id AS id,
       conv.source AS source,
+      multiIf(and(in(lower(conv.source), ['google', 'adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), in(lower(conv.campaign), ['spring_sale_2024', 'spring-sale-2024', 'spring_sale'])), 'Spring Sale 2024', and(in(lower(conv.source), ['google', 'adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), in(lower(conv.campaign), ['bf_2024', 'blackfriday', 'bf-promo'])), 'Black Friday', and(in(lower(conv.source), ['meta', 'facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), in(lower(conv.campaign), ['spring_sale_fb', 'springsalefb'])), 'Spring Sale 2024', and(in(lower(conv.source), ['meta', 'facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), in(lower(conv.campaign), ['summer_2024', 'summer_promo'])), 'Summer Campaign', conv.campaign) AS match_key,
       sum(conv.conversion_0) AS conversion_0
   
   FROM
@@ -310,6 +314,7 @@
       conv.campaign AS campaign,
       conv.id AS id,
       conv.source AS source,
+      conv.campaign AS match_key,
       sum(conv.conversion_0) AS conversion_0,
       sum(conv.conversion_1) AS conversion_1,
       sum(conv.conversion_2) AS conversion_2
@@ -510,6 +515,7 @@
       conv.campaign AS campaign,
       conv.id AS id,
       conv.source AS source,
+      conv.campaign AS match_key,
       sum(conv.conversion_0) AS conversion_0,
       sum(conv.conversion_1) AS conversion_1
   

--- a/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_business.ambr
+++ b/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_business.ambr
@@ -167,7 +167,7 @@
   GROUP BY
           conv.campaign,
           conv.id,
-          conv.source) AS ucg ON and(or(equals(campaign_costs.campaign, ucg.campaign), equals(campaign_costs.id, ucg.id)), equals(campaign_costs.source, ucg.source))
+          conv.source) AS ucg ON and(equals(campaign_costs.campaign, ucg.campaign), equals(campaign_costs.source, ucg.source))
   ORDER BY
       Cost DESC
   

--- a/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_business.ambr
+++ b/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_business.ambr
@@ -19,6 +19,7 @@
           campaign,
           id,
           source,
+          any(match_key) AS match_key,
           sum(cost) AS total_cost,
           sum(clicks) AS total_clicks,
           sum(impressions) AS total_impressions,
@@ -33,7 +34,8 @@
               toFloat(coalesce(impressions1, 0)) AS impressions,
               toFloat(coalesce(clicks1, 0)) AS clicks,
               toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
-              toFloat(coalesce(conversions1, 0)) AS reported_conversion
+              toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+              toString(campaign1) AS match_key
           
   FROM
               `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
@@ -72,6 +74,7 @@
           campaign,
           id,
           source,
+          any(match_key) AS match_key,
           sum(cost) AS total_cost,
           sum(clicks) AS total_clicks,
           sum(impressions) AS total_impressions,
@@ -86,7 +89,8 @@
               toFloat(coalesce(impressions1, 0)) AS impressions,
               toFloat(coalesce(clicks1, 0)) AS clicks,
               toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
-              toFloat(coalesce(conversions1, 0)) AS reported_conversion
+              toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+              toString(campaign1) AS match_key
           
   FROM
               `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
@@ -103,6 +107,7 @@
           conv.campaign AS campaign,
           conv.id AS id,
           conv.source AS source,
+          conv.campaign AS match_key,
           sum(conv.conversion_0) AS conversion_0
       
   FROM
@@ -167,7 +172,7 @@
   GROUP BY
           conv.campaign,
           conv.id,
-          conv.source) AS ucg ON and(equals(campaign_costs.campaign, ucg.campaign), equals(campaign_costs.source, ucg.source))
+          conv.source) AS ucg ON and(equals(campaign_costs.match_key, ucg.match_key), equals(campaign_costs.source, ucg.source))
   ORDER BY
       Cost DESC
   
@@ -195,6 +200,7 @@
           campaign,
           id,
           source,
+          any(match_key) AS match_key,
           sum(cost) AS total_cost,
           sum(clicks) AS total_clicks,
           sum(impressions) AS total_impressions,
@@ -209,7 +215,8 @@
               toFloat(coalesce(impressions1, 0)) AS impressions,
               toFloat(coalesce(clicks1, 0)) AS clicks,
               toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
-              toFloat(coalesce(conversions1, 0)) AS reported_conversion
+              toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+              toString(campaign1) AS match_key
           
   FROM
               `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
@@ -248,6 +255,7 @@
           campaign,
           id,
           source,
+          any(match_key) AS match_key,
           sum(cost) AS total_cost,
           sum(clicks) AS total_clicks,
           sum(impressions) AS total_impressions,
@@ -262,7 +270,8 @@
               toFloat(coalesce(impressions1, 0)) AS impressions,
               toFloat(coalesce(clicks1, 0)) AS clicks,
               toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
-              toFloat(coalesce(conversions1, 0)) AS reported_conversion
+              toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+              toString(campaign1) AS match_key
           
   FROM
               `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
@@ -302,6 +311,7 @@
               campaign,
               id,
               source,
+              any(match_key) AS match_key,
               sum(cost) AS total_cost,
               sum(clicks) AS total_clicks,
               sum(impressions) AS total_impressions,
@@ -316,7 +326,8 @@
                   toFloat(coalesce(impressions1, 0)) AS impressions,
                   toFloat(coalesce(clicks1, 0)) AS clicks,
                   toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
-                  toFloat(coalesce(conversions1, 0)) AS reported_conversion
+                  toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+                  toString(campaign1) AS match_key
               
       FROM
                   `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
@@ -332,7 +343,8 @@
                   toFloat(coalesce(impressions2, 0)) AS impressions,
                   toFloat(coalesce(clicks2, 0)) AS clicks,
                   toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend2, 0)))) AS cost,
-                  toFloat(coalesce(0, 0)) AS reported_conversion
+                  toFloat(coalesce(0, 0)) AS reported_conversion,
+                  toString(campaign2) AS match_key
               
       FROM
                   `bigquery.posthog_test.posthog_test_tiktok_ads_table` AS posthog_test_tiktok_ads_table
@@ -348,7 +360,8 @@
                   toFloat(coalesce(impressions3, 0)) AS impressions,
                   toFloat(coalesce(clicks3, 0)) AS clicks,
                   toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend3, 0)))) AS cost,
-                  toFloat(coalesce(0, 0)) AS reported_conversion
+                  toFloat(coalesce(0, 0)) AS reported_conversion,
+                  toString(campaign3) AS match_key
               
       FROM
                   `bigquery.posthog_test.posthog_test_linkedin_ads_table` AS posthog_test_linkedin_ads_table

--- a/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_compare.ambr
+++ b/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_compare.ambr
@@ -182,7 +182,7 @@
   GROUP BY
               conv.campaign,
               conv.id,
-              conv.source) AS ucg ON and(or(equals(campaign_costs.campaign, ucg.campaign), equals(campaign_costs.id, ucg.id)), equals(campaign_costs.source, ucg.source))) AS current_period
+              conv.source) AS ucg ON and(equals(campaign_costs.id, ucg.id), equals(campaign_costs.source, ucg.source))) AS current_period
       LEFT JOIN (
   SELECT
           campaign_costs.id AS ID,
@@ -298,7 +298,7 @@
   GROUP BY
               conv.campaign,
               conv.id,
-              conv.source) AS ucg ON and(or(equals(campaign_costs.campaign, ucg.campaign), equals(campaign_costs.id, ucg.id)), equals(campaign_costs.source, ucg.source))) AS previous_period ON and(equals(current_period.Campaign, previous_period.Campaign), equals(current_period.Source, previous_period.Source))
+              conv.source) AS ucg ON and(equals(campaign_costs.id, ucg.id), equals(campaign_costs.source, ucg.source))) AS previous_period ON and(equals(current_period.Campaign, previous_period.Campaign), equals(current_period.Source, previous_period.Source))
   ORDER BY
       Cost DESC
   

--- a/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_compare.ambr
+++ b/products/marketing_analytics/backend/hogql_queries/__snapshots__/test_marketing_analytics_table_query_runner_compare.ambr
@@ -19,6 +19,7 @@
           campaign,
           id,
           source,
+          any(match_key) AS match_key,
           sum(cost) AS total_cost,
           sum(clicks) AS total_clicks,
           sum(impressions) AS total_impressions,
@@ -33,7 +34,8 @@
               toFloat(coalesce(impressions1, 0)) AS impressions,
               toFloat(coalesce(clicks1, 0)) AS clicks,
               toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
-              toFloat(coalesce(conversions1, 0)) AS reported_conversion
+              toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+              toString(campaign1) AS match_key
           
   FROM
               `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
@@ -87,6 +89,7 @@
               campaign,
               id,
               source,
+              any(match_key) AS match_key,
               sum(cost) AS total_cost,
               sum(clicks) AS total_clicks,
               sum(impressions) AS total_impressions,
@@ -101,7 +104,8 @@
                   toFloat(coalesce(impressions1, 0)) AS impressions,
                   toFloat(coalesce(clicks1, 0)) AS clicks,
                   toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
-                  toFloat(coalesce(conversions1, 0)) AS reported_conversion
+                  toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+                  toString(campaign1) AS match_key
               
   FROM
                   `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
@@ -118,6 +122,7 @@
               conv.campaign AS campaign,
               conv.id AS id,
               conv.source AS source,
+              conv.campaign AS match_key,
               sum(conv.conversion_0) AS conversion_0
           
   FROM
@@ -182,7 +187,7 @@
   GROUP BY
               conv.campaign,
               conv.id,
-              conv.source) AS ucg ON and(equals(campaign_costs.id, ucg.id), equals(campaign_costs.source, ucg.source))) AS current_period
+              conv.source) AS ucg ON and(equals(campaign_costs.match_key, ucg.match_key), equals(campaign_costs.source, ucg.source))) AS current_period
       LEFT JOIN (
   SELECT
           campaign_costs.id AS ID,
@@ -203,6 +208,7 @@
               campaign,
               id,
               source,
+              any(match_key) AS match_key,
               sum(cost) AS total_cost,
               sum(clicks) AS total_clicks,
               sum(impressions) AS total_impressions,
@@ -217,7 +223,8 @@
                   toFloat(coalesce(impressions1, 0)) AS impressions,
                   toFloat(coalesce(clicks1, 0)) AS clicks,
                   toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
-                  toFloat(coalesce(conversions1, 0)) AS reported_conversion
+                  toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+                  toString(campaign1) AS match_key
               
   FROM
                   `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
@@ -234,6 +241,7 @@
               conv.campaign AS campaign,
               conv.id AS id,
               conv.source AS source,
+              conv.campaign AS match_key,
               sum(conv.conversion_0) AS conversion_0
           
   FROM
@@ -298,7 +306,269 @@
   GROUP BY
               conv.campaign,
               conv.id,
-              conv.source) AS ucg ON and(equals(campaign_costs.id, ucg.id), equals(campaign_costs.source, ucg.source))) AS previous_period ON and(equals(current_period.Campaign, previous_period.Campaign), equals(current_period.Source, previous_period.Source))
+              conv.source) AS ucg ON and(equals(campaign_costs.match_key, ucg.match_key), equals(campaign_costs.source, ucg.source))) AS previous_period ON and(equals(current_period.Campaign, previous_period.Campaign), equals(current_period.Source, previous_period.Source))
+  ORDER BY
+      Cost DESC
+  
+  LIMIT 101
+  OFFSET 0
+  '''
+# ---
+# name: TestMarketingAnalyticsTableQueryRunnerCompare.test_conversion_goal_with_mixed_match_fields
+  '''
+  
+  SELECT
+      tuple(current_period.ID, previous_period.ID) AS ID,
+      tuple(current_period.Campaign, previous_period.Campaign) AS Campaign,
+      tuple(current_period.Source, previous_period.Source) AS Source,
+      tuple(current_period.Cost, previous_period.Cost) AS Cost,
+      tuple(current_period.Clicks, previous_period.Clicks) AS Clicks,
+      tuple(current_period.Impressions, previous_period.Impressions) AS Impressions,
+      tuple(current_period.CPC, previous_period.CPC) AS CPC,
+      tuple(current_period.CTR, previous_period.CTR) AS CTR,
+      tuple(current_period.`Reported Conversion`, previous_period.`Reported Conversion`) AS `Reported Conversion`,
+      tuple(current_period.`Sign Up Conversions`, previous_period.`Sign Up Conversions`) AS `Sign Up Conversions`,
+      tuple(current_period.`Cost per Sign Up Conversions`, previous_period.`Cost per Sign Up Conversions`) AS `Cost per Sign Up Conversions`
+  
+  FROM
+      (
+  SELECT
+          campaign_costs.id AS ID,
+          campaign_costs.campaign AS Campaign,
+          campaign_costs.source AS Source,
+          round(campaign_costs.total_cost, 2) AS Cost,
+          round(campaign_costs.total_clicks, 0) AS Clicks,
+          round(campaign_costs.total_impressions, 0) AS Impressions,
+          round(divide(campaign_costs.total_cost, nullif(campaign_costs.total_clicks, 0)), 2) AS CPC,
+          round(multiply(divide(campaign_costs.total_clicks, nullif(campaign_costs.total_impressions, 0)), 100), 2) AS CTR,
+          round(campaign_costs.total_reported_conversions, 2) AS `Reported Conversion`,
+          ucg.conversion_0 AS `Sign Up Conversions`,
+          round(divide(campaign_costs.total_cost, nullif(ucg.conversion_0, 0)), 2) AS `Cost per Sign Up Conversions`
+      
+  FROM
+          (
+  SELECT
+              campaign,
+              id,
+              source,
+              any(match_key) AS match_key,
+              sum(cost) AS total_cost,
+              sum(clicks) AS total_clicks,
+              sum(impressions) AS total_impressions,
+              sum(reported_conversion) AS total_reported_conversions
+          
+  FROM
+              (
+  SELECT
+                  toString(campaign1) AS campaign,
+                  toString(campaign1) AS id,
+                  toString(source1) AS source,
+                  toFloat(coalesce(impressions1, 0)) AS impressions,
+                  toFloat(coalesce(clicks1, 0)) AS clicks,
+                  toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
+                  toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+                  toString(campaign1) AS match_key
+              
+  FROM
+                  `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
+              
+  WHERE
+                  and(greaterOrEquals(toDateTime(date1), toDateTime('2024-11-01 00:00:00')), lessOrEquals(toDateTime(date1), toDateTime('2024-12-31 23:59:59'))))
+          
+  GROUP BY
+              campaign,
+              id,
+              source) AS campaign_costs
+          LEFT JOIN (
+  SELECT
+              conv.campaign AS campaign,
+              conv.id AS id,
+              conv.source AS source,
+              conv.campaign AS match_key,
+              sum(conv.conversion_0) AS conversion_0
+          
+  FROM
+              (
+  SELECT
+                  if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
+                  if(notEmpty(campaign_id), campaign_id, '-') AS id,
+                  if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
+                  count() AS conversion_0
+              
+  FROM
+                  (
+  SELECT
+                      person_id,
+                      if(notEmpty(conversion_campaign), conversion_campaign, if(notEmpty(fallback_campaign), fallback_campaign, '')) AS campaign_name,
+                      '-' AS campaign_id,
+                      if(notEmpty(conversion_source), conversion_source, if(notEmpty(fallback_source), fallback_source, '')) AS source_name,
+                      1 AS conversion_value
+                  
+  FROM
+                      (
+  SELECT
+                          person_id,
+                          conversion_timestamps[i] AS conversion_time,
+                          conversion_math_values[i] AS conversion_math_value,
+                          conversion_campaigns[i] AS conversion_campaign,
+                          conversion_sources[i] AS conversion_source,
+                          arrayMax(arrayFilter(x -> and(lessOrEquals(x, conversion_timestamps[i]), greaterOrEquals(x, minus(conversion_timestamps[i], 7776000))), utm_timestamps)) AS last_utm_timestamp,
+                          if(isNotNull(last_utm_timestamp), utm_campaigns[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_campaign,
+                          if(isNotNull(last_utm_timestamp), utm_sources[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_source
+                      
+  FROM
+                          (
+  SELECT
+                              events.person_id,
+                              arrayFilter(x -> greater(x, 0), groupArray(if(equals(event, 'test_event'), toUnixTimestamp(events.timestamp), 0))) AS conversion_timestamps,
+                              arrayFilter(x -> greater(x, 0), groupArray(if(equals(event, 'test_event'), toFloat(1), 0))) AS conversion_math_values,
+                              arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(event, 'test_event'), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS conversion_campaigns,
+                              arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(event, 'test_event'), toString(ifNull(events.properties.utm_source, '')), ''))) AS conversion_sources,
+                              arrayFilter(x -> greater(x, 0), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toUnixTimestamp(events.timestamp), 0))) AS utm_timestamps,
+                              arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS utm_campaigns,
+                              arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_source, '')), ''))) AS utm_sources
+                          
+  FROM
+                              events
+                          
+  WHERE
+                              or(and(equals(event, 'test_event'), greaterOrEquals(events.timestamp, toDateTime('2024-11-01 00:00:00')), lessOrEquals(events.timestamp, toDateTime('2024-12-31 23:59:59'))), and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, ''))), greaterOrEquals(events.timestamp, minus(toDateTime('2024-11-01 00:00:00'), toIntervalSecond(7776000))), lessOrEquals(events.timestamp, toDateTime('2024-12-31 23:59:59'))))
+                          
+  GROUP BY
+                              events.person_id
+                          
+  HAVING
+                              greater(length(conversion_timestamps), 0))
+                      ARRAY JOIN arrayEnumerate(conversion_timestamps) AS i)) AS attributed_conversions
+              
+  GROUP BY
+                  campaign,
+                  id,
+                  source) AS conv
+          
+  GROUP BY
+              conv.campaign,
+              conv.id,
+              conv.source) AS ucg ON and(equals(campaign_costs.match_key, ucg.match_key), equals(campaign_costs.source, ucg.source))) AS current_period
+      LEFT JOIN (
+  SELECT
+          campaign_costs.id AS ID,
+          campaign_costs.campaign AS Campaign,
+          campaign_costs.source AS Source,
+          round(campaign_costs.total_cost, 2) AS Cost,
+          round(campaign_costs.total_clicks, 0) AS Clicks,
+          round(campaign_costs.total_impressions, 0) AS Impressions,
+          round(divide(campaign_costs.total_cost, nullif(campaign_costs.total_clicks, 0)), 2) AS CPC,
+          round(multiply(divide(campaign_costs.total_clicks, nullif(campaign_costs.total_impressions, 0)), 100), 2) AS CTR,
+          round(campaign_costs.total_reported_conversions, 2) AS `Reported Conversion`,
+          ucg.conversion_0 AS `Sign Up Conversions`,
+          round(divide(campaign_costs.total_cost, nullif(ucg.conversion_0, 0)), 2) AS `Cost per Sign Up Conversions`
+      
+  FROM
+          (
+  SELECT
+              campaign,
+              id,
+              source,
+              any(match_key) AS match_key,
+              sum(cost) AS total_cost,
+              sum(clicks) AS total_clicks,
+              sum(impressions) AS total_impressions,
+              sum(reported_conversion) AS total_reported_conversions
+          
+  FROM
+              (
+  SELECT
+                  toString(campaign1) AS campaign,
+                  toString(campaign1) AS id,
+                  toString(source1) AS source,
+                  toFloat(coalesce(impressions1, 0)) AS impressions,
+                  toFloat(coalesce(clicks1, 0)) AS clicks,
+                  toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
+                  toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+                  toString(campaign1) AS match_key
+              
+  FROM
+                  `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
+              
+  WHERE
+                  and(greaterOrEquals(toDateTime(date1), toDateTime('2024-09-01 00:00:00')), lessOrEquals(toDateTime(date1), toDateTime('2024-10-31 23:59:59'))))
+          
+  GROUP BY
+              campaign,
+              id,
+              source) AS campaign_costs
+          LEFT JOIN (
+  SELECT
+              conv.campaign AS campaign,
+              conv.id AS id,
+              conv.source AS source,
+              conv.campaign AS match_key,
+              sum(conv.conversion_0) AS conversion_0
+          
+  FROM
+              (
+  SELECT
+                  if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
+                  if(notEmpty(campaign_id), campaign_id, '-') AS id,
+                  if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
+                  count() AS conversion_0
+              
+  FROM
+                  (
+  SELECT
+                      person_id,
+                      if(notEmpty(conversion_campaign), conversion_campaign, if(notEmpty(fallback_campaign), fallback_campaign, '')) AS campaign_name,
+                      '-' AS campaign_id,
+                      if(notEmpty(conversion_source), conversion_source, if(notEmpty(fallback_source), fallback_source, '')) AS source_name,
+                      1 AS conversion_value
+                  
+  FROM
+                      (
+  SELECT
+                          person_id,
+                          conversion_timestamps[i] AS conversion_time,
+                          conversion_math_values[i] AS conversion_math_value,
+                          conversion_campaigns[i] AS conversion_campaign,
+                          conversion_sources[i] AS conversion_source,
+                          arrayMax(arrayFilter(x -> and(lessOrEquals(x, conversion_timestamps[i]), greaterOrEquals(x, minus(conversion_timestamps[i], 7776000))), utm_timestamps)) AS last_utm_timestamp,
+                          if(isNotNull(last_utm_timestamp), utm_campaigns[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_campaign,
+                          if(isNotNull(last_utm_timestamp), utm_sources[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_source
+                      
+  FROM
+                          (
+  SELECT
+                              events.person_id,
+                              arrayFilter(x -> greater(x, 0), groupArray(if(equals(event, 'test_event'), toUnixTimestamp(events.timestamp), 0))) AS conversion_timestamps,
+                              arrayFilter(x -> greater(x, 0), groupArray(if(equals(event, 'test_event'), toFloat(1), 0))) AS conversion_math_values,
+                              arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(event, 'test_event'), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS conversion_campaigns,
+                              arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(event, 'test_event'), toString(ifNull(events.properties.utm_source, '')), ''))) AS conversion_sources,
+                              arrayFilter(x -> greater(x, 0), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toUnixTimestamp(events.timestamp), 0))) AS utm_timestamps,
+                              arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS utm_campaigns,
+                              arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_source, '')), ''))) AS utm_sources
+                          
+  FROM
+                              events
+                          
+  WHERE
+                              or(and(equals(event, 'test_event'), greaterOrEquals(events.timestamp, toDateTime('2024-09-01 00:00:00')), lessOrEquals(events.timestamp, toDateTime('2024-10-31 23:59:59'))), and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, ''))), greaterOrEquals(events.timestamp, minus(toDateTime('2024-09-01 00:00:00'), toIntervalSecond(7776000))), lessOrEquals(events.timestamp, toDateTime('2024-10-31 23:59:59'))))
+                          
+  GROUP BY
+                              events.person_id
+                          
+  HAVING
+                              greater(length(conversion_timestamps), 0))
+                      ARRAY JOIN arrayEnumerate(conversion_timestamps) AS i)) AS attributed_conversions
+              
+  GROUP BY
+                  campaign,
+                  id,
+                  source) AS conv
+          
+  GROUP BY
+              conv.campaign,
+              conv.id,
+              conv.source) AS ucg ON and(equals(campaign_costs.match_key, ucg.match_key), equals(campaign_costs.source, ucg.source))) AS previous_period ON and(equals(current_period.Campaign, previous_period.Campaign), equals(current_period.Source, previous_period.Source))
   ORDER BY
       Cost DESC
   
@@ -340,6 +610,7 @@
                   campaign,
                   id,
                   source,
+                  any(match_key) AS match_key,
                   sum(cost) AS total_cost,
                   sum(clicks) AS total_clicks,
                   sum(impressions) AS total_impressions,
@@ -354,7 +625,8 @@
                       toFloat(coalesce(impressions1, 0)) AS impressions,
                       toFloat(coalesce(clicks1, 0)) AS clicks,
                       toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
-                      toFloat(coalesce(conversions1, 0)) AS reported_conversion
+                      toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+                      toString(campaign1) AS match_key
                   
       FROM
                       `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
@@ -370,7 +642,8 @@
                       toFloat(coalesce(impressions2, 0)) AS impressions,
                       toFloat(coalesce(clicks2, 0)) AS clicks,
                       toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend2, 0)))) AS cost,
-                      toFloat(coalesce(0, 0)) AS reported_conversion
+                      toFloat(coalesce(0, 0)) AS reported_conversion,
+                      toString(campaign2) AS match_key
                   
       FROM
                       `bigquery.posthog_test.posthog_test_tiktok_ads_table` AS posthog_test_tiktok_ads_table
@@ -386,7 +659,8 @@
                       toFloat(coalesce(impressions3, 0)) AS impressions,
                       toFloat(coalesce(clicks3, 0)) AS clicks,
                       toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend3, 0)))) AS cost,
-                      toFloat(coalesce(0, 0)) AS reported_conversion
+                      toFloat(coalesce(0, 0)) AS reported_conversion,
+                      toString(campaign3) AS match_key
                   
       FROM
                       `bigquery.posthog_test.posthog_test_linkedin_ads_table` AS posthog_test_linkedin_ads_table
@@ -416,6 +690,7 @@
                   campaign,
                   id,
                   source,
+                  any(match_key) AS match_key,
                   sum(cost) AS total_cost,
                   sum(clicks) AS total_clicks,
                   sum(impressions) AS total_impressions,
@@ -430,7 +705,8 @@
                       toFloat(coalesce(impressions1, 0)) AS impressions,
                       toFloat(coalesce(clicks1, 0)) AS clicks,
                       toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend1, 0)))) AS cost,
-                      toFloat(coalesce(conversions1, 0)) AS reported_conversion
+                      toFloat(coalesce(conversions1, 0)) AS reported_conversion,
+                      toString(campaign1) AS match_key
                   
       FROM
                       `bigquery.posthog_test.posthog_test_facebook_ads_table` AS posthog_test_facebook_ads_table
@@ -446,7 +722,8 @@
                       toFloat(coalesce(impressions2, 0)) AS impressions,
                       toFloat(coalesce(clicks2, 0)) AS clicks,
                       toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend2, 0)))) AS cost,
-                      toFloat(coalesce(0, 0)) AS reported_conversion
+                      toFloat(coalesce(0, 0)) AS reported_conversion,
+                      toString(campaign2) AS match_key
                   
       FROM
                       `bigquery.posthog_test.posthog_test_tiktok_ads_table` AS posthog_test_tiktok_ads_table
@@ -462,7 +739,8 @@
                       toFloat(coalesce(impressions3, 0)) AS impressions,
                       toFloat(coalesce(clicks3, 0)) AS clicks,
                       toFloat(convertCurrency('USD', 'USD', toFloat(coalesce(spend3, 0)))) AS cost,
-                      toFloat(coalesce(0, 0)) AS reported_conversion
+                      toFloat(coalesce(0, 0)) AS reported_conversion,
+                      toString(campaign3) AS match_key
                   
       FROM
                       `bigquery.posthog_test.posthog_test_linkedin_ads_table` AS posthog_test_linkedin_ads_table

--- a/products/marketing_analytics/backend/hogql_queries/adapters/base.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/base.py
@@ -119,6 +119,7 @@ class MarketingSourceAdapter(ABC, Generic[ConfigType]):
     clicks_field: str = MarketingAnalyticsColumnsSchemaNames.CLICKS
     cost_field: str = MarketingAnalyticsColumnsSchemaNames.COST
     reported_conversion_field: str = MarketingAnalyticsColumnsSchemaNames.REPORTED_CONVERSION
+    match_key_field: str = "match_key"  # Field used for joining with conversion goals
 
     @classmethod
     @abstractmethod
@@ -288,6 +289,9 @@ class MarketingSourceAdapter(ABC, Generic[ConfigType]):
                 ast.Alias(alias=self.clicks_field, expr=self._get_clicks_field()),
                 ast.Alias(alias=self.cost_field, expr=self._get_cost_field()),
                 ast.Alias(alias=self.reported_conversion_field, expr=self._get_reported_conversion_field()),
+                # match_key is used for joining with conversion goals
+                # Each adapter decides whether to use campaign_name or campaign_id based on team preferences
+                ast.Alias(alias=self.match_key_field, expr=self.get_campaign_match_field()),
             ]
 
             # Build query components

--- a/products/marketing_analytics/backend/hogql_queries/adapters/base.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/base.py
@@ -14,6 +14,7 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models.team.team import DEFAULT_CURRENCY, Team
 
 from products.data_warehouse.backend.models import DataWarehouseTable
+from products.marketing_analytics.backend.hogql_queries.constants import MATCH_KEY_FIELD
 
 logger = structlog.get_logger(__name__)
 
@@ -119,7 +120,7 @@ class MarketingSourceAdapter(ABC, Generic[ConfigType]):
     clicks_field: str = MarketingAnalyticsColumnsSchemaNames.CLICKS
     cost_field: str = MarketingAnalyticsColumnsSchemaNames.COST
     reported_conversion_field: str = MarketingAnalyticsColumnsSchemaNames.REPORTED_CONVERSION
-    match_key_field: str = "match_key"  # Field used for joining with conversion goals
+    match_key_field: str = MATCH_KEY_FIELD
 
     @classmethod
     @abstractmethod

--- a/products/marketing_analytics/backend/hogql_queries/constants.py
+++ b/products/marketing_analytics/backend/hogql_queries/constants.py
@@ -68,7 +68,8 @@ TOTAL_IMPRESSIONS_FIELD = "total_impressions"
 TOTAL_REPORTED_CONVERSION_FIELD = "total_reported_conversions"
 
 # Fallback query when no valid adapters are found
-FALLBACK_EMPTY_QUERY = f"SELECT 'No ID' as {MarketingAnalyticsColumnsSchemaNames.ID}, 'No Campaign' as {MarketingAnalyticsColumnsSchemaNames.CAMPAIGN}, 'No Source' as {MarketingAnalyticsColumnsSchemaNames.SOURCE}, 0.0 as {MarketingAnalyticsColumnsSchemaNames.IMPRESSIONS}, 0.0 as {MarketingAnalyticsColumnsSchemaNames.CLICKS}, 0.0 as {MarketingAnalyticsColumnsSchemaNames.COST}, 0.0 as {MarketingAnalyticsColumnsSchemaNames.REPORTED_CONVERSION} WHERE 1=0"
+MATCH_KEY_FIELD = "match_key"  # Field used for joining with conversion goals
+FALLBACK_EMPTY_QUERY = f"SELECT 'No ID' as {MarketingAnalyticsColumnsSchemaNames.ID}, 'No Campaign' as {MarketingAnalyticsColumnsSchemaNames.CAMPAIGN}, 'No Source' as {MarketingAnalyticsColumnsSchemaNames.SOURCE}, 0.0 as {MarketingAnalyticsColumnsSchemaNames.IMPRESSIONS}, 0.0 as {MarketingAnalyticsColumnsSchemaNames.CLICKS}, 0.0 as {MarketingAnalyticsColumnsSchemaNames.COST}, 0.0 as {MarketingAnalyticsColumnsSchemaNames.REPORTED_CONVERSION}, '' as {MATCH_KEY_FIELD} WHERE 1=0"
 
 # AST Expression mappings for MarketingAnalyticsBaseColumns
 BASE_COLUMN_MAPPING = {

--- a/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
@@ -797,10 +797,12 @@ class ConversionGoalProcessor:
 
     def _build_final_aggregation_query(self, attribution_query: ast.SelectQuery) -> ast.SelectQuery:
         """Build final aggregation query with organic defaults"""
+        campaign_expr = self._build_organic_default_expr("campaign_name", self.config.organic_campaign)
+
         select_columns: list[ast.Expr] = [
             ast.Alias(
                 alias=self.config.campaign_field,
-                expr=self._build_organic_default_expr("campaign_name", self.config.organic_campaign),
+                expr=campaign_expr,
             ),
             ast.Alias(
                 alias=self.config.id_field,
@@ -811,6 +813,12 @@ class ConversionGoalProcessor:
                 expr=self._normalize_source_field(
                     self._build_organic_default_expr("source_name", self.config.organic_source)
                 ),
+            ),
+            # match_key is the utm_campaign value used for joining with campaign costs
+            # Users put either campaign name or ID in utm_campaign depending on their integration config
+            ast.Alias(
+                alias=self.config.match_key_field,
+                expr=campaign_expr,
             ),
             ast.Alias(
                 alias=self.config.get_conversion_goal_column_name(self.index),
@@ -861,19 +869,31 @@ class ConversionGoalProcessor:
         where_conditions = add_conversion_goal_property_filters(where_conditions, self.goal, self.team)
         where_conditions.extend(additional_conditions)
 
+        # Campaign expression with organic default
+        campaign_expr = ast.Call(
+            name="coalesce", args=[utm_campaign_expr, ast.Constant(value=self.config.organic_campaign)]
+        )
+
         # Build SELECT columns with organic defaults
+        # Schema: [0]=campaign, [1]=id, [2]=source, [3]=match_key, [4]=conversion
         select_columns: list[ast.Expr] = [
             ast.Alias(
                 alias=self.config.campaign_field,
-                expr=ast.Call(
-                    name="coalesce", args=[utm_campaign_expr, ast.Constant(value=self.config.organic_campaign)]
-                ),
+                expr=campaign_expr,
+            ),
+            ast.Alias(
+                alias=self.config.id_field,
+                expr=ast.Constant(value="-"),  # No campaign ID available for direct queries
             ),
             ast.Alias(
                 alias=self.config.source_field,
                 expr=self._normalize_source_field(
                     ast.Call(name="coalesce", args=[utm_source_expr, ast.Constant(value=self.config.organic_source)])
                 ),
+            ),
+            ast.Alias(
+                alias=self.config.match_key_field,
+                expr=campaign_expr,  # match_key is the utm_campaign value
             ),
             ast.Alias(
                 alias=self.config.get_conversion_goal_column_name(self.index),

--- a/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
@@ -883,7 +883,9 @@ class ConversionGoalProcessor:
             ),
             ast.Alias(
                 alias=self.config.id_field,
-                expr=ast.Constant(value="-"),  # No campaign ID available for direct queries
+                # Events only have UTM parameters - campaign IDs are platform-specific (Meta, Google, etc.)
+                # and don't flow through UTM tracking, so we use a placeholder for schema consistency
+                expr=ast.Constant(value="-"),
             ),
             ast.Alias(
                 alias=self.config.source_field,

--- a/products/marketing_analytics/backend/hogql_queries/conversion_goals_aggregator.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goals_aggregator.py
@@ -112,8 +112,9 @@ class ConversionGoalsAggregator:
             ast.Alias(alias=self.config.campaign_field, expr=mapped_campaign_expr),
             ast.Alias(alias=self.config.id_field, expr=mapped_id_expr),
             ast.Alias(alias=self.config.source_field, expr=source_field_expr),
-            # match_key for UCG is the campaign value (utm_campaign from events)
-            # This will be matched against campaign_costs.match_key (which adapters set based on team prefs)
+            # match_key for conversion goals is always utm_campaign - UTM tracking has no campaign ID param.
+            # Users who prefer campaign_id matching must put IDs in their utm_campaign parameter.
+            # Ad adapters output their match_key based on team prefs; this enables the JOIN to work.
             ast.Alias(alias=self.config.match_key_field, expr=mapped_campaign_expr),
         ]
 
@@ -135,7 +136,8 @@ class ConversionGoalsAggregator:
 
         # GROUP BY the mapped expressions (same expressions used in SELECT)
         # This ensures rows with the same mapped values are consolidated in a single pass
-        # Note: match_key = mapped_campaign, so no need to add it separately to GROUP BY
+        # Note: For conversion goals, match_key is derived from utm_campaign (same as mapped_campaign)
+        # since events don't have platform-specific campaign IDs
         final_query = ast.SelectQuery(
             select=final_select,
             select_from=ast.JoinExpr(table=union_query, alias=subquery_alias),

--- a/products/marketing_analytics/backend/hogql_queries/conversion_goals_aggregator.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goals_aggregator.py
@@ -44,6 +44,7 @@ class ConversionGoalsAggregator:
 
             # Transform the query to include a column for this specific conversion goal
             # and zero columns for all other conversion goals
+            # Note: base_query schema is: [0]=campaign, [1]=id, [2]=source, [3]=match_key, [4]=conversion
             enhanced_select = [
                 # Keep campaign, id, and source
                 base_query.select[0],  # campaign
@@ -56,7 +57,8 @@ class ConversionGoalsAggregator:
                 if p.index == processor.index:
                     # This is the current processor - use the actual conversion value
                     # Extract the expression from the alias to avoid double aliasing
-                    conversion_expr = base_query.select[3]
+                    # Position [4] is the conversion value (after campaign, id, source, match_key)
+                    conversion_expr = base_query.select[4]
                     if isinstance(conversion_expr, ast.Alias):
                         conversion_expr = conversion_expr.expr
                     enhanced_select.append(
@@ -110,6 +112,9 @@ class ConversionGoalsAggregator:
             ast.Alias(alias=self.config.campaign_field, expr=mapped_campaign_expr),
             ast.Alias(alias=self.config.id_field, expr=mapped_id_expr),
             ast.Alias(alias=self.config.source_field, expr=source_field_expr),
+            # match_key for UCG is the campaign value (utm_campaign from events)
+            # This will be matched against campaign_costs.match_key (which adapters set based on team prefs)
+            ast.Alias(alias=self.config.match_key_field, expr=mapped_campaign_expr),
         ]
 
         # Add each conversion goal as a summed column
@@ -130,6 +135,7 @@ class ConversionGoalsAggregator:
 
         # GROUP BY the mapped expressions (same expressions used in SELECT)
         # This ensures rows with the same mapped values are consolidated in a single pass
+        # Note: match_key = mapped_campaign, so no need to add it separately to GROUP BY
         final_query = ast.SelectQuery(
             select=final_select,
             select_from=ast.JoinExpr(table=union_query, alias=subquery_alias),

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -88,13 +88,19 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         # Build SELECT columns for the CTE
         select_columns: list[ast.Expr] = []
 
-        # Only include campaign, ID, and source fields if we're grouping by them
+        # Only include campaign, ID, source, and match_key fields if we're grouping by them
         if group_by_exprs:
             select_columns.extend(
                 [
                     ast.Field(chain=[self.config.campaign_field]),
                     ast.Field(chain=[self.config.id_field]),
                     ast.Field(chain=[self.config.source_field]),
+                    # match_key is used for joining with conversion goals
+                    # Use any() since all rows in a group have the same match_key value
+                    ast.Alias(
+                        alias=self.config.match_key_field,
+                        expr=ast.Call(name="any", args=[ast.Field(chain=[self.config.match_key_field])]),
+                    ),
                 ]
             )
 

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_config.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_config.py
@@ -45,6 +45,7 @@ class MarketingAnalyticsConfig:
     campaign_field: str = MarketingSourceAdapter.campaign_name_field
     id_field: str = MarketingSourceAdapter.campaign_id_field
     source_field: str = MarketingSourceAdapter.source_name_field
+    match_key_field: str = MarketingSourceAdapter.match_key_field
 
     # Column aliases for output
     campaign_column_alias: str = MarketingAnalyticsBaseColumns.CAMPAIGN

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
@@ -139,32 +139,6 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
             right=ast.Field(chain=self.config.get_unified_conversion_field_chain(self.config.source_field)),
         )
 
-    def _get_campaign_match_field(self) -> str:
-        """
-        Determine which field to use for campaign matching based on team preferences.
-
-        ClickHouse doesn't support OR in JOIN ON conditions, so instead of:
-            (campaign_costs.campaign = ucg.campaign OR campaign_costs.id = ucg.id)
-
-        We use either campaign or id field based on team's matching preference:
-        - If any source is configured to match on campaign_id, use the id field
-        - Otherwise, use the campaign field (default)
-        """
-        try:
-            preferences = self.team.marketing_analytics_config.campaign_field_preferences
-        except Exception:
-            preferences = {}
-
-        if not preferences:
-            return self.config.campaign_field
-
-        # If any source is configured for campaign_id matching, use id field
-        for prefs in preferences.values():
-            if prefs.get("match_field") == "campaign_id":
-                return self.config.id_field
-
-        return self.config.campaign_field
-
     def _build_compare_join(
         self, current_period_query: ast.SelectQuery, previous_period_query: ast.SelectQuery
     ) -> ast.JoinExpr:
@@ -302,10 +276,8 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
         if conversion_aggregator:
             join_type = "FULL OUTER JOIN" if self.query.includeAllConversions else "LEFT JOIN"
 
-            # Determine which field to use for matching (campaign or id)
-            # This replaces the OR condition which ClickHouse doesn't support in JOIN ON clauses
-            match_field = self._get_campaign_match_field()
-
+            # Join on match_key - each adapter decides whether to use campaign or id based on team preferences
+            # UCG's match_key is the utm_campaign value from events
             unified_join = ast.JoinExpr(
                 join_type=join_type,
                 table=ast.Field(chain=[UNIFIED_CONVERSION_GOALS_CTE_ALIAS]),
@@ -313,11 +285,14 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
                 constraint=ast.JoinConstraint(
                     expr=ast.And(
                         exprs=[
-                            # Join on campaign or id field based on team preferences
                             ast.CompareOperation(
-                                left=ast.Field(chain=self.config.get_campaign_cost_field_chain(match_field)),
+                                left=ast.Field(
+                                    chain=self.config.get_campaign_cost_field_chain(self.config.match_key_field)
+                                ),
                                 op=ast.CompareOperationOp.Eq,
-                                right=ast.Field(chain=self.config.get_unified_conversion_field_chain(match_field)),
+                                right=ast.Field(
+                                    chain=self.config.get_unified_conversion_field_chain(self.config.match_key_field)
+                                ),
                             ),
                             self._build_flexible_source_join_condition(),
                         ]

--- a/products/marketing_analytics/backend/hogql_queries/test_adapters.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_adapters.py
@@ -1718,9 +1718,7 @@ class TestMarketingAnalyticsAdapters(ClickhouseTestMixin, BaseTest):
     def test_match_key_uses_campaign_id_when_configured(self):
         """Test that match_key uses campaign_id field when campaign_field_preferences is set to campaign_id."""
         # Configure the team to use campaign_id for MetaAds
-        self.team.marketing_analytics_config.campaign_field_preferences = {
-            "MetaAds": {"match_field": "campaign_id"}
-        }
+        self.team.marketing_analytics_config.campaign_field_preferences = {"MetaAds": {"match_field": "campaign_id"}}
         self.team.marketing_analytics_config.save()
 
         # Create MetaAdsAdapter with mock tables
@@ -1751,9 +1749,9 @@ class TestMarketingAnalyticsAdapters(ClickhouseTestMixin, BaseTest):
 
         # Verify the match_key uses the id field, not the name field
         # The id field in Meta Ads is referenced as "metaads_campaigns.id"
-        assert "metaads_campaigns.id" in hogql_query, (
-            f"match_key should use campaign id field (metaads_campaigns.id), but got: {hogql_query}"
-        )
+        assert (
+            "metaads_campaigns.id" in hogql_query
+        ), f"match_key should use campaign id field (metaads_campaigns.id), but got: {hogql_query}"
         # Verify it's in the match_key alias context (not just anywhere in the query)
         # The pattern should be: toString(metaads_campaigns.id) AS match_key
         assert "AS match_key" in hogql_query, "match_key alias should exist"
@@ -1788,9 +1786,9 @@ class TestMarketingAnalyticsAdapters(ClickhouseTestMixin, BaseTest):
 
         # Verify the match_key uses the name field, not the id field
         # The name field in Meta Ads is referenced as "metaads_campaigns.name"
-        assert "metaads_campaigns.name" in hogql_query, (
-            f"match_key should use campaign name field by default (metaads_campaigns.name), but got: {hogql_query}"
-        )
+        assert (
+            "metaads_campaigns.name" in hogql_query
+        ), f"match_key should use campaign name field by default (metaads_campaigns.name), but got: {hogql_query}"
 
         # Snapshot the query to confirm name is used
         assert self._execute_and_snapshot(query) == self.snapshot
@@ -1835,11 +1833,9 @@ class TestMarketingAnalyticsAdapters(ClickhouseTestMixin, BaseTest):
         google_hogql = google_query.to_hogql()
 
         # Meta should use id field
-        assert "metaads_campaigns.id" in meta_hogql, (
-            f"MetaAds match_key should use id field, but got: {meta_hogql}"
-        )
+        assert "metaads_campaigns.id" in meta_hogql, f"MetaAds match_key should use id field, but got: {meta_hogql}"
 
         # Google should use name field (default)
-        assert "google_ads_campaign.campaign_name" in google_hogql, (
-            f"GoogleAds match_key should use campaign_name field by default, but got: {google_hogql}"
-        )
+        assert (
+            "google_ads_campaign.campaign_name" in google_hogql
+        ), f"GoogleAds match_key should use campaign_name field by default, but got: {google_hogql}"

--- a/products/marketing_analytics/backend/hogql_queries/test_adapters.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_adapters.py
@@ -48,8 +48,17 @@ from products.marketing_analytics.backend.hogql_queries.adapters.tiktok_ads impo
 TEST_DATE_FROM = "2024-01-01"
 TEST_DATE_TO = "2024-12-31"
 TEST_BUCKET_BASE = "test_storage_bucket-posthog.marketing_analytics"
-EXPECTED_COLUMN_COUNT = 7
-EXPECTED_COLUMN_ALIASES = ["campaign", "id", "source", "impressions", "clicks", "cost", "reported_conversion"]
+EXPECTED_COLUMN_COUNT = 8
+EXPECTED_COLUMN_ALIASES = [
+    "campaign",
+    "id",
+    "source",
+    "impressions",
+    "clicks",
+    "cost",
+    "reported_conversion",
+    "match_key",
+]
 
 
 logger = logging.getLogger(__name__)
@@ -1701,3 +1710,136 @@ class TestMarketingAnalyticsAdapters(ClickhouseTestMixin, BaseTest):
             assert result.is_valid, "All adapters should validate successfully"
 
         adapters.clear()
+
+    # ================================================================
+    # MATCH KEY PREFERENCE TESTS
+    # ================================================================
+
+    def test_match_key_uses_campaign_id_when_configured(self):
+        """Test that match_key uses campaign_id field when campaign_field_preferences is set to campaign_id."""
+        # Configure the team to use campaign_id for MetaAds
+        self.team.marketing_analytics_config.campaign_field_preferences = {
+            "MetaAds": {"match_field": "campaign_id"}
+        }
+        self.team.marketing_analytics_config.save()
+
+        # Create MetaAdsAdapter with mock tables
+        campaign_table = self._create_mock_table("metaads_campaigns", "MetaAds")
+        stats_table = self._create_mock_table("metaads_campaign_stats", "MetaAds")
+
+        config = MetaAdsConfig(
+            campaign_table=campaign_table,
+            stats_table=stats_table,
+            source_type="MetaAds",
+            source_id="meta_ads_id_preference",
+        )
+
+        adapter = MetaAdsAdapter(config=config, context=self.context)
+        query = adapter.build_query()
+
+        assert query is not None, "MetaAdsAdapter should generate a query"
+
+        # Find the match_key column
+        match_key_col = next(
+            (col for col in query.select if hasattr(col, "alias") and col.alias == "match_key"),
+            None,
+        )
+        assert match_key_col is not None, "Should have match_key column"
+
+        # Convert to HogQL to check the field used
+        hogql_query = query.to_hogql()
+
+        # Verify the match_key uses the id field, not the name field
+        # The id field in Meta Ads is referenced as "metaads_campaigns.id"
+        assert "metaads_campaigns.id" in hogql_query, (
+            f"match_key should use campaign id field (metaads_campaigns.id), but got: {hogql_query}"
+        )
+        # Verify it's in the match_key alias context (not just anywhere in the query)
+        # The pattern should be: toString(metaads_campaigns.id) AS match_key
+        assert "AS match_key" in hogql_query, "match_key alias should exist"
+
+        # Snapshot the query to confirm id is used
+        assert self._execute_and_snapshot(query) == self.snapshot
+
+    def test_match_key_uses_campaign_name_by_default(self):
+        """Test that match_key uses campaign_name field by default (no preferences set)."""
+        # Don't set any preferences - use default behavior
+        self.team.marketing_analytics_config.campaign_field_preferences = {}
+        self.team.marketing_analytics_config.save()
+
+        # Create MetaAdsAdapter with mock tables
+        campaign_table = self._create_mock_table("metaads_campaigns", "MetaAds")
+        stats_table = self._create_mock_table("metaads_campaign_stats", "MetaAds")
+
+        config = MetaAdsConfig(
+            campaign_table=campaign_table,
+            stats_table=stats_table,
+            source_type="MetaAds",
+            source_id="meta_ads_default",
+        )
+
+        adapter = MetaAdsAdapter(config=config, context=self.context)
+        query = adapter.build_query()
+
+        assert query is not None, "MetaAdsAdapter should generate a query"
+
+        # Convert to HogQL to check the field used
+        hogql_query = query.to_hogql()
+
+        # Verify the match_key uses the name field, not the id field
+        # The name field in Meta Ads is referenced as "metaads_campaigns.name"
+        assert "metaads_campaigns.name" in hogql_query, (
+            f"match_key should use campaign name field by default (metaads_campaigns.name), but got: {hogql_query}"
+        )
+
+        # Snapshot the query to confirm name is used
+        assert self._execute_and_snapshot(query) == self.snapshot
+
+    def test_match_key_preference_per_integration(self):
+        """Test that different integrations can have different match_key preferences."""
+        # Configure MetaAds to use campaign_id, but leave GoogleAds with default (campaign_name)
+        self.team.marketing_analytics_config.campaign_field_preferences = {
+            "MetaAds": {"match_field": "campaign_id"},
+            # GoogleAds not specified, should use campaign_name by default
+        }
+        self.team.marketing_analytics_config.save()
+
+        # Create MetaAdsAdapter
+        meta_campaign_table = self._create_mock_table("metaads_campaigns", "MetaAds")
+        meta_stats_table = self._create_mock_table("metaads_campaign_stats", "MetaAds")
+        meta_config = MetaAdsConfig(
+            campaign_table=meta_campaign_table,
+            stats_table=meta_stats_table,
+            source_type="MetaAds",
+            source_id="meta_ads_mixed",
+        )
+        meta_adapter = MetaAdsAdapter(config=meta_config, context=self.context)
+        meta_query = meta_adapter.build_query()
+
+        # Create GoogleAdsAdapter
+        google_campaign_table = self._create_mock_table("google_ads_campaign", "GoogleAds")
+        google_stats_table = self._create_mock_table("google_ads_stats", "GoogleAds")
+        google_config = GoogleAdsConfig(
+            campaign_table=google_campaign_table,
+            stats_table=google_stats_table,
+            source_type="GoogleAds",
+            source_id="google_ads_mixed",
+        )
+        google_adapter = GoogleAdsAdapter(config=google_config, context=self.context)
+        google_query = google_adapter.build_query()
+
+        assert meta_query is not None, "MetaAdsAdapter should generate a query"
+        assert google_query is not None, "GoogleAdsAdapter should generate a query"
+
+        meta_hogql = meta_query.to_hogql()
+        google_hogql = google_query.to_hogql()
+
+        # Meta should use id field
+        assert "metaads_campaigns.id" in meta_hogql, (
+            f"MetaAds match_key should use id field, but got: {meta_hogql}"
+        )
+
+        # Google should use name field (default)
+        assert "google_ads_campaign.campaign_name" in google_hogql, (
+            f"GoogleAds match_key should use campaign_name field by default, but got: {google_hogql}"
+        )

--- a/products/marketing_analytics/backend/hogql_queries/test_conversion_goal_processor.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_conversion_goal_processor.py
@@ -336,7 +336,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert len(response.results) == 1
 
         # Get our test result directly since it's the only one
-        campaign_name, source_name, total_count = response.results[0][0], response.results[0][2], response.results[0][3]
+        campaign_name, source_name, total_count = response.results[0][0], response.results[0][2], response.results[0][4]
 
         # Validation: TOTAL should count all 5 events (3+2), not unique users
         assert campaign_name == "growth_hack"
@@ -424,7 +424,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert len(response.results) == 1
 
         # Get our test result directly since it's the only one
-        campaign_name, source_name, dau_count = response.results[0][0], response.results[0][2], response.results[0][3]
+        campaign_name, source_name, dau_count = response.results[0][0], response.results[0][2], response.results[0][4]
 
         # Validation: DAU should count 3 unique users, not 6 total events
         assert campaign_name == "test_campaign"
@@ -510,7 +510,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         campaign_name, source_name, total_revenue = (
             response.results[0][0],
             response.results[0][2],
-            response.results[0][3],
+            response.results[0][4],
         )
 
         # Validation: SUM should add all revenue values (100 + 0 + missing=0 + 250 + 50 = 400)
@@ -588,7 +588,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         campaign_name, source_name, total_revenue = (
             response.results[0][0],
             response.results[0][2],
-            response.results[0][3],
+            response.results[0][4],
         )
 
         # Validation: SUM should handle missing values as 0 (100 + 0 + 0 + 0 = 100)
@@ -660,7 +660,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         campaign_name, source_name, result_value = (
             response.results[0][0],
             response.results[0][2],
-            response.results[0][3],
+            response.results[0][4],
         )
 
         # Validation: AVG fallback should count 3 events, NOT average revenue (200)
@@ -752,7 +752,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         campaign_name, source_name, filtered_count = (
             response.results[0][0],
             response.results[0][2],
-            response.results[0][3],
+            response.results[0][4],
         )
 
         # Validation: Should only count 2 events (revenue >= 100), not all 4
@@ -832,7 +832,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         campaign_name, source_name, conversion_count = (
             response.results[0][0],
             response.results[0][2],
-            response.results[0][3],
+            response.results[0][4],
         )
 
         assert campaign_name == "multi_filter_test"
@@ -924,7 +924,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         campaign_name, source_name, conversion_count = (
             response.results[0][0],
             response.results[0][2],
-            response.results[0][3],
+            response.results[0][4],
         )
 
         assert campaign_name == "summer_SALE_promo"
@@ -1081,7 +1081,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert len(response.results) == 1
 
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
 
         # Validation: Should use data from custom fields, not default fields
         assert campaign_name == "custom_campaign_test", (
@@ -1241,7 +1241,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         response = execute_hogql_query(query=cte_query, team=self.team)
 
         # If it succeeds, check results - result format: [campaign_name, campaign_id, source_name, conversion_count]
-        total_conversions = sum(row[3] for row in response.results)
+        total_conversions = sum(row[4] for row in response.results)
         assert (
             total_conversions == 3
         ), f"Expected 3 total conversions (all events) with empty event name, got {total_conversions}"
@@ -1296,7 +1296,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         campaign_name, source_name, conversion_count = (
             response.results[0][0],
             response.results[0][2],
-            response.results[0][3],
+            response.results[0][4],
         )
 
         assert campaign_name == "long_name_test"
@@ -1362,7 +1362,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         campaign_name, source_name, conversion_count = (
             response.results[0][0],
             response.results[0][2],
-            response.results[0][3],
+            response.results[0][4],
         )
 
         assert campaign_name == "special_test"
@@ -1427,7 +1427,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         ), f"Expected 2 events with Unicode property mapping, got {len(response.results)}"
 
         # Check that both events are counted correctly - result format: [campaign_name, campaign_id, source_name, conversion_count]
-        total_conversions = sum(row[3] for row in response.results)  # row[3] is conversion_count
+        total_conversions = sum(row[4] for row in response.results)  # row[4] is conversion_count
         assert (
             total_conversions == 2
         ), f"Expected total of 2 conversions with Unicode properties, got {total_conversions}. Unicode property names should not affect conversion counting."
@@ -1493,7 +1493,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         campaign_name, source_name, conversion_count = (
             response.results[0][0],
             response.results[0][2],
-            response.results[0][3],
+            response.results[0][4],
         )
 
         assert (
@@ -1669,7 +1669,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Expected attribution: spring_sale/google (from April ad)
         assert len(response.results) == 1, f"Expected 1 result, got {len(response.results)}"
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "spring_sale", f"Expected spring_sale campaign, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -1737,8 +1737,8 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert first_result[0] == expected_campaign, f"Expected campaign '{expected_campaign}', got '{first_result[0]}'"
         assert first_result[2] == expected_source, f"Expected source '{expected_source}', got '{first_result[2]}'"
         assert (
-            first_result[3] == expected_conversion_count
-        ), f"Expected {expected_conversion_count} conversion, got {first_result[3]}"
+            first_result[4] == expected_conversion_count
+        ), f"Expected {expected_conversion_count} conversion, got {first_result[4]}"
 
     def test_temporal_attribution_backward_order_validation_example(self):
         """
@@ -1794,7 +1794,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert len(response.results) == 1
 
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
 
         # Assert that attribution is Unknown because ad came after conversion
         assert campaign_name == "organic", f"Expected organic attribution, got {campaign_name}"
@@ -1864,7 +1864,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Last-touch attribution should choose Facebook over Email
         # Timeline: newsletter/email (Apr 1) → spring_promo/facebook (Apr 15) → purchase (May 10)
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
 
         assert (
             campaign_name == "spring_promo"
@@ -2016,7 +2016,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Ad after conversion should NOT attribute
         # Expected: Unknown attribution (not "summer_sale")
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name != "summer_sale", f"Should not attribute to late campaign: {campaign_name}"
         assert campaign_name == "organic", f"Expected organic attribution, got {campaign_name}"
         assert source_name == "organic", f"Expected organic source, got {source_name}"
@@ -2084,7 +2084,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Last-touch attribution validation
         # Expected: Most recent ad before conversion (April "spring_sale", not March "early_bird")
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "spring_sale", f"Expected last-touch spring_sale, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -2157,7 +2157,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: First-touch attribution validation
         # Expected: First ad in timeline (March "early_bird", not April "spring_sale")
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "early_bird", f"Expected first-touch early_bird, got {campaign_name}"
         assert source_name == "email", f"Expected email source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -2251,7 +2251,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Should ignore ads after conversion
         # Expected: Attribution to last valid ad before conversion ("spring_sale", not "summer_sale" or "july_promo")
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "spring_sale", f"Expected spring_sale (last valid), got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -2313,7 +2313,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         response = execute_hogql_query(query=cte_query, team=self.team)
         assert len(response.results) == 1, f"Expected 1 result, got {len(response.results)}"
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "new_year", f"Expected new_year campaign, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -2416,7 +2416,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert (
             spring_sale_result is not None
         ), f"Expected spring_sale attribution for April conversion, got results: {response_april.results}"
-        campaign, source, count = spring_sale_result[0], spring_sale_result[2], spring_sale_result[3]
+        campaign, source, count = spring_sale_result[0], spring_sale_result[2], spring_sale_result[4]
         assert campaign == "spring_sale", f"Expected spring_sale for April purchase, got {campaign}"
         assert source == "google", f"Expected google source for April, got {source}"
         assert count == 1, f"Expected 1 conversion attributed to spring_sale, got {count}"
@@ -2449,7 +2449,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert (
             mothers_day_result is not None
         ), f"Expected mothers_day attribution for May conversion, got results: {response_may.results}"
-        may_campaign, may_source, may_count = mothers_day_result[0], mothers_day_result[2], mothers_day_result[3]
+        may_campaign, may_source, may_count = mothers_day_result[0], mothers_day_result[2], mothers_day_result[4]
         assert may_campaign == "mothers_day", f"Expected mothers_day for May purchase, got {may_campaign}"
         assert may_source == "meta", f"Expected meta source for May, got {may_source}"
         assert may_count == 2, f"Expected 2 conversions attributed to mothers_day, got {may_count}"
@@ -2485,7 +2485,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         june_campaign, june_source, june_count = (
             june_mothers_day_result[0],
             june_mothers_day_result[2],
-            june_mothers_day_result[3],
+            june_mothers_day_result[4],
         )
         assert june_campaign == "mothers_day", f"Expected mothers_day for June purchase, got {june_campaign}"
         assert june_source == "meta", f"Expected meta source for June, got {june_source}"
@@ -2549,7 +2549,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         # Validation: Same-day morning ad → evening conversion
         # Expected: Should attribute to "daily_deal" campaign from morning
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "daily_deal", f"Expected daily_deal campaign, got {campaign_name}"
         assert source_name == "email", f"Expected email source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -2607,7 +2607,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         # Validation: Same-day conversion → evening ad should NOT attribute
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name != "daily_deal", f"Should not attribute to late campaign: {campaign_name}"
         assert campaign_name == "organic", f"Expected organic attribution, got {campaign_name}"
         assert source_name == "organic", f"Expected organic source, got {source_name}"
@@ -2666,7 +2666,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Simultaneous timestamps should attribute
         # Expected: Should attribute to "instant" campaign (ad_timestamp <= conversion_timestamp)
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "instant", f"Expected instant campaign, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -2722,7 +2722,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         # Validation: 1-second precision should NOT attribute since ad came after conversion
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name != "too_late", f"Should not attribute to late campaign: {campaign_name}"
         assert campaign_name == "organic", f"Expected organic attribution, got {campaign_name}"
         assert source_name == "organic", f"Expected organic source, got {source_name}"
@@ -2795,7 +2795,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Multiple conversions from same campaign
         # Expected: All 3 purchases should be attributed to "spring_sale" campaign
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "spring_sale", f"Expected spring_sale campaign, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
         assert conversion_count == 3, f"Expected 3 conversions, got {conversion_count}"
@@ -2866,7 +2866,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Multiple users, multiple conversions aggregation
         # Expected: Total 4 conversions from "spring_sale" campaign across all users
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "spring_sale", f"Expected spring_sale campaign, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
         assert conversion_count == 4, f"Expected 4 total conversions across users, got {conversion_count}"
@@ -2973,7 +2973,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Expected: Should attribute to "retargeting" (last valid touchpoint before conversion)
         # Should ignore "upsell" campaign (came after conversion)
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "retarget", f"Expected retarget (last-touch), got {campaign_name}"
         assert source_name == "meta", f"Expected meta source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -3043,7 +3043,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Organic → Paid should attribute to paid
         # Expected: Should attribute to "paid_search" (last paid touchpoint)
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "paid_search", f"Expected paid_search campaign, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -3113,7 +3113,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Paid → Organic should attribute to paid
         # Expected: Should attribute to "paid_search" (last paid touchpoint, ignoring organic)
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "paid_search", f"Expected paid_search campaign, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -3202,7 +3202,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Multi-channel last-touch attribution
         # Expected: Should attribute to "search_ad" (last touchpoint before conversion)
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "search_ad", f"Expected search_ad (last-touch, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -3302,7 +3302,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Multi-session cross-device attribution
         # Expected: Should attribute to "cart_abandonment" (last email touchpoint)
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "cart_abandonment", f"Expected cart_abandonment (last-touch), got {campaign_name}"
         assert source_name == "email", f"Expected email source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -3381,7 +3381,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # This proves use_temporal_attribution=True ignores query_date_range for UTM lookback
 
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
 
         # These assertions validate the CORRECT temporal attribution behavior:
         assert (
@@ -3455,7 +3455,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         # Validation: Within 30-day window should attribute correctly
         within_result = response_within.results[0]
-        within_campaign, within_source, within_count = within_result[0], within_result[2], within_result[3]
+        within_campaign, within_source, within_count = within_result[0], within_result[2], within_result[4]
 
         assert within_campaign == "month_start", f"Expected month_start within window, got {within_campaign}"
         assert within_source == "google", f"Expected google source within window, got {within_source}"
@@ -3479,7 +3479,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         # Validation: Beyond 30-day window should not attribute
         beyond_result = response_beyond.results[0]
-        beyond_campaign, beyond_source, beyond_count = beyond_result[0], beyond_result[2], beyond_result[3]
+        beyond_campaign, beyond_source, beyond_count = beyond_result[0], beyond_result[2], beyond_result[4]
 
         assert beyond_campaign == "organic", f"Expected organic attribution, got {beyond_campaign}"
         assert beyond_count == 1, f"Expected 1 conversion beyond window, got {beyond_count}"
@@ -3542,7 +3542,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         # Validation: Should NOT attribute to 2-year-old campaign (beyond attribution window limits)
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name != "old_campaign", f"Should not attribute to 2-year-old campaign: {campaign_name}"
         assert campaign_name == "organic", f"Expected organic attribution, got {campaign_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -3625,7 +3625,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         # Validation: Should handle malformed UTM gracefully
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         # Should handle gracefully - could attribute to last valid campaign or show Unknown
         assert campaign_name is not None, "Should handle malformed UTM without crashing"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -3696,7 +3696,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Duplicate events handling
         # Expected: Should handle duplicates gracefully (dedupe or use deterministic selection)
         first_result = response.results[0]
-        campaign_name, source_name, _conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, _conversion_count = first_result[0], first_result[2], first_result[4]
         # Should pick first duplicate campaign deterministically
         assert campaign_name == "duplicate2", f"Expected duplicate2 campaign, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
@@ -3767,7 +3767,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Duplicate events handling
         # Expected: Should handle duplicates gracefully (dedupe or use deterministic selection)
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         # Should pick first duplicate campaign deterministically
         assert campaign_name == "duplicate1", f"Expected duplicate1 campaign, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
@@ -3833,7 +3833,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Special characters handling
         # Expected: Should handle special characters correctly in attribution
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name == "spring sale 2023 - 50% off!", f"Expected special chars campaign, got {campaign_name}"
         assert source_name == "google ads & display", f"Expected special chars source, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -3893,7 +3893,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Very long UTM values handling
         # Expected: Should handle very long values gracefully (truncate or handle full value)
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         assert campaign_name is not None, "Should handle very long UTM values"
         assert source_name is not None, "Should handle very long source values"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -3972,7 +3972,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Case sensitivity handling
         # Expected: Should attribute to last-touch (April "SPRING SALE"/"GOOGLE")
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         # Should use last-touch attribution regardless of case variations
         assert campaign_name == "SPRING SALE", f"Expected SPRING SALE (last-touch), got {campaign_name}"
         assert source_name == "GOOGLE", f"Expected GOOGLE (last-touch, got {source_name}"
@@ -4050,7 +4050,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Null vs empty UTM handling
         # Expected: Should show Unknown attribution (all UTM values are null/empty/missing)
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
         # All touchpoints have null/empty UTM, should show Unknown attribution
         assert campaign_name == "organic", f"Expected organic attribution, got {campaign_name}"
         assert source_name == "organic", f"Expected organic source, got {source_name}"
@@ -4138,7 +4138,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: Only $pageview UTM should be considered
         # Expected: Attribution to "valid_pageview" (NOT "ignored_signup" or "ignored_purchase")
         first_result = response.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
 
         # Should attribute to the $pageview event, not the other events with UTM
         assert campaign_name == "valid_pageview", f"Expected attribution to $pageview UTM, got {campaign_name}"
@@ -4275,7 +4275,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         # Validation: First purchase should attribute to Facebook retargeting
         # Expected: "retarget_feb"/facebook (ignores post-purchase upsell and partial UTM on conversion)
         first_result = response_first.results[0]
-        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[3]
+        campaign_name, source_name, conversion_count = first_result[0], first_result[2], first_result[4]
 
         assert campaign_name == "retarget_feb", f"Expected retarget_feb for first purchase, got {campaign_name}"
         assert source_name == "meta", f"Expected meta source, got {source_name}"
@@ -4314,7 +4314,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert (
             retarget_result is not None
         ), f"Expected retarget_feb attribution for first purchase, got results: {response_full.results}"
-        retarget_campaign, retarget_source, retarget_count = retarget_result[0], retarget_result[2], retarget_result[3]
+        retarget_campaign, retarget_source, retarget_count = retarget_result[0], retarget_result[2], retarget_result[4]
         assert retarget_campaign == "retarget_feb", f"Expected retarget_feb for first purchase, got {retarget_campaign}"
         assert retarget_source == "meta", f"Expected meta source, got {retarget_source}"
         assert retarget_count == 1, f"Expected 1 conversion attributed to retarget_feb, got {retarget_count}"
@@ -4323,7 +4323,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert (
             upsell_result is not None
         ), f"Expected upsell_campaign attribution for second purchase, got results: {response_full.results}"
-        upsell_campaign, upsell_source, upsell_count = upsell_result[0], upsell_result[2], upsell_result[3]
+        upsell_campaign, upsell_source, upsell_count = upsell_result[0], upsell_result[2], upsell_result[4]
         assert (
             upsell_campaign == "upsell_campaign"
         ), f"Expected upsell_campaign for second purchase, got {upsell_campaign}"
@@ -4388,7 +4388,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         # Should attribute both purchases to spring_sale campaign from laptop
         assert len(response.results) == 1, f"Expected 1 attribution result, got {len(response.results)}"
-        campaign, source, conversions = response.results[0][0], response.results[0][2], response.results[0][3]
+        campaign, source, conversions = response.results[0][0], response.results[0][2], response.results[0][4]
 
         assert campaign == "spring_sale", f"Expected spring_sale campaign, got {campaign}"
         assert source == "google", f"Expected google source, got {source}"
@@ -4493,7 +4493,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         results_dict = {}
         for result in response.results:
             key = f"{result[0]}/{result[2]}"
-            results_dict[key] = result[3]
+            results_dict[key] = result[4]
 
         # First purchase (2023-03-10) should use valentines_special (most recent before that date)
         # Second purchase (2023-04-15) should use spring_launch (most recent before that date)
@@ -4578,7 +4578,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         # Should attribute to spring_campaign (most recent before conversion)
         result = response.results[0]
-        campaign_name, source_name, conversion_count = result[0], result[2], result[3]
+        campaign_name, source_name, conversion_count = result[0], result[2], result[4]
         assert campaign_name == "spring_campaign", f"Expected spring_campaign, got {campaign_name}"
         assert source_name == "meta", f"Expected meta, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -4657,7 +4657,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         # Should attribute to spring_campaign (most recent before conversion)
         result = response.results[0]
-        campaign_name, source_name, conversion_count = result[0], result[2], result[3]
+        campaign_name, source_name, conversion_count = result[0], result[2], result[4]
         assert campaign_name == "spring_campaign", f"Expected spring_campaign, got {campaign_name}"
         assert source_name == "meta", f"Expected meta, got {source_name}"
         assert conversion_count == 1, f"Expected 1 conversion, got {conversion_count}"
@@ -4751,7 +4751,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         results_dict = {}
         for result in response.results:
             key = f"{result[0]}/{result[2]}"
-            results_dict[key] = result[3]
+            results_dict[key] = result[4]
 
         # Should have exactly 2 results (one per user)
         assert len(results_dict) == 2, f"Expected 2 results, got {len(results_dict)}: {results_dict}"
@@ -4838,7 +4838,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         assert len(response.results) == 1, f"Expected 1 result, got {len(response.results)}"
 
-        campaign_name, campaign_id, source_name, conversion_count = response.results[0]
+        campaign_name, campaign_id, source_name, match_key, conversion_count = response.results[0]
 
         # Validation: TOTAL should count both events (2 conversions)
         assert conversion_count == 2, f"Expected 2 conversions for TOTAL math, got {conversion_count}"
@@ -4944,7 +4944,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert len(response.results) == 1, f"Expected 1 result for TOTAL, got {len(response.results)}"
 
         # Validation: TOTAL should count all events (4 conversions total)
-        campaign_name, campaign_id, source_name, conversion_count = response.results[0]
+        campaign_name, campaign_id, source_name, match_key, conversion_count = response.results[0]
         assert conversion_count == 4, f"Expected 4 total conversions, got {conversion_count}"
 
         # Test with DAU math
@@ -4964,7 +4964,9 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert len(response_dau.results) == 1, f"Expected 1 result for DAU, got {len(response_dau.results)}"
 
         # Validation: DAU should count unique users (3 unique users)
-        campaign_name_dau, campaign_id_dau, source_name_dau, conversion_count_dau = response_dau.results[0]
+        campaign_name_dau, campaign_id_dau, source_name_dau, match_key_dau, conversion_count_dau = response_dau.results[
+            0
+        ]
         assert conversion_count_dau == 3, f"Expected 3 unique users for DAU, got {conversion_count_dau}"
 
     def test_actions_multiple_events_with_property_filters(self):
@@ -5070,7 +5072,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert len(response.results) == 1, f"Expected 1 result, got {len(response.results)}"
 
         # Validation: Should only count events that match property filters (2 conversions)
-        campaign_name, campaign_id, source_name, conversion_count = response.results[0]
+        campaign_name, campaign_id, source_name, match_key, conversion_count = response.results[0]
         assert conversion_count == 2, f"Expected 2 matching conversions, got {conversion_count}"
         assert campaign_name == "property_filter_campaign", f"Expected property_filter_campaign, got {campaign_name}"
         assert source_name == "google", f"Expected google source, got {source_name}"
@@ -5132,7 +5134,8 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         cte_query = processor.generate_cte_query(additional_conditions)
         response = execute_hogql_query(query=cte_query, team=self.team)
 
-        first_event_only_count = response.results[0][3] if response.results else 0
+        # Index [4] is the conversion count (after campaign, id, source, match_key)
+        first_event_only_count = response.results[0][4] if response.results else 0
 
         # Now user triggers the second event too
         with freeze_time("2023-04-20"):
@@ -5141,7 +5144,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         # Test again with both events triggered
         response_both = execute_hogql_query(query=cte_query, team=self.team)
-        both_events_count = response_both.results[0][3] if response_both.results else 0
+        both_events_count = response_both.results[0][4] if response_both.results else 0
 
         # Validation: Multi-event actions use OR logic - each matching event is a separate conversion
         assert first_event_only_count == 1, f"Expected 1 conversion after first event, got {first_event_only_count}"
@@ -5193,9 +5196,10 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         assert len(response.results) == 1, f"Expected 1 result, got {len(response.results)}"
 
-        campaign, campaign_id, source, count = response.results[0]
+        campaign, campaign_id, source, match_key, count = response.results[0]
         assert campaign == "paid_campaign", f"Expected paid_campaign, got {campaign}"
         assert source == "google_ads", f"Expected google_ads, got {source}"
+        assert match_key == "paid_campaign", f"Expected match_key to equal campaign, got {match_key}"
         assert count == 1, f"Expected 1 conversion, got {count}"
 
     @pytest.mark.usefixtures("unittest_snapshot")
@@ -5283,8 +5287,10 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         assert len(events_response.results) == 1
         assert len(actions_response.results) == 1
 
-        events_campaign, events_campaign_id, events_source, events_count = events_response.results[0]
-        actions_campaign, actions_campaign_id, actions_source, actions_count = actions_response.results[0]
+        events_campaign, events_campaign_id, events_source, events_match_key, events_count = events_response.results[0]
+        actions_campaign, actions_campaign_id, actions_source, actions_match_key, actions_count = (
+            actions_response.results[0]
+        )
 
         # Both should attribute to same UTM source
         assert events_campaign == actions_campaign == "summer_launch"
@@ -5356,7 +5362,7 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
         response = execute_hogql_query(query=cte_query, team=self.team)
 
         assert len(response.results) == 1
-        campaign_name, campaign_id, source_name, conversion_count = response.results[0]
+        campaign_name, campaign_id, source_name, match_key, conversion_count = response.results[0]
 
         assert campaign_name == "spring_campaign"
         assert source_name == "meta"

--- a/products/marketing_analytics/backend/hogql_queries/test_conversion_goals_aggregator.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_conversion_goals_aggregator.py
@@ -131,9 +131,11 @@ class TestConversionGoalsAggregator(ClickhouseTestMixin, BaseTest):
 
         final_query = cte.expr
         assert isinstance(final_query, ast.SelectQuery)
-        assert len(final_query.select) == 4  # campaign, id, source, conversion
+        assert len(final_query.select) == 5  # campaign, id, source, match_key, conversion
 
-        conversion_column = final_query.select[3]  # Index 3 is the first conversion column (after campaign, id, source)
+        conversion_column = final_query.select[
+            4
+        ]  # Index 4 is the first conversion column (after campaign, id, source, match_key)
         assert isinstance(conversion_column, ast.Alias)
         assert conversion_column.alias == self.config.get_conversion_goal_column_name(0)
         assert isinstance(conversion_column.expr, ast.Call)
@@ -156,9 +158,9 @@ class TestConversionGoalsAggregator(ClickhouseTestMixin, BaseTest):
 
         final_query = cte.expr
         assert isinstance(final_query, ast.SelectQuery)
-        assert len(final_query.select) == 6  # campaign, id, source, 3 conversions
+        assert len(final_query.select) == 7  # campaign, id, source, match_key, 3 conversions
 
-        conversion_columns = final_query.select[3:]  # Skip campaign, id, source
+        conversion_columns = final_query.select[4:]  # Skip campaign, id, source, match_key
         assert len(conversion_columns) == 3
 
         for i, column in enumerate(conversion_columns):
@@ -197,7 +199,7 @@ class TestConversionGoalsAggregator(ClickhouseTestMixin, BaseTest):
 
         final_query = cte.expr
         assert isinstance(final_query, ast.SelectQuery)
-        assert len(final_query.select) == 5  # campaign, id, source, 2 conversions
+        assert len(final_query.select) == 6  # campaign, id, source, match_key, 2 conversions
         assert isinstance(final_query.select_from, ast.JoinExpr)
         # The table can be either SelectQuery (single processor) or SelectSetQuery (UNION ALL for multiple processors)
         assert isinstance(final_query.select_from.table, ast.SelectQuery | ast.SelectSetQuery)
@@ -339,7 +341,7 @@ class TestConversionGoalsAggregator(ClickhouseTestMixin, BaseTest):
 
         final_query = cte.expr
         assert isinstance(final_query, ast.SelectQuery)
-        assert len(final_query.select) == 6  # campaign, id, source, 3 conversions
+        assert len(final_query.select) == 7  # campaign, id, source, match_key, 3 conversions
 
         columns = aggregator.get_conversion_goal_columns()
         assert len(columns) == 6
@@ -377,9 +379,9 @@ class TestConversionGoalsAggregator(ClickhouseTestMixin, BaseTest):
 
         final_query = cte.expr
         assert isinstance(final_query, ast.SelectQuery)
-        assert len(final_query.select) == 6  # campaign, id, source, 3 conversions
+        assert len(final_query.select) == 7  # campaign, id, source, match_key, 3 conversions
 
-        conversion_columns = final_query.select[3:]  # Skip campaign, id, source
+        conversion_columns = final_query.select[4:]  # Skip campaign, id, source, match_key
         expected_names = [
             self.config.get_conversion_goal_column_name(0),
             self.config.get_conversion_goal_column_name(1),
@@ -415,7 +417,9 @@ class TestConversionGoalsAggregator(ClickhouseTestMixin, BaseTest):
 
         final_query = cte.expr
         assert isinstance(final_query, ast.SelectQuery)
-        conversion_column = final_query.select[3]  # Index 3 is the first conversion column (after campaign, id, source)
+        conversion_column = final_query.select[
+            4
+        ]  # Index 4 is the first conversion column (after campaign, id, source, match_key)
         assert isinstance(conversion_column, ast.Alias)
         assert conversion_column.alias == self.config.get_conversion_goal_column_name(999)
         assert isinstance(conversion_column.expr, ast.Call)
@@ -446,7 +450,9 @@ class TestConversionGoalsAggregator(ClickhouseTestMixin, BaseTest):
 
         final_query = cte.expr
         assert isinstance(final_query, ast.SelectQuery)
-        assert len(final_query.select) == 13  # 3 grouping fields (campaign, id, source) + 10 conversion goals
+        assert (
+            len(final_query.select) == 14
+        )  # 4 grouping fields (campaign, id, source, match_key) + 10 conversion goals
 
         columns = aggregator.get_conversion_goal_columns()
         assert len(columns) == 20

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner_compare.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner_compare.py
@@ -461,6 +461,68 @@ class TestMarketingAnalyticsTableQueryRunnerCompare(ClickhouseTestMixin, BaseTes
 
         assert pretty_print_in_tests(response.hogql, self.team.pk) == self.snapshot
 
+    @pytest.mark.usefixtures("unittest_snapshot")
+    def test_conversion_goal_with_mixed_match_fields(self):
+        """
+        Test that when multiple sources have different campaign_field_preferences,
+        the query uses match_key for joining campaign costs with conversion goals.
+
+        Each adapter outputs a match_key column based on team's campaign_field_preferences:
+        - MetaAds with campaign_id preference: match_key = campaign_id
+        - GoogleAds with campaign_name preference: match_key = campaign_name
+        - BingAds with campaign_id preference: match_key = campaign_id
+
+        The JOIN condition uses match_key from both sides, avoiding OR conditions
+        that ClickHouse doesn't support in JOIN ON clauses.
+        """
+        facebook_info = self._setup_csv_table("facebook_ads")
+
+        source_configs = [
+            {
+                "table_id": facebook_info.table.id,
+                "source_map": FACEBOOK_SOURCE_MAP,
+            }
+        ]
+        self._setup_team_source_configs(source_configs)
+
+        # Configure multiple sources with different match fields
+        config = self.team.marketing_analytics_config
+        config.campaign_field_preferences = {
+            "MetaAds": {"match_field": "campaign_id"},
+            "GoogleAds": {"match_field": "campaign_name"},  # explicit default
+            "BingAds": {"match_field": "campaign_id"},
+        }
+        config.save()
+
+        test_action = _create_action(self.team, "test_conversion_action")
+
+        conversion_goal = ConversionGoalFilter2(
+            kind=NodeKind.ACTIONS_NODE,
+            conversion_goal_id="sign_up_goal",
+            conversion_goal_name="Sign Up Conversions",
+            id=str(test_action.id),
+            math=BaseMathType.TOTAL,
+            schema_map={"utm_campaign_name": "utm_campaign", "utm_source_name": "utm_source"},
+        )
+
+        query = self._create_basic_query(draftConversionGoal=conversion_goal)
+        runner = get_default_query_runner(query, self.team)
+
+        response = runner.calculate()
+
+        assert isinstance(response, MarketingAnalyticsTableQueryResponse)
+        assert response.results is not None
+        assert response.hogql is not None
+
+        # Verify the JOIN uses match_key instead of multiIf
+        assert "campaign_costs.match_key" in response.hogql, "Expected match_key in campaign_costs"
+        assert "ucg.match_key" in response.hogql, "Expected match_key in unified conversion goals"
+        assert (
+            "equals(campaign_costs.match_key, ucg.match_key)" in response.hogql
+        ), "Expected JOIN on match_key equality"
+
+        assert pretty_print_in_tests(response.hogql, self.team.pk) == self.snapshot
+
     def test_multiple_conversion_goals(self):
         facebook_info = self._setup_csv_table("facebook_ads")
 

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner_compare.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner_compare.py
@@ -429,6 +429,11 @@ class TestMarketingAnalyticsTableQueryRunnerCompare(ClickhouseTestMixin, BaseTes
         ]
         self._setup_team_source_configs(source_configs)
 
+        # Configure MetaAds to use campaign_id matching
+        config = self.team.marketing_analytics_config
+        config.campaign_field_preferences = {"MetaAds": {"match_field": "campaign_id"}}
+        config.save()
+
         test_action = _create_action(self.team, "test_conversion_action")
 
         conversion_goal = ConversionGoalFilter2(


### PR DESCRIPTION
## Problem

There is this error in prod (it doesn't happen locally 😢  so I could not catch it):
```
DB::Exception: Unsupported JOIN ON conditions. Unexpected '(campaign = ucg.campaign) OR (id = ucg.id)': While processing (campaign = ucg.campaign) OR (id = ucg.id). Stack trace:

0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x00000000133b761f
1. DB::Exception::Exception(String&&, int, String, bool) @ 0x000000000c8623ce
....
```

This was caused by this query:
```
SELECT
    tuple(current_period.ID, previous_period.ID) AS ID,
    tuple(current_period.Campaign, previous_period.Campaign) AS Campaign,
    tuple(current_period.Source, previous_period.Source) AS Source,
    tuple(current_period.Cost, previous_period.Cost) AS Cost,
    tuple(current_period.Clicks, previous_period.Clicks) AS Clicks,
    tuple(current_period.Impressions, previous_period.Impressions) AS Impressions,
    tuple(current_period.CPC, previous_period.CPC) AS CPC,
    tuple(current_period.CTR, previous_period.CTR) AS CTR,
    tuple(current_period.`Reported Conversion`, previous_period.`Reported Conversion`) AS `Reported Conversion`,
    tuple(current_period.`user signed up`, previous_period.`user signed up`) AS `user signed up`,
    tuple(current_period.`Cost per user signed up`, previous_period.`Cost per user signed up`) AS `Cost per user signed up`
FROM
    (SELECT
        campaign_costs.id AS ID,
        campaign_costs.campaign AS Campaign,
        campaign_costs.source AS Source,
        round(campaign_costs.total_cost, 2) AS Cost,
        round(campaign_costs.total_clicks, 0) AS Clicks,
        round(campaign_costs.total_impressions, 0) AS Impressions,
        round(divide(campaign_costs.total_cost, nullif(campaign_costs.total_clicks, 0)), 2) AS CPC,
        round(multiply(divide(campaign_costs.total_clicks, nullif(campaign_costs.total_impressions, 0)), 100), 2) AS CTR,
        round(campaign_costs.total_reported_conversions, 2) AS `Reported Conversion`,
        ucg.conversion_0 AS `user signed up`,
        round(divide(campaign_costs.total_cost, nullif(ucg.conversion_0, 0)), 2) AS `Cost per user signed up`
    FROM
        (SELECT
            campaign,
            id,
            source,
            sum(cost) AS total_cost,
            sum(clicks) AS total_clicks,
            sum(impressions) AS total_impressions,
            sum(reported_conversion) AS total_reported_conversions
        FROM
            (SELECT
                toString(bingads_campaigns.name) AS campaign,
                toString(bingads_campaigns.id) AS id,
                toString('bing') AS source,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.impressions))) AS impressions,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.clicks))) AS clicks,
                SUM(toFloat(convertCurrency(coalesce(bingads_campaign_performance_report.currency_code, 'USD'), 'USD', toFloatOrZero(bingads_campaign_performance_report.spend)))) AS cost,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.conversions))) AS reported_conversion
            FROM
                `bingads.campaigns` AS bingads_campaigns
                LEFT JOIN `bingads.campaign_performance_report` AS bingads_campaign_performance_report ON equals(toString(bingads_campaigns.id), toString(bingads_campaign_performance_report.campaign_id))
            WHERE
                and(greaterOrEquals(toDateTime(bingads_campaign_performance_report.time_period), toDateTime('2025-11-30 00:00:00')), lessOrEquals(toDateTime(bingads_campaign_performance_report.time_period), toDateTime('2025-11-30 23:59:59')))
            GROUP BY
                toString(bingads_campaigns.name),
                toString(bingads_campaigns.id))
        GROUP BY
            campaign,
            id,
            source) AS campaign_costs
        LEFT JOIN (SELECT
            conv.campaign AS campaign,
            conv.id AS id,
            conv.source AS source,
            sum(conv.conversion_0) AS conversion_0
        FROM
            (SELECT
                if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
                if(notEmpty(campaign_id), campaign_id, '-') AS id,
                if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
                count() AS conversion_0
            FROM
                (SELECT
                    person_id,
                    if(notEmpty(conversion_campaign), conversion_campaign, if(notEmpty(fallback_campaign), fallback_campaign, '')) AS campaign_name,
                    '-' AS campaign_id,
                    if(notEmpty(conversion_source), conversion_source, if(notEmpty(fallback_source), fallback_source, '')) AS source_name,
                    1 AS conversion_value
                FROM
                    (SELECT
                        person_id,
                        conversion_timestamps[i] AS conversion_time,
                        conversion_math_values[i] AS conversion_math_value,
                        conversion_campaigns[i] AS conversion_campaign,
                        conversion_sources[i] AS conversion_source,
                        arrayMax(arrayFilter(x -> and(lessOrEquals(x, conversion_timestamps[i]), greaterOrEquals(x, minus(conversion_timestamps[i], 2592000))), utm_timestamps)) AS last_utm_timestamp,
                        if(isNotNull(last_utm_timestamp), utm_campaigns[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_campaign,
                        if(isNotNull(last_utm_timestamp), utm_sources[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_source
                    FROM
                        (SELECT
                            events.person_id,
                            arrayFilter(x -> greater(x, 0), groupArray(if(equals(events.event, 'user signed up'), toUnixTimestamp(events.timestamp), 0))) AS conversion_timestamps,
                            arrayFilter(x -> greater(x, 0), groupArray(if(equals(events.event, 'user signed up'), toFloat(1), 0))) AS conversion_math_values,
                            arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(events.event, 'user signed up'), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS conversion_campaigns,
                            arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(events.event, 'user signed up'), toString(ifNull(events.properties.utm_source, '')), ''))) AS conversion_sources,
                            arrayFilter(x -> greater(x, 0), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toUnixTimestamp(events.timestamp), 0))) AS utm_timestamps,
                            arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS utm_campaigns,
                            arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_source, '')), ''))) AS utm_sources
                        FROM
                            events
                        WHERE
                            or(and(equals(events.event, 'user signed up'), greaterOrEquals(events.timestamp, toDateTime('2025-11-30 00:00:00')), lessOrEquals(events.timestamp, toDateTime('2025-11-30 23:59:59'))), and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, ''))), greaterOrEquals(events.timestamp, minus(toDateTime('2025-11-30 00:00:00'), toIntervalSecond(2592000))), lessOrEquals(events.timestamp, toDateTime('2025-11-30 23:59:59'))))
                        GROUP BY
                            events.person_id
                        HAVING
                            greater(length(conversion_timestamps), 0))
                    ARRAY JOIN arrayEnumerate(conversion_timestamps) AS i)) AS attributed_conversions
            GROUP BY
                campaign,
                id,
                source) AS conv
        GROUP BY
            conv.campaign,
            conv.id,
            conv.source) AS ucg ON and(or(equals(campaign_costs.campaign, ucg.campaign), equals(campaign_costs.id, ucg.id)), equals(campaign_costs.source, ucg.source))) AS current_period
    LEFT JOIN (SELECT
        campaign_costs.id AS ID,
        campaign_costs.campaign AS Campaign,
        campaign_costs.source AS Source,
        round(campaign_costs.total_cost, 2) AS Cost,
        round(campaign_costs.total_clicks, 0) AS Clicks,
        round(campaign_costs.total_impressions, 0) AS Impressions,
        round(divide(campaign_costs.total_cost, nullif(campaign_costs.total_clicks, 0)), 2) AS CPC,
        round(multiply(divide(campaign_costs.total_clicks, nullif(campaign_costs.total_impressions, 0)), 100), 2) AS CTR,
        round(campaign_costs.total_reported_conversions, 2) AS `Reported Conversion`,
        ucg.conversion_0 AS `user signed up`,
        round(divide(campaign_costs.total_cost, nullif(ucg.conversion_0, 0)), 2) AS `Cost per user signed up`
    FROM
        (SELECT
            campaign,
            id,
            source,
            sum(cost) AS total_cost,
            sum(clicks) AS total_clicks,
            sum(impressions) AS total_impressions,
            sum(reported_conversion) AS total_reported_conversions
        FROM
            (SELECT
                toString(bingads_campaigns.name) AS campaign,
                toString(bingads_campaigns.id) AS id,
                toString('bing') AS source,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.impressions))) AS impressions,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.clicks))) AS clicks,
                SUM(toFloat(convertCurrency(coalesce(bingads_campaign_performance_report.currency_code, 'USD'), 'USD', toFloatOrZero(bingads_campaign_performance_report.spend)))) AS cost,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.conversions))) AS reported_conversion
            FROM
                `bingads.campaigns` AS bingads_campaigns
                LEFT JOIN `bingads.campaign_performance_report` AS bingads_campaign_performance_report ON equals(toString(bingads_campaigns.id), toString(bingads_campaign_performance_report.campaign_id))
            WHERE
                and(greaterOrEquals(toDateTime(bingads_campaign_performance_report.time_period), toDateTime('2025-11-29 00:00:00')), lessOrEquals(toDateTime(bingads_campaign_performance_report.time_period), toDateTime('2025-11-29 23:59:59')))
            GROUP BY
                toString(bingads_campaigns.name),
                toString(bingads_campaigns.id))
        GROUP BY
            campaign,
            id,
            source) AS campaign_costs
        LEFT JOIN (SELECT
            conv.campaign AS campaign,
            conv.id AS id,
            conv.source AS source,
            sum(conv.conversion_0) AS conversion_0
        FROM
            (SELECT
                if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
                if(notEmpty(campaign_id), campaign_id, '-') AS id,
                if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
                count() AS conversion_0
            FROM
                (SELECT
                    person_id,
                    if(notEmpty(conversion_campaign), conversion_campaign, if(notEmpty(fallback_campaign), fallback_campaign, '')) AS campaign_name,
                    '-' AS campaign_id,
                    if(notEmpty(conversion_source), conversion_source, if(notEmpty(fallback_source), fallback_source, '')) AS source_name,
                    1 AS conversion_value
                FROM
                    (SELECT
                        person_id,
                        conversion_timestamps[i] AS conversion_time,
                        conversion_math_values[i] AS conversion_math_value,
                        conversion_campaigns[i] AS conversion_campaign,
                        conversion_sources[i] AS conversion_source,
                        arrayMax(arrayFilter(x -> and(lessOrEquals(x, conversion_timestamps[i]), greaterOrEquals(x, minus(conversion_timestamps[i], 2592000))), utm_timestamps)) AS last_utm_timestamp,
                        if(isNotNull(last_utm_timestamp), utm_campaigns[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_campaign,
                        if(isNotNull(last_utm_timestamp), utm_sources[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_source
                    FROM
                        (SELECT
                            events.person_id,
                            arrayFilter(x -> greater(x, 0), groupArray(if(equals(events.event, 'user signed up'), toUnixTimestamp(events.timestamp), 0))) AS conversion_timestamps,
                            arrayFilter(x -> greater(x, 0), groupArray(if(equals(events.event, 'user signed up'), toFloat(1), 0))) AS conversion_math_values,
                            arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(events.event, 'user signed up'), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS conversion_campaigns,
                            arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(events.event, 'user signed up'), toString(ifNull(events.properties.utm_source, '')), ''))) AS conversion_sources,
                            arrayFilter(x -> greater(x, 0), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toUnixTimestamp(events.timestamp), 0))) AS utm_timestamps,
                            arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS utm_campaigns,
                            arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_source, '')), ''))) AS utm_sources
                        FROM
                            events
                        WHERE
                            or(and(equals(events.event, 'user signed up'), greaterOrEquals(events.timestamp, toDateTime('2025-11-29 00:00:00')), lessOrEquals(events.timestamp, toDateTime('2025-11-29 23:59:59'))), and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, ''))), greaterOrEquals(events.timestamp, minus(toDateTime('2025-11-29 00:00:00'), toIntervalSecond(2592000))), lessOrEquals(events.timestamp, toDateTime('2025-11-29 23:59:59'))))
                        GROUP BY
                            events.person_id
                        HAVING
                            greater(length(conversion_timestamps), 0))
                    ARRAY JOIN arrayEnumerate(conversion_timestamps) AS i)) AS attributed_conversions
            GROUP BY
                campaign,
                id,
                source) AS conv
        GROUP BY
            conv.campaign,
            conv.id,
            conv.source) AS ucg ON and(or(equals(campaign_costs.campaign, ucg.campaign), equals(campaign_costs.id, ucg.id)), equals(campaign_costs.source, ucg.source))) AS previous_period ON and(equals(current_period.Campaign, previous_period.Campaign), equals(current_period.Source, previous_period.Source))
ORDER BY
    Cost DESC
LIMIT 201
OFFSET 0
```

And fixed removing the `or` in the query and deciding by the matching field

```
SELECT
    tuple(current_period.ID, previous_period.ID) AS ID,
    tuple(current_period.Campaign, previous_period.Campaign) AS Campaign,
    tuple(current_period.Source, previous_period.Source) AS Source,
    tuple(current_period.Cost, previous_period.Cost) AS Cost,
    tuple(current_period.Clicks, previous_period.Clicks) AS Clicks,
    tuple(current_period.Impressions, previous_period.Impressions) AS Impressions,
    tuple(current_period.CPC, previous_period.CPC) AS CPC,
    tuple(current_period.CTR, previous_period.CTR) AS CTR,
    tuple(current_period.`Reported Conversion`, previous_period.`Reported Conversion`) AS `Reported Conversion`,
    tuple(current_period.`user signed up`, previous_period.`user signed up`) AS `user signed up`,
    tuple(current_period.`Cost per user signed up`, previous_period.`Cost per user signed up`) AS `Cost per user signed up`
FROM
    (SELECT
        campaign_costs.id AS ID,
        campaign_costs.campaign AS Campaign,
        campaign_costs.source AS Source,
        round(campaign_costs.total_cost, 2) AS Cost,
        round(campaign_costs.total_clicks, 0) AS Clicks,
        round(campaign_costs.total_impressions, 0) AS Impressions,
        round(divide(campaign_costs.total_cost, nullif(campaign_costs.total_clicks, 0)), 2) AS CPC,
        round(multiply(divide(campaign_costs.total_clicks, nullif(campaign_costs.total_impressions, 0)), 100), 2) AS CTR,
        round(campaign_costs.total_reported_conversions, 2) AS `Reported Conversion`,
        ucg.conversion_0 AS `user signed up`,
        round(divide(campaign_costs.total_cost, nullif(ucg.conversion_0, 0)), 2) AS `Cost per user signed up`
    FROM
        (SELECT
            campaign,
            id,
            source,
            sum(cost) AS total_cost,
            sum(clicks) AS total_clicks,
            sum(impressions) AS total_impressions,
            sum(reported_conversion) AS total_reported_conversions
        FROM
            (SELECT
                toString(bingads_campaigns.name) AS campaign,
                toString(bingads_campaigns.id) AS id,
                toString('bing') AS source,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.impressions))) AS impressions,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.clicks))) AS clicks,
                SUM(toFloat(convertCurrency(coalesce(bingads_campaign_performance_report.currency_code, 'USD'), 'USD', toFloatOrZero(bingads_campaign_performance_report.spend)))) AS cost,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.conversions))) AS reported_conversion
            FROM
                `bingads.campaigns` AS bingads_campaigns
                LEFT JOIN `bingads.campaign_performance_report` AS bingads_campaign_performance_report ON equals(toString(bingads_campaigns.id), toString(bingads_campaign_performance_report.campaign_id))
            WHERE
                and(greaterOrEquals(toDateTime(bingads_campaign_performance_report.time_period), toDateTime('2025-11-30 00:00:00')), lessOrEquals(toDateTime(bingads_campaign_performance_report.time_period), toDateTime('2025-11-30 23:59:59')))
            GROUP BY
                toString(bingads_campaigns.name),
                toString(bingads_campaigns.id))
        GROUP BY
            campaign,
            id,
            source) AS campaign_costs
        LEFT JOIN (SELECT
            conv.campaign AS campaign,
            conv.id AS id,
            conv.source AS source,
            sum(conv.conversion_0) AS conversion_0
        FROM
            (SELECT
                if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
                if(notEmpty(campaign_id), campaign_id, '-') AS id,
                if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
                count() AS conversion_0
            FROM
                (SELECT
                    person_id,
                    if(notEmpty(conversion_campaign), conversion_campaign, if(notEmpty(fallback_campaign), fallback_campaign, '')) AS campaign_name,
                    '-' AS campaign_id,
                    if(notEmpty(conversion_source), conversion_source, if(notEmpty(fallback_source), fallback_source, '')) AS source_name,
                    1 AS conversion_value
                FROM
                    (SELECT
                        person_id,
                        conversion_timestamps[i] AS conversion_time,
                        conversion_math_values[i] AS conversion_math_value,
                        conversion_campaigns[i] AS conversion_campaign,
                        conversion_sources[i] AS conversion_source,
                        arrayMax(arrayFilter(x -> and(lessOrEquals(x, conversion_timestamps[i]), greaterOrEquals(x, minus(conversion_timestamps[i], 2592000))), utm_timestamps)) AS last_utm_timestamp,
                        if(isNotNull(last_utm_timestamp), utm_campaigns[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_campaign,
                        if(isNotNull(last_utm_timestamp), utm_sources[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_source
                    FROM
                        (SELECT
                            events.person_id,
                            arrayFilter(x -> greater(x, 0), groupArray(if(equals(events.event, 'user signed up'), toUnixTimestamp(events.timestamp), 0))) AS conversion_timestamps,
                            arrayFilter(x -> greater(x, 0), groupArray(if(equals(events.event, 'user signed up'), toFloat(1), 0))) AS conversion_math_values,
                            arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(events.event, 'user signed up'), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS conversion_campaigns,
                            arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(events.event, 'user signed up'), toString(ifNull(events.properties.utm_source, '')), ''))) AS conversion_sources,
                            arrayFilter(x -> greater(x, 0), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toUnixTimestamp(events.timestamp), 0))) AS utm_timestamps,
                            arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS utm_campaigns,
                            arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_source, '')), ''))) AS utm_sources
                        FROM
                            events
                        WHERE
                            or(and(equals(events.event, 'user signed up'), greaterOrEquals(events.timestamp, toDateTime('2025-11-30 00:00:00')), lessOrEquals(events.timestamp, toDateTime('2025-11-30 23:59:59'))), and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, ''))), greaterOrEquals(events.timestamp, minus(toDateTime('2025-11-30 00:00:00'), toIntervalSecond(2592000))), lessOrEquals(events.timestamp, toDateTime('2025-11-30 23:59:59'))))
                        GROUP BY
                            events.person_id
                        HAVING
                            greater(length(conversion_timestamps), 0))
                    ARRAY JOIN arrayEnumerate(conversion_timestamps) AS i)) AS attributed_conversions
            GROUP BY
                campaign,
                id,
                source) AS conv
        GROUP BY
            conv.campaign,
            conv.id,
            conv.source) AS ucg ON and(equals(campaign_costs.campaign, ucg.campaign), equals(campaign_costs.source, ucg.source))) AS current_period
    LEFT JOIN (SELECT
        campaign_costs.id AS ID,
        campaign_costs.campaign AS Campaign,
        campaign_costs.source AS Source,
        round(campaign_costs.total_cost, 2) AS Cost,
        round(campaign_costs.total_clicks, 0) AS Clicks,
        round(campaign_costs.total_impressions, 0) AS Impressions,
        round(divide(campaign_costs.total_cost, nullif(campaign_costs.total_clicks, 0)), 2) AS CPC,
        round(multiply(divide(campaign_costs.total_clicks, nullif(campaign_costs.total_impressions, 0)), 100), 2) AS CTR,
        round(campaign_costs.total_reported_conversions, 2) AS `Reported Conversion`,
        ucg.conversion_0 AS `user signed up`,
        round(divide(campaign_costs.total_cost, nullif(ucg.conversion_0, 0)), 2) AS `Cost per user signed up`
    FROM
        (SELECT
            campaign,
            id,
            source,
            sum(cost) AS total_cost,
            sum(clicks) AS total_clicks,
            sum(impressions) AS total_impressions,
            sum(reported_conversion) AS total_reported_conversions
        FROM
            (SELECT
                toString(bingads_campaigns.name) AS campaign,
                toString(bingads_campaigns.id) AS id,
                toString('bing') AS source,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.impressions))) AS impressions,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.clicks))) AS clicks,
                SUM(toFloat(convertCurrency(coalesce(bingads_campaign_performance_report.currency_code, 'USD'), 'USD', toFloatOrZero(bingads_campaign_performance_report.spend)))) AS cost,
                toFloat(SUM(toFloatOrZero(bingads_campaign_performance_report.conversions))) AS reported_conversion
            FROM
                `bingads.campaigns` AS bingads_campaigns
                LEFT JOIN `bingads.campaign_performance_report` AS bingads_campaign_performance_report ON equals(toString(bingads_campaigns.id), toString(bingads_campaign_performance_report.campaign_id))
            WHERE
                and(greaterOrEquals(toDateTime(bingads_campaign_performance_report.time_period), toDateTime('2025-11-29 00:00:00')), lessOrEquals(toDateTime(bingads_campaign_performance_report.time_period), toDateTime('2025-11-29 23:59:59')))
            GROUP BY
                toString(bingads_campaigns.name),
                toString(bingads_campaigns.id))
        GROUP BY
            campaign,
            id,
            source) AS campaign_costs
        LEFT JOIN (SELECT
            conv.campaign AS campaign,
            conv.id AS id,
            conv.source AS source,
            sum(conv.conversion_0) AS conversion_0
        FROM
            (SELECT
                if(notEmpty(campaign_name), campaign_name, 'organic') AS campaign,
                if(notEmpty(campaign_id), campaign_id, '-') AS id,
                if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['microsoft']), 'bing', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['facebook', 'instagram', 'messenger', 'fb', 'whatsapp', 'audience_network', 'facebook_marketplace', 'threads']), 'meta', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['li']), 'linkedin', if(in(lower(if(notEmpty(source_name), source_name, 'organic')), ['adwords', 'youtube', 'display', 'gmail', 'google_maps', 'google_play', 'google_discover', 'admob', 'waze']), 'google', if(notEmpty(source_name), source_name, 'organic'))))) AS source,
                count() AS conversion_0
            FROM
                (SELECT
                    person_id,
                    if(notEmpty(conversion_campaign), conversion_campaign, if(notEmpty(fallback_campaign), fallback_campaign, '')) AS campaign_name,
                    '-' AS campaign_id,
                    if(notEmpty(conversion_source), conversion_source, if(notEmpty(fallback_source), fallback_source, '')) AS source_name,
                    1 AS conversion_value
                FROM
                    (SELECT
                        person_id,
                        conversion_timestamps[i] AS conversion_time,
                        conversion_math_values[i] AS conversion_math_value,
                        conversion_campaigns[i] AS conversion_campaign,
                        conversion_sources[i] AS conversion_source,
                        arrayMax(arrayFilter(x -> and(lessOrEquals(x, conversion_timestamps[i]), greaterOrEquals(x, minus(conversion_timestamps[i], 2592000))), utm_timestamps)) AS last_utm_timestamp,
                        if(isNotNull(last_utm_timestamp), utm_campaigns[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_campaign,
                        if(isNotNull(last_utm_timestamp), utm_sources[indexOf(utm_timestamps, last_utm_timestamp)], '') AS fallback_source
                    FROM
                        (SELECT
                            events.person_id,
                            arrayFilter(x -> greater(x, 0), groupArray(if(equals(events.event, 'user signed up'), toUnixTimestamp(events.timestamp), 0))) AS conversion_timestamps,
                            arrayFilter(x -> greater(x, 0), groupArray(if(equals(events.event, 'user signed up'), toFloat(1), 0))) AS conversion_math_values,
                            arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(events.event, 'user signed up'), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS conversion_campaigns,
                            arrayFilter(x -> notEmpty(toString(x)), groupArray(if(equals(events.event, 'user signed up'), toString(ifNull(events.properties.utm_source, '')), ''))) AS conversion_sources,
                            arrayFilter(x -> greater(x, 0), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toUnixTimestamp(events.timestamp), 0))) AS utm_timestamps,
                            arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_campaign, '')), ''))) AS utm_campaigns,
                            arrayFilter(x -> notEmpty(x), groupArray(if(and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, '')))), toString(ifNull(events.properties.utm_source, '')), ''))) AS utm_sources
                        FROM
                            events
                        WHERE
                            or(and(equals(events.event, 'user signed up'), greaterOrEquals(events.timestamp, toDateTime('2025-11-29 00:00:00')), lessOrEquals(events.timestamp, toDateTime('2025-11-29 23:59:59'))), and(equals(events.event, '$pageview'), notEmpty(toString(ifNull(events.properties.utm_campaign, ''))), notEmpty(toString(ifNull(events.properties.utm_source, ''))), greaterOrEquals(events.timestamp, minus(toDateTime('2025-11-29 00:00:00'), toIntervalSecond(2592000))), lessOrEquals(events.timestamp, toDateTime('2025-11-29 23:59:59'))))
                        GROUP BY
                            events.person_id
                        HAVING
                            greater(length(conversion_timestamps), 0))
                    ARRAY JOIN arrayEnumerate(conversion_timestamps) AS i)) AS attributed_conversions
            GROUP BY
                campaign,
                id,
                source) AS conv
        GROUP BY
            conv.campaign,
            conv.id,
            conv.source) AS ucg ON and(equals(campaign_costs.campaign, ucg.campaign), equals(campaign_costs.source, ucg.source))) AS previous_period ON and(equals(current_period.Campaign, previous_period.Campaign), equals(current_period.Source, previous_period.Source))
ORDER BY
    Cost DESC
LIMIT 201
OFFSET 0
```


## Changes

Using the matching field instead of the `OR` in the join clause. This was working locally but not in prod for some reason. You can run the above queries locally, but the first one will fail in prod.

## How did you test this code?
Update a test, to show it decides based on the matching field.

Could not test it manually with events bc I think the plugin server is broken 🤷 
Here I set the matching field
<img width="710" height="190" alt="Screenshot 2025-12-01 at 5 43 08 PM" src="https://github.com/user-attachments/assets/9be7d5ed-3921-46b1-9cb4-2c1c9ec5552e" />
And we can see the results
<img width="1219" height="282" alt="Screenshot 2025-12-01 at 5 43 00 PM" src="https://github.com/user-attachments/assets/db2cf3af-37f8-4c8a-ab91-a0d2e00daab4" />
<img width="1193" height="209" alt="Screenshot 2025-12-01 at 5 35 01 PM" src="https://github.com/user-attachments/assets/af1b2786-09c4-4a3f-b3ef-5344791ce2ed" />

