### PR TITLE
fix(annotations): update chart refs

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -7,7 +7,7 @@ import chartTrendline from 'chartjs-plugin-trendline'
 import clsx from 'clsx'
 import { useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 
 import {
     ActiveElement,
@@ -293,11 +293,6 @@ export function LineGraph_({
     const hideTooltipOnScroll = isInsightVizNode(query) ? query.hideTooltipOnScroll : undefined
 
     const { hideTooltip, getTooltip } = useInsightTooltip()
-
-    const externalCanvasRef = useRef<HTMLCanvasElement | null>(null)
-
-    // Relying on useResizeObserver instead of Chart's onResize because the latter was not reliable
-    const { width: chartWidth, height: chartHeight } = useResizeObserver({ ref: externalCanvasRef })
 
     const colors = getGraphColors()
     const isHorizontal = type === GraphType.HorizontalBar
@@ -1042,11 +1037,8 @@ export function LineGraph_({
         ],
     })
 
-    useEffect(() => {
-        if (externalCanvasRef.current !== canvasRef.current) {
-            externalCanvasRef.current = canvasRef.current
-        }
-    }, [canvasRef.current]) // oxlint-disable-line react-hooks/exhaustive-deps
+    // Use canvasRef directly from useChart for resize observer - avoids sync issues with separate ref
+    const { width: chartWidth, height: chartHeight } = useResizeObserver({ ref: canvasRef })
 
     return (
         <div className={clsx('LineGraph w-full grow relative overflow-hidden')} data-attr={dataAttr}>


### PR DESCRIPTION
## Problem
https://posthog.slack.com/archives/C0368RPHLQH/p1764802874010209

## Changes
Fixes annotations showing up
<img width="590" height="626" alt="image" src="https://github.com/user-attachments/assets/55203209-2c26-433a-a08f-1e00c58befee" />


## How did you test this code?
👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
