### PR TITLE
chore(flags): Add gauge for total keys

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -48,7 +48,10 @@ from posthog.storage.cache_expiry_manager import (
     track_cache_expiry,
 )
 from posthog.storage.hypercache import HyperCache
-from posthog.storage.hypercache_manager import HyperCacheManagementConfig, get_cache_stats
+from posthog.storage.hypercache_manager import (
+    HyperCacheManagementConfig,
+    get_cache_stats as get_cache_stats_generic,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -316,14 +319,14 @@ def cleanup_stale_expiry_tracking() -> int:
     return removed
 
 
-def get_flags_cache_stats() -> dict[str, Any]:
+def get_cache_stats() -> dict[str, Any]:
     """
     Get statistics about the flags cache.
 
     Returns:
         Dictionary with cache statistics including size information
     """
-    return get_cache_stats(FLAGS_HYPERCACHE_MANAGEMENT_CONFIG)
+    return get_cache_stats_generic(FLAGS_HYPERCACHE_MANAGEMENT_CONFIG)
 
 
 # Signal handlers for automatic cache invalidation

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -404,7 +404,7 @@ class TestCacheStats(BaseTest):
     @patch("posthog.storage.hypercache_manager.get_client")
     def test_get_cache_stats_basic(self, mock_get_client):
         """Test basic cache stats gathering with Redis pipelining."""
-        from posthog.models.feature_flag.flags_cache import get_flags_cache_stats
+        from posthog.models.feature_flag.flags_cache import get_cache_stats
 
         # Mock Redis client with pipelining support
         mock_redis = MagicMock()
@@ -436,7 +436,7 @@ class TestCacheStats(BaseTest):
         ]
 
         with patch("posthog.models.team.team.Team.objects.count", return_value=5):
-            stats = get_flags_cache_stats()
+            stats = get_cache_stats()
 
         self.assertEqual(stats["total_cached"], 2)
         self.assertEqual(stats["total_teams"], 5)

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -435,11 +435,15 @@ class TestCacheStats(BaseTest):
             [1024, 2048],  # Memory usage results
         ]
 
+        # Mock zcard for expiry tracking count
+        mock_redis.zcard.return_value = 2
+
         with patch("posthog.models.team.team.Team.objects.count", return_value=5):
             stats = get_cache_stats()
 
         self.assertEqual(stats["total_cached"], 2)
         self.assertEqual(stats["total_teams"], 5)
+        self.assertEqual(stats["expiry_tracked"], 2)
         self.assertEqual(stats["ttl_distribution"]["expires_1h"], 1)
         self.assertEqual(stats["ttl_distribution"]["expires_24h"], 1)
         self.assertEqual(stats["size_statistics"]["sample_count"], 2)

--- a/posthog/storage/test/test_team_metadata_cache.py
+++ b/posthog/storage/test/test_team_metadata_cache.py
@@ -209,11 +209,15 @@ class TestCacheStats(BaseTest):
             [1024, 2048],  # Memory usage results
         ]
 
+        # Mock zcard for expiry tracking count
+        mock_redis.zcard.return_value = 2
+
         with patch("posthog.models.team.team.Team.objects.count", return_value=5):
             stats = get_cache_stats()
 
         self.assertEqual(stats["total_cached"], 2)
         self.assertEqual(stats["total_teams"], 5)
+        self.assertEqual(stats["expiry_tracked"], 2)
         self.assertEqual(stats["ttl_distribution"]["expires_1h"], 1)
         self.assertEqual(stats["ttl_distribution"]["expires_24h"], 1)
         self.assertEqual(stats["size_statistics"]["sample_count"], 2)

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -7,7 +7,7 @@ from celery import shared_task
 
 from posthog.models.feature_flag.flags_cache import (
     cleanup_stale_expiry_tracking,
-    get_flags_cache_stats,
+    get_cache_stats,
     refresh_expiring_flags_caches,
     update_flags_cache,
 )
@@ -100,7 +100,7 @@ def refresh_expiring_flags_cache_entries() -> None:
         # cache_expiry_manager.refresh_expiring_caches() function, so we don't increment it again here
 
         # Only scan once after refresh for metrics
-        stats_after = get_flags_cache_stats()
+        stats_after = get_cache_stats()
 
         coverage_percent = stats_after.get("cache_coverage_percent", 0)
         HYPERCACHE_COVERAGE_GAUGE.labels(namespace="feature_flags").set(coverage_percent)


### PR DESCRIPTION
## Problem

When building the HyperCache for feature-flags team metadata and flag definitions, it'd be nice to have a gauge to see total counts of cache keys. We alerayd have a coverage percentage gauge. I'd love to see both.

## Changes

Adds a gauge for hypercache entries.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
