### PR TITLE
chore(flags): Remove redundant hypercache batch refresh metrics

### DIFF
--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -24,7 +24,7 @@ from django.db import connection
 
 import structlog
 from posthoganalytics import capture_exception
-from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client import Counter, Gauge
 
 from posthog.metrics import pushed_metrics_registry
 from posthog.models.team.team import Team
@@ -55,19 +55,6 @@ CACHE_SIZE_SAMPLE_LIMIT = 1000
 
 # Consolidated HyperCache metrics with namespace labels
 # These replace cache-specific metrics in flags_cache.py and team_metadata_cache.py
-
-HYPERCACHE_BATCH_REFRESH_COUNTER = Counter(
-    "posthog_hypercache_batch_refresh",
-    "Batch refresh operations for HyperCaches",
-    labelnames=["namespace", "result"],
-)
-
-HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM = Histogram(
-    "posthog_hypercache_batch_refresh_duration_seconds",
-    "Time taken for batch refresh operations",
-    labelnames=["namespace"],
-    buckets=(1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, float("inf")),
-)
 
 HYPERCACHE_TEAMS_PROCESSED_COUNTER = Counter(
     "posthog_hypercache_teams_processed",

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -13,11 +13,7 @@ from posthog.models.feature_flag.flags_cache import (
 )
 from posthog.models.feature_flag.local_evaluation import update_flag_caches
 from posthog.models.team import Team
-from posthog.storage.hypercache_manager import (
-    HYPERCACHE_BATCH_REFRESH_COUNTER,
-    HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM,
-    HYPERCACHE_SIGNAL_UPDATE_COUNTER,
-)
+from posthog.storage.hypercache_manager import HYPERCACHE_SIGNAL_UPDATE_COUNTER
 from posthog.tasks.utils import CeleryQueue
 
 logger = structlog.get_logger(__name__)
@@ -102,8 +98,6 @@ def refresh_expiring_flags_cache_entries() -> None:
         stats_after = get_cache_stats()
 
         duration = time.time() - start_time
-        HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM.labels(namespace="feature_flags").observe(duration)
-        HYPERCACHE_BATCH_REFRESH_COUNTER.labels(namespace="feature_flags", result="success").inc()
 
         logger.info(
             "Completed flags cache refresh",
@@ -118,8 +112,6 @@ def refresh_expiring_flags_cache_entries() -> None:
 
     except Exception as e:
         duration = time.time() - start_time
-        HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM.labels(namespace="feature_flags").observe(duration)
-        HYPERCACHE_BATCH_REFRESH_COUNTER.labels(namespace="feature_flags", result="failure").inc()
         logger.exception(
             "Failed to complete flags cache batch refresh",
             error=str(e),

--- a/posthog/tasks/team_metadata.py
+++ b/posthog/tasks/team_metadata.py
@@ -16,11 +16,7 @@ import structlog
 from celery import shared_task
 
 from posthog.models.team import Team
-from posthog.storage.hypercache_manager import (
-    HYPERCACHE_BATCH_REFRESH_COUNTER,
-    HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM,
-    HYPERCACHE_SIGNAL_UPDATE_COUNTER,
-)
+from posthog.storage.hypercache_manager import HYPERCACHE_SIGNAL_UPDATE_COUNTER
 from posthog.storage.team_metadata_cache import (
     cleanup_stale_expiry_tracking,
     clear_team_metadata_cache,
@@ -87,8 +83,6 @@ def refresh_expiring_team_metadata_cache_entries() -> None:
         stats_after = get_cache_stats()
 
         duration = time.time() - start_time
-        HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM.labels(namespace="team_metadata").observe(duration)
-        HYPERCACHE_BATCH_REFRESH_COUNTER.labels(namespace="team_metadata", result="success").inc()
 
         logger.info(
             "Completed team metadata cache refresh",
@@ -103,8 +97,6 @@ def refresh_expiring_team_metadata_cache_entries() -> None:
 
     except Exception as e:
         duration = time.time() - start_time
-        HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM.labels(namespace="team_metadata").observe(duration)
-        HYPERCACHE_BATCH_REFRESH_COUNTER.labels(namespace="team_metadata", result="failure").inc()
         logger.exception(
             "Failed to complete team metadata batch refresh",
             error=str(e),


### PR DESCRIPTION
## Problem

Ok, a little 🥧 in my 🫤 . I added these metrics a couple weeks ago so we can get insight into how long it takes to warm the team_metadata and feature_flags HyperCaches. However, there's existing built-in celery metrics I could have been using.

## Changes

Remove `HYPERCACHE_BATCH_REFRESH_DURATION_HISTOGRAM` and `HYPERCACHE_BATCH_REFRESH_COUNTER` as they are redundant with the generic Celery task metrics (`posthog_celery_task_duration_seconds`, `posthog_celery_task_success`, `posthog_celery_task_failure`).

The generic Celery metrics are collected via signals in `celery.py` and work reliably, whereas the custom metrics weren't being scraped properly from worker pods.

## How did you test this code?

Smoke test.
Unit Tests.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
