### PR TITLE
chore: Add lock file for bin/start

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -41,6 +41,7 @@ rust-analyzer.pkg-group = "rust-analyzer"
 go = { pkg-path = "go", version = "1.22", pkg-group = "go" }
 # CLI tools
 mprocs = { pkg-path = "mprocs" }
+util-linux = { pkg-path = "util-linux" } # flock
 cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }
 sqlx-cli = { pkg-path = "sqlx-cli", version = "0.8.3" } # sqlx
 postgresql = { pkg-path = "postgresql_14" } # psql

--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,20 @@
+# Misc stuff, should be categorized/explained in the future
+# This is sorted in ascending order, keep it that way if you wanna please
+# people's OCDs ^_^
 __emails__
 __pycache__/
-# Local files generated for the ANTLR VS Code extension (https://github.com/mike-lischke/vscode-antlr4)
-.antlr
 .coverage
 .dlt
 .dmypy.json
 .DS_Store
-.env*
-!.env.example
 .eslintcache
-.idea
-!.idea/posthog.iml
 .mypy_cache
 .parcel-cache
-# pyenv local config
+.postgres-backups/
 .python-version
 .temporal-worker-settings
 .turbo
 .venv
-.vscode/*
-!.vscode/launch.json
-!.vscode/settings.example.json
 .wokeignore
 .yalc
 *-esbuild-bundle-visualization.html
@@ -33,8 +27,6 @@ __pycache__/
 *.swo
 *.swp
 **/*.tsbuildinfo
-*Type.ts
-CLAUDE.local.md
 /env
 /playwright-report/
 /test-results/
@@ -45,7 +37,7 @@ celerybeat.pid
 common/hogvm/typescript/.parcel-cache
 common/hogvm/typescript/dist
 common/plugin_transpiler/dist
-common/tailwind/dist
+common/storybook/dist
 coverage-*.xml
 debug.log
 docker-compose.prod.yml
@@ -54,62 +46,81 @@ ee/support_sidebar_max/.env
 ee/support_sidebar_max/.vscode
 ee/support_sidebar_max/.vscode/settings.json
 ee/support_sidebar_max/max-venv/
+frontend/storybook-static
+max-test-venv/
+node_modules/
+object_storage/
+playwright/e2e-vrt/**/*-darwin.png
+pnpm-error.log
+pyrightconfig.json
+settings.yml
+share/GeoLite2-City.*
+staticfiles
+storybook-static
+temp_test_run_data.json
+tmp*/
+upgrade/
+venv
+yalc.lock
+
+# Local ide config should be ignored but keep the example posthog.iml file
+.idea
+!.idea/posthog.iml
+
+# Local VSCode config should be ignored
+# but make sure we commit examples and the shared `launch.json` file
+.vscode/*
+!.vscode/launch.json
+!.vscode/settings.example.json
+
+# Kea types should be ignored
+*Type.ts
+
+# Local files generated for the ANTLR VS Code extension (https://github.com/mike-lischke/vscode-antlr4)
+.antlr
+
+# ANTLR-generated temp files when "npm run grammar:build" crashes
+gen/
+
+# Vite-specific assets (we copy public assets to src/assets) just for development
+.typegen
+frontend/src/assets
+
+# Flox.dev lockfile (will differ slightly per local dev env, even with consistent pinning in TOML file)
+.flox/env/manifest.lock
+
+# Playwright cache + reports
+playwright-report/
+playwright/.auth/
+playwright/playwright-report/
+playwright/test-results/
+test-results/
+
+# Dagster
+.dagster_home/*
+.tmp_dagster_home*/*
+!.dagster_home/.gitkeep
+!.dagster_home/dagster.yaml
+!.dagster_home/workspace.yaml
+
+# Frontend caching, build artifacts, logs, private assets, etc.
+common/tailwind/dist
 frontend/__snapshots__/__diff_output__/
 frontend/__snapshots__/__failures__/
 frontend/.cache/
 frontend/@posthog/apps-common/dist/
 frontend/dist/
 frontend/pnpm-error.log
-frontend/public/Matter*.woff* # Paid font
+frontend/public/Matter*.woff*
 frontend/tmp
 frontend/types/
