### PR TITLE
chore(workflows): indicate disabled workflow saving

### DIFF
--- a/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
@@ -100,7 +100,7 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
                                       : 'No changes to save'
                             }
                         >
-                            {props.id === 'new' ? 'Create' : 'Save'}
+                            {props.id === 'new' ? 'Create disabled' : 'Save'}
                         </LemonButton>
                     </>
                 }

--- a/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
@@ -100,7 +100,7 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
                                       : 'No changes to save'
                             }
                         >
-                            {props.id === 'new' ? 'Create disabled' : 'Save'}
+                            {props.id === 'new' ? 'Create as draft' : 'Save'}
                         </LemonButton>
                     </>
                 }


### PR DESCRIPTION
## Problem
Folks are hesitant to create workflows because its not clear that they get created in a disabled state. 
c.f. https://posthoghelp.zendesk.com/agent/tickets/44026 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46112)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<img width="1055" height="880" alt="Screenshot 2025-12-02 at 10 49 19" src="https://github.com/user-attachments/assets/1ff91af7-5783-4563-a18e-3f65968ecfea" />

- changed button text to indicate it gets created disabled
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- local dev


