### PR TITLE
fix: emoji comment bar would open if you pressed escape

### DIFF
--- a/frontend/src/scenes/session-recordings/player/commenting/CommentOnRecordingButton.tsx
+++ b/frontend/src/scenes/session-recordings/player/commenting/CommentOnRecordingButton.tsx
@@ -101,7 +101,7 @@ export function EmojiCommentOnRecordingButton({ className }: { className?: strin
             visible={quickEmojiIsOpen}
             closeOnClickInside={false}
             onClickOutside={() => {
-                setQuickEmojiIsOpen(!quickEmojiIsOpen)
+                setQuickEmojiIsOpen(false)
             }}
             onVisibilityChange={(visible) => {
                 setQuickEmojiIsOpen(visible)


### PR DESCRIPTION
it had annoyed me multiple times that if you pressed escape

the emoji quick comment bar would open unexpectedly

well, not anymore

(pressing escape does still close it

| before | after | 
| - | - |
| ![2025-12-02 09.08.06.gif](https://app.graphite.com/user-attachments/assets/85c0e52c-b8c7-4d63-9a85-e65aa7de6fbf.gif)|![2025-12-02 09.07.30.gif](https://app.graphite.com/user-attachments/assets/378f7ddb-1a48-4239-b5f8-78693940e7f0.gif)|
