### PR TITLE
fix(experiments): create a shared retention metric

### DIFF
--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -12,6 +12,7 @@ from posthog.schema import (
     ExperimentMeanMetric,
     ExperimentMetricType,
     ExperimentRatioMetric,
+    ExperimentRetentionMetric,
     ExperimentTrendsQuery,
 )
 
@@ -88,8 +89,12 @@ class ExperimentSavedMetricSerializer(TaggedItemSerializerMixin, serializers.Mod
                     ExperimentFunnelMetric(**metric_query)
                 elif metric_query["metric_type"] == ExperimentMetricType.RATIO:
                     ExperimentRatioMetric(**metric_query)
+                elif metric_query["metric_type"] == ExperimentMetricType.RETENTION:
+                    ExperimentRetentionMetric(**metric_query)
                 else:
-                    raise ValidationError("ExperimentMetric metric_type must be 'mean', 'funnel', or 'ratio'")
+                    raise ValidationError(
+                        "ExperimentMetric metric_type must be 'mean', 'funnel', 'ratio', or 'retention'"
+                    )
             elif metric_query["kind"] == "ExperimentTrendsQuery":
                 ExperimentTrendsQuery(**metric_query)
             elif metric_query["kind"] == "ExperimentFunnelsQuery":

--- a/ee/clickhouse/views/test/test_experiment_saved_metrics.py
+++ b/ee/clickhouse/views/test/test_experiment_saved_metrics.py
@@ -259,7 +259,9 @@ class TestExperimentSavedMetricsCRUD(APILicensedTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("ExperimentMetric metric_type must be 'mean', 'funnel', or 'ratio'", response.json()["detail"])
+        self.assertIn(
+            "ExperimentMetric metric_type must be 'mean', 'funnel', 'ratio', or 'retention'", response.json()["detail"]
+        )
 
     def test_create_saved_metric_with_experiment_metric_ratio(self):
         response = self.client.post(


### PR DESCRIPTION
## Problem

A _retention_ shared metric can't be created.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Updated the `ExperimentToSavedMetricSerializer` to include `ExperimentRetentionMetric` in the query validation.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/a9f1c138-d788-46d6-ba82-5b1a426f7372)r

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
