### PR TITLE
fix: decrypt encrypted payloads when copying feature flags

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -40,7 +40,7 @@ from posthog.helpers.dashboard_templates import add_enriched_insights_to_feature
 from posthog.helpers.encrypted_flag_payloads import (
     REDACTED_PAYLOAD_VALUE,
     encrypt_flag_payloads,
-    get_decrypted_flag_payloads,
+    get_decrypted_flag_payloads_protected,
 )
 from posthog.metrics import TOMBSTONE_COUNTER
 from posthog.models import FeatureFlag, Tag
@@ -965,7 +965,9 @@ class FeatureFlagSerializer(
         # If flag is using encrypted payloads, replace them with redacted string or unencrypted value
         # if the request was made with a personal API key
         if instance.has_encrypted_payloads:
-            instance.filters["payloads"] = get_decrypted_flag_payloads(request, instance.filters.get("payloads", {}))
+            instance.filters["payloads"] = get_decrypted_flag_payloads_protected(
+                request, instance.filters.get("payloads", {})
+            )
 
         return instance
 
@@ -1518,7 +1520,7 @@ class FeatureFlagViewSet(
 
             # If flag is using encrypted payloads, replace them with redacted string or unencrypted value
             if feature_flag.get("has_encrypted_payloads", False):
-                feature_flag["filters"]["payloads"] = get_decrypted_flag_payloads(
+                feature_flag["filters"]["payloads"] = get_decrypted_flag_payloads_protected(
                     request, feature_flag["filters"]["payloads"]
                 )
 
@@ -1537,7 +1539,7 @@ class FeatureFlagViewSet(
 
         # If flag is using encrypted payloads, replace them with redacted string or unencrypted value
         if feature_flag_data.get("has_encrypted_payloads", False):
-            feature_flag_data["filters"]["payloads"] = get_decrypted_flag_payloads(
+            feature_flag_data["filters"]["payloads"] = get_decrypted_flag_payloads_protected(
                 request, feature_flag_data["filters"]["payloads"]
             )
 
@@ -2048,9 +2050,11 @@ class FeatureFlagViewSet(
             return Response(payloads.get("true") or None)
 
         # Note: This decryption step is protected by the feature_flag:read scope, so we can assume the
-        # user has access to the flag. However get_decrypted_flag_payloads will also check the authentication
+        # user has access to the flag. However get_decrypted_flag_payloads_protected will also check the authentication
         # method used to make the request as it is used in non-protected endpoints.
-        decrypted_flag_payloads = get_decrypted_flag_payloads(request, feature_flag.filters.get("payloads", {}))
+        decrypted_flag_payloads = get_decrypted_flag_payloads_protected(
+            request, feature_flag.filters.get("payloads", {})
+        )
 
         count = int(1 / settings.DECIDE_BILLING_SAMPLING_RATE)
         increment_request_count(self.team.pk, count, FlagRequestType.REMOTE_CONFIG)

--- a/posthog/api/organization_feature_flag.py
+++ b/posthog/api/organization_feature_flag.py
@@ -82,6 +82,13 @@ class OrganizationFeatureFlagView(
         successful_projects = []
         failed_projects = []
 
+        filters = flag_to_copy.get_filters()
+        if flag_to_copy.has_encrypted_payloads:
+            # Decrypt payloads before copying to ensure the new flag has unencrypted payloads
+            # that will be re-encrypted by the serializer if needed
+            encrypted_payloads = filters.get("payloads", {})
+            filters["payloads"] = get_decrypted_flag_payloads(encrypted_payloads, should_decrypt=True)
+
         for target_project_id in target_project_ids:
             # Target project does not exist
             target_team = Team.objects.filter(project_id=target_project_id).first()
@@ -167,13 +174,6 @@ class OrganizationFeatureFlagView(
                             prop["value"] = name_to_dest_cohort_id[cohort_name]
                         except (ValueError, TypeError):
                             continue
-
-            filters = flag_to_copy.get_filters()
-            if flag_to_copy.has_encrypted_payloads:
-                # Decrypt payloads before copying to ensure the new flag has unencrypted payloads
-                # that will be re-encrypted by the serializer if needed
-                encrypted_payloads = filters.get("payloads", {})
-                filters["payloads"] = get_decrypted_flag_payloads(encrypted_payloads, should_decrypt=True)
 
             flag_data = {
                 "key": flag_to_copy.key,

--- a/posthog/api/organization_feature_flag.py
+++ b/posthog/api/organization_feature_flag.py
@@ -173,7 +173,7 @@ class OrganizationFeatureFlagView(
                 # Decrypt payloads before copying to ensure the new flag has unencrypted payloads
                 # that will be re-encrypted by the serializer if needed
                 encrypted_payloads = filters.get("payloads", {})
-                filters["payloads"] = get_decrypted_flag_payloads(request, encrypted_payloads)
+                filters["payloads"] = get_decrypted_flag_payloads(encrypted_payloads, should_decrypt=True)
 
             flag_data = {
                 "key": flag_to_copy.key,

--- a/posthog/api/organization_feature_flag.py
+++ b/posthog/api/organization_feature_flag.py
@@ -6,6 +6,7 @@ from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action
+from posthog.helpers.encrypted_flag_payloads import get_decrypted_flag_payloads
 from posthog.models import FeatureFlag, Team
 from posthog.models.cohort import Cohort, CohortOrEmpty
 from posthog.models.filters.filter import Filter
@@ -167,10 +168,17 @@ class OrganizationFeatureFlagView(
                         except (ValueError, TypeError):
                             continue
 
+            filters = flag_to_copy.get_filters()
+            if flag_to_copy.has_encrypted_payloads:
+                # Decrypt payloads before copying to ensure the new flag has unencrypted payloads
+                # that will be re-encrypted by the serializer if needed
+                encrypted_payloads = filters.get("payloads", {})
+                filters["payloads"] = get_decrypted_flag_payloads(request, encrypted_payloads)
+
             flag_data = {
                 "key": flag_to_copy.key,
                 "name": flag_to_copy.name,
-                "filters": flag_to_copy.get_filters(),
+                "filters": filters,
                 "active": flag_to_copy.active,
                 "rollout_percentage": flag_to_copy.rollout_percentage,
                 "ensure_experience_continuity": flag_to_copy.ensure_experience_continuity,

--- a/posthog/api/test/test_organization_feature_flag.py
+++ b/posthog/api/test/test_organization_feature_flag.py
@@ -748,5 +748,9 @@ class TestOrganizationFeatureFlagCopy(APIBaseTest, QueryMatchingTest):
         copied_flag = FeatureFlag.objects.get(key=encrypted_flag.key, team=target_project)
         self.assertTrue(copied_flag.is_remote_configuration)
         self.assertTrue(copied_flag.has_encrypted_payloads)
-        # The payload should be encrypted in the database (different from original since it was decrypted and re-encrypted)
-        self.assertIsNotNone(copied_flag.filters.get("payloads", {}).get("true"))
+
+        # Verify the encrypted payload can be decrypted back to the original value
+        from posthog.helpers.encrypted_flag_payloads import get_decrypted_flag_payload
+
+        decrypted_payload = get_decrypted_flag_payload(copied_flag.filters["payloads"]["true"], should_decrypt=True)
+        self.assertEqual(decrypted_payload, '{"key": "secret_value"}')

--- a/posthog/helpers/encrypted_flag_payloads.py
+++ b/posthog/helpers/encrypted_flag_payloads.py
@@ -6,13 +6,16 @@ from posthog.temporal.common.codec import EncryptionCodec
 REDACTED_PAYLOAD_VALUE = '"********* (encrypted)"'
 
 
-def get_decrypted_flag_payloads(request, encrypted_payloads: dict) -> dict:
+def get_decrypted_flag_payloads_protected(request, encrypted_payloads: dict) -> dict:
     # We only decode encrypted flag payloads if the request is made with a personal API key
     is_personal_api_request = isinstance(request.successful_authenticator, PersonalAPIKeyAuthentication)
+    return get_decrypted_flag_payloads(encrypted_payloads, should_decrypt=is_personal_api_request)
 
+
+def get_decrypted_flag_payloads(encrypted_payloads: dict, should_decrypt: bool) -> dict:
     decrypted_payloads = {}
     for key, value in (encrypted_payloads or {}).items():
-        decrypted_payloads[key] = get_decrypted_flag_payload(value, should_decrypt=is_personal_api_request)
+        decrypted_payloads[key] = get_decrypted_flag_payload(value, should_decrypt=should_decrypt)
 
     return decrypted_payloads
 


### PR DESCRIPTION
Follow up to #42732.

When copying a feature flag with encrypted payloads to another project, the encrypted payloads must be decrypted before being passed to the serializer. The serializer will then re-encrypt them for the destination flag.

Without this fix, copying flags with encrypted payloads would fail or create invalid data because the already-encrypted payloads would be treated as plaintext and encrypted again.