### PR TITLE
fix(web-analytics): Make cache favicon dagster job run sync

### DIFF
--- a/dags/cache_favicons.py
+++ b/dags/cache_favicons.py
@@ -49,7 +49,7 @@ def upload_if_missing(s3_client, bucket, key, data, content_type):
         ContentType=content_type,
     )
 
-    logger.info(f"Favicon succesfully cached.")
+    logger.info(f"Favicon successfully cached.")
     return key
 
 

--- a/dags/cache_favicons.py
+++ b/dags/cache_favicons.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import Optional
 
 from django.conf import settings
@@ -13,7 +12,7 @@ from posthog.clickhouse.cluster import ClickhouseCluster
 logger = dagster.get_dagster_logger()
 
 
-async def download_favicon(domain: str, client: httpx.AsyncClient) -> tuple[str, Optional[bytes], Optional[str]]:
+def download_favicon(domain: str, client: httpx.Client) -> tuple[str, Optional[bytes], Optional[str]]:
     logger.info(f"Attempting to download favicon for domain '{domain}'")
     urls = [
         f"https://www.google.com/s2/favicons?sz=32&domain=https://{domain}",
@@ -22,7 +21,7 @@ async def download_favicon(domain: str, client: httpx.AsyncClient) -> tuple[str,
 
     for url in urls:
         try:
-            resp = await client.get(url, timeout=10)
+            resp = client.get(url, timeout=10)
             if resp.status_code == 200 and resp.content:
                 logger.info(f"Found favicon for {domain} at {url}")
                 return domain, resp.content, resp.headers.get("content-type")
@@ -33,21 +32,12 @@ async def download_favicon(domain: str, client: httpx.AsyncClient) -> tuple[str,
     return domain, None, None
 
 
-async def batch_download(domains, concurrency=20):
-    sem = asyncio.Semaphore(concurrency)
-    async with httpx.AsyncClient() as client:
-
-        async def worker(domain):
-            async with sem:
-                return await download_favicon(domain, client)
-
-        return await asyncio.gather(*(worker(domain) for domain in domains))
-
-
 def upload_if_missing(s3_client, bucket, key, data, content_type):
     # Ignore uploading if the favicon already exists in our cache
+    logger.info(f"Attempting to cache {key}")
     try:
         s3_client.head_object(Bucket=bucket, Key=key)
+        logger.info("Favicon already cached, skipping upload.")
         return key
     except s3_client.exceptions.ClientError:
         pass
@@ -58,11 +48,13 @@ def upload_if_missing(s3_client, bucket, key, data, content_type):
         Body=data,
         ContentType=content_type,
     )
+
+    logger.info(f"Favicon succesfully cached.")
     return key
 
 
 @dagster.asset
-async def cache_favicons(s3: S3Resource, cluster: dagster.ResourceParam[ClickhouseCluster]):
+def cache_favicons(s3: S3Resource, cluster: dagster.ResourceParam[ClickhouseCluster]):
     top_referrer_query = """
         SELECT cutToFirstSignificantSubdomainWithWWW(JSONExtractString(properties, '$referrer')) AS referrer
         FROM events
@@ -80,22 +72,22 @@ async def cache_favicons(s3: S3Resource, cluster: dagster.ResourceParam[Clickhou
     domains = [result["referrer"] for result in results]
     logger.info(f"Found {len(domains)} results.")
 
-    items = await batch_download(domains, concurrency=25)
-
     s3_client = s3.get_client()
 
     uploaded = []
-    for domain, data, content_type in items:
-        if data is None:
-            continue
-        key = f"/favicons/{domain}.png"
-        upload_if_missing(
-            s3_client,
-            settings.DAGSTER_FAVICONS_S3_BUCKET,
-            key,
-            data,
-            content_type,
-        )
-        uploaded.append(key)
+    with httpx.Client() as client:
+        for domain in domains:
+            domain, data, content_type = download_favicon(domain, client)
+            if data is None:
+                continue
+            key = f"/favicons/{domain}.png"
+            upload_if_missing(
+                s3_client,
+                settings.DAGSTER_FAVICONS_S3_BUCKET,
+                key,
+                data,
+                content_type,
+            )
+            uploaded.append(key)
 
     return uploaded


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
The dagster job to cache favicons is having issues starting in the cloud. This job worked locally, so my hunch it that it's related to the async code. 

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Made the cache_favicon job run synchronously

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Manual testing locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
