### PR TITLE
fix(experiments): selected variant reset when shipping variant

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -774,12 +774,13 @@ export function ShipVariantModal(): JSX.Element {
     const { aggregationLabel } = useValues(groupsModel)
 
     const [selectedVariantKey, setSelectedVariantKey] = useState<string | null>()
+
     useEffect(() => {
         if (experiment.parameters?.feature_flag_variants?.length > 1) {
             // First test variant selected by default
             setSelectedVariantKey(experiment.parameters.feature_flag_variants[1].key)
         }
-    }, [experiment])
+    }, [experiment.id])
 
     const aggregationTargetName =
         experiment.filters.aggregation_group_type_index != null


### PR DESCRIPTION
## Problem

When selecting a conclusion while shipping a variant, the selected variant resets to the first _non-control_ variant.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

The problem is that `useEffect` compares objects by reference, not value. Each render may create a new reference to an experiment object, causing unnecessary re-runs. We fix this by depending on a primitive compared by value.

| before | after |
| - | - |
| ![default-variant-before](https://github.com/user-attachments/assets/47619b67-8816-46bc-8e17-1928283ca0bb) | ![default-variant-after](https://github.com/user-attachments/assets/044c467d-09de-4a36-aca7-7c4d79ca6195) |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/ee91e23a-b414-4a17-b03b-2d285fda7c6d)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
