### PR TITLE
refactor(logs): extract LogsViewer as self-contained component

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -36,7 +36,7 @@ import { PropertyOperator } from '~/types'
 import { LogTag } from 'products/logs/frontend/components/LogTag'
 import { LogsSparkline } from 'products/logs/frontend/components/LogsSparkline'
 import { LogsTableRowActions } from 'products/logs/frontend/components/LogsTable/LogsTableRowActions'
-import { VirtualizedLogsList } from 'products/logs/frontend/components/VirtualizedLogsList'
+import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
 import { LogsFilterGroup } from 'products/logs/frontend/components/filters/LogsFilters/FilterGroup'
 
 import { AttributeBreakdowns } from './AttributeBreakdowns'
@@ -118,8 +118,27 @@ export function LogsScene(): JSX.Element {
 
 const LogsListContainer = (): JSX.Element => {
     const { featureFlags } = useValues(featureFlagLogic)
+    const { tabId, parsedLogs, logsLoading, totalLogsMatchingFilters, sparklineLoading, hasMoreLogsToLoad, orderBy } =
+        useValues(logsLogic)
+    const { runQuery, fetchNextLogsPage, setOrderBy } = useActions(logsLogic)
     const useVirtualizedList = !!featureFlags[FEATURE_FLAGS.LOGS_VIRTUALIZED_LIST]
-    return useVirtualizedList ? <VirtualizedLogsListLogs /> : <LemonTableLogs />
+    return useVirtualizedList ? (
+        <div className="flex flex-col gap-2 py-2 h-[calc(100vh_-_var(--breadcrumbs-height-compact,_0px)_-_var(--scene-title-section-height,_0px)_-_5px)]">
+            <LogsViewer
+                tabId={tabId}
+                logs={parsedLogs}
+                loading={logsLoading}
+                totalLogsCount={sparklineLoading ? undefined : totalLogsMatchingFilters}
+                hasMoreLogsToLoad={hasMoreLogsToLoad}
+                orderBy={orderBy}
+                onChangeOrderBy={setOrderBy}
+                onRefresh={runQuery}
+                onLoadMore={fetchNextLogsPage}
+            />
+        </div>
+    ) : (
+        <LemonTableLogs />
+    )
 }
 
 const LemonTableLogs = (): JSX.Element => {
@@ -133,9 +152,29 @@ const LemonTableLogs = (): JSX.Element => {
         hasMoreLogsToLoad,
         logsPageSize,
         logsRemainingToLoad,
+        highlightedLogId,
     } = useValues(logsLogic)
 
-    const { fetchNextLogsPage } = useActions(logsLogic)
+    const { fetchNextLogsPage, highlightNextLog, highlightPreviousLog, toggleExpandLog, runQuery } =
+        useActions(logsLogic)
+
+    useKeyboardHotkeys(
+        {
+            arrowdown: { action: highlightNextLog },
+            j: { action: highlightNextLog },
+            arrowup: { action: highlightPreviousLog },
+            k: { action: highlightPreviousLog },
+            enter: {
+                action: () => {
+                    if (highlightedLogId) {
+                        toggleExpandLog(highlightedLogId)
+                    }
+                },
+            },
+            r: { action: () => !logsLoading && runQuery() },
+        },
+        [highlightedLogId, logsLoading, runQuery]
+    )
 
     const tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime'> = {
         formatDate: 'YYYY-MM-DD',
@@ -189,54 +228,6 @@ const LemonTableLogs = (): JSX.Element => {
                         </LemonButton>
                     </div>
                 )}
-            </div>
-        </div>
-    )
-}
-
-const VirtualizedLogsListLogs = (): JSX.Element => {
-    const { wrapBody, prettifyJson, pinnedParsedLogs, parsedLogs, logsLoading, isPinned } = useValues(logsLogic)
-
-    const tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime'> = {
-        formatDate: 'YYYY-MM-DD',
-        formatTime: 'HH:mm:ss.SSS',
-    }
-
-    return (
-        <div className="flex flex-col gap-2 py-2 h-[calc(100vh_-_var(--breadcrumbs-height-compact,_0px)_-_var(--scene-title-section-height,_0px)_-_5px)]">
-            <div className="sticky top-0 z-20 py-2">
-                <VirtualizedLogsListDisplayOptions />
-            </div>
-            {pinnedParsedLogs.length > 0 && (
-                <div className="border rounded-t bg-bg-light shadow-sm">
-                    <VirtualizedLogsList
-                        dataSource={pinnedParsedLogs}
-                        loading={false}
-                        isPinned={isPinned}
-                        wrapBody={wrapBody}
-                        prettifyJson={prettifyJson}
-                        tzLabelFormat={tzLabelFormat}
-                        showPinnedWithOpacity
-                        fixedHeight={250}
-                        disableInfiniteScroll
-                    />
-                </div>
-            )}
-            <div
-                className={cn(
-                    'border bg-bg-light flex-1 min-h-0',
-                    pinnedParsedLogs.length > 0 ? 'rounded-b' : 'rounded'
-                )}
-            >
-                <VirtualizedLogsList
-                    dataSource={parsedLogs}
-                    loading={logsLoading}
-                    isPinned={isPinned}
-                    wrapBody={wrapBody}
-                    prettifyJson={prettifyJson}
-                    tzLabelFormat={tzLabelFormat}
-                    showPinnedWithOpacity
-                />
             </div>
         </div>
     )
@@ -575,60 +566,6 @@ const DisplayOptions = (): JSX.Element => {
                         ]}
                     />
                 </LemonField.Pure>
