### PR TITLE
fix(celery): convert interval schedules to cron to survive beat restarts

### DIFF
--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
@@ -241,7 +241,7 @@
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
          max(s.retention_period_days) AS retention_period_days,
-         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 21))) AS expiry_time,
+         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 30))) AS expiry_time,
          dateDiff('DAY', toDateTime64('2021-08-21 20:00:00.000000', 6, 'UTC'), expiry_time) AS recording_ttl,
          greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2021-08-21 19:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
@@ -292,7 +292,7 @@
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
          max(s.retention_period_days) AS retention_period_days,
-         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 21))) AS expiry_time,
+         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 30))) AS expiry_time,
          dateDiff('DAY', toDateTime64('2021-08-21 20:00:00.000000', 6, 'UTC'), expiry_time) AS recording_ttl,
          greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2021-08-21 19:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -53,3 +53,10 @@ CLEAR_CLICKHOUSE_DELETED_PERSON_SCHEDULE_CRON = get_from_env(
     # Every third month 5AM UTC on 1st of the month
     "0 5 1 */3 *",
 )
+
+# Schedule to count items in playlists. Follows crontab syntax.
+PLAYLIST_COUNTER_SCHEDULE_CRON = get_from_env(
+    "PLAYLIST_COUNTER_SCHEDULE_CRON",
+    # Defaults to every hour at minute 30
+    "30 * * * *",
+)

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -71,35 +71,83 @@ DELAYED_ORGS_EU: list[str] = [
 DELAYED_ORGS_US: list[str] = []
 
 
+def estimate_crontab_interval_seconds(schedule: crontab) -> int:
+    """
+    Estimate interval between crontab executions from the expanded time sets.
+
+    Works by analyzing the crontab's minute/hour/day sets to find the smallest
+    gap between consecutive executions. Handles wrap-around (e.g., minute 50 to 0).
+    """
+    minutes = sorted(schedule.minute)
+    hours = sorted(schedule.hour)
+    days_of_week = sorted(schedule.day_of_week)
+    days_of_month = sorted(schedule.day_of_month)
+
+    all_hours = len(hours) == 24
+    all_days = len(days_of_week) == 7 and len(days_of_month) == 31
+
+    if all_hours and all_days:
+        # Interval is based on minutes
+        if len(minutes) == 60:
+            return 60  # every minute
+        elif len(minutes) > 1:
+            # Find smallest gap between consecutive minutes (including wrap-around)
+            gaps = [minutes[i + 1] - minutes[i] for i in range(len(minutes) - 1)]
+            gaps.append(60 - minutes[-1] + minutes[0])
+            return min(gaps) * 60
+        else:
+            return 3600  # single minute = hourly
+
+    if all_days:
+        # Check hour-based intervals
+        if len(hours) > 1:
+            gaps = [hours[i + 1] - hours[i] for i in range(len(hours) - 1)]
+            gaps.append(24 - hours[-1] + hours[0])
+            return min(gaps) * 3600
+        else:
+            return 86400  # daily
+
+    # Weekly or more complex - default to daily for safety
+    return 86400
+
+
 def add_periodic_task_with_expiry(
     sender: Celery,
-    schedule_seconds: int,
+    schedule: crontab,
     task_signature: Signature,
-    name: str | None = None,
+    name: str,
+    expires_seconds: float | None = None,
 ) -> None:
     """
-    If the workers get delayed in processing tasks, then tasks that fire every X seconds get queued multiple times
-    And so, are processed multiple times. But they often only need to be processed once.
-    This schedules them with an expiry so that they aren't processed multiple times.
-    The expiry is larger than the schedule so that if the worker is only slightly delayed, it still gets processed.
+    Schedule a periodic task with expiry to prevent duplicate processing when workers fall behind.
+
+    Expiry defaults to 1.5x the estimated interval from the crontab schedule, but can be overridden.
+
+    ⚠️  WARNING: DO NOT USE sender.add_periodic_task() DIRECTLY FOR INTERVALS >= 60 SECONDS  ⚠️
+
+    Celery beat resets interval countdowns on every restart. With beat pods restarting every
+    5-10 minutes, any interval-based schedule longer than that will NEVER run. Always use this
+    helper with a crontab schedule instead. Sub-minute intervals are okay since they run more
+    frequently than beat restarts.
     """
+    if expires_seconds is None:
+        expires_seconds = estimate_crontab_interval_seconds(schedule) * 1.5
     sender.add_periodic_task(
-        schedule_seconds,
+        schedule,
         task_signature,
         name=name,
-        # we don't want to run multiple of these if the workers build up a backlog
-        expires=schedule_seconds * 1.5,
+        expires=expires_seconds,
     )
 
 
 def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
+    # Short-interval heartbeat tasks (<60s) use intervals since cron minimum is 1 minute.
+    # These are fine because they run more frequently than beat restarts.
     if not settings.DEBUG:
-        add_periodic_task_with_expiry(sender, 10, redis_celery_queue_depth.s(), "10 sec queue probe")
+        sender.add_periodic_task(10, redis_celery_queue_depth.s(), name="10 sec queue probe")
 
-    # Heartbeat every 10sec to make sure the worker is alive
-    add_periodic_task_with_expiry(sender, 10, redis_heartbeat.s(), "10 sec heartbeat")
-
-    add_periodic_task_with_expiry(sender, 20, start_poll_query_performance.s(), "20 sec query performance heartbeat")
+    sender.add_periodic_task(10, redis_heartbeat.s(), name="10 sec heartbeat")
+    sender.add_periodic_task(20, start_poll_query_performance.s(), name="20 sec query performance heartbeat")
 
     sender.add_periodic_task(
         crontab(hour="*", minute="0"),
@@ -110,7 +158,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     # Team access cache warming - every 10 minutes
     add_periodic_task_with_expiry(
         sender,
-        600,  # Every 10 minutes (no TTL, just fill missing entries)
+        crontab(minute="*/10"),
         warm_all_team_access_caches_task.s(),
         name="warm team access caches",
     )
@@ -215,38 +263,38 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
 
     add_periodic_task_with_expiry(
         sender,
-        120,
+        crontab(minute="*/2"),
         clickhouse_row_count.s(),
         name="clickhouse events table row count",
     )
     add_periodic_task_with_expiry(
         sender,
-        120,
+        crontab(minute="*/2"),
         clickhouse_part_count.s(),
         name="clickhouse table parts count",
     )
     add_periodic_task_with_expiry(
         sender,
-        120,
+        crontab(minute="*/2"),
         clickhouse_mutation_count.s(),
         name="clickhouse table mutations count",
     )
     add_periodic_task_with_expiry(
         sender,
-        120,
+        crontab(minute="*/2"),
         clickhouse_errors_count.s(),
         name="clickhouse instance errors count",
     )
 
     add_periodic_task_with_expiry(
         sender,
-        120,
+        crontab(minute="*/2"),
         pg_row_count.s(),
         name="PG tables row counts",
     )
     add_periodic_task_with_expiry(
         sender,
-        120,
+        crontab(minute="*/2"),
         pg_table_cache_hit_rate.s(),
         name="PG table cache hit rate",
     )
@@ -274,12 +322,17 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
 
     add_periodic_task_with_expiry(
         sender,
-        120,
+        crontab(minute="*/2"),
         process_scheduled_changes.s(),
         name="process scheduled changes",
     )
 
-    add_periodic_task_with_expiry(sender, 3600, replay_count_metrics.s(), name="replay_count_metrics")
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(hour="*", minute="0"),
+        replay_count_metrics.s(),
+        name="replay_count_metrics",
+    )
 
     if clear_clickhouse_crontab := get_crontab(settings.CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON):
         sender.add_periodic_task(
@@ -364,12 +417,13 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
 
         sender.add_periodic_task(crontab(hour="*", minute="55"), schedule_all_subscriptions.s())
 
-        add_periodic_task_with_expiry(
-            sender,
-            settings.PLAYLIST_COUNTER_PROCESSING_SCHEDULE_SECONDS or TWENTY_FOUR_HOURS,
-            count_items_in_playlists.s(),
-            "ee_count_items_in_playlists",
-        )
+        if playlist_counter_crontab := get_crontab(settings.PLAYLIST_COUNTER_SCHEDULE_CRON):
+            sender.add_periodic_task(
+                playlist_counter_crontab,
+                count_items_in_playlists.s(),
+                name="ee_count_items_in_playlists",
+                expires=3600,
+            )
 
         sender.add_periodic_task(
             crontab(minute="0", hour="*"),
@@ -393,7 +447,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     # Check integrations to refresh every minute
     add_periodic_task_with_expiry(
         sender,
-        60,
+        crontab(minute="*"),
         refresh_integrations.s(),
         name="refresh integrations",
     )


### PR DESCRIPTION
Celery beat resets interval-based schedule countdowns on restart. With beat pods restarting every 5-10 min, tasks with intervals longer than that never run - their countdown keeps resetting before reaching zero.

**Changes**
- Convert all interval schedules >= 60s to cron schedules (absolute, unaffected by restarts)
- Add warning to `add_periodic_task_with_expiry` docstring
- Add `PLAYLIST_COUNTER_SCHEDULE_CRON` setting for configurability

**Affected tasks:** warm_all_team_access_caches, ingestion_lag, clickhouse/pg metrics, process_scheduled_changes, replay_count_metrics, count_items_in_playlists, refresh_integrations

Example for task `warm_all_team_access_caches` shows it runs not as intended:
https://grafana.prod-us.posthog.dev/goto/46o_NLWvg?orgId=1