### PR TITLE
fix(ph-ai): add privacy mode

### DIFF
--- a/ee/hogai/core/runner.py
+++ b/ee/hogai/core/runner.py
@@ -35,6 +35,7 @@ from posthog.utils import get_instance_region
 
 from ee.hogai.core.stream_processor import AssistantStreamProcessorProtocol
 from ee.hogai.utils.exceptions import LLM_API_EXCEPTIONS, LLM_PROVIDER_ERROR_COUNTER, GenerationCanceled
+from ee.hogai.utils.feature_flags import is_privacy_mode_enabled
 from ee.hogai.utils.helpers import extract_stream_update
 from ee.hogai.utils.state import validate_state_update
 from ee.hogai.utils.types.base import (
@@ -121,6 +122,7 @@ class BaseAgentRunner(ABC):
                     distinct_id=user.distinct_id if user else None,
                     properties=callback_properties,
                     trace_id=trace_id,
+                    privacy_mode=is_privacy_mode_enabled(team),
                 )
 
             # Local deployment or hobby

--- a/ee/hogai/utils/feature_flags.py
+++ b/ee/hogai/utils/feature_flags.py
@@ -11,3 +11,16 @@ def has_agent_modes_feature_flag(team: Team, user: User) -> bool:
         group_properties={"organization": {"id": str(team.organization_id)}},
         send_feature_flag_events=False,
     )
+
+
+def is_privacy_mode_enabled(team: Team) -> bool:
+    """
+    Check if privacy mode is enabled for a team's organization.
+    """
+    return posthoganalytics.feature_enabled(
+        "phai-privacy-mode",
+        str(team.organization_id),
+        groups={"organization": str(team.organization_id)},
+        group_properties={"organization": {"id": str(team.organization_id)}},
+        send_feature_flag_events=False,
+    )


### PR DESCRIPTION
## Problem

We need to enable privacy mode for a specific organization so that traces from PostHog AI are not captured.

## Changes

Added a `is_privacy_mode_enabled`​ function that checks a flag with organization IDs we don't want to track.

## How did you test this code?

Locally, added my org id to the list