### PR TITLE
fix: Snippets for notable generation

### DIFF
--- a/docs/onboarding/llm-analytics/_snippets/notable-generation-properties.tsx
+++ b/docs/onboarding/llm-analytics/_snippets/notable-generation-properties.tsx
@@ -1,0 +1,26 @@
+import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+export const NotableGenerationProperties = (): JSX.Element => {
+    const { Markdown, dedent } = useMDXComponents()
+
+    return (
+        <>
+            <Markdown>
+                {dedent`
+                    | Property  | Description |
+                    |---------- | -------------|
+                    | \`$ai_model\` | The specific model, like \`gpt-5-mini\` or \`claude-4-sonnet\` |
+                    | \`$ai_latency\` | The latency of the LLM call in seconds |
+                    | \`$ai_tools\` | Tools and functions available to the LLM |
+                    | \`$ai_input\` | List of messages sent to the LLM |
+                    | \`$ai_input_tokens\` | The number of tokens in the input (often found in response.usage) |
+                    | \`$ai_output_choices\` | List of response choices from the LLM |
+                    | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
+                    | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
+                    | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
+                `}
+            </Markdown>
+        </>
+    )
+}
+

--- a/docs/onboarding/llm-analytics/anthropic.tsx
+++ b/docs/onboarding/llm-analytics/anthropic.tsx
@@ -198,25 +198,7 @@ export const AnthropicInstallation = (): JSX.Element => {
                     `}
                 </Markdown>
 
-                {NotableGenerationProperties ? (
-                    <NotableGenerationProperties />
-                ) : (
-                    <Markdown>
-                        {dedent`
-                            | Property  | Description |
-                            |---------- | -------------|
-                            | \`$ai_model\` | The specific model, like \`gpt-5-mini\` or \`claude-4-sonnet\` |
-                            | \`$ai_latency\` | The latency of the LLM call in seconds |
-                            | \`$ai_tools\` | Tools and functions available to the LLM |
-                            | \`$ai_input\` | List of messages sent to the LLM |
-                            | \`$ai_input_tokens\` | The number of tokens in the input (often found in response.usage) |
-                            | \`$ai_output_choices\` | List of response choices from the LLM |
-                            | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
-                            | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
-                        `}
-                    </Markdown>
-                )}
+                {NotableGenerationProperties && <NotableGenerationProperties />}
             </Step>
 
             <Step

