### PR TITLE
fix(workflows): dont bill for hogflow invocations

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -216,7 +216,7 @@ describe.each([
                                 app_source_id: fnFetchNoFilters.id,
                                 count: 1,
                                 metric_kind: 'billing',
-                                metric_name: 'cre_invocation',
+                                metric_name: 'billable_invocation',
                                 team_id: 2,
                                 timestamp: expect.any(String),
                             },

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -375,15 +375,6 @@ export class CdpEventsConsumer extends CdpConsumerBase {
                 metric_name: 'triggered',
                 count: 1,
             })
-
-            // TODO(workflows): Re-add hogflow billable_invocation metric when we have per-step pricing finalized
-            // triggeredInvocationsMetrics.push({
-            //     team_id: item.teamId,
-            //     app_source_id: item.functionId,
-            //     metric_kind: 'billing',
-            //     metric_name: 'billable_invocation',
-            //     count: 1,
-            // })
         })
 
         this.hogFunctionMonitoringService.queueAppMetrics(triggeredInvocationsMetrics, 'hog_flow')

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -376,13 +376,14 @@ export class CdpEventsConsumer extends CdpConsumerBase {
                 count: 1,
             })
 
-            triggeredInvocationsMetrics.push({
-                team_id: item.teamId,
-                app_source_id: item.functionId,
-                metric_kind: 'billing',
-                metric_name: 'billable_invocation',
-                count: 1,
-            })
+            // TODO(workflows): Re-add hogflow billable_invocation metric when we have per-step pricing finalized
+            // triggeredInvocationsMetrics.push({
+            //     team_id: item.teamId,
+            //     app_source_id: item.functionId,
+            //     metric_kind: 'billing',
+            //     metric_name: 'billable_invocation',
+            //     count: 1,
+            // })
         })
 
         this.hogFunctionMonitoringService.queueAppMetrics(triggeredInvocationsMetrics, 'hog_flow')


### PR DESCRIPTION
## Problem

When we first set up hogflow invocations, we left a per-hogflow-invocation billable metric. This should not be there and doesn't reflect the pricing model we've decided on anyway

## Changes

Remove the metric for hogflow invocations, leaving the hogfunction one

## How did you test this code?

added test