### PR TITLE
feat: Make the Toolbar logo jump when there's loading

### DIFF
--- a/frontend/src/lib/brand/AnimatedLogomark.tsx
+++ b/frontend/src/lib/brand/AnimatedLogomark.tsx
@@ -1,0 +1,64 @@
+import clsx from 'clsx'
+import { useEffect, useRef, useState } from 'react'
+
+import { Logomark } from 'lib/brand/Logomark'
+
+export interface AnimatedLogomarkProps {
+    /** Animate the logomark continuously (e.g. during loading states) */
+    animate: boolean
+    className?: string
+}
+
+/**
+ * Animated PostHog logomark that jumps continuously while `animate` is true.
+ *
+ * When `animate` becomes false, the animation completes its current cycle before
+ * stopping - it won't cut off mid-jump.
+ *
+ */
+export function AnimatedLogomark({ animate, className }: AnimatedLogomarkProps): JSX.Element {
+    const ref = useRef<HTMLDivElement | null>(null)
+    const [isAnimating, setIsAnimating] = useState(false)
+    const shouldStopRef = useRef(false)
+
+    // Track stop intent via ref so the listener always sees current value
+    // without needing to be re-attached when `animate` changes
+    shouldStopRef.current = !animate && isAnimating
+
+    // Start animation immediately when requested
+    useEffect(() => {
+        if (animate) {
+            setIsAnimating(true)
+        }
+    }, [animate])
+
+    // Set up iteration listener once when animation starts.
+    // The listener checks shouldStopRef on each cycle to decide whether to stop.
+    useEffect(() => {
+        if (!isAnimating || !ref.current) {
+            return
+        }
+
+        const animatedElement = ref.current.querySelector('svg > *')
+        if (!animatedElement) {
+            return
+        }
+
+        const handleAnimationIteration = (): void => {
+            if (shouldStopRef.current) {
+                setIsAnimating(false)
+            }
+        }
+
+        animatedElement.addEventListener('animationiteration', handleAnimationIteration)
+        return () => {
+            animatedElement.removeEventListener('animationiteration', handleAnimationIteration)
+        }
+    }, [isAnimating])
+
+    return (
+        <div ref={ref} className={clsx(className, isAnimating && 'animate-logomark-jump-continuous')}>
+            <Logomark />
+        </div>
+    )
+}

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -1816,6 +1816,29 @@
                 transform: translateY(0);
             }
         }
+
+        @keyframes Logomark__jump-continuous {
+            0%,
+            44%,
+            100% {
+                transform: translateY(0);
+            }
+
+            22% {
+                transform: translateY(calc(-10px * var(--logomark-jump-magnitude)));
+            }
+        }
+
+        /* stylelint-disable-next-line order/order */
+        &-continuous {
+            @extend .animate-logomark-jump;
+
+            /* stylelint-disable-next-line order/order */
+            svg > * {
+                animation-name: Logomark__jump-continuous;
+                animation-duration: 0.9s;
+            }
+        }
     }
 
     /* stylelint-disable-next-line order/order */

--- a/frontend/src/toolbar/bar/Toolbar.scss
+++ b/frontend/src/toolbar/bar/Toolbar.scss
@@ -152,4 +152,14 @@
             transform: var(--toolbar-translate) scale(0);
         }
     }
+
+    &__logomark {
+        width: 1.5rem;
+        height: 1.5rem;
+
+        svg {
+            width: 100%;
+            height: 100%;
+        }
+    }
 }

