### PR TITLE
fix: Display only sales-led entries on team page

### DIFF
--- a/posthog/admin/admins/user_product_list_admin.py
+++ b/posthog/admin/admins/user_product_list_admin.py
@@ -2,13 +2,11 @@ from django.contrib import admin
 
 
 class UserProductListAdmin(admin.ModelAdmin):
-    list_display = ("id", "user", "team", "product_path", "reason", "enabled", "created_at", "updated_at")
+    list_display = ("id", "user", "team", "product_path", "reason", "enabled", "updated_at")
     list_display_links = ("id",)
     list_filter = (
         "reason",
         "product_path",
-        "team",
-        "user",
         "enabled",
         ("created_at", admin.DateFieldListFilter),
     )

--- a/posthog/admin/inlines/user_product_list_inline.py
+++ b/posthog/admin/inlines/user_product_list_inline.py
@@ -130,8 +130,12 @@ class UserProductListInline(admin.TabularInline):
     fields = ("user", "product_path", "reason", "reason_text", "enabled")
     readonly_fields = ("id",)
     verbose_name = "User Product Entry"
-    verbose_name_plural = "User Product entries"
+    verbose_name_plural = "User Product entries (sales led only)"
     classes = ("collapse",)
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.filter(reason=UserProductList.Reason.SALES_LED)
 
     def get_formset(self, request, obj=None, **kwargs):
         formset = super().get_formset(request, obj, **kwargs)


### PR DESCRIPTION
See https://github.com/PostHog/posthog/pull/42451 for our previous attempt here

Basically, in production, for teams with a lot of users we have huge lists with an even bigger number of items inside the select
To avoid that, let's only render the items who are sales-led in the teams page. We can still see all entries on the proper admin page.