### PR TITLE
fix(signals): Get summary from DB, don't return from Temporal

### DIFF
--- a/posthog/temporal/ai/session_summary/activities/patterns.py
+++ b/posthog/temporal/ai/session_summary/activities/patterns.py
@@ -41,7 +41,6 @@ from ee.hogai.session_summaries.llm.consume import (
 )
 from ee.hogai.session_summaries.session.summarize_session import ExtraSummaryContext
 from ee.hogai.session_summaries.session_group.patterns import (
-    EnrichedSessionGroupSummaryPatternsList,
     RawSessionGroupPatternAssignmentsList,
     RawSessionGroupSummaryPattern,
     RawSessionGroupSummaryPatternsList,
@@ -340,8 +339,8 @@ async def _generate_patterns_assignments(
 @temporalio.activity.defn
 async def assign_events_to_patterns_activity(
     inputs: SessionGroupSummaryOfSummariesInputs,
-) -> tuple[EnrichedSessionGroupSummaryPatternsList, str]:
-    """Summarize a group of sessions in one call. Returns tuple of (patterns, session_group_summary_id)."""
+) -> str:
+    """Summarize a group of sessions in one call. Returns session_group_summary_id."""
     session_ids = _get_session_ids_from_inputs(inputs)
     # Not checking for existing summary in the DB, as the input of `~300 exactly the same ids + context` seems highly unlikely
     redis_client, redis_input_key, _ = get_redis_state_client(
@@ -445,7 +444,7 @@ async def assign_events_to_patterns_activity(
         run_metadata=asdict(SessionSummaryRunMeta(model_used=inputs.model_to_use, visual_confirmation=False)),
         created_by=user,
     )
-    return patterns_with_events_context, str(session_group_summary.id)
+    return str(session_group_summary.id)
 
 
 @temporalio.activity.defn

--- a/posthog/temporal/ai/session_summary/summarize_session_group.py
+++ b/posthog/temporal/ai/session_summary/summarize_session_group.py
@@ -69,7 +69,7 @@ from ee.hogai.session_summaries.session.summarize_session import (
 )
 from ee.hogai.session_summaries.session_group.patterns import EnrichedSessionGroupSummaryPatternsList
 from ee.hogai.session_summaries.utils import logging_session_ids
-from ee.models.session_summaries import SingleSessionSummary
+from ee.models.session_summaries import SessionGroupSummary, SingleSessionSummary
 
 logger = structlog.get_logger(__name__)
 
@@ -530,7 +530,7 @@ class SummarizeSessionGroupWorkflow(PostHogWorkflow):
         return session_ids_with_patterns_extracted
 
     @temporalio.workflow.run
-    async def run(self, inputs: SessionGroupSummaryInputs) -> tuple[EnrichedSessionGroupSummaryPatternsList, str]:
+    async def run(self, inputs: SessionGroupSummaryInputs) -> str:
         self._total_sessions = len(inputs.session_ids)
         # Get events data from the DB (or cache)
         self._current_status.append("Fetching session data from the database")
@@ -625,9 +625,16 @@ async def _start_session_group_summary_workflow(
         patterns_keys: list[str] = await handle.query("get_raw_patterns_extraction_keys")
         # Workflow completed - get and yield the final result
         if workflow_description.status == WorkflowExecutionStatus.COMPLETED:
-            result_raw: list = await handle.result()
-            patterns_dict, summary_id = result_raw
-            patterns = EnrichedSessionGroupSummaryPatternsList(**patterns_dict)
+            summary_id: str = await handle.result()
+            # Fetch the summary from DB by id
+            try:
+                session_group_summary = await SessionGroupSummary.objects.aget(id=summary_id)
+            except SessionGroupSummary.DoesNotExist:
+                msg = f"SessionGroupSummary with id {summary_id} not found in DB after workflow {workflow_id} completed"
+                logger.exception(msg, workflow_id=workflow_id, summary_id=summary_id, signals_type="session-summaries")
+                raise ApplicationError(msg)
+            # Parse the summary JSON into EnrichedSessionGroupSummaryPatternsList
+            patterns = EnrichedSessionGroupSummaryPatternsList.model_validate_json(session_group_summary.summary)
             yield (
                 SessionSummaryStreamUpdate.FINAL_RESULT,
                 (patterns, summary_id),

--- a/posthog/temporal/tests/ai/test_summarize_session_group.py
+++ b/posthog/temporal/tests/ai/test_summarize_session_group.py
@@ -45,6 +45,7 @@ from posthog.temporal.ai.session_summary.state import (
 from posthog.temporal.ai.session_summary.summarize_session_group import (
     SessionGroupSummaryInputs,
     SummarizeSessionGroupWorkflow,
+    _start_session_group_summary_workflow,
     execute_summarize_session_group,
     fetch_session_batch_events_activity,
     get_llm_single_session_summary_activity,
@@ -67,7 +68,7 @@ from ee.hogai.session_summaries.session_group.patterns import (
     EnrichedSessionGroupSummaryPatternStats,
     RawSessionGroupSummaryPatternsList,
 )
-from ee.models.session_summaries import SingleSessionSummary
+from ee.models.session_summaries import SessionGroupSummary, SingleSessionSummary
 
 pytestmark = pytest.mark.django_db
 
@@ -410,10 +411,17 @@ async def test_assign_events_to_patterns_activity_standalone(
             ],
         )
         mock_call_llm.return_value = mock_llm_response
-        result, _ = await assign_events_to_patterns_activity(activity_input)
-        # Verify the activity completed successfully
-        assert isinstance(result, EnrichedSessionGroupSummaryPatternsList)
-        assert len(result.patterns) >= 1  # Should have at least one pattern
+        result = await assign_events_to_patterns_activity(activity_input)
+        # Verify the activity completed successfully - now returns just the summary id
+        assert isinstance(result, str)
+        # Verify the summary was stored in DB
+        from ee.models.session_summaries import SessionGroupSummary
+
+        session_group_summary = await SessionGroupSummary.objects.aget(id=result)
+        assert session_group_summary is not None
+        # Verify the summary content
+        patterns = EnrichedSessionGroupSummaryPatternsList.model_validate_json(session_group_summary.summary)
+        assert len(patterns.patterns) >= 1  # Should have at least one pattern
         # Verify LLM was called (for pattern assignment)
         mock_call_llm.assert_called()  # May be called multiple times for chunks
         # Verify Redis operations:
@@ -582,8 +590,12 @@ async def test_assign_events_to_patterns_threshold_check(
         )
         mock_call_llm.return_value = mock_llm_response
 
-        # Should succeed
-        result, _ = await assign_events_to_patterns_activity(activity_input)
+        # Should succeed - now returns just the summary id
+        summary_id = await assign_events_to_patterns_activity(activity_input)
+        assert isinstance(summary_id, str)
+        # Fetch the result from DB
+        session_group_summary = await SessionGroupSummary.objects.aget(id=summary_id)
+        result = EnrichedSessionGroupSummaryPatternsList.model_validate_json(session_group_summary.summary)
         assert isinstance(result, EnrichedSessionGroupSummaryPatternsList)
         assert len(result.patterns) == 3  # Should have 3 patterns with events
 
@@ -705,9 +717,13 @@ async def test_assign_events_to_patterns_filters_non_blocking_exceptions(
         mock_async_connect.return_value = mock_temporal_client
         # Mock LLM call for pattern assignment
         mock_call_llm.return_value = mock_llm_response
-        # Execute activity
-        result, _ = await assign_events_to_patterns_activity(activity_input)
+        # Execute activity - now returns just the summary id
+        summary_id = await assign_events_to_patterns_activity(activity_input)
     # Assertions
+    assert isinstance(summary_id, str)
+    # Fetch the result from DB
+    session_group_summary = await SessionGroupSummary.objects.aget(id=summary_id)
+    result = EnrichedSessionGroupSummaryPatternsList.model_validate_json(session_group_summary.summary)
     assert isinstance(result, EnrichedSessionGroupSummaryPatternsList)
     # Pattern 1 should only have mnop3456 (blocking, should be included), not xyz98765 (non-blocking, should be skipped)
     pattern_1 = next((p for p in result.patterns if p.pattern_id == 1), None)
@@ -887,8 +903,13 @@ async def test_non_blocking_exceptions_dont_fail_enrichment_ratio(
         # Mock LLM call
         mock_call_llm.return_value = mock_llm_response
         # We provide 3 patterns. With deduplication, all 3 should have exactly 1 event each
-        result, _ = await assign_events_to_patterns_activity(activity_input)
+        # Now returns just the summary id
+        summary_id = await assign_events_to_patterns_activity(activity_input)
     # Assertions
+    assert isinstance(summary_id, str)
+    # Fetch the result from DB
+    session_group_summary = await SessionGroupSummary.objects.aget(id=summary_id)
+    result = EnrichedSessionGroupSummaryPatternsList.model_validate_json(session_group_summary.summary)
     assert isinstance(result, EnrichedSessionGroupSummaryPatternsList)
     # All 3 patterns should exist (deduplication keeps first event from each assignment)
     assert len(result.patterns) == 3, "Should have 3 patterns with valid events"
@@ -1093,6 +1114,82 @@ class TestSummarizeSessionGroupWorkflow:
             )
 
     @pytest.mark.asyncio
+    async def test_start_session_group_summary_workflow_fetches_from_db(
+        self,
+        mock_session_id: str,
+        mock_session_group_summary_inputs: Callable,
+        auser: User,
+        ateam: Team,
+    ):
+        """Test that _start_session_group_summary_workflow fetches the summary from DB after workflow completes"""
+        session_ids, workflow_id, workflow_input = self.setup_workflow_test(
+            mock_session_id, mock_session_group_summary_inputs, "db_fetch", auser.id, ateam.id
+        )
+        # Create expected patterns and store in DB
+        mock_stats = EnrichedSessionGroupSummaryPatternStats(
+            occurences=1,
+            sessions_affected=1,
+            sessions_affected_ratio=0.5,
+            segments_success_ratio=1.0,
+        )
+        mock_pattern = EnrichedSessionGroupSummaryPattern(
+            pattern_id=1,
+            pattern_name="Mock Pattern from DB",
+            pattern_description="A test pattern stored in DB",
+            severity="low",
+            indicators=["test indicator"],
+            events=[],
+            stats=mock_stats,
+        )
+        expected_patterns = EnrichedSessionGroupSummaryPatternsList(patterns=[mock_pattern])
+        # Create the summary in DB
+        session_group_summary = await SessionGroupSummary.objects.acreate(
+            team_id=ateam.id,
+            title="Test summary",
+            session_ids=session_ids,
+            summary=expected_patterns.model_dump_json(exclude_none=True),
+            created_by=auser,
+        )
+        summary_id = str(session_group_summary.id)
+
+        # Mock the Temporal client and workflow handle
+        mock_handle = MagicMock()
+        mock_handle.describe = AsyncMock()
+        mock_handle.query = AsyncMock(return_value=[])
+        mock_handle.result = AsyncMock(return_value=summary_id)
+
+        # Mock workflow as completed
+        mock_description = MagicMock()
+        mock_description.status = WorkflowExecutionStatus.COMPLETED
+        mock_handle.describe.return_value = mock_description
+
+        mock_client = MagicMock()
+        mock_client.start_workflow = AsyncMock(return_value=mock_handle)
+
+        with patch(
+            "posthog.temporal.ai.session_summary.summarize_session_group.async_connect",
+            return_value=mock_client,
+        ):
+            # Collect results from the async generator
+            results = []
+            async for update in _start_session_group_summary_workflow(
+                inputs=workflow_input,
+                workflow_id=workflow_id,
+            ):
+                results.append(update)
+
+            # Verify we got the expected result fetched from DB
+            assert len(results) == 1
+            update_type, data = results[0]
+            assert update_type == SessionSummaryStreamUpdate.FINAL_RESULT
+            assert isinstance(data, tuple)
+            patterns, returned_summary_id = data
+            assert returned_summary_id == summary_id
+            assert isinstance(patterns, EnrichedSessionGroupSummaryPatternsList)
+            assert len(patterns.patterns) == 1
+            assert patterns.patterns[0].pattern_name == "Mock Pattern from DB"
+
+    @pytest.mark.asyncio
     async def test_summarize_session_group_workflow(
         self,
         mocker: MockerFixture,
@@ -1157,11 +1254,14 @@ class TestSummarizeSessionGroupWorkflow:
                 id=workflow_id,
                 task_queue=worker.task_queue,
             )
-            # Verify the result is of the correct type (now returns tuple of patterns and summary_id)
-            assert isinstance(result, tuple)
-            patterns_result, summary_id = result
+            # Verify the result is of the correct type (now returns just summary_id)
+            assert isinstance(result, str)
+            # Verify the summary was stored in DB and can be fetched
+            from ee.models.session_summaries import SessionGroupSummary
+
+            session_group_summary = await SessionGroupSummary.objects.aget(id=result)
+            patterns_result = EnrichedSessionGroupSummaryPatternsList.model_validate_json(session_group_summary.summary)
             assert isinstance(patterns_result, EnrichedSessionGroupSummaryPatternsList)
-            assert isinstance(summary_id, str)
             # Verify Redis operations
             # Since summaries are pre-stored in DB, only pattern-related Redis operations occur:
             # setex operations: pattern extraction (1) (pattern assignment now stores to DB)
@@ -1267,11 +1367,9 @@ class TestSummarizeSessionGroupWorkflow:
                     # Workflow might not be ready yet
                     await asyncio.sleep(0.05)
                     poll_count += 1
-            # Get the final result
+            # Get the final result (now returns just summary_id)
             result = await workflow_handle.result()
-            assert isinstance(result, tuple)
-            patterns_result, _ = result
-            assert isinstance(patterns_result, EnrichedSessionGroupSummaryPatternsList)
+            assert isinstance(result, str)
             # Verify we captured some status updates
             assert len(status_updates) > 0
             # Verify the types of status messages we received


### PR DESCRIPTION
## Problem
- We return summary from Temporal as JSON and hit 2mb limit sometimes

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Don't do that, pass the id only, and than get it from the DB outside of the Temporal workflow

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
