### PR TITLE
fix(ph-ai): flakey feedback logic test

### DIFF
--- a/frontend/src/scenes/max/feedbackPromptLogic.test.ts
+++ b/frontend/src/scenes/max/feedbackPromptLogic.test.ts
@@ -107,6 +107,9 @@ describe('feedbackPromptLogic', () => {
         })
 
         it('does not trigger message_interval twice for same interval', async () => {
+            // Mock Math.random to avoid random sampling trigger
+            jest.spyOn(Math, 'random').mockReturnValue(0.9)
+
             // First trigger at message 10
             logic.actions.checkShouldShowPrompt(10, 0, 0)
             expect(logic.values.isPromptVisible).toBe(true)
@@ -124,6 +127,9 @@ describe('feedbackPromptLogic', () => {
         })
 
         it('triggers message_interval at next interval', async () => {
+            // Mock Math.random to avoid random sampling trigger
+            jest.spyOn(Math, 'random').mockReturnValue(0.9)
+
             // First trigger at message 10
             logic.actions.checkShouldShowPrompt(10, 0, 0)
             logic.actions.hidePrompt()


### PR DESCRIPTION
## Problem
Tests in `feedbackPromptLogic.test.ts` were occasionally failing due to random sampling in the feedback prompt logic.

## Changes
Added `Math.random` mocking in tests

## How did you test this code?
Ran tests multiple times