### PR TITLE
feat: add token to top tracker keys

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -280,7 +280,7 @@ export class SessionRecordingIngester {
         SessionRecordingIngesterMetrics.observeSessionInfo(parsedMessage.metadata.rawSize)
 
         // Track message size per session_id
-        const trackingKey = `session_id:${parsedMessage.session_id}`
+        const trackingKey = `token:${parsedMessage.token ?? 'unknown'}:session_id:${parsedMessage.session_id}`
         this.topTracker.increment('message_size_by_session_id', trackingKey, parsedMessage.metadata.rawSize)
 
         await batch.record(message)

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/types.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/types.ts
@@ -57,6 +57,7 @@ export const EventSchema = z.object({
 export const ParsedMessageDataSchema = z.object({
     distinct_id: z.string(),
     session_id: z.string(),
+    token: z.string().nullable(),
     eventsByWindowId: z.record(z.string(), z.array(SnapshotEventSchema)),
     eventsRange: EventsRangeSchema,
     snapshot_source: z.string().nullable(),

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-format.integration.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-format.integration.test.ts
@@ -114,6 +114,7 @@ describe('session recording integration', () => {
         message: {
             distinct_id: 'distinct_id',
             session_id: sessionId,
+            token: null,
             eventsByWindowId: {
                 window1: events.map((event, index) => ({
                     ...event,

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
@@ -208,6 +208,7 @@ describe('SessionBatchRecorder', () => {
         message: {
             distinct_id: distinctId,
             session_id: sessionId,
+            token: null,
             eventsByWindowId: {
                 window1: events,
             },

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.test.ts
@@ -56,6 +56,7 @@ describe('SessionConsoleLogRecorder', () => {
         message: {
             distinct_id: distinctId,
             session_id: sessionId,
+            token: null,
             eventsByWindowId: {
                 [windowId]: events,
             },

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
@@ -17,6 +17,7 @@ describe('SnappySessionRecorder', () => {
     const createMessage = (windowId: string, events: any[]): ParsedMessageData => ({
         distinct_id: 'distinct_id',
         session_id: 'session_id',
+        token: null,
         eventsByWindowId: {
             [windowId]: events,
         },

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-filter.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-filter.test.ts
@@ -23,6 +23,7 @@ const createMessage = (token?: string, overrides = {}): ParsedMessageData => ({
     headers: token ? [{ token }] : undefined,
     distinct_id: 'distinct_id',
     session_id: 'session_id',
+    token: token ?? null,
     eventsByWindowId: {},
     eventsRange: {
         start: DateTime.fromMillis(0),

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/versions/lib-version-monitor.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/versions/lib-version-monitor.test.ts
@@ -29,6 +29,7 @@ describe('LibVersionMonitor', () => {
             headers,
             distinct_id: 'distinct_id',
             session_id: 'session1',
+            token: null,
             eventsByWindowId: { window1: [] },
             eventsRange: { start: DateTime.fromMillis(0), end: DateTime.fromMillis(0) },
             snapshot_source: null,


### PR DESCRIPTION
## Problem

When using the top tracker, it takes a lot of effort to figure out which token + session_id combination to use for applying event restrictions.

## Changes

Adds the token to the top tracker key, so that we don't need any databases to look up tokens and session ids.

## How did you test this code?

Will review the logs in production.