### PR TITLE
chore(common-geoip): Fix CI by relaxing GeoIP test expectations for varying DB fields

### DIFF
--- a/rust/common/geoip/src/lib.rs
+++ b/rust/common/geoip/src/lib.rs
@@ -85,6 +85,7 @@ mod tests {
 
     use super::*;
     use std::path::Path;
+    use std::{collections::HashSet, iter::FromIterator};
 
     fn get_db_path() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -138,6 +139,9 @@ mod tests {
             ("187.188.10.252", "Mexico"),
         ];
 
+        let allowed_keys =
+            HashSet::<&str>::from_iter(GEOIP_FIELDS.iter().map(|(field, _)| *field));
+
         for (ip, expected_country) in test_cases {
             let result = service.get_geoip_properties(ip).unwrap();
             println!("GeoIP lookup result for IP {ip}: {result:?}");
@@ -150,7 +154,12 @@ mod tests {
                 result.get("$geoip_country_name"),
                 Some(&expected_country.to_string())
             );
-            assert_eq!(result.len(), 7);
+            // GeoIP databases may differ in how many fields they populate; ensure we have a sensible minimum
+            assert!(result.len() >= 5);
+            assert!(result.len() <= GEOIP_FIELDS.len());
+            for key in result.keys() {
+                assert!(allowed_keys.contains(key.as_str()));
+            }
         }
     }
 

--- a/rust/common/geoip/src/lib.rs
+++ b/rust/common/geoip/src/lib.rs
@@ -139,8 +139,7 @@ mod tests {
             ("187.188.10.252", "Mexico"),
         ];
 
-        let allowed_keys =
-            HashSet::<&str>::from_iter(GEOIP_FIELDS.iter().map(|(field, _)| *field));
+        let allowed_keys = HashSet::<&str>::from_iter(GEOIP_FIELDS.iter().map(|(field, _)| *field));
 
         for (ip, expected_country) in test_cases {
             let result = service.get_geoip_properties(ip).unwrap();


### PR DESCRIPTION
## Problem

Slight variations in the geoip db causes this test to fail in CI ([example run where it fails](https://github.com/PostHog/posthog/actions/runs/19895494452/job/57025379273?pr=41281)), while it runs fine locally. A similar problem was fixed in this commit https://github.com/PostHog/posthog/commit/190ab54aaf6da40639bf7b9eccd539c83905564e#diff-163b03d053a0d9c121fe7c0b023759c0e41fef97fc70c1a1a64ff2cf2fbf586c 

## Changes

Loosened the GeoIP test to handle database field variability in CI: the test still checks the country match, but now only asserts the returned keys are from the expected set and that the map contain at least 5 fields.

## How did you test this code?

- Test runs fine locally