### PR TITLE
fix(metalytics): open the right tab

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
@@ -47,7 +47,14 @@ export enum SidePanelActivityTab {
 export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'sidePanelActivityLogic']),
     connect(() => ({
-        values: [sidePanelContextLogic, ['sceneSidePanelContext'], projectLogic, ['currentProjectId']],
+        values: [
+            sidePanelContextLogic,
+            ['sceneSidePanelContext'],
+            projectLogic,
+            ['currentProjectId'],
+            sidePanelStateLogic,
+            ['selectedTabOptions'],
+        ],
         actions: [sidePanelStateLogic, ['openSidePanel']],
     })),
     actions({
@@ -171,5 +178,8 @@ export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([
 
         actions.setContextFromPage(newFilters)
         actions.setActiveFilters(newFilters)
+        if (values.selectedTabOptions) {
+            actions.setActiveTab(values.selectedTabOptions as SidePanelActivityTab)
+        }
     }),
 ])


### PR DESCRIPTION
## Problem

Clicking the flagged "Metalytics" button didn't open the right sidebar activity tab. 

## Changes

Now it does

![2025-12-03 15 36 16](https://github.com/user-attachments/assets/49392b63-39a9-464a-a1e9-e2915a5350f6)

## How did you test this code?

Clicked buttons
