### PR TITLE
chore(ci): run full CI suite on master, no path filtering

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -46,11 +46,11 @@ jobs:
         name: Determine need to run backend and migration checks
         # Set job outputs to values from filter step
         outputs:
-            backend: ${{ steps.filter.outputs.backend }}
+            backend: ${{ steps.filter.outputs.backend || 'true' }}
             backend_files: ${{ steps.filter.outputs.backend_files }}
-            migrations: ${{ steps.filter.outputs.migrations }}
+            migrations: ${{ steps.filter.outputs.migrations || 'true' }}
             migrations_files: ${{ steps.filter.outputs.migrations_files }}
-            tasks_temporal: ${{ steps.filter.outputs.tasks_temporal }}
+            tasks_temporal: ${{ steps.filter.outputs.tasks_temporal || 'true' }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -65,6 +65,7 @@ jobs:
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
+              if: github.event_name != 'push' # Run all tests on master push
               with:
                   list-files: 'escape'
                   filters: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -365,6 +365,8 @@ jobs:
                     sqlx migrate run --source rust/persons_migrations/
 
             - name: Check migrations
+              # Skip migration safety check on master push (no migration_files from path filter)
+              if: github.event_name != 'push'
               run: |
                   DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons" \
                     sqlx migrate info --source rust/persons_migrations/

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -36,7 +36,7 @@ jobs:
         name: Determine need to run dagster checks
         # Set job outputs to values from filter step
         outputs:
-            dagster: ${{ steps.filter.outputs.dagster }}
+            dagster: ${{ steps.filter.outputs.dagster || 'true' }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -46,6 +46,7 @@ jobs:
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
+              if: github.event_name != 'push' # Run all tests on master push
               with:
                   filters: |
                       dagster:

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -133,8 +133,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
+                  ref: ${{ github.event.pull_request.head.sha || github.sha }}
+                  repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
                   token: ${{ secrets.POSTHOG_BOT_PAT || github.token }}
                   clean: false
             - name: Clean up data directories with container permissions

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -7,6 +7,9 @@ name: E2E CI Playwright
 on:
     pull_request:
     workflow_dispatch:
+    push:
+        branches:
+            - master
 
 permissions:
     contents: write
@@ -59,15 +62,17 @@ jobs:
     changes:
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        # Only run on PRs from the same repo (not forks) or on master push
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         name: Determine need to run E2E checks
         # Set job outputs to values from filter step
         outputs:
-            shouldRun: ${{ steps.changes.outputs.shouldRun }}
+            shouldRun: ${{ steps.changes.outputs.shouldRun || 'true' }}
         steps:
             # For pull requests it's not necessary to check out the code
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: changes
+              if: github.event_name != 'push' # Run all tests on master push
               with:
                   filters: |
                       shouldRun:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -20,7 +20,7 @@ jobs:
         timeout-minutes: 5
         name: Determine need to run frontend checks
         outputs:
-            frontend: ${{ steps.filter.outputs.frontend }}
+            frontend: ${{ steps.filter.outputs.frontend || 'true' }}
         steps:
             # For pull requests it's not necessary to check out the code, but we
             # also want this to run on master, so we need to check out
@@ -28,6 +28,7 @@ jobs:
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
+              if: github.event_name != 'push' # Run all tests on master push
               with:
                   filters: |
                       frontend:

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -7,9 +7,6 @@ on:
     push:
         branches:
             - master
-        paths-ignore:
-            - rust/**
-            - livestream/**
     pull_request:
         paths-ignore:
             - rust/**
@@ -24,7 +21,7 @@ jobs:
         name: Determine need to run Hog checks
         # Set job outputs to values from filter step
         outputs:
-            hog: ${{ steps.filter.outputs.hog }}
+            hog: ${{ steps.filter.outputs.hog || 'true' }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -32,6 +29,7 @@ jobs:
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
+              if: github.event_name != 'push' # Run all tests on master push
               with:
                   filters: |
                       hog:

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -13,12 +13,13 @@ jobs:
         timeout-minutes: 5
         name: Determine need to run MCP checks
         outputs:
-            mcp: ${{ steps.filter.outputs.mcp }}
+            mcp: ${{ steps.filter.outputs.mcp || 'true' }}
         steps:
             - uses: actions/checkout@v4
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
+              if: github.event_name != 'push' # Run all tests on master push
               with:
                   filters: |
                       mcp:

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -28,7 +28,7 @@ jobs:
         timeout-minutes: 5
         name: Determine need to run Node.js checks
         outputs:
-            nodejs: ${{ steps.filter.outputs.nodejs }}
+            nodejs: ${{ steps.filter.outputs.nodejs || 'true' }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -38,6 +38,7 @@ jobs:
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
+              if: github.event_name != 'push' # Run all tests on master push
               with:
                   filters: |
                       nodejs:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -16,7 +16,7 @@ jobs:
         name: Determine need to run python checks
         # Set job outputs to values from filter step
         outputs:
-            python: ${{ steps.filter.outputs.python }}
+            python: ${{ steps.filter.outputs.python || 'true' }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -24,6 +24,7 @@ jobs:
 
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
+              if: github.event_name != 'push' # Run all tests on master push
               with:
                   filters: |
                       python:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -19,7 +19,7 @@ jobs:
         name: Determine need to run Rust checks
         # Set job outputs to values from filter step
         outputs:
-            rust: ${{ steps.filter.outputs.rust }}
+            rust: ${{ steps.filter.outputs.rust || 'true' }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -28,6 +28,7 @@ jobs:
                   clean: false
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
+              if: github.event_name != 'push' # Run all tests on master push
               with:
                   filters: |
                       rust:

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -54,8 +54,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
+                  ref: ${{ github.event.pull_request.head.sha || github.sha }}
+                  repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
                   # Use PostHog Bot token when not on forks to enable proper snapshot updating
                   token: ${{ secrets.POSTHOG_BOT_PAT || github.token }}
 
@@ -194,8 +194,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
+                  ref: ${{ github.event.pull_request.head.sha || github.sha }}
+                  repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
                   # Use PostHog Bot token when not on forks to enable proper snapshot updating
                   token: ${{ secrets.POSTHOG_BOT_PAT || github.token }}
 
@@ -406,8 +406,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
+                  ref: ${{ github.event.pull_request.head.sha || github.sha }}
+                  repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
                   token: ${{ secrets.POSTHOG_BOT_PAT || github.token }}
                   fetch-depth: 1
 

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -2,6 +2,9 @@ name: Storybook
 on:
     pull_request:
     merge_group:
+    push:
+        branches:
+            - master
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -23,10 +26,11 @@ jobs:
         if: github.event_name != 'merge_group'
         # Set job outputs to values from filter step
         outputs:
-            frontend: ${{ steps.filter.outputs.frontend }}
+            frontend: ${{ steps.filter.outputs.frontend || 'true' }}
         steps:
             - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
+              if: github.event_name != 'push' # Run all tests on master push
               with:
                   filters: |
                       frontend:


### PR DESCRIPTION
**Problem**
CI workflows on master use the same path filtering as PRs. A frontend-only commit skips backend tests, and vice versa. This means cross-PR interaction bugs can slip through to master undetected.

We also have no clear insights when things start breaking or how they perform over time, unless we take random branches as the source.

**Change**
Skip the `dorny/paths-filter` step on master pushes, defaulting all filter outputs to `'true'`. PRs continue to use path filtering to save CI resources.

Also adds master triggers to `ci-storybook` and `ci-e2e-playwright` which previously only ran on PRs.

**Affected workflows**
- ci-backend.yml
- ci-frontend.yml  
- ci-python.yml
- ci-rust.yml
- ci-dagster.yml
- ci-hog.yml
- ci-nodejs.yml
- ci-mcp.yml
- ci-storybook.yml (+ master trigger)
- ci-e2e-playwright.yml (+ master trigger)