### PR TITLE
feat(funnels): coerce timestamp column for data warehouse sources

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -131,6 +131,7 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
 
             field = self.get_warehouse_field(node.table_name, node.timestamp_field)
 
+            timestamp_expr: ast.Expr
             # TODO: Move validations to funnel base / series entity
             if isinstance(field, DateTimeDatabaseField):
                 timestamp_expr = ast.Field(chain=[self.EVENT_TABLE_ALIAS, node.timestamp_field])

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -128,7 +128,12 @@ class FunnelEventQuery:
             all_step_cols = self._get_funnel_cols(SourceTableKind.DATA_WAREHOUSE, table_name, node)
 
             select: list[ast.Expr] = [
-                ast.Alias(alias="timestamp", expr=ast.Field(chain=[self.EVENT_TABLE_ALIAS, node.timestamp_field])),
+                ast.Alias(
+                    alias="timestamp",
+                    expr=ast.Call(
+                        name="toDateTime", args=[ast.Field(chain=[self.EVENT_TABLE_ALIAS, node.timestamp_field])]
+                    ),
+                ),
                 ast.Alias(
                     alias="aggregation_target",
                     expr=ast.Call(
@@ -144,12 +149,12 @@ class FunnelEventQuery:
             where_exprs: list[ast.Expr] = [
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.GtEq,
-                    left=ast.Field(chain=[self.EVENT_TABLE_ALIAS, node.timestamp_field]),
+                    left=ast.Field(chain=["timestamp"]),
                     right=ast.Constant(value=date_range.date_from()),
                 ),
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.LtEq,
-                    left=ast.Field(chain=[self.EVENT_TABLE_ALIAS, node.timestamp_field]),
+                    left=ast.Field(chain=["timestamp"]),
                     right=ast.Constant(value=date_range.date_to()),
                 ),
             ]

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_data_warehouse.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_data_warehouse.ambr
@@ -36,7 +36,7 @@
                   if(1, 1, 0) AS step_0,
                   if(1, 1, 0) AS step_1
            FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `properties` Nullable(String)') AS e
-           WHERE and(and(ifNull(greaterOrEquals(toTimeZone(e.created, 'UTC'), toDateTime64('2025-11-01 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(e.created, 'UTC'), toDateTime64('2025-11-07 23:59:59.999999', 6, 'UTC')), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           WHERE and(and(greaterOrEquals(timestamp, toDateTime64('2025-11-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('2025-11-07 23:59:59.999999', 6, 'UTC'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -120,7 +120,7 @@
                                0 AS step_0,
                                if(1, 1, 0) AS step_1
               FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.funnels.funnel_data_warehouse/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `created` DateTime64(3, \'UTC\'), `user_id` String, `event_name` String, `properties` Nullable(String)') AS e
-              WHERE and(and(ifNull(greaterOrEquals(toTimeZone(e.created, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(e.created, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0)), ifNull(equals(step_1, 1), 0))) AS e)
+              WHERE and(and(greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), ifNull(equals(step_1, 1), 0))) AS e)
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_event_query.py
@@ -1,9 +1,10 @@
 from textwrap import dedent
 
 from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
 import regex
 import sqlparse
-from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 from posthog.schema import DataWarehouseNode, DataWarehousePropertyFilter, EventPropertyFilter, EventsNode, FunnelsQuery
 
@@ -11,6 +12,7 @@ from posthog.hogql import ast
 
 from posthog.hogql_queries.insights.funnels.funnel_event_query import FunnelEventQuery
 from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQueryContext
+
 from products.data_warehouse.backend.models import DataWarehouseCredential, DataWarehouseTable
 
 

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_event_query.py
@@ -117,7 +117,7 @@ class TestFunnelEventQuery(ClickhouseTestMixin, APIBaseTest):
                    if(1, 1, 0) AS step_0,
                    if(1, 1, 0) AS step_1
             FROM payments AS e
-            WHERE and(and(greaterOrEquals(e.created_at, toDateTime('2025-11-05 00:00:00.000000')), lessOrEquals(e.created_at, toDateTime('2025-11-12 23:59:59.999999'))), or(equals(step_0, 1), equals(step_1, 1)))
+            WHERE and(and(greaterOrEquals(timestamp, toDateTime('2025-11-05 00:00:00.000000')), lessOrEquals(timestamp, toDateTime('2025-11-12 23:59:59.999999'))), or(equals(step_0, 1), equals(step_1, 1)))
         """).strip()
         self.assertEqual(select, expected)
 
@@ -200,7 +200,7 @@ class TestFunnelEventQuery(ClickhouseTestMixin, APIBaseTest):
                    0 AS step_2,
                    if(and(1, equals(other_prop, 'other_value')), 1, 0) AS step_3
             FROM table_one AS e
-            WHERE and(and(greaterOrEquals(e.created_at, toDateTime('2025-11-05 00:00:00.000000')), lessOrEquals(e.created_at, toDateTime('2025-11-12 23:59:59.999999'))), or(equals(step_1, 1), equals(step_3, 1)))
+            WHERE and(and(greaterOrEquals(timestamp, toDateTime('2025-11-05 00:00:00.000000')), lessOrEquals(timestamp, toDateTime('2025-11-12 23:59:59.999999'))), or(equals(step_1, 1), equals(step_3, 1)))
         """).strip()
         self.assertEqual(select_2, expected_2)
 
@@ -213,6 +213,6 @@ class TestFunnelEventQuery(ClickhouseTestMixin, APIBaseTest):
                    if(and(1, equals(another_prop, 'another_value')), 1, 0) AS step_2,
                    0 AS step_3
             FROM table_two AS e
-            WHERE and(and(greaterOrEquals(e.ts, toDateTime('2025-11-05 00:00:00.000000')), lessOrEquals(e.ts, toDateTime('2025-11-12 23:59:59.999999'))), equals(step_2, 1))
+            WHERE and(and(greaterOrEquals(timestamp, toDateTime('2025-11-05 00:00:00.000000')), lessOrEquals(timestamp, toDateTime('2025-11-12 23:59:59.999999'))), equals(step_2, 1))
         """).strip()
         self.assertEqual(select_3, expected_3)

--- a/posthog/hogql_queries/insights/query_context.py
+++ b/posthog/hogql_queries/insights/query_context.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Protocol
 
 from posthog.schema import HogQLQueryModifiers
 
@@ -43,3 +43,7 @@ class QueryContext(ABC):
             modifiers=self.modifiers,
         )
         self.now = now or datetime.now()
+
+
+class QueryContextProtocol(Protocol):
+    context: QueryContext

--- a/posthog/hogql_queries/insights/utils/data_warehouse_schema_mixin.py
+++ b/posthog/hogql_queries/insights/utils/data_warehouse_schema_mixin.py
@@ -1,8 +1,10 @@
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import DatabaseField
 
+from posthog.hogql_queries.insights.query_context import QueryContextProtocol
 
-class DataWarehouseSchemaMixin:
+
+class DataWarehouseSchemaMixin(QueryContextProtocol):
     _hogql_database: Database | None = None
 
     @property

--- a/posthog/hogql_queries/insights/utils/data_warehouse_schema_mixin.py
+++ b/posthog/hogql_queries/insights/utils/data_warehouse_schema_mixin.py
@@ -1,0 +1,20 @@
+from posthog.hogql.database.database import Database
+from posthog.hogql.database.models import DatabaseField
+
+
+class DataWarehouseSchemaMixin:
+    _hogql_database: Database | None = None
+
+    @property
+    def hogql_database(self) -> Database:
+        if self._hogql_database is None:
+            # Lazily create once
+            self._hogql_database = Database.create_for(
+                team=self.context.team,
+                modifiers=self.context.modifiers,
+            )
+        return self._hogql_database
+
+    def get_warehouse_field(self, table_name: str, field_name: str) -> DatabaseField | None:
+        table = self.hogql_database.get_table(table_name)
+        return table.fields.get(field_name)

--- a/posthog/hogql_queries/insights/utils/data_warehouse_schema_mixin.py
+++ b/posthog/hogql_queries/insights/utils/data_warehouse_schema_mixin.py
@@ -1,5 +1,7 @@
+from rest_framework.exceptions import ValidationError
+
 from posthog.hogql.database.database import Database
-from posthog.hogql.database.models import DatabaseField
+from posthog.hogql.database.models import DatabaseField, Table
 
 from posthog.hogql_queries.insights.query_context import QueryContextProtocol
 
@@ -17,6 +19,12 @@ class DataWarehouseSchemaMixin(QueryContextProtocol):
             )
         return self._hogql_database
 
-    def get_warehouse_field(self, table_name: str, field_name: str) -> DatabaseField | None:
+    def get_warehouse_field(self, table_name: str, field_name: str) -> DatabaseField:
         table = self.hogql_database.get_table(table_name)
-        return table.fields.get(field_name)
+        field = table.fields.get(field_name)
+        if field is None:
+            raise ValidationError(detail=f"Unknown field {table_name}.{field_name}")
+        if isinstance(field, Table):
+            raise ValidationError(detail=f"{table_name}.{field_name} points to a table, not a field")
+        assert isinstance(field, DatabaseField)
+        return field

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -672,55 +672,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.10
   '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."queryable_folder",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.11
-  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -739,7 +690,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.12
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.11
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -769,7 +720,7 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.13
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.12
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
@@ -777,6 +728,18 @@
          AND "posthog_sessionrecordingviewed"."user_id" = 99999
          AND "posthog_sessionrecordingviewed"."session_id" IN ('session2',
                                                                'session1'))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.13
+  '''
+  SELECT "posthog_sessionrecordingviewed"."session_id",
+         "posthog_user"."email"
+  FROM "posthog_sessionrecordingviewed"
+  INNER JOIN "posthog_user" ON ("posthog_sessionrecordingviewed"."user_id" = "posthog_user"."id")
+  WHERE ("posthog_sessionrecordingviewed"."session_id" IN ('session2',
+                                                           'session1')
+         AND "posthog_sessionrecordingviewed"."team_id" = 99999
+         AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.14
@@ -1208,19 +1171,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.8
   '''
-  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
-         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
-         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
-         "posthog_teamrevenueanalyticsconfig"."events",
-         "posthog_teamrevenueanalyticsconfig"."goals",
-         "posthog_teamrevenueanalyticsconfig"."base_currency"
-  FROM "posthog_teamrevenueanalyticsconfig"
-  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.9
-  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -1247,6 +1197,55 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.9
+  '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."queryable_folder",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_1_multiple_snapshots


### PR DESCRIPTION
## Problem

The timestamp column of a data warehouse source can be a string.

## Changes

~Coerce it to `DateTime64`, so that the funnels query can use them.~ Lazily instantiate a HogQL database and use it to resolve the type of the timestamp field.

## How did you test this code?

Added tests

## Changelog: (features only) Is this feature complete?

This is an internal feature, not intended for public use (yet)