### PR TITLE
feat(surveys): cross-sell with experiments

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -353,6 +353,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_EMPTY_ONBOARDING: 'web-analytics-empty-onboarding', // owner: @jordanm-posthog #team-web-analytics
     REPLAY_WAIT_FOR_FULL_SNAPSHOT_PLAYBACK: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay
     SURVEYS_INSIGHT_BUTTON_EXPERIMENT: 'ask-users-why-ai-vs-quickcreate', // owner: @adboio #team-surveys multivariate
+    SURVEYS_EXPERIMENTS_CROSS_SELL: 'surveys-experiments-cross-sell', // owner: @adboio #team-surveys
 } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentFeedbackTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentFeedbackTab.tsx
@@ -1,0 +1,45 @@
+import { useValues } from 'kea'
+
+import { IconArrowRight } from '@posthog/icons'
+import { Link, Spinner } from '@posthog/lemon-ui'
+
+import { FeedbackTabContent } from 'scenes/surveys/FeedbackTabContent'
+import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
+import { SurveysTabs, surveysLogic } from 'scenes/surveys/surveysLogic'
+import { urls } from 'scenes/urls'
+
+import { Experiment } from '~/types'
+
+export function ExperimentFeedbackTab({ experiment }: { experiment: Experiment }): JSX.Element {
+    const { data, dataLoading } = useValues(surveysLogic)
+
+    const linkedFlagId = experiment.feature_flag?.id
+    const surveysForExperiment = linkedFlagId ? data.surveys.filter((s) => s.linked_flag_id === linkedFlagId) : []
+
+    if (dataLoading) {
+        return (
+            <div className="flex items-center justify-center py-8">
+                <Spinner className="text-2xl" />
+            </div>
+        )
+    }
+
+    return (
+        <FeedbackTabContent
+            surveys={surveysForExperiment}
+            context={{
+                type: QuickSurveyType.EXPERIMENT,
+                experiment,
+            }}
+            emptyStateBannerMessage="Gather qualitative feedback from users participating in this experiment"
+            multipleSurveysBannerMessage={
+                <>
+                    Showing only surveys associated with this experiment.{' '}
+                    <Link to={urls.surveys(SurveysTabs.Active)}>
+                        See all surveys <IconArrowRight />
+                    </Link>
+                </>
+            }
+        />
+    )
+}

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonTabs } from '@posthog/lemon-ui'
+import { LemonTabs, LemonTag } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -39,6 +39,7 @@ import { experimentSceneLogic } from '../experimentSceneLogic'
 import { getExperimentStatus } from '../experimentsLogic'
 import { isLegacyExperiment, isLegacyExperimentQuery, removeMetricFromOrderingArray } from '../utils'
 import { DistributionModal, DistributionTable } from './DistributionTable'
+import { ExperimentFeedbackTab } from './ExperimentFeedbackTab'
 import { ExperimentHeader } from './ExperimentHeader'
 import { ExposureCriteriaModal } from './ExposureCriteria'
 import { Exposures } from './Exposures'
@@ -217,8 +218,15 @@ const VariantsTab = (): JSX.Element => {
 }
 
 export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.Element {
-    const { experimentLoading, experimentId, experiment, usesNewQueryRunner, isExperimentDraft, exposureCriteria } =
-        useValues(experimentLogic)
+    const {
+        experimentLoading,
+        experimentId,
+        experiment,
+        usesNewQueryRunner,
+        isExperimentDraft,
+        exposureCriteria,
+        featureFlags,
+    } = useValues(experimentLogic)
     const { setExperiment, updateExperimentMetrics, addSharedMetricsToExperiment, removeSharedMetricFromExperiment } =
         useActions(experimentLogic)
 
@@ -288,6 +296,22 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
                                 label: 'History',
                                 content: <ActivityLog scope={ActivityScope.EXPERIMENT} id={experimentId} />,
                             },