-                <span className="text-muted text-xs flex items-center gap-1">
-                    <KeyboardShortcut arrowup />
-                    <KeyboardShortcut arrowdown />
-                    or
-                    <KeyboardShortcut j />
-                    <KeyboardShortcut k />
-                    navigate
-                    <span className="mx-1">·</span>
-                    <KeyboardShortcut enter />
-                    expand
-                    <span className="mx-1">·</span>
-                    <KeyboardShortcut r />
-                    refresh
-                </span>
-            </div>
-        </div>
-    )
-}
-
-const VirtualizedLogsListDisplayOptions = (): JSX.Element => {
-    const { orderBy, wrapBody, prettifyJson, totalLogsMatchingFilters, sparklineLoading } = useValues(logsLogic)
-    const { setOrderBy, setWrapBody, setPrettifyJson } = useActions(logsLogic)
-
-    return (
-        <div className="flex justify-between">
-            <div className="flex gap-2">
-                <LemonSegmentedButton
-                    value={orderBy}
-                    onChange={setOrderBy}
-                    options={[
-                        {
-                            value: 'earliest',
-                            label: 'Earliest',
-                        },
-                        {
-                            value: 'latest',
-                            label: 'Latest',
-                        },
-                    ]}
-                    size="small"
-                />
-                <LemonCheckbox checked={wrapBody} bordered onChange={setWrapBody} label="Wrap message" size="small" />
-                <LemonCheckbox
-                    checked={prettifyJson}
-                    bordered
-                    onChange={setPrettifyJson}
-                    label="Prettify JSON"
-                    size="small"
-                />
-            </div>
-            <div className="flex items-center gap-4">
-                {!sparklineLoading && totalLogsMatchingFilters > 0 && (
-                    <span className="text-muted text-xs">{humanFriendlyNumber(totalLogsMatchingFilters)} logs</span>
-                )}
                 <span className="text-muted text-xs flex items-center gap-1">
                     <KeyboardShortcut arrowup />
                     <KeyboardShortcut arrowdown />

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -123,7 +123,17 @@ function LogsViewerContent({
                 disabled: !isFocused,
             },
         },
-        [isFocused, logs.length, cursorLogId, toggleExpandLog, onRefresh, loading, resetCursor]
+        [
+            isFocused,
+            logs.length,
+            cursorLogId,
+            toggleExpandLog,
+            onRefresh,
+            loading,
+            resetCursor,
+            moveCursorDown,
+            moveCursorUp,
+        ]
     )
 
     return (

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -89,11 +89,8 @@ function LogsViewerContent({
     // Position cursor at linked log when deep linking (URL -> cursor)
     useEffect(() => {
         if (linkToLogId && logs.length > 0) {
-            const index = logs.findIndex((l) => l.uuid === linkToLogId)
             setCursorToLogId(linkToLogId, logs)
-            if (index !== -1) {
-                containerRef.current?.focus()
-            }
+            containerRef.current?.focus()
         }
     }, [linkToLogId, logs, setCursorToLogId])
 

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -1,0 +1,172 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import { useEffect, useRef } from 'react'
+
+import { TZLabelProps } from 'lib/components/TZLabel'
+import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
+import { cn } from 'lib/utils/css-classes'
+
+import { VirtualizedLogsList } from 'products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList'
+import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
+
+import { LogsViewerToolbar } from './LogsViewerToolbar'
+import { LogsViewerLogicProps, logsViewerLogic } from './logsViewerLogic'
+
+export interface LogsViewerProps {
+    tabId: string
+    logs: ParsedLogMessage[]
+    loading: boolean
+    totalLogsCount?: number
+    hasMoreLogsToLoad?: boolean
+    orderBy: LogsOrderBy
+    onChangeOrderBy: (orderBy: LogsOrderBy) => void
+    onRefresh?: () => void
+    onLoadMore?: () => void
+}
+
+export function LogsViewer({
+    tabId,
+    logs,
+    loading,
+    totalLogsCount,
+    hasMoreLogsToLoad,
+    orderBy,
+    onChangeOrderBy,
+    onRefresh,
+    onLoadMore,
+}: LogsViewerProps): JSX.Element {
+    const logicProps: LogsViewerLogicProps = { tabId }
+
+    return (
+        <BindLogic logic={logsViewerLogic} props={logicProps}>
+            <LogsViewerContent
+                logs={logs}
+                loading={loading}
+                totalLogsCount={totalLogsCount}
+                hasMoreLogsToLoad={hasMoreLogsToLoad}
+                orderBy={orderBy}
+                onChangeOrderBy={onChangeOrderBy}
+                onRefresh={onRefresh}
+                onLoadMore={onLoadMore}
+            />
+        </BindLogic>
+    )
+}
+
+interface LogsViewerContentProps {
+    logs: ParsedLogMessage[]
+    loading: boolean
+    totalLogsCount?: number
+    hasMoreLogsToLoad?: boolean
+    orderBy: LogsOrderBy
+    onChangeOrderBy: (orderBy: LogsOrderBy) => void
+    onRefresh?: () => void
+    onLoadMore?: () => void
+}
+
+function LogsViewerContent({
+    logs,
+    loading,
+    totalLogsCount,
+    hasMoreLogsToLoad,
+    orderBy,
+    onChangeOrderBy,
+    onRefresh,
+    onLoadMore,
+}: LogsViewerContentProps): JSX.Element {
+    const { wrapBody, prettifyJson, pinnedLogsArray, isFocused, getCursorLogId } = useValues(logsViewerLogic)
+    const { setFocused, moveCursorDown, moveCursorUp, toggleExpandLog, resetCursor } = useActions(logsViewerLogic)
+    const containerRef = useRef<HTMLDivElement>(null)
+
+    const cursorLogId = getCursorLogId(logs)
+
+    // Reset cursor when logs are cleared (e.g., new query starts)
+    useEffect(() => {
+        if (logs.length === 0) {
+            resetCursor()
+        }
+    }, [logs.length, resetCursor])
+
+    const tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime'> = {
+        formatDate: 'YYYY-MM-DD',
+        formatTime: 'HH:mm:ss.SSS',
+    }
+
+    useKeyboardHotkeys(
+        {
+            arrowdown: { action: () => moveCursorDown(logs.length), disabled: !isFocused },
+            j: { action: () => moveCursorDown(logs.length), disabled: !isFocused },
+            arrowup: { action: () => moveCursorUp(logs.length), disabled: !isFocused },
+            k: { action: () => moveCursorUp(logs.length), disabled: !isFocused },
+            enter: {
+                action: () => {
+                    if (cursorLogId) {
+                        toggleExpandLog(cursorLogId)
+                    }
+                },
+                disabled: !isFocused,
+            },
+            r: {
+                action: () => {
+                    if (onRefresh && !loading) {
+                        resetCursor()
+                        onRefresh()
+                    }
+                },
+                disabled: !isFocused,
+            },
+        },
+        [isFocused, logs.length, cursorLogId, toggleExpandLog, onRefresh, loading, resetCursor]
+    )
+
+    return (
+        <div
+            ref={containerRef}
+            className="flex flex-col gap-2 h-full outline-none focus:ring-1 focus:ring-border-bold focus:ring-offset-1 rounded"
+            tabIndex={0}
+            onFocus={() => {
+                setFocused(true)
+                containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+            }}
+            onBlur={() => setFocused(false)}
+        >
+            <div className="py-2">
+                <LogsViewerToolbar
+                    totalLogsCount={totalLogsCount}
+                    orderBy={orderBy}
+                    onChangeOrderBy={onChangeOrderBy}
+                />
+            </div>
+            {pinnedLogsArray.length > 0 && (
+                <div className="border rounded-t bg-bg-light shadow-sm">
+                    <VirtualizedLogsList
+                        dataSource={pinnedLogsArray}
+                        loading={false}
+                        wrapBody={wrapBody}
+                        prettifyJson={prettifyJson}
+                        tzLabelFormat={tzLabelFormat}
+                        showPinnedWithOpacity
+                        fixedHeight={250}
+                        disableInfiniteScroll
+                    />
+                </div>
+            )}
+            <div
+                className={cn(
+                    'border bg-bg-light flex-1 min-h-0',
+                    pinnedLogsArray.length > 0 ? 'rounded-b' : 'rounded'
+                )}
+            >
+                <VirtualizedLogsList
+                    dataSource={logs}
+                    loading={loading}
+                    wrapBody={wrapBody}
+                    prettifyJson={prettifyJson}
+                    tzLabelFormat={tzLabelFormat}
+                    showPinnedWithOpacity
+                    hasMoreLogsToLoad={hasMoreLogsToLoad}
+                    onLoadMore={onLoadMore}
+                />
+            </div>
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -9,7 +9,7 @@ import { VirtualizedLogsList } from 'products/logs/frontend/components/Virtualiz
 import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
 
 import { LogsViewerToolbar } from './LogsViewerToolbar'
-import { LogsViewerLogicProps, logsViewerLogic } from './logsViewerLogic'
+import { logsViewerLogic } from './logsViewerLogic'
 
 export interface LogsViewerProps {
     tabId: string
@@ -34,10 +34,8 @@ export function LogsViewer({
     onRefresh,
     onLoadMore,
 }: LogsViewerProps): JSX.Element {
-    const logicProps: LogsViewerLogicProps = { tabId }
-
     return (
-        <BindLogic logic={logsViewerLogic} props={logicProps}>
+        <BindLogic logic={logsViewerLogic} props={{ tabId, logs, orderBy }}>
             <LogsViewerContent
                 logs={logs}
                 loading={loading}
@@ -73,8 +71,10 @@ function LogsViewerContent({
     onRefresh,
     onLoadMore,
 }: LogsViewerContentProps): JSX.Element {
-    const { wrapBody, prettifyJson, pinnedLogsArray, isFocused, getCursorLogId } = useValues(logsViewerLogic)
-    const { setFocused, moveCursorDown, moveCursorUp, toggleExpandLog, resetCursor } = useActions(logsViewerLogic)
+    const { wrapBody, prettifyJson, pinnedLogsArray, isFocused, getCursorLogId, linkToLogId } =
+        useValues(logsViewerLogic)
+    const { setFocused, moveCursorDown, moveCursorUp, toggleExpandLog, resetCursor, setCursorToLogId } =
+        useActions(logsViewerLogic)
     const containerRef = useRef<HTMLDivElement>(null)
 
     const cursorLogId = getCursorLogId(logs)
@@ -85,6 +85,17 @@ function LogsViewerContent({
             resetCursor()
         }
     }, [logs.length, resetCursor])
+
+    // Position cursor at linked log when deep linking (URL -> cursor)
+    useEffect(() => {
+        if (linkToLogId && logs.length > 0) {
+            const index = logs.findIndex((l) => l.uuid === linkToLogId)
+            setCursorToLogId(linkToLogId, logs)
+            if (index !== -1) {
+                containerRef.current?.focus()
+            }
+        }
+    }, [linkToLogId, logs, setCursorToLogId])
 
     const tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime'> = {
         formatDate: 'YYYY-MM-DD',

--- a/products/logs/frontend/components/LogsViewer/LogsViewerRowActions.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerRowActions.tsx
@@ -1,0 +1,45 @@
+import { useActions } from 'kea'
+
+import { IconCopy } from '@posthog/icons'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { IconLink } from 'lib/lemon-ui/icons'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
+
+import { ParsedLogMessage } from 'products/logs/frontend/types'
+
+import { logsViewerLogic } from './logsViewerLogic'
+
+interface LogsViewerRowActionsProps {
+    log: ParsedLogMessage
+}
+
+export function LogsViewerRowActions({ log }: LogsViewerRowActionsProps): JSX.Element {
+    const { copyLinkToLog } = useActions(logsViewerLogic)
+
+    return (
+        <More
+            overlay={
+                <>
+                    <LemonButton
+                        onClick={() => copyToClipboard(log.body, 'log message')}
+                        fullWidth
+                        sideIcon={<IconCopy />}
+                        data-attr="logs-viewer-copy-message"
+                    >
+                        Copy log message
+                    </LemonButton>
+                    <LemonButton
+                        onClick={() => copyLinkToLog(log.uuid)}
+                        fullWidth
+                        sideIcon={<IconLink />}
+                        data-attr="logs-viewer-copy-link"
+                    >
+                        Copy link to log
+                    </LemonButton>
+                </>
+            }
+        />
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
@@ -1,0 +1,75 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonCheckbox, LemonSegmentedButton } from '@posthog/lemon-ui'
+
+import { humanFriendlyNumber } from 'lib/utils'
+
+import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
+
+import { LogsOrderBy } from 'products/logs/frontend/types'
+
+import { logsViewerLogic } from './logsViewerLogic'
+
+export interface LogsViewerToolbarProps {
+    totalLogsCount?: number
+    orderBy: LogsOrderBy
+    onChangeOrderBy: (orderBy: LogsOrderBy) => void
+}
+
+export const LogsViewerToolbar = ({
+    totalLogsCount,
+    orderBy,
+    onChangeOrderBy,
+}: LogsViewerToolbarProps): JSX.Element => {
+    const { wrapBody, prettifyJson } = useValues(logsViewerLogic)
+    const { setWrapBody, setPrettifyJson } = useActions(logsViewerLogic)
+
+    return (
+        <div className="flex justify-between">
+            <div className="flex gap-2">
+                <LemonSegmentedButton
+                    value={orderBy}
+                    onChange={onChangeOrderBy}
+                    options={[
+                        {
+                            value: 'earliest',
+                            label: 'Earliest',
+                        },
+                        {
+                            value: 'latest',
+                            label: 'Latest',
+                        },
+                    ]}
+                    size="small"
+                />
+                <LemonCheckbox checked={wrapBody} bordered onChange={setWrapBody} label="Wrap message" size="small" />
+                <LemonCheckbox
+                    checked={prettifyJson}
+                    bordered
+                    onChange={setPrettifyJson}
+                    label="Prettify JSON"
+                    size="small"
+                />
+            </div>
+            <div className="flex items-center gap-4">
+                {totalLogsCount !== undefined && totalLogsCount > 0 && (
+                    <span className="text-muted text-xs">{humanFriendlyNumber(totalLogsCount)} logs</span>
+                )}
+                <span className="text-muted text-xs flex items-center gap-1">
+                    <KeyboardShortcut arrowup />
+                    <KeyboardShortcut arrowdown />
+                    or
+                    <KeyboardShortcut j />
+                    <KeyboardShortcut k />
+                    navigate
+                    <span className="mx-1">·</span>
+                    <KeyboardShortcut enter />
+                    expand
+                    <span className="mx-1">·</span>
+                    <KeyboardShortcut r />
+                    refresh
+                </span>
+            </div>
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/index.ts
+++ b/products/logs/frontend/components/LogsViewer/index.ts
@@ -1,0 +1,3 @@
+export * from './LogsViewer'
+export * from './LogsViewerToolbar'
+export * from './logsViewerLogic'

--- a/products/logs/frontend/components/LogsViewer/index.ts
+++ b/products/logs/frontend/components/LogsViewer/index.ts
@@ -1,3 +1,4 @@
 export * from './LogsViewer'
+export * from './LogsViewerRowActions'
 export * from './LogsViewerToolbar'
 export * from './logsViewerLogic'

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -43,7 +43,7 @@ describe('logsViewerLogic', () => {
         const logsLength = mockLogs.length
 
         beforeEach(() => {
-            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic = logsViewerLogic({ tabId: 'test-tab', logs: mockLogs, orderBy: 'latest' })
             logic.mount()
         })
 
@@ -141,7 +141,7 @@ describe('logsViewerLogic', () => {
 
     describe('empty logs', () => {
         beforeEach(() => {
-            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic = logsViewerLogic({ tabId: 'test-tab', logs: mockLogs, orderBy: 'latest' })
             logic.mount()
         })
 
@@ -164,7 +164,7 @@ describe('logsViewerLogic', () => {
 
     describe('expansion', () => {
         beforeEach(() => {
-            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic = logsViewerLogic({ tabId: 'test-tab', logs: mockLogs, orderBy: 'latest' })
             logic.mount()
         })
         it('expands a log when not expanded', async () => {
@@ -215,7 +215,7 @@ describe('logsViewerLogic', () => {
         const mockLog2 = createMockParsedLog('log-2')
 
         beforeEach(() => {
-            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic = logsViewerLogic({ tabId: 'test-tab', logs: mockLogs, orderBy: 'latest' })
             logic.mount()
         })
 
@@ -275,7 +275,7 @@ describe('logsViewerLogic', () => {
 
     describe('focus state', () => {
         beforeEach(() => {
-            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic = logsViewerLogic({ tabId: 'test-tab', logs: mockLogs, orderBy: 'latest' })
             logic.mount()
         })
 
@@ -300,7 +300,7 @@ describe('logsViewerLogic', () => {
 
     describe('display options', () => {
         beforeEach(() => {
-            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic = logsViewerLogic({ tabId: 'test-tab', logs: mockLogs, orderBy: 'latest' })
             logic.mount()
         })
 

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -1,0 +1,331 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { ParsedLogMessage } from 'products/logs/frontend/types'
+
+import { logsViewerLogic } from './logsViewerLogic'
+
+const createMockParsedLog = (uuid: string): ParsedLogMessage => ({
+    uuid,
+    trace_id: 'trace-1',
+    span_id: 'span-1',
+    body: `Log ${uuid}`,
+    attributes: {},
+    timestamp: '2024-01-01T00:00:00Z',
+    observed_timestamp: '2024-01-01T00:00:00Z',
+    severity_text: 'info',
+    severity_number: 9,
+    level: 'info',
+    resource_attributes: {},
+    instrumentation_scope: 'test',
+    event_name: 'log',
+    cleanBody: `Log ${uuid}`,
+    parsedBody: null,
+})
+
+const mockLogs = [createMockParsedLog('log-1'), createMockParsedLog('log-2'), createMockParsedLog('log-3')]
+
+describe('logsViewerLogic', () => {
+    let logic: ReturnType<typeof logsViewerLogic.build>
+
+    beforeEach(() => {
+        // Clear localStorage to reset persisted state
+        localStorage.clear()
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    describe('cursor navigation', () => {
+        const logsLength = mockLogs.length
+
+        beforeEach(() => {
+            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic.mount()
+        })
+
+        it('sets cursor index', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setCursorIndex(0)
+            }).toMatchValues({
+                cursorIndex: 0,
+            })
+        })
+
+        it('clears cursor when set to null', async () => {
+            logic.actions.setCursorIndex(0)
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.setCursorIndex(null)
+            }).toMatchValues({
+                cursorIndex: null,
+            })
+        })
+
+        describe('moveCursorDown', () => {
+            it('highlights first log when none is highlighted', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.moveCursorDown(logsLength)
+                })
+                    .toDispatchActions(['moveCursorDown', 'setCursorIndex'])
+                    .toMatchValues({
+                        cursorIndex: 0,
+                    })
+            })
+
+            it('highlights next log in sequence', async () => {
+                logic.actions.setCursorIndex(0)
+                await expectLogic(logic).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.moveCursorDown(logsLength)
+                })
+                    .toDispatchActions(['moveCursorDown', 'setCursorIndex'])
+                    .toMatchValues({
+                        cursorIndex: 1,
+                    })
+            })
+
+            it('does nothing when at last log', async () => {
+                logic.actions.setCursorIndex(2)
+                await expectLogic(logic).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.moveCursorDown(logsLength)
+                })
+                    .toDispatchActions(['moveCursorDown'])
+                    .toNotHaveDispatchedActions(['setCursorIndex'])
+            })
+        })
+
+        describe('moveCursorUp', () => {
+            it('highlights last log when none is highlighted', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.moveCursorUp(logsLength)
+                })
+                    .toDispatchActions(['moveCursorUp', 'setCursorIndex'])
+                    .toMatchValues({
+                        cursorIndex: 2,
+                    })
+            })
+
+            it('highlights previous log in sequence', async () => {
+                logic.actions.setCursorIndex(1)
+                await expectLogic(logic).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.moveCursorUp(logsLength)
+                })
+                    .toDispatchActions(['moveCursorUp', 'setCursorIndex'])
+                    .toMatchValues({
+                        cursorIndex: 0,
+                    })
+            })
+
+            it('does nothing when at first log', async () => {
+                logic.actions.setCursorIndex(0)
+                await expectLogic(logic).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.moveCursorUp(logsLength)
+                })
+                    .toDispatchActions(['moveCursorUp'])
+                    .toNotHaveDispatchedActions(['setCursorIndex'])
+            })
+        })
+    })
+
+    describe('empty logs', () => {
+        beforeEach(() => {
+            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic.mount()
+        })
+
+        it('moveCursorDown does nothing when logs are empty', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.moveCursorDown(0)
+            })
+                .toDispatchActions(['moveCursorDown'])
+                .toNotHaveDispatchedActions(['setCursorIndex'])
+        })
+
+        it('moveCursorUp does nothing when logs are empty', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.moveCursorUp(0)
+            })
+                .toDispatchActions(['moveCursorUp'])
+                .toNotHaveDispatchedActions(['setCursorIndex'])
+        })
+    })
+
+    describe('expansion', () => {
+        beforeEach(() => {
+            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic.mount()
+        })
+        it('expands a log when not expanded', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.toggleExpandLog('log-1')
+            }).toMatchValues({
+                expandedLogIds: { 'log-1': true },
+            })
+        })
+
+        it('collapses a log when already expanded', async () => {
+            logic.actions.toggleExpandLog('log-1')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.expandedLogIds['log-1']).toBe(true)
+
+            await expectLogic(logic, () => {
+                logic.actions.toggleExpandLog('log-1')
+            }).toMatchValues({
+                expandedLogIds: {},
+            })
+        })
+
+        it('supports multiple expanded logs', async () => {
+            logic.actions.toggleExpandLog('log-1')
+            logic.actions.toggleExpandLog('log-2')
+            logic.actions.toggleExpandLog('log-3')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.expandedLogIds).toEqual({
+                'log-1': true,
+                'log-2': true,
+                'log-3': true,
+            })
+
+            logic.actions.toggleExpandLog('log-2')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.expandedLogIds).toEqual({
+                'log-1': true,
+                'log-3': true,
+            })
+        })
+    })
+
+    describe('pinning', () => {
+        const mockLog1 = createMockParsedLog('log-1')
+        const mockLog2 = createMockParsedLog('log-2')
+
+        beforeEach(() => {
+            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic.mount()
+        })
+
+        it('pins a log when not pinned', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.togglePinLog(mockLog1)
+            }).toMatchValues({
+                pinnedLogs: { 'log-1': mockLog1 },
+            })
+        })
+
+        it('unpins a log when already pinned', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.togglePinLog(mockLog1)
+            }).toMatchValues({
+                pinnedLogs: { 'log-1': mockLog1 },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.togglePinLog(mockLog1)
+            }).toMatchValues({
+                pinnedLogs: {},
+            })
+        })
+
+        it('supports multiple pinned logs', async () => {
+            logic.actions.togglePinLog(mockLog1)
+            logic.actions.togglePinLog(mockLog2)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.pinnedLogs).toEqual({
+                'log-1': mockLog1,
+                'log-2': mockLog2,
+            })
+        })
+
+        it('pinnedLogsArray returns array of pinned logs', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.togglePinLog(mockLog1)
+                logic.actions.togglePinLog(mockLog2)
+            }).toFinishAllListeners()
+
+            const pinnedArray = logic.values.pinnedLogsArray
+            expect(pinnedArray).toHaveLength(2)
+            expect(pinnedArray).toContainEqual(mockLog1)
+            expect(pinnedArray).toContainEqual(mockLog2)
+        })
+
+        it('provides O(1) lookup via pinnedLogs record', async () => {
+            logic.actions.togglePinLog(mockLog1)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(!!logic.values.pinnedLogs['log-1']).toBe(true)
+            expect(!!logic.values.pinnedLogs['log-2']).toBe(false)
+        })
+    })
+
+    describe('focus state', () => {
+        beforeEach(() => {
+            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic.mount()
+        })
+
+        it('defaults to not focused', () => {
+            expect(logic.values.isFocused).toBe(false)
+        })
+
+        it('sets focus state', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFocused(true)
+            }).toMatchValues({
+                isFocused: true,
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.setFocused(false)
+            }).toMatchValues({
+                isFocused: false,
+            })
+        })
+    })
+
+    describe('display options', () => {
+        beforeEach(() => {
+            logic = logsViewerLogic({ tabId: 'test-tab' })
+            logic.mount()
+        })
+
+        it('defaults wrapBody to true', () => {
+            expect(logic.values.wrapBody).toBe(true)
+        })
+
+        it('sets wrapBody', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setWrapBody(false)
+            }).toMatchValues({
+                wrapBody: false,
+            })
+        })
+
+        it('defaults prettifyJson to true', () => {
+            expect(logic.values.prettifyJson).toBe(true)
+        })
+
+        it('sets prettifyJson', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setPrettifyJson(false)
+            }).toMatchValues({
+                prettifyJson: false,
+            })
+        })
+    })
+})

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -1,0 +1,141 @@
+import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+
+import { ParsedLogMessage } from 'products/logs/frontend/types'
+
+import type { logsViewerLogicType } from './logsViewerLogicType'
+
+export interface LogsViewerLogicProps {
+    tabId: string
+}
+
+export const logsViewerLogic = kea<logsViewerLogicType>([
+    props({} as LogsViewerLogicProps),
+    key((props) => props.tabId),
+    path((tabId) => ['products', 'logs', 'frontend', 'components', 'LogsViewer', 'logsViewerLogic', tabId]),
+
+    actions({
+        // Display options
+        setWrapBody: (wrapBody: boolean) => ({ wrapBody }),
+        setPrettifyJson: (prettifyJson: boolean) => ({ prettifyJson }),
+
+        // Pinning
+        togglePinLog: (log: ParsedLogMessage) => ({ log }),
+
+        // Focus (for keyboard shortcuts)
+        setFocused: (isFocused: boolean) => ({ isFocused }),
+
+        // Cursor (vim-style navigation position)
+        setCursorIndex: (index: number | null) => ({ index }),
+        resetCursor: true,
+        moveCursorDown: (logsLength: number) => ({ logsLength }),
+        moveCursorUp: (logsLength: number) => ({ logsLength }),
+
+        // Expansion
+        toggleExpandLog: (logId: string) => ({ logId }),
+    }),
+
+    reducers({
+        wrapBody: [
+            true,
+            { persist: true },
+            {
+                setWrapBody: (_, { wrapBody }) => wrapBody,
+            },
+        ],
+
+        prettifyJson: [
+            true,
+            { persist: true },
+            {
+                setPrettifyJson: (_, { prettifyJson }) => prettifyJson,
+            },
+        ],
+
+        pinnedLogs: [
+            {} as Record<string, ParsedLogMessage>,
+            { persist: true },
+            {
+                togglePinLog: (state, { log }) => {
+                    if (state[log.uuid]) {
+                        const { [log.uuid]: _, ...rest } = state
+                        return rest
+                    }
+                    return { ...state, [log.uuid]: log }
+                },
+            },
+        ],
+
+        isFocused: [
+            false,
+            {
+                setFocused: (_, { isFocused }) => isFocused,
+            },
+        ],
+
+        cursorIndex: [
+            null as number | null,
+            { persist: true },
+            {
+                setCursorIndex: (_, { index }) => index,
+                resetCursor: () => null,
+            },
+        ],
+
+        expandedLogIds: [
+            {} as Record<string, boolean>,
+            {
+                toggleExpandLog: (state, { logId }) => {
+                    if (state[logId]) {
+                        const { [logId]: _, ...rest } = state
+                        return rest
+                    }
+                    return { ...state, [logId]: true }
+                },
+            },
+        ],
+    }),
+
+    selectors({
+        pinnedLogsArray: [(s) => [s.pinnedLogs], (pinnedLogs): ParsedLogMessage[] => Object.values(pinnedLogs)],
+
+        getCursorLogId: [
+            (s) => [s.cursorIndex],
+            (cursorIndex: number | null) =>
+                (logs: ParsedLogMessage[]): string | null =>
+                    cursorIndex !== null && cursorIndex >= 0 && cursorIndex < logs.length
+                        ? logs[cursorIndex].uuid
+                        : null,
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        moveCursorDown: ({ logsLength }) => {
+            if (logsLength === 0) {
+                return
+            }
+
+            if (values.cursorIndex === null) {
+                actions.setCursorIndex(0)
+                return
+            }
+
+            if (values.cursorIndex < logsLength - 1) {
+                actions.setCursorIndex(values.cursorIndex + 1)
+            }
+        },
+        moveCursorUp: ({ logsLength }) => {
+            if (logsLength === 0) {
+                return
+            }
+
+            if (values.cursorIndex === null) {
+                actions.setCursorIndex(logsLength - 1)
+                return
+            }
+
+            if (values.cursorIndex > 0) {
+                actions.setCursorIndex(values.cursorIndex - 1)
+            }
+        },
+    })),
+])

