### PR TITLE
feat(capture): add custom log tag for backend deploy faceting

### DIFF
--- a/rust/capture/src/lib.rs
+++ b/rust/capture/src/lib.rs
@@ -2,6 +2,7 @@ pub mod ai_endpoint;
 pub mod api;
 pub mod config;
 pub mod limiters;
+pub mod logging;
 pub mod metrics_middleware;
 pub mod prometheus;
 pub mod router;

--- a/rust/capture/src/logging.rs
+++ b/rust/capture/src/logging.rs
@@ -1,0 +1,70 @@
+use std::io::{self, Write};
+
+use tracing_subscriber::fmt::MakeWriter;
+
+/// prepends a custom tag " log_service_name=VALUE " to each stdout log line
+/// where VALUE is set to the app's config.otel_service_name. This allows us
+/// to override the default production behavior from deployed services that
+/// share the capture-rs codebase.
+pub struct ServiceNameWriter<W> {
+    inner: W,
+    tag_bytes: Vec<u8>,
+    at_line_start: bool,
+}
+
+impl<W: Write> Write for ServiceNameWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut remaining = buf;
+
+        while !remaining.is_empty() {
+            if self.at_line_start {
+                // Pre-formatted tag bytes, no allocation
+                self.inner.write_all(&self.tag_bytes)?;
+                self.at_line_start = false;
+            }
+
+            // Find the next newline in the remaining buffer so
+            // we can prepend the custom tag to each line
+            if let Some(newline_pos) = remaining.iter().position(|&b| b == b'\n') {
+                // Write up to and including the newline
+                self.inner.write_all(&remaining[..=newline_pos])?;
+                self.at_line_start = true;
+                remaining = &remaining[newline_pos + 1..];
+            } else {
+                // No newline in this chunk, write everything
+                self.inner.write_all(remaining)?;
+                break;
+            }
+        }
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+pub struct ServiceNameMakeWriter {
+    service_name: String,
+}
+
+impl ServiceNameMakeWriter {
+    pub fn new(service_name: String) -> Self {
+        Self { service_name }
+    }
+}
+
+impl<'a> MakeWriter<'a> for ServiceNameMakeWriter {
+    type Writer = ServiceNameWriter<io::Stdout>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        // Pre-format the tag bytes once to avoid allocation on every line
+        let tag_bytes = format!(" log_service_name={} ", self.service_name).into_bytes();
+        ServiceNameWriter {
+            inner: io::stdout(),
+            tag_bytes,
+            at_line_start: true,
+        }
+    }
+}

--- a/rust/capture/src/main.rs
+++ b/rust/capture/src/main.rs
@@ -13,6 +13,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
 use capture::config::Config;
+use capture::logging::ServiceNameMakeWriter;
 use capture::server::serve;
 
 common_alloc::used!();
@@ -62,9 +63,12 @@ async fn main() {
     let config = Config::init_from_env().expect("Invalid configuration:");
 
     // Instantiate tracing outputs:
-    //   - stdout with a level configured by the RUST_LOG envvar (default=ERROR)
+    //   - stdout logging with level configured by the RUST_LOG envvar (default=ERROR)
     //   - OpenTelemetry if enabled, for levels INFO and higher
-    let log_layer = tracing_subscriber::fmt::layer().with_filter(EnvFilter::from_default_env());
+    let log_layer = tracing_subscriber::fmt::layer()
+        .with_writer(ServiceNameMakeWriter::new(config.otel_service_name.clone()))
+        .with_filter(EnvFilter::from_default_env());
+
     let otel_layer = config
         .otel_url
         .clone()


### PR DESCRIPTION
## Problem
We'd like to address a long-standing bug in internal log faceting/routing for different deployments of the base `capture-rs` service running in different modes/envs. We'd like to do this without addressing a long-standing bug in the deployment config for this, as it leaks into other behaviors for the service and is risky to deploy.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add a custom tag to all `capture-rs` log lines for the backend log aggregation to override against
* Value is set to `OTEL_SERVICE_NAME` which is properly scoped in each deployment already
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
