### PR TITLE
chore(workflows): add Ubuntu font to email templater

### DIFF
--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -394,6 +394,24 @@ function NativeEmailTemplaterForm({
                                 },
                                 projectId: unlayerEditorProjectId,
                                 customJS: isWorkflowsProductEnabled ? [unsubscribeLinkToolCustomJs] : [],
+                                fonts: unlayerEditorProjectId
+                                    ? {
+                                          showDefaultFonts: true,
+                                          customFonts: [
+                                              {
+                                                  label: 'Ubuntu',
+                                                  value: "'Ubuntu',sans-serif",
+                                                  url: 'https://fonts.googleapis.com/css2?family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap',
+                                                  weights: [
+                                                      { label: 'Light', value: 300 },
+                                                      { label: 'Regular', value: 400 },
+                                                      { label: 'Medium', value: 500 },
+                                                      { label: 'Bold', value: 700 },
+                                                  ],
+                                              },
+                                          ],
+                                      }
+                                    : undefined,
                             }}
                         />
                         <LemonModal


### PR DESCRIPTION
## Problem

Sara requested the font we use in Customer.io, https://posthog.slack.com/archives/C06GG249PR6/p1764597524255419

## Changes
<img width="1179" height="289" alt="Screenshot 2025-12-01 at 4 29 02 PM" src="https://github.com/user-attachments/assets/b92d4acd-3be5-4ad5-ba22-729f95391b56" />
<img width="1152" height="419" alt="Screenshot 2025-12-01 at 4 30 03 PM" src="https://github.com/user-attachments/assets/e468df50-f897-4500-bc85-46d9640cc7ec" />


## How did you test this code?

see above, verified all font weights + italics rendering as expected