### PR TITLE
fix: Stop capturing 2FA secret keys on session replay

### DIFF
--- a/frontend/src/scenes/authentication/TwoFactorSetup.tsx
+++ b/frontend/src/scenes/authentication/TwoFactorSetup.tsx
@@ -30,7 +30,7 @@ export function TwoFactorSetup({ onSuccess }: { onSuccess: () => void }): JSX.El
 
                     {/* Secret key for manual entry */}
                     {startSetup?.secret && (
-                        <div className="mt-4 p-3 bg-gray-50 rounded text-center">
+                        <div className="ph-no-capture mt-4 p-3 bg-gray-50 rounded text-center">
                             <p>
                                 If you can't scan the QR code, you can use the secret key below to manually set up your
                                 authenticator app.


### PR DESCRIPTION
These were being captured in our internal session replay videos, but we don't need that to be captured, so let's block it