### PR TITLE
fix(ma): Using total_complete_payment_value which is the total value returned …

### DIFF
--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
@@ -241,7 +241,7 @@
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
          max(s.retention_period_days) AS retention_period_days,
-         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 21))) AS expiry_time,
+         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 30))) AS expiry_time,
          dateDiff('DAY', toDateTime64('2021-08-21 20:00:00.000000', 6, 'UTC'), expiry_time) AS recording_ttl,
          greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2021-08-21 19:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
@@ -292,7 +292,7 @@
          sum(s.console_warn_count) AS console_warn_count,
          sum(s.console_error_count) AS console_error_count,
          max(s.retention_period_days) AS retention_period_days,
-         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 21))) AS expiry_time,
+         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 30))) AS expiry_time,
          dateDiff('DAY', toDateTime64('2021-08-21 20:00:00.000000', 6, 'UTC'), expiry_time) AS recording_ttl,
          greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2021-08-21 19:55:00.000000', 6, 'UTC')) AS ongoing,
          round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score

--- a/posthog/temporal/data_imports/sources/tiktok_ads/settings.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/settings.py
@@ -27,7 +27,7 @@ METRICS_FIELDS = [
     "conversion_rate",
     "conversion",
     "complete_payment",
-    "total_complete_payment_value",
+    "total_complete_payment_rate",
     "cost_per_1000_reached",
     "cost_per_conversion",
     "cost_per_result",

--- a/products/marketing_analytics/backend/hogql_queries/adapters/tiktok_ads.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/tiktok_ads.py
@@ -135,16 +135,16 @@ class TikTokAdsAdapter(MarketingSourceAdapter[TikTokAdsConfig]):
     def _get_reported_conversion_value_field(self) -> ast.Expr:
         stats_table_name = self.config.stats_table.name
 
-        # Check if total_complete_payment_value column exists
+        # Check if total_complete_payment_rate column exists
         try:
             columns = getattr(self.config.stats_table, "columns", None)
-            if columns and hasattr(columns, "__contains__") and "total_complete_payment_value" in columns:
+            if columns and hasattr(columns, "__contains__") and "total_complete_payment_rate" in columns:
                 field_as_float = ast.Call(
                     name="ifNull",
                     args=[
                         ast.Call(
                             name="toFloat",
-                            args=[ast.Field(chain=[stats_table_name, "total_complete_payment_value"])],
+                            args=[ast.Field(chain=[stats_table_name, "total_complete_payment_rate"])],
                         ),
                         ast.Constant(value=0),
                     ],


### PR DESCRIPTION
## Problem

Ticket: https://posthoghelp.zendesk.com/agent/tickets/44405 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46018)

This bug when syncing with tiktok for the first time.
```
ResourceExtractionError: In processing pipe campaign_report_chunk_0: extraction of resource campaign_report_chunk_0 in generator convert_types caused an exception: TikTok API client error (non-retryable): Please correct the information in invalid metric fields and try again. Invalid metric fields: ['total_complete_payment_value']. (code: 40002)
```

## Changes

Using total_complete_payment_value which is the total value returned from complete payment events

## How did you test this code?
Manually:
I was able to reproduce it:
<img width="1143" height="203" alt="image" src="https://github.com/user-attachments/assets/c786fe79-91de-4855-9dc7-46c5355d9cd7" />

Then:
<img width="491" height="451" alt="image" src="https://github.com/user-attachments/assets/8ea9c602-feb6-470f-b40a-543a0ca84855" />


Docs: https://business-api.tiktok.com/portal/docs?id=1751625293044737 
<img width="921" height="75" alt="image" src="https://github.com/user-attachments/assets/06d81298-926e-4c13-baea-12ff58471cf6" />
