### PR TITLE
fix(workflows): borked opt-out button with long description

### DIFF
--- a/posthog/templates/message_preferences/preferences.html
+++ b/posthog/templates/message_preferences/preferences.html
@@ -20,12 +20,12 @@
 
                         {% for category in categories %}
                         <div class="bg-gray-50 rounded-lg p-6 transition-all duration-200 hover:shadow-md">
-                            <div class="flex items-center justify-between">
-                                <div>
+                            <div class="flex items-start justify-between gap-4">
+                                <div class="flex-1 min-w-0">
                                     <h3 class="text-lg font-medium text-gray-900">{{ category.name }}</h3>
                                     <p class="text-sm text-gray-500 mt-1">{{ category.description }}</p>
                                 </div>
-                                <div class="relative inline-block w-12 mr-2 align-middle select-none">
+                                <div class="relative inline-block w-12 flex-shrink-0 align-top select-none">
                                     <input
                                         type="checkbox"
                                         name="{{ category.id }}"


### PR DESCRIPTION
## Problem

When public description is too long the opt-out button for email preferences looks all borked

c.f. 
<img width="1376" height="946" alt="image" src="https://github.com/user-attachments/assets/ce1ed73f-8bd6-4f46-8428-5487f2a061dc" />



<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes


<img width="715" height="774" alt="Screenshot 2025-12-04 at 10 43 47" src="https://github.com/user-attachments/assets/f1996de1-fbe1-4e37-9712-6c264f136a16" />

- fixed that 

## How did you test this code?
- local dev
