### PR TITLE
chore(batch-exports): enhance batch export debugger with Databricks support

### DIFF
--- a/posthog/batch_exports/debug/debugger.py
+++ b/posthog/batch_exports/debug/debugger.py
@@ -1,8 +1,11 @@
 import uuid
 import typing
 import functools
+import contextlib
 import dataclasses
 import collections.abc
+from dataclasses import fields
+from typing import cast
 
 from django.conf import settings
 from django.db.models import Q
@@ -10,11 +13,23 @@ from django.db.models import Q
 import pyarrow as pa
 import pyarrow.fs as fs
 import pyarrow.ipc as ipc
+from rich.console import Console
 
+from posthog.batch_exports.service import (
+    DESTINATION_WORKFLOWS,
+    BaseBatchExportInputs,
+    BatchExportModel,
+    DatabricksBatchExportInputs,
+)
 from posthog.models import BatchExport, BatchExportDestination, BatchExportRun
+from posthog.models.integration import DatabricksIntegration
 from posthog.temporal.common.clickhouse import ClickHouseClient
 
 from products.batch_exports.backend.temporal.destinations.bigquery_batch_export import bigquery_default_fields
+from products.batch_exports.backend.temporal.destinations.databricks_batch_export import (
+    DatabricksClient,
+    databricks_default_fields,
+)
 from products.batch_exports.backend.temporal.destinations.postgres_batch_export import postgres_default_fields
 from products.batch_exports.backend.temporal.destinations.redshift_batch_export import redshift_default_fields
 from products.batch_exports.backend.temporal.destinations.s3_batch_export import s3_default_fields
@@ -34,6 +49,8 @@ from products.batch_exports.backend.temporal.sql import (
     SELECT_FROM_PERSONS,
     SELECT_FROM_PERSONS_BACKFILL,
 )
+
+console = Console()
 
 
 @dataclasses.dataclass
@@ -238,9 +255,30 @@ class BatchExportsDebugger:
             filters["id"] = id
 
         self.loaded_batch_exports = tuple(
-            BatchExport.objects.select_related("destination").filter(team_id=self.team_id, **filters)
+            BatchExport.objects.select_related("destination__integration").filter(team_id=self.team_id, **filters)
         )
         return self.loaded_batch_exports
+
+    @property
+    def batch_export_inputs(self) -> BaseBatchExportInputs:
+        """Get the inputs for the batch export."""
+        _, workflow_inputs = DESTINATION_WORKFLOWS[self.batch_export.destination.type]
+        destination_config_fields = {field.name for field in fields(workflow_inputs)}
+        destination_config = {
+            k: v for k, v in self.batch_export.destination.config.items() if k in destination_config_fields
+        }
+        return workflow_inputs(
+            team_id=self.batch_export.team_id,  # type: ignore
+            batch_export_id=str(self.batch_export.id),
+            interval=str(self.batch_export.interval),
+            batch_export_model=BatchExportModel(
+                name=self.batch_export.model or "events",
+                schema=self.batch_export.schema,
+                filters=self.batch_export.filters,
+            ),
+            integration_id=self.batch_export.destination.integration_id,
+            **destination_config,
+        )
 
     def iter_runs(
         self,
@@ -401,6 +439,8 @@ class BatchExportsDebugger:
                     fields = postgres_default_fields()
                 case BatchExportDestination.Destination.REDSHIFT:
                     fields = redshift_default_fields()
+                case BatchExportDestination.Destination.DATABRICKS:
+                    fields = databricks_default_fields()
                 case t:
                     raise ValueError(f"Unsupported destination: {t}")
 
@@ -441,3 +481,27 @@ class BatchExportsDebugger:
                 column_stats += record_batch
 
         return column_stats
+
+    @contextlib.asynccontextmanager
+    async def get_client(self) -> collections.abc.AsyncIterator[DatabricksClient]:
+        """Get a client for the destination.
+
+        Only Databricks is supported at the moment.
+        """
+        match self.batch_export.destination.type:
+            case BatchExportDestination.Destination.DATABRICKS:
+                console.print("[bold green]Getting Databricks client...[/bold green]")
+                inputs = cast(DatabricksBatchExportInputs, self.batch_export_inputs)
+                integration = DatabricksIntegration(self.batch_export.destination.integration)
+                client = DatabricksClient(
+                    server_hostname=integration.server_hostname,
+                    http_path=inputs.http_path,
+                    client_id=integration.client_id,
+                    client_secret=integration.client_secret,
+                    catalog=inputs.catalog,
+                    schema=inputs.schema,
+                )
+                async with client.connect() as databricks_client:
+                    yield databricks_client
+            case t:
+                raise NotImplementedError(f"get_client not yet implemented for destination: {t}")

--- a/posthog/batch_exports/debug/debugger.py
+++ b/posthog/batch_exports/debug/debugger.py
@@ -268,7 +268,7 @@ class BatchExportsDebugger:
             k: v for k, v in self.batch_export.destination.config.items() if k in destination_config_fields
         }
         return workflow_inputs(
-            team_id=self.batch_export.team_id,  # type: ignore
+            team_id=self.batch_export.team_id,
             batch_export_id=str(self.batch_export.id),
             interval=str(self.batch_export.interval),
             batch_export_model=BatchExportModel(
@@ -492,6 +492,7 @@ class BatchExportsDebugger:
             case BatchExportDestination.Destination.DATABRICKS:
                 console.print("[bold green]Getting Databricks client...[/bold green]")
                 inputs = cast(DatabricksBatchExportInputs, self.batch_export_inputs)
+                assert self.batch_export.destination.integration is not None
                 integration = DatabricksIntegration(self.batch_export.destination.integration)
                 client = DatabricksClient(
                     server_hostname=integration.server_hostname,

--- a/posthog/batch_exports/debug/start_session.py
+++ b/posthog/batch_exports/debug/start_session.py
@@ -43,7 +43,7 @@ def start_session(team_id: int, batch_export_id: str | None = None):
 
     initial_batch_export: BatchExport | None = None
     if batch_export_id:
-        initial_batch_export = BatchExport.objects.select_related("destination").get(
+        initial_batch_export = BatchExport.objects.select_related("destination__integration").get(
             id=batch_export_id, team_id=team_id
         )
 


### PR DESCRIPTION
## Problem

Debugging batch exports is tricky and sometimes involves interacting with the destination in order to figure out what's going on, or to perform some manual operations. Typically this requires custom scripts to be created, which is time consuming. Since these are not stored in the repo, we often duplicate effort amongst ourselves  

## Changes

Updated the batch exports debugger by adding an async context manager `get_client` for obtaining a client for interacting with the destination. So far this has just been implemented for Databricks but we can add to this.

Example usage:

<img width="534" height="88" alt="image" src="https://github.com/user-attachments/assets/c0fbe355-04c9-4718-b1b2-921dfc666643" />


## How did you test this code?

In a toolbox pod.


