### PR TITLE
chore(flags): Add ETag support to local_evaluation endpoint

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -98,6 +98,7 @@ def extract_etag_from_header(header_value: str | None) -> str | None:
     Extract ETag value from an If-None-Match header.
 
     Handles both strong ETags ("abc123") and weak ETags (W/"abc123") per RFC 7232.
+    Malformed weak ETags (ex. "W/abc123" where quotes are missing) are returned as-is.
     Returns None if the header is empty or None.
     """
     if not header_value:

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -28,7 +28,7 @@ from rest_framework import status
 
 from posthog import redis
 from posthog.api.cohort import get_cohort_actors_for_feature_flag
-from posthog.api.feature_flag import FeatureFlagSerializer
+from posthog.api.feature_flag import FeatureFlagSerializer, extract_etag_from_header
 from posthog.constants import AvailableFeature
 from posthog.models import Experiment, FeatureFlag, GroupTypeMapping, Tag, TaggedItem, User
 from posthog.models.cohort import Cohort
@@ -51,6 +51,32 @@ from posthog.test.db_context_capturing import capture_db_queries
 from posthog.test.test_utils import create_group_type_mapping_without_created_at
 
 from products.early_access_features.backend.models import EarlyAccessFeature
+
+
+class TestExtractEtagFromHeader:
+    """Unit tests for extract_etag_from_header function."""
+
+    @parameterized.expand(
+        [
+            # (test_name, input_header, expected_output)
+            ("strong_etag_quoted", '"abc123"', "abc123"),
+            ("strong_etag_unquoted", "abc123", "abc123"),
+            ("weak_etag", 'W/"abc123"', "abc123"),
+            # W/abc123 is malformed per RFC 7232 (weak ETags require quotes)
+            # We treat it as a literal string, which won't match any stored ETag
+            ("weak_etag_malformed", "W/abc123", "W/abc123"),
+            ("etag_starting_with_w", '"WXYZ1234"', "WXYZ1234"),
+            ("etag_starting_with_slash", '"/path/to/resource"', "/path/to/resource"),
+            ("etag_with_special_chars", '"abc-123_456"', "abc-123_456"),
+            ("etag_with_whitespace", '  "abc123"  ', "abc123"),
+            ("empty_string", "", None),
+            ("whitespace_only", "   ", None),
+            ("none_value", None, None),
+            ("empty_quotes", '""', None),
+        ]
+    )
+    def test_extract_etag_from_header(self, _name: str, header_value: str | None, expected: str | None):
+        assert extract_etag_from_header(header_value) == expected
 
 
 class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
@@ -6579,6 +6605,329 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(instance.key, "no-usage-dashboard")
         self.assertEqual(instance.name, "")
         assert instance.usage_dashboard is None, "Usage dashboard should not be created"
+
+    def test_local_evaluation_returns_etag_header(self):
+        """Test that local_evaluation returns an ETag header in the response."""
+        FeatureFlag.objects.filter(team=self.team).delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag-etag",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+
+        clear_flag_caches(self.team)
+
+        self.client.logout()
+        response = self.client.get(
+            "/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("ETag", response.headers)
+        self.assertTrue(response.headers["ETag"].startswith('"'))
+        self.assertTrue(response.headers["ETag"].endswith('"'))
+        self.assertIn("Cache-Control", response.headers)
+        self.assertEqual(response.headers["Cache-Control"], "private, must-revalidate")
+
+    def test_local_evaluation_returns_304_when_etag_matches(self):
+        """Test that local_evaluation returns 304 when If-None-Match header matches."""
+        FeatureFlag.objects.filter(team=self.team).delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag-304",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+
+        clear_flag_caches(self.team)
+
+        self.client.logout()
+
+        # First request to get the ETag
+        response1 = self.client.get(
+            "/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        etag = response1.headers["ETag"]
+
+        # Second request with If-None-Match header
+        response2 = self.client.get(
+            "/api/feature_flag/local_evaluation",
+            headers={"authorization": f"Bearer {personal_api_key}", "If-None-Match": etag},
+        )
+        self.assertEqual(response2.status_code, status.HTTP_304_NOT_MODIFIED)
+        self.assertEqual(response2.headers["ETag"], etag)
+
+    def test_local_evaluation_returns_200_when_etag_does_not_match(self):
+        """Test that local_evaluation returns 200 with new data when ETag doesn't match."""
+        FeatureFlag.objects.filter(team=self.team).delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag-new-etag",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+
+        clear_flag_caches(self.team)
+
+        self.client.logout()
+
+        # Request with non-matching ETag
+        response = self.client.get(
+            "/api/feature_flag/local_evaluation",
+            headers={"authorization": f"Bearer {personal_api_key}", "If-None-Match": '"wrong-etag"'},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("ETag", response.headers)
+        self.assertIn("flags", response.json())
+
+    @patch("django.db.transaction.on_commit", side_effect=lambda f: f())
+    def test_local_evaluation_etag_changes_when_flag_updated(self, mock_on_commit):
+        """Test that ETag changes when a feature flag is modified."""
+        FeatureFlag.objects.filter(team=self.team).delete()
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag-update",
+            filters={"groups": [{"properties": [], "rollout_percentage": 50}]},
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+
+        clear_flag_caches(self.team)
+
+        self.client.logout()
+
+        # First request to get the initial ETag
+        response1 = self.client.get(
+            "/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        etag1 = response1.headers["ETag"]
+
+        # Update the flag
+        flag.filters = {"groups": [{"properties": [], "rollout_percentage": 100}]}
+        flag.save()
+
+        # Second request should have a different ETag
+        response2 = self.client.get(
+            "/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
+        )
+        self.assertEqual(response2.status_code, status.HTTP_200_OK)
+        etag2 = response2.headers["ETag"]
+
+        self.assertNotEqual(etag1, etag2)
+
+    def test_local_evaluation_etag_works_with_send_cohorts(self):
+        """Test that ETag works correctly with send_cohorts parameter."""
+        FeatureFlag.objects.filter(team=self.team).delete()
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Test Cohort",
+            groups=[{"properties": [{"key": "email", "value": "test@example.com", "type": "person"}]}],
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag-cohort-etag",
+            filters={
+                "groups": [
+                    {
+                        "properties": [{"key": "id", "value": cohort.id, "type": "cohort"}],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+
+        clear_flag_caches(self.team)
+
+        self.client.logout()
+
+        # Request with send_cohorts
+        response1 = self.client.get(
+            "/api/feature_flag/local_evaluation?send_cohorts",
+            headers={"authorization": f"Bearer {personal_api_key}"},
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        etag_with_cohorts = response1.headers["ETag"]
+
+        # Second request with same ETag should return 304
+        response2 = self.client.get(
+            "/api/feature_flag/local_evaluation?send_cohorts",
+            headers={"authorization": f"Bearer {personal_api_key}", "If-None-Match": etag_with_cohorts},
+        )
+        self.assertEqual(response2.status_code, status.HTTP_304_NOT_MODIFIED)
+
+        # Request without send_cohorts should have different ETag
+        response3 = self.client.get(
+            "/api/feature_flag/local_evaluation",
+            headers={"authorization": f"Bearer {personal_api_key}"},
+        )
+        self.assertEqual(response3.status_code, status.HTTP_200_OK)
+        etag_without_cohorts = response3.headers["ETag"]
+
+        # Different caches should have different ETags
+        self.assertNotEqual(etag_with_cohorts, etag_without_cohorts)
+
+    def test_local_evaluation_304_response_has_empty_body(self):
+        """Test that 304 responses have empty body per HTTP spec."""
+        FeatureFlag.objects.filter(team=self.team).delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag-empty-body",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+
+        clear_flag_caches(self.team)
+
+        self.client.logout()
+
+        # First request to get the ETag
+        response1 = self.client.get(
+            "/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
+        )
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        etag = response1.headers["ETag"]
+
+        # Second request with matching ETag should return 304 with empty body
+        response2 = self.client.get(
+            "/api/feature_flag/local_evaluation",
+            headers={"authorization": f"Bearer {personal_api_key}", "If-None-Match": etag},
+        )
+        self.assertEqual(response2.status_code, status.HTTP_304_NOT_MODIFIED)
+        self.assertEqual(response2.content, b"")
+
+    def test_local_evaluation_etag_header_parsing_quoted(self):
+        """Test that quoted ETag headers are parsed correctly."""
+        FeatureFlag.objects.filter(team=self.team).delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag-quoted",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+
+        clear_flag_caches(self.team)
+
+        self.client.logout()
+
+        # Get initial ETag
+        response1 = self.client.get(
+            "/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
+        )
+        etag = response1.headers["ETag"]
+        # ETag is returned with quotes, e.g., '"abc123"'
+        self.assertTrue(etag.startswith('"') and etag.endswith('"'))
+
+        # Client sends ETag with quotes (standard format) - should match
+        response2 = self.client.get(
+            "/api/feature_flag/local_evaluation",
+            headers={"authorization": f"Bearer {personal_api_key}", "If-None-Match": etag},
+        )
+        self.assertEqual(response2.status_code, status.HTTP_304_NOT_MODIFIED)
+
+    def test_local_evaluation_etag_header_parsing_unquoted(self):
+        """Test that unquoted ETag headers are handled gracefully."""
+        FeatureFlag.objects.filter(team=self.team).delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag-unquoted",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+
+        clear_flag_caches(self.team)
+
+        self.client.logout()
+
+        # Get initial ETag
+        response1 = self.client.get(
+            "/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
+        )
+        etag = response1.headers["ETag"]
+        # Strip quotes to get raw ETag value
+        raw_etag = etag.strip('"')
+
+        # Client sends ETag without quotes (non-standard but should work)
+        response2 = self.client.get(
+            "/api/feature_flag/local_evaluation",
+            headers={"authorization": f"Bearer {personal_api_key}", "If-None-Match": raw_etag},
+        )
+        self.assertEqual(response2.status_code, status.HTTP_304_NOT_MODIFIED)
+
+    def test_local_evaluation_etag_idempotent_304_responses(self):
+        """Test that same ETag consistently returns 304 across multiple requests."""
+        FeatureFlag.objects.filter(team=self.team).delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag-idempotent",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        from posthog.models.feature_flag.local_evaluation import clear_flag_caches
+
+        clear_flag_caches(self.team)
+
+        self.client.logout()
+
+        # Get initial ETag
+        response1 = self.client.get(
+            "/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
+        )
+        etag = response1.headers["ETag"]
+
+        # Make 5 sequential requests with same ETag - all should return 304
+        for i in range(5):
+            response = self.client.get(
+                "/api/feature_flag/local_evaluation",
+                headers={"authorization": f"Bearer {personal_api_key}", "If-None-Match": etag},
+            )
+            self.assertEqual(response.status_code, status.HTTP_304_NOT_MODIFIED, f"Request {i+1} should return 304")
+            self.assertEqual(response.headers["ETag"], etag)
 
 
 class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):

--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -278,7 +278,8 @@ class HyperCache:
             json_data = json.dumps(data, sort_keys=True)
             if self.enable_etag:
                 etag = self._compute_etag(json_data)
-                # Write data and ETag in single Redis round trip
+                # Write data and ETag via pipeline (single Redis round trip)
+                # Note this is not strictly atomic, but good enough for our use case
                 self.cache_client.set_many({cache_key: json_data, etag_key: etag}, timeout=timeout)
             else:
                 self.cache_client.set(cache_key, json_data, timeout=timeout)

--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -1,5 +1,6 @@
 import json
 import time
+import hashlib
 from collections.abc import Callable
 from typing import Optional
 
@@ -90,6 +91,7 @@ class HyperCache:
         cache_miss_ttl: int = DEFAULT_CACHE_MISS_TTL,
         cache_alias: Optional[str] = None,
         batch_load_fn: Optional[Callable[[list[Team]], dict[int, dict]]] = None,
+        enable_etag: bool = False,
     ):
         self.namespace = namespace
         self.value = value
@@ -98,6 +100,7 @@ class HyperCache:
         self.cache_ttl = cache_ttl
         self.cache_miss_ttl = cache_miss_ttl
         self.batch_load_fn = batch_load_fn
+        self.enable_etag = enable_etag
 
         # Derive cache_client and redis_url from cache_alias (single source of truth)
         if cache_alias:
@@ -125,6 +128,12 @@ class HyperCache:
             if isinstance(key, Team):
                 key = key.id
             return f"cache/teams/{key}/{self.namespace}/{self.value}"
+
+    def get_etag_key(self, key: KeyType) -> str:
+        return f"{self.get_cache_key(key)}:etag"
+
+    def _compute_etag(self, json_data: str) -> str:
+        return hashlib.sha256(json_data.encode("utf-8")).hexdigest()[:16]
 
     def get_from_cache(self, key: KeyType) -> dict | None:
         data, _ = self.get_from_cache_with_source(key)
@@ -164,6 +173,56 @@ class HyperCache:
         HYPERCACHE_CACHE_COUNTER.labels(result="hit_db", namespace=self.namespace, value=self.value).inc()
         return data, "db"
 
+    def get_etag(self, key: KeyType) -> str | None:
+        """Get just the ETag for a cached value without loading the full response."""
+        if not self.enable_etag:
+            return None
+        return self.cache_client.get(self.get_etag_key(key))
+
+    def get_if_none_match(self, key: KeyType, client_etag: str | None) -> tuple[dict | None, str | None, bool]:
+        """
+        Check if client's ETag matches current cache, enabling HTTP 304 responses.
+
+        Requires enable_etag=True in constructor. If ETags are disabled, always returns
+        the full data with modified=True.
+
+        Returns: (data, etag, modified)
+        - If client_etag matches current: (None, current_etag, False) - 304 case
+        - Otherwise: (data, current_etag, True) - 200 case with full data
+
+        Note: If Redis fails during ETag check, gracefully degrades to returning
+        the full data (treating as modified) rather than raising an exception.
+        """
+        if not self.enable_etag:
+            data, _ = self.get_from_cache_with_source(key)
+            return data, None, True
+
+        try:
+            current_etag = self.get_etag(key)
+
+            if client_etag and current_etag and client_etag == current_etag:
+                return None, current_etag, False
+
+            data, source = self.get_from_cache_with_source(key)
+
+            # If we loaded from S3 or DB, the ETag was set during _set_cache_value_redis
+            # Re-fetch it to ensure we return the correct value
+            if source in ("s3", "db"):
+                current_etag = self.get_etag(key)
+
+            return data, current_etag, True
+        except Exception as e:
+            # Gracefully degrade: return full data when Redis fails
+            logger.warning(
+                f"Redis failure during ETag check for {self.namespace}, falling back to full response", error=str(e)
+            )
+            try:
+                data, _ = self.get_from_cache_with_source(key)
+                return data, None, True
+            except Exception:
+                # If everything fails, return None with modified=True
+                return None, None, True
+
     def update_cache(self, key: KeyType, ttl: Optional[int] = None) -> bool:
         logger.info(f"Syncing {self.namespace} cache for team {key}")
 
@@ -199,18 +258,31 @@ class HyperCache:
         kinds = kinds or ["redis", "s3"]
         if "redis" in kinds:
             self.cache_client.delete(self.get_cache_key(key))
+            # Always delete ETag key to clean up stale ETags from when enable_etag was True
+            self.cache_client.delete(self.get_etag_key(key))
         if "s3" in kinds:
             object_storage.delete(self.get_cache_key(key))
 
     def _set_cache_value_redis(
         self, key: KeyType, data: dict | None | HyperCacheStoreMissing, ttl: Optional[int] = None
     ):
-        key = self.get_cache_key(key)
+        cache_key = self.get_cache_key(key)
+        etag_key = self.get_etag_key(key)
         if data is None or isinstance(data, HyperCacheStoreMissing):
-            self.cache_client.set(key, _HYPER_CACHE_EMPTY_VALUE, timeout=self.cache_miss_ttl)
+            self.cache_client.set(cache_key, _HYPER_CACHE_EMPTY_VALUE, timeout=self.cache_miss_ttl)
+            # Always delete ETag key to clean up stale ETags from when enable_etag was True
+            self.cache_client.delete(etag_key)
         else:
             timeout = ttl if ttl is not None else self.cache_ttl
-            self.cache_client.set(key, json.dumps(data), timeout=timeout)
+            # Use sort_keys for deterministic serialization (consistent ETags)
+            json_data = json.dumps(data, sort_keys=True)
+            self.cache_client.set(cache_key, json_data, timeout=timeout)
+            if self.enable_etag:
+                etag = self._compute_etag(json_data)
+                self.cache_client.set(etag_key, etag, timeout=timeout)
+            else:
+                # Clean up stale ETag if ETags were previously enabled
+                self.cache_client.delete(etag_key)
 
     def _set_cache_value_s3(self, key: KeyType, data: dict | None | HyperCacheStoreMissing, ttl: Optional[int] = None):
         """
@@ -224,4 +296,5 @@ class HyperCache:
         if data is None or isinstance(data, HyperCacheStoreMissing):
             object_storage.delete(key)
         else:
-            object_storage.write(key, json.dumps(data))
+            # Use sort_keys for deterministic serialization (consistent ETags)
+            object_storage.write(key, json.dumps(data, sort_keys=True))

--- a/posthog/storage/test/test_hypercache.py
+++ b/posthog/storage/test/test_hypercache.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 from posthog.test.base import BaseTest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from django.core.cache import cache
 from django.test import override_settings
@@ -412,3 +412,287 @@ class TestHyperCacheCustomCacheClient(BaseTest):
         cache_key = hc.get_cache_key(team_id)
         default_value = cache.get(cache_key)
         assert default_value == json.dumps(self.sample_data)
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                "LOCATION": "default-test-cache",
+            },
+            "flags_dedicated": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                "LOCATION": "flags-dedicated-test-cache",
+            },
+        }
+    )
+    def test_custom_cache_client_stores_etag_in_dedicated_cache(self):
+        """Test that ETags are stored in the custom cache, not default"""
+        from django.core.cache import caches
+
+        caches["default"].clear()
+        caches["flags_dedicated"].clear()
+
+        def load_fn(team):
+            return self.sample_data
+
+        hc = HyperCache(
+            namespace="test",
+            value="value",
+            load_fn=load_fn,
+            cache_alias="flags_dedicated",
+            enable_etag=True,
+        )
+
+        team_id = self.team.id
+
+        # Write to cache
+        hc.set_cache_value(team_id, self.sample_data)
+
+        # Verify ETag is in dedicated cache only
+        etag_key = hc.get_etag_key(team_id)
+        dedicated_etag = caches["flags_dedicated"].get(etag_key)
+        default_etag = caches["default"].get(etag_key)
+
+        assert dedicated_etag is not None
+        assert len(dedicated_etag) == 16
+        assert default_etag is None
+
+
+class TestHyperCacheETagDisabled(HyperCacheTestBase):
+    """Tests for HyperCache when ETag is disabled (default)"""
+
+    def test_etag_not_stored_when_disabled(self):
+        """Test that ETags are not stored when enable_etag=False"""
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+
+        # ETag should not be stored
+        etag = self.hypercache.get_etag(self.team_id)
+        assert etag is None
+
+        # Data should still be retrievable
+        data = self.hypercache.get_from_cache(self.team_id)
+        assert data == self.sample_data
+
+    def test_get_if_none_match_returns_data_when_disabled(self):
+        """Test that get_if_none_match always returns data when ETags disabled"""
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+
+        # Even with a client ETag, should return full data
+        data, etag, modified = self.hypercache.get_if_none_match(self.team_id, "some-etag")
+
+        assert data == self.sample_data
+        assert etag is None
+        assert modified is True
+
+
+class TestHyperCacheETag(HyperCacheTestBase):
+    """Tests for ETag functionality in HyperCache"""
+
+    @property
+    def hypercache(self) -> HyperCache:
+        """Override to enable ETag support for these tests"""
+
+        def load_fn(team):
+            return {"default": "data"}
+
+        return HyperCache(namespace="test_namespace", value="test_value", load_fn=load_fn, enable_etag=True)
+
+    def test_etag_key_format(self):
+        """Test that ETag key is derived correctly from cache key"""
+        etag_key = self.hypercache.get_etag_key(self.team_id)
+        assert etag_key == "cache/teams/123/test_namespace/test_value:etag"
+
+    def test_compute_etag_deterministic(self):
+        """Test that ETag computation is deterministic for same input"""
+        json_data = '{"key": "value"}'
+        etag1 = self.hypercache._compute_etag(json_data)
+        etag2 = self.hypercache._compute_etag(json_data)
+        assert etag1 == etag2
+        assert len(etag1) == 16  # SHA-256 truncated to 16 chars
+
+    def test_compute_etag_different_for_different_data(self):
+        """Test that different data produces different ETags"""
+        etag1 = self.hypercache._compute_etag('{"key": "value1"}')
+        etag2 = self.hypercache._compute_etag('{"key": "value2"}')
+        assert etag1 != etag2
+
+    def test_etag_consistent_for_same_dict_content(self):
+        """Test that storing the same dict content produces consistent ETags.
+
+        Uses different key orderings to verify sort_keys=True is working.
+        This is important because data loaded from different sources (DB vs cache)
+        might have different key orderings.
+        """
+        # Store data with keys in one order
+        self.hypercache.set_cache_value(self.team_id, {"z": 3, "a": 1, "m": 2})
+        etag1 = self.hypercache.get_etag(self.team_id)
+
+        # Clear and store same data with keys in different order
+        self.hypercache.clear_cache(self.team_id)
+        self.hypercache.set_cache_value(self.team_id, {"a": 1, "m": 2, "z": 3})
+        etag2 = self.hypercache.get_etag(self.team_id)
+
+        # ETags should match because we use sort_keys=True
+        assert etag1 == etag2
+
+    def test_set_cache_value_stores_etag(self):
+        """Test that set_cache_value stores an ETag alongside the data"""
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+
+        etag = self.hypercache.get_etag(self.team_id)
+        assert etag is not None
+        assert len(etag) == 16
+
+    def test_get_etag_returns_none_when_not_set(self):
+        """Test that get_etag returns None when no ETag is stored"""
+        self.hypercache.clear_cache(self.team_id)
+        etag = self.hypercache.get_etag(self.team_id)
+        assert etag is None
+
+    def test_clear_cache_clears_etag(self):
+        """Test that clear_cache also clears the ETag"""
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+        assert self.hypercache.get_etag(self.team_id) is not None
+
+        self.hypercache.clear_cache(self.team_id, kinds=["redis"])
+        assert self.hypercache.get_etag(self.team_id) is None
+
+    def test_get_if_none_match_returns_not_modified_when_etag_matches(self):
+        """Test that get_if_none_match returns (None, etag, False) when ETags match"""
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+        current_etag = self.hypercache.get_etag(self.team_id)
+
+        data, etag, modified = self.hypercache.get_if_none_match(self.team_id, current_etag)
+
+        assert data is None
+        assert etag == current_etag
+        assert modified is False
+
+    def test_get_if_none_match_returns_data_when_etag_differs(self):
+        """Test that get_if_none_match returns full data when ETags differ"""
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+
+        data, etag, modified = self.hypercache.get_if_none_match(self.team_id, "wrong-etag")
+
+        assert data == self.sample_data
+        assert etag is not None
+        assert modified is True
+
+    def test_get_if_none_match_returns_data_when_no_client_etag(self):
+        """Test that get_if_none_match returns full data when client sends no ETag"""
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+
+        data, etag, modified = self.hypercache.get_if_none_match(self.team_id, None)
+
+        assert data == self.sample_data
+        assert etag is not None
+        assert modified is True
+
+    def test_etag_changes_when_data_changes(self):
+        """Test that ETag changes when cached data is updated"""
+        self.hypercache.set_cache_value(self.team_id, {"key": "value1"})
+        etag1 = self.hypercache.get_etag(self.team_id)
+
+        self.hypercache.set_cache_value(self.team_id, {"key": "value2"})
+        etag2 = self.hypercache.get_etag(self.team_id)
+
+        assert etag1 != etag2
+
+    def test_etag_deleted_when_data_becomes_missing(self):
+        """Test that ETags are deleted when data transitions to missing state"""
+        # First, store data with ETag
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+        old_etag = self.hypercache.get_etag(self.team_id)
+        assert old_etag is not None
+
+        # Store missing value
+        self.hypercache.set_cache_value(self.team_id, HyperCacheStoreMissing())
+
+        # ETag should be deleted
+        assert self.hypercache.get_etag(self.team_id) is None
+
+    def test_get_if_none_match_returns_modified_when_data_becomes_missing(self):
+        """Test that old ETag returns modified=True when data transitions to missing"""
+        # Store data and get ETag
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+        old_etag = self.hypercache.get_etag(self.team_id)
+
+        # Transition to missing
+        self.hypercache.set_cache_value(self.team_id, HyperCacheStoreMissing())
+
+        # Request with old ETag should return modified=True with null data
+        data, etag, modified = self.hypercache.get_if_none_match(self.team_id, old_etag)
+        assert modified is True
+        assert data is None
+        assert etag is None
+
+    def test_etag_consistency_when_loaded_from_s3(self):
+        """Test that ETag remains consistent when data is loaded from S3 fallback"""
+        # Set data in both Redis and S3
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+        original_etag = self.hypercache.get_etag(self.team_id)
+
+        # Clear Redis only, leaving S3 intact
+        self.hypercache.clear_cache(self.team_id, kinds=["redis"])
+
+        # Load from S3 - should repopulate Redis with same ETag
+        data, source = self.hypercache.get_from_cache_with_source(self.team_id)
+        assert source == "s3"
+        assert data == self.sample_data
+
+        # ETag should be regenerated and match original
+        new_etag = self.hypercache.get_etag(self.team_id)
+        assert new_etag == original_etag
+
+    def test_etag_consistency_when_loaded_from_db(self):
+        """Test that ETag is generated correctly when loading from DB"""
+        # Clear all caches
+        self.hypercache.clear_cache(self.team_id, kinds=["redis", "s3"])
+
+        # Load from DB
+        data, source = self.hypercache.get_from_cache_with_source(self.team_id)
+        assert source == "db"
+
+        # ETag should be created and stored
+        etag = self.hypercache.get_etag(self.team_id)
+        assert etag is not None
+        assert len(etag) == 16
+
+        # Subsequent request with matching ETag should return not modified
+        data2, etag2, modified = self.hypercache.get_if_none_match(self.team_id, etag)
+        assert modified is False
+        assert etag2 == etag
+
+    def test_get_if_none_match_idempotent_304_responses(self):
+        """Test that same ETag consistently returns not modified across multiple requests"""
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+        etag = self.hypercache.get_etag(self.team_id)
+
+        # Make 5 sequential requests with same ETag
+        for i in range(5):
+            data, returned_etag, modified = self.hypercache.get_if_none_match(self.team_id, etag)
+            assert modified is False, f"Request {i+1} should return not modified"
+            assert returned_etag == etag
+            assert data is None
+
+    def test_get_if_none_match_handles_redis_failure_gracefully(self):
+        """Test that get_if_none_match degrades gracefully when Redis fails during ETag check.
+
+        When Redis is unavailable, the endpoint should NOT crash with a 500 error.
+        Instead, it returns modified=True so the client knows to fetch fresh data.
+        """
+        # Set up data
+        self.hypercache.set_cache_value(self.team_id, self.sample_data)
+
+        # Mock Redis to fail on get operations
+        def failing_get(key):
+            raise ConnectionError("Redis unavailable")
+
+        with patch.object(self.hypercache.cache_client, "get", side_effect=failing_get):
+            # Should NOT raise - should gracefully degrade
+            data, etag, modified = self.hypercache.get_if_none_match(self.team_id, "some-etag")
+
+            # When Redis fails completely, we can't get data but we don't crash
+            # The caller (API endpoint) should handle None data appropriately
+            assert etag is None  # Can't get ETag when Redis fails
+            assert modified is True  # Signal that client should treat as modified


### PR DESCRIPTION
## Problem

Our SDK clients regularly poll the local evaluation endpoint for flag definitions. However, flag definitions don't change all that often. So most of the time, these requests waste bandwidth and CPU pulling data the clients already have.

## Changes

1. Add new `enable_etag` setting to `HyperCache`. When `True`, etag support is enabled. This means when we store a value in `HyperCache`, we also store a hash of the contents in a separate Redis hash key. This value be used as the `etag` value.
2. Add support for conditional requests to the local_evaluation endpoint via the [`If-None-Match` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-None-Match). If the supplied `etag` in the `If-None-Match` request header matches the `etag` for the current team's flag definitions, then we return `304 Not Modified` response with an empty body.
3. Update local evaluation endpoint to include an `etag` value in the headers of the response. 

## How did you test this code?

Unit Tests
Manually

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
