### PR TITLE
feat(kdedup): consolidate span tags from macros with structured log tags in JSON output

### DIFF
--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -175,6 +175,7 @@ async fn main() -> Result<()> {
         } else {
             // production: use JSON format Loki/Grafana can extract useful filter tags from
             base.json()
+                .with_span_list(false)
                 .with_filter(EnvFilter::from_default_env())
                 .boxed()
         }


### PR DESCRIPTION
## Problem
We'd like our JSON production logs to include the span and per-log-macro log lines to include structured tags in the `fields` attribute
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add logging config
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
CI. Ran service locally and added some test tags to logs to spot check
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
