### PR TITLE
feat: show count of ongoing sessions in livestream

### DIFF
--- a/livestream/configs/configs.example.yml
+++ b/livestream/configs/configs.example.yml
@@ -2,6 +2,8 @@ debug: true
 kafka:
     brokers: 'localhost:9092,localhost:9093'
     topic: 'topic'
+    session_recording_topic: 'session_recording_snapshot_item_events'  # defaults to this value
+    # session_recording_brokers: 'localhost:9094'  # optional, defaults to brokers
     group_id: 'livestream-dev'
 mmdb:
     path: 'mmdb.db'

--- a/livestream/configs/configs.go
+++ b/livestream/configs/configs.go
@@ -33,9 +33,11 @@ type Config struct {
 }
 
 type KafkaConfig struct {
-	Brokers string `mapstructure:"brokers"`
-	Topic   string `mapstructure:"topic"`
-	GroupID string `mapstructure:"group_id"`
+	Brokers                  string `mapstructure:"brokers"`
+	Topic                    string `mapstructure:"topic"`
+	SessionRecordingTopic    string `mapstructure:"session_recording_topic"`
+	SessionRecordingBrokers  string `mapstructure:"session_recording_brokers"`
+	GroupID                  string `mapstructure:"group_id"`
 }
 
 func InitConfigs(filename, configPath string) {
@@ -43,6 +45,7 @@ func InitConfigs(filename, configPath string) {
 	viper.AddConfigPath(configPath)
 
 	viper.SetDefault("kafka.group_id", "livestream")
+	viper.SetDefault("kafka.session_recording_topic", "session_recording_snapshot_item_events")
 
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -75,6 +78,9 @@ func LoadConfig() (*Config, error) {
 	}
 	if len(config.CORSAllowOrigins) == 0 {
 		config.CORSAllowOrigins = []string{"*"}
+	}
+	if config.Kafka.SessionRecordingBrokers == "" {
+		config.Kafka.SessionRecordingBrokers = config.Kafka.Brokers
 	}
 
 	if config.MMDB.Path == "" {

--- a/livestream/configs/configs_test.go
+++ b/livestream/configs/configs_test.go
@@ -28,9 +28,11 @@ func TestLoadConfig(t *testing.T) {
 				Parallelism:      7,
 				CORSAllowOrigins: []string{"https://example.com", "https://sub.example.com"},
 				Kafka: KafkaConfig{
-					Brokers: "localhost:9092,localhost:9093",
-					Topic:   "topic",
-					GroupID: "livestream-dev",
+					Brokers:                 "localhost:9092,localhost:9093",
+					Topic:                   "topic",
+					SessionRecordingTopic:   "session_recording_snapshot_item_events",
+					SessionRecordingBrokers: "localhost:9092,localhost:9093",
+					GroupID:                 "livestream-dev",
 				},
 				Postgres: PostgresConfig{
 					URL: "pg url",

--- a/livestream/events/session_recording_consumer.go
+++ b/livestream/events/session_recording_consumer.go
@@ -1,0 +1,100 @@
+package events
+
+import (
+	"errors"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/posthog/posthog/livestream/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type SessionRecordingEvent struct {
+	Token     string
+	SessionId string
+}
+
+type SessionRecordingKafkaConsumer struct {
+	consumer  KafkaConsumerInterface
+	topic     string
+	statsChan chan SessionRecordingEvent
+}
+
+func NewSessionRecordingKafkaConsumer(
+	brokers string, securityProtocol string, groupID string, topic string,
+	statsChan chan SessionRecordingEvent) (*SessionRecordingKafkaConsumer, error) {
+
+	config := &kafka.ConfigMap{
+		"bootstrap.servers":          brokers,
+		"group.id":                   groupID + "-session-recordings",
+		"auto.offset.reset":          "latest",
+		"enable.auto.commit":         false,
+		"security.protocol":          securityProtocol,
+		"fetch.message.max.bytes":    1_000_000_000,
+		"fetch.max.bytes":            1_000_000_000,
+		"queued.max.messages.kbytes": 2_000_000,
+	}
+
+	consumer, err := kafka.NewConsumer(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SessionRecordingKafkaConsumer{
+		consumer:  consumer,
+		topic:     topic,
+		statsChan: statsChan,
+	}, nil
+}
+
+func (c *SessionRecordingKafkaConsumer) Consume() {
+	if err := c.consumer.SubscribeTopics([]string{c.topic}, nil); err != nil {
+		log.Fatalf("Failed to subscribe to session recording topic: %v", err)
+	}
+
+	for {
+		msg, err := c.consumer.ReadMessage(15 * time.Second)
+		if err != nil {
+			var inErr kafka.Error
+			if errors.As(err, &inErr) {
+				if inErr.Code() == kafka.ErrTransport {
+					metrics.SessionRecordingConnectFailure.Inc()
+				} else if inErr.IsTimeout() {
+					metrics.SessionRecordingTimeoutConsume.Inc()
+					continue
+				}
+			}
+			log.Printf("Error consuming session recording message: %v", err)
+			continue
+		}
+
+		metrics.SessionRecordingMsgConsumed.With(prometheus.Labels{"partition": strconv.Itoa(int(msg.TopicPartition.Partition))}).Inc()
+
+		token, sessionId := parseSessionRecordingHeaders(msg.Headers)
+		if token != "" && sessionId != "" {
+			c.statsChan <- SessionRecordingEvent{Token: token, SessionId: sessionId}
+		} else {
+			metrics.SessionRecordingDroppedMessages.Inc()
+		}
+	}
+}
+
+func parseSessionRecordingHeaders(headers []kafka.Header) (token, sessionId string) {
+	for _, h := range headers {
+		switch h.Key {
+		case "token":
+			token = string(h.Value)
+		case "session_id":
+			sessionId = string(h.Value)
+		}
+	}
+	return
+}
+
+func (c *SessionRecordingKafkaConsumer) Close() {
+	if err := c.consumer.Close(); err != nil {
+		log.Printf("Failed to close session recording consumer: %v", err)
+	}
+}

--- a/livestream/events/session_recording_consumer_test.go
+++ b/livestream/events/session_recording_consumer_test.go
@@ -1,0 +1,83 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSessionRecordingHeaders(t *testing.T) {
+	tests := []struct {
+		name       string
+		headers    []kafka.Header
+		wantToken  string
+		wantSessId string
+	}{
+		{
+			name:       "empty headers",
+			headers:    nil,
+			wantToken:  "",
+			wantSessId: "",
+		},
+		{
+			name:       "empty headers slice",
+			headers:    []kafka.Header{},
+			wantToken:  "",
+			wantSessId: "",
+		},
+		{
+			name: "token only",
+			headers: []kafka.Header{
+				{Key: "token", Value: []byte("tok1")},
+			},
+			wantToken:  "tok1",
+			wantSessId: "",
+		},
+		{
+			name: "session_id only",
+			headers: []kafka.Header{
+				{Key: "session_id", Value: []byte("sess1")},
+			},
+			wantToken:  "",
+			wantSessId: "sess1",
+		},
+		{
+			name: "both present",
+			headers: []kafka.Header{
+				{Key: "token", Value: []byte("tok1")},
+				{Key: "session_id", Value: []byte("sess1")},
+			},
+			wantToken:  "tok1",
+			wantSessId: "sess1",
+		},
+		{
+			name: "both present reversed order",
+			headers: []kafka.Header{
+				{Key: "session_id", Value: []byte("sess1")},
+				{Key: "token", Value: []byte("tok1")},
+			},
+			wantToken:  "tok1",
+			wantSessId: "sess1",
+		},
+		{
+			name: "with extra headers",
+			headers: []kafka.Header{
+				{Key: "distinct_id", Value: []byte("user123")},
+				{Key: "token", Value: []byte("tok1")},
+				{Key: "timestamp", Value: []byte("12345")},
+				{Key: "session_id", Value: []byte("sess1")},
+			},
+			wantToken:  "tok1",
+			wantSessId: "sess1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotToken, gotSessId := parseSessionRecordingHeaders(tt.headers)
+			assert.Equal(t, tt.wantToken, gotToken)
+			assert.Equal(t, tt.wantSessId, gotSessId)
+		})
+	}
+}

--- a/livestream/events/session_stats.go
+++ b/livestream/events/session_stats.go
@@ -1,0 +1,53 @@
+package events
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/posthog/posthog/livestream/metrics"
+)
+
+const SESSION_RECORDING_TTL = 5 * time.Minute
+
+type SessionStats struct {
+	store map[string]*expirable.LRU[string, NoSpaceType]
+	mu    sync.RWMutex
+}
+
+func NewSessionStatsKeeper() *SessionStats {
+	return &SessionStats{
+		store: make(map[string]*expirable.LRU[string, NoSpaceType]),
+	}
+}
+
+func (ss *SessionStats) GetExistingStoreForToken(token string) *expirable.LRU[string, NoSpaceType] {
+	ss.mu.RLock()
+	defer ss.mu.RUnlock()
+	return ss.store[token]
+}
+
+func (ss *SessionStats) GetStoreForToken(token string) *expirable.LRU[string, NoSpaceType] {
+	store := ss.GetExistingStoreForToken(token)
+	if store != nil {
+		return store
+	}
+	ss.mu.Lock()
+	store = ss.store[token]
+	if store == nil {
+		store = expirable.NewLRU[string, NoSpaceType](0, nil, SESSION_RECORDING_TTL)
+		ss.store[token] = store
+	}
+	ss.mu.Unlock()
+	return store
+}
+
+func (ss *SessionStats) KeepStats(statsChan chan SessionRecordingEvent) {
+	log.Println("starting session recording stats keeper...")
+
+	for event := range statsChan {
+		ss.GetStoreForToken(event.Token).Add(event.SessionId, NoSpaceType{})
+		metrics.SessionRecordingHandledEvents.Inc()
+	}
+}

--- a/livestream/events/session_stats_test.go
+++ b/livestream/events/session_stats_test.go
@@ -1,0 +1,159 @@
+package events
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSessionStatsKeeper(t *testing.T) {
+	ss := NewSessionStatsKeeper()
+
+	assert.NotNil(t, ss.store)
+}
+
+func TestSessionStats_GetStoreForToken(t *testing.T) {
+	ss := NewSessionStatsKeeper()
+
+	store1 := ss.GetStoreForToken("token1")
+	assert.NotNil(t, store1)
+
+	store2 := ss.GetStoreForToken("token1")
+	assert.Equal(t, store1, store2)
+
+	store3 := ss.GetStoreForToken("token2")
+	assert.NotNil(t, store3)
+	assert.NotEqual(t, store1, store3)
+}
+
+func TestSessionStats_GetExistingStoreForToken(t *testing.T) {
+	ss := NewSessionStatsKeeper()
+
+	store := ss.GetExistingStoreForToken("nonexistent")
+	assert.Nil(t, store)
+
+	ss.GetStoreForToken("token1")
+	store = ss.GetExistingStoreForToken("token1")
+	assert.NotNil(t, store)
+}
+
+func TestSessionStats_Count(t *testing.T) {
+	tests := []struct {
+		name            string
+		events          []SessionRecordingEvent
+		wantToken1Count int
+		wantToken2Count int
+	}{
+		{
+			name:            "empty",
+			events:          nil,
+			wantToken1Count: 0,
+			wantToken2Count: 0,
+		},
+		{
+			name: "single session",
+			events: []SessionRecordingEvent{
+				{Token: "t1", SessionId: "s1"},
+			},
+			wantToken1Count: 1,
+			wantToken2Count: 0,
+		},
+		{
+			name: "same session twice",
+			events: []SessionRecordingEvent{
+				{Token: "t1", SessionId: "s1"},
+				{Token: "t1", SessionId: "s1"},
+			},
+			wantToken1Count: 1,
+			wantToken2Count: 0,
+		},
+		{
+			name: "different sessions same token",
+			events: []SessionRecordingEvent{
+				{Token: "t1", SessionId: "s1"},
+				{Token: "t1", SessionId: "s2"},
+			},
+			wantToken1Count: 2,
+			wantToken2Count: 0,
+		},
+		{
+			name: "different tokens",
+			events: []SessionRecordingEvent{
+				{Token: "t1", SessionId: "s1"},
+				{Token: "t2", SessionId: "s2"},
+			},
+			wantToken1Count: 1,
+			wantToken2Count: 1,
+		},
+		{
+			name: "same session different tokens",
+			events: []SessionRecordingEvent{
+				{Token: "t1", SessionId: "s1"},
+				{Token: "t2", SessionId: "s1"},
+			},
+			wantToken1Count: 1,
+			wantToken2Count: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ss := NewSessionStatsKeeper()
+			statsChan := make(chan SessionRecordingEvent, 100)
+
+			go ss.KeepStats(statsChan)
+
+			for _, event := range tt.events {
+				statsChan <- event
+			}
+
+			time.Sleep(50 * time.Millisecond)
+			close(statsChan)
+			time.Sleep(10 * time.Millisecond)
+
+			if tt.wantToken1Count > 0 {
+				store := ss.GetExistingStoreForToken("t1")
+				assert.NotNil(t, store)
+				assert.Equal(t, tt.wantToken1Count, store.Len())
+			}
+
+			if tt.wantToken2Count > 0 {
+				store := ss.GetExistingStoreForToken("t2")
+				assert.NotNil(t, store)
+				assert.Equal(t, tt.wantToken2Count, store.Len())
+			}
+		})
+	}
+}
+
+func TestSessionStats_Concurrency(t *testing.T) {
+	ss := NewSessionStatsKeeper()
+	statsChan := make(chan SessionRecordingEvent, 1000)
+
+	go ss.KeepStats(statsChan)
+
+	iterations := 100
+	var wg sync.WaitGroup
+	wg.Add(iterations)
+
+	for i := 0; i < iterations; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			statsChan <- SessionRecordingEvent{
+				Token:     "token1",
+				SessionId: "session1",
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	time.Sleep(50 * time.Millisecond)
+	close(statsChan)
+	time.Sleep(10 * time.Millisecond)
+
+	store := ss.GetExistingStoreForToken("token1")
+	assert.NotNil(t, store)
+	assert.Equal(t, 1, store.Len())
+}

--- a/livestream/handlers/handlers.go
+++ b/livestream/handlers/handlers.go
@@ -33,12 +33,13 @@ func ServedHandler(stats *events.Stats) func(c echo.Context) error {
 	}
 }
 
-func StatsHandler(stats *events.Stats) func(c echo.Context) error {
+func StatsHandler(stats *events.Stats, sessionStats *events.SessionStats) func(c echo.Context) error {
 	return func(c echo.Context) error {
 
 		type resp struct {
-			UsersOnProduct int    `json:"users_on_product,omitempty"`
-			Error          string `json:"error,omitempty"`
+			UsersOnProduct   int    `json:"users_on_product,omitempty"`
+			ActiveRecordings int    `json:"active_recordings,omitempty"`
+			Error            string `json:"error,omitempty"`
 		}
 
 		_, token, err := auth.GetAuthClaims(c.Request().Header)
@@ -46,15 +47,19 @@ func StatsHandler(stats *events.Stats) func(c echo.Context) error {
 			return c.JSON(http.StatusUnauthorized, resp{Error: "wrong token claims"})
 		}
 
-		store := stats.GetExistingStoreForToken(token)
-		if store == nil {
-			resp := resp{
-				Error: "no stats",
-			}
-			return c.JSON(http.StatusOK, resp)
+		userStore := stats.GetExistingStoreForToken(token)
+		sessionStore := sessionStats.GetExistingStoreForToken(token)
+
+		if userStore == nil && sessionStore == nil {
+			return c.JSON(http.StatusOK, resp{Error: "no stats"})
 		}
-		siteStats := resp{
-			UsersOnProduct: store.Len(),
+
+		siteStats := resp{}
+		if userStore != nil {
+			siteStats.UsersOnProduct = userStore.Len()
+		}
+		if sessionStore != nil {
+			siteStats.ActiveRecordings = sessionStore.Len()
 		}
 		return c.JSON(http.StatusOK, siteStats)
 	}

--- a/livestream/metrics/metrics.go
+++ b/livestream/metrics/metrics.go
@@ -50,4 +50,32 @@ var (
 		Name: "livestream_active_event_subscriptions_total",
 		Help: "How many active event subscriptions we have",
 	})
+
+	SessionRecordingMsgConsumed = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "livestream_session_recording_kafka_consumed_total",
+			Help: "The total number of consumed session recording messages",
+		},
+		[]string{"partition"},
+	)
+	SessionRecordingTimeoutConsume = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "livestream_session_recording_kafka_timeout_total",
+		Help: "The total number of session recording consume timeouts",
+	})
+	SessionRecordingConnectFailure = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "livestream_session_recording_kafka_connect_failure_total",
+		Help: "The total number of failed session recording connect attempts",
+	})
+	SessionRecordingHandledEvents = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "livestream_session_recording_events_total",
+		Help: "The total number of handled session recording events",
+	})
+	SessionRecordingStatsQueue = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "livestream_session_recording_stats_queue_use_ratio",
+		Help: "How much of session recording stats queue is used",
+	})
+	SessionRecordingDroppedMessages = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "livestream_session_recording_dropped_messages_total",
+		Help: "The total number of session recording messages dropped due to missing headers",
+	})
 )


### PR DESCRIPTION
As someone who demonstrably last wrote Go in 2015 (pretty complex at that https://github.com/pauldambra/go-checkoutkata) this is 100% Claude, so don't worry about hurting  my feelings

We have a couple of places in the product where we show active users using livestream

But we could also count session recordings from their topic

The session_id is in the header so we don't even have to parse the message

I'm thinking of using this in two ways

1 - just the usual "recordings happening now" indicator

more importantly 

2 - immediately after onboarding you hit an empty replay page. so we can show you if we're receiving recordings yet, and give you different advice if you are or aren't



