### PR TITLE
fix(replay): fix replay popup container height

### DIFF
--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -299,7 +299,7 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
                                                 ) : null}
                                             </div>
                                             <div
-                                                className="SessionRecordingPlayer__body flex-1"
+                                                className="SessionRecordingPlayer__body"
                                                 draggable={draggable}
                                                 {...elementProps}
                                             >


### PR DESCRIPTION
## Problem

i think adding `flex-1`​ broke the pop-up replays -- i always see them show up with this tiny height, and removing `flex-1` from the class fixes it

|  |  |
| --- | --- |
| ![Screenshot 2025-12-02 at 10.07.00 AM.png](https://app.graphite.com/user-attachments/assets/7ffd656d-96f3-4329-9e1f-866d7087c38d.png)<br> | ![Screenshot 2025-12-02 at 10.07.04 AM.png](https://app.graphite.com/user-attachments/assets/1d33b9fc-3141-41c1-8500-fc5b33c48845.png)<br> |

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->