### PR TITLE
chore(kafka): add metrics around broker commits

### DIFF
--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -653,7 +653,7 @@ export class KafkaConsumer {
                 logger.debug('📝', 'librdkafka_offset_commit', { topicPartitionOffsets })
                 // Track successful broker commits and update metrics
                 topicPartitionOffsets?.forEach((tpo) => {
-                    const partitionKey = `${tpo.topic}-${tpo.partition}`
+                    const partitionKey = `${tpo.topic}:${tpo.partition}`
                     const now = Date.now()
 
                     counterBrokerCommitAttempts
@@ -926,7 +926,9 @@ export class KafkaConsumer {
                     // Update time since last broker commit for all tracked partitions
                     const now = Date.now()
                     this.lastBrokerCommitTimestamps.forEach((timestamp, partitionKey) => {
-                        const [topic, partition] = partitionKey.split('-')
+                        const lastColonIndex = partitionKey.lastIndexOf(':')
+                        const topic = partitionKey.substring(0, lastColonIndex)
+                        const partition = partitionKey.substring(lastColonIndex + 1)
                         const timeSinceCommit = now - timestamp
                         gaugeTimeSinceLastBrokerCommit
                             .labels({

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -122,6 +122,25 @@ const counterOffsetStoreAttempts = new Counter({
     labelNames: ['topic', 'partition', 'groupId', 'status'],
 })
 
+// Metrics for tracking actual Kafka broker commits (vs local offset storage)
+const gaugeLastBrokerCommittedOffset = new Gauge({
+    name: 'kafka_consumer_last_broker_committed_offset',
+    help: 'Last offset successfully committed to Kafka broker (not just stored locally)',
+    labelNames: ['topic', 'partition', 'groupId'],
+})
+
+const gaugeTimeSinceLastBrokerCommit = new Gauge({
+    name: 'kafka_consumer_time_since_last_broker_commit_ms',
+    help: 'Time elapsed since last successful commit to Kafka broker',
+    labelNames: ['topic', 'partition', 'groupId'],
+})
+
+const counterBrokerCommitAttempts = new Counter({
+    name: 'kafka_consumer_broker_commit_attempts_total',
+    help: 'Actual commit attempts to Kafka broker (vs local offset storage)',
+    labelNames: ['topic', 'partition', 'groupId', 'status'],
+})
+
 export const findOffsetsToCommit = (messages: TopicPartitionOffset[]): TopicPartitionOffset[] => {
     // We only need to commit the highest offset for a batch of messages
     const messagesByTopicPartition = messages.reduce(
@@ -194,6 +213,7 @@ export class KafkaConsumer {
     private podName: string
     private lastBackgroundTaskCompletionTime: number
     private consumerId: string
+    private lastBrokerCommitTimestamps: Map<string, number>
     // New health monitoring state
     private consumerLoopStallThresholdMs: number
     private lastConsumerLoopTime = 0
@@ -213,6 +233,7 @@ export class KafkaConsumer {
         this.backgroundTask = []
         this.podName = process.env.HOSTNAME || hostname()
         this.lastBackgroundTaskCompletionTime = Date.now()
+        this.lastBrokerCommitTimestamps = new Map()
         // Generate unique consumer ID: pod + group + timestamp + random number (need timestamp/random number because multiple consumers per pod)
         this.consumerId = `${this.podName}-${this.config.groupId}-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`
 
@@ -617,8 +638,54 @@ export class KafkaConsumer {
         consumer.on('offset.commit', (error: LibrdKafkaError, topicPartitionOffsets: TopicPartitionOffset[]) => {
             if (error) {
                 logger.warn('📝', 'librdkafka_offet_commit_error', { error, topicPartitionOffsets })
+                // Track failed broker commits
+                topicPartitionOffsets?.forEach((tpo) => {
+                    counterBrokerCommitAttempts
+                        .labels({
+                            topic: tpo.topic,
+                            partition: tpo.partition.toString(),
+                            groupId: this.config.groupId,
+                            status: 'failed',
+                        })
+                        .inc()
+                })
             } else {
                 logger.debug('📝', 'librdkafka_offset_commit', { topicPartitionOffsets })
+                // Track successful broker commits and update metrics
+                topicPartitionOffsets?.forEach((tpo) => {
+                    const partitionKey = `${tpo.topic}-${tpo.partition}`
+                    const now = Date.now()
+
+                    counterBrokerCommitAttempts
+                        .labels({
+                            topic: tpo.topic,
+                            partition: tpo.partition.toString(),
+                            groupId: this.config.groupId,
+                            status: 'success',
+                        })
+                        .inc()
+
+                    // Update last broker committed offset
+                    gaugeLastBrokerCommittedOffset
+                        .labels({
+                            topic: tpo.topic,
+                            partition: tpo.partition.toString(),
+                            groupId: this.config.groupId,
+                        })
+                        .set(tpo.offset)
+
+                    // Store timestamp for this partition's last commit
+                    this.lastBrokerCommitTimestamps.set(partitionKey, now)
+
+                    // Reset time since last commit for this partition
+                    gaugeTimeSinceLastBrokerCommit
+                        .labels({
+                            topic: tpo.topic,
+                            partition: tpo.partition.toString(),
+                            groupId: this.config.groupId,
+                        })
+                        .set(0)
+                })
             }
         })
 
@@ -855,6 +922,20 @@ export class KafkaConsumer {
 
                     const timeSinceProgress = Date.now() - this.lastBackgroundTaskCompletionTime
                     gaugeTimeSinceLastProgress.labels({ pod: this.podName, groupId }).set(timeSinceProgress)
+
+                    // Update time since last broker commit for all tracked partitions
+                    const now = Date.now()
+                    this.lastBrokerCommitTimestamps.forEach((timestamp, partitionKey) => {
+                        const [topic, partition] = partitionKey.split('-')
+                        const timeSinceCommit = now - timestamp
+                        gaugeTimeSinceLastBrokerCommit
+                            .labels({
+                                topic: topic,
+                                partition: partition,
+                                groupId: this.config.groupId,
+                            })
+                            .set(timeSinceCommit)
+                    })
 
                     // If we have too much "backpressure" we need to await one of the background tasks. We await the oldest one on purpose
 


### PR DESCRIPTION
## Problem

We discovered a discrepancy between our internal Kafka consumer metrics and what Kminion reports. While our existing metrics `(kafka_consumer_last_processed_offset and kafka_consumer_last_stored_offset)` show healthy operation with minimal lag (500-1500 messages, matching our batch size), Kminion shows growing lag of 15-30K messages that only resets when pods are terminated.

This indicates that offsets are being stored locally but not successfully committed to the Kafka broker. Our current pod cycling strategy masks this issue by forcing offset commits during graceful shutdown.

The existing metrics track:
  - kafka_consumer_last_processed_offset: When messages are processed 
  - kafka_consumer_last_stored_offset: When offsetsStore() is called locally 

However, offsetsStore() only prepares offsets for commit. The actual commit to Kafka happens asynchronously via the auto.commit mechanism, and we had no visibility into whether these commits succeed or fail.

## Changes
  1. kafka_consumer_last_broker_committed_offset: The last offset successfully committed to the Kafka broker (not just stored locally)
  2. kafka_consumer_time_since_last_broker_commit_ms: Time elapsed since the last successful broker commit per partition
  3. kafka_consumer_broker_commit_attempts_total: Counter for broker commit attempts with success/failure status

## What can we do with those metrics?

 - The real offset lag (what Kminion sees)
  `kafka_consumer_last_processed_offset - kafka_consumer_last_broker_committed_offset`

 - Detect stuck broker commits (no commits in e.g. 5 minutes)
` kafka_consumer_time_since_last_broker_commit_ms > 300000`

 - Compare local storage vs broker commits (should be nearly identical)
  `kafka_consumer_last_stored_offset - kafka_consumer_last_broker_committed_offset`

 - Monitor broker commit failure rate
  `rate(kafka_consumer_broker_commit_attempts_total{status="failed"}[5m])`