### PR TITLE
fix: Use cached results for static cohorts in dynamic cohort evaluation

### DIFF
--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -317,6 +317,7 @@ pub fn evaluate_dynamic_cohorts(
     initial_cohort_id: CohortId,
     target_properties: &HashMap<String, Value>,
     cohorts: &[Cohort],
+    static_cohort_matches: &HashMap<CohortId, bool>,
 ) -> Result<bool, FlagError> {
     // First check if this is a static cohort
     let initial_cohort = cohorts
@@ -337,6 +338,13 @@ pub fn evaluate_dynamic_cohorts(
 
     // Use for_each_dependencies_first to evaluate each cohort in the correct order
     let results = graph.for_each_dependencies_first(|cohort, results, result| {
+        // If this is a static cohort dependency, use the cached result
+        if cohort.is_static {
+            let cached_result = static_cohort_matches.get(&cohort.id).copied().unwrap_or(false);
+            *result = cached_result;
+            return Ok(());
+        }
+
         *result = evaluate_single_cohort(cohort, target_properties, results)?;
         Ok(())
     })?;
@@ -668,10 +676,10 @@ mod tests {
     }
 
     #[test]
-    fn test_evaluate_dynamic_cohorts_static_cohort_early_exit() {
-        // Create a static cohort
+    fn test_evaluate_dynamic_cohorts_with_static_cohort_dependency() {
+        // Create a static cohort (cohort 10)
         let static_cohort = Cohort {
-            id: 1,
+            id: 10,
             name: Some("Static Cohort".to_string()),
             description: None,
             team_id: 1,
@@ -688,14 +696,68 @@ mod tests {
             created_by_id: None,
         };
 
-        let cohorts = vec![static_cohort];
+        // Create a dynamic cohort (cohort 20) that depends on the static cohort
+        let dynamic_cohort = Cohort {
+            id: 20,
+            name: Some("Dynamic Cohort with Static Dependency".to_string()),
+            description: None,
+            team_id: 1,
+            deleted: false,
+            filters: Some(json!({
+                "properties": {
+                    "type": "OR",
+                    "values": [{
+                        "type": "OR",
+                        "values": [{
+                            "key": "id",
+                            "type": "cohort",
+                            "value": 10,
+                            "negation": false
+                        }]
+                    }]
+                }
+            })),
+            query: None,
+            version: None,
+            pending_version: None,
+            count: None,
+            is_calculating: false,
+            is_static: false,
+            errors_calculating: 0,
+            groups: json!({}),
+            created_by_id: None,
+        };
+
+        let cohorts = vec![static_cohort, dynamic_cohort];
         let target_properties = HashMap::new();
 
-        // evaluate_dynamic_cohorts should return false early for static cohorts
-        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts).unwrap();
+        // Test case 1: Static cohort is in cache and matches
+        let mut static_cohort_matches = HashMap::new();
+        static_cohort_matches.insert(10, true);
+
+        let result = evaluate_dynamic_cohorts(20, &target_properties, &cohorts, &static_cohort_matches).unwrap();
+        assert!(
+            result,
+            "Dynamic cohort should match when its static cohort dependency matches"
+        );
+
+        // Test case 2: Static cohort is in cache but doesn't match
+        let mut static_cohort_matches = HashMap::new();
+        static_cohort_matches.insert(10, false);
+
+        let result = evaluate_dynamic_cohorts(20, &target_properties, &cohorts, &static_cohort_matches).unwrap();
         assert!(
             !result,
-            "Static cohorts should return false from evaluate_dynamic_cohorts"
+            "Dynamic cohort should not match when its static cohort dependency doesn't match"
+        );
+
+        // Test case 3: Static cohort is not in cache (defaults to false)
+        let static_cohort_matches = HashMap::new();
+
+        let result = evaluate_dynamic_cohorts(20, &target_properties, &cohorts, &static_cohort_matches).unwrap();
+        assert!(
+            !result,
+            "Dynamic cohort should not match when static cohort is not in cache"
         );
     }
 
@@ -746,13 +808,14 @@ mod tests {
         };
 
         let cohorts = vec![cohort_with_negation];
+        let static_cohort_matches = HashMap::new();
 
         // Test case 1: User with @example.com email but NOT excluded
         // Should match because: regex matches AND (icontains doesn't match -> negated to true)
         let mut target_properties = HashMap::new();
         target_properties.insert("email".to_string(), json!("test.user@example.com"));
 
-        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts).unwrap();
+        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches).unwrap();
         assert!(
             result,
             "User with @example.com email should match when not excluded"
@@ -762,7 +825,7 @@ mod tests {
         // Should NOT match because: regex matches BUT (icontains matches -> negated to false)
         target_properties.insert("email".to_string(), json!("excluded.user@example.com"));
 
-        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts).unwrap();
+        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches).unwrap();
         assert!(
             !result,
             "User with @example.com email should NOT match when excluded"
@@ -772,14 +835,14 @@ mod tests {
         // Should NOT match because: regex doesn't match (regardless of negation)
         target_properties.insert("email".to_string(), json!("test.user@other.com"));
 
-        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts).unwrap();
+        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches).unwrap();
         assert!(!result, "User without @example.com email should NOT match");
 
         // Test case 4: User with excluded term but wrong domain
         // Should NOT match because: regex doesn't match (regardless of negation)
         target_properties.insert("email".to_string(), json!("excluded.user@other.com"));
 
-        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts).unwrap();
+        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches).unwrap();
         assert!(
             !result,
             "User with wrong domain should NOT match regardless of exclusion"

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -340,7 +340,10 @@ pub fn evaluate_dynamic_cohorts(
     let results = graph.for_each_dependencies_first(|cohort, results, result| {
         // If this is a static cohort dependency, use the cached result
         if cohort.is_static {
-            let cached_result = static_cohort_matches.get(&cohort.id).copied().unwrap_or(false);
+            let cached_result = static_cohort_matches
+                .get(&cohort.id)
+                .copied()
+                .unwrap_or(false);
             *result = cached_result;
             return Ok(());
         }
@@ -735,7 +738,9 @@ mod tests {
         let mut static_cohort_matches = HashMap::new();
         static_cohort_matches.insert(10, true);
 
-        let result = evaluate_dynamic_cohorts(20, &target_properties, &cohorts, &static_cohort_matches).unwrap();
+        let result =
+            evaluate_dynamic_cohorts(20, &target_properties, &cohorts, &static_cohort_matches)
+                .unwrap();
         assert!(
             result,
             "Dynamic cohort should match when its static cohort dependency matches"
@@ -745,7 +750,9 @@ mod tests {
         let mut static_cohort_matches = HashMap::new();
         static_cohort_matches.insert(10, false);
 
-        let result = evaluate_dynamic_cohorts(20, &target_properties, &cohorts, &static_cohort_matches).unwrap();
+        let result =
+            evaluate_dynamic_cohorts(20, &target_properties, &cohorts, &static_cohort_matches)
+                .unwrap();
         assert!(
             !result,
             "Dynamic cohort should not match when its static cohort dependency doesn't match"
@@ -754,7 +761,9 @@ mod tests {
         // Test case 3: Static cohort is not in cache (defaults to false)
         let static_cohort_matches = HashMap::new();
 
-        let result = evaluate_dynamic_cohorts(20, &target_properties, &cohorts, &static_cohort_matches).unwrap();
+        let result =
+            evaluate_dynamic_cohorts(20, &target_properties, &cohorts, &static_cohort_matches)
+                .unwrap();
         assert!(
             !result,
             "Dynamic cohort should not match when static cohort is not in cache"
@@ -815,7 +824,9 @@ mod tests {
         let mut target_properties = HashMap::new();
         target_properties.insert("email".to_string(), json!("test.user@example.com"));
 
-        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches).unwrap();
+        let result =
+            evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches)
+                .unwrap();
         assert!(
             result,
             "User with @example.com email should match when not excluded"
@@ -825,7 +836,9 @@ mod tests {
         // Should NOT match because: regex matches BUT (icontains matches -> negated to false)
         target_properties.insert("email".to_string(), json!("excluded.user@example.com"));
 
-        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches).unwrap();
+        let result =
+            evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches)
+                .unwrap();
         assert!(
             !result,
             "User with @example.com email should NOT match when excluded"
@@ -835,14 +848,18 @@ mod tests {
         // Should NOT match because: regex doesn't match (regardless of negation)
         target_properties.insert("email".to_string(), json!("test.user@other.com"));
 
-        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches).unwrap();
+        let result =
+            evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches)
+                .unwrap();
         assert!(!result, "User without @example.com email should NOT match");
 
         // Test case 4: User with excluded term but wrong domain
         // Should NOT match because: regex doesn't match (regardless of negation)
         target_properties.insert("email".to_string(), json!("excluded.user@other.com"));
 
-        let result = evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches).unwrap();
+        let result =
+            evaluate_dynamic_cohorts(1, &target_properties, &cohorts, &static_cohort_matches)
+                .unwrap();
         assert!(
             !result,
             "User with wrong domain should NOT match regardless of exclusion"

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -31,7 +31,6 @@ use common_metrics::{inc, timing_guard};
 use common_types::{PersonId, TeamId};
 use rayon::prelude::*;
 use serde_json::Value;
-use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::{error, instrument, warn};
@@ -402,15 +401,15 @@ impl FeatureFlagMatcher {
                 .get_cohort_id()
                 .ok_or(FlagError::CohortFiltersParsingError)?;
 
-            let current_matches = cohort_matches.clone();
-            if let Entry::Vacant(e) = cohort_matches.entry(cohort_id) {
+            if !cohort_matches.contains_key(&cohort_id) {
+                let current_matches = cohort_matches.clone();
                 let match_result = evaluate_dynamic_cohorts(
                     cohort_id,
                     target_properties,
                     &cohorts,
                     &current_matches,
                 )?;
-                e.insert(match_result);
+                cohort_matches.insert(cohort_id, match_result);
             }
         }
 

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -402,9 +402,10 @@ impl FeatureFlagMatcher {
                 .get_cohort_id()
                 .ok_or(FlagError::CohortFiltersParsingError)?;
 
+            let current_matches = cohort_matches.clone();
             if let Entry::Vacant(e) = cohort_matches.entry(cohort_id) {
                 let match_result =
-                    evaluate_dynamic_cohorts(cohort_id, target_properties, &cohorts)?;
+                    evaluate_dynamic_cohorts(cohort_id, target_properties, &cohorts, &current_matches)?;
                 e.insert(match_result);
             }
         }

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -404,8 +404,12 @@ impl FeatureFlagMatcher {
 
             let current_matches = cohort_matches.clone();
             if let Entry::Vacant(e) = cohort_matches.entry(cohort_id) {
-                let match_result =
-                    evaluate_dynamic_cohorts(cohort_id, target_properties, &cohorts, &current_matches)?;
+                let match_result = evaluate_dynamic_cohorts(
+                    cohort_id,
+                    target_properties,
+                    &cohorts,
+                    &current_matches,
+                )?;
                 e.insert(match_result);
             }
         }


### PR DESCRIPTION
## Problem

Dynamic cohorts that use static cohorts as filter conditions were incorrectly evaluating to `false` for all users, even when those users were members of the static cohort dependency. This happened because `evaluate_dynamic_cohorts()` didn't have access to the cached static cohort membership results that were already fetched from the database.

For example, if you had:
- Static Cohort A (user is a member)
- Dynamic Cohort B with filter "user is in Cohort A"

Dynamic Cohort B would always evaluate to `false` even though the user was in Static Cohort A.

Context: https://posthoghelp.zendesk.com/agent/tickets/44383 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46013)

## Changes

- Modified dynamic cohort evaluation to use cached static cohort membership results instead of re-evaluating them

## How did you test this code?

- Added new unit tests
- Manually tested with the original scenario