### PR TITLE
chore: backup events only in EU

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -49,7 +49,6 @@ def get_max_backup_bandwidth() -> str:
 
 
 SHARDED_TABLES = [
-    "sharded_events",
     "sharded_app_metrics",
     "sharded_app_metrics2",
     "sharded_heatmaps",
@@ -60,6 +59,10 @@ SHARDED_TABLES = [
     "sharded_session_replay_events",
     "sharded_sessions",
 ]
+# Continue backing up sharded_events in EU using CH BACKUP. For US we
+# already switched to Vector based approach.
+if settings.CLOUD_DEPLOYMENT == "EU":
+    SHARDED_TABLES.append("sharded_events")
 
 NON_SHARDED_TABLES = [
     "asyncdeletion",


### PR DESCRIPTION
## Problem

We are already backing up all events in S3 through Vector, and we backfilled the whole events table into S3.

Only for US, EU is still work in progress, so keep events backup for it.

## Changes

Only backup events if the job is run in EU.
