### PR TITLE
chore(data-warehouse): Added a mongo non-retry error

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -31,7 +31,7 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         return ExternalDataSourceType.MONGODB
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
-        return {"The DNS query name does not exist": None, "authentication failed": None}
+        return {"The DNS query name does not exist": None, "authentication failed": None, "SSL handshake failed": None}
 
     def get_schemas(self, config: MongoDBSourceConfig, team_id: int, with_counts: bool = False) -> list[SourceSchema]:
         mongo_schemas = get_mongo_schemas(config)


### PR DESCRIPTION
## Changes
- Dont try to repeatedly sync mongo sources that have SSL errors
