### PR TITLE
fix: local dev temporal worker exception due to name conflicts

### DIFF
--- a/products/tasks/backend/temporal/create_snapshot/activities/cleanup_sandbox.py
+++ b/products/tasks/backend/temporal/create_snapshot/activities/cleanup_sandbox.py
@@ -16,7 +16,7 @@ class CleanupSandboxInput:
     sandbox_id: str
 
 
-@activity.defn
+@activity.defn(name="snapshot_cleanup_sandbox")
 @asyncify
 def cleanup_sandbox(input: CleanupSandboxInput) -> None:
     with log_activity_execution(


### PR DESCRIPTION
## Problem

when running dev locally, temporal-worker crashes with error "ValueError: More than one activity named cleanup_sandbox", full exception below:

```
2025-12-03 01:50:33.849959 [info     ] Starting Temporal Worker       [posthog.management.commands.start_temporal_worker] filename=start_temporal_worker.py func_name=handle graceful_shutdown_timeout_seconds=None host=127.0.0.1 lineno=350 max_concurrent_activities=None max_concurrent_workflow_tasks=None namespace=default port=7233 target_cpu_usage=None target_memory_usage=None task_queue=development-task-queue
Traceback (most recent call last):
  File "/Users/gwyang/projects/posthog/manage.py", line 22, in <module>
    main()
  File "/Users/gwyang/projects/posthog/manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/Users/gwyang/projects/posthog/.flox/cache/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/Users/gwyang/projects/posthog/.flox/cache/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/gwyang/projects/posthog/.flox/cache/venv/lib/python3.12/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/gwyang/projects/posthog/.flox/cache/venv/lib/python3.12/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gwyang/projects/posthog/posthog/management/commands/start_temporal_worker.py", line 352, in handle
    worker = runner.run(
             ^^^^^^^^^^^
  File "/Users/gwyang/.local/share/uv/python/cpython-3.12.12-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gwyang/.local/share/uv/python/cpython-3.12.12-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/gwyang/projects/posthog/posthog/temporal/common/worker.py", line 136, in create_worker
    worker = Worker(
             ^^^^^^^
  File "/Users/gwyang/projects/posthog/.flox/cache/venv/lib/python3.12/site-packages/temporalio/worker/_worker.py", line 413, in __init__
    self._activity_worker = _ActivityWorker(
                            ^^^^^^^^^^^^^^^^
  File "/Users/gwyang/projects/posthog/.flox/cache/venv/lib/python3.12/site-packages/temporalio/worker/_activity.py", line 98, in __init__
    raise ValueError(f"More than one activity named {defn.name}")
ValueError: More than one activity named cleanup_sandbox
```

## Changes

add activity name to not conflict

## How did you test this code?

hogli start, then watch logs from temporal-worker

## Changelog: (features only) Is this feature complete?

no