### PR TITLE
chore(flags): Add batch_load_fn to team metadata cache

### DIFF
--- a/posthog/management/commands/_base_hypercache_command.py
+++ b/posthog/management/commands/_base_hypercache_command.py
@@ -631,8 +631,11 @@ class BaseHyperCacheCommand(BaseCommand):
             actual_batch_size = batch_size
             actual_invalidate_first = invalidate_first
 
-        # Progress callback to write to stdout
+        # Callbacks to write progress to stdout
         last_percent_reported = [0]  # Use list to allow mutation in closure
+
+        def batch_start_callback(batch_num: int, batch_len: int):
+            self.stdout.write(f"  Processing batch {batch_num} ({batch_len:,} teams)…")
 
         def progress_callback(processed: int, total: int, successful: int, failed: int):
             if total == 0:
@@ -656,6 +659,7 @@ class BaseHyperCacheCommand(BaseCommand):
             max_ttl_days=max_ttl_days,
             team_ids=team_ids,
             progress_callback=progress_callback,
+            batch_start_callback=batch_start_callback,
         )
 
         # Display results

--- a/posthog/management/commands/verify_team_metadata_cache.py
+++ b/posthog/management/commands/verify_team_metadata_cache.py
@@ -78,8 +78,12 @@ class Command(BaseHyperCacheCommand):
                 "details": "No cached data found",
             }
 
-        # Get DB data and compare
-        db_data = self._get_db_data(team)
+        # Get DB data from batch_data if available, otherwise serialize from team object
+        if batch_data and team.id in batch_data:
+            db_data = batch_data[team.id]
+        else:
+            db_data = self._get_db_data(team)
+
         match, diffs = self._compare_data(db_data, cached_data)
 
         if match:


### PR DESCRIPTION
## Problem

Warming the `team_metadata_cache` has an N+1 issue. When running in prod-us, we are trying to warm 228K teams. This takes a long time and produces unnecessary load on the db.

## Changes

1. Implement `batch_load_fn` for the team metadata HyperCache instance (the flags HyperCache already implements this).
2. Add a `batch_start_callback` so we can see that a batch is starting.

## How did you test this code?

Manually.
Unit Tests.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
