### PR TITLE
feat: add ai endpoint quota limiting

### DIFF
--- a/rust/capture/docs/ai-endpoint-parity.md
+++ b/rust/capture/docs/ai-endpoint-parity.md
@@ -1,0 +1,124 @@
+# AI Endpoint Parity Analysis
+
+## Overview
+
+This document compares the `/i/v0/ai` endpoint with the `/i/v0/e` (events) endpoint to identify feature gaps that need to be addressed to bring the AI endpoint to parity.
+
+## Endpoint Comparison
+
+### File References
+- `/i/v0/e` handler: `rust/capture/src/v0_endpoint.rs:118`
+- `/i/v0/ai` handler: `rust/capture/src/ai_endpoint.rs:71`
+- Quota limiter: `rust/capture/src/limiters/mod.rs:17`
+- Token dropper: `rust/capture/src/limiters/token_bucket.rs:1`
+
+## Responsibility Matrix
+
+### Features Only in `/i/v0/e` (Events Endpoint)
+
+| Feature | Description | Priority |
+|---------|-------------|----------|
+| **Quota limiting and billing checks** | Apply quota limiter checks via `state.quota_limiter.check_and_filter()`. Drop events if billing limits are exceeded. | **HIGH** |
+| **Token dropper filtering** | Filter events based on token dropper rules (rate limiting per token + distinct_id basis) | **HIGH** |
+| **Data type routing** | Determine data type routing (AnalyticsMain, AnalyticsHistorical, ClientIngestionWarning, HeatmapMain, ExceptionMain) | **MEDIUM** |
+| **Historical rerouting** | Apply historical rerouting logic based on event timestamp age | **MEDIUM** |
+| Multiple request format support | Support for array, batch, single, engage formats | **LOW** (AI has specific multipart format) |
+| Multiple compression formats | Support GZIP, LZ64, Base64 detection | **LOW** (AI only needs GZIP) |
+| Batch request support | Accept and process multiple events in a single request | **N/A** (AI processes one event per request by design) |
+
+### Features Only in `/i/v0/ai` (AI Endpoint)
+
+| Feature | Description | Notes |
+|---------|-------------|-------|
+| Multipart form-data parsing | Parse and validate multipart requests with events + blobs | AI-specific |
+| Authorization header requirement | Require `Bearer <token>` in Authorization header | AI-specific |
+| AI event type validation | Validate against 6 allowed AI event types: `$ai_generation`, `$ai_trace`, `$ai_span`, `$ai_embedding`, `$ai_metric`, `$ai_feedback` | AI-specific |
+| `$ai_model` property validation | Ensure `$ai_model` is present and non-empty | AI-specific |
+| Blob part handling | Handle blob parts and generate S3 placeholders | AI-specific |
+| Byte range calculation | Calculate byte ranges for blob parts in concatenated format | AI-specific |
+| Content-Type validation per part | Validate Content-Type for each multipart part | AI-specific |
+| Strict size limits per part type | 32KB event, 960KB properties + event, configurable total | AI-specific |
+| Duplicate property name detection | Prevent duplicate property names across parts | AI-specific |
+
+### Features Present in Both
+
+| Feature | Implementation Status |
+|---------|----------------------|
+| Gzip decompression | ✅ Both |
+| Token validation | ✅ Both (format check, reject personal API keys) |
+| Timestamp computation with clock skew correction | ✅ Both |
+| Client IP extraction | ✅ Both |
+| UUID handling | ✅ Both (generate v7 if missing) |
+| Internal event IP redaction | ✅ Both (`capture_internal` property) |
+| Kafka/sink publishing | ✅ Both |
+| Metrics tracking middleware | ✅ Both |
+| CORS handling | ✅ Both |
+| User agent tracking | ✅ Both |
+
+## Critical Gaps for AI Endpoint
+
+### 1. Quota Limiting and Billing Checks (HIGH PRIORITY)
+
+**Current State:** The AI endpoint has no quota or billing limit enforcement.
+
+**How `/e` does it:** Calls `state.quota_limiter.check_and_filter()` on `Vec<RawEvent>` after token validation but before event processing (`v0_endpoint.rs:225-228`). Returns `CaptureError::BillingLimit` if exceeded, which is handled to return 200 OK without sending to Kafka.
+
+**Required Changes:**
+- AI endpoint needs to adapt this for single-event case (not a Vec)
+- Call quota limiter after multipart parsing but before building Kafka event
+- Handle `BillingLimit` error: return 200 OK without sending to Kafka
+- Add appropriate error tracking and metrics
+
+**Impact:** Without this, AI events bypass billing limits and quota enforcement entirely.
+
+### 2. Token Dropper Filtering (HIGH PRIORITY)
+
+**Current State:** The AI endpoint has no token dropper (rate limiting) support.
+
+**How `/e` does it:** After processing events to `ProcessedEvent`, filters the Vec by calling `dropper.should_drop(&token, &distinct_id)` for each event (`v0_endpoint.rs:507-514`). Dropped events are not sent to Kafka and metrics are reported.
+
+**Required Changes:**
+- After building the `ProcessedEvent` in AI endpoint, check `state.token_dropper.should_drop()`
+- If dropped: report metrics via `report_dropped_events("token_dropper", 1)` and return 200 OK without sending to Kafka
+- If not dropped: proceed to send to Kafka as usual
+
+**Impact:** No protection against abuse or rate limiting for AI endpoints.
+
+### 3. Data Type Routing (MEDIUM PRIORITY)
+
+**Current State:** AI endpoint hardcodes `DataType::AnalyticsMain` (`ai_endpoint.rs:278`).
+
+**How `/e` does it:** Routes events based on event name and context (`v0_endpoint.rs:411-417`):
+- `$$client_ingestion_warning` → ClientIngestionWarning
+- `$exception` → ExceptionMain
+- `$$heatmap` → HeatmapMain
+- If `historical_migration=true` → AnalyticsHistorical
+- Otherwise → AnalyticsMain
+
+**Considerations:**
+- AI events have a strict allowlist of 6 event types, none of which are `$$client_ingestion_warning`, `$exception`, or `$$heatmap`
+- Historical migration flag is not exposed in AI endpoint
+- Current hardcoding is likely intentional - AI events don't need special routing
+
+**Required Decision:** Determine if AI events need multi-type routing or if AnalyticsMain is sufficient. Likely can remain as-is.
+
+### 4. Historical Rerouting (MEDIUM PRIORITY)
+
+**Current State:** AI endpoint has no historical data rerouting based on timestamp age. It hardcodes `historical_migration: false` (`ai_endpoint.rs:273`).
+
+**How `/e` does it:** After computing event timestamp, checks `historical_cfg.should_reroute(data_type, computed_timestamp)` which compares event age against a configured threshold (`v0_endpoint.rs:459-466`). Old events get rerouted to `DataType::AnalyticsHistorical`.
+
+**Considerations:**
+- Does the AI use case need historical event support? (e.g., backfilling old AI traces)
+- What is the expected latency for AI event ingestion? (typically real-time)
+- AI events with large blobs may have different performance characteristics for historical processing
+
+**Required Decision:** Determine if historical rerouting is needed for AI events. Likely not needed for initial implementation.
+
+## Notes
+
+- The AI endpoint's unique features (multipart parsing, blob handling, etc.) are intentional and should be preserved
+- Some differences are by design rather than gaps:
+  - **Event type filtering**: `/e` uses denylist (blocks `$performance_event`), AI uses allowlist (only accepts 6 `$ai_*` events)
+  - **Single event vs batch**: AI processes single events, `/e` supports batches
+- Focus parity efforts on security, billing, and abuse prevention features

