### PR TITLE
fix: use team's org instead of user's org for team routes

### DIFF
--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -319,7 +319,7 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" 
             if self._is_team_view:
                 # TODO: self.team.project.organization_id when project environments are rolled out
                 current_organization_id = self.team.organization_id
-            if self._is_project_view:
+            elif self._is_project_view:
                 current_organization_id = self.project.organization_id
             elif user:
                 current_organization_id = user.current_organization_id

--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -629,6 +629,18 @@ class TestPersonalAPIKeysWithOrganizationScopeAPIAuthentication(PersonalAPIKeysB
         response = self._do_request(f"/api/users/@me/")
         assert response.status_code == status.HTTP_200_OK, response.json()
 
+    def test_allows_access_when_user_current_organization_differs_from_scoped_org(self):
+        # When user's current_organization_id differs from the API key's scoped org,
+        # the request should still succeed for projects in the scoped org
+        self.user.current_organization = self.other_organization
+        self.user.save()
+
+        response = self._do_request(f"/api/projects/{self.team.id}/insights/")
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
+        response = self._do_request(f"/api/projects/{self.team.id}/events/")
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
 
 class TestPersonalAPIKeysWithTeamScopeAPIAuthentication(PersonalAPIKeysBaseTest):
     def setUp(self):

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -3,7 +3,6 @@ from enum import Enum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast, get_args
 
-from django.contrib.auth.models import AnonymousUser
 from django.db.models import Case, CharField, Exists, Model, OuterRef, Q, QuerySet, Value, When
 from django.db.models.functions import Cast
 
@@ -882,6 +881,12 @@ class UserAccessControlSerializerMixin(serializers.Serializer):
 
     @property
     def user_access_control(self) -> Optional[UserAccessControl]:
+        request = self.context.get("request")
+
+        # The user could be anonymous - if so there is no access control to be used
+        if request and request.user.is_anonymous:
+            return None
+
         # NOTE: The user_access_control is typically on the view but in specific cases,
         # such as rendering HTML (`render_template()`), it is set at the context level
         if "user_access_control" in self.context:
@@ -890,15 +895,8 @@ class UserAccessControlSerializerMixin(serializers.Serializer):
         elif hasattr(self.context.get("view", None), "user_access_control"):
             # Otherwise from the view (the default case)
             return self.context["view"].user_access_control
-        elif "request" in self.context:
-            user = cast(User | AnonymousUser, self.context["request"].user)
-            # The user could be anonymous - if so there is no access control to be used
-
-            if user.is_anonymous:
-                return None
-
-            user = cast(User, user)
-
+        elif request:
+            user = cast(User, request.user)
             return UserAccessControl(user, organization_id=str(user.current_organization_id))
 
         return None

--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
@@ -241,7 +241,7 @@
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
          max(s.retention_period_days) AS retention_period_days,
-         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 21))) AS expiry_time,
+         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 30))) AS expiry_time,
          dateDiff('DAY', toDateTime64('2021-08-21 20:00:00.000000', 6, 'UTC'), expiry_time) AS recording_ttl,
          greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2021-08-21 19:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
@@ -292,7 +292,7 @@
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
          max(s.retention_period_days) AS retention_period_days,
-         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 21))) AS expiry_time,
+         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 30))) AS expiry_time,
          dateDiff('DAY', toDateTime64('2021-08-21 20:00:00.000000', 6, 'UTC'), expiry_time) AS recording_ttl,
          greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2021-08-21 19:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score


### PR DESCRIPTION
## Problem
User reported intermittent 403 errors when using an org-scoped Personal API Key to access project resources.
https://posthoghelp.zendesk.com/agent/tickets/43220 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46274)

Request details:
```
- URL: https://us.i.posthog.com/api/projects/189424/insights/ (and /events/)
- Method: GET
- Authorization: Bearer phx_SU0N...Edp
- HTTP Status: 403 Forbidden
```

The API key was scoped to the "Dev org", the project belonged to the "Dev org", yet the error referenced a different org (Prod) - which happened to be the user's current_organization_id from their web session.

Root cause: 
```python
if self._is_team_view:           # True
    org_id = self.team.organization_id  # Correctly set to Dev org
if self._is_project_view:        # False
    org_id = self.project.organization_id
elif user:                       # True - OVERWRITES
    org_id = user.current_organization_id  # Prod org
```

## Changes
One-line fix to make the checks mutually exclusive

## How did you test this code?
Tests