--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -13,7 +13,6 @@ import {
     IconEye,
     IconHide,
     IconLive,
-    IconLogomark,
     IconNight,
     IconPieChart,
     IconQuestion,
@@ -26,6 +25,7 @@ import {
 } from '@posthog/icons'
 import { LemonBadge, Spinner } from '@posthog/lemon-ui'
 
+import { AnimatedLogomark } from 'lib/brand/AnimatedLogomark'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { LemonMenu, LemonMenuItem, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
 import { Link } from 'lib/lemon-ui/Link'
@@ -333,7 +333,7 @@ export function ToolbarInfoMenu(): JSX.Element | null {
 
 export function Toolbar(): JSX.Element | null {
     const ref = useRef<HTMLDivElement | null>(null)
-    const { minimized, position, isDragging, hedgehogMode, isEmbeddedInApp } = useValues(toolbarLogic)
+    const { minimized, position, isDragging, hedgehogMode, isEmbeddedInApp, isLoading } = useValues(toolbarLogic)
     const { setVisibleMenu, toggleMinimized, onMouseOrTouchDown, setElement, setIsBlurred } = useActions(toolbarLogic)
     const { isAuthenticated, userIntent } = useValues(toolbarConfigLogic)
     const { authenticate } = useActions(toolbarConfigLogic)
@@ -398,7 +398,7 @@ export function Toolbar(): JSX.Element | null {
                     title={isAuthenticated ? 'Minimize' : 'Authenticate the PostHog Toolbar'}
                     titleMinimized={isAuthenticated ? 'Expand the toolbar' : 'Authenticate the PostHog Toolbar'}
                 >
-                    <IconLogomark />
+                    <AnimatedLogomark animate={isLoading} className="Toolbar__logomark" />
                 </ToolbarButton>
                 {isAuthenticated ? (
                     <>

--- a/frontend/src/toolbar/bar/toolbarLogic.ts
+++ b/frontend/src/toolbar/bar/toolbarLogic.ts
@@ -6,12 +6,16 @@ import { HedgehogActor } from 'lib/components/HedgehogBuddy/HedgehogBuddy'
 import { SPRITE_SIZE } from 'lib/components/HedgehogBuddy/sprites/sprites'
 import { PostHogAppToolbarEvent } from 'lib/components/IframedToolbarBrowser/utils'
 
+import { actionsLogic } from '~/toolbar/actions/actionsLogic'
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
 import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
+import { experimentsLogic } from '~/toolbar/experiments/experimentsLogic'
 import { experimentsTabLogic } from '~/toolbar/experiments/experimentsTabLogic'
+import { flagsToolbarLogic } from '~/toolbar/flags/flagsToolbarLogic'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { TOOLBAR_CONTAINER_CLASS, TOOLBAR_ID, inBounds, makeNavigateWrapper } from '~/toolbar/utils'
+import { webVitalsToolbarLogic } from '~/toolbar/web-vitals/webVitalsToolbarLogic'
 
 import { generatePiiMaskingCSS } from './piiMaskingStyles'
 import type { toolbarLogicType } from './toolbarLogicType'
@@ -46,7 +50,20 @@ export const toolbarLogic = kea<toolbarLogicType>([
     path(['toolbar', 'bar', 'toolbarLogic']),
 
     connect(() => ({
-        values: [toolbarConfigLogic, ['posthog']],
+        values: [
+            toolbarConfigLogic,
+            ['posthog'],
+            heatmapToolbarMenuLogic,
+            ['elementStatsLoading', 'rawHeatmapLoading', 'isRefreshing'],
+            actionsLogic,
+            ['allActionsLoading'],
+            flagsToolbarLogic,
+            ['userFlagsLoading'],
+            experimentsLogic,
+            ['allExperimentsLoading'],
+            webVitalsToolbarLogic,
+            ['remoteWebVitalsLoading'],
+        ],
         actions: [
             actionsTabLogic,
             [
@@ -69,9 +86,6 @@ export const toolbarLogic = kea<toolbarLogicType>([
                 'setHeatmapColorPalette',
                 'setCommonFilters',
                 'toggleClickmapsEnabled',
-                'loadHeatmap',
-                'loadHeatmapSuccess',
-                'loadHeatmapFailure',
             ],
         ],
     })),
@@ -356,6 +370,33 @@ export const toolbarLogic = kea<toolbarLogicType>([
 
                 return warnings
             },
+        ],
+        isLoading: [
+            (s) => [
+                s.elementStatsLoading,
+                s.rawHeatmapLoading,
+                s.isRefreshing,
+                s.allActionsLoading,
+                s.userFlagsLoading,
+                s.allExperimentsLoading,
+                s.remoteWebVitalsLoading,
+            ],
+            (
+                elementStatsLoading,
+                rawHeatmapLoading,
+                isRefreshing,
+                allActionsLoading,
+                userFlagsLoading,
+                allExperimentsLoading,
+                remoteWebVitalsLoading
+            ) =>
+                elementStatsLoading ||
+                rawHeatmapLoading ||
+                isRefreshing ||
+                allActionsLoading ||
+                userFlagsLoading ||
+                allExperimentsLoading ||
+                remoteWebVitalsLoading,
         ],
     }),
     listeners(({ actions, values }) => ({

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -132,6 +132,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         stopElementObservation: true,
         processElements: true,
         refreshClickmap: true,
+        setIsRefreshing: (isRefreshing: boolean) => ({ isRefreshing }),
         setProcessedElements: (elements: CountedHTMLElement[]) => ({ elements }),
         setElementsLoading: (loading: boolean) => ({ loading }),
         setProcessingProgress: (processed: number, total: number) => ({ processed, total }),
@@ -211,6 +212,12 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 setProcessingProgress: (_, { processed, total }) => (processed >= total ? null : { processed, total }),
                 setProcessedElements: () => null,
                 toggleClickmapsEnabled: () => null,
+            },
+        ],
+        isRefreshing: [
+            false,
+            {
+                setIsRefreshing: (_, { isRefreshing }) => isRefreshing,
             },
         ],
     }),
@@ -361,6 +368,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
 
             if (!clickmapsEnabled || !elementStats?.results?.length) {
                 actions.setProcessedElements([])
+                actions.setIsRefreshing(false)
                 return
             }
 
@@ -407,6 +415,8 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 breakpoint()
                 await yieldToMain()
             }
+
+            actions.setIsRefreshing(false)
         },
 
         enableHeatmap: () => {
@@ -526,6 +536,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             if (!values.clickmapsEnabled) {
                 return
             }
+            actions.setIsRefreshing(true)
             invalidatePageElementsCache(cache as ElementProcessingCache)
             actions.processElements()
         },


### PR DESCRIPTION
## Problem

Scratched the itch last night - inspired by Paul in https://github.com/PostHog/posthog/pull/42304#discussion_r2581578632, animate the PostHog logo when we load _stuff_ in the Toolbar. Basically reusing the jumping PostHog logo from the PostHog AI sidebar. I experimented with colour changes initially but didn't really like it - thought this was more fun anyway, plus already had something we could use as a starting point.

I haven't removed any of the existing loading indicators - these aren't super obvious but figured it wouldn't hurt to keep them.

![CleanShot 2025-12-04 at 10 14 24](https://github.com/user-attachments/assets/8c59cbe9-c8d5-42a5-b16c-9db4bed32739)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tested locally.

## Changelog: (features only) Is this feature complete?

Yes
