### PR TITLE
fix: configure a block selector so we don't have to ph-no-capture to avoid recording something

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -114,6 +114,9 @@ export function loadPostHogJS(): void {
             autocapture: {
                 capture_copied_text: true,
             },
+            session_recording: {
+                blockSelector: '.ph-replay-block',
+            },
             person_profiles: 'always',
             __preview_remote_config: true,
             __preview_flags_v2: true,


### PR DESCRIPTION
if we mark something as ph-no-capture
then we don't record it

but we also don't autocapture on it

so let's configure a blockSelector

rrweb will call `element.matches(blockSelector)`

so i've set `.ph-replay-block`