--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -17,6 +17,7 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::api::{CaptureError, CaptureResponse, CaptureResponseCode};
+use crate::prometheus::report_dropped_events;
 use crate::router::State as AppState;
 use crate::timestamp;
 use crate::token::validate_token;
@@ -42,6 +43,15 @@ pub struct AIEndpointResponse {
 struct BlobPart {
     name: String,
     data: Bytes,
+}
+
+/// Metadata extracted from the event part for early checks (token dropper, quota)
+#[derive(Debug)]
+struct EventMetadata {
+    event_name: String,
+    distinct_id: String,
+    event_json: Value,
+    event_part_info: PartInfo,
 }
 
 /// Raw multipart parts retrieved from the request
@@ -132,25 +142,41 @@ pub async fn ai_handler(
     let token = &auth_header[7..]; // Remove "Bearer " prefix
     validate_token(token)?;
 
-    // Step 1: Retrieve and validate multipart parts
+    // Step 1: Retrieve event metadata (parses only the first 'event' part)
+    let event_metadata = retrieve_event_metadata(&decompressed_body, &boundary).await?;
+
+    // Step 2: Check token dropper early - before parsing remaining parts
+    if state
+        .token_dropper
+        .should_drop(token, &event_metadata.distinct_id)
+    {
+        report_dropped_events("token_dropper", 1);
+        // Return success to prevent client retries (matches v0 behavior)
+        return Ok(Json(AIEndpointResponse {
+            accepted_parts: vec![event_metadata.event_part_info],
+        }));
+    }
+
+    // Step 3: Retrieve and validate remaining multipart parts
     let parts = retrieve_multipart_parts(
         &decompressed_body,
         &boundary,
         state.ai_max_sum_of_parts_bytes,
+        event_metadata,
     )
     .await?;
 
-    // Step 2: Parse the parts and build event with blob placeholders
+    // Step 4: Parse the parts and build event with blob placeholders
     let parsed = parse_multipart_data(parts)?;
 
-    // Step 3: Build Kafka event
+    // Step 5: Build Kafka event
     // Extract IP address, defaulting to 127.0.0.1 if not available (e.g., in tests)
     let client_ip = ip
         .map(|InsecureClientIp(addr)| addr.to_string())
         .unwrap_or_else(|| "127.0.0.1".to_string());
     let (accepted_parts, processed_event) = build_kafka_event(parsed, token, &client_ip, &state)?;
 
-    // Step 4: Send event to Kafka
+    // Step 5: Send event to Kafka
     state.sink.send(processed_event).await.map_err(|e| {
         warn!("Failed to send AI event to Kafka: {:?}", e);
         e
@@ -192,6 +218,78 @@ fn decompress_gzip(compressed: &Bytes) -> Result<Bytes, CaptureError> {
         decompressed.len()
     );
     Ok(Bytes::from(decompressed))
+}
+
+/// Retrieve event metadata from the first multipart part for early checks.
+/// This parses only the 'event' part to extract event_name and distinct_id
+/// before processing the rest of the multipart body.
+async fn retrieve_event_metadata(body: &[u8], boundary: &str) -> Result<EventMetadata, CaptureError> {
+    // Create a stream from the body data
+    let body_owned = body.to_vec();
+    let body_stream = stream::once(async move { Ok::<Vec<u8>, std::io::Error>(body_owned) });
+
+    // Create multipart parser
+    let mut multipart = Multipart::new(body_stream, boundary);
+
+    // Get the first field - must be 'event'
+    let field = multipart
+        .next_field()
+        .await
+        .map_err(|e| {
+            warn!("Multipart parsing error: {}", e);
+            CaptureError::RequestDecodingError(format!("Multipart parsing failed: {e}"))
+        })?
+        .ok_or_else(|| {
+            CaptureError::RequestParsingError("Missing required 'event' part in multipart data".to_string())
+        })?;
+
+    let field_name = field.name().unwrap_or("unknown").to_string();
+    let content_type = field.content_type().map(|ct| ct.to_string());
+    let content_encoding = field
+        .headers()
+        .get("content-encoding")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    // Validate that the first part is the event part
+    if field_name != "event" {
+        return Err(CaptureError::RequestParsingError(format!(
+            "First part must be 'event', got '{field_name}'"
+        )));
+    }
+
+    // Read the field data
+    let field_data = field.bytes().await.map_err(|e| {
+        warn!("Failed to read event field data: {}", e);
+        CaptureError::RequestDecodingError(format!("Failed to read field data: {e}"))
+    })?;
+
+    // Process the event part
+    let (event_json, event_part_info) = process_event_part(field_data, content_type, content_encoding)?;
+
+    // Extract event_name and distinct_id
+    let event_obj = event_json.as_object().ok_or_else(|| {
+        CaptureError::RequestParsingError("Event must be a JSON object".to_string())
+    })?;
+
+    let event_name = event_obj
+        .get("event")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| CaptureError::RequestParsingError("Event missing 'event' field".to_string()))?
+        .to_string();
+
+    let distinct_id = event_obj
+        .get("distinct_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| CaptureError::RequestParsingError("Event missing 'distinct_id' field".to_string()))?
+        .to_string();
+
+    Ok(EventMetadata {
+        event_name,
+        distinct_id,
+        event_json,
+        event_part_info,
+    })
 }
 
 /// Validate blob part content type
@@ -406,11 +504,13 @@ fn process_blob_part(
     Ok((blob_part, part_info))
 }
 
-/// Retrieve and validate multipart parts from the request body
+/// Retrieve and validate multipart parts from the request body.
+/// The event metadata (first part) has already been parsed by retrieve_event_metadata.
 async fn retrieve_multipart_parts(
     body: &[u8],
     boundary: &str,
     max_sum_of_parts_bytes: usize,
+    event_metadata: EventMetadata,
 ) -> Result<RetrievedMultipartParts, CaptureError> {
     // Size limits
     const MAX_COMBINED_SIZE: usize = 1024 * 1024 - 64 * 1024; // 1MB - 64KB = 960KB
@@ -423,16 +523,16 @@ async fn retrieve_multipart_parts(
     let mut multipart = Multipart::new(body_stream, boundary);
 
     let mut part_count = 0;
-    let mut has_event_part = false;
-    let mut first_part_processed = false;
     let mut accepted_parts = Vec::new();
     let mut seen_property_names = HashSet::new();
     let mut blob_parts: Vec<BlobPart> = Vec::new();
-    let mut event_json: Option<Value> = None;
     let mut properties_json: Option<Value> = None;
-    let mut event_size: usize = 0;
+    let event_size: usize = event_metadata.event_part_info.length;
     let mut properties_size: usize = 0;
-    let mut sum_of_parts_bytes: usize = 0;
+    let mut sum_of_parts_bytes: usize = event_size;
+
+    // Add the pre-parsed event part info
+    accepted_parts.push(event_metadata.event_part_info);
 
     // Parse each part
     while let Some(field) = multipart.next_field().await.map_err(|e| {
@@ -455,18 +555,11 @@ async fn retrieve_multipart_parts(
             field_name, part_count
         );
 
-        // Check if this is the first part
-        if !first_part_processed {
-            first_part_processed = true;
-
-            // Validate that the first part is the event part
-            if field_name != "event" {
-                return Err(CaptureError::RequestParsingError(format!(
-                    "First part must be 'event', got '{field_name}'"
-                )));
-            }
-
-            debug!("First part is 'event' as expected");
+        // Skip the event part - already processed in retrieve_event_metadata
+        if field_name == "event" {
+            // Consume the field data but don't process it again
+            drop(field.bytes().await);
+            continue;
         }
 
         // Read the field data to get the length (this consumes the field)
@@ -479,14 +572,7 @@ async fn retrieve_multipart_parts(
         sum_of_parts_bytes += field_data.len();
 
         // Process based on field name
-        if field_name == "event" {
-            has_event_part = true;
-            event_size = field_data.len();
-            let (event, part_info) =
-                process_event_part(field_data, content_type, content_encoding)?;
-            event_json = Some(event);
-            accepted_parts.push(part_info);
-        } else if field_name == "event.properties" {
+        if field_name == "event.properties" {
             properties_size = field_data.len();
             let (properties, part_info) =
                 process_properties_part(field_data, content_type, content_encoding)?;
@@ -528,13 +614,6 @@ async fn retrieve_multipart_parts(
         }
     }
 
-    // Validate that we have at least the event part
-    if !has_event_part {
-        return Err(CaptureError::RequestParsingError(
-            "Missing required 'event' part in multipart data".to_string(),
-        ));
-    }
-
     // Check combined size limit
     let combined_size = event_size + properties_size;
     if combined_size > MAX_COMBINED_SIZE {
@@ -550,8 +629,8 @@ async fn retrieve_multipart_parts(
         )));
     }
 
-    // Merge properties into the event
-    let event = event_json.unwrap();
+    // Use the event JSON from the pre-parsed metadata
+    let event = event_metadata.event_json;
 
     // Check for conflicting properties sources
     let has_embedded_properties = event

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -224,7 +224,7 @@ async fn handle_event_payload(
     debug!(context=?context, event_count=?events.len(), "handle_event_payload: evaluating quota limits");
     events = state
         .quota_limiter
-        .check_and_filter(&context, events)
+        .check_and_filter(&context.token, events)
         .await?;
 
     debug!(context=?context,

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -2509,8 +2509,7 @@ async fn test_ai_endpoint_token_dropper_returns_billing_limit_error_message() {
     let response_text = response.text().await;
     assert!(
         response_text.contains("billing limit"),
-        "Response should contain 'billing limit' error message, got: {}",
-        response_text
+        "Response should contain 'billing limit' error message, got: {response_text}"
     );
 }
 
@@ -2645,7 +2644,6 @@ async fn test_ai_endpoint_quota_limiter_returns_billing_limit_error_message() {
     let response_text = response.text().await;
     assert!(
         response_text.contains("billing limit"),
-        "Response should contain 'billing limit' error message, got: {}",
-        response_text
+        "Response should contain 'billing limit' error message, got: {response_text}"
     );
 }

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -2332,9 +2332,7 @@ async fn test_ai_event_with_valid_sent_at_applies_clock_skew_correction() {
 // ----------------------------------------------------------------------------
 
 // Helper to setup test router with custom TokenDropper and CapturingSink
-fn setup_ai_test_router_with_token_dropper(
-    token_dropper: TokenDropper,
-) -> (Router, CapturingSink) {
+fn setup_ai_test_router_with_token_dropper(token_dropper: TokenDropper) -> (Router, CapturingSink) {
     let liveness = HealthRegistry::new("ai_endpoint_tests");
     let sink = CapturingSink::new();
     let sink_clone = sink.clone();
@@ -2532,10 +2530,13 @@ fn setup_ai_test_router_with_llm_quota_limited(token: &str) -> (Router, Capturin
     };
 
     // Set up mock Redis to return this token as limited for LLM events
-    let llm_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, QuotaResource::LLMEvents.as_str());
-    let redis = Arc::new(
-        MockRedisClient::new().zrangebyscore_ret(&llm_key, vec![token.to_string()]),
+    let llm_key = format!(
+        "{}{}",
+        QUOTA_LIMITER_CACHE_KEY,
+        QuotaResource::LLMEvents.as_str()
     );
+    let redis =
+        Arc::new(MockRedisClient::new().zrangebyscore_ret(&llm_key, vec![token.to_string()]));
 
     let mut cfg = DEFAULT_CONFIG.clone();
     cfg.capture_mode = CaptureMode::Events;

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -2389,8 +2389,8 @@ async fn test_ai_endpoint_token_dropper_drops_matching_token() {
     // Use the dropped token
     let response = send_multipart_request(&test_client, form, Some("phc_dropped_token")).await;
 
-    // Should return 200 OK (silently dropped)
-    assert_eq!(response.status(), StatusCode::OK);
+    // Should return 429 Too Many Requests (billing limit)
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
 
     // Verify no event was published to Kafka
     let events = sink.get_events().await;
@@ -2449,8 +2449,8 @@ async fn test_ai_endpoint_token_dropper_drops_matching_token_and_distinct_id() {
 
     let response = send_multipart_request(&test_client, form, Some("phc_specific_token")).await;
 
-    // Should return 200 OK (silently dropped)
-    assert_eq!(response.status(), StatusCode::OK);
+    // Should return 429 Too Many Requests (billing limit)
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
 
     // Verify no event was published
     let events = sink.get_events().await;
@@ -2489,7 +2489,7 @@ async fn test_ai_endpoint_token_dropper_allows_different_distinct_id() {
 }
 
 #[tokio::test]
-async fn test_ai_endpoint_token_dropper_returns_accepted_parts_on_drop() {
+async fn test_ai_endpoint_token_dropper_returns_billing_limit_error_message() {
     // Configure token dropper to drop all events for a specific token
     let token_dropper = TokenDropper::new("phc_dropped_token");
     let (router, _sink) = setup_ai_test_router_with_token_dropper(token_dropper);
@@ -2503,13 +2503,149 @@ async fn test_ai_endpoint_token_dropper_returns_accepted_parts_on_drop() {
 
     let response = send_multipart_request(&test_client, form, Some("phc_dropped_token")).await;
 
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    // Verify response body contains billing limit error message
+    let response_text = response.text().await;
+    assert!(
+        response_text.contains("billing limit"),
+        "Response should contain 'billing limit' error message, got: {}",
+        response_text
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Quota Limiter Tests
+// ----------------------------------------------------------------------------
+
+use capture::limiters::is_llm_event;
+use limiters::redis::{QuotaResource, QUOTA_LIMITER_CACHE_KEY};
+
+// Helper to setup test router with quota limiter configured to limit AI events
+fn setup_ai_test_router_with_llm_quota_limited(token: &str) -> (Router, CapturingSink) {
+    let liveness = HealthRegistry::new("ai_endpoint_tests");
+    let sink = CapturingSink::new();
+    let sink_clone = sink.clone();
+    let timesource = FixedTime {
+        time: DateTime::parse_from_rfc3339(DEFAULT_TEST_TIME)
+            .expect("Invalid fixed time format")
+            .with_timezone(&Utc),
+    };
+
+    // Set up mock Redis to return this token as limited for LLM events
+    let llm_key = format!("{}{}", QUOTA_LIMITER_CACHE_KEY, QuotaResource::LLMEvents.as_str());
+    let redis = Arc::new(
+        MockRedisClient::new().zrangebyscore_ret(&llm_key, vec![token.to_string()]),
+    );
+
+    let mut cfg = DEFAULT_CONFIG.clone();
+    cfg.capture_mode = CaptureMode::Events;
+
+    let quota_limiter = CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60))
+        .add_scoped_limiter(QuotaResource::LLMEvents, Box::new(is_llm_event));
+
+    let router = router(
+        timesource,
+        liveness,
+        sink,
+        redis,
+        quota_limiter,
+        TokenDropper::default(),
+        false,
+        CaptureMode::Events,
+        None,
+        25 * 1024 * 1024,
+        false,
+        1_i64,
+        false,
+        0.0_f32,
+        26_214_400,
+        Some(10),
+    );
+
+    (router, sink_clone)
+}
+
+#[tokio::test]
+async fn test_ai_endpoint_quota_limiter_drops_when_over_quota() {
+    let limited_token = "phc_limited_token_for_quota";
+    let (router, sink) = setup_ai_test_router_with_llm_quota_limited(limited_token);
+    let test_client = TestClient::new(router);
+
+    let properties = json!({
+        "$ai_model": "gpt-4"
+    });
+
+    let form = create_ai_event_form("$ai_generation", "test_user", properties);
+
+    // Use the token that is over quota
+    let response = send_multipart_request(&test_client, form, Some(limited_token)).await;
+
+    // Should return 429 Too Many Requests (billing limit)
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    // Verify no event was published to Kafka
+    let events = sink.get_events().await;
+    assert_eq!(
+        events.len(),
+        0,
+        "Event should be dropped when token is over LLM quota"
+    );
+}
+
+#[tokio::test]
+async fn test_ai_endpoint_quota_limiter_allows_when_not_over_quota() {
+    // Set up quota limiter with a different token limited
+    let limited_token = "phc_other_limited_token";
+    let (router, sink) = setup_ai_test_router_with_llm_quota_limited(limited_token);
+    let test_client = TestClient::new(router);
+
+    let properties = json!({
+        "$ai_model": "gpt-4"
+    });
+
+    let form = create_ai_event_form("$ai_generation", "test_user", properties);
+
+    // Use a different token that is NOT over quota
+    let response = send_multipart_request(
+        &test_client,
+        form,
+        Some("phc_VXRzc3poSG9GZm1JenRianJ6TTJFZGh4OWY2QXzx9f3"),
+    )
+    .await;
+
     assert_eq!(response.status(), StatusCode::OK);
 
-    // Verify response still contains accepted_parts (for the event part that was parsed)
-    let response_json: serde_json::Value = response.json::<serde_json::Value>().await;
-    assert!(response_json["accepted_parts"].is_array());
-    let accepted_parts = response_json["accepted_parts"].as_array().unwrap();
-    // Should have 1 part (event) since we dropped early before processing blobs
-    assert_eq!(accepted_parts.len(), 1);
-    assert_eq!(accepted_parts[0]["name"], "event");
+    // Verify event WAS published to Kafka
+    let events = sink.get_events().await;
+    assert_eq!(
+        events.len(),
+        1,
+        "Event should be published when token is not over quota"
+    );
+}
+
+#[tokio::test]
+async fn test_ai_endpoint_quota_limiter_returns_billing_limit_error_message() {
+    let limited_token = "phc_quota_limited_token";
+    let (router, _sink) = setup_ai_test_router_with_llm_quota_limited(limited_token);
+    let test_client = TestClient::new(router);
+
+    let properties = json!({
+        "$ai_model": "gpt-4"
+    });
+
+    let form = create_ai_event_form("$ai_generation", "test_user", properties);
+
+    let response = send_multipart_request(&test_client, form, Some(limited_token)).await;
+
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    // Verify response body contains billing limit error message
+    let response_text = response.text().await;
+    assert!(
+        response_text.contains("billing limit"),
+        "Response should contain 'billing limit' error message, got: {}",
+        response_text
+    );
 }

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -2,7 +2,6 @@
 mod integration_utils;
 use integration_utils::DEFAULT_CONFIG;
 
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -11,7 +10,6 @@ use axum::http::StatusCode;
 use axum::Router;
 use axum_test_helper::TestClient;
 use common_redis::MockRedisClient;
-use common_types::RawEvent;
 use health::HealthRegistry;
 use limiters::redis::{QuotaResource, QUOTA_LIMITER_CACHE_KEY};
 use limiters::token_dropper::TokenDropper;
@@ -182,32 +180,11 @@ fn extract_captured_event_names(events: &[ProcessedEvent]) -> Vec<String> {
         .collect()
 }
 
-// only useful in ScopedLimiter predicate (event_matcher) tests
-fn gen_stub_events(names: &[&str]) -> Vec<RawEvent> {
-    let mut out = vec![];
-
-    for name in names {
-        out.push(RawEvent {
-            event: name.to_string(),
-            token: Some("test_token".to_string()),
-            distinct_id: Some(Value::String("test_distinct_id".to_string())),
-            uuid: None,
-            properties: HashMap::new(),
-            timestamp: None,
-            offset: None,
-            set: None,
-            set_once: None,
-        });
-    }
-
-    out
-}
-
 #[tokio::test]
 async fn test_exception_predicate() {
     let should_accept_names = vec!["$exception"];
     for name in should_accept_names {
-        assert!(is_exception_event(name), "event {} should be accepted", name);
+        assert!(is_exception_event(name), "event {name} should be accepted");
     }
 
     let should_reject_names = vec![
@@ -222,8 +199,7 @@ async fn test_exception_predicate() {
     for name in should_reject_names {
         assert!(
             !is_exception_event(name),
-            "event {} should not be accepted",
-            name
+            "event {name} should not be accepted"
         );
     }
 }
@@ -240,7 +216,7 @@ async fn test_llm_predicate() {
         "$ai_feedback",
     ];
     for name in should_accept_names {
-        assert!(is_llm_event(name), "event {} should be accepted", name);
+        assert!(is_llm_event(name), "event {name} should be accepted");
     }
 
     let should_reject_names = vec![
@@ -255,8 +231,7 @@ async fn test_llm_predicate() {
     for name in should_reject_names {
         assert!(
             !is_llm_event(name),
-            "event {} should not be accepted",
-            name
+            "event {name} should not be accepted"
         );
     }
 }
@@ -265,7 +240,7 @@ async fn test_llm_predicate() {
 async fn test_survey_predicate() {
     let should_accept_names = vec!["survey sent", "survey shown", "survey dismissed"];
     for name in should_accept_names {
-        assert!(is_survey_event(name), "event {} should be accepted", name);
+        assert!(is_survey_event(name), "event {name} should be accepted");
     }
 
     let should_reject_names = vec![
@@ -283,8 +258,7 @@ async fn test_survey_predicate() {
     for name in should_reject_names {
         assert!(
             !is_survey_event(name),
-            "event {} should not be accepted",
-            name
+            "event {name} should not be accepted"
         );
     }
 }

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -229,10 +229,7 @@ async fn test_llm_predicate() {
         "ai_generation",
     ];
     for name in should_reject_names {
-        assert!(
-            !is_llm_event(name),
-            "event {name} should not be accepted"
-        );
+        assert!(!is_llm_event(name), "event {name} should not be accepted");
     }
 }
 

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -206,13 +206,8 @@ fn gen_stub_events(names: &[&str]) -> Vec<RawEvent> {
 #[tokio::test]
 async fn test_exception_predicate() {
     let should_accept_names = vec!["$exception"];
-    let should_accept_events = gen_stub_events(&should_accept_names);
-    for event in should_accept_events {
-        assert!(
-            is_exception_event(&event),
-            "event {} should be accepted",
-            event.event
-        );
+    for name in should_accept_names {
+        assert!(is_exception_event(name), "event {} should be accepted", name);
     }
 
     let should_reject_names = vec![
@@ -224,12 +219,11 @@ async fn test_exception_predicate() {
         "exceptional_event",
         "$exceptable",
     ];
-    let should_reject_events = gen_stub_events(&should_reject_names);
-    for event in should_reject_events {
+    for name in should_reject_names {
         assert!(
-            !is_exception_event(&event),
+            !is_exception_event(name),
             "event {} should not be accepted",
-            event.event
+            name
         );
     }
 }
@@ -245,13 +239,8 @@ async fn test_llm_predicate() {
         "$ai_metric",
         "$ai_feedback",
     ];
-    let should_accept_events = gen_stub_events(&should_accept_names);
-    for event in should_accept_events {
-        assert!(
-            is_llm_event(&event),
-            "event {} should be accepted",
-            event.event
-        );
+    for name in should_accept_names {
+        assert!(is_llm_event(name), "event {} should be accepted", name);
     }
 
     let should_reject_names = vec![
@@ -263,12 +252,11 @@ async fn test_llm_predicate() {
         "ai_span",
         "ai_generation",
     ];
-    let should_reject_events = gen_stub_events(&should_reject_names);
-    for event in should_reject_events {
+    for name in should_reject_names {
         assert!(
-            !is_llm_event(&event),
+            !is_llm_event(name),
             "event {} should not be accepted",
-            event.event
+            name
         );
     }
 }
@@ -276,13 +264,8 @@ async fn test_llm_predicate() {
 #[tokio::test]
 async fn test_survey_predicate() {
     let should_accept_names = vec!["survey sent", "survey shown", "survey dismissed"];
-    let should_accept_events = gen_stub_events(&should_accept_names);
-    for event in should_accept_events {
-        assert!(
-            is_survey_event(&event),
-            "event {} should be accepted",
-            event.event
-        );
+    for name in should_accept_names {
+        assert!(is_survey_event(name), "event {} should be accepted", name);
     }
 
     let should_reject_names = vec![
@@ -297,12 +280,11 @@ async fn test_survey_predicate() {
         "survey_shown",
         "survey_dismissed",
     ];
-    let should_reject_events = gen_stub_events(&should_reject_names);
-    for event in should_reject_events {
+    for name in should_reject_names {
         assert!(
-            !is_survey_event(&event),
+            !is_survey_event(name),
             "event {} should not be accepted",
-            event.event
+            name
         );
     }
 }

--- a/rust/common/types/src/event.rs
+++ b/rust/common/types/src/event.rs
@@ -9,6 +9,11 @@ use serde_json::Value;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use uuid::Uuid;
 
+/// Trait for types that have an event name, used by quota limiting
+pub trait HasEventName {
+    fn event_name(&self) -> &str;
+}
+
 /// Information about the library/SDK that sent an event
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LibraryInfo {
@@ -293,6 +298,12 @@ impl ClickHouseEvent {
     ) -> Result<(), serde_json::Error> {
         self.properties = Some(serde_json::to_string(&properties)?);
         Ok(())
+    }
+}
+
+impl HasEventName for RawEvent {
+    fn event_name(&self) -> &str {
+        &self.event
     }
 }
 

--- a/rust/common/types/src/lib.rs
+++ b/rust/common/types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod timestamp;
 pub use event::CapturedEvent;
 pub use event::CapturedEventHeaders;
 pub use event::ClickHouseEvent;
+pub use event::HasEventName;
 pub use event::InternallyCapturedEvent;
 pub use event::PersonMode;
 pub use event::RawEngageEvent;


### PR DESCRIPTION
## Problem

We don't have quota limiting in the AI endpoint and because of that we can't expose it in production.

## Changes

- Refactors the quota limiter interface
- Adds quota limiter to the ai endpoint
- Adds token dropper support to the ai endpoint

## How did you test this code?

- Added new tests
- Existing integration tests