### PR TITLE
chore: Make all person distinct id queries use team_id

### DIFF
--- a/ee/hogai/session_summaries/session_group/patterns.py
+++ b/ee/hogai/session_summaries/session_group/patterns.py
@@ -539,7 +539,7 @@ def get_persons_for_sessions_from_distinct_ids(
         persons = persons.prefetch_related(
             Prefetch(
                 "persondistinctid_set",
-                queryset=PersonDistinctId.objects.filter(team_id=team_id),
+                queryset=PersonDistinctId.objects.filter(team_id=team_id).order_by("id"),
                 to_attr="distinct_ids_cache",
             )
         )

--- a/ee/hogai/session_summaries/session_group/patterns.py
+++ b/ee/hogai/session_summaries/session_group/patterns.py
@@ -9,7 +9,7 @@ import structlog
 from pydantic import BaseModel, Field, ValidationError, field_serializer, field_validator
 from temporalio.exceptions import ApplicationError
 
-from posthog.models.person import Person
+from posthog.models.person import Person, PersonDistinctId
 from posthog.models.person.util import get_persons_by_distinct_ids
 
 from ee.hogai.session_summaries import SummaryValidationError
@@ -536,7 +536,13 @@ def get_persons_for_sessions_from_distinct_ids(
         return {}
     try:
         persons = get_persons_by_distinct_ids(team_id=team_id, distinct_ids=distinct_ids)
-        persons = persons.prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
+        persons = persons.prefetch_related(
+            Prefetch(
+                "persondistinctid_set",
+                queryset=PersonDistinctId.objects.filter(team_id=team_id),
+                to_attr="distinct_ids_cache",
+            )
+        )
         session_id_to_person_mapping: dict[str, Person | None] = {}
         for person in persons.iterator(chunk_size=1000):
             for distinct_id in person.distinct_ids:

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -273,7 +273,7 @@ class EventViewSet(
         persons = persons.prefetch_related(
             Prefetch(
                 "persondistinctid_set",
-                queryset=PersonDistinctId.objects.filter(team_id=team.pk),
+                queryset=PersonDistinctId.objects.filter(team_id=team.pk).order_by("id"),
                 to_attr="distinct_ids_cache",
             )
         )

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -30,7 +30,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.clickhouse.client import query_with_columns
 from posthog.exceptions_capture import capture_exception
-from posthog.models import Element, Filter, Person, PropertyDefinition
+from posthog.models import Element, Filter, Person, PersonDistinctId, PropertyDefinition
 from posthog.models.event.query_event_list import query_events_list
 from posthog.models.event.sql import SELECT_ONE_EVENT_SQL
 from posthog.models.event.util import ClickhouseEventSerializer
@@ -270,7 +270,13 @@ class EventViewSet(
     def _get_people(self, query_result: List[dict], team: Team) -> dict[str, Any]:  # noqa: UP006
         distinct_ids = [event["distinct_id"] for event in query_result]
         persons = get_persons_by_distinct_ids(team.pk, distinct_ids)
-        persons = persons.prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
+        persons = persons.prefetch_related(
+            Prefetch(
+                "persondistinctid_set",
+                queryset=PersonDistinctId.objects.filter(team_id=team.pk),
+                to_attr="distinct_ids_cache",
+            )
+        )
         distinct_to_person: dict[str, Person] = {}
         for person in persons:
             for distinct_id in person.distinct_ids:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -232,7 +232,13 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     stickiness_class = Stickiness
 
     def safely_get_queryset(self, queryset):
-        queryset = queryset.prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
+        queryset = queryset.prefetch_related(
+            Prefetch(
+                "persondistinctid_set",
+                queryset=PersonDistinctId.objects.filter(team_id=self.team_id),
+                to_attr="distinct_ids_cache",
+            )
+        )
         queryset = queryset.only("id", "created_at", "properties", "uuid", "is_identified")
         return queryset
 

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -235,7 +235,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         queryset = queryset.prefetch_related(
             Prefetch(
                 "persondistinctid_set",
-                queryset=PersonDistinctId.objects.filter(team_id=self.team_id),
+                queryset=PersonDistinctId.objects.filter(team_id=self.team_id).order_by("id"),
                 to_attr="distinct_ids_cache",
             )
         )

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -335,7 +335,7 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
                     persons = persons.prefetch_related(
                         Prefetch(
                             "persondistinctid_set",
-                            queryset=PersonDistinctId.objects.filter(team_id=self.team.pk),
+                            queryset=PersonDistinctId.objects.filter(team_id=self.team.pk).order_by("id"),
                             to_attr="distinct_ids_cache",
                         )
                     )

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -23,7 +23,7 @@ from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner, get_query_runner
 from posthog.models import Action, Person
 from posthog.models.element import chain_to_elements
-from posthog.models.person.person import READ_DB_FOR_PERSONS, get_distinct_ids_for_subquery
+from posthog.models.person.person import READ_DB_FOR_PERSONS, PersonDistinctId, get_distinct_ids_for_subquery
 from posthog.models.person.util import get_persons_by_distinct_ids
 from posthog.utils import relative_date_parse
 
@@ -332,7 +332,13 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
                 for i in range(0, len(distinct_ids), batch_size):
                     batch_distinct_ids = distinct_ids[i : i + batch_size]
                     persons = get_persons_by_distinct_ids(self.team.pk, batch_distinct_ids)
-                    persons = persons.prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
+                    persons = persons.prefetch_related(
+                        Prefetch(
+                            "persondistinctid_set",
+                            queryset=PersonDistinctId.objects.filter(team_id=self.team.pk),
+                            to_attr="distinct_ids_cache",
+                        )
+                    )
                     for person in persons.iterator(chunk_size=1000):
                         if person:
                             for person_distinct_id in person.distinct_ids:

--- a/posthog/tasks/verify_persons_data_in_sync.py
+++ b/posthog/tasks/verify_persons_data_in_sync.py
@@ -92,7 +92,7 @@ def _team_integrity_statistics(person_data: list[Any]) -> Counter:
             Person.objects.filter(id__in=person_ids).prefetch_related(
                 Prefetch(
                     "persondistinctid_set",
-                    queryset=PersonDistinctId.objects.filter(team_id__in=team_ids),
+                    queryset=PersonDistinctId.objects.filter(team_id__in=team_ids).order_by("id"),
                     to_attr="distinct_ids_cache",
                 )
             )

--- a/posthog/tasks/verify_persons_data_in_sync.py
+++ b/posthog/tasks/verify_persons_data_in_sync.py
@@ -89,7 +89,7 @@ def _team_integrity_statistics(person_data: list[Any]) -> Counter:
     # :TRICKY: To speed up processing, we fetch all models in batch at once and store results in dictionary indexed by person uuid
     pg_persons = _index_by(
         list(
-            Person.objects.filter(id__in=person_ids).prefetch_related(
+            Person.objects.filter(id__in=person_ids, team_id__in=team_ids).prefetch_related(
                 Prefetch(
                     "persondistinctid_set",
                     queryset=PersonDistinctId.objects.filter(team_id__in=team_ids).order_by("id"),


### PR DESCRIPTION
## Problem

We have two index in the persons database both on the `posthog_distinctid` table
`(person_id)` and `(team_id, person_id)`. These are redudant and since we want to remove `(person_id)` we need to adapt the django queries to include team_id for performance reasons


## Changes

- All queries for the person table that use `person_id` also use `team_id`

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
