### PR TITLE
chore: rename a logic before moving things around (playlistLogic is too loose for what it really does)

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -59,7 +59,7 @@ import {
 
 import { sessionRecordingSavedFiltersLogic } from '../filters/sessionRecordingSavedFiltersLogic'
 import { TimestampFormat, playerSettingsLogic } from '../player/playerSettingsLogic'
-import { playlistLogic } from '../playlist/playlistLogic'
+import { playlistFiltersLogic } from '../playlist/playlistFiltersLogic'
 import { createPlaylist, updatePlaylist } from '../playlist/playlistUtils'
 import { defaultRecordingDurationFilter } from '../playlist/sessionRecordingsPlaylistLogic'
 import { sessionRecordingEventUsageLogic } from '../sessionRecordingEventUsageLogic'
@@ -186,8 +186,8 @@ export const RecordingsUniversalFiltersEmbedButton = ({
     totalFiltersCount?: number
     currentSessionRecordingId?: string
 }): JSX.Element => {
-    const { isFiltersExpanded } = useValues(playlistLogic)
-    const { setIsFiltersExpanded } = useActions(playlistLogic)
+    const { isFiltersExpanded } = useValues(playlistFiltersLogic)
+    const { setIsFiltersExpanded } = useActions(playlistFiltersLogic)
     const { playlistTimestampFormat } = useValues(playerSettingsLogic)
     const { setPlaylistTimestampFormat } = useActions(playerSettingsLogic)
     const hasAgentModesFeatureFlag = useFeatureFlag('AGENT_MODES')
@@ -286,8 +286,8 @@ export const RecordingsUniversalFiltersEmbed = ({
 
     const durationFilter = filters.duration?.[0] ?? defaultRecordingDurationFilter
 
-    const { activeFilterTab } = useValues(playlistLogic)
-    const { setIsFiltersExpanded, setActiveFilterTab } = useActions(playlistLogic)
+    const { activeFilterTab } = useValues(playlistFiltersLogic)
+    const { setIsFiltersExpanded, setActiveFilterTab } = useActions(playlistFiltersLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     const taxonomicGroupTypes = [

--- a/frontend/src/scenes/session-recordings/filters/SavedFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SavedFilters.tsx
@@ -29,7 +29,7 @@ import {
 } from '~/types'
 
 import { sessionRecordingSavedFiltersLogic } from '../filters/sessionRecordingSavedFiltersLogic'
-import { playlistLogic } from '../playlist/playlistLogic'
+import { playlistFiltersLogic } from '../playlist/playlistFiltersLogic'
 import { SavedFiltersEmptyState, SavedFiltersLoadingState } from './SavedFiltersStates'
 
 export function isPlaylistRecordingsCounts(x: unknown): x is PlaylistRecordingsCounts {
@@ -127,7 +127,7 @@ export function SavedFilters({
     const { deletePlaylist, setSavedPlaylistsFilters, setAppliedSavedFilter } = useActions(
         sessionRecordingSavedFiltersLogic
     )
-    const { setActiveFilterTab } = useActions(playlistLogic)
+    const { setActiveFilterTab } = useActions(playlistFiltersLogic)
 
     if (savedFiltersLoading && !filters.search) {
         return <SavedFiltersLoadingState />

--- a/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
@@ -14,7 +14,7 @@ import { DraggableToNotebook } from 'scenes/notebooks/AddToNotebook/DraggableToN
 import { SessionRecordingType } from '~/types'
 
 import { playerSettingsLogic } from '../player/playerSettingsLogic'
-import { playlistLogic } from './playlistLogic'
+import { playlistFiltersLogic } from './playlistFiltersLogic'
 
 const SCROLL_TRIGGER_OFFSET = 100
 
@@ -77,7 +77,7 @@ export function Playlist({
     'data-attr': dataAttr,
     filterContent,
 }: PlaylistProps): JSX.Element {
-    const { isFiltersExpanded } = useValues(playlistLogic)
+    const { isFiltersExpanded } = useValues(playlistFiltersLogic)
     const { isCinemaMode } = useValues(playerSettingsLogic)
 
     const firstItem = sections

--- a/frontend/src/scenes/session-recordings/playlist/playlistFiltersLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/playlistFiltersLogic.ts
@@ -5,10 +5,10 @@ import { urls } from 'scenes/urls'
 
 import { ReplayTabs } from '~/types'
 
-import type { playlistLogicType } from './playlistLogicType'
+import type { playlistFiltersLogicType } from './playlistFiltersLogicType'
 
-export const playlistLogic = kea<playlistLogicType>([
-    path(['scenes', 'session-recordings', 'playlist', 'playlistLogicType']),
+export const playlistFiltersLogic = kea<playlistFiltersLogicType>([
+    path(['scenes', 'session-recordings', 'playlist', 'playlistFiltersLogic']),
     actions({
         setIsExpanded: (isExpanded: boolean) => ({ isExpanded }), // WIll be removed together with Mix (R.I.P. Mix)
         setIsFiltersExpanded: (isFiltersExpanded: boolean) => ({ isFiltersExpanded }),

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -8,7 +8,7 @@ import { initKeaTests } from '~/test/init'
 import { FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { sessionRecordingDataCoordinatorLogic } from '../player/sessionRecordingDataCoordinatorLogic'
-import { playlistLogic } from './playlistLogic'
+import { playlistFiltersLogic } from './playlistFiltersLogic'
 import {
     DEFAULT_RECORDING_FILTERS,
     convertLegacyFiltersToUniversalFilters,
@@ -141,8 +141,8 @@ describe('sessionRecordingsPlaylistLogic', () => {
                 updateSearchParams: true,
             })
             logic.mount()
-            playlistLogic.mount()
-            playlistLogic.actions.setIsFiltersExpanded(false)
+            playlistFiltersLogic.mount()
+            playlistFiltersLogic.actions.setIsFiltersExpanded(false)
         })
 
         describe('core assumptions', () => {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -53,7 +53,7 @@ import {
 
 import { playerSettingsLogic } from '../player/playerSettingsLogic'
 import { filtersFromUniversalFilterGroups } from '../utils'
-import { playlistLogic } from './playlistLogic'
+import { playlistFiltersLogic } from './playlistFiltersLogic'
 import { sessionRecordingsListPropertiesLogic } from './sessionRecordingsListPropertiesLogic'
 import type { sessionRecordingsPlaylistLogicType } from './sessionRecordingsPlaylistLogicType'
 import { sessionRecordingsPlaylistSceneLogic } from './sessionRecordingsPlaylistSceneLogic'
@@ -444,7 +444,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             ['maybeLoadPropertiesForSessions'],
             playerSettingsLogic,
             ['setHideViewedRecordings'],
-            playlistLogic,
+            playlistFiltersLogic,
             ['setIsFiltersExpanded'],
         ],
         values: [


### PR DESCRIPTION
splitting out safe steps from https://github.com/PostHog/posthog/pull/42358

this renames a logic since we're going to be change the `playlist` and this claims to be a `playlistLogic` but it only does filtering