### PR TITLE
feat(logs): add timezone support for sparkline and refactor component

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -9,13 +9,11 @@ import {
     LemonSegmentedButton,
     LemonSelect,
     LemonTable,
-    SpinnerOverlay,
     Tooltip,
 } from '@posthog/lemon-ui'
 
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
-import { Sparkline } from 'lib/components/Sparkline'
 import { TZLabel, TZLabelProps } from 'lib/components/TZLabel'
 import { ListHog } from 'lib/components/hedgehogs'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -36,6 +34,7 @@ import { LogMessage, ProductKey } from '~/queries/schema/schema-general'
 import { PropertyOperator } from '~/types'
 
 import { LogTag } from 'products/logs/frontend/components/LogTag'
+import { LogsSparkline } from 'products/logs/frontend/components/LogsSparkline'
 import { LogsTableRowActions } from 'products/logs/frontend/components/LogsTable/LogsTableRowActions'
 import { VirtualizedLogsList } from 'products/logs/frontend/components/VirtualizedLogsList'
 import { LogsFilterGroup } from 'products/logs/frontend/components/filters/LogsFilters/FilterGroup'
@@ -54,9 +53,8 @@ export const scene: SceneExport = {
 }
 
 export function LogsScene(): JSX.Element {
-    const { sparklineData, sparklineLoading, logsLoading } = useValues(logsLogic)
-    const { runQuery, setDateRangeFromSparkline, highlightNextLog, highlightPreviousLog, toggleExpandLog } =
-        useActions(logsLogic)
+    const { logsLoading } = useValues(logsLogic)
+    const { runQuery, highlightNextLog, highlightPreviousLog, toggleExpandLog } = useActions(logsLogic)
     const { highlightedLogId: sceneHighlightedLogId } = useValues(logsLogic)
 
     useEffect(() => {
@@ -80,10 +78,6 @@ export function LogsScene(): JSX.Element {
         },
         [sceneHighlightedLogId, logsLoading, runQuery]
     )
-
-    const onSelectionChange = (selection: { startIndex: number; endIndex: number }): void => {
-        setDateRangeFromSparkline(selection.startIndex, selection.endIndex)
-    }
 
     return (
         <SceneContent>
@@ -115,21 +109,7 @@ export function LogsScene(): JSX.Element {
                 isEmpty={false}
             />
             <Filters />
-            <div className="relative h-40 flex flex-col">
-                {sparklineData.data.length > 0 ? (
-                    <Sparkline
-                        labels={sparklineData.labels}
-                        data={sparklineData.data}
-                        className="w-full flex-1"
-                        onSelectionChange={onSelectionChange}
-                    />
-                ) : !sparklineLoading ? (
-                    <div className="flex-1 text-muted flex items-center justify-center">
-                        No results matching filters
-                    </div>
-                ) : null}
-                {sparklineLoading && <SpinnerOverlay />}
-            </div>
+            <LogsSparkline />
             <SceneDivider />
             <LogsListContainer />
         </SceneContent>

--- a/products/logs/frontend/components/LogsSparkline.tsx
+++ b/products/logs/frontend/components/LogsSparkline.tsx
@@ -74,9 +74,12 @@ export function LogsSparkline(): JSX.Element {
         return sparklineData.dates.map((date) => dayjs(date).toISOString())
     }, [sparklineData.dates])
 
-    const onSelectionChange = (selection: { startIndex: number; endIndex: number }): void => {
-        setDateRangeFromSparkline(selection.startIndex, selection.endIndex)
-    }
+    const onSelectionChange = useCallback(
+        (selection: { startIndex: number; endIndex: number }): void => {
+            setDateRangeFromSparkline(selection.startIndex, selection.endIndex)
+        },
+        [setDateRangeFromSparkline]
+    )
 
     return (
         <div className="relative h-40 flex flex-col">

--- a/products/logs/frontend/components/LogsSparkline.tsx
+++ b/products/logs/frontend/components/LogsSparkline.tsx
@@ -15,7 +15,7 @@ export function LogsSparkline(): JSX.Element {
 
     const isUTC = sparklineTimezone === SparklineTimezone.UTC
     const deviceTimezone = shortTimeZone()
-    const showTimezoneToggle = deviceTimezone !== 'UTC'
+    const showTimezoneToggle = deviceTimezone !== null && deviceTimezone !== 'UTC'
 
     const { timeUnit, tickFormat } = useMemo(() => {
         if (!sparklineData.dates.length) {

--- a/products/logs/frontend/components/LogsSparkline.tsx
+++ b/products/logs/frontend/components/LogsSparkline.tsx
@@ -64,7 +64,7 @@ export function LogsSparkline(): JSX.Element {
     const renderLabel = useCallback(
         (label: string): string => {
             const d = isUTC ? dayjs(label).utc() : dayjs(label)
-            const tz = isUTC ? 'UTC' : shortTimeZone(undefined, d.toDate())
+            const tz = isUTC ? 'UTC' : (shortTimeZone(undefined, d.toDate()) ?? 'Local')
             return `${d.format('D MMM YYYY HH:mm:ss')} ${tz}`
         },
         [isUTC]

--- a/products/logs/frontend/components/LogsSparkline.tsx
+++ b/products/logs/frontend/components/LogsSparkline.tsx
@@ -1,0 +1,111 @@
+import { useActions, useValues } from 'kea'
+import { useCallback, useMemo } from 'react'
+
+import { LemonSegmentedButton, SpinnerOverlay } from '@posthog/lemon-ui'
+
+import { AnyScaleOptions, Sparkline } from 'lib/components/Sparkline'
+import { dayjs } from 'lib/dayjs'
+import { shortTimeZone } from 'lib/utils'
+
+import { SparklineTimezone, logsLogic } from '../logsLogic'
+
+export function LogsSparkline(): JSX.Element {
+    const { sparklineData, sparklineLoading, sparklineTimezone } = useValues(logsLogic)
+    const { setDateRangeFromSparkline, setSparklineTimezone } = useActions(logsLogic)
+
+    const isUTC = sparklineTimezone === SparklineTimezone.UTC
+    const deviceTimezone = shortTimeZone()
+    const showTimezoneToggle = deviceTimezone !== 'UTC'
+
+    const { timeUnit, tickFormat } = useMemo(() => {
+        if (!sparklineData.dates.length) {
+            return { timeUnit: 'hour' as const, tickFormat: 'HH:mm:ss' }
+        }
+        const firstDate = dayjs(sparklineData.dates[0])
+        const lastDate = dayjs(sparklineData.dates[sparklineData.dates.length - 1])
+        const hoursDiff = lastDate.diff(firstDate, 'hours')
+
+        if (hoursDiff <= 1) {
+            return { timeUnit: 'second' as const, tickFormat: 'HH:mm:ss' }
+        } else if (hoursDiff <= 6) {
+            return { timeUnit: 'minute' as const, tickFormat: 'HH:mm:ss' }
+        } else if (hoursDiff <= 48) {
+            return { timeUnit: 'hour' as const, tickFormat: 'HH:mm' }
+        }
+        return { timeUnit: 'day' as const, tickFormat: 'D MMM HH:mm' }
+    }, [sparklineData.dates])
+
+    const withXScale = useCallback(
+        (scale: AnyScaleOptions): AnyScaleOptions => {
+            return {
+                ...scale,
+                type: 'timeseries',
+                ticks: {
+                    display: true,
+                    maxRotation: 0,
+                    maxTicksLimit: 6,
+                    font: {
+                        size: 10,
+                        lineHeight: 1,
+                    },
+                    callback: function (value: string | number) {
+                        const d = isUTC ? dayjs(value).utc() : dayjs(value)
+                        return d.format(tickFormat)
+                    },
+                },
+                time: {
+                    unit: timeUnit,
+                },
+            } as AnyScaleOptions
+        },
+        [timeUnit, tickFormat, isUTC]
+    )
+
+    const renderLabel = useCallback(
+        (label: string): string => {
+            const d = isUTC ? dayjs(label).utc() : dayjs(label)
+            const tz = isUTC ? 'UTC' : shortTimeZone(undefined, d.toDate())
+            return `${d.format('D MMM YYYY HH:mm:ss')} ${tz}`
+        },
+        [isUTC]
+    )
+
+    const sparklineLabels = useMemo(() => {
+        return sparklineData.dates.map((date) => dayjs(date).toISOString())
+    }, [sparklineData.dates])
+
+    const onSelectionChange = (selection: { startIndex: number; endIndex: number }): void => {
+        setDateRangeFromSparkline(selection.startIndex, selection.endIndex)
+    }
+
+    return (
+        <div className="relative h-40 flex flex-col">
+            {showTimezoneToggle && (
+                <div className="absolute top-1 right-1 z-10">
+                    <LemonSegmentedButton
+                        size="xsmall"
+                        value={sparklineTimezone}
+                        onChange={(value) => setSparklineTimezone(value)}
+                        options={[
+                            { value: SparklineTimezone.UTC, label: 'UTC' },
+                            { value: SparklineTimezone.Device, label: deviceTimezone ?? 'Device' },
+                        ]}
+                    />
+                </div>
+            )}
+            {sparklineData.data.length > 0 ? (
+                <Sparkline
+                    labels={sparklineLabels}
+                    data={sparklineData.data}
+                    className="w-full flex-1"
+                    onSelectionChange={onSelectionChange}
+                    withXScale={withXScale}
+                    renderLabel={renderLabel}
+                />
+            ) : !sparklineLoading ? (
+                <div className="flex-1 text-muted flex items-center justify-center">No results matching filters</div>
+            ) : null}
+            {sparklineLoading && <SpinnerOverlay />}
+        </div>
+    )
+}

--- a/products/logs/frontend/logsLogic.test.ts
+++ b/products/logs/frontend/logsLogic.test.ts
@@ -3,7 +3,7 @@ import { expectLogic } from 'kea-test-utils'
 import { LogMessage } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 
-import { logsLogic } from './logsLogic'
+import { SparklineTimezone, logsLogic } from './logsLogic'
 
 const createMockLog = (uuid: string): LogMessage => ({
     uuid,
@@ -192,6 +192,26 @@ describe('logsLogic', () => {
                 expect(logic.values.expandedLogIds.has('log-2')).toBe(false)
                 expect(logic.values.expandedLogIds.has('log-3')).toBe(true)
             })
+        })
+    })
+
+    describe('sparklineTimezone', () => {
+        it('updates when setSparklineTimezone is called', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setSparklineTimezone(SparklineTimezone.Device)
+            })
+                .toDispatchActions(['setSparklineTimezone'])
+                .toMatchValues({
+                    sparklineTimezone: SparklineTimezone.Device,
+                })
+
+            await expectLogic(logic, () => {
+                logic.actions.setSparklineTimezone(SparklineTimezone.UTC)
+            })
+                .toDispatchActions(['setSparklineTimezone'])
+                .toMatchValues({
+                    sparklineTimezone: SparklineTimezone.UTC,
+                })
         })
     })
 })

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -40,6 +40,7 @@ const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MAX_MS = 5000
 
 export enum SparklineTimezone {
     UTC = 'utc',
+    Project = 'project',
     Device = 'device',
 }
 

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -38,6 +38,11 @@ const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
 const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS = 1000
 const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MAX_MS = 5000
 
+export enum SparklineTimezone {
+    UTC = 'utc',
+    Device = 'device',
+}
+
 const parseLogAttributes = (logs: LogMessage[]): void => {
     logs.forEach((row) => {
         Object.keys(row.attributes).forEach((key) => {
@@ -257,6 +262,7 @@ export const logsLogic = kea<logsLogicType>([
         expireLiveTail: () => true,
         setLiveTailExpired: (liveTailExpired: boolean) => ({ liveTailExpired }),
         addLogsToSparkline: (logs: LogMessage[]) => logs,
+        setSparklineTimezone: (sparklineTimezone: SparklineTimezone) => ({ sparklineTimezone }),
     }),
 
     reducers({
@@ -406,6 +412,13 @@ export const logsLogic = kea<logsLogicType>([
             {
                 setLiveTailRunning: (_, { enabled }) => enabled,
                 runQuery: () => false,
+            },
+        ],
+        sparklineTimezone: [
+            SparklineTimezone.UTC as SparklineTimezone,
+            { persist: true },
+            {
+                setSparklineTimezone: (_, { sparklineTimezone }) => sparklineTimezone,
             },
         ],
         liveTailPollInterval: [


### PR DESCRIPTION
## Problem

The logs sparkline timeline lacks time context - users can't tell what time period each bar represents without hovering. Additionally, there's no way to switch between UTC and device timezone for the timeline display.

## Changes

<img width="867" height="191" alt="image" src="https://github.com/user-attachments/assets/8f162033-13db-4c04-b054-d0285538cba6" />
<img width="870" height="185" alt="image" src="https://github.com/user-attachments/assets/26ffad1f-ff79-44fb-937a-8442269474d6" />

- **Added time labels to sparkline X-axis**: Shows timestamps on the timeline that adapt based on date range:
  - ≤1 hour: `HH:mm:ss` with second granularity
  - ≤6 hours: `HH:mm:ss` with minute granularity  
  - ≤48 hours: `HH:mm` with hour granularity
  - \>48 hours: `D MMM HH:mm` with day granularity

- **Added UTC/Device timezone toggle**: Users can switch between UTC and their local timezone. Toggle is hidden when device timezone is already UTC.

- **Extracted sparkline to dedicated component**: Moved all sparkline logic from `LogsScene.tsx` into new `LogsSparkline.tsx` component for better separation of concerns.

- **Added `sparklineTimezone` state to logsLogic**: New persisted state with `SparklineTimezone.UTC` and `SparklineTimezone.Device` options.

**New files:**
- `LogsSparkline.tsx` - Self-contained sparkline with timezone toggle and time-aware X-axis

## How did you test this code?

- Manually tested timezone toggle switches between UTC and device time
- Verified toggle hides when device is in UTC timezone
- Tested different date ranges to confirm appropriate time granularity displays
- Confirmed sparkline selection (drag to zoom) still works
- Verified tooltip shows full timestamp with timezone label on hover
- New unit tests

