### PR TITLE
chore(mcp): use frozen lockfile when publishing, node 22

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -52,7 +52,7 @@ jobs:
                   cache: 'pnpm'
 
             - name: Install dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Run unit tests
               run: cd products/mcp && pnpm run test

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -66,17 +66,17 @@ jobs:
                   fetch-depth: 0
                   filter: blob:none
 
-            - name: Set up Node 24
+            - name: Set up Node 22
               uses: actions/setup-node@v4
               with:
-                  node-version: 24
+                  node-version: 22
                   registry-url: https://registry.npmjs.org
 
             - name: Install pnpm
               run: npm install -g pnpm
 
             - name: Install package.json dependencies with pnpm
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Build the package
               run: cd products/mcp/typescript && pnpm build


### PR DESCRIPTION
this isn’t working due to a mismatching node version