### PR TITLE
chore(customers): Misc adjustments

### DIFF
--- a/frontend/src/products.json
+++ b/frontend/src/products.json
@@ -9,7 +9,7 @@
         },
         {
             "path": "Customer analytics",
-            "category": "Unreleased",
+            "category": "Analytics",
             "iconType": "cohort",
             "type": null,
             "intents": ["customer_analytics"]

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -909,7 +909,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     {
         path: 'Customer analytics',
         intents: [ProductKey.CUSTOMER_ANALYTICS],
-        category: 'Unreleased',
+        category: 'Analytics',
         iconType: 'cohort',
         href: urls.customerAnalytics(),
         tags: ['alpha'],

--- a/frontend/src/scenes/settings/environment/GroupAnalyticsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/GroupAnalyticsConfig.tsx
@@ -6,6 +6,7 @@ import { LemonButton, LemonDialog, LemonInput, Link } from '@posthog/lemon-ui'
 import { GroupsAccessStatus, groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { GroupsIntroduction } from 'scenes/groups/GroupsIntroduction'
 
 import { GroupType } from '~/types'
 
@@ -53,11 +54,10 @@ export function GroupAnalyticsConfig(): JSX.Element | null {
         useValues(groupAnalyticsConfigLogic)
     const { setSingular, setPlural, reset, save, deleteGroupType } = useActions(groupAnalyticsConfigLogic)
 
-    const { groupsAccessStatus } = useValues(groupsAccessLogic)
+    const { groupsAccessStatus, needsUpgradeForGroups } = useValues(groupsAccessLogic)
 
-    if (groupsAccessStatus === GroupsAccessStatus.NoAccess) {
-        // Hide settings if the user doesn't have access
-        return null
+    if (needsUpgradeForGroups) {
+        return <GroupsIntroduction />
     }
 
     const columns: LemonTableColumns<GroupType> = [

--- a/frontend/src/scenes/settings/environment/GroupAnalyticsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/GroupAnalyticsConfig.tsx
@@ -131,7 +131,7 @@ export function GroupAnalyticsConfig(): JSX.Element | null {
                 displayed throughout the app.
             </p>
 
-            {groupsAccessStatus !== GroupsAccessStatus.HasGroupTypes && (
+            {groupsAccessStatus !== GroupsAccessStatus.AlreadyUsing && (
                 <LemonBanner type="info" className="mb-4">
                     Group types will show up here after you send your first event associated with a group. Take a look
                     at{' '}

--- a/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
@@ -16,6 +16,7 @@ import {
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
+import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
@@ -276,6 +277,7 @@ function UsageMetricsForm({ metric }: UsageMetricsFormProps): JSX.Element {
 export function UsageMetricsConfig(): JSX.Element {
     const { isEditing } = useValues(usageMetricsConfigLogic)
     const { setIsEditing, resetUsageMetric } = useActions(usageMetricsConfigLogic)
+    const { groupsEnabled } = useValues(groupsAccessLogic)
 
     const handleAddMetric = (): void => {
         resetUsageMetric()
@@ -285,12 +287,13 @@ export function UsageMetricsConfig(): JSX.Element {
     return (
         <>
             <p>
-                Choose which events matter for each metric: API calls, feature adoption, session frequency, error rates
-                to identify expansion opportunities and churn risk based on real customer behavior.
+                Define what usage means for your product based on one or more events.
+                <br />
+                Usage metrics are displayed in the person {groupsEnabled ? 'and group profiles' : 'profile'}.
             </p>
             <div className="flex flex-col gap-2 items-start">
                 {!isEditing && (
-                    <LemonButton type="primary" onClick={handleAddMetric} icon={<IconPlusSmall />}>
+                    <LemonButton type="primary" size="small" onClick={handleAddMetric} icon={<IconPlusSmall />}>
                         Add metric
                     </LemonButton>
                 )}

--- a/products/customer_analytics/manifest.tsx
+++ b/products/customer_analytics/manifest.tsx
@@ -34,7 +34,7 @@ export const manifest: ProductManifest = {
         {
             path: 'Customer analytics',
             intents: [ProductKey.CUSTOMER_ANALYTICS],
-            category: 'Unreleased',
+            category: 'Analytics',
             iconType: 'cohort',
             href: urls.customerAnalytics(),
             tags: ['alpha'],


### PR DESCRIPTION
## Problem

Customer Analytics is now available for folks who've opted in, so let's move it from the "Unreleased" category to "Analytics".

## Changes

- Moved Customer Analytics from "Unreleased" to "Analytics" category in product navigation
- Updated the Groups access logic in the Group Analytics Config to show the Groups Introduction when an upgrade is needed
- Improved the description for Usage Metrics to be clearer and more concise
- Added conditional text in Usage Metrics description to mention group profiles when groups are enabled
- Fix bug where we showed getting started banner in group analytics config when the project had groups already configured

## How did you test this code?

Verified that Customer Analytics now appears in the Analytics category in the navigation menu. 

Tested the Groups Introduction display logic when a user needs to upgrade for groups access. 

Confirmed that the Usage Metrics description changes display correctly with and without groups enabled.

## Changelog:

Yes