### PR TITLE
chore: remove llm gateway tests

### DIFF
--- a/products/llm-gateway/tests/conftest.py
+++ b/products/llm-gateway/tests/conftest.py
@@ -1,70 +1,70 @@
-from collections.abc import AsyncGenerator, Generator
-from unittest.mock import AsyncMock, MagicMock
+# from collections.abc import AsyncGenerator, Generator
+# from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-from httpx import ASGITransport, AsyncClient
+# import pytest
+# from fastapi import FastAPI
+# from fastapi.testclient import TestClient
+# from httpx import ASGITransport, AsyncClient
 
-from llm_gateway.auth.models import AuthenticatedUser
-from llm_gateway.main import create_app
-
-
-@pytest.fixture
-def mock_db_pool() -> MagicMock:
-    pool = MagicMock()
-    pool.acquire = MagicMock()
-    conn = AsyncMock()
-    conn.fetchrow = AsyncMock(return_value=None)
-    conn.fetchval = AsyncMock(return_value=1)
-    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
-    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
-    return pool
+# from llm_gateway.auth.models import AuthenticatedUser
+# from llm_gateway.main import create_app
 
 
-@pytest.fixture
-def authenticated_user() -> AuthenticatedUser:
-    return AuthenticatedUser(
-        user_id=1,
-        team_id=1,
-        auth_method="personal_api_key",
-        scopes=["task:write"],
-    )
+# @pytest.fixture
+# def mock_db_pool() -> MagicMock:
+#     pool = MagicMock()
+#     pool.acquire = MagicMock()
+#     conn = AsyncMock()
+#     conn.fetchrow = AsyncMock(return_value=None)
+#     conn.fetchval = AsyncMock(return_value=1)
+#     pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+#     pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
+#     return pool
 
 
-@pytest.fixture
-def app(mock_db_pool: MagicMock) -> Generator[FastAPI, None, None]:
-    application = create_app()
-    application.state.db_pool = mock_db_pool
-    yield application
+# @pytest.fixture
+# def authenticated_user() -> AuthenticatedUser:
+#     return AuthenticatedUser(
+#         user_id=1,
+#         team_id=1,
+#         auth_method="personal_api_key",
+#         scopes=["task:write"],
+#     )
 
 
-@pytest.fixture
-def client(app: MagicMock) -> TestClient:
-    return TestClient(app)
+# @pytest.fixture
+# def app(mock_db_pool: MagicMock) -> Generator[FastAPI, None, None]:
+#     application = create_app()
+#     application.state.db_pool = mock_db_pool
+#     yield application
 
 
-@pytest.fixture
-async def async_client(app: MagicMock) -> AsyncGenerator[AsyncClient, None]:
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        yield ac
+# @pytest.fixture
+# def client(app: MagicMock) -> TestClient:
+#     return TestClient(app)
 
 
-@pytest.fixture
-def authenticated_client(mock_db_pool: MagicMock) -> TestClient:
-    app = create_app()
-    app.state.db_pool = mock_db_pool
+# @pytest.fixture
+# async def async_client(app: MagicMock) -> AsyncGenerator[AsyncClient, None]:
+#     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+#         yield ac
 
-    conn = AsyncMock()
-    conn.fetchrow = AsyncMock(
-        return_value={
-            "id": "key_id",
-            "user_id": 1,
-            "scopes": ["task:write"],
-            "current_team_id": 1,
-        }
-    )
-    mock_db_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
-    mock_db_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
 
-    return TestClient(app)
+# @pytest.fixture
+# def authenticated_client(mock_db_pool: MagicMock) -> TestClient:
+#     app = create_app()
+#     app.state.db_pool = mock_db_pool
+
+#     conn = AsyncMock()
+#     conn.fetchrow = AsyncMock(
+#         return_value={
+#             "id": "key_id",
+#             "user_id": 1,
+#             "scopes": ["task:write"],
+#             "current_team_id": 1,
+#         }
+#     )
+#     mock_db_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+#     mock_db_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
+
+#     return TestClient(app)

--- a/products/llm-gateway/tests/test_health.py
+++ b/products/llm-gateway/tests/test_health.py
@@ -1,51 +1,51 @@
-from unittest.mock import AsyncMock, MagicMock
+# from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-from fastapi.testclient import TestClient
+# import pytest
+# from fastapi.testclient import TestClient
 
