### PR TITLE
fix(experiments): remove table prefix when selecting data warehouse timestamp field

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -444,6 +444,100 @@
                                                                                                             join_algorithm = 'auto'
   '''
 # ---
+# name: TestCohortQuery.test_cohort_filter_with_extra.12
+  '''
+  (
+     (SELECT persons.id AS id
+      FROM
+        (SELECT tupleElement(argMax(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '')), person.version), 1) AS properties___name,
+                person.id AS id
+         FROM person
+         WHERE and(equals(person.team_id, 99999), in(id,
+                                                       (SELECT where_optimization.id AS id
+                                                        FROM person AS where_optimization
+                                                        WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
+         GROUP BY person.id
+         HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+      WHERE ifNull(equals(persons.properties___name, 'test'), 0)
+      ORDER BY persons.id ASC
+      LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                                join_algorithm='auto'))
+  UNION DISTINCT (
+                    (SELECT source.id AS id
+                     FROM
+                       (SELECT actor_id AS actor_id,
+                               count() AS event_count,
+                               groupUniqArray(distinct_id) AS event_distinct_ids,
+                               actor_id AS id
+                        FROM
+                          (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,
+                                  toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                                  e.uuid AS uuid,
+                                  e.distinct_id AS distinct_id
+                           FROM events AS e
+                           LEFT OUTER JOIN
+                             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                                     person_distinct_id_overrides.distinct_id AS distinct_id
+                              FROM person_distinct_id_overrides
+                              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                              GROUP BY person_distinct_id_overrides.distinct_id
+                              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                           WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
+                        GROUP BY actor_id) AS source
+                     ORDER BY source.id ASC
+                     LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
+                                               join_algorithm='auto')) SETTINGS readonly=2,
+                                                                                max_execution_time=600,
+                                                                                allow_experimental_object_type=1,
+                                                                                format_csv_allow_double_quotes=0,
+                                                                                max_ast_elements=4000000,
+                                                                                max_expanded_ast_elements=4000000,
+                                                                                max_bytes_before_external_group_by=0,
+                                                                                transform_null_in=1,
+                                                                                optimize_min_equality_disjunction_chain_length=4294967295,
+                                                                                allow_experimental_join_condition=1,
+                                                                                use_hive_partitioning=0
+  '''
+# ---
+# name: TestCohortQuery.test_cohort_filter_with_extra.13
+  '''
+  
+  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  FROM
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+            countIf(timestamp > now() - INTERVAL 1 week
+                    AND timestamp < now()
+                    AND event = '$pageview'
+                    AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_1_level_0_0
+     FROM events e
+     LEFT OUTER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 99999
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     WHERE team_id = 99999
+       AND event IN ['$pageview']
+       AND timestamp <= now()
+       AND timestamp >= now() - INTERVAL 1 week
+     GROUP BY person_id) behavior_query
+  FULL OUTER JOIN
+    (SELECT *,
+            id AS person_id
+     FROM
+       (SELECT id,
+               argMax(properties, version) as person_props
+        FROM person
+        WHERE team_id = 99999
+        GROUP BY id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
+  WHERE 1 = 1
+    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
+          OR ((coalesce(performed_event_condition_None_level_level_0_level_1_level_0_0, false))))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                                            join_algorithm = 'auto'
+  '''
+# ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.2
   '''
   

--- a/posthog/hogql_queries/experiments/base_query_utils.py
+++ b/posthog/hogql_queries/experiments/base_query_utils.py
@@ -451,7 +451,7 @@ def get_source_events_query(
                 select=[
                     ast.Alias(
                         alias="timestamp",
-                        expr=ast.Field(chain=[source.table_name, source.timestamp_field]),
+                        expr=ast.Field(chain=[source.timestamp_field]),
                     ),
                     ast.Alias(
                         alias="entity_identifier",

--- a/posthog/hogql_queries/experiments/base_query_utils.py
+++ b/posthog/hogql_queries/experiments/base_query_utils.py
@@ -471,7 +471,7 @@ def get_source_events_query(
                     exprs=[
                         *get_source_time_window(
                             date_range_query,
-                            left=ast.Field(chain=[source.table_name, source.timestamp_field]),
+                            left=ast.Field(chain=[source.timestamp_field]),
                             conversion_window=conversion_window,
                             conversion_window_unit=conversion_window_unit,
                         ),

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -404,7 +404,7 @@ class ExperimentQueryBuilder:
         if is_dw:
             assert isinstance(self.metric.source, ExperimentDataWarehouseNode)
             table = self.metric.source.table_name
-            timestamp_field = f"{table}.{self.metric.source.timestamp_field}"
+            timestamp_field = self.metric.source.timestamp_field
             join_condition = "{join_condition}"
         else:
             table = "events"
@@ -852,7 +852,7 @@ class ExperimentQueryBuilder:
             assert isinstance(self.metric.numerator, ExperimentDataWarehouseNode)
             num_table = self.metric.numerator.table_name
             num_entity_field = f"{self.metric.numerator.data_warehouse_join_key}"
-            num_timestamp_field = f"{num_table}.{self.metric.numerator.timestamp_field}"
+            num_timestamp_field = self.metric.numerator.timestamp_field
         else:
             num_table = "events"
             num_entity_field = self.entity_key
@@ -863,7 +863,7 @@ class ExperimentQueryBuilder:
             assert isinstance(self.metric.denominator, ExperimentDataWarehouseNode)
             denom_table = self.metric.denominator.table_name
             denom_entity_field = f"{self.metric.denominator.data_warehouse_join_key}"
-            denom_timestamp_field = f"{denom_table}.{self.metric.denominator.timestamp_field}"
+            denom_timestamp_field = self.metric.denominator.timestamp_field
         else:
             denom_table = "events"
             denom_entity_field = self.entity_key


### PR DESCRIPTION
## Problem

It seems like users can have a source prefix on data warehouse tables. If that is the case, it breaks our timestamp selection as we do `{table_name}.{timestamp_field}`, and hogql is not able to resolve the field then, as the selector becomes `bigquery.my_table.timestamp`.

## Changes

Remove the {table_name} prefix. The queries should run fine without that.

## How did you test this code?
- Tested manually in SQL editor. Removing the prefix fixed the issue there.
- Existing tests passes
