### PR TITLE
fix(CI): Change backend migrations CI runner to depot-ubuntu-latest

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -118,7 +118,7 @@ jobs:
         timeout-minutes: 20
 
         name: Validate Django and CH migrations
-        runs-on: ubuntu-latest
+        runs-on: depot-ubuntu-latest
 
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
It used a GH runner with too little disk space.
