### PR TITLE
feat(workflows): ability to name conditional branches

### DIFF
--- a/plugin-server/src/schema/hogflow.ts
+++ b/plugin-server/src/schema/hogflow.ts
@@ -72,6 +72,7 @@ const HogFlowActionSchema = z.discriminatedUnion('type', [
             conditions: z.array(
                 z.object({
                     filters: z.any(), // type this stronger
+                    name: z.string().optional(), // Custom name for the condition
                 })
             ),
             delay_duration: z.string().optional(),

--- a/plugin-server/src/schema/hogflow.ts
+++ b/plugin-server/src/schema/hogflow.ts
@@ -85,6 +85,7 @@ const HogFlowActionSchema = z.discriminatedUnion('type', [
             cohorts: z.array(
                 z.object({
                     percentage: z.number(),
+                    name: z.string().optional(), // Custom name for the cohort
                 })
             ),
         }),
@@ -104,6 +105,7 @@ const HogFlowActionSchema = z.discriminatedUnion('type', [
         config: z.object({
             condition: z.object({
                 filters: z.any(), // type this stronger
+                name: z.string().optional(), // Custom name for the condition
             }),
             max_wait_duration: z.string(),
         }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2552,6 +2552,9 @@ importers:
       react:
         specifier: '*'
         version: 18.2.0
+      use-debounce:
+        specifier: ^9.0.3
+        version: 9.0.3(react@18.2.0)
       zod:
         specifier: '*'
         version: 3.25.76

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.test.ts
@@ -1,0 +1,275 @@
+import { initKeaTests } from '~/test/init'
+
+import { hogFlowEditorLogic } from './hogFlowEditorLogic'
+import { HogFlow, HogFlowAction } from './types'
+
+describe('hogFlowEditorLogic', () => {
+    let logic: ReturnType<typeof hogFlowEditorLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = hogFlowEditorLogic()
+        logic.mount()
+    })
+
+    describe('conditional branch naming', () => {
+        const createMockHogFlow = (conditionNames?: (string | undefined)[]): HogFlow => ({
+            id: 'test-flow',
+            team_id: 1,
+            version: 1,
+            name: 'Test Flow',
+            status: 'draft',
+            exit_condition: 'exit_only_at_end',
+            actions: [
+                {
+                    id: 'trigger',
+                    name: 'Trigger',
+                    description: '',
+                    type: 'trigger',
+                    created_at: Date.now(),
+                    updated_at: Date.now(),
+                    config: {
+                        type: 'event',
+                        filters: {},
+                    },
+                },
+                {
+                    id: 'branch',
+                    name: 'Conditional Branch',
+                    description: '',
+                    type: 'conditional_branch',
+                    created_at: Date.now(),
+                    updated_at: Date.now(),
+                    config: {
+                        conditions: conditionNames
+                            ? conditionNames.map((name) => ({ filters: {}, name }))
+                            : [{ filters: {} }, { filters: {} }],
+                    },
+                },
+                {
+                    id: 'exit',
+                    name: 'Exit',
+                    description: '',
+                    type: 'exit',
+                    created_at: Date.now(),
+                    updated_at: Date.now(),
+                    config: { reason: '' },
+                },
+            ],
+            edges: [
+                { from: 'trigger', to: 'branch', type: 'continue' },
+                { from: 'branch', to: 'exit', type: 'branch', index: 0 },
+                { from: 'branch', to: 'exit', type: 'branch', index: 1 },
+                { from: 'branch', to: 'exit', type: 'continue' },
+            ],
+            updated_at: new Date().toISOString(),
+            created_at: new Date().toISOString(),
+        })
+
+        it('should use default labels when condition names are not provided', () => {
+            const mockFlow = createMockHogFlow()
+            logic.actions.resetFlowFromHogFlow(mockFlow)
+
+            const edges = logic.values.edges
+
+            // Find the branch edges
+            const branchEdge0 = edges.find((e) => e.source === 'branch' && e.sourceHandle?.includes('branch_branch_0'))
+            const branchEdge1 = edges.find((e) => e.source === 'branch' && e.sourceHandle?.includes('branch_branch_1'))
+            const continueEdge = edges.find((e) => e.source === 'branch' && e.sourceHandle?.includes('continue_branch'))
+
+            expect(branchEdge0?.data?.label).toBe('If condition #1 matches')
+            expect(branchEdge1?.data?.label).toBe('If condition #2 matches')
+            expect(continueEdge?.data?.label).toBe('No match')
+        })
+
+        it('should use custom names when provided for conditional branches', () => {
+            const mockFlow = createMockHogFlow(['User is premium', 'User is in trial'])
+            logic.actions.resetFlowFromHogFlow(mockFlow)
+
+            const edges = logic.values.edges
+
+            // Find the branch edges
+            const branchEdge0 = edges.find((e) => e.source === 'branch' && e.sourceHandle?.includes('branch_branch_0'))
+            const branchEdge1 = edges.find((e) => e.source === 'branch' && e.sourceHandle?.includes('branch_branch_1'))
+            const continueEdge = edges.find((e) => e.source === 'branch' && e.sourceHandle?.includes('continue_branch'))
+
+            expect(branchEdge0?.data?.label).toBe('User is premium')
+            expect(branchEdge1?.data?.label).toBe('User is in trial')
+            expect(continueEdge?.data?.label).toBe('No match')
+        })
+
+        it('should fall back to default labels for conditions without names', () => {
+            const mockFlow = createMockHogFlow(['User is premium', undefined])
+            logic.actions.resetFlowFromHogFlow(mockFlow)
+
+            const edges = logic.values.edges
+
+            // Find the branch edges
+            const branchEdge0 = edges.find((e) => e.source === 'branch' && e.sourceHandle?.includes('branch_branch_0'))
+            const branchEdge1 = edges.find((e) => e.source === 'branch' && e.sourceHandle?.includes('branch_branch_1'))
+
+            expect(branchEdge0?.data?.label).toBe('User is premium')
+            expect(branchEdge1?.data?.label).toBe('If condition #2 matches')
+        })
+
+        it('should not show labels for single-edge nodes', () => {
+            const mockFlow = createMockHogFlow()
+            // Remove all but one edge from the branch node
+            mockFlow.edges = [
+                { from: 'trigger', to: 'branch', type: 'continue' },
+                { from: 'branch', to: 'exit', type: 'continue' },
+            ]
+
+            logic.actions.resetFlowFromHogFlow(mockFlow)
+
+            const edges = logic.values.edges
+            const branchEdge = edges.find((e) => e.source === 'branch')
+
+            expect(branchEdge?.data?.label).toBeUndefined()
+        })
+
+        it('should update edge labels when conditions are modified', () => {
+            const mockFlow = createMockHogFlow()
+            logic.actions.resetFlowFromHogFlow(mockFlow)
+
+            // Update the action with new condition names
+            const updatedAction: HogFlowAction = {
+                id: 'branch',
+                name: 'Conditional Branch',
+                description: '',
+                type: 'conditional_branch',
+                created_at: Date.now(),
+                updated_at: Date.now(),
+                config: {
+                    conditions: [
+                        { filters: {}, name: 'New condition 1' },
+                        { filters: {}, name: 'New condition 2' },
+                    ],
+                },
+            }
+
+            logic.actions.setWorkflowAction('branch', updatedAction)
+
+            // Re-trigger the flow reset to update edges
+            const updatedFlow = {
+                ...mockFlow,
+                actions: mockFlow.actions.map((a) => (a.id === 'branch' ? updatedAction : a)),
+            }
+            logic.actions.resetFlowFromHogFlow(updatedFlow)
+
+            const edges = logic.values.edges
+            const branchEdge0 = edges.find((e) => e.source === 'branch' && e.sourceHandle?.includes('branch_branch_0'))
+            const branchEdge1 = edges.find((e) => e.source === 'branch' && e.sourceHandle?.includes('branch_branch_1'))
+
+            expect(branchEdge0?.data?.label).toBe('New condition 1')
+            expect(branchEdge1?.data?.label).toBe('New condition 2')
+        })
+
+        it('should handle wait_until_condition edge labels correctly', () => {
+            const mockFlow: HogFlow = {
+                ...createMockHogFlow(),
+                actions: [
+                    {
+                        id: 'trigger',
+                        name: 'Trigger',
+                        description: '',
+                        type: 'trigger',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: {
+                            type: 'event',
+                            filters: {},
+                        },
+                    },
+                    {
+                        id: 'wait',
+                        name: 'Wait Until',
+                        description: '',
+                        type: 'wait_until_condition',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: {
+                            condition: { filters: {} },
+                            max_wait_duration: '1h',
+                        },
+                    },
+                    {
+                        id: 'exit',
+                        name: 'Exit',
+                        description: '',
+                        type: 'exit',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: { reason: '' },
+                    },
+                ],
+                edges: [
+                    { from: 'trigger', to: 'wait', type: 'continue' },
+                    { from: 'wait', to: 'exit', type: 'branch', index: 0 },
+                    { from: 'wait', to: 'exit', type: 'continue' },
+                ],
+            }
+
+            logic.actions.resetFlowFromHogFlow(mockFlow)
+
+            const edges = logic.values.edges
+            const branchEdge = edges.find((e) => e.source === 'wait' && e.sourceHandle?.includes('branch_wait_0'))
+
+            expect(branchEdge?.data?.label).toBe('If condition matches')
+        })
+
+        it('should handle random_cohort_branch edge labels correctly', () => {
+            const mockFlow: HogFlow = {
+                ...createMockHogFlow(),
+                actions: [
+                    {
+                        id: 'trigger',
+                        name: 'Trigger',
+                        description: '',
+                        type: 'trigger',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: {
+                            type: 'event',
+                            filters: {},
+                        },
+                    },
+                    {
+                        id: 'cohort',
+                        name: 'Random Cohort',
+                        description: '',
+                        type: 'random_cohort_branch',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: {
+                            cohorts: [{ percentage: 50 }, { percentage: 50 }],
+                        },
+                    },
+                    {
+                        id: 'exit',
+                        name: 'Exit',
+                        description: '',
+                        type: 'exit',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: { reason: '' },
+                    },
+                ],
+                edges: [
+                    { from: 'trigger', to: 'cohort', type: 'continue' },
+                    { from: 'cohort', to: 'exit', type: 'branch', index: 0 },
+                    { from: 'cohort', to: 'exit', type: 'branch', index: 1 },
+                ],
+            }
+
+            logic.actions.resetFlowFromHogFlow(mockFlow)
+
+            const edges = logic.values.edges
+            const branchEdge0 = edges.find((e) => e.source === 'cohort' && e.sourceHandle?.includes('branch_cohort_0'))
+            const branchEdge1 = edges.find((e) => e.source === 'cohort' && e.sourceHandle?.includes('branch_cohort_1'))
+
+            expect(branchEdge0?.data?.label).toBe('If cohort #1 matches')
+            expect(branchEdge1?.data?.label).toBe('If cohort #2 matches')
+        })
+    })
+})

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.test.ts
@@ -165,7 +165,60 @@ describe('hogFlowEditorLogic', () => {
             expect(branchEdge1?.data?.label).toBe('New condition 2')
         })
 
-        it('should handle wait_until_condition edge labels correctly', () => {
+        it('should use custom names for wait_until_condition when provided', () => {
+            const mockFlow: HogFlow = {
+                ...createMockHogFlow(),
+                actions: [
+                    {
+                        id: 'trigger',
+                        name: 'Trigger',
+                        description: '',
+                        type: 'trigger',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: {
+                            type: 'event',
+                            filters: {},
+                        },
+                    },
+                    {
+                        id: 'wait',
+                        name: 'Wait Until',
+                        description: '',
+                        type: 'wait_until_condition',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: {
+                            condition: { filters: {}, name: 'User completes onboarding' },
+                            max_wait_duration: '1h',
+                        },
+                    },
+                    {
+                        id: 'exit',
+                        name: 'Exit',
+                        description: '',
+                        type: 'exit',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: { reason: '' },
+                    },
+                ],
+                edges: [
+                    { from: 'trigger', to: 'wait', type: 'continue' },
+                    { from: 'wait', to: 'exit', type: 'branch', index: 0 },
+                    { from: 'wait', to: 'exit', type: 'continue' },
+                ],
+            }
+
+            logic.actions.resetFlowFromHogFlow(mockFlow)
+
+            const edges = logic.values.edges
+            const branchEdge = edges.find((e) => e.source === 'wait' && e.sourceHandle?.includes('branch_wait_0'))
+
+            expect(branchEdge?.data?.label).toBe('User completes onboarding')
+        })
+
+        it('should handle wait_until_condition edge labels without custom names', () => {
             const mockFlow: HogFlow = {
                 ...createMockHogFlow(),
                 actions: [
@@ -218,7 +271,64 @@ describe('hogFlowEditorLogic', () => {
             expect(branchEdge?.data?.label).toBe('If condition matches')
         })
 
-        it('should handle random_cohort_branch edge labels correctly', () => {
+        it('should use custom names for random_cohort_branch when provided', () => {
+            const mockFlow: HogFlow = {
+                ...createMockHogFlow(),
+                actions: [
+                    {
+                        id: 'trigger',
+                        name: 'Trigger',
+                        description: '',
+                        type: 'trigger',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: {
+                            type: 'event',
+                            filters: {},
+                        },
+                    },
+                    {
+                        id: 'cohort',
+                        name: 'Random Cohort',
+                        description: '',
+                        type: 'random_cohort_branch',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: {
+                            cohorts: [
+                                { percentage: 50, name: 'Control group' },
+                                { percentage: 50, name: 'Test group' },
+                            ],
+                        },
+                    },
+                    {
+                        id: 'exit',
+                        name: 'Exit',
+                        description: '',
+                        type: 'exit',
+                        created_at: Date.now(),
+                        updated_at: Date.now(),
+                        config: { reason: '' },
+                    },
+                ],
+                edges: [
+                    { from: 'trigger', to: 'cohort', type: 'continue' },
+                    { from: 'cohort', to: 'exit', type: 'branch', index: 0 },
+                    { from: 'cohort', to: 'exit', type: 'branch', index: 1 },
+                ],
+            }
+
+            logic.actions.resetFlowFromHogFlow(mockFlow)
+
+            const edges = logic.values.edges
+            const branchEdge0 = edges.find((e) => e.source === 'cohort' && e.sourceHandle?.includes('branch_cohort_0'))
+            const branchEdge1 = edges.find((e) => e.source === 'cohort' && e.sourceHandle?.includes('branch_cohort_1'))
+
+            expect(branchEdge0?.data?.label).toBe('Control group')
+            expect(branchEdge1?.data?.label).toBe('Test group')
+        })
+
+        it('should handle random_cohort_branch edge labels without custom names', () => {
             const mockFlow: HogFlow = {
                 ...createMockHogFlow(),
                 actions: [

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -267,10 +267,15 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
                                 return 'condition'
                             case 'random_cohort_branch':
                                 return `cohort #${(edge.index || 0) + 1}`
-                            case 'conditional_branch':
-                                const conditionName = (edgeSourceAction as any)?.config?.conditions?.[edge.index || 0]
-                                    ?.name
+                            case 'conditional_branch': {
+                                const conditionalBranchAction = edgeSourceAction as Extract<
+                                    HogFlowAction,
+                                    { type: 'conditional_branch' }
+                                >
+                                const conditionName =
+                                    conditionalBranchAction?.config?.conditions?.[edge.index || 0]?.name
                                 return conditionName || `condition #${(edge.index || 0) + 1}`
+                            }
                             default:
                                 return `condition #${(edge.index || 0) + 1}`
                         }
@@ -297,9 +302,16 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
                                 ? undefined
                                 : edge.type === 'continue'
                                   ? `No match`
-                                  : edgeSourceAction?.type === 'conditional_branch' &&
-                                      (edgeSourceAction as any)?.config?.conditions?.[edge.index || 0]?.name
-                                    ? (edgeSourceAction as any).config.conditions[edge.index || 0].name
+                                  : edgeSourceAction?.type === 'conditional_branch'
+                                    ? (() => {
+                                          const conditionalBranchAction = edgeSourceAction as Extract<
+                                              HogFlowAction,
+                                              { type: 'conditional_branch' }
+                                          >
+                                          const customName =
+                                              conditionalBranchAction?.config?.conditions?.[edge.index || 0]?.name
+                                          return customName || `If ${branchResourceName()} matches`
+                                      })()
                                     : `If ${branchResourceName()} matches`,
                         },
                         labelShowBg: false,

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -267,6 +267,10 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
                                 return 'condition'
                             case 'random_cohort_branch':
                                 return `cohort #${(edge.index || 0) + 1}`
+                            case 'conditional_branch':
+                                const conditionName = (edgeSourceAction as any)?.config?.conditions?.[edge.index || 0]
+                                    ?.name
+                                return conditionName || `condition #${(edge.index || 0) + 1}`
                             default:
                                 return `condition #${(edge.index || 0) + 1}`
                         }
@@ -293,7 +297,10 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
                                 ? undefined
                                 : edge.type === 'continue'
                                   ? `No match`
-                                  : `If ${branchResourceName()} matches`,
+                                  : edgeSourceAction?.type === 'conditional_branch' &&
+                                      (edgeSourceAction as any)?.config?.conditions?.[edge.index || 0]?.name
+                                    ? (edgeSourceAction as any).config.conditions[edge.index || 0].name
+                                    : `If ${branchResourceName()} matches`,
                         },
                         labelShowBg: false,
                         targetHandle: `target_${edge.to}`,

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -35,6 +35,35 @@ import type { HogFlow, HogFlowAction, HogFlowActionNode } from './types'
 const getEdgeId = (edge: HogFlow['edges'][number]): string =>
     `${edge.from}->${edge.to} ${edge.type} ${edge.index ?? ''}`.trim()
 
+/**
+ * Helper to get branch label with custom name fallback
+ */
+const getBranchLabel = (action: HogFlowAction | undefined, edge: HogFlow['edges'][0]): string => {
+    if (!action) {
+        return `If condition #${(edge.index || 0) + 1} matches`
+    }
+
+    switch (action.type) {
+        case 'wait_until_condition': {
+            const waitAction = action as Extract<HogFlowAction, { type: 'wait_until_condition' }>
+            const customName = waitAction.config.condition?.name
+            return customName || 'If condition matches'
+        }
+        case 'random_cohort_branch': {
+            const cohortAction = action as Extract<HogFlowAction, { type: 'random_cohort_branch' }>
+            const cohort = cohortAction.config.cohorts?.[edge.index || 0]
+            return cohort?.name || `If cohort #${(edge.index || 0) + 1} matches`
+        }
+        case 'conditional_branch': {
+            const branchAction = action as Extract<HogFlowAction, { type: 'conditional_branch' }>
+            const condition = branchAction.config.conditions?.[edge.index || 0]
+            return condition?.name || `If condition #${(edge.index || 0) + 1} matches`
+        }
+        default:
+            return `If condition #${(edge.index || 0) + 1} matches`
+    }
+}
+
 export const HOG_FLOW_EDITOR_MODES = ['build', 'variables', 'test', 'metrics', 'logs'] as const
 export type HogFlowEditorMode = (typeof HOG_FLOW_EDITOR_MODES)[number]
 export type HogFlowEditorActionMetrics = {
@@ -261,36 +290,6 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
                 const edges: Edge[] = hogFlow.edges.map((edge) => {
                     const isOnlyEdgeForNode = hogFlow.edges.filter((e) => e.from === edge.from).length === 1
                     const edgeSourceAction = hogFlow.actions.find((action) => action.id === edge.from)
-                    const branchResourceName = () => {
-                        switch (edgeSourceAction?.type) {
-                            case 'wait_until_condition': {
-                                const waitAction = edgeSourceAction as Extract<
-                                    HogFlowAction,
-                                    { type: 'wait_until_condition' }
-                                >
-                                return waitAction?.config?.condition?.name || 'condition'
-                            }
-                            case 'random_cohort_branch': {
-                                const cohortAction = edgeSourceAction as Extract<
-                                    HogFlowAction,
-                                    { type: 'random_cohort_branch' }
-                                >
-                                const cohortName = cohortAction?.config?.cohorts?.[edge.index || 0]?.name
-                                return cohortName || `cohort #${(edge.index || 0) + 1}`
-                            }
-                            case 'conditional_branch': {
-                                const conditionalBranchAction = edgeSourceAction as Extract<
-                                    HogFlowAction,
-                                    { type: 'conditional_branch' }
-                                >
-                                const conditionName =
-                                    conditionalBranchAction?.config?.conditions?.[edge.index || 0]?.name
-                                return conditionName || `condition #${(edge.index || 0) + 1}`
-                            }
-                            default:
-                                return `condition #${(edge.index || 0) + 1}`
-                        }
-                    }
 
                     return {
                         // Only these values are set by the user
@@ -313,39 +312,7 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
                                 ? undefined
                                 : edge.type === 'continue'
                                   ? `No match`
-                                  : (() => {
-                                        // Check for custom names across all branch types
-                                        if (edgeSourceAction?.type === 'conditional_branch') {
-                                            const action = edgeSourceAction as Extract<
-                                                HogFlowAction,
-                                                { type: 'conditional_branch' }
-                                            >
-                                            const customName = action?.config?.conditions?.[edge.index || 0]?.name
-                                            if (customName) {
-                                                return customName
-                                            }
-                                        } else if (edgeSourceAction?.type === 'random_cohort_branch') {
-                                            const action = edgeSourceAction as Extract<
-                                                HogFlowAction,
-                                                { type: 'random_cohort_branch' }
-                                            >
-                                            const customName = action?.config?.cohorts?.[edge.index || 0]?.name
-                                            if (customName) {
-                                                return customName
-                                            }
-                                        } else if (edgeSourceAction?.type === 'wait_until_condition') {
-                                            const action = edgeSourceAction as Extract<
-                                                HogFlowAction,
-                                                { type: 'wait_until_condition' }
-                                            >
-                                            const customName = action?.config?.condition?.name
-                                            if (customName) {
-                                                return customName
-                                            }
-                                        }
-                                        // Default to generated label
-                                        return `If ${branchResourceName()} matches`
-                                    })(),
+                                  : getBranchLabel(edgeSourceAction, edge),
                         },
                         labelShowBg: false,
                         targetHandle: `target_${edge.to}`,

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react'
 import { IconPlus, IconX } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 
@@ -100,13 +101,6 @@ export function StepConditionalBranchConfiguration({
                         />
                     </div>
 
-                    <LemonInput
-                        value={localConditionNames[index] || ''}
-                        onChange={(value) => handleNameChange(index, value)}
-                        placeholder={`If condition #${index + 1} matches`}
-                        size="small"
-                    />
-
                     <HogFlowPropertyFilters
                         actionId={`${action.id}.${index}`}
                         filters={condition.filters ?? {}}
@@ -119,6 +113,15 @@ export function StepConditionalBranchConfiguration({
                         }
                         typeKey={`workflow-trigger-${index}`}
                     />
+
+                    <LemonField.Pure label="Condition name (optional)">
+                        <LemonInput
+                            value={localConditionNames[index] || ''}
+                            onChange={(value) => handleNameChange(index, value)}
+                            placeholder={`If condition #${index + 1} matches`}
+                            size="small"
+                        />
+                    </LemonField.Pure>
                 </div>
             ))}
 

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -13,6 +13,7 @@ import { HogFlowPropertyFilters } from '../filters/HogFlowFilters'
 import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { HogFlow, HogFlowAction } from '../types'
 import { StepSchemaErrors } from './components/StepSchemaErrors'
+import { updateItemWithOptionalName } from './utils'
 
 export function StepConditionalBranchConfiguration({
     node,
@@ -37,20 +38,7 @@ export function StepConditionalBranchConfiguration({
 
     // Debounced function to update condition names
     const debouncedUpdateConditionName = useDebouncedCallback((index: number, value: string | undefined) => {
-        setConditions(
-            conditions.map((c, i) => {
-                if (i !== index) {
-                    return c
-                }
-                const updated = { ...c }
-                if (value) {
-                    updated.name = value
-                } else {
-                    delete updated.name
-                }
-                return updated
-            })
-        )
+        setConditions(updateItemWithOptionalName(conditions, index, value))
     }, 300)
 
     const nodeEdges = edgesByActionId[action.id] ?? []

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -40,7 +40,7 @@ export function StepConditionalBranchConfiguration({
         setConditions(conditions.map((c, i) => (i === index ? { ...c, name: value || undefined } : c)))
     }, 300)
 
-    const nodeEdges = edgesByActionId[action.id]
+    const nodeEdges = edgesByActionId[action.id] ?? []
 
     const [branchEdges, nonBranchEdges] = useMemo(() => {
         const branchEdges: HogFlow['edges'] = []

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -136,7 +136,9 @@ export function StepConditionalBranchConfiguration({
                         filters={condition.filters ?? {}}
                         setFilters={(filters) =>
                             setConditions(
-                                conditions.map((condition, i) => (i === index ? { filters: filters ?? {} } : condition))
+                                conditions.map((condition, i) =>
+                                    i === index ? { ...condition, filters: filters ?? {} } : condition
+                                )
                             )
                         }
                         typeKey={`workflow-trigger-${index}`}

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react'
 import { IconPlus, IconX } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 
 import { HogFlowPropertyFilters } from '../filters/HogFlowFilters'
@@ -59,7 +60,7 @@ export function StepConditionalBranchConfiguration({
             throw new Error('Continue edge not found')
         }
 
-        setConditions([...conditions, { filters: {} }])
+        setConditions([...conditions, { filters: {}, name: undefined }])
         setWorkflowActionEdges(action.id, [
             ...branchEdges,
             {
@@ -95,6 +96,17 @@ export function StepConditionalBranchConfiguration({
                             disabledReason={selectedNodeCanBeDeleted ? undefined : 'Clean up branching steps first'}
                         />
                     </div>
+
+                    <LemonInput
+                        value={condition.name || ''}
+                        onChange={(value) =>
+                            setConditions(
+                                conditions.map((c, i) => (i === index ? { ...c, name: value || undefined } : c))
+                            )
+                        }
+                        placeholder={`If condition #${index + 1} matches`}
+                        size="small"
+                    />
 
                     <HogFlowPropertyFilters
                         actionId={`${action.id}.${index}`}

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -37,7 +37,20 @@ export function StepConditionalBranchConfiguration({
 
     // Debounced function to update condition names
     const debouncedUpdateConditionName = useDebouncedCallback((index: number, value: string | undefined) => {
-        setConditions(conditions.map((c, i) => (i === index ? { ...c, name: value || undefined } : c)))
+        setConditions(
+            conditions.map((c, i) => {
+                if (i !== index) {
+                    return c
+                }
+                const updated = { ...c }
+                if (value) {
+                    updated.name = value
+                } else {
+                    delete updated.name
+                }
+                return updated
+            })
+        )
     }, 300)
 
     const nodeEdges = edgesByActionId[action.id] ?? []
@@ -76,7 +89,7 @@ export function StepConditionalBranchConfiguration({
             throw new Error('Continue edge not found')
         }
 
-        setConditions([...conditions, { filters: {}, name: undefined }])
+        setConditions([...conditions, { filters: {} }])
         setWorkflowActionEdges(action.id, [
             ...branchEdges,
             {

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -35,13 +35,10 @@ export function StepConditionalBranchConfiguration({
         setLocalConditionNames(conditions.map((c) => c.name))
     }, [conditions.length]) // Only update when number of conditions changes
 
-    // Debounced function to update the actual conditions
-    const debouncedSetConditions = useDebouncedCallback(
-        (index: number, value: string | undefined) => {
-            setConditions(conditions.map((c, i) => (i === index ? { ...c, name: value || undefined } : c)))
-        },
-        300 // Wait 300ms after user stops typing
-    )
+    // Debounced function to update condition names
+    const debouncedUpdateConditionName = useDebouncedCallback((index: number, value: string | undefined) => {
+        setConditions(conditions.map((c, i) => (i === index ? { ...c, name: value || undefined } : c)))
+    }, 300)
 
     const nodeEdges = edgesByActionId[action.id]
 
@@ -124,8 +121,8 @@ export function StepConditionalBranchConfiguration({
                             newNames[index] = value
                             setLocalConditionNames(newNames)
 
-                            // Also update the actual conditions after a delay
-                            debouncedSetConditions(index, value)
+                            // Debounced update to persist the name
+                            debouncedUpdateConditionName(index, value)
                         }}
                         placeholder={`If condition #${index + 1} matches`}
                         size="small"

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
@@ -37,7 +37,7 @@ export function StepRandomCohortBranchConfiguration({
         setCohorts(cohorts.map((c, i) => (i === index ? { ...c, name: value || undefined } : c)))
     }, 300)
 
-    const nodeEdges = edgesByActionId[action.id]
+    const nodeEdges = edgesByActionId[action.id] ?? []
 
     const [branchEdges, nonBranchEdges] = useMemo(() => {
         const branchEdges: HogFlow['edges'] = []

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
@@ -12,6 +12,7 @@ import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { HogFlow, HogFlowAction } from '../types'
 import { StepSchemaErrors } from './components/StepSchemaErrors'
+import { updateItemWithOptionalName } from './utils'
 
 export function StepRandomCohortBranchConfiguration({
     node,
@@ -34,20 +35,7 @@ export function StepRandomCohortBranchConfiguration({
 
     // Debounced function to update cohort names
     const debouncedUpdateCohortName = useDebouncedCallback((index: number, value: string | undefined) => {
-        setCohorts(
-            cohorts.map((c, i) => {
-                if (i !== index) {
-                    return c
-                }
-                const updated = { ...c }
-                if (value) {
-                    updated.name = value
-                } else {
-                    delete updated.name
-                }
-                return updated
-            })
-        )
+        setCohorts(updateItemWithOptionalName(cohorts, index, value))
     }, 300)
 
     const nodeEdges = edgesByActionId[action.id] ?? []

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
@@ -34,7 +34,20 @@ export function StepRandomCohortBranchConfiguration({
 
     // Debounced function to update cohort names
     const debouncedUpdateCohortName = useDebouncedCallback((index: number, value: string | undefined) => {
-        setCohorts(cohorts.map((c, i) => (i === index ? { ...c, name: value || undefined } : c)))
+        setCohorts(
+            cohorts.map((c, i) => {
+                if (i !== index) {
+                    return c
+                }
+                const updated = { ...c }
+                if (value) {
+                    updated.name = value
+                } else {
+                    delete updated.name
+                }
+                return updated
+            })
+        )
     }, 300)
 
     const nodeEdges = edgesByActionId[action.id] ?? []

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
@@ -33,7 +33,13 @@ export function StepWaitUntilConditionConfiguration({
 
     // Debounced function to update condition name
     const debouncedUpdateConditionName = useDebouncedCallback((value: string | undefined) => {
-        partialSetWorkflowActionConfig(action.id, { condition: { ...condition, name: value || undefined } })
+        const updated = { ...condition }
+        if (value) {
+            updated.name = value
+        } else {
+            delete updated.name
+        }
+        partialSetWorkflowActionConfig(action.id, { condition: updated })
     }, 300)
 
     return (

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
@@ -1,7 +1,5 @@
 import { Node } from '@xyflow/react'
 import { useActions } from 'kea'
-import { useEffect, useState } from 'react'
-import { useDebouncedCallback } from 'use-debounce'
 
 import { LemonLabel } from '@posthog/lemon-ui'
 
@@ -12,7 +10,7 @@ import { HogFlowPropertyFilters } from '../filters/HogFlowFilters'
 import { HogFlowAction } from '../types'
 import { HogFlowDuration } from './components/HogFlowDuration'
 import { StepSchemaErrors } from './components/StepSchemaErrors'
-import { updateOptionalName } from './utils'
+import { useDebouncedNameInput } from './utils'
 
 export function StepWaitUntilConditionConfiguration({
     node,
@@ -24,18 +22,9 @@ export function StepWaitUntilConditionConfiguration({
 
     const { partialSetWorkflowActionConfig } = useActions(workflowLogic)
 
-    // Local state for condition name to avoid input lag
-    const [localConditionName, setLocalConditionName] = useState<string | undefined>(condition.name)
-
-    // Update local state when condition changes from external sources
-    useEffect(() => {
-        setLocalConditionName(condition.name)
-    }, [condition.name])
-
-    // Debounced function to update condition name
-    const debouncedUpdateConditionName = useDebouncedCallback((value: string | undefined) => {
-        partialSetWorkflowActionConfig(action.id, { condition: updateOptionalName(condition, value) })
-    }, 300)
+    const { localName: localConditionName, handleNameChange } = useDebouncedNameInput(condition, (updatedCondition) =>
+        partialSetWorkflowActionConfig(action.id, { condition: updatedCondition })
+    )
 
     return (
         <>
@@ -55,13 +44,7 @@ export function StepWaitUntilConditionConfiguration({
                 <LemonLabel>Conditions to wait for</LemonLabel>
                 <LemonInput
                     value={localConditionName || ''}
-                    onChange={(value) => {
-                        // Update local state immediately for responsive typing
-                        setLocalConditionName(value)
-
-                        // Debounced update to persist the name
-                        debouncedUpdateConditionName(value)
-                    }}
+                    onChange={handleNameChange}
                     placeholder="If condition matches"
                     size="small"
                 />

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepWaitUntilCondition.tsx
@@ -12,6 +12,7 @@ import { HogFlowPropertyFilters } from '../filters/HogFlowFilters'
 import { HogFlowAction } from '../types'
 import { HogFlowDuration } from './components/HogFlowDuration'
 import { StepSchemaErrors } from './components/StepSchemaErrors'
+import { updateOptionalName } from './utils'
 
 export function StepWaitUntilConditionConfiguration({
     node,
@@ -33,13 +34,7 @@ export function StepWaitUntilConditionConfiguration({
 
     // Debounced function to update condition name
     const debouncedUpdateConditionName = useDebouncedCallback((value: string | undefined) => {
-        const updated = { ...condition }
-        if (value) {
-            updated.name = value
-        } else {
-            delete updated.name
-        }
-        partialSetWorkflowActionConfig(action.id, { condition: updated })
+        partialSetWorkflowActionConfig(action.id, { condition: updateOptionalName(condition, value) })
     }, 300)
 
     return (

--- a/products/workflows/frontend/Workflows/hogflows/steps/types.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/types.ts
@@ -146,6 +146,7 @@ export const HogFlowActionSchema = z.discriminatedUnion('type', [
             cohorts: z.array(
                 z.object({
                     percentage: z.number(),
+                    name: z.string().optional(), // Custom name for the cohort
                 })
             ),
         }),
@@ -165,6 +166,7 @@ export const HogFlowActionSchema = z.discriminatedUnion('type', [
         config: z.object({
             condition: z.object({
                 filters: ActionFiltersSchema.optional().nullable(),
+                name: z.string().optional(), // Custom name for the condition
             }),
             max_wait_duration: z.string(),
         }),

--- a/products/workflows/frontend/Workflows/hogflows/steps/types.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/types.ts
@@ -133,6 +133,7 @@ export const HogFlowActionSchema = z.discriminatedUnion('type', [
             conditions: z.array(
                 z.object({
                     filters: ActionFiltersSchema,
+                    name: z.string().optional(), // Custom name for the condition
                 })
             ),
             delay_duration: z.string().optional(),

--- a/products/workflows/frontend/Workflows/hogflows/steps/utils.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/utils.test.ts
@@ -1,0 +1,168 @@
+import { updateItemWithOptionalName, updateOptionalName } from './utils'
+
+describe('utils', () => {
+    describe('updateOptionalName', () => {
+        it('should add name when value is provided', () => {
+            const obj = { id: '1', filters: {} }
+            const result = updateOptionalName(obj, 'Custom Name')
+
+            expect(result).toEqual({
+                id: '1',
+                filters: {},
+                name: 'Custom Name',
+            })
+        })
+
+        it('should update existing name when new value is provided', () => {
+            const obj = { id: '1', filters: {}, name: 'Old Name' }
+            const result = updateOptionalName(obj, 'New Name')
+
+            expect(result).toEqual({
+                id: '1',
+                filters: {},
+                name: 'New Name',
+            })
+        })
+
+        it('should remove name when value is empty string', () => {
+            const obj = { id: '1', filters: {}, name: 'Existing Name' }
+            const result = updateOptionalName(obj, '')
+
+            expect(result).toEqual({
+                id: '1',
+                filters: {},
+            })
+            expect('name' in result).toBe(false)
+        })
+
+        it('should remove name when value is undefined', () => {
+            const obj = { id: '1', filters: {}, name: 'Existing Name' }
+            const result = updateOptionalName(obj, undefined)
+
+            expect(result).toEqual({
+                id: '1',
+                filters: {},
+            })
+            expect('name' in result).toBe(false)
+        })
+
+        it('should preserve other properties', () => {
+            const obj = {
+                id: '1',
+                filters: { test: true },
+                otherProp: 'value',
+                nested: { deep: 'object' },
+            }
+            const result = updateOptionalName(obj, 'Name')
+
+            expect(result).toEqual({
+                id: '1',
+                filters: { test: true },
+                otherProp: 'value',
+                nested: { deep: 'object' },
+                name: 'Name',
+            })
+        })
+    })
+
+    describe('updateItemWithOptionalName', () => {
+        it('should update name at specified index', () => {
+            const items = [
+                { id: '1', filters: {} },
+                { id: '2', filters: {} },
+                { id: '3', filters: {} },
+            ]
+            const result = updateItemWithOptionalName(items, 1, 'Middle Item')
+
+            expect(result).toEqual([
+                { id: '1', filters: {} },
+                { id: '2', filters: {}, name: 'Middle Item' },
+                { id: '3', filters: {} },
+            ])
+        })
+
+        it('should remove name at specified index when value is empty', () => {
+            const items = [
+                { id: '1', filters: {}, name: 'First' },
+                { id: '2', filters: {}, name: 'Second' },
+                { id: '3', filters: {}, name: 'Third' },
+            ]
+            const result = updateItemWithOptionalName(items, 1, '')
+
+            expect(result).toEqual([
+                { id: '1', filters: {}, name: 'First' },
+                { id: '2', filters: {} },
+                { id: '3', filters: {}, name: 'Third' },
+            ])
+            expect('name' in result[1]).toBe(false)
+        })
+
+        it('should only modify the item at the specified index', () => {
+            const items = [
+                { id: '1', filters: {}, name: 'First' },
+                { id: '2', filters: {} },
+                { id: '3', filters: {}, name: 'Third' },
+            ]
+            const result = updateItemWithOptionalName(items, 1, 'Second')
+
+            expect(result[0]).toEqual({ id: '1', filters: {}, name: 'First' })
+            expect(result[1]).toEqual({ id: '2', filters: {}, name: 'Second' })
+            expect(result[2]).toEqual({ id: '3', filters: {}, name: 'Third' })
+        })
+
+        it('should handle index out of bounds gracefully', () => {
+            const items = [
+                { id: '1', filters: {} },
+                { id: '2', filters: {} },
+            ]
+            const result = updateItemWithOptionalName(items, 5, 'Out of bounds')
+
+            expect(result).toEqual([
+                { id: '1', filters: {} },
+                { id: '2', filters: {} },
+            ])
+        })
+
+        it('should handle negative index gracefully', () => {
+            const items = [
+                { id: '1', filters: {} },
+                { id: '2', filters: {} },
+            ]
+            const result = updateItemWithOptionalName(items, -1, 'Negative')
+
+            expect(result).toEqual([
+                { id: '1', filters: {} },
+                { id: '2', filters: {} },
+            ])
+        })
+
+        it('should return a new array (immutability)', () => {
+            const items = [
+                { id: '1', filters: {} },
+                { id: '2', filters: {} },
+            ]
+            const result = updateItemWithOptionalName(items, 0, 'First')
+
+            expect(result).not.toBe(items)
+            expect(items[0]).toEqual({ id: '1', filters: {} }) // Original unchanged
+        })
+
+        it('should return new objects for modified items (deep immutability)', () => {
+            const items = [
+                { id: '1', filters: {} },
+                { id: '2', filters: {} },
+            ]
+            const result = updateItemWithOptionalName(items, 0, 'First')
+
+            expect(result[0]).not.toBe(items[0]) // Modified item is new
+            expect(result[1]).toBe(items[1]) // Unmodified item is same reference
+        })
+
+        it('should handle empty array', () => {
+            const items: Array<{ filters: {}; name?: string }> = []
+            const result = updateItemWithOptionalName(items, 0, 'Name')
+
+            expect(result).toEqual([])
+        })
+    })
+})

--- a/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
@@ -1,6 +1,6 @@
-/**
- * Updates an optional name field in an object, properly handling deletion when empty
- */
+import { useEffect, useState } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
+
 export function updateOptionalName<T>(obj: T & { name?: string }, name: string | undefined): T & { name?: string } {
     const updated = { ...obj }
     if (name) {
@@ -11,9 +11,6 @@ export function updateOptionalName<T>(obj: T & { name?: string }, name: string |
     return updated
 }
 
-/**
- * Updates an item in an array by index with an optional name field
- */
 export function updateItemWithOptionalName<T>(
     items: Array<T & { name?: string }>,
     index: number,
@@ -25,4 +22,74 @@ export function updateItemWithOptionalName<T>(
         }
         return updateOptionalName(item, name)
     })
+}
+
+export function useDebouncedNameInputs<T extends { name?: string }>(
+    items: T[],
+    updateItems: (items: T[]) => void,
+    debounceDelay: number = 300
+): {
+    localNames: (string | undefined)[]
+    handleNameChange: (index: number, value: string | undefined) => void
+} {
+    const [localNames, setLocalNames] = useState<(string | undefined)[]>(items.map((item) => item.name))
+
+    // Update local state when items change from external sources
+    useEffect(() => {
+        setLocalNames(items.map((item) => item.name))
+    }, [items.length]) // Only update when number of items changes
+
+    // Debounced function to update items
+    const debouncedUpdate = useDebouncedCallback((index: number, value: string | undefined) => {
+        updateItems(updateItemWithOptionalName(items, index, value))
+    }, debounceDelay)
+
+    const handleNameChange = (index: number, value: string | undefined): void => {
+        // Update local state immediately for responsive typing
+        const newNames = [...localNames]
+        newNames[index] = value
+        setLocalNames(newNames)
+
+        // Debounced update to persist the name
+        debouncedUpdate(index, value)
+    }
+
+    return {
+        localNames,
+        handleNameChange,
+    }
+}
+
+export function useDebouncedNameInput<T extends { name?: string }>(
+    item: T,
+    updateItem: (item: T) => void,
+    debounceDelay: number = 300
+): {
+    localName: string | undefined
+    handleNameChange: (value: string | undefined) => void
+} {
+    const [localName, setLocalName] = useState<string | undefined>(item.name)
+
+    // Update local state when item changes from external sources
+    useEffect(() => {
+        setLocalName(item.name)
+    }, [item.name])
+
+    // Debounced function to update item
+    const debouncedUpdate = useDebouncedCallback((value: string | undefined) => {
+        updateItem(updateOptionalName(item, value))
+    }, debounceDelay)
+
+    const handleNameChange = (value: string | undefined): void => {
+        // Update local state immediately for responsive typing
+        setLocalName(value)
+
+        // Debounced update to persist the name
+        debouncedUpdate(value)
+    }
+
+    return {
+        localName,
+        handleNameChange,
+    }
 }

--- a/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Updates an optional name field in an object, properly handling deletion when empty
+ */
+export function updateOptionalName<T>(obj: T & { name?: string }, name: string | undefined): T & { name?: string } {
+    const updated = { ...obj }
+    if (name) {
+        updated.name = name
+    } else {
+        delete updated.name
+    }
+    return updated
+}
+
+/**
+ * Updates an item in an array by index with an optional name field
+ */
+export function updateItemWithOptionalName<T>(
+    items: Array<T & { name?: string }>,
+    index: number,
+    name: string | undefined
+): Array<T & { name?: string }> {
+    return items.map((item, i) => {
+        if (i !== index) {
+            return item
+        }
+        return updateOptionalName(item, name)
+    })
+}

--- a/products/workflows/package.json
+++ b/products/workflows/package.json
@@ -6,7 +6,8 @@
         "kea-loaders": "^3.1.1",
         "kea-router": "^3.4.1",
         "kea-subscriptions": "^3.0.1",
-        "posthog-js": "1.297.0"
+        "posthog-js": "1.297.0",
+        "use-debounce": "^9.0.3"
     },
     "peerDependencies": {
         "@posthog/icons": "*",


### PR DESCRIPTION
## Problem

Its hard to parse when you set up conditional branches which branch does what so would be cool to have names

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes


![2025-12-03 15 36 54](https://github.com/user-attachments/assets/d8e7ce1e-7546-4d5c-9154-3c4b5b538281)

- adds names for the conditions of conditinal_branches

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
