### PR TITLE
fix(batch-exports): Improve handling of extra columns in Snowflake table

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -804,12 +804,16 @@ class SnowflakeClient:
             else:
                 raise
 
+        fields = (
+            SnowflakeDestinationField(metadata.name, FIELD_ID_TO_NAME[metadata.type_code], metadata.is_nullable)  # type: ignore[arg-type]
+            for metadata in metadata
+            # Only include fields that are present in the record batch schema
+            if metadata.name.lower() in [field.name.lower() for field in table.fields]
+        )
+
         return SnowflakeTable.from_snowflake_table(
             table.name,
-            fields=(
-                SnowflakeDestinationField(metadata.name, FIELD_ID_TO_NAME[metadata.type_code], metadata.is_nullable)  # type: ignore[arg-type]
-                for metadata in metadata
-            ),
+            fields=fields,
             parents=table.parents,
             primary_key=table.primary_key,
             version_key=table.version_key,

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -804,11 +804,12 @@ class SnowflakeClient:
             else:
                 raise
 
+        record_batch_field_names = [field.name.lower() for field in table.fields]
         fields = (
             SnowflakeDestinationField(metadata.name, FIELD_ID_TO_NAME[metadata.type_code], metadata.is_nullable)  # type: ignore[arg-type]
             for metadata in metadata
             # Only include fields that are present in the record batch schema
-            if metadata.name.lower() in [field.name.lower() for field in table.fields]
+            if metadata.name.lower() in record_batch_field_names
         )
 
         return SnowflakeTable.from_snowflake_table(

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
@@ -6,6 +6,7 @@ Note: This module uses a real Snowflake connection.
 
 import os
 import uuid
+import typing as t
 import datetime as dt
 import collections.abc
 
@@ -63,6 +64,7 @@ async def _run_activity(
     assert_clickhouse_records: bool = True,
     timestamp_columns: collections.abc.Sequence[str] = (),
     uppercase_columns: list[str] | None = None,
+    extra_fields: dict[str, t.Any] | None = None,
 ):
     """Helper function to run insert_into_snowflake_activity_from_stage and assert records in Snowflake"""
     insert_inputs = SnowflakeInsertInputs(
@@ -113,6 +115,7 @@ async def _run_activity(
             primary_key=primary_key,
             timestamp_columns=timestamp_columns,
             uppercase_columns=uppercase_columns,
+            extra_fields=extra_fields,
         )
     return result
 
@@ -704,4 +707,56 @@ async def test_insert_into_snowflake_activity_handles_uppercased_columns(
         batch_export_model=model,
         sort_key=sort_key,
         uppercase_columns=uppercase_columns,
+    )
+
+
+@pytest.mark.parametrize("model", [BatchExportModel(name="events", schema=None)])
+async def test_insert_into_snowflake_activity_handles_extra_columns_in_destination(
+    clickhouse_client,
+    activity_environment,
+    snowflake_cursor,
+    snowflake_config,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    ateam,
+    model,
+):
+    """Test that the `insert_into_snowflake_activity_from_stage` can handle target
+    table having extra columns. In addition, it should respect extra columns that have default values (i.e. we shouldn't
+    be inserting NULL values explicitly).
+
+    This test first runs the batch export normally to create a target table, then
+    adds an extra column to the target table, and finally re-runs the batch export.
+    """
+    table_name = f"test_insert_activity_{model.name}_handles_extra_columns_{ateam.pk}"
+
+    await _run_activity(
+        activity_environment=activity_environment,
+        snowflake_cursor=snowflake_cursor,
+        clickhouse_client=clickhouse_client,
+        snowflake_config=snowflake_config,
+        team=ateam,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        table_name=table_name,
+        batch_export_model=model,
+        sort_key="uuid",
+    )
+
+    snowflake_cursor.execute(f'TRUNCATE TABLE "{table_name}"')
+    snowflake_cursor.execute(f'ALTER TABLE "{table_name}" ADD COLUMN "extra_column" TEXT DEFAULT \'test\'')
+
+    await _run_activity(
+        activity_environment=activity_environment,
+        snowflake_cursor=snowflake_cursor,
+        clickhouse_client=clickhouse_client,
+        snowflake_config=snowflake_config,
+        team=ateam,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        table_name=table_name,
+        batch_export_model=model,
+        sort_key="uuid",
+        extra_fields={"extra_column": "test"},
     )

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
@@ -381,6 +381,7 @@ async def assert_clickhouse_records_in_snowflake(
     primary_key: list[str] | None = None,
     timestamp_columns: collections.abc.Sequence[str] = (),
     uppercase_columns: list[str] | None = None,
+    extra_fields: dict[str, t.Any] | None = None,
 ):
     """Assert ClickHouse records are written to Snowflake table.
 
@@ -396,6 +397,7 @@ async def assert_clickhouse_records_in_snowflake(
         batch_export_model: The model, or custom schema, used in the batch export.
         expected_fields: List of fields expected to be in the destination table.
         expect_duplicates: Whether duplicates are expected (e.g. when testing retrying logic).
+        extra_fields: Additional fields present in the Snowflake table (that are not present in the ClickHouse table).
     """
     snowflake_cursor.execute(f'SELECT * FROM "{table_name}"')
 
@@ -493,6 +495,10 @@ async def assert_clickhouse_records_in_snowflake(
                 if uppercase_columns and k in uppercase_columns:
                     expected_record[k.upper()] = expected_record[k]
                     del expected_record[k]
+
+            if extra_fields:
+                for field, value in extra_fields.items():
+                    expected_record[field] = value
 
             expected_records.append(expected_record)
 


### PR DESCRIPTION
## Problem

A regression was introduced into our Snowflake batch exports where if a destination table has extra columns that are not present in the data set, we explicitly insert null values into these columns. This breaks the previous behaviour where we didn't try inserting data into those extra columns, instead relying on them having default values. For instance, if there is an extra column defined as `"extra_column" TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP` we are now inserting `NULL` into that column rather than letting it default to `CURRENT_TIMESTAMP`

## Changes

When creating stage table, do not add columns which are not in the record batch schema.

## How did you test this code?

Added a test to reproduce this issue, and ensure it now passes.
