### PR TITLE
chore: isolate endpoint's materialization status endpoint

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1807,6 +1807,9 @@ const api = {
 
             return result
         },
+        async getMaterializationStatus(name: string): Promise<EndpointType['materialization']> {
+            return await new ApiRequest().endpointDetail(name).withAction('materialization_status').get()
+        },
         async listVersions(name: string): Promise<EndpointVersion[]> {
             return await new ApiRequest().endpointDetail(name).withAction('versions').get()
         },

--- a/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
@@ -50,13 +50,15 @@ function getStatusTagType(status: string | undefined): 'success' | 'danger' | 'w
 }
 
 export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JSX.Element {
-    const { setCacheAge, setSyncFrequency, setIsMaterialized, loadEndpoint } = useActions(endpointLogic({ tabId }))
+    const { setCacheAge, setSyncFrequency, setIsMaterialized, loadMaterializationStatus } = useActions(
+        endpointLogic({ tabId })
+    )
     const {
         endpoint,
         cacheAge,
         syncFrequency,
         isMaterialized: localIsMaterialized,
-        endpointLoading,
+        materializationStatusLoading,
     } = useValues(endpointLogic({ tabId }))
 
     if (!endpoint) {
@@ -111,8 +113,8 @@ export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JS
                                     <LemonButton
                                         size="xsmall"
                                         icon={<IconRefresh />}
-                                        onClick={() => endpoint.name && loadEndpoint(endpoint.name)}
-                                        loading={endpointLoading}
+                                        onClick={() => endpoint.name && loadMaterializationStatus(endpoint.name)}
+                                        loading={materializationStatusLoading}
                                         tooltip="Refresh status"
                                     />
                                 </div>


### PR DESCRIPTION
## Problem

Refreshing an endpoint's materialization status or toggling materialization on/off currently reloads the entire endpoint state. This is inefficient as it fetches unnecessary data (e.g., query definition, full configuration). Users need a way to quickly refresh only the materialization status.

## Changes

-   **Backend**: Introduced a new API endpoint (`/api/environments/{team_id}/endpoints/{name}/materialization_status/`) to fetch only materialization-related data.
-   **Frontend**:
    -   Created a dedicated Kea loader (`materializationStatus`) in `endpointLogic.tsx` to utilize this new API.
    -   Updated the refresh button and the `updateEndpointSuccess` listener in `EndpointConfiguration.tsx` to use `loadMaterializationStatus`, preventing full endpoint reloads.
-   **Tests**: Added `test_materialization_status_endpoint` to verify the new API endpoint.

## How did you test this code?

-   **Automated tests**: Added `test_materialization_status_endpoint` to `products/endpoints/backend/tests/test_endpoint_materialization.py`.
-   **Manual testing**: Verified locally by refreshing materialization status and toggling materialization on/off, ensuring only the status updates without a full page reload. Ran `npm run lint`, `npm run test`, and `python manage.py test products/endpoints`.

## Changelog: (features only) Is this feature complete?

not rly

---
[Slack Thread](https://posthog.slack.com/archives/C0932JBCUFL/p1764871649164819?thread_ts=1764871649.164819&cid=C0932JBCUFL)

<a href="https://cursor.com/background-agent?bcId=bc-05a0b9b4-8546-4a2f-9e2c-c8a0988acd34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-05a0b9b4-8546-4a2f-9e2c-c8a0988acd34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

