### PR TITLE
fix: Include `UserProductList` for invited users

### DIFF
--- a/posthog/models/file_system/user_product_list.py
+++ b/posthog/models/file_system/user_product_list.py
@@ -10,16 +10,16 @@ from django.dispatch.dispatcher import receiver
 
 from posthog.schema import ProductIntentContext, ProductKey
 
-from posthog.models.team import Team
-from posthog.models.user import User
 from posthog.models.utils import UpdatedMetaFields, UUIDModel, uuid7
 from posthog.products import Products
 
 if TYPE_CHECKING:
     from posthog.models.product_intent.product_intent import ProductIntent
+    from posthog.models.team import Team
+    from posthog.models.user import User
 
 
-def get_user_product_list_count(team: Team) -> list[dict[str, Any]]:
+def get_user_product_list_count(team: "Team") -> list[dict[str, Any]]:
     """
     Get product counts for all items in a team, ranked by popularity.
     Returns a list of dicts with 'product_path' and 'colleague_count' keys, ordered by count descending.
@@ -32,6 +32,15 @@ def get_user_product_list_count(team: Team) -> list[dict[str, Any]]:
     )
 
 
+def backfill_user_product_list_for_new_user(user: "User", team: "Team") -> None:
+    """
+    Backfill UserProductList entries for a new user in a new team based on what
+    they have enabled in other teams they belong to.
+    """
+    UserProductList.backfill_from_other_teams(user, team)
+    UserProductList.sync_from_team_colleagues(user, team, count=3)
+
+
 class UserProductList(UUIDModel, UpdatedMetaFields):
     """
     Stores a user's custom list of products they care about.
@@ -39,8 +48,8 @@ class UserProductList(UUIDModel, UpdatedMetaFields):
     """
 
     id = models.UUIDField(primary_key=True, default=uuid7, editable=False)
-    team = models.ForeignKey(Team, on_delete=models.CASCADE)
-    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    team = models.ForeignKey("Team", on_delete=models.CASCADE)
+    user = models.ForeignKey("User", on_delete=models.CASCADE)
     product_path = models.CharField(max_length=200)
 
     # Not using `CreatedMetaFields` because of the clashing `user` reference with `created_by`
@@ -91,7 +100,7 @@ class UserProductList(UUIDModel, UpdatedMetaFields):
         verbose_name_plural = "User Product Lists"
 
     @staticmethod
-    def create_from_product_intent(product_intent: "ProductIntent", user: User) -> "list[UserProductList]":
+    def create_from_product_intent(product_intent: "ProductIntent", user: "User") -> "list[UserProductList]":
         if user.allow_sidebar_suggestions is False:
             return []
 
@@ -124,8 +133,8 @@ class UserProductList(UUIDModel, UpdatedMetaFields):
 
     @staticmethod
     def sync_from_team_colleagues(
-        user: User,
-        team: Team,
+        user: "User",
+        team: "Team",
         count: int = 1,
         colleague_product_counts: list[dict[str, Any]] | None = None,
     ) -> "list[UserProductList]":
@@ -179,11 +188,13 @@ class UserProductList(UUIDModel, UpdatedMetaFields):
         return created_items
 
     @staticmethod
-    def backfill_from_other_teams(user: User, team: Team) -> "list[UserProductList]":
+    def backfill_from_other_teams(user: "User", team: "Team") -> "list[UserProductList]":
         """
         Backfill UserProductList entries for a user in a new team based on what
         they have enabled in other teams they belong to.
         """
+        from posthog.models.team import Team
+
         # We IGNORE the user's suggestion config because we want them to have
         # at least some products in their sidebar to start with when backfilling from
         # their own teams.
@@ -222,8 +233,8 @@ class UserProductList(UUIDModel, UpdatedMetaFields):
 
     @staticmethod
     def sync_cross_sell_products(
-        user: User,
-        team: Team,
+        user: "User",
+        team: "Team",
         max_products: int = 1,
         ignored_categories: list[str] | None = None,
     ) -> "list[UserProductList]":
@@ -318,11 +329,7 @@ def access_control_created(sender, instance, created, **kwargs):
         user = instance.organization_member.user
         team = instance.team
 
-        def create_user_product_lists():
-            UserProductList.backfill_from_other_teams(user, team)
-            UserProductList.sync_from_team_colleagues(user, team, count=3)
-
         if settings.TEST:
-            create_user_product_lists()
+            backfill_user_product_list_for_new_user(user, team)
         else:
-            transaction.on_commit(lambda: create_user_product_lists())
+            transaction.on_commit(lambda: backfill_user_product_list_for_new_user(user, team))

--- a/posthog/models/test/test_user_product_list_invites.py
+++ b/posthog/models/test/test_user_product_list_invites.py
@@ -229,7 +229,7 @@ class TestUserProductListInvites(BaseTest):
         invite = OrganizationInvite.objects.create(
             organization=self.organization,
             target_email="newuser@posthog.com",
-            private_project_access=[{"id": self.team.id, "level": "member"}],
+            private_project_access=[],
         )
 
         # Use the invite (count=3, so top 3 should be synced)
@@ -247,6 +247,71 @@ class TestUserProductListInvites(BaseTest):
         self.assertIn("feature_flags", product_paths)
         self.assertNotIn("experiments", product_paths)
         self.assertLessEqual(len(product_paths), 3)  # Should not exceed count=3
+
+
+class TestUserProductListInvitesWithoutPrivateProjectAccess(BaseTest):
+    def test_invite_user_without_private_project_access_syncs_products(self):
+        """Test that when a user accepts an invite without private_project_access, they still get products synced"""
+        # Create existing team members with products
+        colleague = User.objects.create_user(email="colleague@posthog.com", password="password", first_name="Colleague")
+        colleague.join(organization=self.organization)
+
+        # Create products for colleague
+        UserProductList.objects.create(user=colleague, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=colleague, team=self.team, product_path="session_replay", enabled=True)
+
+        # Create new user to invite
+        new_user = User.objects.create_user(
+            email="newuser@posthog.com", password="password", first_name="New", allow_sidebar_suggestions=True
+        )
+
+        # Create invite WITHOUT private_project_access
+        invite = OrganizationInvite.objects.create(
+            organization=self.organization,
+            target_email="newuser@posthog.com",
+            private_project_access=None,
+        )
+
+        # Use the invite
+        invite.use(new_user, prevalidated=True)
+
+        # Verify products were synced from colleagues
+        user_products = UserProductList.objects.filter(user=new_user, team=self.team, enabled=True)
+        product_paths = set(user_products.values_list("product_path", flat=True))
+
+        self.assertIn("product_analytics", product_paths)
+        self.assertIn("session_replay", product_paths)
+
+    def test_invite_user_without_private_project_access_backfills_from_other_teams(self):
+        """Test that invite without private_project_access still backfills from user's other teams"""
+        # Create a second organization and team for the user
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+
+        # Create user and add them to other organization
+        user = User.objects.create_user(
+            email="existing@posthog.com", password="password", first_name="Existing", allow_sidebar_suggestions=True
+        )
+        user.join(organization=other_org)
+
+        # Create products for user in other team
+        UserProductList.objects.create(user=user, team=other_team, product_path="product_analytics", enabled=True)
+
+        # Create invite WITHOUT private_project_access
+        invite = OrganizationInvite.objects.create(
+            organization=self.organization,
+            target_email="existing@posthog.com",
+            private_project_access=None,
+        )
+
+        # Use the invite
+        invite.use(user, prevalidated=True)
+
+        # Verify products were backfilled from other teams
+        user_products = UserProductList.objects.filter(user=user, team=self.team, enabled=True)
+        product_paths = set(user_products.values_list("product_path", flat=True))
+
+        self.assertIn("product_analytics", product_paths)
 
 
 class TestUserProductListTeamCreation(BaseTest):
