### PR TITLE
fix(data-management): Fix pagination on event definitions table

### DIFF
--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -43,7 +43,7 @@ const eventTypeOptions: LemonSelectOptions<EventDefinitionType> = [
 
 export function EventDefinitionsTable(): JSX.Element {
     const { eventDefinitions, eventDefinitionsLoading, filters } = useValues(eventDefinitionsTableLogic)
-    const { loadEventDefinitions, setFilters } = useActions(eventDefinitionsTableLogic)
+    const { setFilters } = useActions(eventDefinitionsTableLogic)
     const { hasTagging } = useValues(organizationLogic)
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
 
@@ -227,16 +227,7 @@ export function EventDefinitionsTable(): JSX.Element {
                     currentPage: eventDefinitions?.page ?? 1,
                     entryCount: eventDefinitions?.count ?? 0,
                     pageSize: EVENT_DEFINITIONS_PER_PAGE,
-                    onForward: eventDefinitions.next
-                        ? () => {
-                              loadEventDefinitions(eventDefinitions.next)
-                          }
-                        : undefined,
-                    onBackward: eventDefinitions.previous
-                        ? () => {
-                              loadEventDefinitions(eventDefinitions.previous)
-                          }
-                        : undefined,
+                    // Pagination is handled via URL: PaginationControl updates URL -> urlToAction -> setFilters -> load
                 }}
                 onSort={(newSorting) =>
                     setFilters({


### PR DESCRIPTION
- Add page to Filters state and sync bidirectionally with URL
- Create filtersToApiParams() helper to centralize filter → API params conversion
- Remove redundant onForward/onBackward callbacks that caused double-fetching
- Guard setFilters listener to skip redundant loads when filters unchanged
- Ensure initial load happens even when URL filters match defaults

The pagination was broken because:
1. actionToUrl wasn't preserving the page parameter
2. urlToAction wasn't reading the page parameter
3. onForward/onBackward callbacks + URL sync caused double API calls


