### PR TITLE
fix(flags): gracefully handle pod restarts

### DIFF
--- a/rust/feature-flags/src/main.rs
+++ b/rust/feature-flags/src/main.rs
@@ -31,7 +31,9 @@ async fn shutdown() {
         _ = interrupt.recv() => {},
     };
 
-    tracing::info!("Shutting down gracefully...");
+    tracing::info!("Received shutdown signal, waiting 5s for load balancer to drain...");
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    tracing::info!("Proceeding with graceful shutdown...");
 }
 
 fn init_tracer(
@@ -127,5 +129,5 @@ async fn main() {
         .await
         .expect("could not bind port");
     serve(config, listener, shutdown()).await;
-    unreachable!("Server exited unexpectedly");
+    tracing::info!("Server shut down cleanly");
 }


### PR DESCRIPTION
## Problem

This is an attempt at handling the graceful termination issue I talked about [here](https://posthog.slack.com/archives/C0A061FEZTM/p1764334945138279?thread_ts=1764334680.207209&cid=C0A061FEZTM)

I'm not sure it's the right approach yet.

## Changes

- add a timer to shutting down pods
