### PR TITLE
feat(llma): add `organization_name` to usage report event

### DIFF
--- a/posthog/tasks/llm_analytics_usage_report.py
+++ b/posthog/tasks/llm_analytics_usage_report.py
@@ -852,6 +852,7 @@ def _get_all_llm_analytics_reports(
     # Get team to organization mapping
     teams = Team.objects.filter(id__in=all_teams_with_ai).select_related("organization")
     team_to_org: dict[int, str] = {team.id: str(team.organization_id) for team in teams}
+    org_id_to_name: dict[str, str] = {str(team.organization_id): team.organization.name for team in teams}
 
     # Aggregate by organization
     org_reports: dict[str, dict[str, Any]] = {}
@@ -860,6 +861,7 @@ def _get_all_llm_analytics_reports(
         if org_id not in org_reports:
             org_reports[org_id] = {
                 "organization_id": org_id,
+                "organization_name": org_id_to_name.get(org_id, ""),
                 "period_start": period_start.isoformat(),
                 "period_end": period_end.isoformat(),
                 "ai_generation_count": 0,

--- a/posthog/tasks/test/test_llm_analytics_usage_report.py
+++ b/posthog/tasks/test/test_llm_analytics_usage_report.py
@@ -526,6 +526,7 @@ class TestLLMAnalyticsUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDe
 
         # Verify org 1 report
         org_1_report = org_reports[str(self.organization.id)]
+        assert org_1_report["organization_name"] == self.organization.name
         assert org_1_report["ai_generation_count"] == 13  # 10 + 3
         assert org_1_report["ai_evaluation_count"] == 5
         assert org_1_report["total_ai_cost_usd"] == pytest.approx(0.150, rel=1e-6)  # 3 * 0.050
@@ -549,6 +550,7 @@ class TestLLMAnalyticsUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDe
 
         # Verify org 2 report
         org_2_report = org_reports[str(org_2.id)]
+        assert org_2_report["organization_name"] == org_2.name
         assert org_2_report["ai_embedding_count"] == 7
         assert org_2_report["ai_generation_count"] == 2
         assert org_2_report["total_ai_cost_usd"] == pytest.approx(0.050, rel=1e-6)  # 2 * 0.025


### PR DESCRIPTION
@Radu-Raicea - was going to see about a filterable report where we can quickly filter by org name. i think adding `organization_name` here is step 1 there and then can have a filterable dashboard in posthog to quickly have our own custom org level report and for dogfooding etc too.

## Problem

When analyzing LLM analytics usage events, there's no easy way to identify organizations by name - only by ID.

## Changes

- Add `organization_name` to the "llm analytics usage" event properties
- The organization is already fetched via `select_related("organization")`, so no additional queries are needed
- Add test assertions to verify the field is included

## How did you test this code?

Added assertions in `test_full_llm_analytics_report` to verify `organization_name` is correctly populated for both organizations in the test.

## Changelog: (features only) Is this feature complete?

No - internal telemetry change only