### PR TITLE
feat(persons): Allow all attributes to be updated

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -321,6 +321,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         PERSON_PROPERTIES_DB_CONSTRAINT_LIMIT_BYTES: 655360,
         // Trim target is the customer-facing limit (512kb)
         PERSON_PROPERTIES_TRIM_TARGET_BYTES: 512 * 1024,
+        // When true, all property changes trigger person updates (disables filtering)
+        PERSON_PROPERTIES_UPDATE_ALL: false,
         // Limit per merge for moving distinct IDs. 0 disables limiting (move all)
         PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 0,
         // Topic for async person merge processing

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -276,6 +276,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig,
     PERSON_UPDATE_CALCULATE_PROPERTIES_SIZE: number
     PERSON_PROPERTIES_DB_CONSTRAINT_LIMIT_BYTES: number // maximum size in bytes for person properties JSON as stored, checked via pg_column_size(properties)
     PERSON_PROPERTIES_TRIM_TARGET_BYTES: number // target size in bytes we trim JSON to before writing (customer-facing 512kb)
+    PERSON_PROPERTIES_UPDATE_ALL: boolean // when true, all property changes trigger person updates (disables filtering of eventToPersonProperties and geoip)
     // Limit per merge for moving distinct IDs. 0 disables limiting.
     PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
     // Topic for async person merge processing

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -29,7 +29,8 @@ export async function processPersonsStep(
         runner.hub.db.kafkaProducer,
         personStoreBatch,
         runner.hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
-        runner.mergeMode
+        runner.mergeMode,
+        runner.hub.PERSON_PROPERTIES_UPDATE_ALL
     )
 
     const processor = new PersonEventProcessor(

--- a/plugin-server/src/worker/ingestion/persons/person-context.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-context.ts
@@ -24,7 +24,8 @@ export class PersonContext {
         public readonly kafkaProducer: KafkaProducerWrapper,
         public readonly personStore: PersonsStoreForBatch,
         public readonly measurePersonJsonbSize: number = 0,
-        public readonly mergeMode: MergeMode
+        public readonly mergeMode: MergeMode,
+        public readonly updateAllProperties: boolean = false // When true, all property changes trigger person updates
     ) {
         this.eventProperties = event.properties!
     }

--- a/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-service.ts
@@ -388,7 +388,11 @@ export class PersonMergeService {
         //   we're calling aliasDeprecated as we need to refresh the persons info completely first
 
         const mergedProperties: Properties = { ...otherPerson.properties, ...mergeInto.properties }
-        const propertyUpdates = computeEventPropertyUpdates(this.context.event, mergedProperties)
+        const propertyUpdates = computeEventPropertyUpdates(
+            this.context.event,
+            mergedProperties,
+            this.context.updateAllProperties
+        )
 
         // Create a temporary person object to apply property updates to
         const tempPerson: InternalPerson = { ...mergeInto, properties: mergedProperties }

--- a/plugin-server/src/worker/ingestion/persons/person-property-service.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-property-service.ts
@@ -71,7 +71,11 @@ export class PersonPropertyService {
         person.properties ||= {}
 
         // Compute property changes
-        const propertyUpdates = computeEventPropertyUpdates(this.context.event, person.properties)
+        const propertyUpdates = computeEventPropertyUpdates(
+            this.context.event,
+            person.properties,
+            this.context.updateAllProperties
+        )
 
         const otherUpdates: Partial<InternalPerson> = {}
         if (this.context.updateIsIdentified && !person.is_identified) {

--- a/plugin-server/src/worker/ingestion/persons/person-update.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update.test.ts
@@ -410,6 +410,148 @@ describe('person-update', () => {
                 expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'changed' })
             })
         })
