### PR TITLE
feat(surveys): add followup to error tracking template

### DIFF
--- a/frontend/src/scenes/surveys/quick-create/components/ExceptionFilters.tsx
+++ b/frontend/src/scenes/surveys/quick-create/components/ExceptionFilters.tsx
@@ -37,7 +37,7 @@ export function ExceptionFilters(): JSX.Element {
     }
 
     return (
-        <div>
+        <div className="mt-2">
             <LemonLabel className="mb-2">Exception filters</LemonLabel>
             <div className="border rounded p-3 bg-bg-light">
                 <div className="text-xs font-medium text-muted-alt mb-2">

--- a/frontend/src/scenes/surveys/quick-create/utils.ts
+++ b/frontend/src/scenes/surveys/quick-create/utils.ts
@@ -98,6 +98,8 @@ export const buildLogicProps = (context: QuickSurveyContext): Omit<QuickSurveyFo
                     scaleType: 'number',
                     ratingLowerBound: 'Minor glitch',
                     ratingUpperBound: "Can't continue",
+                    followUpEnabled: true,
+                    followUpQuestion: 'What were you trying to do?',
                     conditions: {
                         actions: null,
                         events: {

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ScenePanel/ErrorTrackingIssueScenePanel.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ScenePanel/ErrorTrackingIssueScenePanel.tsx
@@ -118,6 +118,7 @@ const CreateSurveyButton = (): JSX.Element | null => {
                 info="This survey will trigger when users encounter matching exceptions. Adjust the filters below to target specific errors."
                 isOpen={showSurveyModal}
                 onCancel={() => setShowSurveyModal(false)}
+                showFollowupToggle={true}
             />
         </>
     )


### PR DESCRIPTION
## Problem

the error tracking template we already have in surveys, + most surveys that use exception targeting, ask a follow-up question.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes
adding that option to the modal

![Screenshot 2025-12-04 at 7.13.51 PM.png](https://app.graphite.com/user-attachments/assets/a1a413a7-15e0-464f-8984-8e56cace5f76.png)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->