### PR TITLE
fix(experiments): save shared metric tags with fewer clicks

### DIFF
--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
@@ -110,6 +110,9 @@ export function SharedMetric(): JSX.Element {
                             setSharedMetric({
                                 tags: tags,
                             })
+                            if (action === 'update') {
+                                updateSharedMetric(false)
+                            }
                         }}
                         canEdit
                         tags={sharedMetric.tags}

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -52,7 +52,7 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
     actions({
         setSharedMetric: (metric: Partial<SharedMetric>) => ({ metric }),
         createSharedMetric: true,
-        updateSharedMetric: true,
+        updateSharedMetric: (redirect?: boolean) => ({ redirect }),
         deleteSharedMetric: true,
     }),
 
@@ -102,7 +102,7 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
                 router.actions.push('/experiments?tab=shared-metrics')
             }
         },
-        updateSharedMetric: async () => {
+        updateSharedMetric: async ({ redirect = true }: { redirect?: boolean } = {}) => {
             const response = await api.update(
                 `api/projects/@current/experiment_saved_metrics/${values.sharedMetricId}`,
                 values.sharedMetric
@@ -110,7 +110,9 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
             if (response.id) {
                 lemonToast.success('Shared metric updated successfully')
                 actions.loadSharedMetrics()
-                router.actions.push('/experiments?tab=shared-metrics')
+                if (redirect) {
+                    router.actions.push('/experiments?tab=shared-metrics')
+                }
             }
         },
         deleteSharedMetric: async () => {


### PR DESCRIPTION
## Problem

Tagging shared metrics is cumbersome and prone to error.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

When a shared metric is updated, managing tags results in a direct update operation over the shared metric.

| Before | After |
| - | - |
| ![tag-shared-metric-before](https://github.com/user-attachments/assets/64445cb6-c758-4889-8cb9-307a3015cfbf) | ![tag-shared-metric-after](https://github.com/user-attachments/assets/630345d7-f1f1-44d5-85a4-adcdef23de2a) |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/8069a86c-3adf-43dc-9f4a-1a6525fdce19)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
