### PR TITLE
feat(workflows): adds unseen events to event filter

### DIFF
--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -43,6 +43,7 @@ export interface TaxonomicPopoverProps<ValueType extends TaxonomicFilterValue = 
     showNumericalPropsOnly?: boolean
     dataWarehousePopoverFields?: DataWarehousePopoverField[]
     maxContextOptions?: MaxContextTaxonomicFilterOption[]
+    allowNonCapturedEvents?: boolean
 }
 
 /** Like TaxonomicPopover, but convenient when you know you will only use string values */
@@ -79,6 +80,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
         showNumericalPropsOnly,
         dataWarehousePopoverFields,
         maxContextOptions,
+        allowNonCapturedEvents,
         width,
         placement,
         ...buttonPropsRest
@@ -129,6 +131,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
                     showNumericalPropsOnly={showNumericalPropsOnly}
                     dataWarehousePopoverFields={dataWarehousePopoverFields}
                     maxContextOptions={maxContextOptions}
+                    allowNonCapturedEvents={allowNonCapturedEvents}
                     width={width}
                 />
             }

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -247,6 +247,7 @@ export function HogFunctionFilters({
                                         }}
                                         buttonCopy="Add event matcher"
                                         excludedProperties={excludedProperties}
+                                        allowNonCapturedEvents
                                     />
                                 </>
                             ) : null}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -99,6 +99,8 @@ export interface ActionFilterProps {
     addFilterDocLink?: string
     /** Properties to exclude from the properties filter */
     excludedProperties?: TaxonomicPopoverProps['excludedProperties']
+    /** Allow adding non-captured events */
+    allowNonCapturedEvents?: boolean
 }
 
 export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(function ActionFilter(
@@ -134,6 +136,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         filtersLeftPadding,
         addFilterDocLink,
         excludedProperties,
+        allowNonCapturedEvents,
     },
     ref
 ): JSX.Element {
@@ -197,6 +200,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         filtersLeftPadding,
         addFilterDocLink,
         excludedProperties,
+        allowNonCapturedEvents,
     }
 
     const reachedLimit: boolean = Boolean(entitiesLimit && localFilters.length >= entitiesLimit)

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -152,6 +152,8 @@ export interface ActionFilterRowProps {
     filtersLeftPadding?: boolean
     /** Doc link to show in the tooltip of the New Filter button */
     addFilterDocLink?: string
+    /** Allow adding non-captured events */
+    allowNonCapturedEvents?: boolean
 }
 
 export function ActionFilterRow({
@@ -186,7 +188,8 @@ export function ActionFilterRow({
     filtersLeftPadding = false,
     addFilterDocLink,
     excludedProperties,
-}: ActionFilterRowProps & Pick<TaxonomicPopoverProps, 'excludedProperties'>): JSX.Element {
+    allowNonCapturedEvents,
+}: ActionFilterRowProps & Pick<TaxonomicPopoverProps, 'excludedProperties' | 'allowNonCapturedEvents'>): JSX.Element {
     const { entityFilterVisible } = useValues(logic)
     const {
         updateFilter,
@@ -347,6 +350,7 @@ export function ActionFilterRow({
             showNumericalPropsOnly={showNumericalPropsOnly}
             dataWarehousePopoverFields={dataWarehousePopoverFields}
             excludedProperties={excludedProperties}
+            allowNonCapturedEvents={allowNonCapturedEvents}
         />
     )
 

--- a/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters.tsx
@@ -59,6 +59,7 @@ export function HogFlowEventFilters({ filters, setFilters, typeKey, buttonCopy }
                 type: 'secondary',
             }}
             buttonCopy={buttonCopy ?? 'Add filter'}
+            allowNonCapturedEvents
         />
     )
 }


### PR DESCRIPTION
## Problem

We have no way to create a trigger for an event that has not been fired yet.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<img width="1316" height="884" alt="Screenshot 2025-12-04 at 14 38 26" src="https://github.com/user-attachments/assets/69bcdf85-e53d-4d46-b4e4-428fbd017e7b" />

- adds the possibility to add unseen events to event filters

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
