### PR TITLE
feat: add survey button to customer analytics funnels

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -29,6 +29,7 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { getOverrideWarningPropsForButton } from 'scenes/insights/utils'
 import { SurveyOpportunityButton } from 'scenes/surveys/components/SurveyOpportunityButton'
+import { isSurveyableFunnelInsight } from 'scenes/surveys/utils/opportunityDetection'
 import { urls } from 'scenes/urls'
 
 import { dashboardsModel } from '~/models/dashboardsModel'
@@ -160,7 +161,9 @@ export function InsightMeta({
         ) : null
 
     const surveyOpportunityButton =
-        surveyOpportunity && featureFlags[FEATURE_FLAGS.SURVEYS_FUNNELS_CROSS_SELL] ? (
+        surveyOpportunity &&
+        featureFlags[FEATURE_FLAGS.SURVEYS_FUNNELS_CROSS_SELL] &&
+        isSurveyableFunnelInsight(insight) ? (
             <div className="flex">
                 <SurveyOpportunityButton insight={insight} disableAutoPromptSubmit={true} />
             </div>

--- a/frontend/src/lib/components/Cards/InsightCard/QueryCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/QueryCard.tsx
@@ -27,6 +27,8 @@ export interface QueryCardProps extends Pick<InsightCardProps, 'highlighted' | '
     /** Attach ourselves to another logic, such as the scene logic */
     attachTo?: BuiltLogic | LogicWrapper
     uniqueKey?: string | number
+    /** Additional controls to show in the top controls area */
+    extraControls?: JSX.Element | null
 }
 
 /** This is like InsightCard, except for presentation of queries that aren't saved insights. */
@@ -42,6 +44,7 @@ export const QueryCard = React.forwardRef<HTMLDivElement, QueryCardProps>(functi
         sceneSource,
         attachTo,
         uniqueKey,
+        extraControls,
         ...divProps
     },
     ref
@@ -82,6 +85,7 @@ export const QueryCard = React.forwardRef<HTMLDivElement, QueryCardProps>(functi
                             ]}
                         />
                     }
+                    extraControls={extraControls}
                     showEditingControls
                 />
                 <div className="InsightCard__viz">

--- a/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
@@ -13,26 +13,39 @@ import { addProductIntent } from 'lib/utils/product-intents'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { urls } from 'scenes/urls'
 
