### PR TITLE
fix(experiments): remove table_name prefix so hogql can resolve field name

### DIFF
--- a/posthog/hogql_queries/experiments/base_query_utils.py
+++ b/posthog/hogql_queries/experiments/base_query_utils.py
@@ -447,6 +447,10 @@ def get_source_events_query(
     """
     match source:
         case ExperimentDataWarehouseNode():
+            # For DW tables, don't prefix fields with table name since:
+            # 1. We're in a single-table query context where field names are unambiguous
+            # 2. DW table names may contain dots (e.g., "bigquery.table_name") which
+            #    confuse HogQL field resolution when used as a prefix
             return ast.SelectQuery(
                 select=[
                     ast.Alias(
@@ -455,12 +459,7 @@ def get_source_events_query(
                     ),
                     ast.Alias(
                         alias="entity_identifier",
-                        expr=ast.Field(
-                            chain=[
-                                source.table_name,
-                                *source.data_warehouse_join_key.split("."),
-                            ]
-                        ),
+                        expr=ast.Field(chain=[*source.data_warehouse_join_key.split(".")]),
                     ),
                     ast.Alias(alias="value", expr=get_source_value_expr(source)),
                 ],

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -1067,7 +1067,11 @@ class ExperimentQueryBuilder:
         # Data warehouse sources use different table and predicate logic
         timestamp_field_chain: list[str | int]
         if isinstance(source, ExperimentDataWarehouseNode):
-            timestamp_field_chain = [table_alias, source.timestamp_field]
+            # For DW tables, don't prefix with table name since:
+            # 1. We're in a single-table CTE context where field names are unambiguous
+            # 2. DW table names may contain dots (e.g., "bigquery.table_name") which
+            #    confuse HogQL field resolution when used as a prefix
+            timestamp_field_chain = [source.timestamp_field]
             metric_event_filter = data_warehouse_node_to_filter(self.team, source)
         else:
             timestamp_field_chain = [table_alias, "timestamp"]


### PR DESCRIPTION
## Problem

Hogql fails when it tries to resolve the field as the chain could be prefixed with table name _that contains a dot_. This didn't used to be the case (at least I think so?), not sure when this started.

## Changes

Remove the table name prefix such that no data warehouse fields are prefixed with the table name.

## How did you test this code?

- Tests passes
