### PR TITLE
fix(logs): adds highlight color for logs light mode

### DIFF
--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -818,6 +818,7 @@
     --muted-3000: var(--muted-3000-light);
     --trace-3000: var(--trace-3000-light);
     --primary-3000: var(--primary-3000-light);
+    --primary-highlight: var(--primary-highlight-light);
     --primary-3000-hover: var(--primary-3000-hover-light);
     --primary-3000-active: var(--primary-3000-active-light);
     --secondary-3000: var(--secondary-3000-light);


### PR DESCRIPTION
## Problem

Logs weren't highlighting in lightmode

## Changes

<img width="1182" height="109" alt="image" src="https://github.com/user-attachments/assets/1f0e00f8-af08-443e-a32d-d97210d34889" />

Adds the correct light mode CSS var.

## How did you test this code?

Local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._