-import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
-import { QueryBasedInsightModel } from '~/types'
+import { DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import {
+    FunnelsQuery,
+    FunnelsQueryResponse,
+    InsightVizNode,
+    ProductIntentContext,
+    ProductKey,
+    QuerySchema,
+} from '~/queries/schema/schema-general'
+import { InsightLogicProps } from '~/types'
 
 import { QuickSurveyModal } from '../QuickSurveyModal'
 import { SURVEY_CREATED_SOURCE } from '../constants'
 import { QuickSurveyType } from '../quick-create/types'
 import { captureMaxAISurveyCreationException } from '../utils'
-import { extractFunnelContext } from '../utils/opportunityDetection'
+import { SurveyableFunnelInsight, extractFunnelContext } from '../utils/opportunityDetection'
 
 export interface SurveyOpportunityButtonProps {
-    insight: QueryBasedInsightModel
+    insight: SurveyableFunnelInsight
     disableAutoPromptSubmit?: boolean
+    source?: SURVEY_CREATED_SOURCE
 }
 
 export function SurveyOpportunityButton({
     insight,
     disableAutoPromptSubmit,
+    source,
 }: SurveyOpportunityButtonProps): JSX.Element | null {
     const [modalOpen, setModalOpen] = useState(false)
     const { featureFlags } = useValues(featureFlagLogic)
+
+    const creationSource = source ?? SURVEY_CREATED_SOURCE.INSIGHT_CROSS_SELL
 
     const shouldUseQuickCreate = featureFlags[FEATURE_FLAGS.SURVEYS_INSIGHT_BUTTON_EXPERIMENT] === 'test'
 
@@ -40,7 +53,7 @@ export function SurveyOpportunityButton({
     const initialMaxPrompt = funnelContext
         ? `${disableAutoPromptSubmit ? '' : '!'}Create a survey to help me identify and fix the root ` +
           `cause for ${formatPercentage(funnelContext.conversionRate * 100)} conversion in my ` +
-          `"${funnelContext.insightName}" funnel (\`${insight.id}\`). Read this insight to understand the ` +
+          `"${funnelContext.insightName}" funnel${insight.id ? ` (\`${insight.id}\`)` : ''}. Read this insight to understand the ` +
           `conversion goal, and suggest the best display / targeting strategies.`
         : ''
 
@@ -52,6 +65,7 @@ export function SurveyOpportunityButton({
         posthog.capture('survey opportunity displayed', {
             linked_insight_id: insight.id,
             conversionRate: funnelContext.conversionRate,
+            source: creationSource,
         })
     }, [insight.id, funnelContext])
 
@@ -69,13 +83,13 @@ export function SurveyOpportunityButton({
                 intent_context: ProductIntentContext.SURVEY_CREATED,
                 metadata: {
                     survey_id: toolOutput.survey_id,
-                    source: SURVEY_CREATED_SOURCE.INSIGHT_CROSS_SELL,
+                    source: creationSource,
                     created_successfully: !toolOutput?.error,
                 },
             })
 
             if (toolOutput?.error || !toolOutput?.survey_id) {
-                return captureMaxAISurveyCreationException(toolOutput.error, SURVEY_CREATED_SOURCE.INSIGHT_CROSS_SELL)
+                return captureMaxAISurveyCreationException(toolOutput.error, creationSource)
             }
 
             router.actions.push(urls.survey(toolOutput.survey_id))
@@ -86,6 +100,7 @@ export function SurveyOpportunityButton({
         posthog.capture('survey opportunity clicked', {
             linked_insight_id: insight.id,
             conversionRate: funnelContext?.conversionRate,
+            source: creationSource,
         })
         shouldUseQuickCreate ? setModalOpen(true) : openMax?.()
     }
@@ -108,4 +123,40 @@ export function SurveyOpportunityButton({
             )}
         </>
     )
+}
+
+export interface SurveyOpportunityButtonWithQueryProps {
+    insight: {
+        name: string
+        query: InsightVizNode
+    }
+    insightProps: InsightLogicProps<QuerySchema>
+    source?: SURVEY_CREATED_SOURCE
+}
+
+export function SurveyOpportunityButtonWithQuery({
+    insight,
+    insightProps,
+    source,
+}: SurveyOpportunityButtonWithQueryProps): JSX.Element | null {
+    const vizKey = insightVizDataNodeKey(insightProps)
+    const dataNodeLogicProps: DataNodeLogicProps = {
+        key: vizKey,
+        query: insight.query.source,
+    }
+
+    const { response } = useValues(dataNodeLogic(dataNodeLogicProps))
+
+    const result = (response as FunnelsQueryResponse | null)?.results
+    if (!result) {
+        return null
+    }
+
+    const surveyableInsight: SurveyableFunnelInsight = {
+        name: insight.name,
+        query: insight.query as InsightVizNode<FunnelsQuery>,
+        result,
+    }
+
+    return <SurveyOpportunityButton insight={surveyableInsight} source={source} />
 }

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -635,6 +635,7 @@ export enum SURVEY_CREATED_SOURCE {
     SURVEY_EMPTY_STATE = 'survey_empty_state',
     EXPERIMENTS = 'experiments',
     INSIGHT_CROSS_SELL = 'insight_cross_sell',
+    CUSTOMER_ANALYTICS_INSIGHT = 'customer_analytics_insight',
 }
 
 export enum SURVEY_EMPTY_STATE_EXPERIMENT_VARIANT {

--- a/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
+++ b/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
@@ -6,6 +6,9 @@ import { CardMeta } from 'lib/components/Cards/CardMeta'
 import { InsightMetaContent } from 'lib/components/Cards/InsightCard/InsightMeta'
 import { QueryCard } from 'lib/components/Cards/InsightCard/QueryCard'
 import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
+import { SurveyOpportunityButtonWithQuery } from 'scenes/surveys/components/SurveyOpportunityButton'
+import { SURVEY_CREATED_SOURCE } from 'scenes/surveys/constants'
+import { isValidFunnelQuery } from 'scenes/surveys/utils/opportunityDetection'
 import { urls } from 'scenes/urls'
 
 import { QuerySchema } from '~/queries/schema/schema-general'
@@ -51,6 +54,17 @@ export function CustomerAnalyticsQueryCard({ insight, tabId }: CustomerAnalytics
         query: insight.query,
     }
 
+    // isValidFunnelQuery does not check "business logic" such as conversion
+    // rate threshold, etc -- it only checks if the funnel can be targeted
+    // by a survey.
+    const surveyOpportunityButton = isValidFunnelQuery(insight.query) ? (
+        <SurveyOpportunityButtonWithQuery
+            insight={insight}
+            insightProps={insightProps}
+            source={SURVEY_CREATED_SOURCE.CUSTOMER_ANALYTICS_INSIGHT}
+        />
+    ) : null
+
     if (needsConfig) {
         const missingSeries = insight?.requiredSeries ? getEmptySeriesNames(insight.requiredSeries) : []
 
@@ -93,6 +107,7 @@ export function CustomerAnalyticsQueryCard({ insight, tabId }: CustomerAnalytics
             context={{ refresh: 'force_blocking', insightProps }}
             className={insight?.className || ''}
             attachTo={customerAnalyticsSceneLogic}
+            extraControls={surveyOpportunityButton}
         />
     )
 }


### PR DESCRIPTION
## Problem

want to give users an easy way to create surveys from customer analytics funnels

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

![Screenshot 2025-12-02 at 5.24.55 PM.png](https://app.graphite.com/user-attachments/assets/5d0fed61-1a5b-4f4e-bc0e-2f5d30eef7cb.png)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->