### PR TITLE
chore(flags): Push teams processed metrics to Pushgateway

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -282,7 +282,7 @@ def refresh_expiring_flags_caches(ttl_threshold_hours: int = 24, limit: int = 50
     Processes teams in batches (default 5000). If more teams are expiring than the limit,
     subsequent runs will process the next batch.
 
-    Note: Metrics are tracked by refresh_expiring_caches() using consolidated HYPERCACHE_TEAMS_PROCESSED_COUNTER
+    Note: Metrics are pushed to Pushgateway by refresh_expiring_caches() via push_hypercache_teams_processed_metrics()
 
     Args:
         ttl_threshold_hours: Refresh caches expiring within this many hours

--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -55,12 +55,7 @@ CACHE_SIZE_SAMPLE_LIMIT = 1000
 
 # Consolidated HyperCache metrics with namespace labels
 # These replace cache-specific metrics in flags_cache.py and team_metadata_cache.py
-
-HYPERCACHE_TEAMS_PROCESSED_COUNTER = Counter(
-    "posthog_hypercache_teams_processed",
-    "Teams processed by batch refresh operations",
-    labelnames=["namespace", "result"],
-)
+# Note: Batch refresh duration is tracked by the generic posthog_celery_task_duration_seconds metric
 
 HYPERCACHE_SIGNAL_UPDATE_COUNTER = Counter(
     "posthog_hypercache_signal_updates",
@@ -134,6 +129,40 @@ def push_hypercache_stats_metrics(
                 size_gauge.labels(namespace=namespace).set(size_bytes)
     except Exception as e:
         logger.warning("Failed to push hypercache stats to Pushgateway", error=str(e), namespace=namespace)
+
+
+def push_hypercache_teams_processed_metrics(
+    namespace: str,
+    successful: int,
+    failed: int,
+) -> None:
+    """
+    Push teams processed metrics to Pushgateway after batch refresh operations.
+
+    Uses Gauges instead of Counters because Counters don't work well with PushGateway
+    (they reset on each push). Gauges show the count from the most recent batch run,
+    which is the relevant information for an hourly task.
+
+    Args:
+        namespace: The HyperCache namespace (e.g., "feature_flags", "team_metadata")
+        successful: Number of teams successfully processed
+        failed: Number of teams that failed processing
+    """
+    if not settings.PROM_PUSHGATEWAY_ADDRESS:
+        return
+
+    try:
+        with pushed_metrics_registry(f"hypercache_teams_processed_{namespace}") as registry:
+            success_gauge = Gauge(
+                "posthog_hypercache_teams_processed_last_run",
+                "Teams processed in the last batch refresh run",
+                labelnames=["namespace", "result"],
+                registry=registry,
+            )
+            success_gauge.labels(namespace=namespace, result="success").set(successful)
+            success_gauge.labels(namespace=namespace, result="failure").set(failed)
+    except Exception as e:
+        logger.warning("Failed to push hypercache teams processed to Pushgateway", error=str(e), namespace=namespace)
 
 
 class UpdateFn(Protocol):

--- a/posthog/storage/team_metadata_cache.py
+++ b/posthog/storage/team_metadata_cache.py
@@ -374,7 +374,7 @@ def refresh_expiring_caches(ttl_threshold_hours: int = 24, limit: int = 5000) ->
     Processes teams in batches (default 5000). If more teams are expiring than the limit,
     subsequent runs will process the next batch.
 
-    Note: Metrics are tracked by refresh_expiring_caches() using consolidated HYPERCACHE_TEAMS_PROCESSED_COUNTER
+    Note: Metrics are pushed to Pushgateway by refresh_expiring_caches() via push_hypercache_teams_processed_metrics()
 
     Args:
         ttl_threshold_hours: Refresh caches expiring within this many hours

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -91,8 +91,8 @@ def refresh_expiring_flags_cache_entries() -> None:
             limit=settings.FLAGS_CACHE_REFRESH_LIMIT,
         )
 
-        # Note: HYPERCACHE_TEAMS_PROCESSED_COUNTER is already incremented by the generic
-        # cache_expiry_manager.refresh_expiring_caches() function, so we don't increment it again here
+        # Note: Teams processed metrics are pushed to Pushgateway by
+        # cache_expiry_manager.refresh_expiring_caches() via push_hypercache_teams_processed_metrics()
 
         # Scan after refresh for metrics (pushes to Pushgateway via get_cache_stats)
         stats_after = get_cache_stats()

--- a/posthog/tasks/team_metadata.py
+++ b/posthog/tasks/team_metadata.py
@@ -76,8 +76,8 @@ def refresh_expiring_team_metadata_cache_entries() -> None:
     try:
         successful, failed = refresh_expiring_caches(ttl_threshold_hours=24)
 
-        # Note: HYPERCACHE_TEAMS_PROCESSED_COUNTER is already incremented by the generic
-        # cache_expiry_manager.refresh_expiring_caches() function, so we don't increment it again here
+        # Note: Teams processed metrics are pushed to Pushgateway by
+        # cache_expiry_manager.refresh_expiring_caches() via push_hypercache_teams_processed_metrics()
 
         # Scan after refresh for metrics (pushes to Pushgateway via get_cache_stats)
         stats_after = get_cache_stats()


### PR DESCRIPTION
## Problem

The "Teams Processed" panel in the Feature Flags Cache Grafana dashboard shows no data. The `posthog_hypercache_teams_processed_total` Counter metric was being emitted from Celery workers during the hourly batch refresh task, but Counters don't work reliably from batch jobs because:

1. Counter values accumulate within worker processes and reset when workers restart
2. The hourly task may complete between scrape intervals
3. Each worker has its own metric registry that may never be scraped

## Changes

- Replace `HYPERCACHE_TEAMS_PROCESSED_COUNTER` with a Gauge pushed to PushGateway via new `push_hypercache_teams_processed_metrics()` function
- The new metric `posthog_hypercache_teams_processed_last_run` shows teams processed in the most recent batch run
- Update `cache_expiry_manager.py` to call the push function after each refresh
- Update docstrings to reflect the new approach

## How did you test this code?

Unit Tests pass
Will verify metrics appear in Grafana after deployment to staging.

## Changelog: (features only) Is this feature complete?

No - this is an infrastructure fix, not a user-facing feature.
