### PR TITLE
refactor(logs): remove duplicate hotkey binding from LogsScene

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -53,31 +53,11 @@ export const scene: SceneExport = {
 }
 
 export function LogsScene(): JSX.Element {
-    const { logsLoading } = useValues(logsLogic)
-    const { runQuery, highlightNextLog, highlightPreviousLog, toggleExpandLog } = useActions(logsLogic)
-    const { highlightedLogId: sceneHighlightedLogId } = useValues(logsLogic)
+    const { runQuery } = useActions(logsLogic)
 
     useEffect(() => {
         runQuery()
     }, [runQuery])
-
-    useKeyboardHotkeys(
-        {
-            arrowdown: { action: highlightNextLog },
-            j: { action: highlightNextLog },
-            arrowup: { action: highlightPreviousLog },
-            k: { action: highlightPreviousLog },
-            enter: {
-                action: () => {
-                    if (sceneHighlightedLogId) {
-                        toggleExpandLog(sceneHighlightedLogId)
-                    }
-                },
-            },
-            r: { action: () => !logsLoading && runQuery() },
-        },
-        [sceneHighlightedLogId, logsLoading, runQuery]
-    )
 
     return (
         <SceneContent>


### PR DESCRIPTION
## Problem

There should only be one hotkey hook used in LogsScene - in the lemontable logs implementation.

## Changes

- removes the duplicate from LogsScene

## How did you test this code?

Local dev

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._