### PR TITLE
chore(flags): Add `FLAGS_REDIS_URL` to flox `[vars]`

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -53,6 +53,7 @@ ffmpeg.pkg-path = "ffmpeg"
 [vars]
 DEBUG = "1"
 POSTHOG_SKIP_MIGRATION_CHECKS = "1"
+FLAGS_REDIS_URL = "redis://localhost:6379/1"
 DIRENV_LOG_FORMAT = "" # Disable direnv activation logging (in case direnv is present)
 RUST_LOG = "flox=error,flox_rust_sdk=error,flox_watchdog=error" # Suppress Flox logs only (also set in .envrc for early activation)
 OPENSSL_ROOT_DIR = "$FLOX_ENV"


### PR DESCRIPTION
`FLAGS_REDIS_URL` is the setting for the dedicated feature flags Redis instance. This is now set in prod (and cloud dev).

This change makes sure its set for local development.

## Problem

When running flags locally directly (such as `cargo run -p feature-flags`) or running Django management commands, the `FLAGS_REDIS_URL` setting isn't set.

## Changes

Update the flox manifest so that flox users get this setting.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
