### PR TITLE
fix: Fix timestamp for `copy link to event`

### DIFF
--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { IconAI, IconWarning } from '@posthog/icons'
 
 import ViewRecordingButton from 'lib/components/ViewRecordingButton/ViewRecordingButton'
+import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { IconLink } from 'lib/lemon-ui/icons'
@@ -97,18 +98,22 @@ export const EventCopyLinkButton = React.forwardRef<
     HTMLButtonElement,
     { event: Pick<EventType, 'uuid' | 'timestamp'> }
 >(function EventCopyLinkButton({ event }, ref) {
+    const handleClick = (): void => {
+        // Use the same approach as TZLabel: parse and convert to UTC explicitly
+        const utcTimestamp = dayjs(event.timestamp).tz('UTC').toISOString()
+        void copyToClipboard(
+            urls.absolute(urls.currentProject(urls.event(String(event.uuid), utcTimestamp))),
+            'link to event'
+        )
+    }
+
     return (
         <LemonButton
             ref={ref}
             fullWidth
             sideIcon={<IconLink />}
             data-attr="events-table-event-link"
-            onClick={() =>
-                void copyToClipboard(
-                    urls.absolute(urls.currentProject(urls.event(String(event.uuid), event.timestamp))),
-                    'link to event'
-                )
-            }
+            onClick={handleClick}
         >
             Copy link to event
         </LemonButton>


### PR DESCRIPTION
## Problem
See https://posthoghelp.zendesk.com/agent/tickets/44000 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/45796)

## Changes

Set the timestamp to the correct timezone.

## How did you test this code?
In local dev, changed my timezone to PST, then created a link to an event and opened it -> it works


## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
