### PR TITLE
feat(surveys): swap experiment survey button with quick-create modal

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { router } from 'kea-router'
 import { useEffect, useState } from 'react'
 
 import { IconCopy, IconEye, IconFlask, IconPause, IconPlusSmall, IconRefresh } from '@posthog/icons'
@@ -28,15 +27,11 @@ import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { IconAreaChart } from 'lib/lemon-ui/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
-import { addProductIntent } from 'lib/utils/product-intents'
-import { useMaxTool } from 'scenes/max/useMaxTool'
 import { sceneLogic } from 'scenes/sceneLogic'
-import { SURVEY_CREATED_SOURCE } from 'scenes/surveys/constants'
-import { captureMaxAISurveyCreationException } from 'scenes/surveys/utils'
+import { QuickSurveyModal } from 'scenes/surveys/QuickSurveyModal'
+import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
 import { urls } from 'scenes/urls'
-import { userLogic } from 'scenes/userLogic'
 
-import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { ScenePanel, ScenePanelActionsSection } from '~/layout/scenes/SceneLayout'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { groupsModel } from '~/models/groupsModel'
@@ -48,8 +43,6 @@ import {
     InsightQueryNode,
     InsightVizNode,
     NodeKind,
-    ProductIntentContext,
-    ProductKey,
     TrendsQuery,
 } from '~/queries/schema/schema-general'
 import {
@@ -57,11 +50,9 @@ import {
     AccessControlResourceType,
     ActionFilter,
     AnyPropertyFilter,
-    Experiment,
     ExperimentConclusion,
     InsightShortId,
     ProgressStatus,
-    UserType,
 } from '~/types'
 
 import { DuplicateExperimentModal } from '../DuplicateExperimentModal'
@@ -70,91 +61,6 @@ import { experimentLogic } from '../experimentLogic'
 import { getExperimentStatusColor } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
 import { getVariantColor } from '../utils'
-
-// Utility function to create MaxTool configuration for experiment survey creation
-export function createMaxToolExperimentSurveyConfig(
-    experiment: Experiment,
-    user: UserType | null
-): {
-    identifier: 'create_survey'
-    active: boolean
-    initialMaxPrompt: string
-    suggestions: string[]
-    context: Record<string, any>
-    contextDescription: {
-        text: string
-        icon: JSX.Element
-    }
-    callback: (toolOutput: { survey_id?: string; survey_name?: string; error?: string }) => void
-} {
-    const variants = experiment.parameters?.feature_flag_variants || []
-    const hasMultipleVariants = variants.length > 1
-    const featureFlagKey = experiment.feature_flag?.key
-
-    return {
-        identifier: 'create_survey' as const,
-        active: Boolean(user?.uuid && experiment.id),
-        initialMaxPrompt: `Create a survey to collect feedback about the "${experiment.name}" experiment${experiment.description ? ` (${experiment.description})` : ''}${featureFlagKey ? ` using feature flag "${featureFlagKey}"` : ''}${hasMultipleVariants ? ` which tests variants: ${variants.map((v) => `"${v.key}"`).join(', ')}` : ''}`,
-        suggestions: !featureFlagKey
-            ? [] // No suggestions if no feature flag key
-            : hasMultipleVariants
-              ? [
-                    `Create a feedback survey comparing variants in the "${experiment.name}" experiment targeting users with feature flag "${featureFlagKey}"`,
-                    // Include specific variant suggestion only if variant exists
-                    ...(variants[0]?.key
-                        ? [
-                              `Create a survey for users who saw the "${variants[0].key}" variant of feature flag "${featureFlagKey}" in the "${experiment.name}" experiment`,
-                          ]
-                        : []),
-                    `Create an A/B test survey asking users to compare variants from feature flag "${featureFlagKey}" in the "${experiment.name}" experiment`,
-                    `Create a survey to understand which variant of feature flag "${featureFlagKey}" performed better in the "${experiment.name}" experiment`,
-                    `Create a survey targeting users exposed to any variant of feature flag "${featureFlagKey}" to gather feedback on the "${experiment.name}" test`,
-                ]
-              : [
-                    `Create a feedback survey for users who were exposed to feature flag "${featureFlagKey}" in the "${experiment.name}" experiment`,
-                    `Create an NPS survey for users who saw feature flag "${featureFlagKey}" during the "${experiment.name}" experiment`,
-                    `Create a satisfaction survey asking about the experience with feature flag "${featureFlagKey}" in the "${experiment.name}" experiment`,
-                    `Create a survey to understand user reactions to changes introduced by feature flag "${featureFlagKey}" in the "${experiment.name}" experiment`,
-                ],
-        context: {
-            experiment_name: experiment.name,
-            experiment_description: experiment.description,
-            feature_flag_key: experiment.feature_flag?.key,
-            feature_flag_id: experiment.feature_flag?.id,
-            feature_flag_name: experiment.feature_flag?.name,
-            target_feature_flag: experiment.feature_flag?.key,
-            survey_purpose: 'collect_feedback_for_experiment',
-            has_multiple_variants: hasMultipleVariants,
-            variants: variants.map((v) => ({
-                key: v.key,
-                name: v.name || '',
-                rollout_percentage: v.rollout_percentage,
-            })),
-            variant_count: variants?.length || 0,
-        },
-        contextDescription: {
-            text: experiment.name,
-            icon: iconForType('experiment'),
-        },
-        callback: (toolOutput: { survey_id?: string; survey_name?: string; error?: string }) => {
-            addProductIntent({
-                product_type: ProductKey.SURVEYS,
-                intent_context: ProductIntentContext.SURVEY_CREATED,
-                metadata: {
-                    survey_id: toolOutput.survey_id,
-                    source: SURVEY_CREATED_SOURCE.EXPERIMENTS,
-                    created_successfully: !toolOutput?.error,
-                },
-            })
-
-            if (toolOutput?.error || !toolOutput?.survey_id) {
-                return captureMaxAISurveyCreationException(toolOutput.error, SURVEY_CREATED_SOURCE.EXPERIMENTS)
-            }
-            // Redirect to the new survey
-            router.actions.push(urls.survey(toolOutput.survey_id))
-        },
-    }
-}
 
 export function VariantTag({
     variantKey,
@@ -421,11 +327,9 @@ export function PageHeaderCustom(): JSX.Element {
         setHogfettiTrigger,
     } = useActions(experimentLogic)
     const { openShipVariantModal, openStopExperimentModal } = useActions(modalsLogic)
-    const { user } = useValues(userLogic)
     const [duplicateModalOpen, setDuplicateModalOpen] = useState(false)
+    const [surveyModalOpen, setSurveyModalOpen] = useState(false)
     const { newTab } = useActions(sceneLogic)
-    // Initialize MaxTool hook for experiment survey creation
-    const { openMax } = useMaxTool(createMaxToolExperimentSurveyConfig(experiment, user))
     const { trigger, HogfettiComponent } = useHogfetti()
 
     useOnMountEffect(() => {
@@ -579,13 +483,7 @@ export function PageHeaderCustom(): JSX.Element {
                         </ButtonPrimitive>
 
                         {experiment.feature_flag && (
-                            <ButtonPrimitive
-                                menuItem
-                                onClick={openMax || undefined}
-                                disabledReasons={{
-                                    'PostHog AI not available': !openMax,
-                                }}
-                            >
+                            <ButtonPrimitive menuItem onClick={() => setSurveyModalOpen(true)}>
                                 <IconPlusSmall /> Create survey
                             </ButtonPrimitive>
                         )}
@@ -607,6 +505,11 @@ export function PageHeaderCustom(): JSX.Element {
                     </ScenePanelActionsSection>
                 </ScenePanel>
             )}
+            <QuickSurveyModal
+                context={{ type: QuickSurveyType.EXPERIMENT, experiment }}
+                isOpen={surveyModalOpen}
+                onCancel={() => setSurveyModalOpen(false)}
+            />
         </>
     )
 }


### PR DESCRIPTION
## Problem

the surveys AI integration is not yet very good, and not many people are creating surveys with that flow

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

replace AI integration with quick-create modal!

[experiment-survey-button.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/01b13824-0d53-4fd6-b8e3-af0d16da3f1f.mp4" />](https://app.graphite.com/user-attachments/video/01b13824-0d53-4fd6-b8e3-af0d16da3f1f.mp4)

we'll come back to integrate AI differently in the near future, there is still value there, but not as much in current form

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->

yep yep