### PR TITLE
fix(workflows): add missing bytecode gen for wait_until_condition action

### DIFF
--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -99,6 +99,8 @@ class HogFlowActionSerializer(serializers.Serializer):
         conditions = data.get("config", {}).get("conditions", [])
 
         single_condition = data.get("config", {}).get("condition", None)
+        if conditions and single_condition:
+            raise serializers.ValidationError({"config": "Cannot specify both 'conditions' and 'condition' fields"})
         if single_condition:
             conditions = [single_condition]
 

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -97,6 +97,11 @@ class HogFlowActionSerializer(serializers.Serializer):
             data["config"]["inputs"] = function_config_serializer.validated_data["inputs"]
 
         conditions = data.get("config", {}).get("conditions", [])
+
+        single_condition = data.get("config", {}).get("condition", None)
+        if single_condition:
+            conditions = [single_condition]
+
         if conditions:
             for condition in conditions:
                 filters = condition.get("filters")

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -259,7 +259,7 @@ class TestHogFlowAPI(APIBaseTest):
 
         response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
         assert response.status_code == 201, response.json()
-        # The condition should be compiled to bytecode and present in the response
+
         condition = response.json()["actions"][1]["config"]["condition"]
         assert "filters" in condition
         assert "bytecode" in condition["filters"], condition["filters"]

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -321,12 +321,11 @@ class TestHogFlowAPI(APIBaseTest):
 
         response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
         assert response.status_code == 400, response.json()
-        assert response.json() == {
-            "attr": "actions__1__config",
-            "code": "invalid_input",
-            "detail": "Cannot specify both 'condition' and 'conditions' fields. They are mutually exclusive.",
-            "type": "validation_error",
-        }
+
+        data = response.json()
+        assert data["attr"] == "actions__1__config"
+        assert data["code"] == "invalid_input"
+        assert data["type"] == "validation_error"
 
     def test_hog_flow_enable_disable(self):
         hog_flow, _ = self._create_hog_flow_with_action(

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -265,6 +265,69 @@ class TestHogFlowAPI(APIBaseTest):
         assert "bytecode" in condition["filters"], condition["filters"]
         assert condition["filters"]["bytecode"] == snapshot(["_H", 1, 32, "custom_event", 32, "event", 1, 1, 11])
 
+    def test_hog_flow_condition_and_conditions_mutually_exclusive(self):
+        trigger_action = {
+            "id": "trigger_node",
+            "name": "trigger_1",
+            "type": "trigger",
+            "config": {
+                "type": "event",
+                "filters": {
+                    "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                },
+            },
+        }
+
+        wait_action = {
+            "id": "wait_1",
+            "name": "wait_1",
+            "type": "wait_until_condition",
+            "config": {
+                "template_id": "template-webhook",
+                "inputs": {"url": {"value": "https://example.com"}},
+                "condition": {
+                    "filters": {
+                        "properties": [
+                            {
+                                "key": "event",
+                                "type": "event_metadata",
+                                "value": ["custom_event"],
+                                "operator": "exact",
+                            }
+                        ]
+                    }
+                },
+                "conditions": [
+                    {
+                        "filters": {
+                            "properties": [
+                                {
+                                    "key": "event",
+                                    "type": "event_metadata",
+                                    "value": ["another_event"],
+                                    "operator": "exact",
+                                }
+                            ]
+                        }
+                    }
+                ],
+            },
+        }
+
+        hog_flow = {
+            "name": "Test Flow Mutually Exclusive",
+            "actions": [trigger_action, wait_action],
+        }
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 400, response.json()
+        assert response.json() == {
+            "attr": "actions__1__config",
+            "code": "invalid_input",
+            "detail": "Cannot specify both 'condition' and 'conditions' fields. They are mutually exclusive.",
+            "type": "validation_error",
+        }
+
     def test_hog_flow_enable_disable(self):
         hog_flow, _ = self._create_hog_flow_with_action(
             {

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -217,6 +217,54 @@ class TestHogFlowAPI(APIBaseTest):
         assert "bytecode" in conditions[0]["filters"], conditions[0]["filters"]
         assert conditions[0]["filters"]["bytecode"] == snapshot(["_H", 1, 32, "custom_event", 32, "event", 1, 1, 11])
 
+    def test_hog_flow_single_condition_field(self):
+        trigger_action = {
+            "id": "trigger_node",
+            "name": "trigger_1",
+            "type": "trigger",
+            "config": {
+                "type": "event",
+                "filters": {
+                    "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                },
+            },
+        }
+
+        wait_action = {
+            "id": "wait_1",
+            "name": "wait_1",
+            "type": "wait_until_condition",
+            "config": {
+                "template_id": "template-webhook",
+                "inputs": {"url": {"value": "https://example.com"}},
+                "condition": {
+                    "filters": {
+                        "properties": [
+                            {
+                                "key": "event",
+                                "type": "event_metadata",
+                                "value": ["custom_event"],
+                                "operator": "exact",
+                            }
+                        ]
+                    }
+                },
+            },
+        }
+
+        hog_flow = {
+            "name": "Test Flow Single Condition",
+            "actions": [trigger_action, wait_action],
+        }
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 201, response.json()
+        # The condition should be compiled to bytecode and present in the response
+        condition = response.json()["actions"][1]["config"]["condition"]
+        assert "filters" in condition
+        assert "bytecode" in condition["filters"], condition["filters"]
+        assert condition["filters"]["bytecode"] == snapshot(["_H", 1, 32, "custom_event", 32, "event", 1, 1, 11])
+
     def test_hog_flow_enable_disable(self):
         hog_flow, _ = self._create_hog_flow_with_action(
             {


### PR DESCRIPTION
## Problem

Follow-up to https://github.com/PostHog/posthog/pull/42115 for the wait_until_condition step which has a slightly different data shape

## How did you test this code?

Tested locally, added test case