### PR TITLE
feat: Allow customizing default log mode in Temporal

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -366,7 +366,7 @@ class Command(BaseCommand):
         with asyncio.Runner() as runner:
             loop = runner.get_loop()
 
-            configure_logger(loop=loop, default_mode=settings.TEMPORAL_LOG_DEFAULT_MODE)
+            configure_logger(loop=loop, default_mode=settings.TEMPORAL_LOG_DEFAULT_MODE)  # type: ignore[arg-type]
             logger = LOGGER.bind(
                 host=temporal_host,
                 port=temporal_port,

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -366,7 +366,7 @@ class Command(BaseCommand):
         with asyncio.Runner() as runner:
             loop = runner.get_loop()
 
-            configure_logger(loop=loop)
+            configure_logger(loop=loop, default_mode=settings.TEMPORAL_LOG_DEFAULT_MODE)
             logger = LOGGER.bind(
                 host=temporal_host,
                 port=temporal_port,

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -28,12 +28,12 @@ TARGET_MEMORY_USAGE: float | None = get_from_env("TARGET_MEMORY_USAGE", None, op
 TARGET_CPU_USAGE: float | None = get_from_env("TARGET_CPU_USAGE", None, optional=True, type_cast=float)
 
 TEMPORAL_LOG_LEVEL: str = os.getenv("TEMPORAL_LOG_LEVEL", "INFO")
+TEMPORAL_LOG_DEFAULT_MODE: str = os.getenv("TEMPORAL_LOG_DEFAULT_MODE", "ALL")
 
 SANDBOX_PROVIDER: str | None = get_from_env(
     "SANDBOX_PROVIDER", None, optional=True
 )  # When not set: defaults to "docker" in DEBUG mode, "modal" in production
 
-TEMPORAL_LOG_LEVEL_PRODUCE: str = os.getenv("TEMPORAL_LOG_LEVEL_PRODUCE", "DEBUG")
 TEMPORAL_EXTERNAL_LOGS_QUEUE_SIZE: int = get_from_env("TEMPORAL_EXTERNAL_LOGS_QUEUE_SIZE", 0, type_cast=int)
 
 CLICKHOUSE_MAX_EXECUTION_TIME: int = get_from_env("CLICKHOUSE_MAX_EXECUTION_TIME", 86400, type_cast=int)  # 1 day

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -116,6 +116,7 @@ class LogMessages(typing.TypedDict):
 
 
 DEFAULT_SERIALIZER = functools.partial(json.dumps, default=str)
+LOG_MODE = typing.Literal["ALL", "WRITE", "PRODUCE"]
 
 
 class LogMessagesRenderer:
@@ -128,6 +129,7 @@ class LogMessagesRenderer:
         self,
         event_key: str = "event",
         json_serializer: typing.Callable[[structlog.types.EventDict], str] = DEFAULT_SERIALIZER,
+        default_mode: LOG_MODE = "ALL",
     ):
         """Initialize renderer.
 
@@ -139,16 +141,17 @@ class LogMessagesRenderer:
         """
         self.json_serializer = json_serializer
         self.event_key = event_key
+        self.default_mode = default_mode
 
     def __call__(self, logger: Logger, name: str, event_dict: structlog.types.EventDict) -> LogMessages:
         """Return rendered messages meant for `Logger.process`.
 
         The 'write_only' and 'produce_only' context keys can be used to limit what gets
-        rendered. These are set by users when logging. By default, messages for both
-        writing and producing will be rendered.
+        rendered. These are set by users when logging. When omitted,
+        ``self.default_mode`` controls which messages are rendered.
         """
-        write_only = event_dict.pop("write_only", False)
-        produce_only = event_dict.pop("produce_only", False)
+        write_only = event_dict.pop("write_only", self.default_mode == "WRITE")
+        produce_only = event_dict.pop("produce_only", self.default_mode == "PRODUCE")
 
         write_message = None
         if not produce_only:
@@ -370,8 +373,9 @@ class WrapperLogger(structlog.BoundLoggerBase):
         >>> logger = structlog.get_logger()
         >>> await logger.ainfo("Hello World")
 
-        Do **NOT** use in workflow context! Async variants run in a separate thread, and
-        Temporal does not allow threads to be spawned in workflow context!
+        Do **NOT** use async variants in workflow context! Using them will make your
+        workflows crash. Async variants run in a separate thread, and Temporal does not
+        allow threads to be spawned in a workflow context.
     """
 
     debug = _make_method("debug")
@@ -474,6 +478,7 @@ def configure_logger(
     cache_logger_on_first_use: bool = True,
     loop: asyncio.AbstractEventLoop | None = None,
     file: typing.TextIO | None = None,
+    default_mode: LOG_MODE = "ALL",
 ) -> None:
     """Configure a structlog for Temporal workflows.
 
@@ -500,6 +505,9 @@ def configure_logger(
         cache_logger_on_first_use: Set whether to cache logger for performance.
             Should always be `True` except in tests.
         loop: The loop where the aforementioned tasks will run on.
+        default_mode: Specify the default logging mode. Will affect whether the default
+            logger returned by structlog.get_logger should write only, produce only, or
+            both.
     """
     base_processors: list[structlog.types.Processor] = [
         structlog.stdlib.add_log_level,
@@ -548,7 +556,7 @@ def configure_logger(
         base_processors += [
             structlog.processors.dict_tracebacks,
             EventRenamer("msg"),
-            LogMessagesRenderer(event_key="msg"),
+            LogMessagesRenderer(event_key="msg", default_mode=default_mode),
         ]
 
     extra_processors_to_add = extra_processors if extra_processors is not None else []

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -33,7 +33,7 @@ from posthog.clickhouse.log_entries import (
 )
 from posthog.kafka_client.topics import KAFKA_LOG_ENTRIES
 from posthog.temporal.common.logger import (
-    BACKGROUND_LOGGER_TASKS,
+    _BACKGROUND_LOGGER_TASKS,
     configure_default_ssl_context,
     configure_logger,
     resolve_log_source,
@@ -193,11 +193,11 @@ async def configure_logger_auto(log_capture, queue, producer, log_mode):
 
     yield
 
-    for task in BACKGROUND_LOGGER_TASKS.values():
+    for task in _BACKGROUND_LOGGER_TASKS.values():
         # Clean up logger tasks to avoid leaking/warnings.
         task.cancel()
 
-    await asyncio.wait(BACKGROUND_LOGGER_TASKS.values())
+    await asyncio.wait(_BACKGROUND_LOGGER_TASKS.values())
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -675,7 +675,7 @@ async def test_logger_skips_produce_with_log_mode_write(activity_environment, pr
     log_counts = (3, 2)
 
     expected_log_count = 0
-    for log_count, activity in zip(log_counts, activities):
+    for index, (log_count, activity) in enumerate(zip(log_counts, activities)):
         with freezegun.freeze_time("2023-11-03 10:00:00.123123"):
             if fut := activity_environment.run(activity):
                 await fut
@@ -687,14 +687,14 @@ async def test_logger_skips_produce_with_log_mode_write(activity_environment, pr
             await asyncio.sleep(0)
 
         # One log explicitly produced on each activity
-        assert len(queue.entries) == 1 or len(queue.entries) == 2
+        assert len(queue.entries) == index + 1
         await queue.join()
-        assert len(producer.entries) == 1 or len(producer.entries) == 2
+        assert len(producer.entries) == index + 1
 
         expected_log_count += log_count
         assert len(log_capture.write_entries) == expected_log_count
         # One log explicitly produced on each activity
-        assert len(log_capture.produce_entries) == 1 or len(log_capture.produce_entries) == 2
+        assert len(log_capture.produce_entries) == index + 1
 
 
 @freezegun.freeze_time("2023-11-02 10:00:00.123123")
@@ -729,7 +729,7 @@ async def test_logger_skips_write_with_log_mode_produce(activity_environment, pr
     log_counts = (3, 2)
 
     expected_log_count = 0
-    for log_count, activity in zip(log_counts, activities):
+    for index, (log_count, activity) in enumerate(zip(log_counts, activities)):
         with freezegun.freeze_time("2023-11-03 10:00:00.123123"):
             if fut := activity_environment.run(activity):
                 await fut
@@ -744,7 +744,7 @@ async def test_logger_skips_write_with_log_mode_produce(activity_environment, pr
         assert len(producer.entries) == expected_log_count
 
         # One log explicitly written on each activity
-        assert len(log_capture.write_entries) == 1 or len(log_capture.write_entries) == 2
+        assert len(log_capture.write_entries) == index + 1
         assert len(log_capture.produce_entries) == expected_log_count
 
 

--- a/products/batch_exports/backend/temporal/pipeline/consumer.py
+++ b/products/batch_exports/backend/temporal/pipeline/consumer.py
@@ -4,7 +4,7 @@ import collections.abc
 
 import temporalio.common
 
-from posthog.temporal.common.logger import get_logger, get_write_only_logger
+from posthog.temporal.common.logger import get_logger
 
 from products.batch_exports.backend.temporal.metrics import get_bytes_exported_metric, get_rows_exported_metric
 from products.batch_exports.backend.temporal.pipeline.transformer import ChunkTransformerProtocol
@@ -12,8 +12,7 @@ from products.batch_exports.backend.temporal.pipeline.types import BatchExportRe
 from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, raise_on_task_failure
 from products.batch_exports.backend.temporal.utils import cast_record_batch_json_columns
 
-LOGGER = get_write_only_logger(__name__)
-EXTERNAL_LOGGER = get_logger("EXTERNAL")
+LOGGER = get_logger(__name__)
 
 
 class Consumer:
@@ -25,7 +24,6 @@ class Consumer:
 
     def __init__(self):
         self.logger = LOGGER.bind()
-        self.external_logger = EXTERNAL_LOGGER.bind()
 
         # Progress tracking
         self.total_record_batches_count = 0

--- a/products/batch_exports/backend/temporal/spmc.py
+++ b/products/batch_exports/backend/temporal/spmc.py
@@ -28,7 +28,7 @@ from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.heartbeat import Heartbeater
-from posthog.temporal.common.logger import get_logger, get_write_only_logger
+from posthog.temporal.common.logger import get_logger
 
 from products.batch_exports.backend.temporal.heartbeat import BatchExportRangeHeartbeatDetails, DateRange
 from products.batch_exports.backend.temporal.metrics import get_bytes_exported_metric, get_rows_exported_metric
@@ -57,8 +57,7 @@ from products.batch_exports.backend.temporal.utils import (
     cast_record_batch_schema_json_columns,
 )
 
-LOGGER = get_write_only_logger(__name__)
-EXTERNAL_LOGGER = get_logger("EXTERNAL")
+LOGGER = get_logger(__name__)
 
 
 class RecordBatchQueue(asyncio.Queue):
@@ -217,7 +216,6 @@ class Consumer:
         self.data_interval_end = data_interval_end
         self.writer_format = writer_format
         self.logger = LOGGER.bind(writer_format=writer_format)
-        self.external_logger = EXTERNAL_LOGGER.bind(writer_format=writer_format)
 
     @property
     def rows_exported_counter(self) -> temporalio.common.MetricCounter:


### PR DESCRIPTION
## Problem

By default, Temporal loggers will both produce and write unlessexplicitly requesting a write-only and produce-only loggers, or passing a write_only/produce_only argument to each log call.

I usually prefer the default behavior to cover all bases, but individual teams may have specific requirements for their logging setups. In particular, batch exports uses produced logs to inform users, and everything else should only be consumed internally. On the other hand, data warehouse expects all logs to be both written and produced.


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

To support all use cases, this PR introduces a new configuration 'TEMPORAL_LOG_DEFAULT_MODE'
which changes how the default loggers returned by `structlog.get_logger` behave: They can still do both write and produce and will still obey the `write_only`/`produce_only` arguments, but when not explicitly requesting one mode or the other they can be set to write-only or produce-only by default.

This allows supporting teams that wish to write-only by default (i.e. batch exports), but have the option to produce when required, and vice-versa.

The default mode remains the same ('ALL'): This means that nothing changes for existing users that are happy with the current behavior (write and produce).

Moreover, I've deprecated the "EXTERNAL_LOGGER" from batch exports. Before, we needed an additional logger to multiplex based on logger name, as our setup relied on the stdlib logging module. However, now that we are fully integrated into structlog, the same behavior can be achieved by using `write_only=False` on the default logger.

This reduces some duplication across the codebase.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

New unit tests introduced.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
