### PR TITLE
feat(surveys): cross-sell with web analytics

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -29,10 +29,12 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { getOverrideWarningPropsForButton } from 'scenes/insights/utils'
 import { SurveyOpportunityButton } from 'scenes/surveys/components/SurveyOpportunityButton'
+import { SURVEY_CREATED_SOURCE } from 'scenes/surveys/constants'
 import { isSurveyableFunnelInsight } from 'scenes/surveys/utils/opportunityDetection'
 import { urls } from 'scenes/urls'
 
 import { dashboardsModel } from '~/models/dashboardsModel'
+import { ProductKey } from '~/queries/schema/schema-general'
 import { isDataVisualizationNode } from '~/queries/utils'
 import {
     AccessControlLevel,
@@ -165,7 +167,12 @@ export function InsightMeta({
         featureFlags[FEATURE_FLAGS.SURVEYS_FUNNELS_CROSS_SELL] &&
         isSurveyableFunnelInsight(insight) ? (
             <div className="flex">
-                <SurveyOpportunityButton insight={insight} disableAutoPromptSubmit={true} />
+                <SurveyOpportunityButton
+                    insight={insight}
+                    disableAutoPromptSubmit={true}
+                    source={SURVEY_CREATED_SOURCE.INSIGHT_CROSS_SELL}
+                    fromProduct={ProductKey.PRODUCT_ANALYTICS}
+                />
             </div>
         ) : null
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -322,6 +322,7 @@ export const FEATURE_FLAGS = {
     SURVEYS_FF_CROSS_SELL: 'surveys-ff-cross-sell', // owner: @adboio #team-surveys
     SURVEYS_FUNNELS_CROSS_SELL: 'survey-funnels-cross-sell', // owner: @adboio #team-surveys
     SURVEYS_INSIGHT_BUTTON_EXPERIMENT: 'ask-users-why-ai-vs-quickcreate', // owner: @adboio #team-surveys multivariate=true
+    SURVEYS_WEB_ANALYTICS_CROSS_SELL: 'surveys-in-web-analytics', // owner: @adboio #team-surveys
     SWITCH_SUBSCRIPTION_PLAN: 'switch-subscription-plan', // owner: @a-lider #team-platform-features
     TASK_SUMMARIES: 'task-summaries', // owner: #team-llm-analytics
     TASK_TOOL: 'phai-task-tool', // owner: @kappa90 #team-posthog-ai

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -44,6 +44,8 @@ export interface LemonButtonPropsBase
     disableClientSideRouting?: boolean
     /** If set clicking this button will open the page in a new tab. */
     targetBlank?: boolean
+    /** Disable automatically displaying an external link icon when targetBlank is set */
+    hideExternalLinkIcon?: boolean
 
     /** Icon displayed on the left. */
     icon?: React.ReactElement | null
@@ -154,6 +156,7 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                 noPadding,
                 to,
                 targetBlank,
+                hideExternalLinkIcon,
                 disableClientSideRouting,
                 onClick,
                 truncate = false,
@@ -269,7 +272,7 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                         {children ? <span className="LemonButton__content">{children}</span> : null}
                         {sideIcon ? (
                             <span className="LemonButton__icon">{sideIcon}</span>
-                        ) : targetBlank ? (
+                        ) : targetBlank && !hideExternalLinkIcon ? (
                             <IconExternal />
                         ) : null}
                     </span>

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -21010,6 +21010,7 @@
                 "survey_bulk_duplicated",
                 "survey_edited",
                 "survey_analyzed",
+                "quick_survey_started",
                 "revenue_analytics_viewed",
                 "revenue_analytics_onboarding_completed",
                 "revenue_analytics_event_created",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -5008,6 +5008,7 @@ export enum ProductIntentContext {
     SURVEY_BULK_DUPLICATED = 'survey_bulk_duplicated',
     SURVEY_EDITED = 'survey_edited',
     SURVEY_ANALYZED = 'survey_analyzed',
+    QUICK_SURVEY_STARTED = 'quick_survey_started',
 
     // Revenue Analytics
     REVENUE_ANALYTICS_VIEWED = 'revenue_analytics_viewed',

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -27,6 +27,7 @@ import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { IconAreaChart } from 'lib/lemon-ui/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
+import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { QuickSurveyModal } from 'scenes/surveys/QuickSurveyModal'
 import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
@@ -43,6 +44,8 @@ import {
     InsightQueryNode,
     InsightVizNode,
     NodeKind,
+    ProductIntentContext,
+    ProductKey,
     TrendsQuery,
 } from '~/queries/schema/schema-general'
 import {
@@ -483,7 +486,17 @@ export function PageHeaderCustom(): JSX.Element {
                         </ButtonPrimitive>
 
                         {experiment.feature_flag && (
-                            <ButtonPrimitive menuItem onClick={() => setSurveyModalOpen(true)}>
+                            <ButtonPrimitive
+                                menuItem
+                                onClick={() => {
+                                    setSurveyModalOpen(true)
+                                    void addProductIntentForCrossSell({
+                                        from: ProductKey.EXPERIMENTS,
+                                        to: ProductKey.SURVEYS,
+                                        intent_context: ProductIntentContext.QUICK_SURVEY_STARTED,
+                                    })
+                                }}
+                            >
                                 <IconPlusSmall /> Create survey
                             </ButtonPrimitive>
                         )}

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -19,6 +19,7 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { atColumn, createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import stringWithWBR from 'lib/utils/stringWithWBR'
 import MaxTool from 'scenes/max/MaxTool'
 import { useMaxTool } from 'scenes/max/useMaxTool'
@@ -29,7 +30,7 @@ import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { ProductKey } from '~/queries/schema/schema-general'
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import {
     AccessControlLevel,
     AccessControlResourceType,
@@ -257,7 +258,14 @@ const ExperimentsTable = ({
                                 </LemonButton>
                                 <ExperimentSurveyButton
                                     experiment={experiment}
-                                    onOpenModal={() => openSurveyModal(experiment)}
+                                    onOpenModal={() => {
+                                        openSurveyModal(experiment)
+                                        void addProductIntentForCrossSell({
+                                            from: ProductKey.EXPERIMENTS,
+                                            to: ProductKey.SURVEYS,
+                                            intent_context: ProductIntentContext.QUICK_SURVEY_STARTED,
+                                        })
+                                    }}
                                 />
                                 {!experiment.archived &&
                                     experiment?.end_date &&

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -49,6 +49,7 @@ import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label } from 'lib/ui/Label/Label'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { FeatureFlagPermissions } from 'scenes/FeatureFlagPermissions'
 import { Dashboard } from 'scenes/dashboard/Dashboard'
 import { EmptyDashboardComponent } from 'scenes/dashboard/EmptyDashboardComponent'
@@ -169,6 +170,12 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
 
         reportUserFeedbackButtonClicked(SURVEY_CREATED_SOURCE.FEATURE_FLAGS, {
             existingSurvey: hasVariantSurvey,
+        })
+
+        void addProductIntentForCrossSell({
+            from: ProductKey.FEATURE_FLAGS,
+            to: ProductKey.SURVEYS,
+            intent_context: ProductIntentContext.QUICK_SURVEY_STARTED,
         })
 
         if (hasVariantSurvey) {

--- a/frontend/src/scenes/surveys/QuickSurveyModal.tsx
+++ b/frontend/src/scenes/surveys/QuickSurveyModal.tsx
@@ -2,7 +2,15 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { SurveyQuestionType } from 'posthog-js'
 import { useMemo, useRef } from 'react'
 
-import { LemonBanner, LemonButton, LemonInput, LemonLabel, LemonModal, LemonTextArea } from '@posthog/lemon-ui'
+import {
+    LemonBanner,
+    LemonButton,
+    LemonInput,
+    LemonLabel,
+    LemonModal,
+    LemonSwitch,
+    LemonTextArea,
+} from '@posthog/lemon-ui'
 
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { SurveyAppearancePreview } from 'scenes/surveys/SurveyAppearancePreview'
@@ -29,7 +37,7 @@ import {
 import { QuickSurveyFormProps, QuickSurveyType } from './quick-create/types'
 import { buildLogicProps } from './quick-create/utils'
 
-export function QuickSurveyForm({ context, info, onCancel }: QuickSurveyFormProps): JSX.Element {
+export function QuickSurveyForm({ context, info, onCancel, showFollowupToggle }: QuickSurveyFormProps): JSX.Element {
     const logicProps: QuickSurveyFormLogicProps = useMemo(() => {
         return {
             ...buildLogicProps(context),
@@ -63,7 +71,7 @@ export function QuickSurveyForm({ context, info, onCancel }: QuickSurveyFormProp
                 <div className="space-y-4">
                     {context.type !== QuickSurveyType.ANNOUNCEMENT && (
                         <div>
-                            <LemonLabel className="mb-2">Question for users</LemonLabel>
+                            <LemonLabel className="mb-2">Ask your users</LemonLabel>
                             <LemonTextArea
                                 value={surveyForm.question}
                                 onChange={(value) => setSurveyFormValue('question', value)}
@@ -147,10 +155,33 @@ export function QuickSurveyForm({ context, info, onCancel }: QuickSurveyFormProp
                         </div>
                     )}
 
+                    {showFollowupToggle && (
+                        <>
+                            <div className="flex items-center gap-2">
+                                <LemonSwitch
+                                    checked={!!surveyForm.followUpEnabled}
+                                    onChange={(checked) => setSurveyFormValue('followUpEnabled', checked)}
+                                    label="Ask a follow-up question"
+                                />
+                            </div>
+                            {surveyForm.followUpEnabled && (
+                                <div className="mt-2">
+                                    <LemonTextArea
+                                        value={surveyForm.followUpQuestion || ''}
+                                        onChange={(value) => setSurveyFormValue('followUpQuestion', value)}
+                                        placeholder="Tell us more (optional)"
+                                        minRows={2}
+                                    />
+                                </div>
+                            )}
+                        </>
+                    )}
+
                     {context.type === QuickSurveyType.FEATURE_FLAG && (
                         <>
                             <VariantSelector variants={context.flag.filters?.multivariate?.variants || []} />
                             <EventSelector />
+                            <URLInput />
                         </>
                     )}
 
@@ -163,10 +194,11 @@ export function QuickSurveyForm({ context, info, onCancel }: QuickSurveyFormProp
                                 defaultOptionText="All users exposed to this experiment"
                             />
                             <EventSelector />
+                            <URLInput />
                         </>
                     )}
 
-                    <URLInput />
+                    {context.type === QuickSurveyType.ERROR_TRACKING && <URLInput />}
                 </div>
 
                 <div>
@@ -247,16 +279,25 @@ export function QuickSurveyModal({
     onCancel,
     isOpen,
     modalTitle,
+    showFollowupToggle,
 }: {
     context?: QuickSurveyFormProps['context']
     info?: QuickSurveyFormProps['info']
     onCancel: () => void
     isOpen: boolean
     modalTitle?: string
+    showFollowupToggle?: boolean
 }): JSX.Element {
     return (
         <LemonModal title={modalTitle || 'Quick feedback survey'} isOpen={isOpen} onClose={onCancel} width={900}>
-            {context && <QuickSurveyForm context={context} info={info} onCancel={onCancel} />}
+            {context && (
+                <QuickSurveyForm
+                    context={context}
+                    info={info}
+                    onCancel={onCancel}
+                    showFollowupToggle={showFollowupToggle}
+                />
+            )}
         </LemonModal>
     )
 }

--- a/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
@@ -9,7 +9,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { formatPercentage } from 'lib/utils'
-import { addProductIntent } from 'lib/utils/product-intents'
+import { addProductIntent, addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { urls } from 'scenes/urls'
 
@@ -34,18 +34,18 @@ import { SurveyableFunnelInsight, extractFunnelContext } from '../utils/opportun
 export interface SurveyOpportunityButtonProps {
     insight: SurveyableFunnelInsight
     disableAutoPromptSubmit?: boolean
-    source?: SURVEY_CREATED_SOURCE
+    source: SURVEY_CREATED_SOURCE
+    fromProduct: ProductKey
 }
 
 export function SurveyOpportunityButton({
     insight,
     disableAutoPromptSubmit,
     source,
+    fromProduct,
 }: SurveyOpportunityButtonProps): JSX.Element | null {
     const [modalOpen, setModalOpen] = useState(false)
     const { featureFlags } = useValues(featureFlagLogic)
-
-    const creationSource = source ?? SURVEY_CREATED_SOURCE.INSIGHT_CROSS_SELL
 
     const shouldUseQuickCreate = featureFlags[FEATURE_FLAGS.SURVEYS_INSIGHT_BUTTON_EXPERIMENT] === 'test'
 
@@ -65,9 +65,9 @@ export function SurveyOpportunityButton({
         posthog.capture('survey opportunity displayed', {
             linked_insight_id: insight.id,
             conversionRate: funnelContext.conversionRate,
-            source: creationSource,
+            source: source,
         })
-    }, [insight.id, funnelContext, creationSource])
+    }, [insight.id, funnelContext, source])
 
     const { openMax } = useMaxTool({
         identifier: 'create_survey',
@@ -83,13 +83,13 @@ export function SurveyOpportunityButton({
                 intent_context: ProductIntentContext.SURVEY_CREATED,
                 metadata: {
                     survey_id: toolOutput.survey_id,
-                    source: creationSource,
+                    source: source,
                     created_successfully: !toolOutput?.error,
                 },
             })
 
             if (toolOutput?.error || !toolOutput?.survey_id) {
-                return captureMaxAISurveyCreationException(toolOutput.error, creationSource)
+                return captureMaxAISurveyCreationException(toolOutput.error, source)
             }
 
             router.actions.push(urls.survey(toolOutput.survey_id))
@@ -100,7 +100,12 @@ export function SurveyOpportunityButton({
         posthog.capture('survey opportunity clicked', {
             linked_insight_id: insight.id,
             conversionRate: funnelContext?.conversionRate,
-            source: creationSource,
+            source: source,
+        })
+        void addProductIntentForCrossSell({
+            from: fromProduct,
+            to: ProductKey.SURVEYS,
+            intent_context: ProductIntentContext.QUICK_SURVEY_STARTED,
         })
         shouldUseQuickCreate ? setModalOpen(true) : openMax?.()
     }
@@ -131,13 +136,15 @@ export interface SurveyOpportunityButtonWithQueryProps {
         query: InsightVizNode
     }
     insightProps: InsightLogicProps<QuerySchema>
-    source?: SURVEY_CREATED_SOURCE
+    source: SURVEY_CREATED_SOURCE
+    fromProduct: ProductKey
 }
 
 export function SurveyOpportunityButtonWithQuery({
     insight,
     insightProps,
     source,
+    fromProduct,
 }: SurveyOpportunityButtonWithQueryProps): JSX.Element | null {
     const vizKey = insightVizDataNodeKey(insightProps)
     const dataNodeLogicProps: DataNodeLogicProps = {
@@ -158,5 +165,5 @@ export function SurveyOpportunityButtonWithQuery({
         result,
     }
 
-    return <SurveyOpportunityButton insight={surveyableInsight} source={source} />
+    return <SurveyOpportunityButton insight={surveyableInsight} source={source} fromProduct={fromProduct} />
 }

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -680,6 +680,7 @@ export enum SURVEY_CREATED_SOURCE {
     INSIGHT_CROSS_SELL = 'insight_cross_sell',
     CUSTOMER_ANALYTICS_INSIGHT = 'customer_analytics_insight',
     ERROR_TRACKING = 'error_tracking',
+    WEB_ANALYTICS = 'web_analytics',
 }
 
 export enum SURVEY_FORM_INPUT_IDS {

--- a/frontend/src/scenes/surveys/quick-create/types.ts
+++ b/frontend/src/scenes/surveys/quick-create/types.ts
@@ -8,11 +8,13 @@ export type QuickSurveyContext =
     | { type: QuickSurveyType.EXPERIMENT; experiment: Experiment }
     | { type: QuickSurveyType.ANNOUNCEMENT }
     | { type: QuickSurveyType.ERROR_TRACKING; exceptionType: string; exceptionMessage?: string | null }
+    | { type: QuickSurveyType.WEB_PATH; path: string }
 
 export interface QuickSurveyFormProps {
     context: QuickSurveyContext
     info?: React.ReactNode
     onCancel?: () => void
+    showFollowupToggle?: boolean
 }
 
 export enum QuickSurveyType {
@@ -21,4 +23,5 @@ export enum QuickSurveyType {
     EXPERIMENT = 'experiment',
     ANNOUNCEMENT = 'announcement',
     ERROR_TRACKING = 'error_tracking',
+    WEB_PATH = 'web_path',
 }

--- a/frontend/src/scenes/surveys/quick-create/utils.ts
+++ b/frontend/src/scenes/surveys/quick-create/utils.ts
@@ -1,6 +1,7 @@
 import { SurveyQuestionType } from 'posthog-js'
 
 import { EventsNode } from '~/queries/schema/schema-general'
+import { SurveyMatchType } from '~/types'
 
 import { SURVEY_CREATED_SOURCE, defaultSurveyAppearance } from '../constants'
 import { toSurveyEvent } from '../utils/opportunityDetection'
@@ -117,6 +118,33 @@ export const buildLogicProps = (context: QuickSurveyContext): Omit<QuickSurveyFo
                                 },
                             ],
                         },
+                    },
+                },
+            }
+
+        case QuickSurveyType.WEB_PATH:
+            return {
+                key: `web-path-${context.path}-${randomId}`,
+                contextType: context.type,
+                source: SURVEY_CREATED_SOURCE.WEB_ANALYTICS,
+                defaults: {
+                    name: `Survey users on ${context.path} (${randomId})`,
+                    question: 'How was your experience on this page?',
+                    questionType: SurveyQuestionType.Rating,
+                    scaleType: 'emoji',
+                    ratingLowerBound: 'Terrible',
+                    ratingUpperBound: 'Amazing',
+                    followUpEnabled: true,
+                    followUpQuestion: 'What could we improve?',
+                    conditions: {
+                        actions: null,
+                        events: null,
+                        url: context.path,
+                        urlMatchType: SurveyMatchType.Contains,
+                    },
+                    appearance: {
+                        ...defaultSurveyAppearance,
+                        surveyPopupDelaySeconds: 15,
                     },
                 },
             }

--- a/frontend/src/scenes/web-analytics/CrossSellButtons/CreateSurveyButton.tsx
+++ b/frontend/src/scenes/web-analytics/CrossSellButtons/CreateSurveyButton.tsx
@@ -1,0 +1,48 @@
+import { useActions, useValues } from 'kea'
+
+import { IconMessage } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
+
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
+
+import { webAnalyticsLogic } from '../webAnalyticsLogic'
+
+interface CreateSurveyButtonProps {
+    value: string
+}
+
+export const CreateSurveyButton = ({ value }: CreateSurveyButtonProps): JSX.Element => {
+    const { openSurveyModal } = useActions(webAnalyticsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    if (!featureFlags[FEATURE_FLAGS.SURVEYS_WEB_ANALYTICS_CROSS_SELL]) {
+        return <></>
+    }
+
+    if (!value || value === '') {
+        return <></>
+    }
+
+    return (
+        <LemonButton
+            icon={<IconMessage />}
+            type="tertiary"
+            size="xsmall"
+            tooltip="Survey users on this page"
+            className="no-underline"
+            onClick={(e: React.MouseEvent) => {
+                e.stopPropagation()
+                openSurveyModal(value)
+                void addProductIntentForCrossSell({
+                    from: ProductKey.WEB_ANALYTICS,
+                    to: ProductKey.SURVEYS,
+                    intent_context: ProductIntentContext.QUICK_SURVEY_STARTED,
+                })
+            }}
+        />
+    )
+}

--- a/frontend/src/scenes/web-analytics/CrossSellButtons/ErrorTrackingButton.tsx
+++ b/frontend/src/scenes/web-analytics/CrossSellButtons/ErrorTrackingButton.tsx
@@ -48,6 +48,7 @@ export const ErrorTrackingButton = ({ breakdownBy, value }: ErrorTrackingButtonP
             tooltip="View errors for this page"
             className="no-underline"
             targetBlank
+            hideExternalLinkIcon={true}
             onClick={(e: React.MouseEvent) => {
                 e.stopPropagation()
                 void addProductIntentForCrossSell({

--- a/frontend/src/scenes/web-analytics/CrossSellButtons/HeatmapButton.tsx
+++ b/frontend/src/scenes/web-analytics/CrossSellButtons/HeatmapButton.tsx
@@ -68,6 +68,7 @@ export const HeatmapButton = ({ breakdownBy, value }: HeatmapButtonProps): JSX.E
             tooltip="View heatmap for this page"
             className="no-underline"
             targetBlank
+            hideExternalLinkIcon={true}
             onClick={(e: React.MouseEvent) => {
                 e.stopPropagation()
                 void addProductIntentForCrossSell({

--- a/frontend/src/scenes/web-analytics/CrossSellButtons/ReplayButton.tsx
+++ b/frontend/src/scenes/web-analytics/CrossSellButtons/ReplayButton.tsx
@@ -66,6 +66,7 @@ export const ReplayButton = ({ date_from, date_to, breakdownBy, value }: ReplayB
         tooltip: 'View recordings',
         className: 'no-underline',
         targetBlank: true,
+        hideExternalLinkIcon: true,
         onClick: (e: React.MouseEvent) => {
             e.stopPropagation()
             void addProductIntentForCrossSell({

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -20,6 +20,8 @@ import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isNotNil } from 'lib/utils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
+import { QuickSurveyModal } from 'scenes/surveys/QuickSurveyModal'
+import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { PageReports, PageReportsFilters } from 'scenes/web-analytics/PageReports'
@@ -453,11 +455,32 @@ const healthTab = (featureFlags: FeatureFlagsSet): { key: ProductTab; label: JSX
     ]
 }
 
+const WebAnalyticsSurveyModal = (): JSX.Element | null => {
+    const { surveyModalPath } = useValues(webAnalyticsLogic)
+    const { closeSurveyModal } = useActions(webAnalyticsLogic)
+
+    if (!surveyModalPath) {
+        return null
+    }
+
+    return (
+        <QuickSurveyModal
+            context={{ type: QuickSurveyType.WEB_PATH, path: surveyModalPath }}
+            isOpen={!!surveyModalPath}
+            onCancel={closeSurveyModal}
+            showFollowupToggle={true}
+            modalTitle={`Survey users on ${surveyModalPath}`}
+            info={`Shown to users who spend more than 15 seconds on URLs containing ${surveyModalPath}, once per unique user`}
+        />
+    )
+}
+
 export const WebAnalyticsDashboard = (): JSX.Element => {
     return (
         <BindLogic logic={webAnalyticsLogic} props={{}}>
             <BindLogic logic={dataNodeCollectionLogic} props={{ key: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID }}>
                 <WebAnalyticsModal />
+                <WebAnalyticsSurveyModal />
                 <VersionCheckerBanner />
                 <SceneContent className="WebAnalyticsDashboard">
                     <WebAnalyticsTabs />

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -50,6 +50,7 @@ import { ChartDisplayType, InsightLogicProps, PropertyFilterType } from '~/types
 
 import { NewActionButton } from 'products/actions/frontend/components/NewActionButton'
 
+import { CreateSurveyButton } from '../CrossSellButtons/CreateSurveyButton'
 import { ErrorTrackingButton } from '../CrossSellButtons/ErrorTrackingButton'
 import { HeatmapButton } from '../CrossSellButtons/HeatmapButton'
 import { ReplayButton } from '../CrossSellButtons/ReplayButton'
@@ -469,6 +470,7 @@ export const webAnalyticsDataTableQueryContext: QueryContext = {
                         />
                         <HeatmapButton breakdownBy={breakdownBy} value={value} />
                         <ErrorTrackingButton breakdownBy={breakdownBy} value={value} />
+                        <CreateSurveyButton value={value} />
                     </div>
                 )
             },

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -161,6 +161,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         setPathTab: (tab: string) => ({ tab }),
         setGeographyTab: (tab: string) => ({ tab }),
         setActiveHoursTab: (tab: string) => ({ tab }),
+        openSurveyModal: (path: string) => ({ path }),
+        closeSurveyModal: true,
         setDomainFilter: (domain: string | null) => ({ domain }),
         setDeviceTypeFilter: (deviceType: DeviceType | null) => ({ deviceType }),
         clearTablesOrderBy: () => true,
@@ -233,6 +235,13 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         },
     })),
     reducers({
+        surveyModalPath: [
+            null as string | null,
+            {
+                openSurveyModal: (_, { path }) => path,
+                closeSurveyModal: () => null,
+            },
+        ],
         rawWebAnalyticsFilters: [
             INITIAL_WEB_ANALYTICS_FILTER,
             persistConfig,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2624,6 +2624,7 @@ class ProductIntentContext(StrEnum):
     SURVEY_BULK_DUPLICATED = "survey_bulk_duplicated"
     SURVEY_EDITED = "survey_edited"
     SURVEY_ANALYZED = "survey_analyzed"
+    QUICK_SURVEY_STARTED = "quick_survey_started"
     REVENUE_ANALYTICS_VIEWED = "revenue_analytics_viewed"
     REVENUE_ANALYTICS_ONBOARDING_COMPLETED = "revenue_analytics_onboarding_completed"
     REVENUE_ANALYTICS_EVENT_CREATED = "revenue_analytics_event_created"

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -1976,55 +1976,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.10
   '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."queryable_folder",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.11
-  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -2043,7 +1994,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.12
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.11
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -2072,13 +2023,24 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.13
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.12
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
   WHERE ("posthog_sessionrecordingviewed"."team_id" = 99999
          AND "posthog_sessionrecordingviewed"."user_id" = 99999
          AND "posthog_sessionrecordingviewed"."session_id" IN ('session_many_ids'))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.13
+  '''
+  SELECT "posthog_sessionrecordingviewed"."session_id",
+         "posthog_user"."email"
+  FROM "posthog_sessionrecordingviewed"
+  INNER JOIN "posthog_user" ON ("posthog_sessionrecordingviewed"."user_id" = "posthog_user"."id")
+  WHERE ("posthog_sessionrecordingviewed"."session_id" IN ('session_many_ids')
+         AND "posthog_sessionrecordingviewed"."team_id" = 99999
+         AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.14
@@ -2883,19 +2845,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.8
   '''
-  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
-         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
-         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
-         "posthog_teamrevenueanalyticsconfig"."events",
-         "posthog_teamrevenueanalyticsconfig"."goals",
-         "posthog_teamrevenueanalyticsconfig"."base_currency"
-  FROM "posthog_teamrevenueanalyticsconfig"
-  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.9
-  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -2922,6 +2871,55 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.9
+  '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."queryable_folder",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_

--- a/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
+++ b/products/customer_analytics/frontend/components/CustomerAnalyticsQueryCard.tsx
@@ -11,7 +11,7 @@ import { SURVEY_CREATED_SOURCE } from 'scenes/surveys/constants'
 import { isValidFunnelQuery } from 'scenes/surveys/utils/opportunityDetection'
 import { urls } from 'scenes/urls'
 
-import { QuerySchema } from '~/queries/schema/schema-general'
+import { ProductKey, QuerySchema } from '~/queries/schema/schema-general'
 import { InsightLogicProps } from '~/types'
 
 import {
@@ -62,6 +62,7 @@ export function CustomerAnalyticsQueryCard({ insight, tabId }: CustomerAnalytics
             insight={insight}
             insightProps={insightProps}
             source={SURVEY_CREATED_SOURCE.CUSTOMER_ANALYTICS_INSIGHT}
+            fromProduct={ProductKey.CUSTOMER_ANALYTICS}
         />
     ) : null
 

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ScenePanel/ErrorTrackingIssueScenePanel.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ScenePanel/ErrorTrackingIssueScenePanel.tsx
@@ -14,13 +14,14 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { pluralize } from 'lib/utils'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { QuickSurveyModal } from 'scenes/surveys/QuickSurveyModal'
 import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
 import { urls } from 'scenes/urls'
 
 import { ScenePanel, ScenePanelDivider, ScenePanelInfoSection, ScenePanelLabel } from '~/layout/scenes/SceneLayout'
 import { ScenePanelActionsSection } from '~/layout/scenes/SceneLayout'
-import { ErrorTrackingRelationalIssue } from '~/queries/schema/schema-general'
+import { ErrorTrackingRelationalIssue, ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 
 import { ExternalReferences } from '../../../components/ExternalReferences'
 import { errorTrackingIssueSceneLogic } from '../errorTrackingIssueSceneLogic'
@@ -94,7 +95,17 @@ const CreateSurveyButton = (): JSX.Element | null => {
     }
     return (
         <>
-            <ButtonPrimitive fullWidth onClick={() => setShowSurveyModal(true)}>
+            <ButtonPrimitive
+                fullWidth
+                onClick={() => {
+                    setShowSurveyModal(true)
+                    void addProductIntentForCrossSell({
+                        from: ProductKey.ERROR_TRACKING,
+                        to: ProductKey.SURVEYS,
+                        intent_context: ProductIntentContext.QUICK_SURVEY_STARTED,
+                    })
+                }}
+            >
                 <IconMessage />
                 Create survey
             </ButtonPrimitive>


### PR DESCRIPTION
## Problem

59% of surveys launched in 2025 used URL targeting, and over 90% of those were targeted to ONLY a URL.

if most of our users are popping surveys up on particular pages, let's make it easy and give them a two-click launch from web analytics!

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds new surveys cross-sell button in "Paths" on web analytics page (and removed all the external link icons):

![Screenshot 2025-12-04 at 7.19.26 PM.png](https://app.graphite.com/user-attachments/assets/e9213735-66ee-4848-b587-12925bb7d436.png)

<!-- If there are frontend changes, please include screenshots. -->

![Screenshot 2025-12-04 at 6.35.58 PM.png](https://app.graphite.com/user-attachments/assets/cfa88aef-b54e-4c22-8322-b03e44045977.png)

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

sorry for the length, this PR also fixes intent events for other survey cross-selling ...

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->