### PR TITLE
fix(max): make tools tooltip scrollable for long content

### DIFF
--- a/frontend/src/scenes/max/components/ModeSelector.tsx
+++ b/frontend/src/scenes/max/components/ModeSelector.tsx
@@ -27,7 +27,7 @@ type ModeValue = AgentMode | SpecialMode | null
 
 function buildModeTooltip(description: string, tools: ToolDefinition[]): JSX.Element {
     return (
-        <div className="flex flex-col gap-1.5">
+        <div className="max-h-[calc(100vh - (var(--spacing) * 5))] overflow-y-auto show-scrollbar-on-hover flex flex-col gap-1.5">
             <div>{description}</div>
             {tools.length > 0 && (
                 <div>
@@ -76,7 +76,7 @@ function buildGeneralTooltip(description: string, defaultTools: ToolDefinition[]
     )
 
     return (
-        <div className="flex flex-col gap-1.5">
+        <div className="max-h-[calc(100vh - (var(--spacing) * 5))] overflow-y-auto show-scrollbar-on-hover flex flex-col gap-1.5">
             <div>{description}</div>
             {defaultTools.length > 0 && (
                 <div>


### PR DESCRIPTION
Add max-height and overflow-y-auto to ToolsExplanation component to prevent tooltip from overflowing viewport when there are many tools. Uses show-scrollbar-on-hover class for transparent scrollbar background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Problem
Currently the tooltip under PostHog AI chat has its content overflowing, however it is not reachable.

## Changes
This PR is a proposal to make the tooltip interactive (to be able to access content) and scrollable though height limitation againts the screen.

| state | preview |
| -------|------|
| before | <img width="640" height="780" alt="image" src="https://github.com/user-attachments/assets/e7ed7997-354f-43aa-9947-82c228b8c020" /> |
| after | <img width="640" height="780" alt="image" src="https://github.com/user-attachments/assets/e1b57a31-f975-43c1-9180-63f601a99290" /> | 