### PR TITLE
feat(DateFilter): add fixed date range with time picker

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.test.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.test.tsx
@@ -55,14 +55,14 @@ describe('DateFilter', () => {
     })
 })
 
-describe('DateFilter with allowTimePrecision', () => {
+describe('DateFilter with allowFixedRangeWithTime', () => {
     let onChange = jest.fn()
     beforeEach(() => {
         initKeaTests()
         onChange = jest.fn()
         render(
             <Provider>
-                <DateFilter onChange={onChange} dateOptions={dateMapping} allowTimePrecision />
+                <DateFilter onChange={onChange} dateOptions={dateMapping} allowFixedRangeWithTime />
             </Provider>
         )
     })

--- a/frontend/src/lib/components/DateFilter/DateFilter.test.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.test.tsx
@@ -75,19 +75,19 @@ describe('DateFilter with allowTimePrecision', () => {
         const dateFilter = screen.getByTestId('date-filter')
         userEvent.click(dateFilter)
 
-        expect(screen.getByText('Custom fixed date range with time…')).toBeInTheDocument()
-        expect(screen.getByText('Custom fixed date range…')).toBeInTheDocument()
+        expect(screen.getByText(/custom fixed date range with time/i)).toBeInTheDocument()
+        expect(screen.getByText(/custom fixed date range…$/i)).toBeInTheDocument()
     })
 
     it('opens the time range picker when clicking custom fixed date range with time', async () => {
         const dateFilter = screen.getByTestId('date-filter')
         userEvent.click(dateFilter)
 
-        const timeRangeOption = screen.getByText('Custom fixed date range with time…')
+        const timeRangeOption = screen.getByText(/custom fixed date range with time/i)
         userEvent.click(timeRangeOption)
 
         await waitFor(() => {
-            expect(screen.getByText('Select a date and time range')).toBeInTheDocument()
+            expect(screen.getByText(/select a date and time range/i)).toBeInTheDocument()
         })
     })
 })

--- a/frontend/src/lib/components/DateFilter/DateFilter.test.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.test.tsx
@@ -54,3 +54,40 @@ describe('DateFilter', () => {
         await waitFor(() => expect(onChange).toHaveBeenCalledWith('-5d', '', false))
     })
 })
