### PR TITLE
fix: double encoded url in re-auth flow

### DIFF
--- a/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
+++ b/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
@@ -24,8 +24,7 @@ export function TimeSensitiveAuthenticationModal(): JSX.Element {
     const showPassword = !ssoEnforcement && user?.has_password
 
     const extraQueryParams = {
-        // Don't use encodeURI, it would double-encode special characters (e.g., %3A becomes %253A)
-        next: location.pathname + location.search + location.hash,
+        next: location.href.replace(location.origin, ''),
         email: user?.email || '',
         reauth: 'true',
     }

--- a/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
+++ b/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
@@ -24,7 +24,8 @@ export function TimeSensitiveAuthenticationModal(): JSX.Element {
     const showPassword = !ssoEnforcement && user?.has_password
 
     const extraQueryParams = {
-        next: encodeURI(location.href.replace(location.origin, '')),
+        // Don't use encodeURI, it would double-encode special characters (e.g., %3A becomes %253A)
+        next: location.pathname + location.search + location.hash,
         email: user?.email || '',
         reauth: 'true',
     }


### PR DESCRIPTION
## Problem

User was viewing an LLM Analytics trace page (`/llm-analytics/traces/:id?timestamp=2025-11-26T02:31:16Z`), then clicked "Invite members" which triggered re-authentication. After OAuth redirect, the timestamp became `2025-11-26T02%3A31%3A16Z` (double-encoded them %3A -> %253A) which dayjs() cannot parse. 

<img width="1359" height="685" alt="Screenshot 2025-12-02 at 17 22 07" src="https://github.com/user-attachments/assets/d030b0f1-7475-442c-882b-89fce2f4dca8" />

- Ticket: https://posthoghelp.zendesk.com/agent/tickets/43607 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46275)
- Session replay: https://us.posthog.com/project/2/replay/019abdf8-740b-7283-818f-3e0b4ea3de53?t=1103
- Error: https://us.posthog.com/project/2/error_tracking/019a1128-e166-76b1-8590-41ef4cccaf2f?db849d029ac5fa31c4f166fdda1a2dfaf6f7b5a296bf25a0d910f1db5630dc433e311611e66fcc61e95257aaa0032224c325716335c92837a3fa895fc6db2ba0&timestamp=2025-10-23%2006%3A01%3A34.370000-07%3A00

## Changes
Fixed URL in re-auth flow to prevent double-encoding. 

## How did you test this code?
- Set env variable `SESSION_SENSITIVE_ACTIONS_AGE=30` to trigger reauth every 30 seconds. 
- Open any sensitive page (eg. Members).
- Add timestamp to the query params. (e.g.:g `http://localhost:8010/project/1/settings/organization-members?timestamp=2025-01-01T12:00:00Z`
- Go through reauth process with google. 
