### PR TITLE
chore: polishing endpoints papercuts

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/Endpoint.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/Endpoint.tsx
@@ -81,10 +81,14 @@ export function Endpoint({ tabId }: EndpointProps): JSX.Element {
         }
 
         if (isUpdateMode && selectedEndpointName) {
-            updateEndpoint(selectedEndpointName, {
-                description: endpointDescription || undefined,
-                query: queryPayload,
-            })
+            updateEndpoint(
+                selectedEndpointName,
+                {
+                    description: endpointDescription || undefined,
+                    query: queryPayload,
+                },
+                true
+            )
         } else {
             createEndpoint({
                 name: endpointName || undefined,

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -378,7 +378,8 @@ export const QueryDatabase = (): JSX.Element => {
                                             undefined,
                                             undefined,
                                             undefined,
-                                            OutputTab.Endpoint
+                                            OutputTab.Endpoint,
+                                            item.record?.endpoint?.name
                                         )
                                     )
                                 }}

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -547,7 +547,6 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
     ) -> Response:
         """Execute query directly against ClickHouse."""
         try:
-            tag_queries(workload=Workload.ENDPOINTS)
             insight_query_override = data.query_override or {}
             for query_field, value in insight_query_override.items():
                 query[query_field] = value

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -547,6 +547,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
     ) -> Response:
         """Execute query directly against ClickHouse."""
         try:
+            tag_queries(workload=Workload.ENDPOINTS)
             insight_query_override = data.query_override or {}
             for query_field, value in insight_query_override.items():
                 query[query_field] = value
@@ -655,6 +656,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
     @action(methods=["POST"], detail=False, url_path="last_execution_times")
     def get_endpoints_last_execution_times(self, request: Request, *args, **kwargs) -> Response:
         try:
+            tag_queries(product=Product.ENDPOINTS)
             data = EndpointLastExecutionTimesRequest.model_validate(request.data)
             names = data.names
             if not names:

