### PR TITLE
fix: Docs links need to be absolute

### DIFF
--- a/docs/onboarding/llm-analytics/anthropic.tsx
+++ b/docs/onboarding/llm-analytics/anthropic.tsx
@@ -63,7 +63,7 @@ export const AnthropicInstallation = (): JSX.Element => {
                         These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
                         background to send the data. You can also use LLM analytics with other SDKs or our API, but you
                         will need to capture the data in the right format. See the schema in the [manual capture
-                        section](/docs/llm-analytics/installation/manual-capture) for more details.
+                        section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
                     </Markdown>
                 </CalloutBox>
             </Step>
@@ -187,7 +187,7 @@ export const AnthropicInstallation = (): JSX.Element => {
                         - This also works when message streams are used (e.g. \`stream=True\` or \`client.messages.stream(...)\`).
                         - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
 
-                        See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more.
+                        See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         `}
                     </Markdown>
                 </Blockquote>
@@ -213,7 +213,7 @@ export const AnthropicInstallation = (): JSX.Element => {
                             | \`$ai_output_choices\` | List of response choices from the LLM |
                             | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
                             | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](/docs/llm-analytics/generations#event-properties) | See [full list](/docs/llm-analytics/generations#event-properties) of properties|
+                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
                         `}
                     </Markdown>
                 )}

--- a/docs/onboarding/llm-analytics/google.tsx
+++ b/docs/onboarding/llm-analytics/google.tsx
@@ -71,7 +71,7 @@ export const GoogleInstallation = (): JSX.Element => {
                     <Markdown>
                         These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the background to send the data.
 
-                        You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](/docs/llm-analytics/installation/manual-capture) for more details.
+                        You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
                     </Markdown>
                 </CalloutBox>
             </Step>
@@ -249,7 +249,7 @@ export const GoogleInstallation = (): JSX.Element => {
 
                 <Blockquote>
                     <Markdown>
-                        **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more.
+                        **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                     </Markdown>
                 </Blockquote>
 
@@ -274,7 +274,7 @@ export const GoogleInstallation = (): JSX.Element => {
                             | \`$ai_output_choices\` | List of response choices from the LLM |
                             | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
                             | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](/docs/llm-analytics/generations#event-properties) | See [full list](/docs/llm-analytics/generations#event-properties) of properties|
+                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
                         `}
                     </Markdown>
                 )}

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -71,7 +71,7 @@ export const LangChainInstallation = (): JSX.Element => {
                     <Markdown>
                         These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the background to send the data.
 
-                        You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](/docs/llm-analytics/installation/manual-capture) for more details.
+                        You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
                     </Markdown>
                 </CalloutBox>
             </Step>
