### PR TITLE
fix: when viewing a discussion, be able to jump to the right point in the recording

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -596,7 +596,21 @@ export const productUrls = {
             ...(order ? { order } : {}),
         }).url,
     replayPlaylist: (id: string): string => `/replay/playlists/${id}`,
-    replaySingle: (id: string): string => `/replay/${id}`,
+    replaySingle: (
+        id: string,
+        options?: {
+            secondsOffsetFromStart?: number
+            unixTimestampMillis?: number
+        }
+    ): string => {
+        if (options?.unixTimestampMillis) {
+            return `/replay/${id}?timestamp=${options.unixTimestampMillis}`
+        }
+        if (options?.secondsOffsetFromStart) {
+            return `/replay/${id}?t=${options.secondsOffsetFromStart}`
+        }
+        return `/replay/${id}`
+    },
     replayFilePlayback: (): string => '/replay/file-playback',
     replaySettings: (sectionId?: string): string => `/replay/settings${sectionId ? `?sectionId=${sectionId}` : ''}`,
     revenueAnalytics: (): string => '/revenue_analytics',

--- a/frontend/src/scenes/comments/Comment.tsx
+++ b/frontend/src/scenes/comments/Comment.tsx
@@ -1,9 +1,10 @@
 import { generateText } from '@tiptap/core'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 import { useEffect, useRef } from 'react'
 
-import { IconCheck, IconEllipsis, IconPencil, IconShare } from '@posthog/icons'
+import { IconCheck, IconEllipsis, IconEye, IconPencil, IconShare } from '@posthog/icons'
 import { LemonButton, LemonMenu, ProfilePicture } from '@posthog/lemon-ui'
 
 import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
@@ -15,40 +16,217 @@ import {
     LemonRichContentEditor,
     serializationOptions,
 } from 'lib/lemon-ui/LemonRichContent/LemonRichContentEditor'
+import { colonDelimitedDuration } from 'lib/utils'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { CommentType } from '~/types'
 
+import { getRecordingLinkInfo, isViewingRecording } from './commentUtils'
 import { CommentWithRepliesType, commentsLogic } from './commentsLogic'
 
 export type CommentProps = {
     commentWithReplies: CommentWithRepliesType
 }
 