--- a/docs/onboarding/llm-analytics/google.tsx
+++ b/docs/onboarding/llm-analytics/google.tsx
@@ -259,25 +259,7 @@ export const GoogleInstallation = (): JSX.Element => {
                     `}
                 </Markdown>
 
-                {NotableGenerationProperties ? (
-                    <NotableGenerationProperties />
-                ) : (
-                    <Markdown>
-                        {dedent`
-                            | Property  | Description |
-                            |---------- | -------------|
-                            | \`$ai_model\` | The specific model, like \`gpt-5-mini\` or \`claude-4-sonnet\` |
-                            | \`$ai_latency\` | The latency of the LLM call in seconds |
-                            | \`$ai_tools\` | Tools and functions available to the LLM |
-                            | \`$ai_input\` | List of messages sent to the LLM |
-                            | \`$ai_input_tokens\` | The number of tokens in the input (often found in response.usage) |
-                            | \`$ai_output_choices\` | List of response choices from the LLM |
-                            | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
-                            | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
-                        `}
-                    </Markdown>
-                )}
+                {NotableGenerationProperties && <NotableGenerationProperties />}
             </Step>
 
             <Step checkpoint title="Verify traces and generations" subtitle="Confirm LLM events are being sent to PostHog" docsOnly>

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -204,25 +204,7 @@ export const LangChainInstallation = (): JSX.Element => {
                     PostHog automatically captures an `$ai_generation` event along with these properties:
                 </Markdown>
 
-                {NotableGenerationProperties ? (
-                    <NotableGenerationProperties />
-                ) : (
-                    <Markdown>
-                        {dedent`
-                            | Property  | Description |
-                            |---------- | -------------|
-                            | \`$ai_model\` | The specific model, like \`gpt-5-mini\` or \`claude-4-sonnet\` |
-                            | \`$ai_latency\` | The latency of the LLM call in seconds |
-                            | \`$ai_tools\` | Tools and functions available to the LLM |
-                            | \`$ai_input\` | List of messages sent to the LLM |
-                            | \`$ai_input_tokens\` | The number of tokens in the input (often found in response.usage) |
-                            | \`$ai_output_choices\` | List of response choices from the LLM |
-                            | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
-                            | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
-                        `}
-                    </Markdown>
-                )}
+                {NotableGenerationProperties && <NotableGenerationProperties />}
 
                 <Markdown>
                     It also automatically creates a trace hierarchy based on how LangChain components are nested.

--- a/docs/onboarding/llm-analytics/litellm.tsx
+++ b/docs/onboarding/llm-analytics/litellm.tsx
@@ -159,25 +159,7 @@ export const LiteLLMInstallation = (): JSX.Element => {
                     `}
                 </Markdown>
 
-                {NotableGenerationProperties ? (
-                    <NotableGenerationProperties />
-                ) : (
-                    <Markdown>
-                        {dedent`
-                            | Property  | Description |
-                            |---------- | -------------|
-                            | \`$ai_model\` | The specific model, like \`gpt-5-mini\` or \`claude-4-sonnet\` |
-                            | \`$ai_latency\` | The latency of the LLM call in seconds |
-                            | \`$ai_tools\` | Tools and functions available to the LLM |
-                            | \`$ai_input\` | List of messages sent to the LLM |
-                            | \`$ai_input_tokens\` | The number of tokens in the input (often found in response.usage) |
-                            | \`$ai_output_choices\` | List of response choices from the LLM |
-                            | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
-                            | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
-                        `}
-                    </Markdown>
-                )}
+                {NotableGenerationProperties && <NotableGenerationProperties />}
             </Step>
 
             <Step

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -1,8 +1,11 @@
 import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 
 export const OpenAIInstallation = (): JSX.Element => {
-    const { Steps, Step, CodeBlock, CalloutBox, ProductScreenshot, OSButton, Markdown, Blockquote, dedent } =
+    const { Steps, Step, CodeBlock, CalloutBox, ProductScreenshot, OSButton, Markdown, Blockquote, dedent, snippets } =
         useMDXComponents()
+    
+    const NotableGenerationProperties = snippets?.NotableGenerationProperties
+    
     return (
         <Steps>
             <Step title="Install the PostHog SDK" badge="required">
@@ -187,20 +190,10 @@ export const OpenAIInstallation = (): JSX.Element => {
                 <Markdown>
                     {dedent`
                         You can expect captured \`$ai_generation\` events to have the following properties:
-
-                        | Property | Description |
-                        |----------|-------------|
-                        | \`$ai_model\` | The specific model, like \`gpt-5-mini\` or \`claude-4-sonnet\` |
-                        | \`$ai_latency\` | The latency of the LLM call in seconds |
-                        | \`$ai_tools\` | Tools and functions available to the LLM |
-                        | \`$ai_input\` | List of messages sent to the LLM |
-                        | \`$ai_input_tokens\` | The number of tokens in the input (often found in response.usage) |
-                        | \`$ai_output_choices\` | List of response choices from the LLM |
-                        | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
-                        | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                        | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties |
                     `}
                 </Markdown>
+
+                {NotableGenerationProperties && <NotableGenerationProperties />}
             </Step>
 
             <Step

--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -193,25 +193,7 @@ export const OpenRouterInstallation = (): JSX.Element => {
                     `}
                 </Markdown>
 
-                {NotableGenerationProperties ? (
-                    <NotableGenerationProperties />
-                ) : (
-                    <Markdown>
-                        {dedent`
-                            | Property  | Description |
-                            |---------- | -------------|
-                            | \`$ai_model\` | The specific model, like \`gpt-5-mini\` or \`claude-4-sonnet\` |
-                            | \`$ai_latency\` | The latency of the LLM call in seconds |
-                            | \`$ai_tools\` | Tools and functions available to the LLM |
-                            | \`$ai_input\` | List of messages sent to the LLM |
-                            | \`$ai_input_tokens\` | The number of tokens in the input (often found in response.usage) |
-                            | \`$ai_output_choices\` | List of response choices from the LLM |
-                            | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
-                            | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
-                        `}
-                    </Markdown>
-                )}
+                {NotableGenerationProperties && <NotableGenerationProperties />}
             </Step>
 
             <Step

--- a/docs/onboarding/llm-analytics/vercel-ai.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai.tsx
@@ -123,25 +123,7 @@ export const VercelAIInstallation = (): JSX.Element => {
                     `}
                 </Markdown>
 
-                {NotableGenerationProperties ? (
-                    <NotableGenerationProperties />
-                ) : (
-                    <Markdown>
-                        {dedent`
-                            | Property  | Description |
-                            |---------- | -------------|
-                            | \`$ai_model\` | The specific model, like \`gpt-5-mini\` or \`claude-4-sonnet\` |
-                            | \`$ai_latency\` | The latency of the LLM call in seconds |
-                            | \`$ai_tools\` | Tools and functions available to the LLM |
-                            | \`$ai_input\` | List of messages sent to the LLM |
-                            | \`$ai_input_tokens\` | The number of tokens in the input (often found in response.usage) |
-                            | \`$ai_output_choices\` | List of response choices from the LLM |
-                            | \`$ai_output_tokens\` | The number of tokens in the output (often found in \`response.usage\`) |
-                            | \`$ai_total_cost_usd\` | The total cost in USD (input + output) |
-                            | [[...]](https://posthog.com/docs/llm-analytics/generations#event-properties) | See [full list](https://posthog.com/docs/llm-analytics/generations#event-properties) of properties|
-                        `}
-                    </Markdown>
-                )}
+                {NotableGenerationProperties && <NotableGenerationProperties />}
             </Step>
 
             <Step checkpoint title="Verify traces and generations" subtitle="Confirm LLM events are being sent to PostHog" docsOnly>

