### PR TITLE
fix(surveys): update internal targeting flag when iterations are added to existing survey

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -803,7 +803,8 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
 
         if instance.internal_targeting_flag:
             existing_targeting_flag = instance.internal_targeting_flag
-            serialized_data_filters = {**user_submitted_dismissed_filter, **existing_targeting_flag.filters}
+            # Note: new filters must come LAST to overwrite old iteration-unaware properties
+            serialized_data_filters = {**existing_targeting_flag.filters, **user_submitted_dismissed_filter}
 
             internal_targeting_flag = self._create_or_update_targeting_flag(
                 instance.internal_targeting_flag, serialized_data_filters, flag_name_suffix="-custom"

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -196,6 +196,95 @@ class TestSurvey(APIBaseTest):
         survey = Survey.objects.get(id=response_data["id"])
         assert survey.internal_targeting_flag.active is True
 
+    def test_adding_iterations_to_existing_survey_updates_internal_targeting_flag(self):
+        # Step 1: Create a survey WITHOUT iterations
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "Survey without iterations initially",
+                "type": "popover",
+                "questions": [{"type": "open", "question": "What do you think?"}],
+            },
+            format="json",
+        )
+        response_data = response.json()
+        assert response.status_code == status.HTTP_201_CREATED, response_data
+
+        survey = Survey.objects.get(id=response_data["id"])
+        survey_id = str(survey.id)
+
+        # Verify the internal_targeting_flag has properties WITHOUT iteration suffix
+        expected_filters_without_iteration = {
+            "groups": [
+                {
+                    "variant": "",
+                    "rollout_percentage": 100,
+                    "properties": [
+                        {
+                            "key": f"$survey_dismissed/{survey_id}",
+                            "type": "person",
+                            "value": "is_not_set",
+                            "operator": "is_not_set",
+                        },
+                        {
+                            "key": f"$survey_responded/{survey_id}",
+                            "type": "person",
+                            "value": "is_not_set",
+                            "operator": "is_not_set",
+                        },
+                    ],
+                }
+            ]
+        }
+        assert survey.internal_targeting_flag is not None
+        assert survey.internal_targeting_flag.filters == expected_filters_without_iteration
+
+        # Step 2: Update the survey to ADD iterations
+        update_response = self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={
+                "start_date": datetime.now() - timedelta(days=1),
+                "iteration_count": 3,
+                "iteration_frequency_days": 30,
+            },
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK, update_response.json()
+
+        survey.refresh_from_db()
+
+        # Verify current_iteration is set
+        assert survey.current_iteration == 1
+
+        # Step 3: Verify the internal_targeting_flag NOW has properties WITH iteration suffix
+        expected_filters_with_iteration = {
+            "groups": [
+                {
+                    "variant": "",
+                    "rollout_percentage": 100,
+                    "properties": [
+                        {
+                            "key": f"$survey_dismissed/{survey_id}/1",
+                            "type": "person",
+                            "value": "is_not_set",
+                            "operator": "is_not_set",
+                        },
+                        {
+                            "key": f"$survey_responded/{survey_id}/1",
+                            "type": "person",
+                            "value": "is_not_set",
+                            "operator": "is_not_set",
+                        },
+                    ],
+                }
+            ]
+        }
+
+        survey.internal_targeting_flag.refresh_from_db()
+        assert (
+            survey.internal_targeting_flag.filters == expected_filters_with_iteration
+        ), f"Expected iteration-aware filters but got: {survey.internal_targeting_flag.filters}"
+
     def test_can_create_survey_with_linked_flag_and_targeting(self):
         notebooks_flag = FeatureFlag.objects.create(team=self.team, key="notebooks", created_by=self.user)
 

--- a/posthog/tasks/update_survey_iteration.py
+++ b/posthog/tasks/update_survey_iteration.py
@@ -50,7 +50,8 @@ def _get_targeting_flag(survey: Survey) -> ForeignKey | ForeignKey | Any:
 
     if existing_targeting_flag:
         existing_targeting_flag = survey.internal_targeting_flag
-        serialized_data_filters = {**user_submitted_dismissed_filter, **existing_targeting_flag.filters}
+        # Note: new filters must come LAST to overwrite old iteration-unaware properties
+        serialized_data_filters = {**existing_targeting_flag.filters, **user_submitted_dismissed_filter}
         existing_targeting_flag.filters = serialized_data_filters
         existing_targeting_flag.save()
         return existing_targeting_flag


