### PR TITLE
chore(flags): Migrate gauge metrics to Pushgateway

### DIFF
--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -26,6 +26,7 @@ import structlog
 from posthoganalytics import capture_exception
 from prometheus_client import Counter, Gauge, Histogram
 
+from posthog.metrics import pushed_metrics_registry
 from posthog.models.team.team import Team
 from posthog.redis import get_client
 from posthog.storage.hypercache import HyperCache
@@ -86,29 +87,66 @@ HYPERCACHE_INVALIDATION_COUNTER = Counter(
     labelnames=["namespace"],
 )
 
-HYPERCACHE_COVERAGE_GAUGE = Gauge(
-    "posthog_hypercache_coverage_percent",
-    "Percentage of teams with cached data",
-    labelnames=["namespace"],
-)
 
-HYPERCACHE_SIZE_GAUGE = Gauge(
-    "posthog_hypercache_size_bytes",
-    "Estimated total cache size in bytes",
-    labelnames=["namespace"],
-)
+def push_hypercache_stats_metrics(
+    namespace: str,
+    coverage_percent: float,
+    entries_total: int,
+    expiry_tracked_total: int,
+    size_bytes: int | None,
+) -> None:
+    """
+    Push HyperCache stats metrics to Pushgateway for single-value display.
 
-HYPERCACHE_ENTRIES_GAUGE = Gauge(
-    "posthog_hypercache_entries_total",
-    "Total number of entries in the HyperCache",
-    labelnames=["namespace"],
-)
+    Gauge metrics are pushed to Pushgateway instead of using module-level gauges
+    to ensure only one value per metric appears in Grafana dashboards.
 
-HYPERCACHE_EXPIRY_TRACKED_GAUGE = Gauge(
-    "posthog_hypercache_expiry_tracked_total",
-    "Number of entries tracked in the expiry sorted set",
-    labelnames=["namespace"],
-)
+    Args:
+        namespace: The HyperCache namespace (e.g., "feature_flags", "team_metadata")
+        coverage_percent: Percentage of teams with cached data
+        entries_total: Total number of entries in the HyperCache
+        expiry_tracked_total: Number of entries tracked in the expiry sorted set
+        size_bytes: Estimated total cache size in bytes (None if unknown)
+    """
+    if not settings.PROM_PUSHGATEWAY_ADDRESS:
+        return
+
+    try:
+        with pushed_metrics_registry("hypercache_stats") as registry:
+            coverage_gauge = Gauge(
+                "posthog_hypercache_coverage_percent",
+                "Percentage of teams with cached data",
+                labelnames=["namespace"],
+                registry=registry,
+            )
+            coverage_gauge.labels(namespace=namespace).set(coverage_percent)
+
+            entries_gauge = Gauge(
+                "posthog_hypercache_entries_total",
+                "Total number of entries in the HyperCache",
+                labelnames=["namespace"],
+                registry=registry,
+            )
+            entries_gauge.labels(namespace=namespace).set(entries_total)
+
+            expiry_tracked_gauge = Gauge(
+                "posthog_hypercache_expiry_tracked_total",
+                "Number of entries tracked in the expiry sorted set",
+                labelnames=["namespace"],
+                registry=registry,
+            )
+            expiry_tracked_gauge.labels(namespace=namespace).set(expiry_tracked_total)
+
+            if size_bytes is not None:
+                size_gauge = Gauge(
+                    "posthog_hypercache_size_bytes",
+                    "Estimated total cache size in bytes",
+                    labelnames=["namespace"],
+                    registry=registry,
+                )
+                size_gauge.labels(namespace=namespace).set(size_bytes)
+    except Exception as e:
+        logger.warning("Failed to push hypercache stats to Pushgateway", error=str(e), namespace=namespace)
 
 
 class UpdateFn(Protocol):
