### PR TITLE
fix: fix x-axis overflow in project menu on safari browsers

### DIFF
--- a/frontend/src/lib/components/Account/ProjectMenu.tsx
+++ b/frontend/src/lib/components/Account/ProjectMenu.tsx
@@ -85,7 +85,7 @@ export function ProjectMenu({
                         <Label intent="menu" className="px-2">
                             Current project
                         </Label>
-                        <div className="-mx-1 my-1 h-px bg-border-primary shrink-0" />
+                        <div className="my-1 h-px bg-border-primary shrink-0" />
 
                         <Combobox.Empty>No projects found</Combobox.Empty>
 
@@ -129,7 +129,7 @@ export function ProjectMenu({
                                     <Label intent="menu" className="px-2 mt-2">
                                         Other projects
                                     </Label>
-                                    <div className="-mx-1 my-1 h-px bg-border-primary shrink-0" />
+                                    <div className="my-1 h-px bg-border-primary shrink-0" />
                                 </>
                             )}
 
@@ -182,7 +182,7 @@ export function ProjectMenu({
                                     </Combobox.Group>
                                 )
                             })}
-                        <div className="-mx-1 my-1 h-px bg-border-primary shrink-0" />
+                        <div className="my-1 h-px bg-border-primary shrink-0" />
                         {preflight?.can_create_org && (
                             <Combobox.Item
                                 asChild


### PR DESCRIPTION
## Problem

In safari browsers there is this annoying x-axis overflow in the project selector which makes the UI scroll weird. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Removed negative x-axis margin for project menu dividers. Tested in Firefox, chrome, and safari and all look consistent and have no overflow issues anymore.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tested manually:
1. Safari
2. Chrome
3. Firefox


In each browser I tried scrolling left-right to verify there is no x-axis overflow.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
