### PR TITLE
fix(workflows): hide behavioral cohort from conditional filters

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
@@ -74,6 +74,7 @@ export function HogFlowPropertyFilters({ actionId, filters, setFilters }: HogFlo
                 TaxonomicFilterGroupType.EventProperties,
                 TaxonomicFilterGroupType.EventFeatureFlags,
                 TaxonomicFilterGroupType.PersonProperties,
+                TaxonomicFilterGroupType.Cohorts,
                 TaxonomicFilterGroupType.HogQLExpression,
                 TaxonomicFilterGroupType.EventMetadata,
             ]}

--- a/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
@@ -74,10 +74,10 @@ export function HogFlowPropertyFilters({ actionId, filters, setFilters }: HogFlo
                 TaxonomicFilterGroupType.EventProperties,
                 TaxonomicFilterGroupType.EventFeatureFlags,
                 TaxonomicFilterGroupType.PersonProperties,
-                TaxonomicFilterGroupType.Cohorts,
                 TaxonomicFilterGroupType.HogQLExpression,
                 TaxonomicFilterGroupType.EventMetadata,
             ]}
+            hideBehavioralCohorts
             metadataSource={{ kind: NodeKind.ActorsQuery }}
         />
     )


### PR DESCRIPTION
## Problem

Context: https://posthoghelp.zendesk.com/agent/tickets/41504 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46067)

Until #project-behavioral-cohorts lands, we can't properly target behavioral cohorts in workflow conditionals

## Changes

Hiding all behavorial cohorts from the conditional filters UX

## How did you test this code?

ensured `hideBehavioralCohorts` prop working as expected here as it does elsewhere
