### PR TITLE
feat: Auto wildcard the URL on navigation

### DIFF
--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -3,8 +3,7 @@ import posthog from 'posthog-js'
 import React from 'react'
 
 import { IconMagicWand } from '@posthog/icons'
-import { Link } from '@posthog/lemon-ui'
-import { LemonButton, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonButton, LemonSwitch, Link } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { heatmapDateOptions } from 'lib/components/IframedToolbarBrowser/utils'
@@ -74,8 +73,9 @@ const SectionButton = ({
 }
 
 export const HeatmapToolbarMenu = (): JSX.Element => {
-    const { wildcardHref } = useValues(currentPageLogic)
-    const { setWildcardHref, autoWildcardHref } = useActions(currentPageLogic)
+    const { wildcardHref, autoWildcardEnabled } = useValues(currentPageLogic)
+    const { setWildcardHref, autoWildcardHref, setAutoWildcardEnabled, onWildcardHrefBlur } =
+        useActions(currentPageLogic)
 
     const {
         matchLinksByHref,
@@ -110,11 +110,16 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
         <ToolbarMenu>
             <ToolbarMenu.Header>
                 <div className="flex gap-1">
-                    <LemonInput className="flex-1" value={wildcardHref} onChange={setWildcardHref} />
+                    <LemonInput
+                        className="flex-1"
+                        value={wildcardHref}
+                        onChange={setWildcardHref}
+                        onBlur={onWildcardHrefBlur}
+                    />
                     <LemonButton
-                        type="secondary"
+                        type={autoWildcardEnabled ? 'primary' : 'secondary'}
                         icon={<IconMagicWand />}
-                        size="small"
+                        size="medium"
                         onClick={() => autoWildcardHref()}
                         tooltip={
                             <>
@@ -122,9 +127,31 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                                 example, <code>https://example.com/*</code> will match{' '}
                                 <code>https://example.com/page</code> and <code>https://example.com/page/1</code>.
                                 <br />
-                                Click this button to automatically wildcards where we believe it would make sense
+                                Click this button to automatically wildcard where we believe it would make sense
                             </>
                         }
+                        sideAction={{
+                            dropdown: {
+                                placement: 'bottom-end',
+                                matchWidth: false,
+                                closeOnClickInside: false,
+                                overlay: (
+                                    <div className="p-2 flex flex-col gap-2 min-w-80">
+                                        <LemonSwitch
+                                            checked={autoWildcardEnabled}
+                                            onChange={setAutoWildcardEnabled}
+                                            label="Auto-wildcard on navigation"
+                                            fullWidth
+                                            bordered
+                                        />
+                                        <div className="text-xs text-muted">
+                                            When enabled, the URL will be automatically wildcarded whenever you navigate
+                                            to a new page.
+                                        </div>
+                                    </div>
+                                ),
+                            },
+                        }}
                     />
                 </div>
 

--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -74,8 +74,7 @@ const SectionButton = ({
 
 export const HeatmapToolbarMenu = (): JSX.Element => {
     const { wildcardHref, autoWildcardEnabled } = useValues(currentPageLogic)
-    const { setWildcardHref, autoWildcardHref, setAutoWildcardEnabled, onWildcardHrefBlur } =
-        useActions(currentPageLogic)
+    const { setWildcardHref, autoWildcardHref, setAutoWildcardEnabled } = useActions(currentPageLogic)
 
     const {
         matchLinksByHref,
@@ -110,12 +109,7 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
         <ToolbarMenu>
             <ToolbarMenu.Header>
                 <div className="flex gap-1">
-                    <LemonInput
-                        className="flex-1"
-                        value={wildcardHref}
-                        onChange={setWildcardHref}
-                        onBlur={onWildcardHrefBlur}
-                    />
+                    <LemonInput className="flex-1" value={wildcardHref} onChange={setWildcardHref} />
                     <LemonButton
                         type={autoWildcardEnabled ? 'primary' : 'secondary'}
                         icon={<IconMagicWand />}


### PR DESCRIPTION
## Problem

Was using heatmaps to get a sense of which bits of the app people are interacting with and found myself constantly clicking the "autowildcard" button. Lets just make it automagical.

## Changes

![2025-12-04 14 03 02](https://github.com/user-attachments/assets/66567196-d222-44b9-91bb-77a07064a942)

* Makes it so we have a setting to persist which then auto wildcards on load and on navigate

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
