### PR TITLE
chore(flags): Add progress reporting to cache warming commands

### DIFF
--- a/posthog/management/commands/_base_hypercache_command.py
+++ b/posthog/management/commands/_base_hypercache_command.py
@@ -53,8 +53,8 @@ class BaseHyperCacheCommand(BaseCommand):
         parser.add_argument(
             "--batch-size",
             type=int,
-            default=100,
-            help="Number of teams to process at a time (default: 100)",
+            default=1000,
+            help="Number of teams to process at a time (default: 1000)",
         )
         parser.add_argument(
             "--invalidate-first",
@@ -595,6 +595,8 @@ class BaseHyperCacheCommand(BaseCommand):
         Subclasses must implement:
             - get_hypercache_config() -> HyperCacheManagementConfig
         """
+        from posthog.storage.hypercache_manager import get_cache_stats
+
         config = self.get_hypercache_config()
         cache_name = config.cache_display_name
 
@@ -608,15 +610,19 @@ class BaseHyperCacheCommand(BaseCommand):
             actual_batch_size = len(teams)
             actual_invalidate_first = False  # Never invalidate for specific teams
         else:
-            # Handle all teams - show configuration and get confirmation if needed
+            # Get current cache stats for upfront reporting
+            total_teams = Team.objects.count()
+            cache_stats = get_cache_stats(config)
+
+            # Handle all teams - show configuration and current state
             self.stdout.write(
-                self.style.WARNING(
-                    f"\nStarting {cache_name} cache warm:\n"
-                    f"  Batch size: {batch_size}\n"
-                    f"  Invalidate first: {invalidate_first}\n"
-                    f"  Stagger TTL: {stagger_ttl}\n"
-                    f"  TTL range: {min_ttl_days}-{max_ttl_days} days\n"
-                )
+                f"\nStarting {cache_name} cache warm:\n"
+                f"  Total teams: {total_teams:,}\n"
+                f"  Current cache coverage: {cache_stats.get('cache_coverage', 'unknown')}\n"
+                f"  Batch size: {batch_size}\n"
+                f"  Invalidate first: {invalidate_first}\n"
+                f"  Stagger TTL: {stagger_ttl}\n"
+                f"  TTL range: {min_ttl_days}-{max_ttl_days} days\n"
             )
 
             if invalidate_first and not self._confirm_invalidate(cache_name):
@@ -624,6 +630,21 @@ class BaseHyperCacheCommand(BaseCommand):
 
             actual_batch_size = batch_size
             actual_invalidate_first = invalidate_first
+
+        # Progress callback to write to stdout
+        last_percent_reported = [0]  # Use list to allow mutation in closure
+
+        def progress_callback(processed: int, total: int, successful: int, failed: int):
+            if total == 0:
+                return
+            percent = int(100 * processed / total)
+            # Report every 5% to avoid too much output
+            if percent >= last_percent_reported[0] + 5 or processed == total:
+                self.stdout.write(
+                    f"  Progress: {processed:,}/{total:,} teams ({percent}%) "
+                    f"- {successful:,} successful, {failed:,} failed"
+                )
+                last_percent_reported[0] = percent
 
         # Warm the caches
         successful, failed = warm_caches(
@@ -634,6 +655,7 @@ class BaseHyperCacheCommand(BaseCommand):
             min_ttl_days=min_ttl_days,
             max_ttl_days=max_ttl_days,
             team_ids=team_ids,
+            progress_callback=progress_callback,
         )
 
         # Display results


### PR DESCRIPTION
## Problem

The new management command to warm the team metadata cache (and flags cache) don't report progress. This makes it hard to tell if it's working or not.

## Changes

- Add `progress_callback parameter` to `warm_caches()` for real-time progress updates
- Display total teams and current cache coverage upfront when warming
- Show progress every 5% with successful/failed counts
- Increase default batch size from 100 to 1000 for better performance

This only changes code that affects the management commands.

## How did you test this code?

Unit Tests
Manual Tests.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