### PR DESCRIPTION
## Problem

When iterations were added to an existing survey (or when the celery job updated iteration numbers), the `internal_targeting_flag` wasn't being updated with the correct iteration-aware property keys.

**Root cause:** The dict merge order was wrong when updating existing flags:
```python
# Bug: old filters overwrote new filters
serialized_data_filters = {**user_submitted_dismissed_filter, **existing_targeting_flag.filters}
```

This caused the flag to retain old property keys like `$survey_responded/{survey_id}` instead of updating to `$survey_responded/{survey_id}/1`, resulting in surveys showing repeatedly to users who had already responded.

### Affected Scenarios

| Scenario | Symptom | Example |
|----------|---------|---------|
| Survey created without iterations, then iterations added later | Missing iteration suffix | `$survey_responded/{id}` instead of `$survey_responded/{id}/1` |
| Survey with iterations where iteration number changed | Wrong iteration number | Flag has `/7` but `current_iteration` is `6` |

Surveys created with iterations from the start that never changed iteration were **not affected** (no existing flag to merge with).

## Fix

Reversed the merge order so new iteration-aware filters take precedence:
```python
serialized_data_filters = {**existing_targeting_flag.filters, **user_submitted_dismissed_filter}
```

Fixed in both:
- `posthog/api/survey.py` - when survey is updated via API
- `posthog/tasks/update_survey_iteration.py` - when celery job advances iterations

## Tests

1. `test_adding_iterations_to_existing_survey_updates_internal_targeting_flag` - verifies API update scenario
2. `test_iteration_change_updates_flag_with_new_iteration_suffix` - verifies celery job scenario where iteration changes and flag should update with new suffix

## Production Fix Script

To fix affected surveys that already have incorrect flags, I ran this script:

```python
from posthog.models import Survey
DRY_RUN = True
affected = []
for survey in Survey.objects.filter(iteration_count__isnull=False, iteration_count__gt=0, internal_targeting_flag__isnull=False).select_related("internal_targeting_flag"):
    flag = survey.internal_targeting_flag
    if not flag or not flag.filters:
        continue
    groups = flag.filters.get("groups", [])
    if not groups:
        continue
    sid = str(survey.id)
    current_iter = survey.current_iteration or 1
    expected_suffix = f"{sid}/{current_iter}"
    is_affected = False
    reason = ""
    for prop in groups[0].get("properties", []):
        key = prop.get("key", "")
        if key == f"$survey_dismissed/{sid}" or key == f"$survey_responded/{sid}":
            is_affected = True
            reason = "missing iteration suffix"
            break
        if key.startswith(f"$survey_dismissed/{sid}/") or key.startswith(f"$survey_responded/{sid}/"):
            if expected_suffix not in key:
                is_affected = True
                reason = "wrong iteration number"
                break
    if is_affected:
        affected.append((survey, flag, reason))

print(f"Found {len(affected)} affected survey(s)")
for survey, flag, reason in affected:
    print(f"Survey: {survey.id} | Team: {survey.team_id} | Iter: {survey.current_iteration} | Reason: {reason}")
    print(f"  Current: {[p['key'] for p in flag.filters.get('groups', [{}])[0].get('properties', [])]}")
    iteration = survey.current_iteration or 1
    new_filters = {"groups": [{"variant": "", "rollout_percentage": 100, "properties": [{"key": f"$survey_dismissed/{survey.id}/{iteration}", "value": "is_not_set", "operator": "is_not_set", "type": "person"}, {"key": f"$survey_responded/{survey.id}/{iteration}", "value": "is_not_set", "operator": "is_not_set", "type": "person"}]}]}
    print(f"  Fixed:   {[p['key'] for p in new_filters['groups'][0]['properties']]}")
    if not DRY_RUN:
        flag.filters = {**flag.filters, **new_filters}
        flag.save()
        print("  >>> SAVED")
    else:
        print("  >>> DRY RUN")

print(f"{'DRY RUN complete' if DRY_RUN else 'DONE'}. {len(affected)} survey(s).")
```

Set `DRY_RUN = False` to apply fixes. This was run on US (~609 surveys) and EU (~460 surveys) prod on 2025-12-05.