### PR TITLE
chore: capture invalid coupon submission

### DIFF
--- a/frontend/src/scenes/coupons/couponLogic.ts
+++ b/frontend/src/scenes/coupons/couponLogic.ts
@@ -70,6 +70,11 @@ export const couponLogic = kea<couponLogicType>([
                     })
                 } catch (error: any) {
                     lemonToast.error(error.detail || 'Failed to claim coupon')
+                    posthog.capture('billing coupon claim failed', {
+                        campaign: props.campaign,
+                        code: formValues.code,
+                        error: error.detail || 'Unknown error',
+                    })
                     throw error
                 }
             },


### PR DESCRIPTION
## Changes

Adding an event to keep track of the reasons why the coupon submission is failing - non-validation exceptions will be captured in `billing` so this is mainly to track validate error reasons/types.

## How did you test this code?

n/a