### PR TITLE
chore(flags): Emit pool utilization metric on all DB connection acquisitions

### DIFF
--- a/rust/feature-flags/src/database/connection.rs
+++ b/rust/feature-flags/src/database/connection.rs
@@ -97,7 +97,7 @@ pub async fn get_connection_with_metrics(
     // Record pool utilization before acquisition to capture state at request time
     if let Some(stats) = client.as_ref().get_pool_stats() {
         let utilization = if stats.size > 0 {
-            (stats.size - stats.num_idle as u32) as f64 / stats.size as f64
+            stats.size.saturating_sub(stats.num_idle as u32) as f64 / stats.size as f64
         } else {
             0.0
         };

--- a/rust/feature-flags/src/database/mod.rs
+++ b/rust/feature-flags/src/database/mod.rs
@@ -1,5 +1,7 @@
 pub mod connection;
 pub mod postgres_router;
 
-pub use connection::{get_connection_with_metrics, get_writer_connection_with_metrics};
+pub use connection::{
+    get_connection_with_metrics, get_writer_connection_with_metrics, TrackedConnection,
+};
 pub use postgres_router::PostgresRouter;

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -26,10 +26,9 @@ use crate::{
     cohorts::cohort_models::CohortId,
     flags::flag_models::FeatureFlagId,
     metrics::consts::{
-        FLAG_COHORT_PROCESSING_TIME, FLAG_COHORT_QUERY_TIME, FLAG_CONNECTION_HOLD_TIME,
-        FLAG_DATABASE_ERROR_COUNTER, FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME,
-        FLAG_GROUP_QUERY_TIME, FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME,
-        FLAG_PERSON_QUERY_TIME,
+        FLAG_COHORT_PROCESSING_TIME, FLAG_COHORT_QUERY_TIME, FLAG_DATABASE_ERROR_COUNTER,
+        FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME, FLAG_GROUP_QUERY_TIME,
+        FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME, FLAG_PERSON_QUERY_TIME,
     },
     properties::{
         property_matching::match_property,
@@ -1151,18 +1150,7 @@ async fn try_should_write_hash_key_override(
             })?;
         person_query_timer.fin();
 
-        // Record connection hold time for persons_reader pool
-        common_metrics::histogram(
-            FLAG_CONNECTION_HOLD_TIME,
-            &[
-                ("pool".to_string(), "persons_reader".to_string()),
-                ("operation".to_string(), "should_write_check".to_string()),
-            ],
-            persons_conn_start.elapsed().as_millis() as f64,
-        );
-
         person_data_rows
-        // Connection automatically released here when persons_conn goes out of scope
     };
 
     // If no person_ids found, there's nothing to check
@@ -1242,16 +1230,6 @@ async fn try_should_write_hash_key_override(
                 FlagError::DatabaseError(e, Some("Failed to fetch flags".to_string()))
             })?;
         flags_query_timer.fin();
-
-        // Record connection hold time for non_persons_reader pool
-        common_metrics::histogram(
-            FLAG_CONNECTION_HOLD_TIME,
-            &[
-                ("pool".to_string(), "non_persons_reader".to_string()),
-                ("operation".to_string(), "should_write_check".to_string()),
-            ],
-            non_persons_conn_start.elapsed().as_millis() as f64,
-        );
 
         rows
         // Connection automatically released here when non_persons_conn goes out of scope

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -29,7 +29,7 @@ use crate::{
         FLAG_COHORT_PROCESSING_TIME, FLAG_COHORT_QUERY_TIME, FLAG_CONNECTION_HOLD_TIME,
         FLAG_DATABASE_ERROR_COUNTER, FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME,
         FLAG_GROUP_QUERY_TIME, FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME,
-        FLAG_PERSON_QUERY_TIME, FLAG_POOL_UTILIZATION_GAUGE,
+        FLAG_PERSON_QUERY_TIME,
     },
     properties::{
         property_matching::match_property,
@@ -1081,17 +1081,6 @@ async fn try_should_write_hash_key_override(
                 "High pool utilization before should_write_hash_key_override"
             );
         }
-
-        common_metrics::gauge(
-            FLAG_POOL_UTILIZATION_GAUGE,
-            &[("pool".to_string(), "persons_reader".to_string())],
-            pr_utilization,
-        );
-        common_metrics::gauge(
-            FLAG_POOL_UTILIZATION_GAUGE,
-            &[("pool".to_string(), "non_persons_reader".to_string())],
-            npr_utilization,
-        );
     }
 
     // Step 1: Get person data and existing overrides (scoped connection)


### PR DESCRIPTION
## Problem

Connection pool metrics (hold time, utilization) were only emitted in some code paths, making it difficult to get a complete picture of pool behavior during investigations.

## Changes

- Add `TrackedConnection` wrapper that automatically records connection hold time via `Drop`
- Emit pool utilization gauge on every connection acquisition
- Centralize all connection metrics in `get_connection_with_metrics()`
- Remove ~40 lines of scattered manual metric tracking from `flag_matching_utils.rs`

New metrics:
- `flags_connection_hold_time_ms` - histogram of how long connections are held
- `flags_pool_utilization_ratio` - gauge of pool usage (0.0-1.0)

## How did you test this code?

- Unit Tests
- Manual smoke test of `/flags`

## Changelog: (features only) Is this feature complete?

No - internal observability improvement, not user-facing.