@@ -80,7 +80,7 @@ export const LangChainInstallation = (): JSX.Element => {
                 <Markdown>
                     Initialize PostHog with your project API key and host from [your project settings](https://app.posthog.com/settings/project), then pass it to the LangChain `CallbackHandler` wrapper.
 
-                    Optionally, you can provide a user distinct ID, trace ID, PostHog properties, [groups](/docs/product-analytics/group-analytics), and privacy mode.
+                    Optionally, you can provide a user distinct ID, trace ID, PostHog properties, [groups](https://posthog.com/docs/product-analytics/group-analytics), and privacy mode.
                 </Markdown>
 
                 <CodeBlock
@@ -139,7 +139,7 @@ export const LangChainInstallation = (): JSX.Element => {
 
                 <Blockquote>
                     <Markdown>
-                        **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the `CallbackHandler`. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more.
+                        **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the `CallbackHandler`. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                     </Markdown>
                 </Blockquote>
             </Step>
@@ -219,7 +219,7 @@ export const LangChainInstallation = (): JSX.Element => {
                             | \`$ai_output_choices\` | List of response choices from the LLM |
                             | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
                             | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](/docs/llm-analytics/generations#event-properties) | See [full list](/docs/llm-analytics/generations#event-properties) of properties|
+                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
                         `}
                     </Markdown>
                 )}

--- a/docs/onboarding/llm-analytics/litellm.tsx
+++ b/docs/onboarding/llm-analytics/litellm.tsx
@@ -148,7 +148,7 @@ export const LiteLLMInstallation = (): JSX.Element => {
                             - To disable logging for specific requests, add \`{"no-log": true}\` to metadata.
                             - If you want to capture LLM events anonymously, **don't** pass a \`user_id\` in metadata.
 
-                            See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more.
+                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         `}
                     </Markdown>
                 </Blockquote>
@@ -174,7 +174,7 @@ export const LiteLLMInstallation = (): JSX.Element => {
                             | \`$ai_output_choices\` | List of response choices from the LLM |
                             | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
                             | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](/docs/llm-analytics/generations#event-properties) | See [full list](/docs/llm-analytics/generations#event-properties) of properties|
+                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
                         `}
                     </Markdown>
                 )}

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -118,7 +118,7 @@ export const OpenAIInstallation = (): JSX.Element => {
                         These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
                         background to send the data. You can also use LLM analytics with other SDKs or our API, but you
                         will need to capture the data in the right format. See the schema in the [manual capture
-                        section](/docs/llm-analytics/installation/manual-capture) for more details.
+                        section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
                     </Markdown>
                 </CalloutBox>
             </Step>
@@ -179,7 +179,7 @@ export const OpenAIInstallation = (): JSX.Element => {
                         - This works with responses where \`stream=True\`.
                         - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
 
-                        See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more.
+                        See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         `}
                     </Markdown>
                 </Blockquote>
@@ -198,7 +198,7 @@ export const OpenAIInstallation = (): JSX.Element => {
                         | \`$ai_output_choices\` | List of response choices from the LLM |
                         | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
                         | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                        | [[...]](/docs/llm-analytics/generations#event-properties) | See [full list](/docs/llm-analytics/generations#event-properties) of properties |
+                        | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties |
                     `}
                 </Markdown>
             </Step>

--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -121,7 +121,7 @@ export const OpenRouterInstallation = (): JSX.Element => {
                         These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
                         background to send the data. You can also use LLM analytics with other SDKs or our API, but you
                         will need to capture the data in the right format. See the schema in the [manual capture
-                        section](/docs/llm-analytics/installation/manual-capture) for more details.
+                        section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
                     </Markdown>
                 </CalloutBox>
             </Step>
@@ -182,7 +182,7 @@ export const OpenRouterInstallation = (): JSX.Element => {
                         - This works with responses where \`stream=True\`.
                         - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
 
-                        See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more.
+                        See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         `}
                     </Markdown>
                 </Blockquote>
@@ -208,7 +208,7 @@ export const OpenRouterInstallation = (): JSX.Element => {
                             | \`$ai_output_choices\` | List of response choices from the LLM |
                             | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
                             | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](/docs/llm-analytics/generations#event-properties) | See [full list](/docs/llm-analytics/generations#event-properties) of properties|
+                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
                         `}
                     </Markdown>
                 )}

--- a/docs/onboarding/llm-analytics/vercel-ai.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai.tsx
@@ -47,7 +47,7 @@ export const VercelAIInstallation = (): JSX.Element => {
                     <Markdown>
                         These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the background to send the data.
 
-                        You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](/docs/llm-analytics/installation/manual-capture) for more details.
+                        You can also use LLM analytics with other SDKs or our API, but you will need to capture the data in the right format. See the schema in the [manual capture section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more details.
                     </Markdown>
                 </CalloutBox>
             </Step>
@@ -113,7 +113,7 @@ export const VercelAIInstallation = (): JSX.Element => {
 
                 <Blockquote>
                     <Markdown>
-                        **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more.
+                        **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                     </Markdown>
                 </Blockquote>
 
@@ -138,7 +138,7 @@ export const VercelAIInstallation = (): JSX.Element => {
                             | \`$ai_output_choices\` | List of response choices from the LLM |
                             | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
                             | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](/docs/llm-analytics/generations#event-properties) | See [full list](/docs/llm-analytics/generations#event-properties) of properties|
+                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
                         `}
                     </Markdown>
                 )}


### PR DESCRIPTION
## Problem

Some links are broken in the new LLMA onboarding :oops: 

## Changes

Updates a bunch of docs links to be absolute 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