-# Vite-specific assets (we copy public assets to src/assets) just for development
-frontend/src/assets
-.typegen
-# ANTLR-generated temp files when "npm run grammar:build" crashes
-gen/
-max-test-venv/
-node_modules/
-object_storage/
-data/seaweedfs/
-.migration-checkpoint.json
-.postgres-backups/
-playwright/e2e-vrt/**/*-darwin.png
-pnpm-error.log
-# pyright config (keep this until we have a standardized one)
-pyrightconfig.json
-settings.yml
-share/GeoLite2-City.*
-staticfiles
-storybook-static
-frontend/storybook-static
-common/storybook/dist
-temp_test_run_data.json
-# ignore all dagster tmp directories that may be created
-tmp*/
-upgrade/
-venv
-yalc.lock
-# Flox.dev lockfile (will differ slightly per local dev env, even with consistent pinning in TOML file)
-.flox/env/manifest.lock
-
-playwright/.auth/
-playwright-report/
-test-results/
-playwright/playwright-report/
-playwright/test-results/
-
-.dagster_home/*
-!.dagster_home/.gitkeep
-!.dagster_home/workspace.yaml
-!.dagster_home/dagster.yaml
-.tmp_dagster_home*/*
 
 # Dist release target dir
 target/*
 
 # Ignore user's Cursor rules
 .cursor/**/user*.mdc
+CLAUDE.local.md
 
 # Ignore file for clearing demo data on local
 posthog/management/commands/clear_demo_data.py
@@ -120,11 +131,21 @@ posthog/management/commands/clear_demo_data.py
 # Ignore local mprocs configs
 bin/mprocs*.local.yaml
 
+# Ignore bin lockfiles
+bin/*.lock
+
 # Debug output of our session summaries product
 .session-summaries
 
 # Claude Code review outputs
-CODE_REVIEW.md
 CODE_DEBUGGING_SESSION.md
+CODE_REVIEW.md
 
+# SeaweedFS data + migration checkpoint
+.migration-checkpoint.json
 data/seaweedfs
+data/seaweedfs/
+
+# No env files except for the example
+.env*
+!.env.example

--- a/bin/start
+++ b/bin/start
@@ -3,6 +3,26 @@
 set -e
 
 export REPOSITORY_ROOT=$(realpath "$(dirname "$0")/..")
+export LOCK_FILE="$REPOSITORY_ROOT/bin/start.lock"
+
+# Check for existing lock file
+if [ -f "$LOCK_FILE" ]; then
+    echo "⚠️  Another instance of bin/start is already running (lock file exists: $LOCK_FILE)"
+    echo "   To skip this check, delete the lock file: rm $LOCK_FILE"
+    exit 1
+fi
+
+# Create lock file
+touch "$LOCK_FILE"
+
+# Cleanup function to remove lock file on exit
+cleanup() {
+    rm -f "$LOCK_FILE"
+}
+
+# Register cleanup trap for normal exit and errors
+trap cleanup EXIT INT TERM
+
 export DEBUG=${DEBUG:-1}
 export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
 
@@ -101,8 +121,8 @@ if [[ "$*" == *"--custom"* ]]; then
         exit 1
     fi
     exec mprocs --config "$config_path"
-# Use minimal config
-elif [[ "$*" == *"--minimal"* ]]; then
+    # Use minimal config
+    elif [[ "$*" == *"--minimal"* ]]; then
     exec mprocs --config bin/mprocs-minimal.yaml
 else
     exec mprocs --config bin/mprocs.yaml

--- a/bin/start
+++ b/bin/start
@@ -5,23 +5,13 @@ set -e
 export REPOSITORY_ROOT=$(realpath "$(dirname "$0")/..")
 export LOCK_FILE="$REPOSITORY_ROOT/bin/start.lock"
 
-# Check for existing lock file
-if [ -f "$LOCK_FILE" ]; then
-    echo "⚠️  Another instance of bin/start is already running (lock file exists: $LOCK_FILE)"
+# Acquire exclusive lock using flock (atomic, no race condition)
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    echo "⚠️  Another instance of bin/start is already running (lock file: $LOCK_FILE)"
     echo "   To skip this check, delete the lock file: rm $LOCK_FILE"
     exit 1
 fi
-
-# Create lock file
-touch "$LOCK_FILE"
-
-# Cleanup function to remove lock file on exit
-cleanup() {
-    rm -f "$LOCK_FILE"
-}
-
-# Register cleanup trap for normal exit and errors
-trap cleanup EXIT INT TERM
 
 export DEBUG=${DEBUG:-1}
 export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}


### PR DESCRIPTION
This means we will be warned when we try running more than one `bin/start` instance at the same time. There's never a reason to do that, so let's just block that from happening!

I sometimes run more than one by mistake and everything explodes :)