### PR TITLE
chore: hide edit endpoint query for non-HogQL

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/Endpoint.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/Endpoint.tsx
@@ -132,10 +132,12 @@ export function Endpoint({ tabId }: EndpointProps): JSX.Element {
                         <LemonSelect
                             value={selectedEndpointName}
                             onChange={(value) => setSelectedEndpointName(value)}
-                            options={endpoints.map((endpoint) => ({
-                                value: endpoint.name,
-                                label: endpoint.name,
-                            }))}
+                            options={endpoints
+                                .filter((endpoint) => endpoint.query.kind === NodeKind.HogQLQuery)
+                                .map((endpoint) => ({
+                                    value: endpoint.name,
+                                    label: endpoint.name,
+                                }))}
                             placeholder="Select an endpoint to update"
                             className="w-1/3"
                         />

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -357,6 +357,7 @@ export const QueryDatabase = (): JSX.Element => {
 
                 // Show menu for endpoints
                 if (item.record?.type === 'endpoint') {
+                    const isHogQLEndpoint = item.record?.endpoint?.query.kind === 'HogQLQuery'
                     return (
                         <DropdownMenuGroup>
                             <DropdownMenuItem
@@ -368,24 +369,26 @@ export const QueryDatabase = (): JSX.Element => {
                             >
                                 <ButtonPrimitive menuItem>View endpoint</ButtonPrimitive>
                             </DropdownMenuItem>
-                            <DropdownMenuItem
-                                asChild
-                                onClick={(e) => {
-                                    e.stopPropagation()
-                                    sceneLogic.actions.newTab(
-                                        urls.sqlEditor(
-                                            item.record?.endpoint?.query.query,
-                                            undefined,
-                                            undefined,
-                                            undefined,
-                                            OutputTab.Endpoint,
-                                            item.record?.endpoint?.name
+                            {isHogQLEndpoint && (
+                                <DropdownMenuItem
+                                    asChild
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        sceneLogic.actions.newTab(
+                                            urls.sqlEditor(
+                                                item.record?.endpoint?.query.query,
+                                                undefined,
+                                                undefined,
+                                                undefined,
+                                                OutputTab.Endpoint,
+                                                item.record?.endpoint?.name
+                                            )
                                         )
-                                    )
-                                }}
-                            >
-                                <ButtonPrimitive menuItem>Edit endpoint query</ButtonPrimitive>
-                            </DropdownMenuItem>
+                                    }}
+                                >
+                                    <ButtonPrimitive menuItem>Edit endpoint query</ButtonPrimitive>
+                                </DropdownMenuItem>
+                            )}
                         </DropdownMenuGroup>
                     )
                 }


### PR DESCRIPTION
## Problem

Users are presented with an "Edit endpoint query" option for endpoints that are not of HogQL type, which cannot be edited via the SQL editor. Additionally, when updating an endpoint, the dropdown lists all endpoints, including those not editable in the SQL editor, leading to confusion.

## Changes

- The "Edit endpoint query" action in the SQL editor sidebar is now hidden for endpoints whose underlying query is not of HogQL type.
- The dropdown for updating an endpoint in the SQL editor's OutputTab.ENDPOINTS now only displays endpoints with HogQL queries.

## How did you test this code?

- Manually verified that "Edit endpoint query" is not visible for non-HogQL endpoints in the sidebar.
- Manually verified that only HogQL endpoints appear in the "Select an endpoint to update" dropdown.

## Changelog: (features only) Is this feature complete?

No

---
[Slack Thread](https://posthog.slack.com/archives/C0932JBCUFL/p1764956804041319?thread_ts=1764956804.041319&cid=C0932JBCUFL)

<a href="https://cursor.com/background-agent?bcId=bc-ade64a4f-144b-4489-953c-59458f5b7340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ade64a4f-144b-4489-953c-59458f5b7340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

