### PR TITLE
chore(dev-setup): bump ch mem to 8gb

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -113,7 +113,7 @@ services:
             service: clickhouse
         hostname: clickhouse
         # Development performance optimizations
-        mem_limit: 6g
+        mem_limit: 8g
         cpus: 2
         environment:
             - AWS_ACCESS_KEY_ID=object_storage_root_user


### PR DESCRIPTION
## Problem

Running backend tests locally started failing with ClickHouse MEMORY_LIMIT_EXCEEDED errors like:
> Code: 241. DB::Exception: (total) memory limit exceeded: would use 6.18 GiB (attempt to allocate chunk of 0.00 B bytes), current RSS: 3.55 GiB, maximum: 5.40 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing AggregatingTransform.

c.f. https://posthog.slack.com/archives/C09ADEV3AJD/p1764836299866139

- In docker-compose.dev.yml the clickhouse service is capped at mem_limit: 6g.
- In docker/clickhouse/config.xml we set max_server_memory_usage_to_ram_ratio to 0.9, so ClickHouse’s effective server-wide memory cap is ≈ 5.4 GiB.
- Dev config (docker/clickhouse/config.d/dev-memory.xml) also sets large caches (mark_cache_size and uncompressed_cache_size at 1 GiB each)
- pushes total RSS over the 5.4 GiB ceiling, causing OvercommitTracker to kill queries even in normal test workflows.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- bumping mem for now

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- test run locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
