### PR TITLE
fix(migrations): use direct postgres connection to bypass PgBouncer

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -54,22 +54,29 @@ echo "0" > $CLICKHOUSE_STATUS
 ) & # ClickHouse migrations can run in parallel to Postgres ones
 CLICKHOUSE_PID=$!
 
-# Run postgres migrations with lock timeout and retry logic
-# This allows short-locking migrations to succeed even under load
+# Run postgres migrations with retry logic
+# If POSTHOG_POSTGRES_DIRECT_HOST is set, use direct connection (bypasses PgBouncer)
+# which allows lock_timeout to be set in Django database OPTIONS
 MIGRATE_MAX_RETRIES=${MIGRATE_MAX_RETRIES:-10}
 MIGRATE_RETRY_DELAY=${MIGRATE_RETRY_DELAY:-3}
 MIGRATE_BACKOFF=${MIGRATE_BACKOFF:-2}
-MIGRATE_LOCK_TIMEOUT=${MIGRATE_LOCK_TIMEOUT:-2000}  # 2 seconds
 
 MIGRATE_ATTEMPT=1
 MIGRATE_SUCCESS=false
 MIGRATE_START_TIME=$(date +%s.%N)
 
-while [ $MIGRATE_ATTEMPT -le $MIGRATE_MAX_RETRIES ]; do
-    echo "[migrate] Django migration attempt $MIGRATE_ATTEMPT/$MIGRATE_MAX_RETRIES (lock_timeout=${MIGRATE_LOCK_TIMEOUT}ms)"
+# Build migrate command - use direct connection if available
+if [ -n "$POSTHOG_POSTGRES_DIRECT_HOST" ]; then
+    MIGRATE_CMD="python manage.py migrate --noinput --database=default_direct"
+    echo "[migrate] Using direct database connection (lock_timeout enabled)"
+else
+    MIGRATE_CMD="python manage.py migrate --noinput"
+fi
 
-    # PGOPTIONS sets lock_timeout for this command only
-    if PGOPTIONS="-c lock_timeout=${MIGRATE_LOCK_TIMEOUT}" python manage.py migrate --noinput; then
+while [ $MIGRATE_ATTEMPT -le $MIGRATE_MAX_RETRIES ]; do
+    echo "[migrate] Django migration attempt $MIGRATE_ATTEMPT/$MIGRATE_MAX_RETRIES"
+
+    if $MIGRATE_CMD; then
         MIGRATE_SUCCESS=true
         break
     fi

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -124,6 +124,20 @@ if read_host:
     DATABASES["replica"] = postgres_config(read_host)
     DATABASE_ROUTERS.append("posthog.dbrouter.ReplicaRouter")
 
+# Configure a direct database connection bypassing PgBouncer.
+# This allows using PGOPTIONS like lock_timeout which PgBouncer doesn't support.
+# Used for migrations: python manage.py migrate --database=default_direct
+direct_host = os.getenv("POSTHOG_POSTGRES_DIRECT_HOST")
+if direct_host:
+    DATABASES["default_direct"] = postgres_config(direct_host)
+    # Override port for direct connection (PgBouncer uses 6543, Postgres uses 5432)
+    DATABASES["default_direct"]["PORT"] = os.getenv("POSTHOG_POSTGRES_DIRECT_PORT", "5432")
+    # Disable server-side cursors is not needed for direct connection
+    DATABASES["default_direct"]["DISABLE_SERVER_SIDE_CURSORS"] = False
+    # Set lock_timeout for migrations to fail fast on lock contention
+    lock_timeout_ms = os.getenv("MIGRATE_LOCK_TIMEOUT", "2000")
+    DATABASES["default_direct"]["OPTIONS"] = {"options": f"-c lock_timeout={lock_timeout_ms}"}
+
 # Add the persons_db_writer database configuration using PERSONS_DB_WRITER_URL
 # For local development, default to the persons database in the main container if no URL is provided
 persons_db_writer_url = os.getenv("PERSONS_DB_WRITER_URL")

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -129,8 +129,10 @@ if read_host:
 # Used for migrations: python manage.py migrate --database=default_direct
 direct_host = os.getenv("POSTHOG_POSTGRES_DIRECT_HOST")
 if direct_host:
-    DATABASES["default_direct"] = postgres_config(direct_host)
-    # Override port for direct connection (PgBouncer uses 6543, Postgres uses 5432)
+    # Copy from default database config (works with both DATABASE_URL and POSTHOG_DB_NAME setups)
+    DATABASES["default_direct"] = DATABASES["default"].copy()
+    # Override host and port for direct connection (bypassing PgBouncer)
+    DATABASES["default_direct"]["HOST"] = direct_host
     DATABASES["default_direct"]["PORT"] = os.getenv("POSTHOG_POSTGRES_DIRECT_PORT", "5432")
     # Disable server-side cursors is not needed for direct connection
     DATABASES["default_direct"]["DISABLE_SERVER_SIDE_CURSORS"] = False


### PR DESCRIPTION
**Hotfix for migration failures in dev/prod**

PgBouncer doesn't support the `options` startup parameter, causing migrations to fail with:
```
FATAL: unsupported startup parameter: options
```

**Fix:** Add a `default_direct` Django database alias that connects directly to Postgres (bypassing PgBouncer), with `lock_timeout` configured in Django's `OPTIONS`.

**Changes:**
- Add `default_direct` database config derived from `default` when `POSTHOG_POSTGRES_DIRECT_HOST` is set
- Update `bin/migrate` to use `--database=default_direct` when direct host available
- Retry logic works in both cases, lock_timeout only applies with direct connection

**Charts change required:** Set `POSTHOG_POSTGRES_DIRECT_HOST` to RDS endpoint for migration job.

**Tested locally:**
- `default` → `lock_timeout: 0`
- `default_direct` → `lock_timeout: 2s`