### PR TITLE
fix(ph-ai): dedupe tools in tool display

### DIFF
--- a/frontend/src/scenes/max/components/ToolsDisplay.tsx
+++ b/frontend/src/scenes/max/components/ToolsDisplay.tsx
@@ -232,7 +232,10 @@ function ToolsExplanation({ toolsInReverse }: { toolsInReverse: ToolRegistration
                         if (!acc[tool.product]) {
                             acc[tool.product] = []
                         }
-                        acc[tool.product]!.push(tool)
+                        // Dedupe tools with the same name within a product
+                        if (!acc[tool.product]!.some((t) => t.name === tool.name)) {
+                            acc[tool.product]!.push(tool)
+                        }
                         return acc
                     },
                     {} as Partial<Record<Scene, ToolDefinition[]>>


### PR DESCRIPTION
## Problem
When displaying tools in the ToolDisplay interface, tools with the same name within a product (`generate_sql_query`, `execute_sql`) are being shown multiple times.

[uploading image.png...]

Mentioned in a ticket: https://posthoghelp.zendesk.com/agent/tickets/43784 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/45918)

## Changes
Added deduplication logic to prevent tools with the same name from appearing multiple times within the same product category.

## How did you test this code?
Locally
