### PR TITLE
chore: Fix phrasing ("at between time and time" to "between time and time")

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.test.ts
@@ -64,7 +64,7 @@ describe('stepWaitUntilTimeWindowLogic', () => {
             workflow: partial({
                 actions: expect.arrayContaining([
                     expect.objectContaining({
-                        description: 'Wait until weekends at between 09:00 and 17:00 (UTC).',
+                        description: 'Wait until weekends between 09:00 and 17:00 (UTC).',
                     }),
                 ]),
             }),
@@ -85,7 +85,7 @@ describe('stepWaitUntilTimeWindowLogic', () => {
             workflow: partial({
                 actions: expect.arrayContaining([
                     expect.objectContaining({
-                        description: 'Wait until weekdays at between 10:00 and 18:00 (UTC).',
+                        description: 'Wait until weekdays between 10:00 and 18:00 (UTC).',
                     }),
                 ]),
             }),
@@ -106,7 +106,7 @@ describe('stepWaitUntilTimeWindowLogic', () => {
             workflow: partial({
                 actions: expect.arrayContaining([
                     expect.objectContaining({
-                        description: 'Wait until weekdays at between 09:00 and 17:00 (America/New_York).',
+                        description: 'Wait until weekdays between 09:00 and 17:00 (America/New_York).',
                     }),
                 ]),
             }),

--- a/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/stepWaitUntilTimeWindowLogic.ts
@@ -14,7 +14,7 @@ export type WaitUntilTimeWindowConfig = {
     time?: TimeConfig
 }
 
-const AUTO_DESCRIPTION_REGEX = /^Wait until .+ at .+ \(.+\)\.$/
+const AUTO_DESCRIPTION_REGEX = /^Wait until .+ (at any time|between .+ and .+) \(.+\)\.$/
 const LEGACY_DEFAULT_DESCRIPTION = 'Wait until a specified time window.'
 
 function capitalize(str: string): string {
@@ -54,7 +54,9 @@ export function getWaitUntilTimeWindowDescription(day: DayConfig, time: TimeConf
     const dayDesc = getDayDescription(day)
     const timeDesc = getTimeDescription(time)
     const tz = timezone || 'UTC'
-    return `Wait until ${dayDesc} at ${timeDesc} (${tz}).`
+    // Use "at" only for "any time", otherwise use the time description directly (e.g., "between X and Y")
+    const timeClause = time === 'any' ? `at ${timeDesc}` : timeDesc
+    return `Wait until ${dayDesc} ${timeClause} (${tz}).`
 }
 
 export function shouldAutoUpdateDescription(description: string): boolean {


### PR DESCRIPTION
Tiny followup to https://github.com/PostHog/posthog/pull/42561

Just updates the phrasing to sound more natural (and be less wrong, probably)