### PR TITLE
fix: Configure socket to keepalive in internal stage

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -1,9 +1,9 @@
+import sys
 import uuid
 import socket
 import typing
 import asyncio
 import datetime as dt
-import platform
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 
@@ -76,14 +76,16 @@ def socket_factory(addr_info):
     sock = socket.socket(family=family, type=type_, proto=proto)
     # Enable keepalive in the socket
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
-    if platform.system() == "Linux":
-        # Start sending keepalive probes after 30s
-        # Ensure that any idle timeouts allow at least 30s
+
+    if sys.platform == "linux":
+        # Start sending keepalive probes after 60s
+        # Ensure that any idle timeouts allow at least 60s
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 30)
-        # Start sending keepalive probes every 10s
+        # Send keepalive probes every 10s
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)
         # Give up after 5 failed probes
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5)
+
     return sock
 
 


### PR DESCRIPTION
## Problem

We are seeing intermittent connection resets from S3.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Configure the socket used by aiobotocore to send keepalive probes. Unfortunately, we cannot simply pass a `socket_factory` in `AioConfig` as `connector_args`, as `AioConfig` has a validation method that does not allow unknown args to be passed (and `socket_factory` is relatively new, and not known).

So, to get around this, we subclass the `AIOHTTPSession` class that aiobotocore spawns to include the socket factory as `connector_args` when initialized. These get eventually passed to `aiohttp.TCPConnector`, which uses `socket_factory` to obtain a socket.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran batch exports destination tests. Also made some manually fail just to inspect `socket_factory` is being passed to `aiohttp.TCPConnector`.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
