### PR TITLE
feat(logs): Add refresh shortcut to LogsScene and display options

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -54,7 +54,7 @@ export const scene: SceneExport = {
 }
 
 export function LogsScene(): JSX.Element {
-    const { sparklineData, sparklineLoading } = useValues(logsLogic)
+    const { sparklineData, sparklineLoading, logsLoading } = useValues(logsLogic)
     const { runQuery, setDateRangeFromSparkline, highlightNextLog, highlightPreviousLog, toggleExpandLog } =
         useActions(logsLogic)
     const { highlightedLogId: sceneHighlightedLogId } = useValues(logsLogic)
@@ -76,7 +76,7 @@ export function LogsScene(): JSX.Element {
                     }
                 },
             },
-            r: { action: () => runQuery() },
+            r: { action: () => !logsLoading && runQuery() },
         },
         [sceneHighlightedLogId, runQuery]
     )

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -76,8 +76,9 @@ export function LogsScene(): JSX.Element {
                     }
                 },
             },
+            r: { action: () => runQuery() },
         },
-        [sceneHighlightedLogId]
+        [sceneHighlightedLogId, runQuery]
     )
 
     const onSelectionChange = (selection: { startIndex: number; endIndex: number }): void => {
@@ -604,6 +605,9 @@ const DisplayOptions = (): JSX.Element => {
                     <span className="mx-1">·</span>
                     <KeyboardShortcut enter />
                     expand
+                    <span className="mx-1">·</span>
+                    <KeyboardShortcut r />
+                    refresh
                 </span>
             </div>
         </div>
@@ -655,6 +659,9 @@ const VirtualizedLogsListDisplayOptions = (): JSX.Element => {
                     <span className="mx-1">·</span>
                     <KeyboardShortcut enter />
                     expand
+                    <span className="mx-1">·</span>
+                    <KeyboardShortcut r />
+                    refresh
                 </span>
             </div>
         </div>

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -78,7 +78,7 @@ export function LogsScene(): JSX.Element {
             },
             r: { action: () => !logsLoading && runQuery() },
         },
-        [sceneHighlightedLogId, runQuery]
+        [sceneHighlightedLogId, logsLoading, runQuery]
     )
 
     const onSelectionChange = (selection: { startIndex: number; endIndex: number }): void => {


### PR DESCRIPTION
## Problem

Couldn't refresh query when using keyboard nav

## Changes

<img width="448" height="52" alt="image" src="https://github.com/user-attachments/assets/b098b990-848a-41cd-a034-428fe0c7413f" />

- Introduced a new keyboard shortcut 'r' for refreshing logs in LogsScene.
- Updated DisplayOptions and VirtualizedLogsListDisplayOptions to include the refresh shortcut.

## How did you test this code?

Local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._