### PR TITLE
chore(kafka): adds metrics for offset commiting

### DIFF
--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -103,6 +103,25 @@ const counterBackgroundTaskNotFound = new Counter({
     labelNames: ['pod', 'groupId'],
 })
 
+// Simple metrics to track offset commits
+const gaugeLastProcessedOffset = new Gauge({
+    name: 'kafka_consumer_last_processed_offset',
+    help: 'Last processed offset per partition',
+    labelNames: ['topic', 'partition', 'groupId'],
+})
+
+const gaugeLastStoredOffset = new Gauge({
+    name: 'kafka_consumer_last_stored_offset',
+    help: 'Last stored (committed) offset per partition',
+    labelNames: ['topic', 'partition', 'groupId'],
+})
+
+const counterOffsetStoreAttempts = new Counter({
+    name: 'kafka_consumer_offset_store_attempts_total',
+    help: 'Total offset store attempts per partition',
+    labelNames: ['topic', 'partition', 'groupId', 'status'],
+})
+
 export const findOffsetsToCommit = (messages: TopicPartitionOffset[]): TopicPartitionOffset[] => {
     // We only need to commit the highest offset for a batch of messages
     const messagesByTopicPartition = messages.reduce(
@@ -611,7 +630,39 @@ export class KafkaConsumer {
             logger.debug('📝', 'Storing offsets', { topicPartitionOffsetsToCommit })
             try {
                 this.rdKafkaConsumer.offsetsStore(topicPartitionOffsetsToCommit)
+
+                // Track successful offset stores
+                topicPartitionOffsetsToCommit.forEach((tpo) => {
+                    counterOffsetStoreAttempts
+                        .labels({
+                            topic: tpo.topic,
+                            partition: tpo.partition.toString(),
+                            groupId: this.config.groupId,
+                            status: 'success',
+                        })
+                        .inc()
+
+                    // Track the last stored offset
+                    gaugeLastStoredOffset
+                        .labels({
+                            topic: tpo.topic,
+                            partition: tpo.partition.toString(),
+                            groupId: this.config.groupId,
+                        })
+                        .set(tpo.offset)
+                })
             } catch (e) {
+                // Track failed offset stores
+                topicPartitionOffsetsToCommit.forEach((tpo) => {
+                    counterOffsetStoreAttempts
+                        .labels({
+                            topic: tpo.topic,
+                            partition: tpo.partition.toString(),
+                            groupId: this.config.groupId,
+                            status: 'failed',
+                        })
+                        .inc()
+                })
                 // NOTE: We don't throw here - this can happen if we were re-assigned partitions
                 // and the offsets are no longer valid whilst processing a batch
                 let assignedPartitions: Assignment[] | string = []
@@ -737,6 +788,17 @@ export class KafkaConsumer {
                     const taskCreatedAt = Date.now()
                     // Pull out the offsets to commit from the messages so we can release the messages reference
                     const topicPartitionOffsetsToCommit = findOffsetsToCommit(messages)
+
+                    // Track last processed offsets
+                    topicPartitionOffsetsToCommit.forEach((tpo) => {
+                        gaugeLastProcessedOffset
+                            .labels({
+                                topic: tpo.topic,
+                                partition: tpo.partition.toString(),
+                                groupId: this.config.groupId,
+                            })
+                            .set(tpo.offset)
+                    })
 
                     void backgroundTask.finally(async () => {
                         // Track that we made progress


### PR DESCRIPTION
## Problem

Currently we have the following pattern appearing periodically:

<img width="2227" height="222" alt="Screenshot 2025-12-05 at 10 22 43" src="https://github.com/user-attachments/assets/2c56ba61-e965-4c23-8af5-6940b28f4097" />

- Production of messages to the topic seems to be somewhat stable
- some partitions appear to be stuck, lag is growing 
- batch utilization of p90 topping out at 100% (graph changed know so can't rely on this as this is taken in the past)
- CPU does not look suspicious. Not dropping and therefore indicating that we stop processing
- production vs consumption does not look suspicious compared to lag building up and partitions getting stuck (slight drop in consumption is probably due to a restart)
- hot partitions are not a thing as events are spread evenly with no particular partition-key

--> restart of the pods / all pods instantly relieves the stuck partitions

Hypothesis:

1. kafka client is not committing offsets properly but processing continues leading to metrics reported being wrong 
2. background-tasks tamper with off-set committing leaving the problem on our end and how we handle offsets

## Changes

Adding metrics

 1. kafka_consumer_last_processed_offset - Tracks when messages are processed
 2. kafka_consumer_last_stored_offset - Tracks when offsets are actually stored/committed
 3. kafka_consumer_offset_store_attempts_total - Shows if commits are failing

 The key metric to watch is:

`kafka_consumer_last_processed_offset - kafka_consumer_last_stored_offset`

This "offset commit delay" will show:
  - Normal: Small values that periodically return to 0
  - Our issue: Growing values that only reset on restart, indicating offsets are processed but not committed due to stuck background tasks

In the end we want to generate graphs that look like this 

<img width="929" height="217" alt="Screenshot 2025-12-05 at 10 31 31" src="https://github.com/user-attachments/assets/b9e1572c-74cf-4a1b-a49f-ca33012b75c9" />

- If this graph looks somewhat like the current lag by partition graph we can be sure it is related to our code and handling of background tasks.