--- a/frontend/src/scenes/onboarding/OnboardingDocsContentWrapper.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingDocsContentWrapper.tsx
@@ -58,21 +58,25 @@ interface OnboardingComponents {
 const OnboardingContext = createContext<OnboardingComponents | null>(null)
 
 function Steps({ children }: { children: ReactNode }): JSX.Element {
-    const validSteps = Children.toArray(children).filter((child) => {
+    let stepNumber = 0
+
+    const processedChildren = Children.map(children, (child) => {
         if (!isValidElement(child)) {
-            return false
+            return child
         }
-        return !child.props.docsOnly
+
+        // Only number Step components - check if it's actually a Step component
+        const isStep = child.type === Step && 'title' in child.props && typeof child.props.title === 'string'
+
+        if (isStep && !child.props.docsOnly) {
+            stepNumber += 1
+            return React.cloneElement(child, { stepNumber } as any)
+        }
+
+        return child
     })
 
-    const numberedSteps = validSteps.map((step, index) => {
-        if (isValidElement(step)) {
-            return React.cloneElement(step, { stepNumber: index + 1 } as any)
-        }
-        return step
-    })
-
-    return <div className="space-y-6">{numberedSteps}</div>
+    return <div className="space-y-6">{processedChildren}</div>
 }
 
 function Step({

--- a/frontend/src/scenes/onboarding/sdks/llm-analytics/LLMAnalyticsSDKInstructions.tsx
+++ b/frontend/src/scenes/onboarding/sdks/llm-analytics/LLMAnalyticsSDKInstructions.tsx
@@ -1,5 +1,6 @@
 import { EmbeddingEvent } from '@posthog/shared-onboarding/llm-analytics/_snippets/embedding-event'
 import { GenerationEvent } from '@posthog/shared-onboarding/llm-analytics/_snippets/generation-event'
+import { NotableGenerationProperties } from '@posthog/shared-onboarding/llm-analytics/_snippets/notable-generation-properties'
 import { SpanEvent } from '@posthog/shared-onboarding/llm-analytics/_snippets/span-event'
 import { TraceEvent } from '@posthog/shared-onboarding/llm-analytics/_snippets/trace-event'
 import { AnthropicInstallation } from '@posthog/shared-onboarding/llm-analytics/anthropic'
@@ -30,25 +31,25 @@ function LLMManualInstructions(): JSX.Element {
     )
 }
 
-function LLMOpenAIInstructions(): JSX.Element {
+function LLMAnthropicInstructions(): JSX.Element {
     return (
-        <OnboardingDocsContentWrapper>
-            <OpenAIInstallation />
+        <OnboardingDocsContentWrapper snippets={{ NotableGenerationProperties }}>
+            <AnthropicInstallation />
         </OnboardingDocsContentWrapper>
     )
 }
 
-function LLMAnthropicInstructions(): JSX.Element {
+function LLMOpenAIInstructions(): JSX.Element {
     return (
-        <OnboardingDocsContentWrapper>
-            <AnthropicInstallation />
+        <OnboardingDocsContentWrapper snippets={{ NotableGenerationProperties }}>
+            <OpenAIInstallation />
         </OnboardingDocsContentWrapper>
     )
 }
 
 function LLMGoogleInstructions(): JSX.Element {
     return (
-        <OnboardingDocsContentWrapper>
+        <OnboardingDocsContentWrapper snippets={{ NotableGenerationProperties }}>
             <GoogleInstallation />
         </OnboardingDocsContentWrapper>
     )
@@ -56,7 +57,7 @@ function LLMGoogleInstructions(): JSX.Element {
 
 function LLMOpenRouterInstructions(): JSX.Element {
     return (
-        <OnboardingDocsContentWrapper>
+        <OnboardingDocsContentWrapper snippets={{ NotableGenerationProperties }}>
             <OpenRouterInstallation />
         </OnboardingDocsContentWrapper>
     )
@@ -64,7 +65,7 @@ function LLMOpenRouterInstructions(): JSX.Element {
 
 function LLMLangChainInstructions(): JSX.Element {
     return (
-        <OnboardingDocsContentWrapper>
+        <OnboardingDocsContentWrapper snippets={{ NotableGenerationProperties }}>
             <LangChainInstallation />
         </OnboardingDocsContentWrapper>
     )
@@ -72,7 +73,7 @@ function LLMLangChainInstructions(): JSX.Element {
 
 function LLMLiteLLMInstructions(): JSX.Element {
     return (
-        <OnboardingDocsContentWrapper>
+        <OnboardingDocsContentWrapper snippets={{ NotableGenerationProperties }}>
             <LiteLLMInstallation />
         </OnboardingDocsContentWrapper>
     )
@@ -80,7 +81,7 @@ function LLMLiteLLMInstructions(): JSX.Element {
 
 function LLMVercelAIInstructions(): JSX.Element {
     return (
-        <OnboardingDocsContentWrapper>
+        <OnboardingDocsContentWrapper snippets={{ NotableGenerationProperties }}>
             <VercelAIInstallation />
         </OnboardingDocsContentWrapper>
     )


### PR DESCRIPTION
## Problem

Some duplication in onboarding can be a snippet :)

Also increment bug 

<img width="841" height="480" alt="Screenshot 2025-12-03 at 2 29 48 PM" src="https://github.com/user-attachments/assets/03cbd3bc-534b-456f-bb2d-a9099848dc47" />


## Changes

- Add a snippet for duplicate content
- Fixes a increment bug

<img width="841" height="480" alt="Screenshot 2025-12-03 at 2 29 59 PM" src="https://github.com/user-attachments/assets/27eed6b1-c79e-424a-98be-ec99bd4d7050" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