--- a/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconDatabase, IconRefresh } from '@posthog/icons'
-import { LemonBanner, LemonDivider, LemonSelect, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonDivider, LemonSelect, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
@@ -50,12 +50,13 @@ function getStatusTagType(status: string | undefined): 'success' | 'danger' | 'w
 }
 
 export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JSX.Element {
-    const { setCacheAge, setSyncFrequency, setIsMaterialized } = useActions(endpointLogic({ tabId }))
+    const { setCacheAge, setSyncFrequency, setIsMaterialized, loadEndpoint } = useActions(endpointLogic({ tabId }))
     const {
         endpoint,
         cacheAge,
         syncFrequency,
         isMaterialized: localIsMaterialized,
+        endpointLoading,
     } = useValues(endpointLogic({ tabId }))
 
     if (!endpoint) {
@@ -103,9 +104,18 @@ export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JS
                                     <IconDatabase className="text-lg" />
                                     <span className="font-medium">Materialization status</span>
                                 </div>
-                                <LemonTag type={getStatusTagType(materializationStatus)}>
-                                    {materializationStatus || 'Pending'}
-                                </LemonTag>
+                                <div className="flex items-center gap-2">
+                                    <LemonTag type={getStatusTagType(materializationStatus)}>
+                                        {materializationStatus || 'Pending'}
+                                    </LemonTag>
+                                    <LemonButton
+                                        size="xsmall"
+                                        icon={<IconRefresh />}
+                                        onClick={() => endpoint.name && loadEndpoint(endpoint.name)}
+                                        loading={endpointLoading}
+                                        tooltip="Refresh status"
+                                    />
+                                </div>
                             </div>
 
                             {lastMaterializedAt && (

--- a/products/endpoints/frontend/endpoint-tabs/EndpointPlayground.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointPlayground.tsx
@@ -1,12 +1,14 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
+import { IconExternal } from '@posthog/icons'
 import { LemonButton, LemonDivider, LemonLabel, LemonSelect } from '@posthog/lemon-ui'
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { IconPlayCircle } from 'lib/lemon-ui/icons'
 import { CodeEditorInline } from 'lib/monaco/CodeEditorInline'
+import { urls } from 'scenes/urls'
 
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { EndpointType } from '~/types'
@@ -325,6 +327,15 @@ export function EndpointPlayground({ tabId }: EndpointPlaygroundProps): JSX.Elem
                         }}
                         value={activeCodeExampleTab}
                     />
+                    <LemonButton
+                        to={urls.settings('user', 'personal-api-keys')}
+                        type="secondary"
+                        size="small"
+                        icon={<IconExternal />}
+                        targetBlank
+                    >
+                        API keys
+                    </LemonButton>
                 </div>
                 <div>
                     <CodeSnippet language={getLanguage(activeCodeExampleTab)} wrap={true}>

--- a/products/endpoints/frontend/endpointLogic.tsx
+++ b/products/endpoints/frontend/endpointLogic.tsx
@@ -9,6 +9,7 @@ import { debounce, slugify } from 'lib/utils'
 import { permanentlyMount } from 'lib/utils/kea-logic-builders'
 import { urls } from 'scenes/urls'
 
+import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
 import { EndpointRequest } from '~/queries/schema/schema-general'
 import { DataWarehouseSyncInterval, EndpointType } from '~/types'
 
@@ -26,7 +27,7 @@ export const endpointLogic = kea<endpointLogicType>([
     props({} as EndpointLogicProps),
     key((props) => props.tabId),
     connect(() => ({
-        actions: [endpointsLogic, ['loadEndpoints']],
+        actions: [endpointsLogic, ['loadEndpoints'], sceneLayoutLogic, ['setScenePanelOpen']],
     })),
     actions({
         setEndpointName: (endpointName: string) => ({ endpointName }),
@@ -41,8 +42,12 @@ export const endpointLogic = kea<endpointLogicType>([
         createEndpoint: (request: EndpointRequest) => ({ request }),
         createEndpointSuccess: (response: any) => ({ response }),
         createEndpointFailure: () => ({}),
-        updateEndpoint: (name: string, request: Partial<EndpointRequest>) => ({ name, request }),
-        updateEndpointSuccess: (response: any) => ({ response }),
+        updateEndpoint: (name: string, request: Partial<EndpointRequest>, showViewButton?: boolean) => ({
+            name,
+            request,
+            showViewButton,
+        }),
+        updateEndpointSuccess: (response: any, showViewButton?: boolean) => ({ response, showViewButton }),
         updateEndpointFailure: () => ({}),
         deleteEndpoint: (name: string) => ({ name }),
         deleteEndpointSuccess: (response: any) => ({ response }),
@@ -144,25 +149,40 @@ export const endpointLogic = kea<endpointLogicType>([
                 lemonToast.success(<>Endpoint created</>, {
                     button: {
                         label: 'View',
-                        action: () => router.actions.push(urls.endpoint(response.name)),
+                        action: () => {
+                            // Close the scene panel (info & actions panel) if endpoint was created from insight
+                            if (response.derived_from_insight) {
+                                actions.setScenePanelOpen(false)
+                            }
+                            router.actions.push(urls.endpoint(response.name))
+                        },
                     },
                 })
             },
             createEndpointFailure: () => {
                 lemonToast.error('Failed to create endpoint')
             },
-            updateEndpoint: async ({ name, request }) => {
+            updateEndpoint: async ({ name, request, showViewButton }) => {
                 try {
                     const response = await api.endpoint.update(name, request)
-                    actions.updateEndpointSuccess(response)
+                    actions.updateEndpointSuccess(response, showViewButton)
                     actions.loadEndpoints()
                 } catch (error) {
                     console.error('Failed to update endpoint:', error)
                     actions.updateEndpointFailure()
                 }
             },
-            updateEndpointSuccess: ({ response }) => {
-                lemonToast.success('Endpoint updated')
+            updateEndpointSuccess: ({ response, showViewButton }) => {
+                if (showViewButton) {
+                    lemonToast.success(<>Endpoint updated</>, {
+                        button: {
+                            label: 'View',
+                            action: () => router.actions.push(urls.endpoint(response.name)),
+                        },
+                    })
+                } else {
+                    lemonToast.success('Endpoint updated')
+                }
                 reloadEndpoint(response.name)
             },
             updateEndpointFailure: () => {


### PR DESCRIPTION
## Problem

This PR introduces several product improvements to the Endpoints feature, focusing on enhancing user experience, providing better visibility into endpoint status, and improving backend query tracking.

## Changes

This PR addresses 6 Endpoints product improvements:

1.  **Backend**: Added `tag_queries(product=Product.ENDPOINTS)` to `get_endpoints_last_execution_times` API method for better query tracking.
2.  **Backend**: Added `tag_queries(workload=Workload.ENDPOINTS)` to inline query execution (not just materialized endpoints).
3.  **Frontend (`EndpointPlayground.tsx`)**: Added an "API keys" link button in the Playground tab under the Example usage section that opens the personal API keys page in a new tab.
4.  **Frontend (`EndpointConfiguration.tsx`)**: Added a small refresh button next to the materialization status tag that allows users to refresh the endpoint status on demand.
5.  **Frontend (`endpointLogic.tsx` + `Endpoint.tsx`)**: Added a "View" button to the "Endpoint updated" toast, but only when updating from the SQL editor scene. The button navigates directly to the updated endpoint.
6.  **Frontend (`endpointLogic.tsx`)**: When creating an endpoint from an insight's info & actions panel and clicking the "View" button on the "Endpoint created" toast, the info & actions panel now closes automatically.

## How did you test this code?

The changes were verified by the assistant after implementation, checking for any issues and confirming the intended behavior.

## Changelog: (features only) Is this feature complete?

Yes

---
[Slack Thread](https://posthog.slack.com/archives/C0932JBCUFL/p1764766312947819?thread_ts=1764766312.947819&cid=C0932JBCUFL)

<a href="https://cursor.com/background-agent?bcId=bc-04982e31-66db-42eb-8e0c-445b549ae590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-04982e31-66db-42eb-8e0c-445b549ae590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

