### PR TITLE
fix: add error banner for invite signup failure

### DIFF
--- a/frontend/src/scenes/authentication/InviteSignup.tsx
+++ b/frontend/src/scenes/authentication/InviteSignup.tsx
@@ -10,6 +10,8 @@ import { BridgePage } from 'lib/components/BridgePage/BridgePage'
 import PasswordStrength from 'lib/components/PasswordStrength'
 import SignupRoleSelect from 'lib/components/SignupRoleSelect'
 import { SSOEnforcedLoginButton, SocialLoginButtons } from 'lib/components/SocialLoginButton/SocialLoginButton'
+import { supportLogic } from 'lib/components/Support/supportLogic'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { Link } from 'lib/lemon-ui/Link'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
@@ -194,8 +196,9 @@ function AuthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite }): 
 }
 
 function UnauthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite }): JSX.Element {
-    const { isSignupSubmitting, validatedPassword } = useValues(inviteSignupLogic)
+    const { isSignupSubmitting, validatedPassword, signupManualErrors } = useValues(inviteSignupLogic)
     const { preflight } = useValues(preflightLogic)
+    const { openSupportForm } = useActions(supportLogic)
 
     const { precheck } = useActions(loginLogic)
     const { precheckResponse, precheckResponseLoading } = useValues(loginLogic)
@@ -230,6 +233,26 @@ function UnauthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite })
             footer={<SupportModalButton name={invite.first_name} email={invite.target_email} />}
         >
             <h2 className="text-center">Create your PostHog account</h2>
+            {signupManualErrors?.generic && (
+                <LemonBanner type="error" className="mb-4">
+                    {signupManualErrors.generic.detail || 'Could not complete your signup.'}{' '}
+                    {preflight?.cloud && (
+                        <Link
+                            data-attr="invite-signup-error-contact-support"
+                            onClick={(e) => {
+                                e.preventDefault()
+                                openSupportForm({
+                                    kind: 'support',
+                                    target_area: 'login',
+                                    email: invite.target_email,
+                                })
+                            }}
+                        >
+                            Need help?
+                        </Link>
+                    )}
+                </LemonBanner>
+            )}
             <Form logic={inviteSignupLogic} formKey="signup" className="deprecated-space-y-4" enableFormOnSubmit>
                 <LemonField.Pure label="Email">
                     <LemonInput type="email" disabled value={invite?.target_email} />

--- a/frontend/src/scenes/authentication/inviteSignupLogic.ts
+++ b/frontend/src/scenes/authentication/inviteSignupLogic.ts
@@ -2,6 +2,7 @@ import { actions, kea, listeners, path, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { urlToAction } from 'kea-router'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { ValidatedPasswordResult, validatePassword } from 'lib/components/PasswordStrength'
@@ -100,6 +101,7 @@ export const inviteSignupLogic = kea<inviteSignupLogicType>([
                     const res = await api.create(`api/signup/${values.invite.id}/`, payload)
                     location.href = res.redirect_url || '/' // hard refresh because the current_organization changed
                 } catch (e) {
+                    posthog.captureException(e)
                     actions.setSignupManualErrors({
                         generic: {
                             code: (e as Record<string, any>).code,


### PR DESCRIPTION
## Problem
A customer was unable to sign up via invite. Ticket: https://posthoghelp.zendesk.com/agent/tickets/43977 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46102)
After clicking "Continue" button, nothing happens. Django serializer errors are not displayed. 

Logs show 400 Bad Request. But I couldn't reproduce the original issue locally. 

## Changes
- Added LemonBanner with error detail similar to the Login form (with "Need help?" link at the end)
- Added client-side exception capture for signup failures

![2025-12-01 22 45 03](https://github.com/user-attachments/assets/090fdc28-2e38-47b2-bf04-7ff4b8cf5cf7)

## How did you test this code?
To verify the error banner displays:
1. Invite a new user to the org
2. Open the invite URL
3. Make the invite expired using Django shell:
```python
from posthog.models import OrganizationInvite
from datetime import timedelta
from django.utils import timezone

invite_id = "019adbdc-a724-0000-9b95-bc55124253c3"  # replace with your invite id

invite = OrganizationInvite.objects.get(id=invite_id)
invite.created_at = timezone.now() - timedelta(days=4)
invite.save()
```
4. Submit the invite signup form
