### PR TITLE
feat(kdedup): expose more Kafka consumer configs with new defaults

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -13,6 +13,15 @@ pub struct Config {
     #[envconfig(default = "kafka-deduplicator")]
     pub kafka_consumer_group: String,
 
+    #[envconfig(default = "10485760")] // 10MB
+    pub kafka_consumer_max_partition_fetch_bytes: u32,
+
+    #[envconfig(default = "10000")] // 10 seconds
+    pub kafka_topic_metadata_refresh_interval_ms: u32,
+
+    #[envconfig(default = "30000")] // 30 seconds
+    pub kafka_metadata_max_age_ms: u32,
+
     // supplied by k8s deploy env, used as part of kafka
     // consumer client ID for sticky partition mappings
     #[envconfig(from = "HOSTNAME")]

--- a/rust/kafka-deduplicator/src/kafka/config.rs
+++ b/rust/kafka-deduplicator/src/kafka/config.rs
@@ -19,19 +19,18 @@ impl ConsumerConfigBuilder {
         config
             .set("enable.auto.offset.store", "false") // Manual store for full control
             .set("enable.auto.commit", "false") // Manual commit for exactly-once semantics
-            .set("auto.offset.reset", "earliest") // Don't miss data
+            .set("socket.timeout.ms", "10000")
             .set("session.timeout.ms", "30000")
-            .set("heartbeat.interval.ms", "10000")
+            .set("heartbeat.interval.ms", "5000")
             .set("max.poll.interval.ms", "300000")
             .set("fetch.min.bytes", "1")
-            .set("fetch.wait.max.ms", "500")
-            .set("max.partition.fetch.bytes", "1048576"); // 1MB
+            .set("fetch.wait.max.ms", "500");
 
         Self { config }
     }
 
     /// Override offset reset policy
-    pub fn offset_reset(mut self, policy: &str) -> Self {
+    pub fn with_offset_reset(mut self, policy: &str) -> Self {
         self.config.set("auto.offset.reset", policy);
         self
     }
@@ -49,6 +48,23 @@ impl ConsumerConfigBuilder {
                 .set("security.protocol", "ssl")
                 .set("enable.ssl.certificate.verification", "false");
         }
+        self
+    }
+
+    pub fn with_max_partition_fetch_bytes(mut self, bytes: u32) -> Self {
+        self.config
+            .set("max.partition.fetch.bytes", bytes.to_string());
+        self
+    }
+
+    pub fn with_topic_metadata_refresh_interval_ms(mut self, ms: u32) -> Self {
+        self.config
+            .set("topic.metadata.refresh.interval.ms", ms.to_string());
+        self
+    }
+
+    pub fn with_metadata_max_age_ms(mut self, ms: u32) -> Self {
+        self.config.set("metadata.max.age.ms", ms.to_string());
         self
     }
 

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -244,8 +244,15 @@ impl KafkaDeduplicatorService {
         let consumer_config =
             ConsumerConfigBuilder::new(&self.config.kafka_hosts, &self.config.kafka_consumer_group)
                 .with_tls(self.config.kafka_tls)
+                .with_max_partition_fetch_bytes(
+                    self.config.kafka_consumer_max_partition_fetch_bytes,
+                )
+                .with_topic_metadata_refresh_interval_ms(
+                    self.config.kafka_topic_metadata_refresh_interval_ms,
+                )
+                .with_metadata_max_age_ms(self.config.kafka_metadata_max_age_ms)
                 .with_sticky_partition_assignment(self.config.pod_hostname.as_deref())
-                .offset_reset(&self.config.kafka_consumer_offset_reset)
+                .with_offset_reset(&self.config.kafka_consumer_offset_reset)
                 .build();
 
         // Create shutdown channel


### PR DESCRIPTION
## Problem
We want to tune a few Kafka consumer configs for the new batch consumer and deduplicator pipeline.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add several more config values with defaults
* Expose some of them via env config
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No update required
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
