### PR TITLE
feat(persons): Update geoip_country and geoip_city_name

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -36,8 +36,7 @@ import {
     personWriteMethodAttemptCounter,
     totalPersonUpdateLatencyPerBatchHistogram,
 } from './metrics'
-import { eventToPersonProperties } from './person-property-utils'
-import { getMetricKey } from './person-update'
+import { getMetricKey, isFilteredPersonPropertyKey } from './person-update'
 import { PersonUpdate, fromInternalPerson, toInternalPerson } from './person-update-batch'
 import { PersonsStore } from './persons-store'
 import { FlushResult, PersonsStoreForBatch } from './persons-store-for-batch'
@@ -207,7 +206,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                 return true
             }
 
-            const isFiltered = eventToPersonProperties.has(key) || key.startsWith('$geoip_')
+            const isFiltered = isFilteredPersonPropertyKey(key)
             if (isFiltered) {
                 ignoredProperties.push(key)
                 return false


### PR DESCRIPTION
## Problem

Currently we don't update geoip data if it's the only data being updated for the person, this PR allows that if `geoip_country` or `geoip_city_name` changes, then we update all attributes

## Changes

- Always updates person properties if `geoip_country` or `geoip_city_name` change
- Standardizes logic between `person-update` and `batch-writing-person-store` to use same method for property filtering


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
