### PR TITLE
feat: Add quarterly and yearly

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
@@ -36,6 +36,8 @@ const INTERVAL_UNIT_TO_HUMAN_DAYJS_FORMAT: Record<IntervalType, string> = {
     day: 'MMMM D, YYYY',
     week: '[Week of] MMMM D, YYYY',
     month: 'MMMM D',
+    quarter: '[Q]Q YYYY',
+    year: 'YYYY',
 }
 
 export interface AnnotationsOverlayProps {

--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.test.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.test.ts
@@ -398,7 +398,7 @@ describe('annotationsOverlayLogic', () => {
     describe('groupedAnnotations', () => {
         const EXPECTED_GROUPINGS_BY_INTERVAL_AND_TIMEZONE: Record<
             string,
-            Record<IntervalType, Record<string, AnnotationType[]>> // All IntervalType variants should be covered
+            Partial<Record<IntervalType, Record<string, AnnotationType[]>>>
         > = {
             UTC: {
                 second: {

--- a/frontend/src/lib/components/DateDisplay/index.tsx
+++ b/frontend/src/lib/components/DateDisplay/index.tsx
@@ -23,6 +23,8 @@ const DISPLAY_DATE_FORMAT: Record<IntervalType, string> = {
     day: 'D MMM',
     week: 'D MMM',
     month: 'MMM',
+    quarter: '[Q]Q',
+    year: 'YYYY',
 }
 
 const dateHighlight = (parsedDate: dayjs.Dayjs, interval: IntervalType): string => {

--- a/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
+++ b/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
@@ -71,6 +71,8 @@ const DEFAULT_OPTIONS: LemonSelectOption<IntervalType>[] = [
     { value: 'day', label: 'Day' },
     { value: 'week', label: 'Week' },
     { value: 'month', label: 'Month' },
+    { value: 'quarter', label: 'Quarter' },
+    { value: 'year', label: 'Year' },
 ]
 
 export function IntervalFilterStandalone({

--- a/frontend/src/lib/components/IntervalFilter/intervals.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervals.ts
@@ -1,4 +1,4 @@
-export type IntervalKeyType = 'minute' | 'hour' | 'day' | 'week' | 'month'
+export type IntervalKeyType = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year'
 
 export type Intervals = {
     [key in IntervalKeyType]: {
@@ -29,5 +29,13 @@ export const intervals: Intervals = {
     month: {
         label: 'month',
         newDateFrom: '-90d',
+    },
+    quarter: {
+        label: 'quarter',
+        newDateFrom: '-1y',
+    },
+    year: {
+        label: 'year',
+        newDateFrom: '-5y',
     },
 }

--- a/frontend/src/lib/components/SmoothingFilter/smoothings.ts
+++ b/frontend/src/lib/components/SmoothingFilter/smoothings.ts
@@ -50,6 +50,8 @@ export const smoothingOptions: Record<IntervalType, { label: string; value: Smoo
     ],
     week: [],
     month: [],
+    quarter: [],
+    year: [],
 }
 
 export type SmoothingKeyType = keyof typeof smoothingOptions

--- a/frontend/src/lib/dayjs.ts
+++ b/frontend/src/lib/dayjs.ts
@@ -85,4 +85,11 @@ export type UnitType = UnitTypeLong | UnitTypeLongPlural | UnitTypeShort
 
 export type OpUnitType = UnitType | 'week' | 'weeks' | 'w'
 export type QUnitType = UnitType | 'quarter' | 'quarters' | 'Q'
-export type ManipulateType = Exclude<OpUnitType, 'date' | 'dates'>
+export type ManipulateType =
+    | Exclude<OpUnitType, 'date' | 'dates'>
+    | 'quarter'
+    | 'quarters'
+    | 'Q'
+    | 'year'
+    | 'years'
+    | 'y'

--- a/frontend/src/lib/dayjs.ts
+++ b/frontend/src/lib/dayjs.ts
@@ -84,7 +84,7 @@ export type UnitTypeLongPlural =
 export type UnitType = UnitTypeLong | UnitTypeLongPlural | UnitTypeShort
 
 export type OpUnitType = UnitType | 'week' | 'weeks' | 'w'
-export type QUnitType = UnitType | 'quarter' | 'quarters' | 'Q'
+export type QUnitType = UnitType | 'quarter' | 'quarters' | 'Q' | 'week' | 'weeks' | 'w'
 export type ManipulateType =
     | Exclude<OpUnitType, 'date' | 'dates'>
     | 'quarter'

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1403,16 +1403,22 @@ export const areDatesValidForInterval = (
             parsedOldDateTo.diff(parsedOldDateFrom, 'second') >= 2 &&
             parsedOldDateTo.diff(parsedOldDateFrom, 'second') < 60 * 60 // 1 hour
         )
+    } else if (interval === 'quarter') {
+        return parsedOldDateTo.diff(parsedOldDateFrom, 'month') >= 6
+    } else if (interval === 'year') {
+        return parsedOldDateTo.diff(parsedOldDateFrom, 'year') >= 2
     }
     throw new UnexpectedNeverError(interval)
 }
 
-const defaultDatesForInterval = {
+const defaultDatesForInterval: Partial<Record<IntervalType, { dateFrom: string; dateTo: null }>> = {
     minute: { dateFrom: '-1h', dateTo: null },
     hour: { dateFrom: '-24h', dateTo: null },
     day: { dateFrom: '-7d', dateTo: null },
     week: { dateFrom: '-28d', dateTo: null },
     month: { dateFrom: '-6m', dateTo: null },
+    quarter: { dateFrom: '-1y', dateTo: null },
+    year: { dateFrom: '-5y', dateTo: null },
 }
 
 export const updateDatesWithInterval = (
@@ -1426,7 +1432,7 @@ export const updateDatesWithInterval = (
             dateTo: oldDateTo,
         }
     }
-    return defaultDatesForInterval[interval]
+    return defaultDatesForInterval[interval] ?? { dateFrom: oldDateFrom, dateTo: oldDateTo }
 }
 
 export function is12HoursOrLess(dateFrom: string | undefined | null): boolean {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -17258,7 +17258,7 @@
             "type": "string"
         },
         "IntervalType": {
-            "enum": ["second", "minute", "hour", "day", "week", "month"],
+            "enum": ["second", "minute", "hour", "day", "week", "month", "quarter", "year"],
             "type": "string"
         },
         "LLMTrace": {

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -100,7 +100,9 @@ export const INTERVAL_UNIT_TO_DAYJS_FORMAT: Record<IntervalType, string> = {
     hour: 'D MMM YYYY HH:00',
     day: 'D MMM YYYY',
     week: 'D MMM YYYY',
-    month: 'MMMM YYYY',
+    month: 'MMMM YYYY',
+    quarter: '[Q]Q YYYY',
+    year: 'YYYY',
 }
 
 /**

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -425,6 +425,16 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                             disabledReason:
                                 'Grouping by month is not supported on insights with weekly active users series.',
                         }
+                        enabledIntervals.quarter = {
+                            ...enabledIntervals.quarter,
+                            disabledReason:
+                                'Grouping by quarter is not supported on insights with weekly active users series.',
+                        }
+                        enabledIntervals.year = {
+                            ...enabledIntervals.year,
+                            disabledReason:
+                                'Grouping by year is not supported on insights with weekly active users series.',
+                        }
                     }
                 }
 

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -59,6 +59,8 @@ export const INTERVAL_TO_DEFAULT_MOVING_AVERAGE_PERIOD: Record<IntervalType, num
     day: 7,
     week: 4,
     month: 3,
+    quarter: 2,
+    year: 2,
 }
 
 const DEFAULT_CONFIDENCE_LEVEL = 95

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2483,7 +2483,7 @@ export type BreakdownType =
     | 'data_warehouse'
     | 'data_warehouse_person_property'
     | 'revenue_analytics'
-export type IntervalType = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month'
+export type IntervalType = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year'
 export type SimpleIntervalType = 'day' | 'month'
 export type SmoothingType = number
 export type InsightSceneSource = 'web-analytics' | 'llm-analytics'

--- a/posthog/hogql_queries/utils/timestamp_utils.py
+++ b/posthog/hogql_queries/utils/timestamp_utils.py
@@ -240,7 +240,13 @@ def format_label_date(
         "minute": "%-d-%b %H:%M",
         "hour": "%-d-%b %H:%M",
         "month": "%b %Y",
+        "quarter": "Q%q %Y",
+        "year": "%Y",
     }
     labels_format = date_formats.get(interval, date_formats["day"])
+
+    if interval == "quarter":
+        quarter = (input_date.month - 1) // 3 + 1
+        return f"Q{quarter} {input_date.year}"
 
     return input_date.strftime(labels_format)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1925,6 +1925,8 @@ class IntervalType(StrEnum):
     DAY = "day"
     WEEK = "week"
     MONTH = "month"
+    QUARTER = "quarter"
+    YEAR = "year"
 
 
 class LLMTraceEvent(BaseModel):

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -672,55 +672,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.10
   '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."queryable_folder",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.11
-  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -739,7 +690,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.12
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.11
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -769,7 +720,7 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.13
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.12
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
@@ -777,6 +728,18 @@
          AND "posthog_sessionrecordingviewed"."user_id" = 99999
          AND "posthog_sessionrecordingviewed"."session_id" IN ('session2',
                                                                'session1'))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.13
+  '''
+  SELECT "posthog_sessionrecordingviewed"."session_id",
+         "posthog_user"."email"
+  FROM "posthog_sessionrecordingviewed"
+  INNER JOIN "posthog_user" ON ("posthog_sessionrecordingviewed"."user_id" = "posthog_user"."id")
+  WHERE ("posthog_sessionrecordingviewed"."session_id" IN ('session2',
+                                                           'session1')
+         AND "posthog_sessionrecordingviewed"."team_id" = 99999
+         AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.14
@@ -1208,19 +1171,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.8
   '''
-  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
-         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
-         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
-         "posthog_teamrevenueanalyticsconfig"."events",
-         "posthog_teamrevenueanalyticsconfig"."goals",
-         "posthog_teamrevenueanalyticsconfig"."base_currency"
-  FROM "posthog_teamrevenueanalyticsconfig"
-  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.9
-  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -1247,6 +1197,55 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.9
+  '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."queryable_folder",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_1_multiple_snapshots


### PR DESCRIPTION
## Problem

Adds quarterly and yearly aggregation to insight trends
https://posthoghelp.zendesk.com/agent/tickets/44050 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46489) 

## Changes

Added quarterly and yearly aggregations.
<img width="550" height="372" alt="image" src="https://github.com/user-attachments/assets/1b902143-53c4-4a82-a057-eaad51d6f632" />

## How did you test this code?

Ran local dev to test

## Changelog: (features only) Is this feature complete?
No