### PR TITLE
chore(data-modeling): Turn off mat views if they exceed the 10-min query timeout

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -48,6 +48,7 @@ from posthog.temporal.data_modeling.metrics import get_data_modeling_finished_me
 from posthog.temporal.utils import DataModelingDuckLakeCopyInputs, DuckLakeCopyModelInput
 
 from products.data_warehouse.backend.data_load.create_table import create_table_from_saved_query
+from products.data_warehouse.backend.data_load.saved_query_service import pause_saved_query_schedule
 from products.data_warehouse.backend.models import (
     DataWarehouseModelPath,
     DataWarehouseSavedQuery,
@@ -77,6 +78,16 @@ class DataModelingCancelledException(Exception):
     """Exception raised when a data modeling job is cancelled."""
 
     pass
+
+
+class NonRetryableException(Exception):
+    @property
+    def cause(self) -> BaseException | None:
+        """Cause of the exception.
+
+        This is the same as ``Exception.__cause__``.
+        """
+        return self.__cause__
 
 
 @dataclasses.dataclass(frozen=True)
@@ -469,6 +480,12 @@ async def materialize_model(
             job.rows_expected = rows_expected
             await database_sync_to_async(job.save)()
         except Exception as e:
+            exception_str = str(e)
+
+            # If the count doesn't succeed due to the query timeout being exceeded, then re-raise
+            if "Timeout exceeded" in exception_str:
+                raise
+
             await logger.awarning(f"Failed to get expected row count: {str(e)}. Continuing without progress tracking.")
             job.rows_expected = None
             await database_sync_to_async(job.save)()
@@ -583,7 +600,8 @@ async def materialize_model(
             saved_query.latest_error = error_message
             await logger.ainfo("Query exceeded timeout limit for model %s", model_label)
             await mark_job_as_failed(job, error_message, logger)
-            raise Exception(f"Query exceeded timeout limit for model {model_label}: {error_message}") from e
+            await set_view_to_never_sync(job, logger)
+            raise NonRetryableException(f"Query exceeded timeout limit for model {model_label}: {error_message}") from e
         else:
             saved_query.latest_error = f"Query failed to materialize: {error_message}"
             await logger.aerror("Failed to materialize model with unexpected error: %s", str(e))
@@ -651,6 +669,18 @@ async def mark_job_as_failed(job: DataModelingJob, error_message: str, logger: F
     job.status = DataModelingJob.Status.FAILED
     job.error = error_message
     await database_sync_to_async(job.save)()
+
+
+async def set_view_to_never_sync(job: DataModelingJob, logger: FilteringBoundLogger) -> None:
+    """Update job to set the sync schedule to "never" to protect from high strain on clickhouse"""
+    saved_query: DataWarehouseSavedQuery | None = job.saved_query
+    if not saved_query:
+        await logger.adebug("set_view_to_never_sync: No saved query found for job")
+        return
+
+    saved_query.sync_frequency_interval = None
+    pause_saved_query_schedule(str(saved_query.id))
+    await logger.adebug(f"Updated saved query {saved_query.id} to never sync")
 
 
 async def revert_materialization(saved_query: DataWarehouseSavedQuery, logger: FilteringBoundLogger) -> None:
@@ -1480,7 +1510,7 @@ class RunWorkflow(PostHogWorkflow):
                 start_to_close_timeout=dt.timedelta(hours=1),
                 heartbeat_timeout=dt.timedelta(minutes=2),
                 retry_policy=temporalio.common.RetryPolicy(
-                    maximum_attempts=3,
+                    maximum_attempts=3, non_retryable_error_types=["NonRetryableException"]
                 ),
                 cancellation_type=temporalio.workflow.ActivityCancellationType.TRY_CANCEL,
             )

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -679,7 +679,10 @@ async def set_view_to_never_sync(job: DataModelingJob, logger: FilteringBoundLog
         return
 
     saved_query.sync_frequency_interval = None
+    await database_sync_to_async(saved_query.save)()
+
     pause_saved_query_schedule(str(saved_query.id))
+
     await logger.adebug(f"Updated saved query {saved_query.id} to never sync")
 
 

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -977,6 +977,75 @@ async def test_run_workflow_revert_materialization(
         assert query.is_materialized is False
 
 
+async def test_run_workflow_timeout_exceeded(
+    minio_client,
+    ateam,
+    bucket_name,
+    pageview_events,
+    saved_queries,
+    temporal_client,
+):
+    workflow_id = str(uuid.uuid4())
+    inputs = RunWorkflowInputs(team_id=ateam.pk)
+
+    with (
+        override_settings(
+            BUCKET_URL=f"s3://{bucket_name}",
+            AIRBYTE_BUCKET_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+            AIRBYTE_BUCKET_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+            AIRBYTE_BUCKET_REGION="us-east-1",
+            AIRBYTE_BUCKET_DOMAIN="objectstorage:19000",
+        ),
+        freeze_time(TEST_TIME),
+        unittest.mock.patch("posthog.temporal.data_modeling.run_workflow.hogql_table") as mock_hogql_table,
+        unittest.mock.patch(
+            "posthog.temporal.data_modeling.run_workflow.pause_saved_query_schedule"
+        ) as mock_pause_saved_query_schedule,
+    ):
+        mock_hogql_table.side_effect = Exception(
+            "Code: 159. DB::Exception: Timeout exceeded: elapsed 600585.167566 ms, maximum: 600000 ms. (TIMEOUT_EXCEEDED) (version 25.8.11.66 (official build))"
+        )
+
+        async with temporalio.worker.Worker(
+            temporal_client,
+            task_queue=settings.DATA_MODELING_TASK_QUEUE,
+            workflows=[RunWorkflow],
+            activities=[
+                start_run_activity,
+                build_dag_activity,
+                run_dag_activity,
+                finish_run_activity,
+                create_job_model_activity,
+                fail_jobs_activity,
+                cleanup_running_jobs_activity,
+            ],
+            workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+        ):
+            # Ensure the team exists in the DB context before running workflow
+            await database_sync_to_async(Team.objects.get)(pk=ateam.pk)
+            await temporal_client.execute_workflow(
+                RunWorkflow.run,
+                inputs,
+                id=workflow_id,
+                task_queue=settings.DATA_MODELING_TASK_QUEUE,
+                retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
+                execution_timeout=dt.timedelta(seconds=30),
+            )
+
+    # Temporal shouldn't reattempt the activity
+    assert mock_hogql_table.call_count == 1
+    mock_pause_saved_query_schedule.assert_called()
+
+    job = await DataModelingJob.objects.aget(workflow_id=workflow_id)
+    assert job is not None
+    assert job.status == DataModelingJob.Status.FAILED
+
+    for query in saved_queries:
+        await database_sync_to_async(query.refresh_from_db)()
+        assert query.is_materialized is False
+        assert query.sync_frequency_interval is None
+
+
 async def test_run_workflow_triggers_ducklake_copy_child(monkeypatch):
     model_label = "model-under-test"
     ducklake_model = DuckLakeCopyModelInput(


### PR DESCRIPTION
## Problem
- We're repeatedly running mat views with queries that will never complete on clickhouse due to the 10-mins query timeout - this is causing high strain on clickhouse with wasted resources

## Changes
- when a mat view hits these limits we now turn it off and dont attempt it again (e.g. it wont attempt to sync without user action)
- We also cut the run short if the `count` query also hits the same limits 

## How did you test this code?
- Added a test
