### PR TITLE
feat(workflows): Auto-update Delay & wait-until node descriptions when changing params

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2555,6 +2555,10 @@ importers:
       zod:
         specifier: '*'
         version: 3.25.76
+    devDependencies:
+      kea-test-utils:
+        specifier: '*'
+        version: 0.2.4(kea@3.1.7(react@18.2.0))
 
   rust/cyclotron-node:
     devDependencies:

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuild.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuild.tsx
@@ -11,6 +11,7 @@ import { HogFunctionTemplateType } from '~/types'
 
 import { CreateActionType, hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { useHogFlowStep } from '../steps/HogFlowSteps'
+import { getDelayDescription } from '../steps/StepDelay'
 import { HogFlowAction } from '../types'
 
 export const ACTION_NODES_TO_SHOW: CreateActionType[] = [
@@ -46,8 +47,14 @@ export const ACTION_NODES_TO_SHOW: CreateActionType[] = [
     },
 ]
 
+const DEFAULT_DELAY = '10m'
 export const DELAY_NODES_TO_SHOW: CreateActionType[] = [
-    { type: 'delay', name: 'Delay', description: 'Wait for a specified duration.', config: { delay_duration: '10m' } },
+    {
+        type: 'delay',
+        name: 'Delay',
+        description: getDelayDescription(DEFAULT_DELAY),
+        config: { delay_duration: DEFAULT_DELAY },
+    },
     {
         type: 'wait_until_time_window',
         name: 'Wait until window',

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuild.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuild.tsx
@@ -11,7 +11,7 @@ import { HogFunctionTemplateType } from '~/types'
 
 import { CreateActionType, hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { useHogFlowStep } from '../steps/HogFlowSteps'
-import { getDelayDescription } from '../steps/StepDelay'
+import { getDelayDescription } from '../steps/stepDelayLogic'
 import { HogFlowAction } from '../types'
 
 export const ACTION_NODES_TO_SHOW: CreateActionType[] = [

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepDelay.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepDelay.tsx
@@ -1,33 +1,11 @@
 import { Node } from '@xyflow/react'
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 
 import { workflowLogic } from '../../workflowLogic'
 import { HogFlowAction } from '../types'
 import { HogFlowDuration } from './components/HogFlowDuration'
 import { StepSchemaErrors } from './components/StepSchemaErrors'
-
-export function getDelayDescription(duration: string): string {
-    const DURATION_REGEX = /^(\d*\.?\d+)([dhm])$/
-
-    const parts = duration.match(DURATION_REGEX) ?? ['', '10', 'm']
-    const [, numberValueString, unit] = parts
-    const number = parseFloat(numberValueString)
-    const unitLabel = unit === 'm' ? 'minute' : unit === 'h' ? 'hour' : 'day'
-    const durationText = `${number} ${unitLabel}${number !== 1 ? 's' : ''}`
-
-    return `Wait for ${durationText}.`
-}
-
-function shouldAutoUpdateDescription(description: string): boolean {
-    const AUTO_DESCRIPTION_REGEX = /^Wait for \d*\.?\d+ (minute|hour|day)s?\.$/
-    const legacyDefaultDescription = 'Wait for a specified duration.'
-
-    return (
-        description.trim() === '' ||
-        AUTO_DESCRIPTION_REGEX.test(description) ||
-        description === legacyDefaultDescription
-    )
-}
+import { stepDelayLogic } from './stepDelayLogic'
 
 export function StepDelayConfiguration({
     node,
@@ -37,7 +15,8 @@ export function StepDelayConfiguration({
     const action = node.data
     const { delay_duration } = action.config
 
-    const { setWorkflowActionConfig, setWorkflowAction } = useActions(workflowLogic)
+    const { logicProps } = useValues(workflowLogic)
+    const { setDelayWorkflowActionConfig } = useActions(stepDelayLogic({ workflowLogicProps: logicProps }))
 
     return (
         <>
@@ -47,10 +26,7 @@ export function StepDelayConfiguration({
             <HogFlowDuration
                 value={delay_duration}
                 onChange={(value) => {
-                    setWorkflowActionConfig(action.id, { delay_duration: value })
-                    if (shouldAutoUpdateDescription(action.description)) {
-                        setWorkflowAction(action.id, { ...action, description: getDelayDescription(value) })
-                    }
+                    setDelayWorkflowActionConfig(action.id, { delay_duration: value })
                 }}
             />
         </>

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepDelay.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepDelay.tsx
@@ -6,6 +6,24 @@ import { HogFlowAction } from '../types'
 import { HogFlowDuration } from './components/HogFlowDuration'
 import { StepSchemaErrors } from './components/StepSchemaErrors'
 
+export function getDelayDescription(duration: string): string {
+    const DURATION_REGEX = /^(\d*\.?\d+)([dhm])$/
+
+    const parts = duration.match(DURATION_REGEX) ?? ['', '10', 'm']
+    const [, numberValueString, unit] = parts
+    const number = parseFloat(numberValueString)
+    const unitLabel = unit === 'm' ? 'minute' : unit === 'h' ? 'hour' : 'day'
+    const durationText = `${number} ${unitLabel}${number !== 1 ? 's' : ''}`
+
+    return `Wait for ${durationText}.`
+}
+
+function shouldAutoUpdateDescription(description: string): boolean {
+    const AUTO_DESCRIPTION_REGEX = /^Wait for \d+\.?\d* (minute|hour|day)s?\.$/
+
+    return description.trim() === '' || AUTO_DESCRIPTION_REGEX.test(description)
+}
+
 export function StepDelayConfiguration({
     node,
 }: {
@@ -14,7 +32,7 @@ export function StepDelayConfiguration({
     const action = node.data
     const { delay_duration } = action.config
 
-    const { setWorkflowActionConfig } = useActions(workflowLogic)
+    const { setWorkflowActionConfig, setWorkflowAction } = useActions(workflowLogic)
 
     return (
         <>
@@ -23,7 +41,12 @@ export function StepDelayConfiguration({
             <p className="mb-0">Wait for a specified duration.</p>
             <HogFlowDuration
                 value={delay_duration}
-                onChange={(value) => setWorkflowActionConfig(action.id, { delay_duration: value })}
+                onChange={(value) => {
+                    setWorkflowActionConfig(action.id, { delay_duration: value })
+                    if (shouldAutoUpdateDescription(action.description)) {
+                        setWorkflowAction(action.id, { ...action, description: getDelayDescription(value) })
+                    }
+                }}
             />
         </>
     )

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepDelay.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepDelay.tsx
@@ -20,8 +20,13 @@ export function getDelayDescription(duration: string): string {
 
 function shouldAutoUpdateDescription(description: string): boolean {
     const AUTO_DESCRIPTION_REGEX = /^Wait for \d+\.?\d* (minute|hour|day)s?\.$/
+    const legacyDefaultDescription = 'Wait for a specified duration.'
 
-    return description.trim() === '' || AUTO_DESCRIPTION_REGEX.test(description)
+    return (
+        description.trim() === '' ||
+        AUTO_DESCRIPTION_REGEX.test(description) ||
+        description === legacyDefaultDescription
+    )
 }
 
 export function StepDelayConfiguration({

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepDelay.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepDelay.tsx
@@ -19,7 +19,7 @@ export function getDelayDescription(duration: string): string {
 }
 
 function shouldAutoUpdateDescription(description: string): boolean {
-    const AUTO_DESCRIPTION_REGEX = /^Wait for \d+\.?\d* (minute|hour|day)s?\.$/
+    const AUTO_DESCRIPTION_REGEX = /^Wait for \d*\.?\d+ (minute|hour|day)s?\.$/
     const legacyDefaultDescription = 'Wait for a specified duration.'
 
     return (

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilTimeWindow.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilTimeWindow.tsx
@@ -12,6 +12,7 @@ import { WeekdayType } from '~/types'
 import { workflowLogic } from '../../workflowLogic'
 import { HogFlowAction } from '../types'
 import { StepSchemaErrors } from './components/StepSchemaErrors'
+import { stepWaitUntilTimeWindowLogic } from './stepWaitUntilTimeWindowLogic'
 
 type DayConfig = 'any' | 'weekday' | 'weekend' | WeekdayType[]
 type TimeConfig = 'any' | [string, string]
@@ -104,7 +105,10 @@ export function StepWaitUntilTimeWindowConfiguration({ node }: { node: Node<Wait
     const action = node.data
     const { timezone, day, time } = action.config
 
-    const { partialSetWorkflowActionConfig } = useActions(workflowLogic)
+    const { logicProps } = useValues(workflowLogic)
+    const { setWaitUntilTimeWindowConfig } = useActions(
+        stepWaitUntilTimeWindowLogic({ workflowLogicProps: logicProps })
+    )
     const { preflight } = useValues(preflightLogic)
     const { currentTeam } = useValues(teamLogic)
 
@@ -120,7 +124,7 @@ export function StepWaitUntilTimeWindowConfiguration({ node }: { node: Node<Wait
         if (!preflight?.available_timezones) {
             throw new Error('No timezones are available')
         }
-        partialSetWorkflowActionConfig(action.id, { timezone: newTimezone[0] })
+        setWaitUntilTimeWindowConfig(action.id, { timezone: newTimezone[0] })
     }
 
     return (
@@ -133,10 +137,10 @@ export function StepWaitUntilTimeWindowConfiguration({ node }: { node: Node<Wait
                         isCustomDate={isCustomDate}
                         onDayChange={(value) => {
                             const config = getUpdatedDayConfig(value)
-                            partialSetWorkflowActionConfig(action.id, config)
+                            setWaitUntilTimeWindowConfig(action.id, config)
                         }}
                         onCustomDaysChange={(newDays) =>
-                            partialSetWorkflowActionConfig(action.id, { day: [...newDays] as WeekdayType[] })
+                            setWaitUntilTimeWindowConfig(action.id, { day: [...newDays] as WeekdayType[] })
                         }
                     />
 
@@ -147,12 +151,12 @@ export function StepWaitUntilTimeWindowConfiguration({ node }: { node: Node<Wait
                         isCustomTime={isCustomTimeRange}
                         onTimeChange={(value) => {
                             const config = getUpdatedTimeConfig(value)
-                            partialSetWorkflowActionConfig(action.id, config)
+                            setWaitUntilTimeWindowConfig(action.id, config)
                         }}
                         onTimeRangeChange={(newTime, index) => {
                             if (isCustomTimeRange) {
                                 const config = getUpdatedTimeRangeConfig(newTime, index, time)
-                                partialSetWorkflowActionConfig(action.id, config)
+                                setWaitUntilTimeWindowConfig(action.id, config)
                             }
                         }}
                     />

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilTimeWindow.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilTimeWindow.tsx
@@ -106,7 +106,7 @@ export function StepWaitUntilTimeWindowConfiguration({ node }: { node: Node<Wait
     const { timezone, day, time } = action.config
 
     const { logicProps } = useValues(workflowLogic)
-    const { setWaitUntilTimeWindowConfig } = useActions(
+    const { partialSetWaitUntilTimeWindowConfig } = useActions(
         stepWaitUntilTimeWindowLogic({ workflowLogicProps: logicProps })
     )
     const { preflight } = useValues(preflightLogic)
@@ -124,7 +124,7 @@ export function StepWaitUntilTimeWindowConfiguration({ node }: { node: Node<Wait
         if (!preflight?.available_timezones) {
             throw new Error('No timezones are available')
         }
-        setWaitUntilTimeWindowConfig(action.id, { timezone: newTimezone[0] })
+        partialSetWaitUntilTimeWindowConfig(action.id, { timezone: newTimezone[0] })
     }
 
     return (
@@ -137,10 +137,10 @@ export function StepWaitUntilTimeWindowConfiguration({ node }: { node: Node<Wait
                         isCustomDate={isCustomDate}
                         onDayChange={(value) => {
                             const config = getUpdatedDayConfig(value)
-                            setWaitUntilTimeWindowConfig(action.id, config)
+                            partialSetWaitUntilTimeWindowConfig(action.id, config)
                         }}
                         onCustomDaysChange={(newDays) =>
-                            setWaitUntilTimeWindowConfig(action.id, { day: [...newDays] as WeekdayType[] })
+                            partialSetWaitUntilTimeWindowConfig(action.id, { day: [...newDays] as WeekdayType[] })
                         }
                     />
 
@@ -151,12 +151,12 @@ export function StepWaitUntilTimeWindowConfiguration({ node }: { node: Node<Wait
                         isCustomTime={isCustomTimeRange}
                         onTimeChange={(value) => {
                             const config = getUpdatedTimeConfig(value)
-                            setWaitUntilTimeWindowConfig(action.id, config)
+                            partialSetWaitUntilTimeWindowConfig(action.id, config)
                         }}
                         onTimeRangeChange={(newTime, index) => {
                             if (isCustomTimeRange) {
                                 const config = getUpdatedTimeRangeConfig(newTime, index, time)
-                                setWaitUntilTimeWindowConfig(action.id, config)
+                                partialSetWaitUntilTimeWindowConfig(action.id, config)
                             }
                         }}
                     />

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -126,13 +126,17 @@ export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
                                 autoFocus
                                 value={editDescriptionValue}
                                 onChange={setEditDescriptionValue}
+                                onFocus={(e: React.FocusEvent<HTMLTextAreaElement>) => {
+                                    const el = e.target
+                                    el.setSelectionRange(el.value.length, el.value.length)
+                                }}
                                 onBlur={(e: React.FocusEvent) => {
                                     e.stopPropagation()
                                     saveDescription()
                                 }}
                                 onKeyDown={(e: React.KeyboardEvent) => {
                                     e.stopPropagation()
-                                    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                                    if (e.key === 'Enter' && !e.shiftKey) {
                                         e.preventDefault()
                                         saveDescription()
                                         ;(e.target as HTMLTextAreaElement).blur()
@@ -148,7 +152,7 @@ export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
                     ) : (
                         <Tooltip title={action.description || ''}>
                             <div
-                                className={`text-[0.3rem]/1.5 text-muted line-clamp-2 rounded px-0.5 -mx-0.5 transition-colors pl-1 min-w-0 overflow-hidden ${isSelected ? 'cursor-text hover:bg-fill-button-tertiary-hover' : ''}`}
+                                className={`text-[0.3rem]/1.5 text-muted line-clamp-2 rounded px-0.5 -mx-0.5 transition-colors pl-1 min-w-0 min-h-[0.45rem] overflow-hidden ${isSelected ? 'cursor-text hover:bg-fill-button-tertiary-hover' : ''}`}
                                 onClick={(e) => {
                                     if (isSelected) {
                                         e.stopPropagation()

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/stepViewLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/stepViewLogic.ts
@@ -82,7 +82,7 @@ export const stepViewLogic = kea<stepViewLogicType>([
         },
         saveDescription: () => {
             const trimmedDescription = values.editDescriptionValue.trim()
-            if (trimmedDescription && trimmedDescription !== (props.action.description || '')) {
+            if (trimmedDescription !== (props.action.description || '')) {
                 actions.setWorkflowAction(props.action.id, {
                     ...props.action,
                     description: trimmedDescription,

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepDelayLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepDelayLogic.test.ts
@@ -1,0 +1,86 @@
+import { resetContext } from 'kea'
+import { expectLogic, partial, testUtilsPlugin } from 'kea-test-utils'
+
+import { uuid } from 'lib/utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { workflowLogic } from '../../workflowLogic'
+import { HogFlowAction } from '../types'
+import { getDelayDescription, stepDelayLogic } from './stepDelayLogic'
+
+describe('stepDelayLogic', () => {
+    let sdLogic: ReturnType<typeof stepDelayLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+
+        resetContext({
+            plugins: [testUtilsPlugin],
+        })
+
+        workflowLogic.mount()
+
+        sdLogic = stepDelayLogic({ workflowLogicProps: workflowLogic.props })
+        sdLogic.mount()
+    })
+
+    const setupInitialDelayAction = async (initialDescription: string): Promise<HogFlowAction> => {
+        const delayAction = {
+            id: `delay_action_${uuid()}`,
+            type: 'delay',
+            name: 'Delay',
+            description: initialDescription,
+            config: { delay_duration: '10m' },
+            created_at: Date.now(),
+            updated_at: Date.now(),
+        } as HogFlowAction
+
+        await expectLogic(workflowLogic, () => {
+            workflowLogic.actions.setWorkflowInfo({
+                actions: [...workflowLogic.values.workflow.actions, delayAction],
+            })
+        }).toDispatchActions(['setWorkflowInfo'])
+
+        await expectLogic(workflowLogic).toMatchValues({
+            workflow: partial({
+                actions: expect.arrayContaining([expect.objectContaining({ description: initialDescription })]),
+            }),
+        })
+
+        return delayAction
+    }
+
+    it('should update the description when the duration is changed', async () => {
+        const delayAction = await setupInitialDelayAction(getDelayDescription('10m'))
+
+        await expectLogic(sdLogic, () => {
+            sdLogic.actions.setDelayWorkflowActionConfig(delayAction.id, { delay_duration: '5m' })
+        })
+            .toDispatchActions(['setWorkflowActionConfig'])
+            .toFinishListeners()
+
+        await expectLogic(sdLogic).toMatchValues({
+            workflow: partial({
+                actions: expect.arrayContaining([expect.objectContaining({ description: 'Wait for 5 minutes.' })]),
+            }),
+        })
+    })
+
+    it('should not update the description when the description is customized', async () => {
+        const customDescription = 'Custom description, dont delete me pls :('
+        const delayAction = await setupInitialDelayAction(customDescription)
+
+        await expectLogic(sdLogic, () => {
+            sdLogic.actions.setDelayWorkflowActionConfig(delayAction.id, { delay_duration: '5m' })
+        })
+            .toDispatchActions(['setWorkflowActionConfig'])
+            .toFinishListeners()
+
+        await expectLogic(sdLogic).toMatchValues({
+            workflow: partial({
+                actions: expect.arrayContaining([expect.objectContaining({ description: customDescription })]),
+            }),
+        })
+    })
+})

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepDelayLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepDelayLogic.ts
@@ -1,0 +1,60 @@
+import { actions, connect, kea, key, listeners, path, props } from 'kea'
+
+import { WorkflowLogicProps, workflowLogic } from '../../workflowLogic'
+import type { stepDelayLogicType } from './stepDelayLogicType'
+
+const DURATION_REGEX = /^(\d*\.?\d+)([dhm])$/
+const AUTO_DESCRIPTION_REGEX = /^Wait for \d*\.?\d+ (minute|hour|day)s?\.$/
+const LEGACY_DEFAULT_DESCRIPTION = 'Wait for a specified duration.'
+
+export function getDelayDescription(duration: string): string {
+    const parts = duration.match(DURATION_REGEX) ?? ['', '10', 'm']
+    const [, numberValueString, unit] = parts
+    const number = parseFloat(numberValueString)
+    const unitLabel = unit === 'm' ? 'minute' : unit === 'h' ? 'hour' : 'day'
+    const durationText = `${number} ${unitLabel}${number !== 1 ? 's' : ''}`
+    return `Wait for ${durationText}.`
+}
+
+export function shouldAutoUpdateDescription(description: string): boolean {
+    return (
+        description.trim() === '' ||
+        AUTO_DESCRIPTION_REGEX.test(description) ||
+        description === LEGACY_DEFAULT_DESCRIPTION
+    )
+}
+
+export type StepDelayLogicProps = {
+    workflowLogicProps: WorkflowLogicProps
+}
+
+export const stepDelayLogic = kea<stepDelayLogicType>([
+    path((key) => ['products', 'workflows', 'frontend', 'Workflows', 'hogflows', 'steps', 'stepDelayLogic', key]),
+    props({} as StepDelayLogicProps),
+    key(({ workflowLogicProps }: StepDelayLogicProps) => workflowLogicProps.id || 'new'),
+    connect(({ workflowLogicProps }: StepDelayLogicProps) => ({
+        values: [workflowLogic(workflowLogicProps), ['workflow']],
+        actions: [workflowLogic(workflowLogicProps), ['setWorkflowActionConfig', 'setWorkflowAction']],
+    })),
+    actions({
+        setDelayWorkflowActionConfig: (actionId: string, config: { delay_duration: string }) => ({ actionId, config }),
+    }),
+    listeners(({ values, actions }) => ({
+        setDelayWorkflowActionConfig: ({ actionId, config }) => {
+            actions.setWorkflowActionConfig(actionId, config)
+
+            const action = values.workflow.actions.find((a) => a.id === actionId)
+            if (!action || action.type !== 'delay') {
+                return
+            }
+
+            const delayConfig = config as { delay_duration: string }
+            if (shouldAutoUpdateDescription(action.description)) {
+                actions.setWorkflowAction(actionId, {
+                    ...action,
+                    description: getDelayDescription(delayConfig.delay_duration),
+                })
+            }
+        },
+    })),
+])

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.test.ts
@@ -1,0 +1,132 @@
+import { resetContext } from 'kea'
+import { expectLogic, partial, testUtilsPlugin } from 'kea-test-utils'
+
+import { uuid } from 'lib/utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { workflowLogic } from '../../workflowLogic'
+import { HogFlowAction } from '../types'
+import { getWaitUntilTimeWindowDescription, stepWaitUntilTimeWindowLogic } from './stepWaitUntilTimeWindowLogic'
+
+describe('stepWaitUntilTimeWindowLogic', () => {
+    let logic: ReturnType<typeof stepWaitUntilTimeWindowLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+
+        resetContext({
+            plugins: [testUtilsPlugin],
+        })
+
+        workflowLogic.mount()
+
+        logic = stepWaitUntilTimeWindowLogic({ workflowLogicProps: workflowLogic.props })
+        logic.mount()
+    })
+
+    const setupInitialAction = async (initialDescription: string): Promise<HogFlowAction> => {
+        const action = {
+            id: `wait_action_${uuid()}`,
+            type: 'wait_until_time_window',
+            name: 'Wait until time window',
+            description: initialDescription,
+            config: { day: 'weekday', time: ['09:00', '17:00'], timezone: 'UTC' },
+            created_at: Date.now(),
+            updated_at: Date.now(),
+        } as HogFlowAction
+
+        await expectLogic(workflowLogic, () => {
+            workflowLogic.actions.setWorkflowInfo({
+                actions: [...workflowLogic.values.workflow.actions, action],
+            })
+        }).toDispatchActions(['setWorkflowInfo'])
+
+        await expectLogic(workflowLogic).toMatchValues({
+            workflow: partial({
+                actions: expect.arrayContaining([expect.objectContaining({ description: initialDescription })]),
+            }),
+        })
+
+        return action
+    }
+    it('should update the description when day is changed', async () => {
+        const initialDesc = getWaitUntilTimeWindowDescription('weekday', ['09:00', '17:00'], 'UTC')
+        const action = await setupInitialAction(initialDesc)
+
+        await expectLogic(logic, () => {
+            logic.actions.setWaitUntilTimeWindowConfig(action.id, { day: 'weekend' })
+        })
+            .toDispatchActions(['partialSetWorkflowActionConfig'])
+            .toFinishListeners()
+
+        await expectLogic(logic).toMatchValues({
+            workflow: partial({
+                actions: expect.arrayContaining([
+                    expect.objectContaining({
+                        description: 'Wait until weekends at between 09:00 and 17:00 (UTC).',
+                    }),
+                ]),
+            }),
+        })
+    })
+
+    it('should update the description when time is changed', async () => {
+        const initialDesc = getWaitUntilTimeWindowDescription('weekday', ['09:00', '17:00'], 'UTC')
+        const action = await setupInitialAction(initialDesc)
+
+        await expectLogic(logic, () => {
+            logic.actions.setWaitUntilTimeWindowConfig(action.id, { time: ['10:00', '18:00'] })
+        })
+            .toDispatchActions(['partialSetWorkflowActionConfig'])
+            .toFinishListeners()
+
+        await expectLogic(logic).toMatchValues({
+            workflow: partial({
+                actions: expect.arrayContaining([
+                    expect.objectContaining({
+                        description: 'Wait until weekdays at between 10:00 and 18:00 (UTC).',
+                    }),
+                ]),
+            }),
+        })
+    })
+
+    it('should update the description when timezone is changed', async () => {
+        const initialDesc = getWaitUntilTimeWindowDescription('weekday', ['09:00', '17:00'], 'UTC')
+        const action = await setupInitialAction(initialDesc)
+
+        await expectLogic(logic, () => {
+            logic.actions.setWaitUntilTimeWindowConfig(action.id, { timezone: 'America/New_York' })
+        })
+            .toDispatchActions(['partialSetWorkflowActionConfig'])
+            .toFinishListeners()
+
+        await expectLogic(logic).toMatchValues({
+            workflow: partial({
+                actions: expect.arrayContaining([
+                    expect.objectContaining({
+                        description: 'Wait until weekdays at between 09:00 and 17:00 (America/New_York).',
+                    }),
+                ]),
+            }),
+        })
+    })
+
+    it('should not update the description when the description is customized', async () => {
+        const customDescription = 'Custom description, dont delete me pls :('
+        const action = await setupInitialAction(customDescription)
+
+        await expectLogic(logic, () => {
+            logic.actions.setWaitUntilTimeWindowConfig(action.id, { day: 'weekend' })
+        })
+            .toDispatchActions(['partialSetWorkflowActionConfig'])
+            .toFinishListeners()
+
+        await expectLogic(logic).toMatchValues({
+            workflow: partial({
+                actions: expect.arrayContaining([expect.objectContaining({ description: customDescription })]),
+            }),
+        })
+    })
+})

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.test.ts
@@ -55,7 +55,7 @@ describe('stepWaitUntilTimeWindowLogic', () => {
         const action = await setupInitialAction(initialDesc)
 
         await expectLogic(logic, () => {
-            logic.actions.setWaitUntilTimeWindowConfig(action.id, { day: 'weekend' })
+            logic.actions.partialSetWaitUntilTimeWindowConfig(action.id, { day: 'weekend' })
         })
             .toDispatchActions(['partialSetWorkflowActionConfig'])
             .toFinishListeners()
@@ -76,7 +76,7 @@ describe('stepWaitUntilTimeWindowLogic', () => {
         const action = await setupInitialAction(initialDesc)
 
         await expectLogic(logic, () => {
-            logic.actions.setWaitUntilTimeWindowConfig(action.id, { time: ['10:00', '18:00'] })
+            logic.actions.partialSetWaitUntilTimeWindowConfig(action.id, { time: ['10:00', '18:00'] })
         })
             .toDispatchActions(['partialSetWorkflowActionConfig'])
             .toFinishListeners()
@@ -97,7 +97,7 @@ describe('stepWaitUntilTimeWindowLogic', () => {
         const action = await setupInitialAction(initialDesc)
 
         await expectLogic(logic, () => {
-            logic.actions.setWaitUntilTimeWindowConfig(action.id, { timezone: 'America/New_York' })
+            logic.actions.partialSetWaitUntilTimeWindowConfig(action.id, { timezone: 'America/New_York' })
         })
             .toDispatchActions(['partialSetWorkflowActionConfig'])
             .toFinishListeners()
@@ -118,7 +118,7 @@ describe('stepWaitUntilTimeWindowLogic', () => {
         const action = await setupInitialAction(customDescription)
 
         await expectLogic(logic, () => {
-            logic.actions.setWaitUntilTimeWindowConfig(action.id, { day: 'weekend' })
+            logic.actions.partialSetWaitUntilTimeWindowConfig(action.id, { day: 'weekend' })
         })
             .toDispatchActions(['partialSetWorkflowActionConfig'])
             .toFinishListeners()

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.ts
@@ -87,10 +87,13 @@ export const stepWaitUntilTimeWindowLogic = kea<stepWaitUntilTimeWindowLogicType
         actions: [workflowLogic(workflowLogicProps), ['partialSetWorkflowActionConfig', 'setWorkflowAction']],
     })),
     actions({
-        setWaitUntilTimeWindowConfig: (actionId: string, config: WaitUntilTimeWindowConfig) => ({ actionId, config }),
+        partialSetWaitUntilTimeWindowConfig: (actionId: string, config: WaitUntilTimeWindowConfig) => ({
+            actionId,
+            config,
+        }),
     }),
     listeners(({ values, actions }) => ({
-        setWaitUntilTimeWindowConfig: ({ actionId, config }) => {
+        partialSetWaitUntilTimeWindowConfig: ({ actionId, config }) => {
             actions.partialSetWorkflowActionConfig(actionId, config)
 
             const action = values.workflow.actions.find((a) => a.id === actionId)

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.ts
@@ -1,0 +1,114 @@
+import { actions, connect, kea, key, listeners, path, props } from 'kea'
+
+import { WeekdayType } from '~/types'
+
+import { WorkflowLogicProps, workflowLogic } from '../../workflowLogic'
+import type { stepWaitUntilTimeWindowLogicType } from './stepWaitUntilTimeWindowLogicType'
+
+type DayConfig = 'any' | 'weekday' | 'weekend' | WeekdayType[]
+type TimeConfig = 'any' | [string, string]
+
+type WaitUntilTimeWindowConfig = {
+    timezone?: string | null
+    day?: DayConfig
+    time?: TimeConfig
+}
+
+const AUTO_DESCRIPTION_REGEX = /^Wait until .+ at .+ \(.+\)\.$/
+const LEGACY_DEFAULT_DESCRIPTION = 'Wait until a specified time window.'
+
+function capitalize(str: string): string {
+    return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+function getDayDescription(day: DayConfig): string {
+    if (day === 'any') {
+        return 'any day'
+    }
+    if (day === 'weekday') {
+        return 'weekdays'
+    }
+    if (day === 'weekend') {
+        return 'weekends'
+    }
+    if (Array.isArray(day)) {
+        if (day.length === 0) {
+            return 'no days'
+        }
+        return day.map(capitalize).join(', ')
+    }
+    return 'any day'
+}
+
+function getTimeDescription(time: TimeConfig): string {
+    if (time === 'any') {
+        return 'any time'
+    }
+    if (Array.isArray(time)) {
+        return `between ${time[0]} and ${time[1]}`
+    }
+    return 'any time'
+}
+
+export function getWaitUntilTimeWindowDescription(day: DayConfig, time: TimeConfig, timezone: string | null): string {
+    const dayDesc = getDayDescription(day)
+    const timeDesc = getTimeDescription(time)
+    const tz = timezone || 'UTC'
+    return `Wait until ${dayDesc} at ${timeDesc} (${tz}).`
+}
+
+export function shouldAutoUpdateDescription(description: string): boolean {
+    return (
+        description.trim() === '' ||
+        AUTO_DESCRIPTION_REGEX.test(description) ||
+        description === LEGACY_DEFAULT_DESCRIPTION
+    )
+}
+
+export type StepWaitUntilTimeWindowLogicProps = {
+    workflowLogicProps: WorkflowLogicProps
+}
+
+export const stepWaitUntilTimeWindowLogic = kea<stepWaitUntilTimeWindowLogicType>([
+    path((key) => [
+        'products',
+        'workflows',
+        'frontend',
+        'Workflows',
+        'hogflows',
+        'steps',
+        'stepWaitUntilTimeWindowLogic',
+        key,
+    ]),
+    props({} as StepWaitUntilTimeWindowLogicProps),
+    key(({ workflowLogicProps }: StepWaitUntilTimeWindowLogicProps) => workflowLogicProps.id || 'new'),
+    connect(({ workflowLogicProps }: StepWaitUntilTimeWindowLogicProps) => ({
+        values: [workflowLogic(workflowLogicProps), ['workflow']],
+        actions: [workflowLogic(workflowLogicProps), ['partialSetWorkflowActionConfig', 'setWorkflowAction']],
+    })),
+    actions({
+        setWaitUntilTimeWindowConfig: (actionId: string, config: WaitUntilTimeWindowConfig) => ({ actionId, config }),
+    }),
+    listeners(({ values, actions }) => ({
+        setWaitUntilTimeWindowConfig: ({ actionId, config }) => {
+            actions.partialSetWorkflowActionConfig(actionId, config)
+
+            const action = values.workflow.actions.find((a) => a.id === actionId)
+            if (!action || action.type !== 'wait_until_time_window') {
+                return
+            }
+
+            const currentConfig = action.config as { day: DayConfig; time: TimeConfig; timezone: string | null }
+            const newDay = config.day ?? currentConfig.day
+            const newTime = config.time ?? currentConfig.time
+            const newTimezone = config.timezone !== undefined ? config.timezone : currentConfig.timezone
+
+            if (shouldAutoUpdateDescription(action.description)) {
+                actions.setWorkflowAction(actionId, {
+                    ...action,
+                    description: getWaitUntilTimeWindowDescription(newDay, newTime, newTimezone),
+                })
+            }
+        },
+    })),
+])

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.ts
@@ -8,7 +8,7 @@ import type { stepWaitUntilTimeWindowLogicType } from './stepWaitUntilTimeWindow
 type DayConfig = 'any' | 'weekday' | 'weekend' | WeekdayType[]
 type TimeConfig = 'any' | [string, string]
 
-type WaitUntilTimeWindowConfig = {
+export type WaitUntilTimeWindowConfig = {
     timezone?: string | null
     day?: DayConfig
     time?: TimeConfig

--- a/products/workflows/package.json
+++ b/products/workflows/package.json
@@ -8,6 +8,9 @@
         "kea-subscriptions": "^3.0.1",
         "posthog-js": "1.297.0"
     },
+    "devDependencies": {
+        "kea-test-utils": "*"
+    },
     "peerDependencies": {
         "@posthog/icons": "*",
         "@types/react": "*",


### PR DESCRIPTION
## Problem

Delay descriptions didn't contain much information and manually updating them risks having outdated descriptions (says "this delays for 10min", but might actually delay for 2 days)
Same for wait-until -time-window descriptions.

## Changes
[delay_descriptions.webm](https://github.com/user-attachments/assets/e3c47ba4-2f75-46e5-9b1e-6a617d660294)

[wait-until-time-description.webm](https://github.com/user-attachments/assets/013d378c-c1f6-4145-b137-a5cda2d53017)


Description now automatically updates if you change the delay logic, unless you have a custom description.

* "Enter" now confirms editing unless you hold shift (used to create newline unless you held cmd/ctrl)
* You can now set the description to an empty string

Tested locally and with automated tests