### PR TITLE
fix(logs): Safari-specific bugs in logs viewer

### DIFF
--- a/products/logs/frontend/AttributeBreakdowns.tsx
+++ b/products/logs/frontend/AttributeBreakdowns.tsx
@@ -32,6 +32,7 @@ export const AttributeBreakdowns = ({
         <div className="flex flex-col p-2 gap-y-2">
             {attributeValues.length} of the {logCount} logs have the label {attribute}
             <LemonTable
+                className="w-fit"
                 hideScrollbar
                 dataSource={dataSource}
                 size="small"

--- a/products/logs/frontend/logsLogic.test.ts
+++ b/products/logs/frontend/logsLogic.test.ts
@@ -1,9 +1,18 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { lemonToast } from '@posthog/lemon-ui'
+
 import { LogMessage } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 
 import { SparklineTimezone, logsLogic } from './logsLogic'
+
+jest.mock('@posthog/lemon-ui', () => ({
+    ...jest.requireActual('@posthog/lemon-ui'),
+    lemonToast: {
+        error: jest.fn(),
+    },
+}))
 
 const createMockLog = (uuid: string): LogMessage => ({
     uuid,
@@ -212,6 +221,52 @@ describe('logsLogic', () => {
                 .toMatchValues({
                     sparklineTimezone: SparklineTimezone.UTC,
                 })
+        })
+    })
+
+    describe('error handling', () => {
+        beforeEach(() => {
+            jest.clearAllMocks()
+        })
+
+        it.each([
+            ['new query started', 'exact match for NEW_QUERY_STARTED_ERROR_MESSAGE'],
+            ['Fetch is aborted', 'Safari abort message'],
+            ['The operation was aborted', 'alternative abort message'],
+            ['ABORTED', 'uppercase abort'],
+            ['Request aborted by user', 'abort substring'],
+        ])('suppresses error "%s" (%s)', async (error) => {
+            logic.actions.fetchLogsFailure(error)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(lemonToast.error).not.toHaveBeenCalled()
+        })
+
+        it.each([['Network error'], ['Server returned 500'], ['Timeout exceeded']])(
+            'shows toast for legitimate error "%s"',
+            async (error) => {
+                logic.actions.fetchLogsFailure(error)
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(lemonToast.error).toHaveBeenCalledWith(`Failed to load logs: ${error}`)
+            }
+        )
+
+        it.each([
+            ['Fetch is aborted', 'Safari abort message'],
+            ['new query started', 'exact match for NEW_QUERY_STARTED_ERROR_MESSAGE'],
+        ])('suppresses fetchNextLogsPage error "%s" (%s)', async (error) => {
+            logic.actions.fetchNextLogsPageFailure(error)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(lemonToast.error).not.toHaveBeenCalled()
+        })
+
+        it('shows toast for legitimate fetchNextLogsPage error', async () => {
+            logic.actions.fetchNextLogsPageFailure('Network error')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith('Failed to load more logs: Network error')
         })
     })
 })

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -750,12 +750,14 @@ export const logsLogic = kea<logsLogicType>([
 
     listeners(({ values, actions, cache }) => ({
         fetchLogsFailure: ({ error }) => {
-            if (error !== NEW_QUERY_STARTED_ERROR_MESSAGE) {
+            const errorStr = String(error).toLowerCase()
+            if (error !== NEW_QUERY_STARTED_ERROR_MESSAGE && !errorStr.includes('abort')) {
                 lemonToast.error(`Failed to load logs: ${error}`)
             }
         },
         fetchNextLogsPageFailure: ({ error }) => {
-            if (error !== NEW_QUERY_STARTED_ERROR_MESSAGE) {
+            const errorStr = String(error).toLowerCase()
+            if (error !== NEW_QUERY_STARTED_ERROR_MESSAGE && !errorStr.includes('abort')) {
                 lemonToast.error(`Failed to load more logs: ${error}`)
             }
         },


### PR DESCRIPTION
## Problem

Two Safari-specific issues in the logs viewer:
- AttributeBreakdowns table was stretching to full width, causing columns to spread apart and be difficult to read
- "Failed to load logs: Fetch is aborted" error toasts appearing when queries are cancelled (Chrome silently handles this, Safari reports it differently)

## Changes

<img width="428" height="286" alt="image" src="https://github.com/user-attachments/assets/2ccf203b-8ac8-43b0-8121-e13110cec40d" />

- Add w-fit class to AttributeBreakdowns LemonTable so it only takes the width it needs
- Check for "abort" in error messages (case-insensitive) to suppress abort-related toasts across browsers

## How did you test this code?

Local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._