### PR TITLE
fix: we can throw away the snapshots once we've passed them to the player

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -296,6 +296,7 @@ export const FEATURE_FLAGS = {
     REMOTE_CONFIG: 'remote-config', // owner: #team-platform-features
     REPLAY_CLIENT_SIDE_DECOMPRESSION: 'replay-client-side-decompression', // owner: @pauldambra #team-replay
     REPLAY_DECOMPRESSION_WORKER: 'replay-decompression-worker', // owner: @pauldambra #team-replay
+    REPLAY_DISCARD_RAW_SNAPSHOTS: 'replay-discard-raw-snapshots', // owner: @pauldambra #team-replay
     REPLAY_FILTERS_REDESIGN: 'replay-filters-redesign', // owner: @ksvat #team-replay
     REPLAY_NEW_DETECTED_URL_COLLECTIONS: 'replay-new-detected-url-collections', // owner: @ksvat #team-replay multivariate
     REPLAY_WAIT_FOR_FULL_SNAPSHOT_PLAYBACK: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay


### PR DESCRIPTION
i tried interning strings in the session recording snapshot data, but it didn't have much impact

i tried hashing and deduplicating the objects
but the time spent hashing everything was noticeable

i remembered @TueHaulund wondering if we could just throw the data away once we'd passed it to the player

well, we can throw _at least_ one copy away

tested memory footprint by refreshing the page on recording B, starting tracing, and then loading recording A, several times (very not scientific)

| before | after |
| - | - |
|![normal1.png](https://app.graphite.com/user-attachments/assets/84613b01-fa82-4aa5-8a3a-7bf0fafd2d0a.png)|![discard4.png](https://app.graphite.com/user-attachments/assets/9df3ab3b-6212-4b24-84ae-176a2c689d51.png)
|
|![normal3.png](https://app.graphite.com/user-attachments/assets/ca23c82e-8a0e-42d1-aea8-1c89b4da36ba.png)|![discard3.png](https://app.graphite.com/user-attachments/assets/9af64e42-9fed-4894-8152-c7f8f3e63f24.png)|
|![normal2.png](https://app.graphite.com/user-attachments/assets/827d9ecb-efef-434a-b734-8bef49a69e06.png)|![discard2.png](https://app.graphite.com/user-attachments/assets/a58ee13c-597f-44c2-a5d7-6ef5abed79b6.png)|

this suggests a lower min and a lower max 🤞 

