### PR TITLE
fix: Change group search to query clickhouse

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -33,6 +33,8 @@ import {
     FileSystemCount,
     FileSystemEntry,
     FileSystemViewLogEntry,
+    GroupsQuery,
+    GroupsQueryResponse,
     HogCompileResponse,
     HogQLQuery,
     HogQLQueryResponse,
@@ -2775,6 +2777,14 @@ const api = {
     groups: {
         async list(params: GroupListParams): Promise<CountedPaginatedResponse<Group>> {
             return await new ApiRequest().groups().withQueryString(toParams(params, true)).get()
+        },
+        async listClickhouse(params: GroupListParams): Promise<GroupsQueryResponse> {
+            const groupsQuery: GroupsQuery = {
+                kind: NodeKind.GroupsQuery,
+                ...params,
+            }
+
+            return await new ApiRequest().query().create({ data: { query: groupsQuery } })
         },
         async create(data: CreateGroupParams): Promise<Group> {
             return await new ApiRequest().groups().create({ data })

--- a/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
+++ b/frontend/src/scenes/new-tab/newTabSceneLogic.tsx
@@ -42,6 +42,7 @@ import {
     FileSystemIconType,
     FileSystemImport,
     FileSystemViewLogEntry,
+    GroupsQueryResponse,
 } from '~/queries/schema/schema-general'
 import { ActivityTab, EventDefinition, Group, GroupTypeIndex, PersonType, PropertyDefinition } from '~/types'
 
@@ -98,6 +99,8 @@ export interface CategoryWithItems {
     isLoading: boolean
 }
 
+export type GroupQueryResult = Pick<Group, 'group_key' | 'group_properties'>
+
 const INITIAL_SECTION_LIMIT = 5
 const SINGLE_CATEGORY_SECTION_LIMIT = 15
 const INITIAL_RECENTS_LIMIT = 5
@@ -152,6 +155,15 @@ function matchesRecentsSearch(entry: FileSystemEntry, searchChunks: string[]): b
     return searchChunks.every(
         (chunk) => nameLower.includes(chunk) || typeLower.includes(chunk) || categoryLower.includes(chunk)
     )
+}
+
+function mapGroupQueryResponse(response: GroupsQueryResponse): GroupQueryResult[] {
+    return response.results.map((row) => ({
+        group_key: row[response.columns.indexOf('key')],
+        group_properties: {
+            name: row[response.columns.indexOf('group_name')],
+        },
+    }))
 }
 
 export const newTabSceneLogic = kea<newTabSceneLogicType>([
@@ -410,7 +422,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
 
                     const responses = await Promise.all(
                         groupTypesList.map((groupType) =>
-                            api.groups.list({
+                            api.groups.listClickhouse({
                                 group_type_index: groupType.group_type_index,
                                 search: trimmed,
                                 limit: GROUP_SEARCH_LIMIT,
@@ -422,8 +434,8 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
 
                     const resultEntries = responses.map((response, index) => [
                         groupTypesList[index].group_type_index,
-                        (response.results ?? []).slice(0, GROUP_SEARCH_LIMIT),
-                    ]) as [GroupTypeIndex, Group[]][]
+                        mapGroupQueryResponse(response),
+                    ]) as [GroupTypeIndex, GroupQueryResult[]][]
 
                     const combinedResultsCount = resultEntries.reduce(
                         (count, [, groupResults]) => count + groupResults.length,
@@ -434,7 +446,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                         actions.setFirstNoResultsSearchPrefix('groups', trimmed)
                     }
 
-                    return Object.fromEntries(resultEntries) as Record<GroupTypeIndex, Group[]>
+                    return Object.fromEntries(resultEntries) as Record<GroupTypeIndex, GroupQueryResult[]>
                 },
                 loadInitialGroups: async (_, breakpoint) => {
                     const groupTypesList = Array.from(values.groupTypes.values())
@@ -446,7 +458,7 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
 
                     const responses = await Promise.all(
                         groupTypesList.map((groupType) =>
-                            api.groups.list({
+                            api.groups.listClickhouse({
                                 group_type_index: groupType.group_type_index,
                                 search: '',
                                 limit: GROUP_SEARCH_LIMIT,
@@ -461,9 +473,9 @@ export const newTabSceneLogic = kea<newTabSceneLogicType>([
                     return Object.fromEntries(
                         responses.map((response, index) => [
                             groupTypesList[index].group_type_index,
-                            response.results.slice(0, GROUP_SEARCH_LIMIT),
+                            mapGroupQueryResponse(response),
                         ])
-                    ) as Record<GroupTypeIndex, Group[]>
+                    ) as Record<GroupTypeIndex, GroupQueryResult[]>
                 },
             },
         ],


### PR DESCRIPTION
## Problem
Group search in postgres is timing out since we migrated the reads to persons db replica (which has stricter timeouts). Orgs with lots of groups were getting error toasts every time they opened the new tab page.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes https://github.com/PostHog/posthog/issues/42377
## Changes
Let's fix that by querying clickhouse instead. We have more relaxed timeouts and is the same mechanism as in groups list page/search, so we minimize the "moving parts" by consolidating it.


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Making sure groups section was being populated in new tab page in the initial load and that the search was returning the correct results
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<img width="1604" height="962" alt="image" src="https://github.com/user-attachments/assets/a584ad22-3b23-478c-b73f-38666436c7f3" />
<img width="1604" height="962" alt="image" src="https://github.com/user-attachments/assets/d8466fc9-7d95-4c6d-8296-99e822fc1597" />

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No, bug fix
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