+
+        describe('updateAllProperties flag enabled', () => {
+            it.each(Array.from(eventToPersonProperties))(
+                'should trigger update for "%s" when updateAllProperties is true',
+                (propertyName) => {
+                    const event: PluginEvent = {
+                        event: 'pageview',
+                        properties: {
+                            $set: { [propertyName]: 'new_value' },
+                        },
+                    } as any
+
+                    const personProperties = { [propertyName]: 'old_value' }
+
+                    const result = computeEventPropertyUpdates(event, personProperties, true)
+
+                    expect(result.hasChanges).toBe(true)
+                    expect(result.toSet).toEqual({ [propertyName]: 'new_value' })
+                    expect(result.shouldForceUpdate).toBe(true) // updateAllProperties forces updates
+                    // With updateAllProperties=true, no metrics should be tracked
+                    expect(mockPersonProfileUpdateOutcomeCounter.labels).not.toHaveBeenCalled()
+                    expect(mockPersonProfileIgnoredPropertiesCounter.labels).not.toHaveBeenCalled()
+                }
+            )
+
+            it('should trigger update for $geoip_* properties when updateAllProperties is true', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set: { $geoip_city_name: 'San Francisco' },
+                    },
+                } as any
+
+                const personProperties = { $geoip_city_name: 'New York' }
+
+                const result = computeEventPropertyUpdates(event, personProperties, true)
+
+                expect(result.hasChanges).toBe(true)
+                expect(result.toSet).toEqual({ $geoip_city_name: 'San Francisco' })
+                expect(result.shouldForceUpdate).toBe(true) // updateAllProperties forces updates
+                // With updateAllProperties=true, no metrics should be tracked
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).not.toHaveBeenCalled()
+                expect(mockPersonProfileIgnoredPropertiesCounter.labels).not.toHaveBeenCalled()
+            })
+
+            it('should trigger update for multiple eventToPersonProperties when updateAllProperties is true', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set: {
+                            $browser: 'Chrome',
+                            $os: 'macOS',
+                        },
+                    },
+                } as any
+
+                const personProperties = {
+                    $browser: 'Firefox',
+                    $os: 'Windows',
+                }
+
+                const result = computeEventPropertyUpdates(event, personProperties, true)
+
+                expect(result.hasChanges).toBe(true)
+                expect(result.toSet).toEqual({ $browser: 'Chrome', $os: 'macOS' })
+                expect(result.shouldForceUpdate).toBe(true) // updateAllProperties forces updates
+                // With updateAllProperties=true, no metrics should be tracked
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).not.toHaveBeenCalled()
+                expect(mockPersonProfileIgnoredPropertiesCounter.labels).not.toHaveBeenCalled()
+            })
+
+            it('should trigger update for mixed eventToPersonProperties and custom properties when updateAllProperties is true', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set: { $browser: 'Chrome', custom_prop: 'same_value' },
+                    },
+                } as any
+
+                const personProperties = { $browser: 'Firefox', custom_prop: 'same_value' }
+
+                const result = computeEventPropertyUpdates(event, personProperties, true)
+
+                expect(result.hasChanges).toBe(true)
+                expect(result.toSet).toEqual({ $browser: 'Chrome' })
+                expect(result.shouldForceUpdate).toBe(true) // updateAllProperties forces updates
+                // With updateAllProperties=true, no metrics should be tracked
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).not.toHaveBeenCalled()
+                expect(mockPersonProfileIgnoredPropertiesCounter.labels).not.toHaveBeenCalled()
+            })
+
+            it('should trigger update for mixed $geoip_* and eventToPersonProperties when updateAllProperties is true', () => {
+                const event: PluginEvent = {
+                    event: 'pageview',
+                    properties: {
+                        $set: {
+                            $browser: 'Chrome',
+                            $geoip_city_name: 'San Francisco',
+                            $geoip_country_code: 'US',
+                        },
+                    },
+                } as any
+
+                const personProperties = {
+                    $browser: 'Firefox',
+                    $geoip_city_name: 'New York',
+                    $geoip_country_code: 'CA',
+                }
+
+                const result = computeEventPropertyUpdates(event, personProperties, true)
+
+                expect(result.hasChanges).toBe(true)
+                expect(result.toSet).toEqual({
+                    $browser: 'Chrome',
+                    $geoip_city_name: 'San Francisco',
+                    $geoip_country_code: 'US',
+                })
+                expect(result.shouldForceUpdate).toBe(true) // updateAllProperties forces updates
+                // With updateAllProperties=true, no metrics should be tracked
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).not.toHaveBeenCalled()
+                expect(mockPersonProfileIgnoredPropertiesCounter.labels).not.toHaveBeenCalled()
+            })
+
+            it('should not change behavior for NO_PERSON_UPDATE_EVENTS when updateAllProperties is true', () => {
+                const event: PluginEvent = {
+                    event: '$exception',
+                    properties: {
+                        $set: { $browser: 'Chrome' },
+                    },
+                } as any
+
+                const personProperties = { $browser: 'Firefox' }
+
+                const result = computeEventPropertyUpdates(event, personProperties, true)
+
+                // NO_PERSON_UPDATE_EVENTS should still be skipped regardless of flag
+                expect(result.hasChanges).toBe(false)
+                expect(result.toSet).toEqual({})
+                expect(result.shouldForceUpdate).toBe(false)
+                expect(mockPersonProfileUpdateOutcomeCounter.labels).toHaveBeenCalledWith({ outcome: 'unsupported' })
+            })
+        })
     })
 
     describe('applyEventPropertyUpdates', () => {

--- a/plugin-server/src/worker/ingestion/persons/person-update.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-update.ts
@@ -38,16 +38,22 @@ export function getMetricKey(key: string): string {
  * Computes property changes from an event without modifying personProperties
  * @param event The event to extract property changes from
  * @param personProperties Current person properties (not modified)
+ * @param updateAllProperties When true, all property changes trigger updates (no filtering)
  * @returns Object with properties to set, unset, and whether there are changes
  */
-export function computeEventPropertyUpdates(event: PluginEvent, personProperties: Properties): PropertyUpdates {
+export function computeEventPropertyUpdates(
+    event: PluginEvent,
+    personProperties: Properties,
+    updateAllProperties: boolean = false
+): PropertyUpdates {
     if (NO_PERSON_UPDATE_EVENTS.has(event.event)) {
         personProfileUpdateOutcomeCounter.labels({ outcome: 'unsupported' }).inc()
         return { hasChanges: false, toSet: {}, toUnset: [], shouldForceUpdate: false }
     }
 
     // Check if this is a PERSON_EVENT that should bypass batch-level filtering
-    const shouldForceUpdate = PERSON_EVENTS.has(event.event)
+    // Also force update when updateAllProperties is enabled
+    const shouldForceUpdate = PERSON_EVENTS.has(event.event) || updateAllProperties
 
     const properties: Properties = event.properties!['$set'] || {}
     const propertiesOnce: Properties = event.properties!['$set_once'] || {}
@@ -64,7 +70,7 @@ export function computeEventPropertyUpdates(event: PluginEvent, personProperties
         if (typeof personProperties[key] === 'undefined') {
             hasChanges = true
             toSet[key] = value
-            if (shouldUpdatePersonIfOnlyChange(event, key)) {
+            if (shouldUpdatePersonIfOnlyChange(event, key, updateAllProperties)) {
                 hasNonFilteredChanges = true
             }
         }
@@ -73,7 +79,7 @@ export function computeEventPropertyUpdates(event: PluginEvent, personProperties
     Object.entries(properties).forEach(([key, value]) => {
         if (personProperties[key] !== value) {
             const isNewProperty = typeof personProperties[key] === 'undefined'
-            const shouldUpdate = isNewProperty || shouldUpdatePersonIfOnlyChange(event, key)
+            const shouldUpdate = isNewProperty || shouldUpdatePersonIfOnlyChange(event, key, updateAllProperties)
 
             if (shouldUpdate) {
                 hasChanges = true
@@ -96,19 +102,21 @@ export function computeEventPropertyUpdates(event: PluginEvent, personProperties
         }
     })
 
-    // Track person profile update outcomes at event level
-    const hasPropertyChanges = Object.keys(toSet).length > 0 || toUnset.length > 0
-    if (hasPropertyChanges) {
-        if (hasNonFilteredChanges) {
-            personProfileUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc()
+    // Track person profile update outcomes at event level (skip when updateAllProperties is enabled)
+    if (!updateAllProperties) {
+        const hasPropertyChanges = Object.keys(toSet).length > 0 || toUnset.length > 0
+        if (hasPropertyChanges) {
+            if (hasNonFilteredChanges) {
+                personProfileUpdateOutcomeCounter.labels({ outcome: 'changed' }).inc()
+            } else {
+                personProfileUpdateOutcomeCounter.labels({ outcome: 'ignored' }).inc()
+                ignoredProperties.forEach((property) => {
+                    personProfileIgnoredPropertiesCounter.labels({ property }).inc()
+                })
+            }
         } else {
-            personProfileUpdateOutcomeCounter.labels({ outcome: 'ignored' }).inc()
-            ignoredProperties.forEach((property) => {
-                personProfileIgnoredPropertiesCounter.labels({ property }).inc()
-            })
+            personProfileUpdateOutcomeCounter.labels({ outcome: 'no_change' }).inc()
         }
-    } else {
-        personProfileUpdateOutcomeCounter.labels({ outcome: 'no_change' }).inc()
     }
 
     return { hasChanges, toSet, toUnset, shouldForceUpdate }
@@ -153,7 +161,11 @@ export function applyEventPropertyUpdates(
 
 // Minimize useless person updates by not overriding properties if it's not a person event and we added from the event
 // They will still show up for PoE as it's not removed from the event, we just don't update the person in PG anymore
-function shouldUpdatePersonIfOnlyChange(event: PluginEvent, key: string): boolean {
+function shouldUpdatePersonIfOnlyChange(event: PluginEvent, key: string, updateAllProperties: boolean): boolean {
+    if (updateAllProperties) {
+        // When flag is enabled, all property changes trigger updates
+        return true
+    }
     if (PERSON_EVENTS.has(event.event)) {
         // for person events always update everything
         return true


### PR DESCRIPTION
## Problem

Currently we do not update certain attributes (which change a lot) if they are the only attributes being changed, this PR allows us to override this setting via the flag `PERSON_PROPERTIES_UPDATE_ALL`. 

## Changes

- When PERSON_PROPERTIES_UPDATE_ALL is set to true, we update all person properties

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
