### PR TITLE
feat(ai): Allow opening recordings modal from session filtering result

### DIFF
--- a/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
+++ b/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
@@ -3,6 +3,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
+import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { SessionRecordingPreview } from 'scenes/session-recordings/playlist/SessionRecordingPreview'
 import {
     SessionRecordingPlaylistLogicProps,
@@ -62,6 +63,7 @@ export function RecordingsWidget({
 function RecordingsListContent(): JSX.Element {
     const { otherRecordings, sessionRecordingsResponseLoading, hasNext } = useValues(sessionRecordingsPlaylistLogic)
     const { maybeLoadSessionRecordings } = useActions(sessionRecordingsPlaylistLogic)
+    const { openSessionPlayer } = useActions(sessionPlayerModalLogic())
 
     const hasRecordings = otherRecordings.length > 0
 
@@ -79,7 +81,13 @@ function RecordingsListContent(): JSX.Element {
             ) : (
                 <>
                     {otherRecordings.map((recording) => (
-                        <div key={recording.id}>
+                        <div
+                            key={recording.id}
+                            onClick={(e) => {
+                                e.preventDefault()
+                                openSessionPlayer(recording)
+                            }}
+                        >
                             <SessionRecordingPreview recording={recording} selectable={false} />
                         </div>
                     ))}


### PR DESCRIPTION
## Problem

Users naturally want to view the recordings found by PostHog AI in recordings mode. Currently, the list items appear clickable, but actually aren't. See ZEN-44371.

## Changes

Clicking is now useful:

![2025-12-05 13 06 37](https://github.com/user-attachments/assets/ee5840f0-22d3-489a-9d97-6f1f98d8dd4e)
