### PR TITLE
feat(llma): send info logs for LLMA usage cron

### DIFF
--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -95,6 +95,7 @@ LOGGING = {
         "posthog.tasks.alerts": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "posthog.tasks.email": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "posthog.tasks.exports": {"level": "INFO", "handlers": ["console"], "propagate": False},
+        "posthog.tasks.llm_analytics_usage_report": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "boto3": {"level": "WARN"},  # boto3 logs are noisy
         "botocore": {"level": "WARN"},  # botocore logs are noisy
     },


### PR DESCRIPTION
## Problem

Info logs weren't sent for our LLMA usage cron.

## Changes

This makes them be sent so that we can debug stuff.