### PR TITLE
chore: sort activity log dropdown

### DIFF
--- a/frontend/src/scenes/audit-logs/BasicFiltersTab.tsx
+++ b/frontend/src/scenes/audit-logs/BasicFiltersTab.tsx
@@ -66,10 +66,12 @@ export const BasicFiltersTab = (): JSX.Element => {
                         value={filters.scopes || []}
                         onChange={(scopes) => setFilters({ scopes: scopes as ActivityScope[] })}
                         options={
-                            availableFilters?.static_filters?.scopes?.map((s: any) => ({
-                                key: s.value,
-                                label: humanizeScope(s.value, true),
-                            })) || []
+                            availableFilters?.static_filters?.scopes
+                                ?.map((s: any) => ({
+                                    key: s.value,
+                                    label: humanizeScope(s.value, true),
+                                }))
+                                .sort((a, b) => a.label.localeCompare(b.label)) || []
                         }
                         placeholder="All scopes"
                         allowCustomValues={false}
@@ -88,10 +90,12 @@ export const BasicFiltersTab = (): JSX.Element => {
                         value={filters.activities || []}
                         onChange={(activities) => setFilters({ activities })}
                         options={
-                            availableFilters?.static_filters?.activities?.map((a: any) => ({
-                                key: a.value,
-                                label: humanizeActivity(a.value),
-                            })) || []
+                            availableFilters?.static_filters?.activities
+                                ?.map((a: any) => ({
+                                    key: a.value,
+                                    label: humanizeActivity(a.value),
+                                }))
+                                .sort((a, b) => a.label.localeCompare(b.label)) || []
                         }
                         placeholder="All activities"
                         allowCustomValues={false}


### PR DESCRIPTION
## Problem

Users found it difficult to locate specific scopes and activities within the Activity Log dropdowns due to unsorted options. This change improves the usability and discoverability of options in these filters.

## Changes

-   Modified `frontend/src/scenes/audit-logs/BasicFiltersTab.tsx` to sort options alphabetically.
-   Added `.sort((a, b) => a.label.localeCompare(b.label))` to the options for both the "Scope" and "Activity" dropdowns.

## How did you test this code?

Manually verified that the "Scope" and "Activity" dropdowns on the Activity Log page now display their options in alphabetical order.

---
[Slack Thread](https://posthog.slack.com/archives/C08UM214Z50/p1764664800690699?thread_ts=1764664800.690699&cid=C08UM214Z50)

<a href="https://cursor.com/background-agent?bcId=bc-feef67ba-4193-45eb-8de6-e98efc322ec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-feef67ba-4193-45eb-8de6-e98efc322ec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