-const Comment = ({ comment }: { comment: CommentType }): JSX.Element => {
-    const {
-        editingComment,
-        commentsLoading,
-        replyingCommentId,
-        emojiReactionsByComment,
-        isMyComment,
-        editingCommentRichContentEditor,
-        isEditingCommentEmpty,
-    } = useValues(commentsLogic)
-    const {
-        deleteComment,
-        setEditingComment,
-        persistEditedComment,
-        setReplyingComment,
-        sendEmojiReaction,
-        setEditingCommentRichContentEditor,
-        onEditingCommentRichContentEditorUpdate,
-    } = useActions(commentsLogic)
+const CommentBottomRow = ({ comment }: { comment: CommentType }): JSX.Element => {
+    const { editingComment, replyingCommentId, emojiReactionsByComment, isMyComment } = useValues(commentsLogic)
+    const { deleteComment, sendEmojiReaction } = useActions(commentsLogic)
 
     const ref = useRef<HTMLDivElement | null>(null)
 
     const isHighlighted = replyingCommentId === comment.id || editingComment?.id === comment.id
     const reactions = emojiReactionsByComment[comment.id] || {}
+    const recordingLinkInfo = getRecordingLinkInfo(comment)
+
+    const handleViewInRecording = (): void => {
+        if (!recordingLinkInfo) {
+            return
+        }
+        if (isViewingRecording(recordingLinkInfo.recordingId) && recordingLinkInfo.unixTimestampMillis) {
+            router.actions.push(recordingLinkInfo.url)
+        } else {
+            window.location.href = recordingLinkInfo.url
+        }
+    }
+
+    useEffect(() => {
+        if (isHighlighted) {
+            ref.current?.scrollIntoView()
+        }
+    }, [isHighlighted])
+
+    let timeInRecordingLabel: string | null = null
+    if (comment.item_context?.milliseconds_into_recording !== undefined) {
+        timeInRecordingLabel = colonDelimitedDuration(comment.item_context?.milliseconds_into_recording / 1000, null)
+    }
+
+    return (
+        <div className="flex flex-row items-center justify-between">
+            <div className="flex flex-row items-center gap-1">
+                {recordingLinkInfo ? (
+                    <LemonButton
+                        icon={<IconEye />}
+                        size="xsmall"
+                        type="tertiary"
+                        onClick={handleViewInRecording}
+                        tooltip="View in recording"
+                        data-attr="view-comment-in-recording-at-timestamp"
+                    >
+                        {timeInRecordingLabel}
+                    </LemonButton>
+                ) : null}
+                <span className="text-xs text-secondary italic">{comment.version ? <span>(edited)</span> : null}</span>
+            </div>
+            <div className="flex items-center">
+                <div data-attr="comment-reactions" className="flex items-center">
+                    {Object.entries(reactions).map(([emoji, commentList]) => (
+                        <LemonButton
+                            key={emoji}
+                            type="tertiary"
+                            onClick={() => {
+                                const existingCurrentUserReaction = commentList.find((emojiReaction) =>
+                                    isMyComment(emojiReaction)
+                                )
+                                if (existingCurrentUserReaction) {
+                                    deleteComment(existingCurrentUserReaction)
+                                } else {
+                                    sendEmojiReaction(emoji, comment.id)
+                                }
+                            }}
+                            size="small"
+                            data-attr={`comment-reaction-${emoji}`}
+                            tooltip={
+                                <div className="flex flex-col gap-">
+                                    <div className="text-2xl">{emoji}</div>
+                                    <SentenceList
+                                        listParts={commentList.map((c) =>
+                                            isMyComment(c) ? 'you' : (c.created_by?.first_name ?? 'Unknown user')
+                                        )}
+                                    />
+                                </div>
+                            }
+                        >
+                            <div className="flex flex-row gap-1 items-center">
+                                <span>{emoji}</span>
+                                <span className="text-xs font-semibold">{commentList.length}</span>
+                            </div>
+                        </LemonButton>
+                    ))}
+                    <EmojiPickerPopover
+                        onSelect={(emoji: string): void => {
+                            sendEmojiReaction(emoji, comment.id)
+                        }}
+                    />
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const CommentEditingForm = ({ comment }: { comment: CommentType }): JSX.Element | null => {
+    const { editingComment, commentsLoading, editingCommentRichContentEditor, isEditingCommentEmpty } =
+        useValues(commentsLogic)
+    const {
+        setEditingComment,
+        persistEditedComment,
+        setEditingCommentRichContentEditor,
+        onEditingCommentRichContentEditorUpdate,
+    } = useActions(commentsLogic)
+
+    return editingComment?.id === comment.id ? (
+        <div className="deprecated-space-y-2 border-t p-2">
+            <LemonRichContentEditor
+                placeholder="Edit comment"
+                initialContent={comment.rich_content}
+                onCreate={setEditingCommentRichContentEditor}
+                onUpdate={(isEmpty) => {
+                    if (editingCommentRichContentEditor) {
+                        setEditingComment({
+                            ...editingComment,
+                            rich_content: editingCommentRichContentEditor.getJSON(),
+                        })
+                        onEditingCommentRichContentEditorUpdate(isEmpty)
+                    }
+                }}
+                onPressCmdEnter={persistEditedComment}
+                disabled={commentsLoading}
+            />
+            <div className="flex justify-between items-center gap-2">
+                <div className="flex-1" />
+                <LemonButton
+                    type="secondary"
+                    onClick={() => {
+                        setEditingComment(null)
+                        setEditingCommentRichContentEditor(null)
+                    }}
+                    disabled={commentsLoading}
+                >
+                    Cancel
+                </LemonButton>
+                <LemonButton
+                    type="primary"
+                    onClick={persistEditedComment}
+                    disabledReason={isEditingCommentEmpty ? 'No message' : commentsLoading ? 'Saving...' : null}
+                    sideIcon={<KeyboardShortcut command enter />}
+                >
+                    Save changes
+                </LemonButton>
+            </div>
+        </div>
+    ) : null
+}
+
+const CommentTopRow = ({ comment }: { comment: CommentType }): JSX.Element => {
+    const {} = useValues(commentsLogic)
+    const { deleteComment, setEditingComment, setReplyingComment } = useActions(commentsLogic)
+
+    return (
+        <div className="flex items-center justify-between gap-2">
+            <div>
+                <span className="ph-no-capture flex-1 font-semibold">
+                    {comment.created_by?.first_name ?? 'Unknown user'}
+                </span>
+            </div>
+            <div className="flex items-center gap-1">
+                {comment.created_at ? (
+                    <span className="text-xs">
+                        <TZLabel time={comment.created_at} />
+                    </span>
+                ) : null}
+
+                <LemonMenu
+                    items={[
+                        {
+                            icon: <IconShare />,
+                            label: 'Reply',
+                            onClick: () => setReplyingComment(comment.source_comment ?? comment.id),
+                        },
+                        {
+                            icon: <IconPencil />,
+                            label: 'Edit',
+                            onClick: () => setEditingComment(comment),
+                        },
+                        {
+                            icon: <IconCheck />,
+                            label: 'Delete',
+                            onClick: () => deleteComment(comment),
+                            // disabledReason: "Only admins can archive other peoples comments"
+                        },
+                    ]}
+                >
+                    <LemonButton icon={<IconEllipsis />} size="xsmall" />
+                </LemonMenu>
+            </div>
+        </div>
+    )
+}
+
+const Comment = ({ comment }: { comment: CommentType }): JSX.Element => {
+    const { editingComment, replyingCommentId } = useValues(commentsLogic)
+
+    const ref = useRef<HTMLDivElement | null>(null)
+
+    const isHighlighted = replyingCommentId === comment.id || editingComment?.id === comment.id
 
     useEffect(() => {
         if (isHighlighted) {
@@ -59,138 +237,22 @@ const Comment = ({ comment }: { comment: CommentType }): JSX.Element => {
     return (
         <div
             ref={ref}
-            className={clsx('Comment border rounded-lg bg-surface-primary', isHighlighted && 'border-accent')}
+            className={clsx('Comment border rounded-lg bg-surface-primary px-2 py-1', isHighlighted && 'border-accent')}
             data-comment-id={comment.id}
         >
-            <div className="flex-1 flex justify-start p-2 gap-2">
-                <ProfilePicture className="mt-1" size="xl" user={comment.created_by} />
+            <div className="flex flex-col justify-start gap-2">
+                <div className="flex-1 flex justify-start gap-2">
+                    <ProfilePicture size="xl" user={comment.created_by} />
 
-                <div className="flex flex-col flex-1">
-                    <div className="flex items-center gap-2">
-                        <span className="ph-no-capture flex-1 font-semibold">
-                            {comment.created_by?.first_name ?? 'Unknown user'}
-                        </span>
-                        {comment.created_at ? (
-                            <span className="text-xs">
-                                <TZLabel time={comment.created_at} />
-                            </span>
-                        ) : null}
-
-                        <LemonMenu
-                            items={[
-                                {
-                                    icon: <IconShare />,
-                                    label: 'Reply',
-                                    onClick: () => setReplyingComment(comment.source_comment ?? comment.id),
-                                },
-                                {
-                                    icon: <IconPencil />,
-                                    label: 'Edit',
-                                    onClick: () => setEditingComment(comment),
-                                },
-                                {
-                                    icon: <IconCheck />,
-                                    label: 'Delete',
-                                    onClick: () => deleteComment(comment),
-                                    // disabledReason: "Only admins can archive other peoples comments"
-                                },
-                            ]}
-                        >
-                            <LemonButton icon={<IconEllipsis />} size="xsmall" />
-                        </LemonMenu>
-                    </div>
-                    <LemonMarkdown lowKeyHeadings>{getText(comment)}</LemonMarkdown>
-                    <div className="flex flex-row items-center justify-between">
-                        <span className="text-xs text-secondary italic">
-                            {comment.version ? <span>(edited)</span> : null}
-                        </span>
-                        <div data-attr="comment-reactions" className="flex items-center">
-                            {Object.entries(reactions).map(([emoji, commentList]) => (
-                                <LemonButton
-                                    key={emoji}
-                                    type="tertiary"
-                                    onClick={() => {
-                                        const existingCurrentUserReaction = commentList.find((emojiReaction) =>
-                                            isMyComment(emojiReaction)
-                                        )
-                                        if (existingCurrentUserReaction) {
-                                            deleteComment(existingCurrentUserReaction)
-                                        } else {
-                                            sendEmojiReaction(emoji, comment.id)
-                                        }
-                                    }}
-                                    size="small"
-                                    data-attr={`comment-reaction-${emoji}`}
-                                    tooltip={
-                                        <div className="flex flex-col gap-">
-                                            <div className="text-2xl">{emoji}</div>
-                                            <SentenceList
-                                                listParts={commentList.map((c) =>
-                                                    isMyComment(c)
-                                                        ? 'you'
-                                                        : (c.created_by?.first_name ?? 'Unknown user')
-                                                )}
-                                            />
-                                        </div>
-                                    }
-                                >
-                                    <div className="flex flex-row gap-1 items-center">
-                                        <span>{emoji}</span>
-                                        <span className="text-xs font-semibold">{commentList.length}</span>
-                                    </div>
-                                </LemonButton>
-                            ))}
-                            <EmojiPickerPopover
-                                onSelect={(emoji: string): void => {
-                                    sendEmojiReaction(emoji, comment.id)
-                                }}
-                            />
-                        </div>
+                    <div className="flex flex-col flex-1">
+                        <CommentTopRow comment={comment} />
+                        <LemonMarkdown lowKeyHeadings>{getText(comment)}</LemonMarkdown>
                     </div>
                 </div>
+                <CommentBottomRow comment={comment} />
             </div>
 
-            {editingComment?.id === comment.id ? (
-                <div className="deprecated-space-y-2 border-t p-2">
-                    <LemonRichContentEditor
-                        placeholder="Edit comment"
-                        initialContent={comment.rich_content}
-                        onCreate={setEditingCommentRichContentEditor}
-                        onUpdate={(isEmpty) => {
-                            if (editingCommentRichContentEditor) {
-                                setEditingComment({
-                                    ...editingComment,
-                                    rich_content: editingCommentRichContentEditor.getJSON(),
-                                })
-                                onEditingCommentRichContentEditorUpdate(isEmpty)
-                            }
-                        }}
-                        onPressCmdEnter={persistEditedComment}
-                        disabled={commentsLoading}
-                    />
-                    <div className="flex justify-between items-center gap-2">
-                        <div className="flex-1" />
-                        <LemonButton
-                            type="secondary"
-                            onClick={() => {
-                                setEditingComment(null)
-                                setEditingCommentRichContentEditor(null)
-                            }}
-                            disabled={commentsLoading}
-                        >
-                            Cancel
-                        </LemonButton>
-                        <LemonButton
-                            type="primary"
-                            onClick={persistEditedComment}
-                            disabledReason={isEditingCommentEmpty ? 'No message' : commentsLoading ? 'Saving...' : null}
-                            sideIcon={<KeyboardShortcut command enter />}
-                        >
-                            Save changes
-                        </LemonButton>
-                    </div>
-                </div>
-            ) : null}
+            <CommentEditingForm comment={comment} />
         </div>
     )
 }

--- a/frontend/src/scenes/comments/commentUtils.ts
+++ b/frontend/src/scenes/comments/commentUtils.ts
@@ -1,0 +1,36 @@
+import { dayjs } from 'lib/dayjs'
+import { urls } from 'scenes/urls'
+
+import { ActivityScope, CommentType } from '~/types'
+
+export interface RecordingLinkInfo {
+    recordingId: string
+    unixTimestampMillis: number | undefined
+    url: string
+}
+
+export function getRecordingLinkInfo(comment: CommentType): RecordingLinkInfo | null {
+    const isRecordingComment = comment.scope === ActivityScope.REPLAY || comment.scope === ActivityScope.RECORDING
+    if (!isRecordingComment || !comment.item_id) {
+        return null
+    }
+    const timeInRecording = comment.item_context?.time_in_recording
+    const unixTimestampMillis = timeInRecording ? dayjs(timeInRecording).valueOf() : undefined
+    const url = urls.replaySingle(comment.item_id, unixTimestampMillis ? { unixTimestampMillis } : undefined)
+    return {
+        recordingId: comment.item_id,
+        unixTimestampMillis,
+        url,
+    }
+}
+
+export function isViewingRecording(recordingId: string): boolean {
+    const url = new URL(window.location.href)
+    const pathMatch = url.pathname.match(/\/replay\/([^/?#]+)/)
+    if (pathMatch && pathMatch[1] === recordingId) {
+        return true
+    }
+    const sessionRecordingId =
+        url.searchParams.get('sessionRecordingId') || url.hash.match(/sessionRecordingId=([^&]+)/)?.[1]
+    return sessionRecordingId === recordingId
+}

--- a/frontend/src/scenes/data-management/comments/Comments.tsx
+++ b/frontend/src/scenes/data-management/comments/Comments.tsx
@@ -14,6 +14,7 @@ import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconOpenInApp } from 'lib/lemon-ui/icons'
+import { getText } from 'scenes/comments/Comment'
 import { Scene } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
 import { userLogic } from 'scenes/userLogic'
@@ -43,8 +44,9 @@ export function Comments(): JSX.Element {
             key: 'content',
             width: '30%',
             render: function RenderComment(_, comment: CommentType): JSX.Element {
-                let renderedContent = <>{comment.content ?? ''}</>
-                if ((comment.content || '').trim().length > 50) {
+                const textContent = getText(comment)
+                let renderedContent = <>{textContent}</>
+                if (textContent.length > 50) {
                     renderedContent = (
                         <Tooltip
                             title={
@@ -52,11 +54,11 @@ export function Comments(): JSX.Element {
                                     className="whitespace-pre-wrap break-words"
                                     data-attr="comment-scene-comment-title-rendered-content"
                                 >
-                                    {comment.content ?? ''}
+                                    {textContent}
                                 </div>
                             }
                         >
-                            {(comment.content ?? '').slice(0, 47) + '...'}
+                            {textContent.slice(0, 47) + '...'}
                         </Tooltip>
                     )
                 }

--- a/frontend/src/scenes/data-management/comments/commentsLogic.ts
+++ b/frontend/src/scenes/data-management/comments/commentsLogic.ts
@@ -6,6 +6,7 @@ import { LemonSelectOption, lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { capitalizeFirstLetter } from 'lib/utils'
+import { getRecordingLinkInfo } from 'scenes/comments/commentUtils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -23,12 +24,13 @@ SCOPE_OPTIONS.unshift({
     label: 'Any',
 })
 
+const replayUrlWithTimestamp = (c: CommentType): string | null => getRecordingLinkInfo(c)?.url ?? null
+
 const openUrls: Partial<Record<ActivityScope, (c: CommentType) => string | null>> = {
     [ActivityScope.INSIGHT]: (c) =>
         c.item_context?.short_id ? urls.insightView(c.item_context?.short_id as InsightShortId) : null,
-    // TODO we only support this in modal apparently, but we should be able to open these at the timestamp of the comment
-    [ActivityScope.REPLAY]: (c) => (c.item_id ? urls.replaySingle(c.item_id as string) : null),
-    [ActivityScope.RECORDING]: (c) => (c.item_id ? urls.replaySingle(c.item_id as string) : null),
+    [ActivityScope.REPLAY]: replayUrlWithTimestamp,
+    [ActivityScope.RECORDING]: replayUrlWithTimestamp,
     [ActivityScope.DASHBOARD]: (c) => (c.item_id ? urls.dashboard(c.item_id) : null),
     [ActivityScope.FEATURE_FLAG]: (c) => (c.item_id ? urls.featureFlag(c.item_id) : null),
     [ActivityScope.EXPERIMENT]: (c) => (c.item_id ? urls.experiment(c.item_id) : null),

--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
@@ -129,6 +129,7 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                     item_context: {
                         is_emoji: true,
                         time_in_recording: dayjs(values.currentTimestamp).toISOString(),
+                        milliseconds_into_recording: values.currentPlayerTime,
                     },
                 })
                 playerCommentModel.actions.commentEdited(props.recordingId)
@@ -172,6 +173,7 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                     item_id: props.recordingId,
                     item_context: {
                         time_in_recording: dateForTimestamp.toISOString(),
+                        milliseconds_into_recording: values.currentPlayerTime,
                     },
                 }
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -12,7 +12,7 @@ import {
     reducers,
     selectors,
 } from 'kea'
-import { router } from 'kea-router'
+import { router, urlToAction } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import { delay } from 'kea-test-utils'
 import posthog from 'posthog-js'
@@ -1874,6 +1874,31 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         actions.updatePlayerTimeTracking()
         // Schedule periodic updates
         actions.schedulePlayerTimeTracking()
+    }),
+
+    urlToAction(({ actions, props }) => {
+        const handleTimestampParams = (searchParams: Record<string, string>): void => {
+            if (searchParams.timestamp) {
+                const desiredStartTime = Number(searchParams.timestamp)
+                if (!isNaN(desiredStartTime)) {
+                    actions.seekToTimestamp(desiredStartTime, true)
+                }
+            } else if (searchParams.t) {
+                const desiredStartTime = Number(searchParams.t) * 1000
+                if (!isNaN(desiredStartTime)) {
+                    actions.seekToTime(desiredStartTime)
+                }
+            }
+        }
+
+        return {
+            '/replay/:id': (_, searchParams) => handleTimestampParams(searchParams),
+            '/replay': (_, searchParams) => {
+                if (searchParams.sessionRecordingId === props.sessionRecordingId) {
+                    handleTimestampParams(searchParams)
+                }
+            },
+        }
     }),
 ])
 

--- a/products/replay/manifest.tsx
+++ b/products/replay/manifest.tsx
@@ -21,7 +21,18 @@ export const manifest: ProductManifest = {
                 ...(order ? { order } : {}),
             }).url,
         replayPlaylist: (id: string): string => `/replay/playlists/${id}`,
-        replaySingle: (id: string): string => `/replay/${id}`,
+        replaySingle: (
+            id: string,
+            options?: { secondsOffsetFromStart?: number; unixTimestampMillis?: number }
+        ): string => {
+            if (options?.unixTimestampMillis) {
+                return `/replay/${id}?timestamp=${options.unixTimestampMillis}`
+            }
+            if (options?.secondsOffsetFromStart) {
+                return `/replay/${id}?t=${options.secondsOffsetFromStart}`
+            }
+            return `/replay/${id}`
+        },
         replayFilePlayback: (): string => '/replay/file-playback',
         replaySettings: (sectionId?: string): string => `/replay/settings${sectionId ? `?sectionId=${sectionId}` : ''}`,
     },


### PR DESCRIPTION


we only store the ISO date on comments right now, which means the comment doesn't know how far into the recording it is (unless you load recording metadata)  
  
instead of doing that i've started adding the data into the comments  
since we don't know we will always have access to the recording when viewing a comment



![Screenshot 2025-12-03 at 18.03.22.png](https://app.graphite.com/user-attachments/assets/a95bd347-017e-43d4-ba52-2bbea4edb9ed.png)

reorganised the component a little so i can have the button on the left without making the profile picture wider  
and then show the time in the recording _only_ if we know it



[get to recording.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/f583d5f3-8331-49e2-b861-5a7350963063.mov" />](https://app.graphite.com/user-attachments/video/f583d5f3-8331-49e2-b861-5a7350963063.mov)

adds a button to let someone jump from a comment in a discussion to that point in the recording

(fly-by fixes the comments view in data management)