### PR TITLE
feat: show active coupons on billing and coupon claim page

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -524,6 +524,17 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             else:
                 raise
 
+    @action(methods=["GET"], detail=False, url_path="coupons/overview")
+    def coupons_overview(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        license = get_cached_instance_license()
+        if not license:
+            return Response({"claimed_coupons": []}, status=status.HTTP_200_OK)
+
+        organization = self._get_org_required()
+        billing_manager = self.get_billing_manager()
+        res = billing_manager.coupons_overview(organization)
+        return Response(res, status=status.HTTP_200_OK)
+
     @action(
         methods=["GET"],
         detail=False,

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -528,6 +528,15 @@ class BillingManager:
         handle_billing_service_error(res)
         return res.json()
 
+    def coupons_overview(self, organization: Organization) -> dict[str, Any]:
+        res = requests.get(
+            f"{BILLING_SERVICE_URL}/api/coupons/overview",
+            headers=self.get_auth_headers(organization),
+        )
+
+        handle_billing_service_error(res)
+        return res.json()
+
     def get_usage_data(self, organization: Organization, params: dict[str, Any]) -> dict[str, Any]:
         """
         Get usage data from the billing service.

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -19,6 +19,7 @@ import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { toSentenceCase } from 'lib/utils'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { couponLogic } from 'scenes/coupons/couponLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -55,6 +56,7 @@ export function Billing(): JSX.Element {
     const { openSupportForm } = useActions(supportLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { location, searchParams } = useValues(router)
+    const { activeCoupons, couponsOverviewLoading } = useValues(couponLogic({}))
 
     const restrictionReason = useRestrictedArea({
         minimumAccessLevel: OrganizationMembershipLevel.Admin,
@@ -78,7 +80,7 @@ export function Billing(): JSX.Element {
         router.actions.push(urls.default())
     }
 
-    if (!billing && billingLoading) {
+    if ((!billing && billingLoading) || couponsOverviewLoading) {
         return (
             <>
                 <SpinnerOverlay sceneLevel />
@@ -188,6 +190,29 @@ export function Billing(): JSX.Element {
             )}
 
             {!showBillingSummary && <StripePortalButton />}
+
+            {!couponsOverviewLoading && activeCoupons.length > 0 && (
+                <div className="mt-6 max-w-300">
+                    <h3 className="mb-2">Active coupons</h3>
+                    <div className="space-y-2">
+                        {activeCoupons.map((coupon) => (
+                            <div
+                                key={coupon.code}
+                                className="flex items-center justify-between p-3 bg-surface-secondary rounded"
+                            >
+                                <div>
+                                    <span className="font-medium">{coupon.campaign_name}</span>
+                                    {coupon.expires_at && (
+                                        <span className="text-muted ml-2">
+                                            Valid until {dayjs(coupon.expires_at).format('LL')}
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
 
             <LemonDivider className="mt-6 mb-8" />
 

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -10,7 +10,7 @@ import { LemonButton, LemonDivider, LemonInput, Link } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { supportLogic } from 'lib/components/Support/supportLogic'
-import { JudgeHog } from 'lib/components/hedgehogs'
+import { JudgeHog, StarHog } from 'lib/components/hedgehogs'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
@@ -193,24 +193,26 @@ export function Billing(): JSX.Element {
 
             {!couponsOverviewLoading && activeCoupons.length > 0 && (
                 <div className="mt-6 max-w-300">
-                    <h3 className="mb-2">Active coupons</h3>
-                    <div className="space-y-2">
-                        {activeCoupons.map((coupon) => (
-                            <div
-                                key={coupon.code}
-                                className="flex items-center justify-between p-3 bg-surface-secondary rounded"
-                            >
-                                <div>
-                                    <span className="font-medium">{coupon.campaign_name}</span>
-                                    {coupon.expires_at && (
-                                        <span className="text-muted ml-2">
-                                            Valid until {dayjs(coupon.expires_at).format('LL')}
-                                        </span>
-                                    )}
-                                </div>
+                    <LemonBanner type="info" hideIcon>
+                        <div className="flex items-center gap-4">
+                            <StarHog className="w-16 h-16 flex-shrink-0" />
+                            <div>
+                                <p className="font-semibold mb-2">You have active coupons!</p>
+                                <ul className="list-disc list-inside space-y-1">
+                                    {activeCoupons.map((coupon) => (
+                                        <li key={coupon.code} className="text-sm">
+                                            <span>{coupon.campaign_name}</span>
+                                            {coupon.expires_at && (
+                                                <span className="text-muted ml-1">
+                                                    · until {dayjs(coupon.expires_at).format('LL')}
+                                                </span>
+                                            )}
+                                        </li>
+                                    ))}
+                                </ul>
                             </div>
-                        ))}
-                    </div>
+                        </div>
+                    </LemonBanner>
                 </div>
             )}
 

--- a/frontend/src/scenes/coupons/couponLogic.ts
+++ b/frontend/src/scenes/coupons/couponLogic.ts
@@ -1,5 +1,6 @@
-import { actions, connect, kea, path, props, reducers } from 'kea'
+import { actions, afterMount, connect, kea, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
+import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
@@ -9,10 +10,12 @@ import { billingLogic } from 'scenes/billing/billingLogic'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { userLogic } from 'scenes/userLogic'
 
+import { ClaimedCouponInfo, CouponsOverview } from '~/types'
+
 import type { couponLogicType } from './couponLogicType'
 
 export interface CouponLogicProps {
-    campaign: string
+    campaign?: string
 }
 
 export interface CouponFormValues {
@@ -37,9 +40,34 @@ export const couponLogic = kea<couponLogicType>([
         setClaimed: (claimed: boolean) => ({ claimed }),
         setClaimedDetails: (details: any) => ({ details }),
     }),
+    loaders(() => ({
+        couponsOverview: [
+            { claimed_coupons: [] } as CouponsOverview,
+            {
+                loadCouponsOverview: async () => {
+                    return await api.get('api/billing/coupons/overview')
+                },
+            },
+        ],
+    })),
     reducers({
         claimed: [false, { setClaimed: (_, { claimed }) => claimed }],
         claimedDetails: [null as any, { setClaimedDetails: (_, { details }) => details }],
+    }),
+    selectors({
+        getClaimedCouponForCampaign: [
+            (s) => [s.couponsOverview],
+            (couponsOverview) =>
+                (campaignSlug: string): ClaimedCouponInfo | null => {
+                    return couponsOverview.claimed_coupons.find((c) => c.campaign_slug === campaignSlug) || null
+                },
+        ],
+        activeCoupons: [
+            (s) => [s.couponsOverview],
+            (couponsOverview): ClaimedCouponInfo[] => {
+                return couponsOverview.claimed_coupons.filter((c) => c.status === 'claimed')
+            },
+        ],
     }),
     forms(({ values, actions, props }) => ({
         coupon: {
@@ -64,6 +92,7 @@ export const couponLogic = kea<couponLogicType>([
                     })
                     actions.setClaimed(true)
                     actions.setClaimedDetails(res)
+                    actions.loadCouponsOverview()
                     posthog.capture('billing coupon claimed', {
                         campaign: props.campaign,
                         code: formValues.code,
@@ -80,4 +109,7 @@ export const couponLogic = kea<couponLogicType>([
             },
         },
     })),
+    afterMount(({ actions }) => {
+        actions.loadCouponsOverview()
+    }),
 ])

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1977,6 +1977,19 @@ export interface BillingType {
     }
 }
 
+export interface ClaimedCouponInfo {
+    code: string
+    campaign_name: string
+    campaign_slug: string | null
+    claimed_at: string
+    expires_at: string | null
+    status: 'claimed' | 'expired'
+}
+
+export interface CouponsOverview {
+    claimed_coupons: ClaimedCouponInfo[]
+}
+
 export interface BillingPeriod {
     start: Dayjs | null
     end: Dayjs | null


### PR DESCRIPTION
## Problem

Some of Lenny's community members were confused after claiming the coupon as they weren't sure it actually worked.

## Changes

- Fetch claimed coupons from `/api/billing/coupons/overview` via `couponLogic`
- Show "Active coupons" section on Billing page with campaign name and expiration date
  - Not the prettiest but want to get this out ASAP
- Detect already-claimed campaigns on coupon redemption pages

Related `billing` changes: https://github.com/PostHog/billing/pull/1648

I want to get this out ASAP so a quick review would be appreciated 🙏

## How did you test this code?

Manually: https://www.loom.com/share/70147252ffc748bb972512b00c25dcb3