### PR TITLE
fix(notebooks): insight full height

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
@@ -48,6 +48,10 @@
         transition: all 150ms linear 1000ms;
     }
 
+    .InsightCard__viz {
+        height: 100%;
+    }
+
     &--editable:hover,
     &--selected {
         .NotebookNode__gap {


### PR DESCRIPTION
## Problem

<img width="1709" height="1035" alt="Screenshot 2025-12-02 at 09 43 03" src="https://github.com/user-attachments/assets/15437701-5642-4328-9c70-35084bb0b99b" />

## Changes

<img width="1693" height="1106" alt="Screenshot 2025-12-02 at 09 42 21" src="https://github.com/user-attachments/assets/ca07c896-f56a-409f-a6bf-7f296558e460" />

## How did you test this code?

👀 