### PR TITLE
fix(ph-ai): prevent disabling context if no input

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -794,14 +794,8 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         ],
 
         submissionDisabledReason: [
-            (s) => [s.formPending, s.multiQuestionFormPending, s.question, s.threadLoading, s.activeStreamingThreads],
-            (
-                formPending,
-                multiQuestionFormPending,
-                question,
-                threadLoading,
-                activeStreamingThreads
-            ): string | undefined => {
+            (s) => [s.formPending, s.multiQuestionFormPending, s.threadLoading, s.activeStreamingThreads],
+            (formPending, multiQuestionFormPending, threadLoading, activeStreamingThreads): string | undefined => {
                 // Allow users to cancel the generation
                 if (threadLoading) {
                     return undefined
@@ -813,10 +807,6 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
 
                 if (multiQuestionFormPending) {
                     return 'Please answer the questions above'
-                }
-
-                if (!question) {
-                    return 'I need some input first'
                 }
 
                 // Prevent submission if there are active streaming threads


### PR DESCRIPTION
## Problem

The current implementation of `submissionDisabledReason` in `maxThreadLogic` prevents users from submitting empty questions, but this behavior is unnecessary and potentially confusing for users.

## Changes

Removed the check for an empty question in the `submissionDisabledReason` selector. This eliminates the "I need some input first" message that was previously shown when no question was provided.

The change also removes the unnecessary `question` dependency from the selector, streamlining the logic.

## How did you test this code?

Tested by:
- Submitting empty questions to verify they're now allowed
- Verifying other submission blocking conditions still work correctly (form pending, multi-question form pending, active streaming threads)
- Ensuring the thread loading state still allows cancellation of generation

## Changelog: Yes