+
+describe('DateFilter with allowTimePrecision', () => {
+    let onChange = jest.fn()
+    beforeEach(() => {
+        initKeaTests()
+        onChange = jest.fn()
+        render(
+            <Provider>
+                <DateFilter onChange={onChange} dateOptions={dateMapping} allowTimePrecision />
+            </Provider>
+        )
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('shows custom fixed date range with time option', async () => {
+        const dateFilter = screen.getByTestId('date-filter')
+        userEvent.click(dateFilter)
+
+        expect(screen.getByText('Custom fixed date range with time…')).toBeInTheDocument()
+        expect(screen.getByText('Custom fixed date range…')).toBeInTheDocument()
+    })
+
+    it('opens the time range picker when clicking custom fixed date range with time', async () => {
+        const dateFilter = screen.getByTestId('date-filter')
+        userEvent.click(dateFilter)
+
+        const timeRangeOption = screen.getByText('Custom fixed date range with time…')
+        userEvent.click(timeRangeOption)
+
+        await waitFor(() => {
+            expect(screen.getByText('Select a date and time range')).toBeInTheDocument()
+        })
+    })
+})

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -55,6 +55,7 @@ interface RawDateFilterProps extends DateFilterProps {
     max?: number | null
     allowedRollingDateOptions?: DateOption[]
     allowTimePrecision?: boolean
+    allowFixedRangeWithTime?: boolean
     /**
      * Granularity is picked based on the dateFrom value
      * but can be overridden to force a specific granularity.
@@ -83,6 +84,7 @@ export function DateFilter({
     isFixedDateMode = false,
     allowedRollingDateOptions,
     allowTimePrecision = false,
+    allowFixedRangeWithTime = false,
     placeholder,
     fullWidth = false,
     forceGranularity,
@@ -259,7 +261,7 @@ export function DateFilter({
                         <LemonButton onClick={openFixedRange} active={isFixedRange && !isFixedRangeWithTime} fullWidth>
                             Custom fixed date range…
                         </LemonButton>
-                        {allowTimePrecision && (
+                        {allowFixedRangeWithTime && (
                             <LemonButton onClick={openFixedRangeWithTime} active={isFixedRangeWithTime} fullWidth>
                                 Custom fixed date range with time…
                             </LemonButton>

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -24,6 +24,7 @@ import { ResolvedDateRangeResponse } from '~/queries/schema/schema-general'
 import { DateMappingOption, PropertyOperator } from '~/types'
 
 import { PropertyFilterDatePicker } from '../PropertyFilters/components/PropertyFilterDatePicker'
+import { FixedRangeWithTimePicker } from './FixedRangeWithTimePicker'
 import { RollingDateRangeFilter } from './RollingDateRangeFilter'
 import { dateFilterLogic } from './dateFilterLogic'
 import { DateOption } from './rollingDateRangeFilterLogic'
@@ -105,6 +106,7 @@ export function DateFilter({
     const {
         open,
         openFixedRange,
+        openFixedRangeWithTime,
         openDateToNow,
         openFixedDate,
         close,
@@ -121,6 +123,7 @@ export function DateFilter({
         rangeDateTo,
         label,
         isFixedRange,
+        isFixedRangeWithTime,
         isDateToNow,
         isFixedDate,
         isRollingDateRange,
@@ -145,6 +148,13 @@ export function DateFilter({
                 }}
                 onClose={open}
                 months={2}
+            />
+        ) : view === DateFilterView.FixedRangeWithTime ? (
+            <FixedRangeWithTimePicker
+                rangeDateFrom={rangeDateFrom}
+                rangeDateTo={rangeDateTo}
+                setDate={setDate}
+                onClose={open}
             />
         ) : view === DateFilterView.DateToNow ? (
             <LemonCalendarSelect
@@ -246,9 +256,14 @@ export function DateFilter({
                         <LemonButton onClick={openDateToNow} active={isDateToNow} fullWidth>
                             From custom date until now…
                         </LemonButton>
-                        <LemonButton onClick={openFixedRange} active={isFixedRange} fullWidth>
+                        <LemonButton onClick={openFixedRange} active={isFixedRange && !isFixedRangeWithTime} fullWidth>
                             Custom fixed date range…
                         </LemonButton>
+                        {allowTimePrecision && (
+                            <LemonButton onClick={openFixedRangeWithTime} active={isFixedRangeWithTime} fullWidth>
+                                Custom fixed date range with time…
+                            </LemonButton>
+                        )}
                     </>
                 )}
                 {showExplicitDateToggle && (

--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.test.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.test.tsx
@@ -1,0 +1,82 @@
+import '@testing-library/jest-dom'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { dayjs } from 'lib/dayjs'
+
+import { FixedRangeWithTimePicker } from './FixedRangeWithTimePicker'
+
+describe('FixedRangeWithTimePicker', () => {
+    const setDate = jest.fn()
+    const onClose = jest.fn()
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('renders header', () => {
+        render(<FixedRangeWithTimePicker rangeDateFrom={null} rangeDateTo={null} setDate={setDate} onClose={onClose} />)
+
+        expect(screen.getByText(/select a date and time range/i)).toBeInTheDocument()
+    })
+
+    it('renders Start and End buttons', () => {
+        render(
+            <FixedRangeWithTimePicker
+                rangeDateFrom={dayjs('2024-01-15T10:00:00')}
+                rangeDateTo={dayjs('2024-01-15T11:00:00')}
+                setDate={setDate}
+                onClose={onClose}
+            />
+        )
+
+        expect(screen.getAllByText(/start:/i).length).toBeGreaterThan(0)
+        expect(screen.getAllByText(/end:/i).length).toBeGreaterThan(0)
+    })
+
+    it('calls onClose when close button is clicked', () => {
+        const { container } = render(
+            <FixedRangeWithTimePicker
+                rangeDateFrom={dayjs('2024-01-15T10:00:00')}
+                rangeDateTo={dayjs('2024-01-15T11:00:00')}
+                setDate={setDate}
+                onClose={onClose}
+            />
+        )
+
+        const closeButton = container.querySelector('[aria-label="close"]') as HTMLElement
+        expect(closeButton).toBeTruthy()
+        userEvent.click(closeButton)
+        expect(onClose).toHaveBeenCalled()
+    })
+
+    it('calls setDate with ISO format when Apply is clicked', () => {
+        const { container } = render(
+            <FixedRangeWithTimePicker
+                rangeDateFrom={dayjs('2024-01-15T10:00:00')}
+                rangeDateTo={dayjs('2024-01-15T11:00:00')}
+                setDate={setDate}
+                onClose={onClose}
+            />
+        )
+
+        const footer = container.querySelector('[data-attr="lemon-calendar-range-with-time-footer"]') as HTMLElement
+        userEvent.click(within(footer).getByText(/apply/i))
+        expect(setDate).toHaveBeenCalledWith('2024-01-15T10:00:00', '2024-01-15T11:00:00', false, true)
+    })
+
+    it('swaps dates on Apply if start is after end', () => {
+        const { container } = render(
+            <FixedRangeWithTimePicker
+                rangeDateFrom={dayjs('2024-01-15T14:00:00')}
+                rangeDateTo={dayjs('2024-01-15T10:00:00')}
+                setDate={setDate}
+                onClose={onClose}
+            />
+        )
+
+        const footer = container.querySelector('[data-attr="lemon-calendar-range-with-time-footer"]') as HTMLElement
+        userEvent.click(within(footer).getByText(/apply/i))
+        expect(setDate).toHaveBeenCalledWith('2024-01-15T10:00:00', '2024-01-15T14:00:00', false, true)
+    })
+})

--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.test.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.test.tsx
@@ -94,4 +94,34 @@ describe('FixedRangeWithTimePicker', () => {
         userEvent.click(within(footer).getByText(/apply/i))
         expect(setDate).toHaveBeenCalledWith('2024-01-15T14:30:00', '2024-01-15T16:00:00', false, true)
     })
+
+    it('adjusts end time when start hour is changed to be after end', () => {
+        const { container } = render(
+            <FixedRangeWithTimePicker
+                rangeDateFrom={dayjs('2024-01-15T10:00:00')}
+                rangeDateTo={dayjs('2024-01-15T11:00:00')}
+                setDate={setDate}
+                onClose={onClose}
+            />
+        )
+
+        // Click on hour 12 (PM) - this should be after the end time of 11:00 AM
+        const hourButton = container.querySelector('[data-attr="12-h"]') as HTMLElement
+        expect(hourButton).toBeTruthy()
+        userEvent.click(hourButton)
+
+        // Click PM to make it 12 PM (noon)
+        const pmButton = container.querySelector('[data-attr="pm-a"]') as HTMLElement
+        expect(pmButton).toBeTruthy()
+        userEvent.click(pmButton)
+
+        // Apply and verify end was adjusted (start 12:00 PM, end should be 1:00 PM)
+        const footer = container.querySelector('[data-attr="lemon-calendar-range-with-time-footer"]') as HTMLElement
+        userEvent.click(within(footer).getByText(/apply/i))
+
+        // The handleApply swaps if needed, so result should be valid
+        expect(setDate).toHaveBeenCalled()
+        const [from, to] = setDate.mock.calls[0]
+        expect(dayjs(from).isBefore(dayjs(to))).toBe(true)
+    })
 })

--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.test.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.test.tsx
@@ -79,4 +79,19 @@ describe('FixedRangeWithTimePicker', () => {
         userEvent.click(within(footer).getByText(/apply/i))
         expect(setDate).toHaveBeenCalledWith('2024-01-15T10:00:00', '2024-01-15T14:00:00', false, true)
     })
+
+    it('preserves PM time when initialized with PM', () => {
+        const { container } = render(
+            <FixedRangeWithTimePicker
+                rangeDateFrom={dayjs('2024-01-15T14:30:00')}
+                rangeDateTo={dayjs('2024-01-15T16:00:00')}
+                setDate={setDate}
+                onClose={onClose}
+            />
+        )
+
+        const footer = container.querySelector('[data-attr="lemon-calendar-range-with-time-footer"]') as HTMLElement
+        userEvent.click(within(footer).getByText(/apply/i))
+        expect(setDate).toHaveBeenCalledWith('2024-01-15T14:30:00', '2024-01-15T16:00:00', false, true)
+    })
 })

--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
@@ -114,8 +114,17 @@ export function FixedRangeWithTimePicker({
                                     }
                                     if (selectingStart) {
                                         setLocalFrom(newDate)
+                                        if (localTo && newDate.isAfter(localTo)) {
+                                            setLocalTo(newDate)
+                                            setLocalFrom(localTo)
+                                        }
                                     } else {
-                                        setLocalTo(newDate)
+                                        if (localFrom && newDate.isBefore(localFrom)) {
+                                            setLocalFrom(newDate)
+                                            setLocalTo(localFrom)
+                                        } else {
+                                            setLocalTo(newDate)
+                                        }
                                     }
                                 }
                             },

--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react'
+
+import { IconX } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+import { LemonCalendar } from 'lib/lemon-ui/LemonCalendar/LemonCalendar'
+
+export interface FixedRangeWithTimePickerProps {
+    rangeDateFrom: dayjs.Dayjs | null
+    rangeDateTo: dayjs.Dayjs | null
+    setDate: (dateFrom: string | null, dateTo: string | null, keepPopoverOpen: boolean, explicitDate: boolean) => void
+    onClose: () => void
+}
+
+export function FixedRangeWithTimePicker({
+    rangeDateFrom,
+    rangeDateTo,
+    setDate,
+    onClose,
+}: FixedRangeWithTimePickerProps): JSX.Element {
+    const [selectingStart, setSelectingStart] = useState(true)
+    const [localFrom, setLocalFrom] = useState<dayjs.Dayjs | null>(rangeDateFrom)
+    const [localTo, setLocalTo] = useState<dayjs.Dayjs | null>(rangeDateTo)
+
+    const handleApply = (): void => {
+        if (localFrom && localTo) {
+            setDate(localFrom.format('YYYY-MM-DDTHH:mm:ss'), localTo.format('YYYY-MM-DDTHH:mm:ss'), false, true)
+        }
+    }
+
+    return (
+        <div className="LemonCalendarRangeWithTime" data-attr="lemon-calendar-range-with-time">
+            <div className="flex justify-between border-b p-2 pb-4">
+                <h3 className="text-base mb-0">Select a date and time range</h3>
+                <LemonButton icon={<IconX />} size="small" noPadding onClick={onClose} aria-label="close" />
+            </div>
+            <div className="flex gap-2 p-2 border-b">
+                <LemonButton
+                    type={selectingStart ? 'primary' : 'secondary'}
+                    size="small"
+                    onClick={() => setSelectingStart(true)}
+                >
+                    Start: {localFrom ? localFrom.format('MMM D, YYYY h:mm A') : 'Not set'}
+                </LemonButton>
+                <LemonButton
+                    type={!selectingStart ? 'primary' : 'secondary'}
+                    size="small"
+                    onClick={() => setSelectingStart(false)}
+                >
+                    End: {localTo ? localTo.format('MMM D, YYYY h:mm A') : 'Not set'}
+                </LemonButton>
+            </div>
+            <div className="p-2">
+                <LemonCalendar
+                    onDateClick={(date) => {
+                        if (date) {
+                            const currentValue = selectingStart ? localFrom : localTo
+                            const newDate = date
+                                .hour(currentValue?.hour() ?? dayjs().hour())
+                                .minute(currentValue?.minute() ?? dayjs().minute())
+
+                            if (selectingStart) {
+                                setLocalFrom(newDate)
+                                // Auto-set end to 1 hour later if not set or if new start is after current end
+                                if (!localTo || newDate.isAfter(localTo)) {
+                                    setLocalTo(newDate.add(1, 'hour'))
+                                }
+                            } else {
+                                // If end date is before start, swap them
+                                if (localFrom && newDate.isBefore(localFrom)) {
+                                    setLocalTo(localFrom)
+                                    setLocalFrom(newDate)
+                                } else {
+                                    setLocalTo(newDate)
+                                }
+                            }
+                        }
+                    }}
+                    leftmostMonth={(selectingStart ? localFrom : localTo)?.startOf('month')}
+                    getLemonButtonProps={({ date, props }) => {
+                        const currentValue = selectingStart ? localFrom : localTo
+                        if (date.isSame(currentValue, 'd')) {
+                            return { ...props, status: 'default', type: 'primary' }
+                        }
+                        return props
+                    }}
+                    getLemonButtonTimeProps={(timeProps) => {
+                        const currentValue = selectingStart ? localFrom : localTo
+                        const selected = currentValue ? currentValue.format(timeProps.unit) : null
+
+                        return {
+                            active: selected === String(timeProps.value),
+                            className: 'rounded-none',
+                            onClick: () => {
+                                if (currentValue) {
+                                    let newDate = currentValue
+                                    if (timeProps.unit === 'h') {
+                                        const isPM = currentValue.format('a') === 'pm'
+                                        newDate = currentValue.hour(
+                                            isPM && timeProps.value !== 12
+                                                ? Number(timeProps.value) + 12
+                                                : !isPM && timeProps.value === 12
+                                                  ? 0
+                                                  : Number(timeProps.value)
+                                        )
+                                    } else if (timeProps.unit === 'm') {
+                                        newDate = currentValue.minute(Number(timeProps.value))
+                                    } else if (timeProps.unit === 'a') {
+                                        newDate =
+                                            timeProps.value === 'am'
+                                                ? currentValue.subtract(12, 'hour')
+                                                : currentValue.add(12, 'hour')
+                                    }
+                                    if (selectingStart) {
+                                        setLocalFrom(newDate)
+                                    } else {
+                                        setLocalTo(newDate)
+                                    }
+                                }
+                            },
+                        }
+                    }}
+                    granularity="minute"
+                />
+            </div>
+            <div className="flex justify-end gap-2 border-t p-2 pt-4">
+                <LemonButton type="secondary" onClick={onClose}>
+                    Cancel
+                </LemonButton>
+                <LemonButton type="primary" disabled={!localFrom || !localTo} onClick={handleApply}>
+                    Apply
+                </LemonButton>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
@@ -134,7 +134,7 @@ export function FixedRangeWithTimePicker({
                     granularity="minute"
                 />
             </div>
-            <div className="flex justify-end gap-2 border-t p-2 pt-4">
+            <div className="flex justify-end gap-2 border-t p-2 pt-4" data-attr="lemon-calendar-range-with-time-footer">
                 <LemonButton type="secondary" onClick={onClose}>
                     Cancel
                 </LemonButton>

--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
@@ -25,7 +25,8 @@ export function FixedRangeWithTimePicker({
 
     const handleApply = (): void => {
         if (localFrom && localTo) {
-            setDate(localFrom.format('YYYY-MM-DDTHH:mm:ss'), localTo.format('YYYY-MM-DDTHH:mm:ss'), false, true)
+            const [from, to] = localFrom.isBefore(localTo) ? [localFrom, localTo] : [localTo, localFrom]
+            setDate(from.format('YYYY-MM-DDTHH:mm:ss'), to.format('YYYY-MM-DDTHH:mm:ss'), false, true)
         }
     }
 

--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
@@ -108,10 +108,12 @@ export function FixedRangeWithTimePicker({
                                     } else if (timeProps.unit === 'm') {
                                         newDate = currentValue.minute(Number(timeProps.value))
                                     } else if (timeProps.unit === 'a') {
-                                        newDate =
-                                            timeProps.value === 'am'
-                                                ? currentValue.subtract(12, 'hour')
-                                                : currentValue.add(12, 'hour')
+                                        const currentHour = currentValue.hour()
+                                        if (timeProps.value === 'am' && currentHour >= 12) {
+                                            newDate = currentValue.subtract(12, 'hour')
+                                        } else if (timeProps.value === 'pm' && currentHour < 12) {
+                                            newDate = currentValue.add(12, 'hour')
+                                        }
                                     }
                                     if (selectingStart) {
                                         setLocalFrom(newDate)

--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
@@ -93,6 +93,7 @@ export function FixedRangeWithTimePicker({
                         return {
                             active: selected === String(timeProps.value),
                             className: 'rounded-none',
+                            'data-attr': `${timeProps.value}-${timeProps.unit}`,
                             onClick: () => {
                                 if (currentValue) {
                                     let newDate = currentValue

--- a/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
+++ b/frontend/src/lib/components/DateFilter/FixedRangeWithTimePicker.tsx
@@ -118,15 +118,12 @@ export function FixedRangeWithTimePicker({
                                     if (selectingStart) {
                                         setLocalFrom(newDate)
                                         if (localTo && newDate.isAfter(localTo)) {
-                                            setLocalTo(newDate)
-                                            setLocalFrom(localTo)
+                                            setLocalTo(newDate.add(1, 'hour'))
                                         }
                                     } else {
+                                        setLocalTo(newDate)
                                         if (localFrom && newDate.isBefore(localFrom)) {
-                                            setLocalFrom(newDate)
-                                            setLocalTo(localFrom)
-                                        } else {
-                                            setLocalTo(newDate)
+                                            setLocalFrom(newDate.subtract(1, 'hour'))
                                         }
                                     }
                                 }

--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.test.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.test.ts
@@ -41,6 +41,11 @@ describe('dateFilterLogic', () => {
             isVisible: true,
             view: DateFilterView.FixedRange,
         })
+        logic.actions.openFixedRangeWithTime()
+        await expectLogic(logic).toMatchValues({
+            isVisible: true,
+            view: DateFilterView.FixedRangeWithTime,
+        })
         logic.actions.openDateToNow()
         await expectLogic(logic).toMatchValues({
             isVisible: true,
@@ -50,6 +55,86 @@ describe('dateFilterLogic', () => {
         await expectLogic(logic).toMatchValues({
             isVisible: false,
             view: DateFilterView.DateToNow,
+        })
+    })
+
+    it('isFixedRangeWithTime is true when both dates have time precision', async () => {
+        props = {
+            key: 'test-time-precision',
+            onChange,
+            dateFrom: '2024-01-15T10:30:00',
+            dateTo: '2024-01-16T14:45:00',
+            dateOptions: dateMapping,
+            isDateFormatted: false,
+        }
+        const withTimePrecision = dateFilterLogic(props)
+        withTimePrecision.mount()
+
+        await expectLogic(withTimePrecision).toMatchValues({
+            isFixedRange: true,
+            isFixedRangeWithTime: true,
+            dateFromHasTimePrecision: true,
+            dateToHasTimePrecision: true,
+        })
+    })
+
+    it('isFixedRangeWithTime is false when dates have no time precision', async () => {
+        props = {
+            key: 'test-no-time-precision',
+            onChange,
+            dateFrom: '2024-01-15',
+            dateTo: '2024-01-16',
+            dateOptions: dateMapping,
+            isDateFormatted: false,
+        }
+        const withoutTimePrecision = dateFilterLogic(props)
+        withoutTimePrecision.mount()
+
+        await expectLogic(withoutTimePrecision).toMatchValues({
+            isFixedRange: true,
+            isFixedRangeWithTime: false,
+            dateFromHasTimePrecision: false,
+            dateToHasTimePrecision: false,
+        })
+    })
+
+    it('isFixedRangeWithTime is true when only dateFrom has time precision', async () => {
+        props = {
+            key: 'test-from-time-precision',
+            onChange,
+            dateFrom: '2024-01-15T10:30:00',
+            dateTo: '2024-01-16',
+            dateOptions: dateMapping,
+            isDateFormatted: false,
+        }
+        const withFromTimePrecision = dateFilterLogic(props)
+        withFromTimePrecision.mount()
+
+        await expectLogic(withFromTimePrecision).toMatchValues({
+            isFixedRange: true,
+            isFixedRangeWithTime: true,
+            dateFromHasTimePrecision: true,
+            dateToHasTimePrecision: false,
+        })
+    })
+
+    it('isFixedRangeWithTime is true when only dateTo has time precision', async () => {
+        props = {
+            key: 'test-to-time-precision',
+            onChange,
+            dateFrom: '2024-01-15',
+            dateTo: '2024-01-16T14:45:00',
+            dateOptions: dateMapping,
+            isDateFormatted: false,
+        }
+        const withToTimePrecision = dateFilterLogic(props)
+        withToTimePrecision.mount()
+
+        await expectLogic(withToTimePrecision).toMatchValues({
+            isFixedRange: true,
+            isFixedRangeWithTime: true,
+            dateFromHasTimePrecision: false,
+            dateToHasTimePrecision: true,
         })
     })
 

--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
@@ -28,6 +28,7 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
     actions({
         open: true,
         openFixedRange: true,
+        openFixedRangeWithTime: true,
         openDateToNow: true,
         openFixedDate: true,
         close: true,
@@ -53,6 +54,7 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
             {
                 open: () => DateFilterView.QuickList,
                 openFixedRange: () => DateFilterView.FixedRange,
+                openFixedRangeWithTime: () => DateFilterView.FixedRangeWithTime,
                 openDateToNow: () => DateFilterView.DateToNow,
                 openFixedDate: () => DateFilterView.FixedDate,
             },
@@ -62,6 +64,7 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
             {
                 open: () => true,
                 openFixedRange: () => true,
+                openFixedRangeWithTime: () => true,
                 openDateToNow: () => true,
                 openFixedDate: () => true,
                 setDate: (_, { keepPopoverOpen }) => keepPopoverOpen,
@@ -108,6 +111,11 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
         isFixedRange: [
             (s) => [s.dateFrom, s.dateTo],
             (dateFrom, dateTo) => !!(dateFrom && dateTo && dayjs(dateFrom).isValid() && dayjs(dateTo).isValid()),
+        ],
+        isFixedRangeWithTime: [
+            (s) => [s.isFixedRange, s.dateFromHasTimePrecision, s.dateToHasTimePrecision],
+            (isFixedRange, dateFromHasTimePrecision, dateToHasTimePrecision) =>
+                isFixedRange && (dateFromHasTimePrecision || dateToHasTimePrecision),
         ],
         isDateToNow: [
             (s) => [s.dateFrom, s.dateTo, (_, p) => p.isFixedDateMode],

--- a/frontend/src/lib/components/DateFilter/types.ts
+++ b/frontend/src/lib/components/DateFilter/types.ts
@@ -6,6 +6,7 @@ export enum DateFilterView {
     QuickList = 'QuickList',
     DateToNow = 'DateToNow',
     FixedRange = 'FixedRange',
+    FixedRangeWithTime = 'FixedRangeWithTime',
     FixedDate = 'FixedDate',
 }
 

--- a/frontend/src/lib/components/DateFilter/types.ts
+++ b/frontend/src/lib/components/DateFilter/types.ts
@@ -20,6 +20,7 @@ export type DateFilterLogicProps = {
     isFixedDateMode?: boolean
     placeholder?: string
     allowTimePrecision?: boolean
+    allowFixedRangeWithTime?: boolean
     explicitDate?: boolean
 }
 

--- a/products/logs/frontend/filters/DateRangeFilter.tsx
+++ b/products/logs/frontend/filters/DateRangeFilter.tsx
@@ -67,6 +67,7 @@ export const DateRangeFilter = (): JSX.Element => {
                 setDateRange({ date_from: changedDateFrom, date_to: changedDateTo })
             }}
             allowTimePrecision
+            allowFixedRangeWithTime
             allowedRollingDateOptions={['minutes', 'hours', 'days', 'weeks', 'months']}
         />
     )


### PR DESCRIPTION
## Problem

Users debugging issues in Logs need to filter to specific time windows.

The Logs date filter currently supports:
- Relative ranges ("Last 5 minutes", "Last 1 hour", etc.)
- "From custom date until now" with time picker
- "Custom fixed date range" - but only date selection, no time picker

When debugging a production issue that occurred at a specific time (e.g., 2:47 PM), users cannot select a precise time window like 2:45 PM - 2:50 PM. They must either:

- Use a broad range and scroll through irrelevant logs
- Drag on the sparkline chart to narrow down (not discoverable, imprecise)
- Mentally convert to "Last X minutes" relative to now (doesn't work for past issues)

## Changes

<img width="368" height="460" alt="image" src="https://github.com/user-attachments/assets/c6f8517c-5921-4105-a0d7-064cce8a5aae" />
<img width="482" height="559" alt="image" src="https://github.com/user-attachments/assets/81ff8c29-0d0f-4676-b836-74458f6f6a92" />

Adds a new "Custom fixed date range with time…" option to the DateFilter component when `allowTimePrecision` is enabled. This allows users to select both start and end dates with hour/minute precision.

Previously, time precision was only available for "From custom date until now" selections. This extends it to fixed date ranges, which is useful for debugging logs within specific time windows.

- Add `FixedRangeWithTime` view type and `openFixedRangeWithTime` action
- Add `isFixedRangeWithTime` selector to detect time-precision ranges
- Create `FixedRangeWithTimePicker` component with Start/End toggle
- Only show option when allowFixedRangeWithTime={true} (currently enabled for Logs only)
- Add tests for new logic and component behavior

Opt in via the `allowFixedRangeWithTime` prop

## How did you test this code?

Local development + new unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