--- a/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
@@ -59,27 +59,27 @@ const getCellStyle = (column: LogColumnConfig, flexWidth?: number): React.CSSPro
 
 export interface LogRowProps {
     log: ParsedLogMessage
-    isHighlighted: boolean
+    isAtCursor: boolean
     pinned: boolean
     showPinnedWithOpacity: boolean
     wrapBody: boolean
     prettifyJson: boolean
     tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime'>
-    onTogglePin: (uuid: string) => void
-    onSetHighlighted: (uuid: string | null) => void
+    onTogglePin: (log: ParsedLogMessage) => void
+    onSetCursor: () => void
     rowWidth?: number
 }
 
 export function LogRow({
     log,
-    isHighlighted,
+    isAtCursor,
     pinned,
     showPinnedWithOpacity,
     wrapBody,
     prettifyJson,
     tzLabelFormat,
     onTogglePin,
-    onSetHighlighted,
+    onSetCursor,
     rowWidth,
 }: LogRowProps): JSX.Element {
     const isNew = 'new' in log && log.new
@@ -140,7 +140,7 @@ export function LogRow({
                             icon={pinned ? <IconPinFilled /> : <IconPin />}
                             onClick={(e) => {
                                 e.stopPropagation()
-                                onTogglePin(log.uuid)
+                                onTogglePin(log)
                             }}
                             tooltip={pinned ? 'Unpin log' : 'Pin log'}
                             className={cn(pinned ? 'text-warning' : 'text-muted opacity-0 group-hover:opacity-100')}
@@ -159,13 +159,13 @@ export function LogRow({
         <div
             className={cn(
                 'flex items-center border-b border-border cursor-pointer hover:bg-fill-highlight-100 group',
-                isHighlighted && 'bg-primary-highlight',
+                isAtCursor && 'bg-primary-highlight',
                 pinned && 'bg-warning-highlight',
                 pinned && showPinnedWithOpacity && 'opacity-50',
                 isNew && 'VirtualizedLogsList__row--new'
             )}
             style={rowWidth ? { width: rowWidth } : undefined}
-            onClick={() => onSetHighlighted(isHighlighted ? null : log.uuid)}
+            onClick={onSetCursor}
         >
             {LOG_COLUMNS.map(renderCell)}
         </div>

--- a/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
@@ -6,7 +6,7 @@ import { cn } from 'lib/utils/css-classes'
 
 import { LogMessage } from '~/queries/schema/schema-general'
 
-import { LogsTableRowActions } from 'products/logs/frontend/components/LogsTable/LogsTableRowActions'
+import { LogsViewerRowActions } from 'products/logs/frontend/components/LogsViewer/LogsViewerRowActions'
 import { ParsedLogMessage } from 'products/logs/frontend/types'
 
 const SEVERITY_BAR_COLORS: Record<LogMessage['severity_text'], string> = {
@@ -146,7 +146,7 @@ export function LogRow({
                             className={cn(pinned ? 'text-warning' : 'text-muted opacity-0 group-hover:opacity-100')}
                         />
                         <div className="opacity-0 group-hover:opacity-100" onClick={(e) => e.stopPropagation()}>
-                            <LogsTableRowActions log={log} />
+                            <LogsViewerRowActions log={log} />
                         </div>
                     </div>
                 )

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -8,6 +8,7 @@ import { List, ListRowProps } from 'react-virtualized/dist/es/List'
 
 import { TZLabelProps } from 'lib/components/TZLabel'
 
+import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
 import {
     LOG_ROW_HEADER_HEIGHT,
     LogRow,
@@ -15,34 +16,35 @@ import {
     getMinRowWidth,
 } from 'products/logs/frontend/components/VirtualizedLogsList/LogRow'
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
-import { logsLogic } from 'products/logs/frontend/logsLogic'
 import { ParsedLogMessage } from 'products/logs/frontend/types'
 
 interface VirtualizedLogsListProps {
     dataSource: ParsedLogMessage[]
     loading: boolean
-    isPinned: (uuid: string) => boolean
     wrapBody: boolean
     prettifyJson: boolean
     tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime'>
     showPinnedWithOpacity?: boolean
     fixedHeight?: number
     disableInfiniteScroll?: boolean
+    hasMoreLogsToLoad?: boolean
+    onLoadMore?: () => void
 }
 
 export function VirtualizedLogsList({
     dataSource,
     loading,
-    isPinned,
     wrapBody,
     prettifyJson,
     tzLabelFormat,
     showPinnedWithOpacity = false,
     fixedHeight,
     disableInfiniteScroll = false,
+    hasMoreLogsToLoad = false,
+    onLoadMore,
 }: VirtualizedLogsListProps): JSX.Element {
-    const { togglePinLog, setHighlightedLogId, fetchNextLogsPage } = useActions(logsLogic)
-    const { highlightedLogId, hasMoreLogsToLoad, logsLoading } = useValues(logsLogic)
+    const { togglePinLog, setCursorIndex } = useActions(logsViewerLogic)
+    const { pinnedLogs, cursorIndex } = useValues(logsViewerLogic)
     const { shouldLoadMore, containerWidth } = useValues(virtualizedLogsListLogic)
     const { setContainerWidth } = useActions(virtualizedLogsListLogic)
     const listRef = useRef<List>(null)
@@ -82,36 +84,28 @@ export function VirtualizedLogsList({
 
     // Clear cache when display options change or when a fresh query starts
     useEffect(() => {
-        if (logsLoading && dataSource.length === 0) {
+        if (loading && dataSource.length === 0) {
             cache.clearAll()
         }
-    }, [logsLoading, dataSource.length, cache])
+    }, [loading, dataSource.length, cache])
 
     useEffect(() => {
         cache.clearAll()
         listRef.current?.recomputeRowHeights()
     }, [wrapBody, prettifyJson, cache])
 
-    const prevHighlightedLogIdRef = useRef<string | null>(null)
-
     useEffect(() => {
-        if (highlightedLogId && highlightedLogId !== prevHighlightedLogIdRef.current) {
-            requestAnimationFrame(() => {
-                const index = dataSource.findIndex((log) => log.uuid === highlightedLogId)
-                if (index !== -1) {
-                    listRef.current?.scrollToRow(index)
-                }
-            })
+        if (cursorIndex !== null) {
+            listRef.current?.scrollToRow(cursorIndex)
         }
-        prevHighlightedLogIdRef.current = highlightedLogId
-    }, [highlightedLogId, dataSource])
+    }, [cursorIndex])
 
     const handleRowsRendered = ({ stopIndex }: { stopIndex: number }): void => {
         if (disableInfiniteScroll) {
             return
         }
-        if (shouldLoadMore(stopIndex, dataSource.length, hasMoreLogsToLoad, logsLoading)) {
-            fetchNextLogsPage(250)
+        if (shouldLoadMore(stopIndex, dataSource.length, hasMoreLogsToLoad, loading)) {
+            onLoadMore?.()
         }
     }
 
@@ -119,8 +113,6 @@ export function VirtualizedLogsList({
         (rowWidth?: number) =>
             ({ index, key, style, parent }: ListRowProps): JSX.Element => {
                 const log = dataSource[index]
-                const isHighlighted = log.uuid === highlightedLogId
-                const pinned = isPinned(log.uuid)
 
                 return (
                     <CellMeasurer cache={cache} columnIndex={0} key={key} parent={parent} rowIndex={index}>
@@ -132,14 +124,14 @@ export function VirtualizedLogsList({
                             >
                                 <LogRow
                                     log={log}
-                                    isHighlighted={isHighlighted}
-                                    pinned={pinned}
+                                    isAtCursor={index === cursorIndex}
+                                    pinned={!!pinnedLogs[log.uuid]}
                                     showPinnedWithOpacity={showPinnedWithOpacity}
                                     wrapBody={wrapBody}
                                     prettifyJson={prettifyJson}
                                     tzLabelFormat={tzLabelFormat}
                                     onTogglePin={togglePinLog}
-                                    onSetHighlighted={setHighlightedLogId}
+                                    onSetCursor={() => setCursorIndex(index)}
                                     rowWidth={rowWidth}
                                 />
                             </div>
@@ -149,15 +141,15 @@ export function VirtualizedLogsList({
             },
         [
             dataSource,
-            highlightedLogId,
-            isPinned,
+            cursorIndex,
+            pinnedLogs,
             cache,
             showPinnedWithOpacity,
             wrapBody,
             prettifyJson,
             tzLabelFormat,
             togglePinLog,
-            setHighlightedLogId,
+            setCursorIndex,
         ]
     )
 

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -81,11 +81,22 @@ export function VirtualizedLogsList({
     useEffect(() => {
         if (cursorIndex !== null && dataSource.length > 0) {
             listRef.current?.scrollToRow(cursorIndex)
-            // Double scroll with delay to ensure row measurement is complete
-            const timer = setTimeout(() => {
-                listRef.current?.scrollToRow(cursorIndex)
-            }, 100)
-            return () => clearTimeout(timer)
+            // Double scroll after two animation frames to ensure row measurement is complete
+            let raf1: number | null = null
+            let raf2: number | null = null
+            raf1 = requestAnimationFrame(() => {
+                raf2 = requestAnimationFrame(() => {
+                    listRef.current?.scrollToRow(cursorIndex)
+                })
+            })
+            return () => {
+                if (raf1 !== null) {
+                    cancelAnimationFrame(raf1)
+                }
+                if (raf2 !== null) {
+                    cancelAnimationFrame(raf2)
+                }
+            }
         }
     }, [cursorIndex, dataSource.length])
 

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -223,7 +223,7 @@ export const logsLogic = kea<logsLogicType>([
             liveTailAbortController,
         }),
         setDateRange: (dateRange: DateRange) => ({ dateRange }),
-        setOrderBy: (orderBy: LogsQuery['orderBy']) => ({ orderBy }),
+        setOrderBy: (orderBy: LogsOrderBy) => ({ orderBy }),
         setSearchTerm: (searchTerm: LogsQuery['searchTerm']) => ({ searchTerm }),
         setSeverityLevels: (severityLevels: LogsQuery['severityLevels']) => ({ severityLevels }),
         setServiceNames: (serviceNames: LogsQuery['serviceNames']) => ({ serviceNames }),

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -23,7 +23,7 @@ import { JsonType, PropertyFilterType, PropertyGroupFilter, PropertyOperator, Un
 
 import { zoomDateRange } from './filters/zoom-utils'
 import type { logsLogicType } from './logsLogicType'
-import { ParsedLogMessage } from './types'
+import { LogsOrderBy, ParsedLogMessage } from './types'
 
 const DEFAULT_DATE_RANGE = { date_from: '-1h', date_to: null }
 const DEFAULT_SEVERITY_LEVELS = [] as LogsQuery['severityLevels']

--- a/products/logs/frontend/types.ts
+++ b/products/logs/frontend/types.ts
@@ -2,3 +2,5 @@ import { LogMessage } from '~/queries/schema/schema-general'
 import { JsonType } from '~/types'
 
 export type ParsedLogMessage = LogMessage & { cleanBody: string; parsedBody: JsonType | null }
+
+export type LogsOrderBy = 'earliest' | 'latest' | undefined


### PR DESCRIPTION
## Problem

The virtualized logs list had all its state (cursor, pinning, display options, keyboard shortcuts) scattered across `logsLogic` and `LogsScene`. This made it hard to reason about and tightly coupled the viewer to the scene.

## Changes

This PR extracts the LogsViewer as a self-contained component with its own Kea logic, decoupling it from the LogsScene. The refactoring moves display options, cursor navigation, pinning, and keyboard shortcuts into a dedicated `logsViewerLogic`, making the logs viewer reusable and easier to reason about.

- Introduces `logsViewerLogic` to manage viewer-specific state (cursor, pinning, display options, deep linking)
- Refactors `VirtualizedLogsList` to depend on `logsViewerLogic` instead of `logsLogic`
- Renames properties for clarity: `isHighlighted` → `isAtCursor`, `highlightedLogId` → `cursorLogId`

## How did you test this code?

- Unit tests for `logsViewerLogic`
- Manual testing: focus, keyboard nav, pinning, deep linking, copy link to log