### PR TITLE
fix(experiments): Stagger dagster schedules

### DIFF
--- a/dags/experiment_regular_metrics_timeseries.py
+++ b/dags/experiment_regular_metrics_timeseries.py
@@ -308,7 +308,7 @@ def experiment_regular_metrics_timeseries_discovery_sensor(context: dagster.Sens
 
 @dagster.schedule(
     job=experiment_regular_metrics_timeseries_job,
-    cron_schedule="0 * * * *",  # Every hour at minute 0
+    cron_schedule="5 * * * *",  # Every hour at minute 5 (staggered from saved metrics at minute 0)
     execution_timezone="UTC",
     tags={"owner": JobOwners.TEAM_EXPERIMENTS.value},
 )


### PR DESCRIPTION
## Problem
The experiment metrics schedules (`experiment_saved_metrics_timeseries_refresh_schedule` and `experiment_regular_metrics_timeseries_refresh_schedule`) have been timing out at 02:00 UTC with  DagsterUserCodeUnreachableError after 60 seconds.

The 02:00 UTC is particularly problematic because it's the default recalculation time for teams that haven't configured a custom `experiment_recalculation_time`. This means the majority of experiments all try to run at exactly the same moment.

I suspect the issue here is contention: both schedules fire at minute 0, and since they're evaluated by the same Dagster user code server, they compete for resources.
 
## Changes
Let's test this hypothesis by staggering the two schedules by 5 minutes.