### PR TITLE
fix(replay): wait for full snapshot before applying incremental snapshots

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -352,6 +352,7 @@ export const FEATURE_FLAGS = {
     HOME_FEED_TAB: 'home-feed-tab', // owner: @ksvat #team-replay
     SURVEYS_FF_CROSS_SELL: 'surveys-ff-cross-sell', // owner: @adboio #team-surveys
     WEB_ANALYTICS_EMPTY_ONBOARDING: 'web-analytics-empty-onboarding', // owner: @jordanm-posthog #team-web-analytics
+    REPLAY_WAIT_FOR_FULL_SNAPSHOT_PLAYBACK: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay
 } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1265,10 +1265,9 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     values.featureFlags[FEATURE_FLAGS.REPLAY_WAIT_FOR_FULL_SNAPSHOT_PLAYBACK] &&
                     newSnapshots.length > 0
                 ) {
-                    const hasFullSnapshotInExisting = currentEvents.some((e) => e.type === EventType.FullSnapshot)
-                    const hasFullSnapshotInNew = newSnapshots.some((e) => e.type === EventType.FullSnapshot)
+                    const hasFullSnapshot = allSnapshots.some((e) => e.type === EventType.FullSnapshot)
 
-                    if (!hasFullSnapshotInExisting && !hasFullSnapshotInNew) {
+                    if (!hasFullSnapshot) {
                         // We have new snapshots but no full snapshot anywhere yet - wait for it
                         return
                     }

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1254,14 +1254,24 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             const eventsToAdd = []
 
             if (values.currentSegment?.windowId !== undefined) {
-                // TODO: Probably need to check for de-dupes here....
-                // TODO: We do some sorting and rearranging in the data logic... We may need to handle that here, replacing the
-                // whole events stream....
-                eventsToAdd.push(
-                    ...(values.sessionPlayerData.snapshotsByWindowId[values.currentSegment?.windowId] ?? []).slice(
-                        currentEvents.length
-                    )
-                )
+                const allSnapshots = values.sessionPlayerData.snapshotsByWindowId[values.currentSegment?.windowId] ?? []
+                const newSnapshots = allSnapshots.slice(currentEvents.length)
+
+                // Check if we have a full snapshot before adding incremental mutations
+                // This prevents the white screen bug where incremental mutations arrive before the full snapshot
+                if (newSnapshots.length > 0) {
+                    const hasFullSnapshotInExisting = currentEvents.some((e) => e.type === EventType.FullSnapshot)
+                    const hasFullSnapshotInNew = newSnapshots.some((e) => e.type === EventType.FullSnapshot)
+                    const hasFullSnapshotInAll = allSnapshots.some((e) => e.type === EventType.FullSnapshot)
+
+                    if (!hasFullSnapshotInExisting && !hasFullSnapshotInNew && !hasFullSnapshotInAll) {
+                        // We have new snapshots but no full snapshot anywhere yet - wait for it
+                        // The subscription on sessionPlayerData will trigger another sync when the full snapshot arrives
+                        return
+                    }
+                }
+
+                eventsToAdd.push(...newSnapshots)
             }
 
             // If replayer isn't initialized, it will be initialized with the already loaded snapshots

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1262,9 +1262,8 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 if (newSnapshots.length > 0) {
                     const hasFullSnapshotInExisting = currentEvents.some((e) => e.type === EventType.FullSnapshot)
                     const hasFullSnapshotInNew = newSnapshots.some((e) => e.type === EventType.FullSnapshot)
-                    const hasFullSnapshotInAll = allSnapshots.some((e) => e.type === EventType.FullSnapshot)
 
-                    if (!hasFullSnapshotInExisting && !hasFullSnapshotInNew && !hasFullSnapshotInAll) {
+                    if (!hasFullSnapshotInExisting && !hasFullSnapshotInNew) {
                         // We have new snapshots but no full snapshot anywhere yet - wait for it
                         // The subscription on sessionPlayerData will trigger another sync when the full snapshot arrives
                         return


### PR DESCRIPTION
## Problem

Users are seeing a "white screen" on replays until doing some workaround (like opening the "inspect DOM" viewer and closing it) 

I noticed when spoofing that BEFORE the inspect dom (ie, during white screen) we're seeing thousands of these types of errors: 

![Screenshot 2025-12-02 at 2.27.33 PM.png](https://app.graphite.com/user-attachments/assets/ab6443be-7b7d-401a-b173-151fb5cb2c9f.png)

This indicates we're trying to process incremental snapshot updates without a full snapshot. I also examined the first snapshots we receive for this video, and they're all type 3 (incremental) not type 2 (full). 

A full snapshot might arrive very shortly after, but due to us calling `slice() ` with the length of already-received snapshots, if its inserted earlier in a sort, and not strictly appended, it will be ignored/skipped. 

The hypothesis is that the "inspect DOM" workaround "fixes" this because it causes a rerender / reload where we already have all the snapshots loaded/sorted, including the _full_ snapshot. 

This is definitely a hypothesis -- i was able to semi-jankily repro this locally by forcing my local dev to ignore an initial first full snapshot, but it definitely wasnt perfect 
(local dev repro testing) 
![Screenshot 2025-12-02 at 1.29.31 PM.png](https://app.graphite.com/user-attachments/assets/f90b7ba5-6049-43da-aa24-d9fa34075ab5.png)


this hypothesis is ALSO supported by the fact that this issue **does not repro** when using "upload from JSON" on a problematic recording. This is probably because upload from JSON has access to all snapshots (including an initial full snapshot) at once, vs the API loads it in chunks (again, leading to incrementals somehow coming in before a full snapshot). 
## Changes
first of all i definitely wrapped this in a flag


hold/pause/wait to add initial snapshots to currentEvents until we have a full snapshot somewhere

I debated using a kea state/reducer to have a flag "has received full snapshot" so we dont have to check every time, but i worried about lifecycle weirdness on resetting that to false if we're jumping around different recordings. I could be convinced to go that direction though. 

## How did you test this code?

oh man. I tried to force the bug to exist locally in the first place by ignoring snapshots, and then logging when it "would have" fixed itself.... but its kind of a mess

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