@@ -520,9 +558,10 @@ def get_cache_stats(config: HyperCacheManagementConfig) -> dict[str, Any]:
         coverage_percent = (total_keys / total_teams * 100) if total_teams else 0
 
         size_stats = {}
+        estimated_total_bytes: int | None = None
         if sample_sizes:
             avg_size = statistics.mean(sample_sizes)
-            estimated_total_bytes = avg_size * total_keys
+            estimated_total_bytes = int(avg_size * total_keys)
 
             size_stats = {
                 "sample_count": len(sample_sizes),
@@ -533,14 +572,17 @@ def get_cache_stats(config: HyperCacheManagementConfig) -> dict[str, Any]:
                 "estimated_total_mb": round(estimated_total_bytes / (1024 * 1024), 2),
             }
 
-            HYPERCACHE_SIZE_GAUGE.labels(namespace=config.namespace).set(estimated_total_bytes)
-
-        HYPERCACHE_COVERAGE_GAUGE.labels(namespace=config.namespace).set(coverage_percent)
-        HYPERCACHE_ENTRIES_GAUGE.labels(namespace=config.namespace).set(total_keys)
-
-        # Update expiry tracking gauge using ZCARD (O(1) operation)
+        # Get expiry tracking count using ZCARD (O(1) operation)
         expiry_tracked_count = redis_client.zcard(config.expiry_sorted_set_key)