+                            ...(experiment.feature_flag && featureFlags[FEATURE_FLAGS.SURVEYS_EXPERIMENTS_CROSS_SELL]
+                                ? [
+                                      {
+                                          key: 'feedback',
+                                          label: (
+                                              <div className="flex flex-row">
+                                                  <div>User feedback</div>
+                                                  <LemonTag className="ml-2 float-right uppercase" type="primary">
+                                                      New
+                                                  </LemonTag>
+                                              </div>
+                                          ),
+                                          content: <ExperimentFeedbackTab experiment={experiment} />,
+                                      },
+                                  ]
+                                : []),
                         ]}
                     />
 

--- a/frontend/src/scenes/feature-flags/FeatureFlagFeedbackTab.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagFeedbackTab.tsx
@@ -1,117 +1,32 @@
-import { BindLogic, useValues } from 'kea'
-
 import { IconArrowRight } from '@posthog/icons'
-import { LemonBanner, LemonTable, LemonTableColumn, Link, Spinner } from '@posthog/lemon-ui'
+import { Link } from '@posthog/lemon-ui'
 
-import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
-import { createdAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
-import stringWithWBR from 'lib/utils/stringWithWBR'
-import { QuickSurveyForm } from 'scenes/surveys/QuickSurveyModal'
-import { SurveyResult } from 'scenes/surveys/SurveyView'
-import { SurveyStatusTag } from 'scenes/surveys/components/SurveyStatusTag'
+import { FeedbackTabContent } from 'scenes/surveys/FeedbackTabContent'
 import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
-import { surveyLogic } from 'scenes/surveys/surveyLogic'
-import { SurveysTabs, surveysLogic } from 'scenes/surveys/surveysLogic'
+import { SurveysTabs } from 'scenes/surveys/surveysLogic'
 import { urls } from 'scenes/urls'
 
-import { FeatureFlagType, Survey } from '~/types'
+import { FeatureFlagType } from '~/types'
 
 export function FeedbackTab({ featureFlag }: { featureFlag: FeatureFlagType }): JSX.Element {
-    const { surveysResponsesCountLoading, surveysResponsesCount } = useValues(surveysLogic)
-    const surveysForFlag = featureFlag.surveys || []
-
-    if (surveysForFlag.length === 0) {
-        return (
-            <div className="flex flex-col items-center pt-5">
-                <div className="w-full max-w-5xl">
-                    <LemonBanner type="info" className="mb-6">
-                        Gather valuable insights by automatically displaying a survey to users in this feature flag
-                    </LemonBanner>
-                    <div className="border rounded p-6 bg-bg-light">
-                        <QuickSurveyForm
-                            context={{
-                                type: QuickSurveyType.FEATURE_FLAG,
-                                flag: featureFlag,
-                            }}
-                        />
-                    </div>
-                </div>
-            </div>
-        )
-    }
-
-    if (surveysForFlag.length === 1) {
-        return (
-            <BindLogic logic={surveyLogic} props={{ id: surveysForFlag[0].id }}>
-                <div className="">
-                    <LemonBanner type="info" className="mb-6">
-                        Showing results for survey "{surveysForFlag[0].name}".{' '}
-                        <Link to={urls.survey(surveysForFlag[0].id)}>
-                            Manage in surveys <IconArrowRight />
-                        </Link>
-                    </LemonBanner>
-                    <SurveyResult />
-                </div>
-            </BindLogic>
-        )
-    }
+    const surveys = featureFlag.surveys || []
 
     return (
-        <div className="space-y-6">
-            <LemonBanner type="info" className="">
-                Showing only surveys associated with this feature flag.{' '}
-                <Link to={urls.surveys(SurveysTabs.Active)}>
-                    See all surveys <IconArrowRight />
-                </Link>
-            </LemonBanner>
-
-            <LemonTable
-                dataSource={surveysForFlag}
-                defaultSorting={{
-                    columnKey: 'created_at',
-                    order: -1,
-                }}
-                rowKey="name"
-                nouns={['survey', 'surveys']}
-                data-attr="surveys-table"
-                columns={[
-                    {
-                        dataIndex: 'name',
-                        title: 'Name',
-                        render: function RenderName(_, survey) {
-                            return <LemonTableLink to={urls.survey(survey.id)} title={stringWithWBR(survey.name, 17)} />
-                        },
-                    },
-                    {
-                        title: 'Responses',
-                        dataIndex: 'id',
-                        render: function RenderResponses(_, survey) {
-                            return (
-                                <>
-                                    {surveysResponsesCountLoading ? (
-                                        <Spinner />
-                                    ) : (
-                                        <div>{surveysResponsesCount[survey.id] ?? 0}</div>
-                                    )}
-                                </>
-                            )
-                        },
-                        sorter: (surveyA, surveyB) => {
-                            const countA = surveysResponsesCount[surveyA.id] ?? 0
-                            const countB = surveysResponsesCount[surveyB.id] ?? 0
-                            return countA - countB
-                        },
-                    },
-                    createdAtColumn<Survey>() as LemonTableColumn<Survey, keyof Survey | undefined>,
-                    {
-                        title: 'Status',
-                        width: 100,
-                        render: function Render(_: any, survey: Survey) {
-                            return <SurveyStatusTag survey={survey} />
-                        },
-                    },
-                ]}
-            />
-        </div>
+        <FeedbackTabContent
+            surveys={surveys}
+            context={{
+                type: QuickSurveyType.FEATURE_FLAG,
+                flag: featureFlag,
+            }}
+            emptyStateBannerMessage="Gather valuable insights by automatically displaying a survey to users in this feature flag"
+            multipleSurveysBannerMessage={
+                <>
+                    Showing only surveys associated with this feature flag.{' '}
+                    <Link to={urls.surveys(SurveysTabs.Active)}>
+                        See all surveys <IconArrowRight />
+                    </Link>
+                </>
+            }
+        />
     )
 }

--- a/frontend/src/scenes/surveys/FeedbackTabContent.tsx
+++ b/frontend/src/scenes/surveys/FeedbackTabContent.tsx
@@ -1,0 +1,120 @@
+import { BindLogic, useValues } from 'kea'
+
+import { IconArrowRight } from '@posthog/icons'
+import { LemonBanner, LemonTable, LemonTableColumn, Link, Spinner } from '@posthog/lemon-ui'
+
+import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { createdAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+import stringWithWBR from 'lib/utils/stringWithWBR'
+import { SurveyResult } from 'scenes/surveys/SurveyView'
+import { SurveyStatusTag } from 'scenes/surveys/components/SurveyStatusTag'
+import { QuickSurveyContext } from 'scenes/surveys/quick-create/types'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { surveysLogic } from 'scenes/surveys/surveysLogic'
+import { urls } from 'scenes/urls'
+
+import { Survey } from '~/types'
+
+import { QuickSurveyForm } from './QuickSurveyModal'
+
+export interface FeedbackTabContentProps {
+    surveys: Survey[]
+    context: QuickSurveyContext
+    emptyStateBannerMessage: string
+    multipleSurveysBannerMessage: React.ReactNode
+}
+
+export function FeedbackTabContent({
+    surveys,
+    context,
+    emptyStateBannerMessage,
+    multipleSurveysBannerMessage,
+}: FeedbackTabContentProps): JSX.Element {
+    const { surveysResponsesCountLoading, surveysResponsesCount } = useValues(surveysLogic)
+
+    if (surveys.length === 0) {
+        return (
+            <div className="flex flex-col items-center pt-5">
+                <div className="w-full max-w-5xl">
+                    <LemonBanner type="info" className="mb-6">
+                        {emptyStateBannerMessage}
+                    </LemonBanner>
+                    <div className="border rounded p-6 bg-bg-light">
+                        <QuickSurveyForm context={context} />
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    if (surveys.length === 1) {
+        const survey = surveys[0]
+        return (
+            <BindLogic logic={surveyLogic} props={{ id: survey.id }}>
+                <div>
+                    <LemonBanner type="info" className="mb-6">
+                        Showing results for survey "{survey.name}".{' '}
+                        <Link to={urls.survey(survey.id)}>
+                            Manage in surveys <IconArrowRight />
+                        </Link>
+                    </LemonBanner>
+                    <SurveyResult />
+                </div>
+            </BindLogic>
+        )
+    }
+
+    return (
+        <div className="space-y-6">
+            <LemonBanner type="info">{multipleSurveysBannerMessage}</LemonBanner>
+
+            <LemonTable
+                dataSource={surveys}
+                defaultSorting={{
+                    columnKey: 'created_at',
+                    order: -1,
+                }}
+                rowKey="name"
+                nouns={['survey', 'surveys']}
+                data-attr="surveys-table"
+                columns={[
+                    {
+                        dataIndex: 'name',
+                        title: 'Name',
+                        render: function RenderName(_, survey) {
+                            return <LemonTableLink to={urls.survey(survey.id)} title={stringWithWBR(survey.name, 17)} />
+                        },
+                    },
+                    {
+                        title: 'Responses',
+                        dataIndex: 'id',
+                        render: function RenderResponses(_, survey) {
+                            return (
+                                <>
+                                    {surveysResponsesCountLoading ? (
+                                        <Spinner />
+                                    ) : (
+                                        <div>{surveysResponsesCount[survey.id] ?? 0}</div>
+                                    )}
+                                </>
+                            )
+                        },
+                        sorter: (surveyA, surveyB) => {
+                            const countA = surveysResponsesCount[surveyA.id] ?? 0
+                            const countB = surveysResponsesCount[surveyB.id] ?? 0
+                            return countA - countB
+                        },
+                    },
+                    createdAtColumn<Survey>() as LemonTableColumn<Survey, keyof Survey | undefined>,
+                    {
+                        title: 'Status',
+                        width: 100,
+                        render: function Render(_: any, survey: Survey) {
+                            return <SurveyStatusTag survey={survey} />
+                        },
+                    },
+                ]}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/QuickSurveyModal.tsx
+++ b/frontend/src/scenes/surveys/QuickSurveyModal.tsx
@@ -1,7 +1,8 @@
 import { BindLogic, useActions, useValues } from 'kea'
+import { SurveyQuestionType } from 'posthog-js'
 import { useMemo, useRef } from 'react'
 
-import { LemonBanner, LemonButton, LemonLabel, LemonModal, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonInput, LemonLabel, LemonModal, LemonTextArea } from '@posthog/lemon-ui'
 
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { SurveyAppearancePreview } from 'scenes/surveys/SurveyAppearancePreview'
@@ -13,6 +14,8 @@ import { FunnelSequence } from './quick-create/components/FunnelSequence'
 import { URLInput } from './quick-create/components/URLInput'
 import { VariantSelector } from './quick-create/components/VariantSelector'
 import {
+    DEFAULT_RATING_LOWER_LABEL,
+    DEFAULT_RATING_UPPER_LABEL,
     QuickSurveyCreateMode,
     QuickSurveyFormLogicProps,
     quickSurveyFormLogic,
@@ -54,18 +57,52 @@ export function QuickSurveyForm({ context, info, onCancel }: QuickSurveyFormProp
                             placeholder="What do you think?"
                             minRows={2}
                             data-attr="quick-survey-question-input"
+                            onFocus={(e) => e.currentTarget.select()}
                         />
                     </div>
+
+                    {surveyForm.questionType === SurveyQuestionType.Rating && (
+                        <div className="grid grid-cols-2 gap-4">
+                            <div>
+                                <LemonLabel className="mb-2">Low rating label</LemonLabel>
+                                <LemonInput
+                                    value={surveyForm.ratingLowerBound || ''}
+                                    onChange={(value) => setSurveyFormValue('ratingLowerBound', value)}
+                                    placeholder={DEFAULT_RATING_LOWER_LABEL}
+                                    onFocus={(e) => e.currentTarget.select()}
+                                />
+                            </div>
+                            <div>
+                                <LemonLabel className="mb-2">High rating label</LemonLabel>
+                                <LemonInput
+                                    value={surveyForm.ratingUpperBound || ''}
+                                    onChange={(value) => setSurveyFormValue('ratingUpperBound', value)}
+                                    placeholder={DEFAULT_RATING_UPPER_LABEL}
+                                    onFocus={(e) => e.currentTarget.select()}
+                                />
+                            </div>
+                        </div>
+                    )}
 
                     <BindLogic logic={quickSurveyFormLogic} props={logicProps}>
                         {context.type === QuickSurveyType.FEATURE_FLAG && (
                             <>
-                                <VariantSelector flag={context.flag} />
+                                <VariantSelector variants={context.flag.filters?.multivariate?.variants || []} />
                                 <EventSelector />
                             </>
                         )}
 
                         {context.type === QuickSurveyType.FUNNEL && <FunnelSequence steps={context.funnel.steps} />}
+
+                        {context.type === QuickSurveyType.EXPERIMENT && (
+                            <>
+                                <VariantSelector
+                                    variants={context.experiment.parameters?.feature_flag_variants || []}
+                                    defaultOptionText="All users exposed to this experiment"
+                                />
+                                <EventSelector />
+                            </>
+                        )}
 
                         <URLInput />
                     </BindLogic>

--- a/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
@@ -67,7 +67,7 @@ export function SurveyOpportunityButton({
             conversionRate: funnelContext.conversionRate,
             source: creationSource,
         })
-    }, [insight.id, funnelContext])
+    }, [insight.id, funnelContext, creationSource])
 
     const { openMax } = useMaxTool({
         identifier: 'create_survey',

--- a/frontend/src/scenes/surveys/quick-create/components/VariantSelector.tsx
+++ b/frontend/src/scenes/surveys/quick-create/components/VariantSelector.tsx
@@ -4,48 +4,50 @@ import { LemonLabel } from '@posthog/lemon-ui'
 
 import { quickSurveyFormLogic } from 'scenes/surveys/quick-create/quickSurveyFormLogic'
 
-import { FeatureFlagType } from '~/types'
+import { MultivariateFlagVariant } from '~/types'
 
-export function VariantSelector({ flag }: { flag: FeatureFlagType }): JSX.Element {
+interface VariantSelectorProps {
+    variants: MultivariateFlagVariant[]
+    defaultOptionText?: string
+}
+
+export function VariantSelector({ variants, defaultOptionText }: VariantSelectorProps): JSX.Element | null {
     const { surveyForm } = useValues(quickSurveyFormLogic)
     const { updateConditions } = useActions(quickSurveyFormLogic)
 
+    if (variants.length <= 1) {
+        return null
+    }
+
     const targetVariant = surveyForm.conditions?.linkedFlagVariant || null
 
-    const variants = flag?.filters?.multivariate?.variants || []
-    const isMultivariate = variants.length > 1
-
     return (
-        <>
-            {isMultivariate && (
-                <div>
-                    <LemonLabel>Who should see this survey?</LemonLabel>
-                    <div className="space-y-2 mt-2">
-                        <label className="flex items-center gap-2 cursor-pointer">
-                            <input
-                                type="radio"
-                                checked={targetVariant === null}
-                                onChange={() => updateConditions({ linkedFlagVariant: undefined })}
-                                className="cursor-pointer"
-                            />
-                            <span className="text-sm">All users with this flag enabled</span>
-                        </label>
-                        {variants.map((v) => (
-                            <label key={v.key} className="flex items-center gap-2 cursor-pointer">
-                                <input
-                                    type="radio"
-                                    checked={targetVariant === v.key}
-                                    onChange={() => updateConditions({ linkedFlagVariant: v.key })}
-                                    className="cursor-pointer"
-                                />
-                                <span className="text-sm">
-                                    Only users in the <code className="text-xs">{v.key}</code> variant
-                                </span>
-                            </label>
-                        ))}
-                    </div>
-                </div>
-            )}
-        </>
+        <div>
+            <LemonLabel>Who should see this survey?</LemonLabel>
+            <div className="space-y-2 mt-2">
+                <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                        type="radio"
+                        checked={targetVariant === null}
+                        onChange={() => updateConditions({ linkedFlagVariant: undefined })}
+                        className="cursor-pointer"
+                    />
+                    <span className="text-sm">{defaultOptionText ?? 'All users with this flag enabled'}</span>
+                </label>
+                {variants.map((v) => (
+                    <label key={v.key} className="flex items-center gap-2 cursor-pointer">
+                        <input
+                            type="radio"
+                            checked={targetVariant === v.key}
+                            onChange={() => updateConditions({ linkedFlagVariant: v.key })}
+                            className="cursor-pointer"
+                        />
+                        <span className="text-sm">
+                            Only users in the <code className="text-xs">{v.key}</code> variant
+                        </span>
+                    </label>
+                ))}
+            </div>
+        </div>
     )
 }

--- a/frontend/src/scenes/surveys/quick-create/types.ts
+++ b/frontend/src/scenes/surveys/quick-create/types.ts
@@ -1,10 +1,11 @@
-import { FeatureFlagType } from '~/types'
+import { Experiment, FeatureFlagType } from '~/types'
 
 import { FunnelContext } from '../utils/opportunityDetection'
 
 export type QuickSurveyContext =
     | { type: QuickSurveyType.FEATURE_FLAG; flag: FeatureFlagType; initialVariantKey?: string | null }
     | { type: QuickSurveyType.FUNNEL; funnel: FunnelContext }
+    | { type: QuickSurveyType.EXPERIMENT; experiment: Experiment }
 
 export interface QuickSurveyFormProps {
     context: QuickSurveyContext
@@ -15,4 +16,5 @@ export interface QuickSurveyFormProps {
 export enum QuickSurveyType {
     FEATURE_FLAG = 'feature_flag',
     FUNNEL = 'funnel',
+    EXPERIMENT = 'experiment',
 }

--- a/frontend/src/scenes/surveys/quick-create/utils.ts
+++ b/frontend/src/scenes/surveys/quick-create/utils.ts
@@ -1,8 +1,14 @@
+import { SurveyQuestionType } from 'posthog-js'
+
 import { EventsNode } from '~/queries/schema/schema-general'
 
 import { SURVEY_CREATED_SOURCE, defaultSurveyAppearance } from '../constants'
 import { toSurveyEvent } from '../utils/opportunityDetection'
-import { QuickSurveyFormLogicProps } from './quickSurveyFormLogic'
+import {
+    DEFAULT_RATING_LOWER_LABEL,
+    DEFAULT_RATING_UPPER_LABEL,
+    QuickSurveyFormLogicProps,
+} from './quickSurveyFormLogic'
 import { QuickSurveyContext, QuickSurveyType } from './types'
 
 export const buildLogicProps = (context: QuickSurveyContext): Omit<QuickSurveyFormLogicProps, 'onSuccess'> => {
@@ -47,6 +53,21 @@ export const buildLogicProps = (context: QuickSurveyContext): Omit<QuickSurveyFo
                         ...defaultSurveyAppearance,
                         surveyPopupDelaySeconds: 15,
                     },
+                },
+            }
+
+        case QuickSurveyType.EXPERIMENT:
+            return {
+                key: `experiment-${context.experiment.id}`,
+                contextType: context.type,
+                source: SURVEY_CREATED_SOURCE.EXPERIMENTS,
+                defaults: {
+                    name: `${context.experiment.name} - Quick feedback ${randomId}`,
+                    question: 'This update?',
+                    questionType: SurveyQuestionType.Rating,
+                    ratingLowerBound: DEFAULT_RATING_LOWER_LABEL,
+                    ratingUpperBound: DEFAULT_RATING_UPPER_LABEL,
+                    linkedFlagId: context.experiment.feature_flag?.id,
                 },
             }
     }


### PR DESCRIPTION
## Problem
there's not an easy way to get qualitative feedback from experiments!
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

adds new 'user feedback' tab to experiments page - exactly the same as what we have now in feature flags

![Screenshot 2025-12-02 at 12.30.11 PM.png](https://app.graphite.com/user-attachments/assets/af3be1b2-e4a6-4fab-b7e8-0fc11b0d38d2.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
manual testing

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
no, feature flag