@@ -286,6 +351,41 @@ class TestUserProductListTeamCreation(BaseTest):
         # Verify no products were backfilled
         user_products = UserProductList.objects.filter(user=user, team=new_team)
         self.assertEqual(user_products.count(), 0)
+
+    def test_create_team_syncs_products_for_all_users_with_access(self):
+        """Test that when a new team is created, all org members get products synced"""
+        # Create existing org members with products in the existing team
+        member1 = User.objects.create_user(
+            email="member1@posthog.com", password="password", first_name="Member1", allow_sidebar_suggestions=True
+        )
+        member2 = User.objects.create_user(
+            email="member2@posthog.com", password="password", first_name="Member2", allow_sidebar_suggestions=True
+        )
+        member1.join(organization=self.organization)
+        member2.join(organization=self.organization)
+
+        # Create products for members in existing team
+        UserProductList.objects.create(user=member1, team=self.team, product_path="product_analytics", enabled=True)
+        UserProductList.objects.create(user=member2, team=self.team, product_path="session_replay", enabled=True)
+
+        # Create a new team (without specifying initiating_user to test all members sync)
+        creator = User.objects.create_user(
+            email="creator@posthog.com", password="password", first_name="Creator", allow_sidebar_suggestions=True
+        )
+        creator.join(organization=self.organization)
+        new_team = Team.objects.create_with_data(
+            initiating_user=creator, organization=self.organization, name="New Team"
+        )
+
+        # Verify member1's products were backfilled to new team
+        member1_products = UserProductList.objects.filter(user=member1, team=new_team, enabled=True)
+        member1_paths = set(member1_products.values_list("product_path", flat=True))
+        self.assertIn("product_analytics", member1_paths)
+
+        # Verify member2's products were backfilled to new team
+        member2_products = UserProductList.objects.filter(user=member2, team=new_team, enabled=True)
+        member2_paths = set(member2_products.values_list("product_path", flat=True))
+        self.assertIn("session_replay", member2_paths)
 
     @patch("django.db.transaction.on_commit", lambda fn: fn())
     def test_access_control_signal_triggers_backfill(self):


### PR DESCRIPTION
We are only handling the case where we create an `AccessControl` to connect a user to a project.

However, most of the orgs don't have AccessControl setup and in those cases everyone has access to all projects.
We need to handle that case when backfilling the `UserProductList` when a user is created and/or a new project is created.