### PR TITLE
fix(batch-exports): Databricks - ensure cleanup of volume and stage table on error

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -445,11 +445,13 @@ class DatabricksClient:
 
         await self.acreate_table(table_name=table_name, fields=fields)
 
-        yield table_name
-
-        if delete is True:
-            self.logger.info("Deleting Databricks table %s", table_name)
-            await self.adelete_table(table_name)
+        try:
+            yield table_name
+        # ensure we always clean up the table even if there is an error
+        finally:
+            if delete is True:
+                self.logger.info("Deleting Databricks table %s", table_name)
+                await self.adelete_table(table_name)
 
     async def acreate_table(self, table_name: str, fields: list[DatabricksField]):
         """Asynchronously create the Databricks delta table if it doesn't exist."""
@@ -551,9 +553,12 @@ class DatabricksClient:
         """Manage a volume in Databricks by ensuring it exists while in context."""
         self.logger.info("Creating Databricks volume %s", volume)
         await self.acreate_volume(volume)
-        yield volume
-        self.logger.info("Deleting Databricks volume %s", volume)
-        await self.adelete_volume(volume)
+        # ensure we always clean up the volume even if there is an error
+        try:
+            yield volume
+        finally:
+            self.logger.info("Deleting Databricks volume %s", volume)
+            await self.adelete_volume(volume)
 
     async def acreate_volume(self, volume: str):
         """Asynchronously create a Databricks volume."""


### PR DESCRIPTION
## Problem

At the moment, in our Databricks batch export we do not clean up created volumes and stage tables if an error occurs midway through the batch export.
This can cause issues on subsequent retries due to duplicate data being present.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Updated the DatabricksClient to guarantee that the volume and stage table are deleted even if an error occurs during the export process.


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added test to verify that cleanup happens correctly when an error is simulated during the merge operation.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

