### PR TITLE
feat(signals): Add `Beta` label to the report

### DIFF
--- a/products/session_summaries/frontend/SessionGroupSummaryScene.tsx
+++ b/products/session_summaries/frontend/SessionGroupSummaryScene.tsx
@@ -9,6 +9,7 @@ import {
     LemonCollapse,
     LemonInput,
     LemonSkeleton,
+    LemonTag,
     Tooltip,
 } from '@posthog/lemon-ui'
 
@@ -466,6 +467,7 @@ export function SessionGroupSummary(): JSX.Element {
             />
             <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted">
                 <div className="flex items-center gap-3">
+                    <LemonTag type="warning">BETA</LemonTag>
                     <span>{totalSessions} sessions analyzed</span>
                     <span className="hidden sm:inline">·</span>
                     <span>{new Date(sessionGroupSummary.created_at).toLocaleString()}</span>


### PR DESCRIPTION
## Problem
- Beta label is only visible in the reports list, not in the report itslef

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Add beta label
<img width="2390" height="1060" alt="CleanShot 2025-12-02 at 16 34 06@2x" src="https://github.com/user-attachments/assets/7d649615-8018-447e-8788-2581c30e2e44" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
