### PR TITLE
fix(tests): mock feature flag in session recording playlist tests

### DIFF
--- a/posthog/session_recordings/test/test_session_recording_playlist.py
+++ b/posthog/session_recordings/test/test_session_recording_playlist.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, QueryMatchingTest, snapshot_postgres_queries
 from unittest import mock
+from unittest.mock import patch
 
 from django.db import transaction
 from django.test import override_settings
@@ -38,6 +39,7 @@ TEST_BUCKET = "test_storage_bucket-ee.TestSessionRecordingPlaylist"
 @override_settings(
     OBJECT_STORAGE_SESSION_RECORDING_BLOB_INGESTION_FOLDER=TEST_BUCKET,
 )
+@patch("posthog.session_recordings.synthetic_playlists.posthoganalytics.get_feature_flag", return_value=None)
 class TestSessionRecordingPlaylist(APIBaseTest, QueryMatchingTest):
     def teardown_method(self, method) -> None:
         s3 = resource(


### PR DESCRIPTION
**Problem**

`TestSessionRecordingPlaylist.test_filters_playlist_by_type` is flaky - it generates between 62 and 67 snapshot entries depending on the CI run. This causes query snapshots to flip-flop on master.

**Root cause**

The test indirectly calls `posthoganalytics.get_feature_flag("replay-new-detected-url-collections", ...)` via `synthetic_playlists.py`. This external call returns different values on different runs, causing different code paths and query counts.

**Evidence**

Recent commits to `test_session_recording_playlist.ambr` show the count changing:
- `8f3121aec1`: 62 entries  
- `2fe95ba7e8`: 67 entries
- Keeps flipping between these values

**Fix**

Mock the feature flag at the test class level to return `None` consistently, ensuring deterministic query counts.