### PR TITLE
chore(data-modeling): Added retries to materialization

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -401,7 +401,8 @@
                                                                                 max_bytes_before_external_group_by=0,
                                                                                 transform_null_in=1,
                                                                                 optimize_min_equality_disjunction_chain_length=4294967295,
-                                                                                allow_experimental_join_condition=1
+                                                                                allow_experimental_join_condition=1,
+                                                                                use_hive_partitioning=0
   '''
 # ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.11

--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
@@ -241,7 +241,7 @@
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
          max(s.retention_period_days) AS retention_period_days,
-         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 21))) AS expiry_time,
+         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 30))) AS expiry_time,
          dateDiff('DAY', toDateTime64('2021-08-21 20:00:00.000000', 6, 'UTC'), expiry_time) AS recording_ttl,
          greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2021-08-21 19:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
@@ -292,7 +292,7 @@
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
          max(s.retention_period_days) AS retention_period_days,
-         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 21))) AS expiry_time,
+         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 30))) AS expiry_time,
          dateDiff('DAY', toDateTime64('2021-08-21 20:00:00.000000', 6, 'UTC'), expiry_time) AS recording_ttl,
          greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2021-08-21 19:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -43,7 +43,6 @@ from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger
-from posthog.temporal.common.shutdown import ShutdownMonitor
 from posthog.temporal.data_imports.util import prepare_s3_files_for_querying
 from posthog.temporal.data_modeling.metrics import get_data_modeling_finished_metric
 from posthog.temporal.utils import DataModelingDuckLakeCopyInputs, DuckLakeCopyModelInput
@@ -208,18 +207,15 @@ async def run_dag_activity(inputs: RunDagActivityInputs) -> Results:
 
     running_tasks = set()
 
-    async with Heartbeater(), ShutdownMonitor() as shutdown_monitor:
+    async with Heartbeater():
         while True:
             message = await queue.get()
-            shutdown_monitor.raise_if_is_worker_shutdown()
 
             match message:
                 case QueueMessage(status=ModelStatus.READY, label=label):
                     await logger.adebug(f"Handling queue message READY. label={label}")
                     model = inputs.dag[label]
-                    task = asyncio.create_task(
-                        handle_model_ready(model, inputs.team_id, queue, inputs.job_id, logger, shutdown_monitor)
-                    )
+                    task = asyncio.create_task(handle_model_ready(model, inputs.team_id, queue, inputs.job_id, logger))
                     running_tasks.add(task)
                     task.add_done_callback(running_tasks.discard)
 
@@ -309,7 +305,6 @@ async def handle_model_ready(
     queue: asyncio.Queue[QueueMessage],
     job_id: str,
     logger: FilteringBoundLogger,
-    shutdown_monitor: ShutdownMonitor,
 ) -> None:
     """Handle a model that is ready to run by materializing.
 
@@ -332,7 +327,7 @@ async def handle_model_ready(
             saved_query = await get_saved_query(team, model.label)
             job = await database_sync_to_async(DataModelingJob.objects.get)(id=job_id)
 
-            await materialize_model(model.label, team, saved_query, job, logger, shutdown_monitor)
+            await materialize_model(model.label, team, saved_query, job, logger)
             ducklake_model = DuckLakeCopyModelInput(
                 model_label=model.label,
                 saved_query_id=str(saved_query.id),
@@ -431,7 +426,6 @@ async def materialize_model(
     saved_query: DataWarehouseSavedQuery,
     job: DataModelingJob,
     logger: FilteringBoundLogger,
-    shutdown_monitor: ShutdownMonitor,
 ) -> tuple[str, DeltaTable, uuid.UUID]:
     """Materialize a given model by running its query and piping the results into a delta table.
 
@@ -518,8 +512,6 @@ async def materialize_model(
 
             # Explicitly delete batch to free memory after writing
             del batch, ch_types
-
-            shutdown_monitor.raise_if_is_worker_shutdown()
 
         await logger.adebug(f"Finished writing to delta table. row_count={row_count}")
 
@@ -1479,7 +1471,7 @@ class RunWorkflow(PostHogWorkflow):
                 start_to_close_timeout=dt.timedelta(hours=1),
                 heartbeat_timeout=dt.timedelta(minutes=2),
                 retry_policy=temporalio.common.RetryPolicy(
-                    maximum_attempts=1,
+                    maximum_attempts=3,
                 ),
                 cancellation_type=temporalio.workflow.ActivityCancellationType.TRY_CANCEL,
             )

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -299,7 +299,6 @@ async def test_materialize_model(ateam, bucket_name, minio_client, pageview_even
             saved_query,
             job,
             unittest.mock.AsyncMock(),
-            unittest.mock.AsyncMock(),
         )
 
     s3_objects = await minio_client.list_objects_v2(
@@ -362,7 +361,6 @@ async def test_materialize_model_timestamps(ateam, bucket_name, minio_client, pa
             saved_query,
             job,
             unittest.mock.AsyncMock(),
-            unittest.mock.AsyncMock(),
         )
 
     table = delta_table.to_pyarrow_table(columns=["now_converted", "now"])
@@ -407,7 +405,6 @@ async def test_materialize_model_nullable_nothing_column(ateam, bucket_name, min
             saved_query,
             job,
             unittest.mock.AsyncMock(),
-            unittest.mock.AsyncMock(),
         )
 
     table = delta_table.to_pyarrow_table(columns=["nullable_nothing_column", "nullable_nothing_column_type"])
@@ -450,7 +447,6 @@ async def test_materialize_model_with_pascal_cased_name(ateam, bucket_name, mini
             ateam,
             saved_query,
             job,
-            unittest.mock.AsyncMock(),
             unittest.mock.AsyncMock(),
         )
 
@@ -1107,7 +1103,6 @@ async def test_dlt_direct_naming(ateam, bucket_name, minio_client, pageview_even
             saved_query,
             job,
             unittest.mock.AsyncMock(),
-            unittest.mock.AsyncMock(),
         )
 
     await database_sync_to_async(saved_query.refresh_from_db)()
@@ -1170,7 +1165,6 @@ async def test_materialize_model_with_decimal256_fix(ateam, bucket_name, minio_c
             ateam,
             saved_query,
             job,
-            unittest.mock.AsyncMock(),
             unittest.mock.AsyncMock(),
         )
 
@@ -1243,7 +1237,6 @@ async def test_materialize_model_with_decimal256_downscale_to_decimal128(ateam, 
             ateam,
             saved_query,
             job,
-            unittest.mock.AsyncMock(),
             unittest.mock.AsyncMock(),
         )
 
@@ -1381,7 +1374,6 @@ async def test_materialize_model_progress_tracking(ateam, bucket_name, minio_cli
             saved_query,
             job,
             unittest.mock.AsyncMock(),
-            unittest.mock.AsyncMock(),
         )
 
         # Verify final state
@@ -1421,7 +1413,6 @@ async def test_materialize_model_with_non_utc_timestamp(ateam, bucket_name, mini
             ateam,
             saved_query,
             job,
-            unittest.mock.AsyncMock(),
             unittest.mock.AsyncMock(),
         )
 
@@ -1471,7 +1462,6 @@ async def test_materialize_model_with_utc_timestamp(ateam, bucket_name, minio_cl
             saved_query,
             job,
             unittest.mock.AsyncMock(),
-            unittest.mock.AsyncMock(),
         )
 
         assert key == saved_query.normalized_name
@@ -1520,7 +1510,6 @@ async def test_materialize_model_with_date(ateam, bucket_name, minio_client, tru
             saved_query,
             job,
             unittest.mock.AsyncMock(),
-            unittest.mock.AsyncMock(),
         )
 
         assert key == saved_query.normalized_name
@@ -1568,7 +1557,6 @@ async def test_materialize_model_with_plain_datetime(ateam, bucket_name, minio_c
             ateam,
             saved_query,
             job,
-            unittest.mock.AsyncMock(),
             unittest.mock.AsyncMock(),
         )
 


### PR DESCRIPTION
## Problem
- Materializations are failing when they run on a pod that is getting shut down, but not retrying, just totally failing and staying failed 
- We dont attempt any retries for materialization

## Changes
- Remove the shutdown monitor logic, when the pod is shutting down, we have a grace period; we don't need to early exit jobs, considering they have a max run time of ~10 mins anyway
- Added retries to the activity responsible for running the CH queries and throwing stuff in S3


