### PR TITLE
refactor: add ingestion lag metric

### DIFF
--- a/plugin-server/src/ingestion/event-processing/emit-event-step.test.ts
+++ b/plugin-server/src/ingestion/event-processing/emit-event-step.test.ts
@@ -431,13 +431,13 @@ describe('emit-event-step', () => {
             jest.useRealTimers()
         })
 
-        it('should record ingestion lag when headers.now and message are present', async () => {
+        it('should record ingestion lag when inputHeaders.now and inputMessage are present', async () => {
             const captureTime = new Date(FAKE_NOW_MS - 5432) // 5.432 seconds before fake now
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
-                headers: createHeaders({ now: captureTime }),
-                message: createMessage(),
+                inputHeaders: createHeaders({ now: captureTime }),
+                inputMessage: createMessage(),
             }
 
             await step(input)
@@ -451,12 +451,12 @@ describe('emit-event-step', () => {
             expect(mockSetFn).toHaveBeenCalledWith(5432)
         })
 
-        it('should not record ingestion lag when headers.now is missing', async () => {
+        it('should not record ingestion lag when inputHeaders.now is missing', async () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
-                headers: createHeaders(),
-                message: createMessage(),
+                inputHeaders: createHeaders(),
+                inputMessage: createMessage(),
             }
 
             await step(input)
@@ -465,11 +465,11 @@ describe('emit-event-step', () => {
             expect(mockSetFn).not.toHaveBeenCalled()
         })
 
-        it('should not record ingestion lag when message is missing', async () => {
+        it('should not record ingestion lag when inputMessage is missing', async () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
-                headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+                inputHeaders: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
             }
 
             await step(input)
@@ -478,12 +478,12 @@ describe('emit-event-step', () => {
             expect(mockSetFn).not.toHaveBeenCalled()
         })
 
-        it('should not record ingestion lag when message.topic is undefined', async () => {
+        it('should not record ingestion lag when inputMessage.topic is undefined', async () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
-                headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
-                message: createMessage({ topic: undefined as unknown as string }),
+                inputHeaders: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+                inputMessage: createMessage({ topic: undefined as unknown as string }),
             }
 
             await step(input)
@@ -492,12 +492,12 @@ describe('emit-event-step', () => {
             expect(mockSetFn).not.toHaveBeenCalled()
         })
 
-        it('should not record ingestion lag when message.partition is undefined', async () => {
+        it('should not record ingestion lag when inputMessage.partition is undefined', async () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
-                headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
-                message: createMessage({ partition: undefined as unknown as number }),
+                inputHeaders: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+                inputMessage: createMessage({ partition: undefined as unknown as number }),
             }
 
             await step(input)
@@ -511,8 +511,8 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(customConfig)
             const input = {
                 eventToEmit: mockRawEvent,
-                headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
-                message: createMessage(),
+                inputHeaders: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+                inputMessage: createMessage(),
             }
 
             await step(input)
@@ -528,8 +528,8 @@ describe('emit-event-step', () => {
             const step = createEmitEventStep(config)
             const input = {
                 eventToEmit: mockRawEvent,
-                headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
-                message: createMessage({ partition: 0 }),
+                inputHeaders: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+                inputMessage: createMessage({ partition: 0 }),
             }
 
             await step(input)

--- a/plugin-server/src/ingestion/event-processing/emit-event-step.test.ts
+++ b/plugin-server/src/ingestion/event-processing/emit-event-step.test.ts
@@ -1,5 +1,8 @@
+import { Message } from 'node-rdkafka'
+
 import { KafkaProducerWrapper } from '../../kafka/producer'
-import { ProjectId, RawKafkaEvent, TimestampFormat } from '../../types'
+import { ingestionLagGauge } from '../../main/ingestion-queues/metrics'
+import { EventHeaders, ProjectId, RawKafkaEvent, TimestampFormat } from '../../types'
 import { MessageSizeTooLarge } from '../../utils/db/error'
 import { castTimestampOrNow } from '../../utils/utils'
 import { eventProcessedAndIngestedCounter } from '../../worker/ingestion/event-pipeline/metrics'
@@ -19,8 +22,18 @@ jest.mock('../../worker/ingestion/event-pipeline/metrics', () => ({
     },
 }))
 
+// Mock the ingestion lag gauge
+jest.mock('../../main/ingestion-queues/metrics', () => ({
+    ingestionLagGauge: {
+        labels: jest.fn().mockReturnValue({
+            set: jest.fn(),
+        }),
+    },
+}))
+
 const mockCaptureIngestionWarning = jest.mocked(captureIngestionWarning)
 const mockEventProcessedAndIngestedCounter = jest.mocked(eventProcessedAndIngestedCounter)
+const mockIngestionLagGauge = jest.mocked(ingestionLagGauge)
 
 describe('emit-event-step', () => {
     let mockKafkaProducer: jest.Mocked<KafkaProducerWrapper>
@@ -39,6 +52,7 @@ describe('emit-event-step', () => {
         config = {
             kafkaProducer: mockKafkaProducer,
             clickhouseJsonEventsTopic: 'clickhouse_events_json',
+            groupId: 'test-group-id',
         }
 
         const testTimestamp = castTimestampOrNow('2023-01-01T00:00:00.000Z', TimestampFormat.ClickHouse)
@@ -383,6 +397,161 @@ describe('emit-event-step', () => {
         it('should return "general" for custom events', () => {
             const customEvent = { ...mockRawEvent, event: 'user_signed_up' }
             expect(productTrackHeader(customEvent)).toBe('general')
+        })
+    })
+
+    describe('ingestion lag metric', () => {
+        const FAKE_NOW_MS = 1702654321987 // 2023-12-15T14:32:01.987Z
+        let mockSetFn: jest.Mock
+
+        const createMessage = (overrides: Partial<Message> = {}): Message => ({
+            value: Buffer.from('test-value'),
+            key: Buffer.from('test-key'),
+            offset: 100,
+            partition: 5,
+            topic: 'test-topic',
+            size: 10,
+            ...overrides,
+        })
+
+        const createHeaders = (overrides: Partial<EventHeaders> = {}): EventHeaders => ({
+            force_disable_person_processing: false,
+            ...overrides,
+        })
+
+        beforeEach(() => {
+            jest.useFakeTimers()
+            jest.setSystemTime(FAKE_NOW_MS)
+
+            mockSetFn = jest.fn()
+            mockIngestionLagGauge.labels.mockReturnValue({ set: mockSetFn } as any)
+        })
+
+        afterEach(() => {
+            jest.useRealTimers()
+        })
+
+        it('should record ingestion lag when headers.now and message are present', async () => {
+            const captureTime = new Date(FAKE_NOW_MS - 5432) // 5.432 seconds before fake now
+            const step = createEmitEventStep(config)
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: createHeaders({ now: captureTime }),
+                message: createMessage(),
+            }
+
+            await step(input)
+
+            expect(mockIngestionLagGauge.labels).toHaveBeenCalledWith({
+                topic: 'test-topic',
+                partition: '5',
+                groupId: 'test-group-id',
+            })
+            expect(mockSetFn).toHaveBeenCalledTimes(1)
+            expect(mockSetFn).toHaveBeenCalledWith(5432)
+        })
+
+        it('should not record ingestion lag when headers.now is missing', async () => {
+            const step = createEmitEventStep(config)
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: createHeaders(),
+                message: createMessage(),
+            }
+
+            await step(input)
+
+            expect(mockIngestionLagGauge.labels).not.toHaveBeenCalled()
+            expect(mockSetFn).not.toHaveBeenCalled()
+        })
+
+        it('should not record ingestion lag when message is missing', async () => {
+            const step = createEmitEventStep(config)
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+            }
+
+            await step(input)
+
+            expect(mockIngestionLagGauge.labels).not.toHaveBeenCalled()
+            expect(mockSetFn).not.toHaveBeenCalled()
+        })
+
+        it('should not record ingestion lag when message.topic is undefined', async () => {
+            const step = createEmitEventStep(config)
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+                message: createMessage({ topic: undefined as unknown as string }),
+            }
+
+            await step(input)
+
+            expect(mockIngestionLagGauge.labels).not.toHaveBeenCalled()
+            expect(mockSetFn).not.toHaveBeenCalled()
+        })
+
+        it('should not record ingestion lag when message.partition is undefined', async () => {
+            const step = createEmitEventStep(config)
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+                message: createMessage({ partition: undefined as unknown as number }),
+            }
+
+            await step(input)
+
+            expect(mockIngestionLagGauge.labels).not.toHaveBeenCalled()
+            expect(mockSetFn).not.toHaveBeenCalled()
+        })
+
+        it('should use groupId from config in metric labels', async () => {
+            const customConfig = { ...config, groupId: 'custom-consumer-group' }
+            const step = createEmitEventStep(customConfig)
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+                message: createMessage(),
+            }
+
+            await step(input)
+
+            expect(mockIngestionLagGauge.labels).toHaveBeenCalledWith({
+                topic: 'test-topic',
+                partition: '5',
+                groupId: 'custom-consumer-group',
+            })
+        })
+
+        it('should handle partition 0 correctly', async () => {
+            const step = createEmitEventStep(config)
+            const input = {
+                eventToEmit: mockRawEvent,
+                headers: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+                message: createMessage({ partition: 0 }),
+            }
+
+            await step(input)
+
+            expect(mockIngestionLagGauge.labels).toHaveBeenCalledWith({
+                topic: 'test-topic',
+                partition: '0',
+                groupId: 'test-group-id',
+            })
+        })
+
+        it('should still emit event even if lag metric data is missing', async () => {
+            const step = createEmitEventStep(config)
+            const input = {
+                eventToEmit: mockRawEvent,
+            }
+
+            const result = await step(input)
+
+            expect(isOkResult(result)).toBe(true)
+            expect(mockKafkaProducer.produce).toHaveBeenCalled()
+            expect(mockIngestionLagGauge.labels).not.toHaveBeenCalled()
         })
     })
 })

--- a/plugin-server/src/ingestion/event-processing/emit-event-step.ts
+++ b/plugin-server/src/ingestion/event-processing/emit-event-step.ts
@@ -1,5 +1,8 @@
+import { Message } from 'node-rdkafka'
+
 import { KafkaProducerWrapper } from '../../kafka/producer'
-import { RawKafkaEvent } from '../../types'
+import { ingestionLagGauge } from '../../main/ingestion-queues/metrics'
+import { EventHeaders, RawKafkaEvent } from '../../types'
 import { MessageSizeTooLarge } from '../../utils/db/error'
 import { eventProcessedAndIngestedCounter } from '../../worker/ingestion/event-pipeline/metrics'
 import { captureIngestionWarning } from '../../worker/ingestion/utils'
@@ -9,18 +12,25 @@ import { ProcessingStep } from '../pipelines/steps'
 export interface EmitEventStepConfig {
     kafkaProducer: KafkaProducerWrapper
     clickhouseJsonEventsTopic: string
+    groupId: string
 }
 
-export function createEmitEventStep<T extends { eventToEmit?: RawKafkaEvent }>(
-    config: EmitEventStepConfig
-): ProcessingStep<T, void> {
+export function createEmitEventStep<
+    T extends { eventToEmit?: RawKafkaEvent; headers?: EventHeaders; message?: Message },
+>(config: EmitEventStepConfig): ProcessingStep<T, void> {
     return function emitEventStep(input: T): Promise<PipelineResult<void>> {
-        const { eventToEmit } = input
+        const { eventToEmit, headers, message } = input
 
         if (!eventToEmit) {
             return Promise.resolve(ok(undefined, []))
         }
-        const { kafkaProducer, clickhouseJsonEventsTopic } = config
+        const { kafkaProducer, clickhouseJsonEventsTopic, groupId } = config
+
+        // Record ingestion lag metric if we have the required data
+        if (headers?.now && message?.topic !== undefined && message?.partition !== undefined) {
+            const lag = Date.now() - headers.now.getTime()
+            ingestionLagGauge.labels({ topic: message.topic, partition: String(message.partition), groupId }).set(lag)
+        }
 
         // TODO: It's not great that we put the produce outcome in side effects, we should probably await it here
         //       but it might slow the pipeline down. Historically, it has always been like that.

--- a/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
+++ b/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
@@ -24,8 +24,8 @@ export function createEventPipelineRunnerV1Step(
         const {
             event,
             team,
-            headers,
-            message,
+            headers: inputHeaders,
+            message: inputMessage,
             personsStoreForBatch,
             groupStoreForBatch,
             processPerson,
@@ -38,14 +38,14 @@ export function createEventPipelineRunnerV1Step(
             hogTransformer,
             personsStoreForBatch,
             groupStoreForBatch,
-            headers
+            inputHeaders
         )
         const result = await runner.runEventPipeline(event, team, processPerson, forceDisablePersonProcessing)
 
         // Pass through message and headers for downstream metric recording
         if (isOkResult(result)) {
-            result.value.headers = headers
-            result.value.message = message
+            result.value.inputHeaders = inputHeaders
+            result.value.inputMessage = inputMessage
         }
 
         return result

--- a/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
+++ b/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
@@ -4,7 +4,7 @@ import { EventPipelineRunner } from '../../worker/ingestion/event-pipeline/runne
 import { EventPipelineResult } from '../../worker/ingestion/event-pipeline/runner'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStoreForBatch } from '../../worker/ingestion/persons/persons-store-for-batch'
-import { PipelineResult } from '../pipelines/results'
+import { PipelineResult, isOkResult } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export interface EventPipelineRunnerInput extends IncomingEventWithTeam {
@@ -25,6 +25,7 @@ export function createEventPipelineRunnerV1Step(
             event,
             team,
             headers,
+            message,
             personsStoreForBatch,
             groupStoreForBatch,
             processPerson,
@@ -40,6 +41,13 @@ export function createEventPipelineRunnerV1Step(
             headers
         )
         const result = await runner.runEventPipeline(event, team, processPerson, forceDisablePersonProcessing)
+
+        // Pass through message and headers for downstream metric recording
+        if (isOkResult(result)) {
+            result.value.headers = headers
+            result.value.message = message
+        }
+
         return result
     }
 }

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -333,6 +333,7 @@ export class IngestionConsumer {
                                             createEmitEventStep({
                                                 kafkaProducer: this.kafkaProducer!,
                                                 clickhouseJsonEventsTopic: this.hub.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,
+                                                groupId: this.groupId,
                                             })
                                         ),
                                 {

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -914,6 +914,11 @@ export const parseEventHeaders = (headers?: MessageHeader[]): EventHeaders => {
                 result.uuid = value
             } else if (key === 'force_disable_person_processing') {
                 result.force_disable_person_processing = value === 'true'
+            } else if (key === 'now') {
+                const parsed = new Date(value)
+                if (!isNaN(parsed.getTime())) {
+                    result.now = parsed
+                }
             }
         })
     })

--- a/plugin-server/src/main/ingestion-queues/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/metrics.ts
@@ -60,3 +60,9 @@ export const kafkaHeaderStatusCounter = new Counter({
     help: 'Count of events by header name and presence status',
     labelNames: ['header', 'status'],
 })
+
+export const ingestionLagGauge = new Gauge({
+    name: 'ingestion_lag_ms',
+    help: 'Time difference in ms between event capture time (now header) and ingestion time',
+    labelNames: ['topic', 'partition', 'groupId'],
+})

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1385,6 +1385,7 @@ export interface EventHeaders {
     timestamp?: string
     event?: string
     uuid?: string
+    now?: Date
     force_disable_person_processing: boolean
 }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon'
+import { Message } from 'node-rdkafka'
 
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
@@ -38,6 +39,9 @@ export type EventPipelineResult = {
     lastStep: string
     eventToEmit?: RawKafkaEvent
     error?: string
+    // For ingestion lag metric
+    headers?: EventHeaders
+    message?: Message
 }
 
 export type EventPipelinePipelineResult = PipelineResult<EventPipelineResult>

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -40,8 +40,8 @@ export type EventPipelineResult = {
     eventToEmit?: RawKafkaEvent
     error?: string
     // For ingestion lag metric
-    headers?: EventHeaders
-    message?: Message
+    inputHeaders?: EventHeaders
+    inputMessage?: Message
 }
 
 export type EventPipelinePipelineResult = PipelineResult<EventPipelineResult>

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -119,6 +119,7 @@ describe('processEvent', () => {
             const emitEventStep = createEmitEventStep({
                 kafkaProducer: hub.kafkaProducer,
                 clickhouseJsonEventsTopic: hub.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,
+                groupId: 'test-group-id',
             })
             const emitResult = await emitEventStep(res.value)
 
@@ -242,6 +243,7 @@ describe('processEvent', () => {
             const emitEventStep = createEmitEventStep({
                 kafkaProducer: hub.kafkaProducer,
                 clickhouseJsonEventsTopic: hub.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,
+                groupId: 'test-group-id',
             })
             const emitResult = await emitEventStep(res.value)
 


### PR DESCRIPTION
## Problem

We have approximate ingestion lag metrics, which do not allow us to precisely measure the lag.

## Changes

Adds a new metric to the emit event step based on the now timestamp value and the ingestion wall clock.

## How did you test this code?

Added tests to the step and header parsing code.