### PR TITLE
fix: do not show success component when re-navigating to reset password reset form after previous successful submissions

### DIFF
--- a/frontend/src/scenes/authentication/PasswordReset.tsx
+++ b/frontend/src/scenes/authentication/PasswordReset.tsx
@@ -28,14 +28,14 @@ export const scene: SceneExport = {
 export function PasswordReset(): JSX.Element {
     const { preflight, preflightLoading } = useValues(preflightLogic)
     const { requestPasswordResetSucceeded, requestPasswordResetManualErrors } = useValues(passwordResetLogic)
-    const { reset } = useActions(passwordResetLogic)
+    const { resetRequestPasswordReset } = useActions(passwordResetLogic)
 
     useEffect(() => {
         // reset the logic success states on component unmount
         return () => {
-            reset()
+            resetRequestPasswordReset()
         }
-    }, [reset])
+    }, [resetRequestPasswordReset])
 
     return (
         <BridgePage view="password-reset" footer={<SupportModalButton />}>

--- a/frontend/src/scenes/authentication/PasswordReset.tsx
+++ b/frontend/src/scenes/authentication/PasswordReset.tsx
@@ -4,6 +4,7 @@ Scene to request a password reset email.
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { router } from 'kea-router'
+import { useEffect } from 'react'
 
 import { IconCheckCircle } from '@posthog/icons'
 import { LemonButton, LemonDivider, LemonInput, Link } from '@posthog/lemon-ui'
@@ -27,6 +28,14 @@ export const scene: SceneExport = {
 export function PasswordReset(): JSX.Element {
     const { preflight, preflightLoading } = useValues(preflightLogic)
     const { requestPasswordResetSucceeded, requestPasswordResetManualErrors } = useValues(passwordResetLogic)
+    const { reset } = useActions(passwordResetLogic)
+
+    useEffect(() => {
+        // reset the logic success states on component unmount
+        return () => {
+            reset()
+        }
+    }, [reset])
 
     return (
         <BridgePage view="password-reset" footer={<SupportModalButton />}>

--- a/frontend/src/scenes/authentication/PasswordReset.tsx
+++ b/frontend/src/scenes/authentication/PasswordReset.tsx
@@ -31,7 +31,6 @@ export function PasswordReset(): JSX.Element {
     const { resetRequestPasswordReset } = useActions(passwordResetLogic)
 
     useEffect(() => {
-        // reset the logic success states on component unmount
         return () => {
             resetRequestPasswordReset()
         }

--- a/frontend/src/scenes/authentication/passwordResetLogic.ts
+++ b/frontend/src/scenes/authentication/passwordResetLogic.ts
@@ -1,4 +1,4 @@
-import { kea, path, reducers, selectors } from 'kea'
+import { actions, kea, path, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { urlToAction } from 'kea-router'
@@ -31,6 +31,9 @@ export interface PasswordResetForm {
 
 export const passwordResetLogic = kea<passwordResetLogicType>([
     path(['scenes', 'authentication', 'passwordResetLogic']),
+    actions({
+        reset: true,
+    }),
     loaders(() => ({
         validatedResetToken: [
             null as ValidatedTokenResponseType | null,
@@ -51,12 +54,14 @@ export const passwordResetLogic = kea<passwordResetLogicType>([
             false,
             {
                 submitRequestPasswordResetSuccess: () => true,
+                reset: () => false,
             },
         ],
         passwordResetSucceeded: [
             false,
             {
                 submitPasswordResetSuccess: () => true,
+                reset: () => false,
             },
         ],
     }),

--- a/frontend/src/scenes/authentication/passwordResetLogic.ts
+++ b/frontend/src/scenes/authentication/passwordResetLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, path, reducers, selectors } from 'kea'
+import { kea, path, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { urlToAction } from 'kea-router'
@@ -31,9 +31,6 @@ export interface PasswordResetForm {
 
 export const passwordResetLogic = kea<passwordResetLogicType>([
     path(['scenes', 'authentication', 'passwordResetLogic']),
-    actions({
-        reset: true,
-    }),
     loaders(() => ({
         validatedResetToken: [
             null as ValidatedTokenResponseType | null,
@@ -54,14 +51,14 @@ export const passwordResetLogic = kea<passwordResetLogicType>([
             false,
             {
                 submitRequestPasswordResetSuccess: () => true,
-                reset: () => false,
+                resetRequestPasswordReset: () => false,
             },
         ],
         passwordResetSucceeded: [
             false,
             {
                 submitPasswordResetSuccess: () => true,
-                reset: () => false,
+                resetPasswordReset: () => false,
             },
         ],
     }),

--- a/frontend/src/scenes/authentication/passwordResetLogic.ts
+++ b/frontend/src/scenes/authentication/passwordResetLogic.ts
@@ -58,7 +58,6 @@ export const passwordResetLogic = kea<passwordResetLogicType>([
             false,
             {
                 submitPasswordResetSuccess: () => true,
-                resetPasswordReset: () => false,
             },
         ],
     }),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Fixes an issue where users were unable to re-enter the password reset request form after requesting a reset email, pressing back button, and clicking "Forgot your password?" again.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

When the `PasswordReset` component is unmounted, the form submission state is cleared which allows the user to re-enter the form in the future.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

Manually



https://github.com/user-attachments/assets/fb00d30e-c952-4250-bd9a-0a86265cc744


## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
