### PR TITLE
fix(experiments): HogQL print fix vol. 2

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1636,7 +1636,7 @@ class _Printer(Visitor[str]):
                     is_nullable=materialized_column.is_nullable,
                 )
 
-            if self.context.modifiers.propertyGroupsMode in (
+            if self.dialect == "clickhouse" and self.context.modifiers.propertyGroupsMode in (
                 PropertyGroupsMode.ENABLED,
                 PropertyGroupsMode.OPTIMIZED,
             ):


### PR DESCRIPTION
## Problem
After merging https://github.com/PostHog/posthog/pull/42474, the HogQL output from experiment results still fails with a parsing error

**The bug:**
When `is_cloud==true`, we optimize property access using `propertyGroupsMode=OPTIMIZED`, which transforms `properties.key` into Clickhouse-specific syntax like `properties_group_custom[%(hogql_val_0)s]`. The printer applies this transformation even when outputting HogQL, not just Clickhouse.

This wasn't caught before because the existing tests use Clickhouse dialect, and it only affects custom properties that are in property groups (not common $-prefixed properties which have materialized columns).

## Changes
Add a `dialect == "clickhouse"` check before applying property group transformations.