### PR TITLE
feat(persons): Update app* attributes

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -1745,9 +1745,10 @@ describe('BatchWritingPersonStore', () => {
             const personStoreForBatch = testPersonStore.forBatch() as BatchWritingPersonsStoreForBatch
 
             // Update person with only filtered properties but with force_update=true (simulating $identify/$set events)
+            // Using $current_url and $pathname which are in FILTERED_PERSON_UPDATE_PROPERTIES
             await personStoreForBatch.updatePersonWithPropertiesDiffForUpdate(
-                { ...person, properties: { $browser: 'Firefox', $app_build: '100' } },
-                { $browser: 'Chrome', $app_build: '200' },
+                { ...person, properties: { $current_url: 'https://old.com', $pathname: '/old' } },
+                { $current_url: 'https://new.com', $pathname: '/new' },
                 [],
                 {},
                 'test',
@@ -1769,8 +1770,8 @@ describe('BatchWritingPersonStore', () => {
             expect(mockPersonProfileBatchIgnoredPropertiesCounter.labels).not.toHaveBeenCalled()
             // personPropertyKeyUpdateCounter should be called for the updated properties
             expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledTimes(2)
-            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: '$browser' })
-            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: '$app_build' })
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: '$current_url' })
+            expect(mockPersonPropertyKeyUpdateCounter.labels).toHaveBeenCalledWith({ key: '$pathname' })
         })
 
         it('integration: multiple events with only filtered properties should not trigger database write', async () => {

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -36,7 +36,8 @@ import {
     personWriteMethodAttemptCounter,
     totalPersonUpdateLatencyPerBatchHistogram,
 } from './metrics'
-import { getMetricKey, isFilteredPersonPropertyKey } from './person-update'
+import { isFilteredPersonUpdateProperty } from './person-property-utils'
+import { getMetricKey } from './person-update'
 import { PersonUpdate, fromInternalPerson, toInternalPerson } from './person-update-batch'
 import { PersonsStore } from './persons-store'
 import { FlushResult, PersonsStoreForBatch } from './persons-store-for-batch'
@@ -206,7 +207,7 @@ export class BatchWritingPersonsStoreForBatch implements PersonsStoreForBatch, B
                 return true
             }
 
-            const isFiltered = isFilteredPersonPropertyKey(key)
+            const isFiltered = isFilteredPersonUpdateProperty(key)
             if (isFiltered) {
                 ignoredProperties.push(key)
                 return false

--- a/plugin-server/src/worker/ingestion/persons/person-property-utils.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-property-utils.ts
@@ -169,6 +169,15 @@ export const FILTERED_PERSON_UPDATE_PROPERTIES = new Set([
     '$viewport_height',
     '$viewport_width',
 
+    // Browser/device properties - change less frequently but still filtered
+    '$browser',
+    '$browser_version',
+    '$device_type',
+    '$raw_user_agent',
+    '$os',
+    '$os_name',
+    '$os_version',
+
     // GeoIP properties - filtered because they change frequently
     '$geoip_postal_code',
     '$geoip_time_zone',

--- a/plugin-server/src/worker/ingestion/persons/person-property-utils.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-property-utils.ts
@@ -143,3 +143,59 @@ export const initialCampaignParams = new Set(
 export const initialEventToPersonProperties = new Set(
     Array.from(eventToPersonProperties, (key) => `$initial_${key.replace('$', '')}`)
 )
+
+/**
+ * Properties that should NOT trigger a person update on their own.
+ * These change frequently but aren't valuable enough to update the person record for.
+ * They will still be included in the person properties when an update happens for other reasons.
+ *
+ * This is the single source of truth for person update filtering logic.
+ *
+ * Note: Properties NOT in this list will trigger updates by default.
+ *
+ * GeoIP properties source: posthog/geoip.py and posthog/taxonomy/taxonomy.py
+ * GeoIP properties that DO trigger updates (not listed here): $geoip_country_name, $geoip_city_name
+ */
+export const FILTERED_PERSON_UPDATE_PROPERTIES = new Set([
+    // URL/navigation properties - change on every page view
+    '$current_url',
+    '$pathname',
+    '$referring_domain',
+    '$referrer',
+
+    // Screen/viewport dimensions - can change on window resize
+    '$screen_height',
+    '$screen_width',
+    '$viewport_height',
+    '$viewport_width',
+
+    // GeoIP properties - filtered because they change frequently
+    '$geoip_postal_code',
+    '$geoip_time_zone',
+    '$geoip_latitude',
+    '$geoip_longitude',
+    '$geoip_accuracy_radius',
+    '$geoip_subdivision_1_code',
+    '$geoip_subdivision_1_name',
+    '$geoip_subdivision_2_code',
+    '$geoip_subdivision_2_name',
+    '$geoip_subdivision_3_code',
+    '$geoip_subdivision_3_name',
+    '$geoip_city_confidence',
+    '$geoip_country_confidence',
+    '$geoip_postal_code_confidence',
+    '$geoip_subdivision_1_confidence',
+    '$geoip_subdivision_2_confidence',
+])
+
+/**
+ * Determines if a property key should be filtered out from triggering person updates.
+ * These are properties that change frequently but aren't valuable enough to update the person record for.
+ *
+ * This is the single source of truth for property filtering logic, used by both:
+ * - Event-level processing (computeEventPropertyUpdates in person-update.ts)
+ * - Batch-level processing (getPersonUpdateOutcome in batch-writing-person-store.ts)
+ */
+export function isFilteredPersonUpdateProperty(key: string): boolean {
+    return FILTERED_PERSON_UPDATE_PROPERTIES.has(key)
+}


### PR DESCRIPTION
## Problem

We currently don't update app* attributes for persons if they are the only attributes being updated on a event, this PR changes that.

## Changes

- Allow all of the attributes above to be updated for a person when they are the only values being updated in a event
- Refactor the code so it's more explicit which attributes are not allowed

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