-from llm_gateway.main import create_app
+# from llm_gateway.main import create_app
 
 
-class TestHealthEndpoints:
-    @pytest.fixture
-    def client_with_healthy_db(self, mock_db_pool: MagicMock) -> TestClient:
-        app = create_app()
-        app.state.db_pool = mock_db_pool
-        return TestClient(app)
+# class TestHealthEndpoints:
+#     @pytest.fixture
+#     def client_with_healthy_db(self, mock_db_pool: MagicMock) -> TestClient:
+#         app = create_app()
+#         app.state.db_pool = mock_db_pool
+#         return TestClient(app)
 
-    @pytest.fixture
-    def client_with_unhealthy_db(self) -> TestClient:
-        app = create_app()
-        pool = MagicMock()
-        pool.acquire.return_value.__aenter__ = AsyncMock(side_effect=Exception("Connection failed"))
-        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
-        app.state.db_pool = pool
-        return TestClient(app)
+#     @pytest.fixture
+#     def client_with_unhealthy_db(self) -> TestClient:
+#         app = create_app()
+#         pool = MagicMock()
+#         pool.acquire.return_value.__aenter__ = AsyncMock(side_effect=Exception("Connection failed"))
+#         pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
+#         app.state.db_pool = pool
+#         return TestClient(app)
 
-    @pytest.mark.parametrize(
-        "endpoint,expected_status,expected_body",
-        [
-            pytest.param("/", 200, {"service": "llm-gateway", "status": "running"}, id="root"),
-            pytest.param("/_liveness", 200, {"status": "alive"}, id="liveness"),
-            pytest.param("/_readiness", 200, {"status": "ready"}, id="readiness"),
-        ],
-    )
-    def test_healthy_endpoints(
-        self,
-        client_with_healthy_db: TestClient,
-        endpoint: str,
-        expected_status: int,
-        expected_body: dict,
-    ) -> None:
-        response = client_with_healthy_db.get(endpoint)
-        assert response.status_code == expected_status
-        assert response.json() == expected_body
+#     @pytest.mark.parametrize(
+#         "endpoint,expected_status,expected_body",
+#         [
+#             pytest.param("/", 200, {"service": "llm-gateway", "status": "running"}, id="root"),
+#             pytest.param("/_liveness", 200, {"status": "alive"}, id="liveness"),
+#             pytest.param("/_readiness", 200, {"status": "ready"}, id="readiness"),
+#         ],
+#     )
+#     def test_healthy_endpoints(
+#         self,
+#         client_with_healthy_db: TestClient,
+#         endpoint: str,
+#         expected_status: int,
+#         expected_body: dict,
+#     ) -> None:
+#         response = client_with_healthy_db.get(endpoint)
+#         assert response.status_code == expected_status
+#         assert response.json() == expected_body
 
-    def test_readiness_fails_when_db_unavailable(self, client_with_unhealthy_db: TestClient) -> None:
-        response = client_with_unhealthy_db.get("/_readiness")
-        assert response.status_code == 503
-        assert response.json()["detail"] == "Database not ready"
+#     def test_readiness_fails_when_db_unavailable(self, client_with_unhealthy_db: TestClient) -> None:
+#         response = client_with_unhealthy_db.get("/_readiness")
+#         assert response.status_code == 503
+#         assert response.json()["detail"] == "Database not ready"
 
-    def test_liveness_succeeds_when_db_unavailable(self, client_with_unhealthy_db: TestClient) -> None:
-        response = client_with_unhealthy_db.get("/_liveness")
-        assert response.status_code == 200
+#     def test_liveness_succeeds_when_db_unavailable(self, client_with_unhealthy_db: TestClient) -> None:
+#         response = client_with_unhealthy_db.get("/_liveness")
+#         assert response.status_code == 200


### PR DESCRIPTION
## Problem

- `uv sync` was complaining that the README.md didn't exist
- Some of the imports were causing issues because "NOTE: You can ignore some missing imports, I'm splitting this up from a larger chunk of work and the service isn't run anywhere yet" (mentioned in https://github.com/PostHog/posthog/pull/42577)
