### PR TITLE
fix: Default pinned folder to `custom-products://` when FF is enabled

### DIFF
--- a/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
@@ -37,7 +37,7 @@ export function PinnedFolder(): JSX.Element {
 
     const { featureFlags } = useValues(featureFlagLogic)
     const isCustomProductsSidebarEnabled =
-        featureFlags[FEATURE_FLAGS.CUSTOM_PRODUCTS_SIDEBAR] || pinnedFolder === 'custom-products://'
+        featureFlags[FEATURE_FLAGS.CUSTOM_PRODUCTS_SIDEBAR] === 'test' || pinnedFolder === 'custom-products://'
 
     const showDefaultHeader = !['products://', 'data://', 'custom-products://'].includes(pinnedFolder)
 


### PR DESCRIPTION
When we have the FF enabled (for our A/B test) besides just having "My Apps" in the sidebar
we should also guarantee people see that by default or else this is useless - people won't discover this on their own