### PR TITLE
fix(logs): Fix virtualized wrap and pretty JSON compat

### DIFF
--- a/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
@@ -107,19 +107,30 @@ export function LogRow({
                         </span>
                     </div>
                 )
-            case 'message':
+            case 'message': {
+                const isPrettyJson = prettifyJson && log.parsedBody
+                const content = isPrettyJson ? JSON.stringify(log.parsedBody, null, 2) : log.cleanBody
+
+                if (isPrettyJson) {
+                    return (
+                        <div key={column.key} style={cellStyle} className="flex items-start py-1.5 overflow-hidden">
+                            <pre className={cn('font-mono text-xs m-0', wrapBody ? '' : 'whitespace-nowrap truncate')}>
+                                {content}
+                            </pre>
+                        </div>
+                    )
+                }
+
                 return (
                     <div key={column.key} style={cellStyle} className="flex items-start py-1.5 overflow-hidden">
                         <span
-                            className={cn(
-                                'font-mono text-xs break-all',
-                                wrapBody || (prettifyJson && log.parsedBody) ? 'whitespace-pre-wrap' : 'truncate'
-                            )}
+                            className={cn('font-mono text-xs', wrapBody ? 'whitespace-pre-wrap break-all' : 'truncate')}
                         >
-                            {log.parsedBody && prettifyJson ? JSON.stringify(log.parsedBody, null, 2) : log.cleanBody}
+                            {content}
                         </span>
                     </div>
                 )
+            }
             case 'actions':
                 return (
                     <div key={column.key} style={cellStyle} className="flex items-center gap-1 justify-end shrink-0">


### PR DESCRIPTION
## Problem
Looks like in the virtualised list, "wrap" and "pretty" toggles don't work together.

## Changes
https://www.loom.com/share/a8f9dc55393447c18d45cd66215c9b0e

I restored the previous functionality, lmk if this looks correct:
- wrap=off, pretty=on: pretty JSON with spaces on a single line (no wrapping)
- wrap=on, pretty=on: pretty JSON with line breaks (wrapping)

## How did you test this code?

localdev