-        HYPERCACHE_EXPIRY_TRACKED_GAUGE.labels(namespace=config.namespace).set(expiry_tracked_count)
+
+        # Push metrics to Pushgateway for single-value display in Grafana
+        push_hypercache_stats_metrics(
+            namespace=config.namespace,
+            coverage_percent=coverage_percent,
+            entries_total=total_keys,
+            expiry_tracked_total=expiry_tracked_count,
+            size_bytes=estimated_total_bytes,
+        )
 
         return {
             "total_cached": total_keys,

--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -112,7 +112,7 @@ def push_hypercache_stats_metrics(
         return
 
     try:
-        with pushed_metrics_registry("hypercache_stats") as registry:
+        with pushed_metrics_registry(f"hypercache_stats_{namespace}") as registry:
             coverage_gauge = Gauge(
                 "posthog_hypercache_coverage_percent",
                 "Percentage of teams with cached data",

--- a/posthog/storage/test/test_hypercache_manager.py
+++ b/posthog/storage/test/test_hypercache_manager.py
@@ -445,7 +445,7 @@ class TestPushHypercacheStatsMetrics(BaseTest):
                 size_bytes=1024000,
             )
 
-        mock_registry_cm.assert_called_once_with("hypercache_stats")
+        mock_registry_cm.assert_called_once_with("hypercache_stats_feature_flags")
 
     @patch("posthog.storage.hypercache_manager.pushed_metrics_registry")
     def test_skips_push_when_no_pushgateway_address(self, mock_registry_cm):
@@ -477,7 +477,7 @@ class TestPushHypercacheStatsMetrics(BaseTest):
                 size_bytes=None,
             )
 
-        mock_registry_cm.assert_called_once()
+        mock_registry_cm.assert_called_once_with("hypercache_stats_team_metadata")
 
     @patch("posthog.storage.hypercache_manager.pushed_metrics_registry")
     @patch("posthog.storage.hypercache_manager.logger")

--- a/posthog/storage/test/test_hypercache_manager.py
+++ b/posthog/storage/test/test_hypercache_manager.py
@@ -11,7 +11,12 @@ from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
 from posthog.storage.hypercache import HyperCache
-from posthog.storage.hypercache_manager import HyperCacheManagementConfig, get_cache_stats, invalidate_all_caches
+from posthog.storage.hypercache_manager import (
+    HyperCacheManagementConfig,
+    get_cache_stats,
+    invalidate_all_caches,
+    push_hypercache_stats_metrics,
+)
 
 
 def create_test_hypercache(
@@ -419,3 +424,76 @@ class TestGetCacheStats(BaseTest):
         # First scan call should use the stats pattern
         first_call = mock_redis.scan_iter.call_args_list[0]
         assert first_call[1]["match"] == "posthog:1:cache/teams/*/feature_flags/flags.json"
+
+
+class TestPushHypercacheStatsMetrics(BaseTest):
+    """Test push_hypercache_stats_metrics functionality."""
+
+    @patch("posthog.storage.hypercache_manager.pushed_metrics_registry")
+    def test_pushes_metrics_to_pushgateway(self, mock_registry_cm):
+        """Test that metrics are pushed to Pushgateway when configured."""
+        mock_registry = MagicMock()
+        mock_registry_cm.return_value.__enter__ = MagicMock(return_value=mock_registry)
+        mock_registry_cm.return_value.__exit__ = MagicMock(return_value=False)
+
+        with self.settings(PROM_PUSHGATEWAY_ADDRESS="http://pushgateway:9091"):
+            push_hypercache_stats_metrics(
+                namespace="feature_flags",
+                coverage_percent=85.5,
+                entries_total=1000,
+                expiry_tracked_total=950,
+                size_bytes=1024000,
+            )
+
+        mock_registry_cm.assert_called_once_with("hypercache_stats")
+
+    @patch("posthog.storage.hypercache_manager.pushed_metrics_registry")
+    def test_skips_push_when_no_pushgateway_address(self, mock_registry_cm):
+        """Test that no push happens when PROM_PUSHGATEWAY_ADDRESS is not set."""
+        with self.settings(PROM_PUSHGATEWAY_ADDRESS=None):
+            push_hypercache_stats_metrics(
+                namespace="feature_flags",
+                coverage_percent=85.5,
+                entries_total=1000,
+                expiry_tracked_total=950,
+                size_bytes=1024000,
+            )
+
+        mock_registry_cm.assert_not_called()
+
+    @patch("posthog.storage.hypercache_manager.pushed_metrics_registry")
+    def test_skips_size_gauge_when_size_bytes_is_none(self, mock_registry_cm):
+        """Test that size gauge is not created when size_bytes is None."""
+        mock_registry = MagicMock()
+        mock_registry_cm.return_value.__enter__ = MagicMock(return_value=mock_registry)
+        mock_registry_cm.return_value.__exit__ = MagicMock(return_value=False)
+
+        with self.settings(PROM_PUSHGATEWAY_ADDRESS="http://pushgateway:9091"):
+            push_hypercache_stats_metrics(
+                namespace="team_metadata",
+                coverage_percent=90.0,
+                entries_total=500,
+                expiry_tracked_total=500,
+                size_bytes=None,
+            )
+
+        mock_registry_cm.assert_called_once()
+
+    @patch("posthog.storage.hypercache_manager.pushed_metrics_registry")
+    @patch("posthog.storage.hypercache_manager.logger")
+    def test_logs_warning_on_push_failure(self, mock_logger, mock_registry_cm):
+        """Test that a warning is logged when push fails."""
+        mock_registry_cm.return_value.__enter__ = MagicMock(side_effect=Exception("Connection failed"))
+        mock_registry_cm.return_value.__exit__ = MagicMock(return_value=False)
+
+        with self.settings(PROM_PUSHGATEWAY_ADDRESS="http://pushgateway:9091"):
+            push_hypercache_stats_metrics(
+                namespace="feature_flags",
+                coverage_percent=85.5,
+                entries_total=1000,
+                expiry_tracked_total=950,
+                size_bytes=1024000,
+            )
+
+        mock_logger.warning.assert_called_once()
+        assert "Failed to push hypercache stats" in str(mock_logger.warning.call_args)

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -16,7 +16,6 @@ from posthog.models.team import Team
 from posthog.storage.hypercache_manager import (
     HYPERCACHE_BATCH_REFRESH_COUNTER,
     HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM,
-    HYPERCACHE_COVERAGE_GAUGE,
     HYPERCACHE_SIGNAL_UPDATE_COUNTER,
 )
 from posthog.tasks.utils import CeleryQueue
@@ -99,11 +98,8 @@ def refresh_expiring_flags_cache_entries() -> None:
         # Note: HYPERCACHE_TEAMS_PROCESSED_COUNTER is already incremented by the generic
         # cache_expiry_manager.refresh_expiring_caches() function, so we don't increment it again here
 
-        # Only scan once after refresh for metrics
+        # Scan after refresh for metrics (pushes to Pushgateway via get_cache_stats)
         stats_after = get_cache_stats()
-
-        coverage_percent = stats_after.get("cache_coverage_percent", 0)
-        HYPERCACHE_COVERAGE_GAUGE.labels(namespace="feature_flags").set(coverage_percent)
 
         duration = time.time() - start_time
         HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM.labels(namespace="feature_flags").observe(duration)

--- a/posthog/tasks/team_metadata.py
+++ b/posthog/tasks/team_metadata.py
@@ -19,7 +19,6 @@ from posthog.models.team import Team
 from posthog.storage.hypercache_manager import (
     HYPERCACHE_BATCH_REFRESH_COUNTER,
     HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM,
-    HYPERCACHE_COVERAGE_GAUGE,
     HYPERCACHE_SIGNAL_UPDATE_COUNTER,
 )
 from posthog.storage.team_metadata_cache import (
@@ -84,11 +83,8 @@ def refresh_expiring_team_metadata_cache_entries() -> None:
         # Note: HYPERCACHE_TEAMS_PROCESSED_COUNTER is already incremented by the generic
         # cache_expiry_manager.refresh_expiring_caches() function, so we don't increment it again here
 
-        # Only scan once after refresh for metrics
+        # Scan after refresh for metrics (pushes to Pushgateway via get_cache_stats)
         stats_after = get_cache_stats()
-
-        coverage_percent = stats_after.get("cache_coverage_percent", 0)
-        HYPERCACHE_COVERAGE_GAUGE.labels(namespace="team_metadata").set(coverage_percent)
 
         duration = time.time() - start_time
         HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM.labels(namespace="team_metadata").observe(duration)


### PR DESCRIPTION
## Problem

Running management commands and scheduled tasks can end up running on multiple different pods over time. Metrics recorded from those runs will have different pods associated with them. This leads to confusing gauges like:

<img width="795" height="313" alt="Screenshot 2025-12-04 at 9 17 16 AM" src="https://github.com/user-attachments/assets/59cdbac2-b6b6-4998-996e-a52d9f10da04" />

[`PushGateway` is ideal for this situation](https://prometheus.io/docs/practices/pushing/):

> Usually, the only valid use case for the Pushgateway is for capturing the outcome of a service-level batch job. A "service-level" batch job is one which is not semantically related to a specific machine or job instance (for example, a batch job that deletes a number of users for an entire service). Such a job's metrics should not include a machine or instance label to decouple the lifecycle of specific machines or instances from the pushed metrics. This decreases the burden for managing stale metrics in the Pushgateway.

## Changes

Gauge metrics (coverage, entries, expiry tracked, size) now push to `Pushgateway` instead of using module-level gauges. This ensures only one value per metric appears in Grafana dashboards, eliminating the multiple-values-per-pod issue.

- Add `push_hypercache_stats_metrics() helper using `pushed_metrics_registry`
- Update `get_cache_stats()`` to push metrics via Pushgateway
- Remove module-level gauge definitions `(HYPERCACHE_*_GAUGE)``
- Remove gauge usage from Celery tasks (`get_cache_stats` handles it)
- Add unit tests for the new Pushgateway helper

Counter and histogram metrics remain as module-level since they aggregate correctly across pods.

The `push_hypercache_stats_metrics` implementation is all in a big try/catch to make sure it's safe.

## How did you test this code?

- Add unit tests
- Manual test

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
