### PR TITLE
feat(capture): revert facet Rust deploy OTEL service namespaces

### DIFF
--- a/rust/capture/src/main.rs
+++ b/rust/capture/src/main.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
-use capture::config::{CaptureMode, Config};
+use capture::config::Config;
 use capture::server::serve;
 
 common_alloc::used!();
@@ -61,23 +61,10 @@ fn init_tracer(sink_url: &str, sampling_rate: f64, service_name: &str) -> Tracer
 async fn main() {
     let config = Config::init_from_env().expect("Invalid configuration:");
 
-    // Determine service name based on mirror deploy flag
-    let otel_service_name = match (&config.capture_mode, config.is_mirror_deploy) {
-        (&CaptureMode::Events, true) => format!("{}-mirrored", config.otel_service_name),
-        (&CaptureMode::Events, false) => config.otel_service_name.clone(),
-        (&CaptureMode::Recordings, true) => format!("{}-replay-mirrored", config.otel_service_name),
-        (&CaptureMode::Recordings, false) => format!("{}-replay", config.otel_service_name),
-    };
-
     // Instantiate tracing outputs:
     //   - stdout with a level configured by the RUST_LOG envvar (default=ERROR)
     //   - OpenTelemetry if enabled, for levels INFO and higher
-    // Use JSON formatting to include service name field for mirror deploy distinction
-    let log_layer = tracing_subscriber::fmt::layer()
-        .json()
-        .with_current_span(false)
-        .with_span_list(false)
-        .with_filter(EnvFilter::from_default_env());
+    let log_layer = tracing_subscriber::fmt::layer().with_filter(EnvFilter::from_default_env());
     let otel_layer = config
         .otel_url
         .clone()
@@ -85,7 +72,7 @@ async fn main() {
             OpenTelemetryLayer::new(init_tracer(
                 &url,
                 config.otel_sampling_rate,
-                &otel_service_name,
+                &config.otel_service_name,
             ))
         })
         .with_filter(LevelFilter::from_level(config.log_level));
@@ -93,13 +80,6 @@ async fn main() {
         .with(log_layer)
         .with(otel_layer)
         .init();
-
-    // Log service name for mirror deploy distinction
-    if config.is_mirror_deploy {
-        tracing::info!(service_name = %otel_service_name, "Starting capture service (mirror deploy)");
-    } else {
-        tracing::info!(service_name = %otel_service_name, "Starting capture service");
-    }
 
     // Open the TCP port and start the server
     let listener = tokio::net::TcpListener::bind(config.address)

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -973,7 +973,7 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
     // simple defaults - payload validation isn't the focus of these tests
     let enable_historical_rerouting = false;
     let historical_rerouting_threshold_days = 1_i64;
-    let is_mirror_deploy = false;
+    let is_mirror_deploy = false; // TODO: remove after migration to 100% capture-rs backend
     let verbose_sample_percent = 0.0_f32;
 
     (


### PR DESCRIPTION
Reverts PostHog/posthog#42344 the `OTEL_SERVICE_NAME` env var is not set up or propagating correctly [here](https://github.com/PostHog/charts/blob/f4d4aab4d3a4cdbf8f6cbbb57c78e618f947043e/charts/capture/templates/_helpers.tpl#L163-L164) and I think we'd best solve the log faceting problem that way. JSON output change is a nice-to-have at this point, and strips our structured log tags applied on the handlers; we can sort that out later it's not the prob we set out to solve here