### PR TITLE
test(e2e): fix flaky insight variables test

### DIFF
--- a/playwright/e2e/product-analytics/insight-variables.spec.ts
+++ b/playwright/e2e/product-analytics/insight-variables.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test } from '../../utils/playwright-test-base'
 
 test.describe('insight variables', () => {
-    test('show correctly on dashboards', async ({ page }) => {
+    // :FIXME: This test is flaky on CI.
+    test.skip('show correctly on dashboards', async ({ page }) => {
         // Go to "Insight variables" dashboard.
         await page.goToMenuItem('dashboards')
         await page.getByText('Insight variables').click()

--- a/playwright/e2e/product-analytics/insight-variables.spec.ts
+++ b/playwright/e2e/product-analytics/insight-variables.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test } from '../../utils/playwright-test-base'
 
 test.describe('insight variables', () => {
-    // :FIXME: This test is flaky on CI.
-    test.skip('show correctly on dashboards', async ({ page }) => {
+    test('show correctly on dashboards', async ({ page }) => {
         // Go to "Insight variables" dashboard.
         await page.goToMenuItem('dashboards')
         await page.getByText('Insight variables').click()
@@ -10,27 +9,19 @@ test.describe('insight variables', () => {
         // Add a temporary override
         await page.goto(page.url() + '?query_variables=%7B"variable_4"%3A40%7D%20')
 
-        const cardForDefaultVariable = page
-            .getByText('Variable default')
-            .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+        const cardForDefaultVariable = page.locator('.InsightCard').nth(0)
         await cardForDefaultVariable.scrollIntoViewIfNeeded()
         await expect(cardForDefaultVariable.locator('.BoldNumber')).toHaveText('10')
 
-        const cardForDashboardOverride = page
-            .getByText('Dashboard override')
-            .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+        const cardForDashboardOverride = page.locator('.InsightCard').nth(1)
         await cardForDashboardOverride.scrollIntoViewIfNeeded()
         await expect(cardForDashboardOverride.locator('.BoldNumber')).toHaveText('20')
 
-        const cardForInsightOverride = page
-            .getByText('Insight override')
-            .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+        const cardForInsightOverride = page.locator('.InsightCard').nth(2)
         await cardForInsightOverride.scrollIntoViewIfNeeded()
         await expect(cardForInsightOverride.locator('.BoldNumber')).toHaveText('30')
 
-        const cardForURLOverride = page
-            .getByText('Temporary override')
-            .locator('xpath=ancestor::*[contains(@class, "InsightCard")]')
+        const cardForURLOverride = page.locator('.InsightCard').nth(3)
         await cardForURLOverride.scrollIntoViewIfNeeded()
         await expect(cardForURLOverride.locator('.BoldNumber')).toHaveText('40')
     })


### PR DESCRIPTION
Virtualization of the dashboard made the test flaky. Using the card order instead of text for selectors fixes this.