### PR TITLE
fix(ph-ai): don't disable context when there's no chat input

### DIFF
--- a/frontend/src/scenes/max/Context.tsx
+++ b/frontend/src/scenes/max/Context.tsx
@@ -301,7 +301,7 @@ interface ContextDisplayProps {
 
 export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
-    const { deepResearchMode, showContextUI, submissionDisabledReason } = useValues(maxThreadLogic)
+    const { deepResearchMode, showContextUI, contextDisabledReason } = useValues(maxThreadLogic)
     const { hasData, contextOptions, taxonomicGroupTypes, mainTaxonomicGroupType, toolContextItems } =
         useValues(maxContextLogic)
     const { handleTaxonomicFilterChange } = useActions(maxContextLogic)
@@ -327,7 +327,7 @@ export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.E
                         Turn off deep research to add context
                     </LemonButton>
                 ) : (
-                    <Tooltip title={submissionDisabledReason ?? 'Add context to help PostHog AI answer your question'}>
+                    <Tooltip title={contextDisabledReason ?? 'Add context to help PostHog AI answer your question'}>
                         <TaxonomicPopover
                             size="xxsmall"
                             type="tertiary"
@@ -340,7 +340,7 @@ export function ContextDisplay({ size = 'default' }: ContextDisplayProps): JSX.E
                             placeholderClass="text-secondary"
                             maxContextOptions={contextOptions}
                             width={450}
-                            disabledReason={submissionDisabledReason}
+                            disabledReason={contextDisabledReason}
                         />
                     </Tooltip>
                 )}

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -870,11 +870,10 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 isImpersonatingExistingConversation,
         ],
 
-        submissionDisabledReason: [
+        contextDisabledReason: [
             (s) => [
                 s.formPending,
                 s.multiQuestionFormPending,
-                s.question,
                 s.threadLoading,
                 s.activeStreamingThreads,
                 s.isImpersonatingExistingConversation,
@@ -882,7 +881,6 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             (
                 formPending,
                 multiQuestionFormPending,
-                question,
                 threadLoading,
                 activeStreamingThreads,
                 isImpersonatingExistingConversation
@@ -905,13 +903,25 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     return 'Please answer the questions above'
                 }
 
-                if (!question) {
-                    return 'I need some input first'
-                }
-
                 // Prevent submission if too many active streaming threads (limit: 10)
                 if (activeStreamingThreads >= 10) {
                     return 'You have too many chats running. Please wait for one to finish.'
+                }
+
+                return undefined
+            },
+        ],
+
+        submissionDisabledReason: [
+            (s) => [s.contextDisabledReason, s.question],
+            (contextDisabledReason, question): string | undefined => {
+                // Context-related reasons take precedence (form pending, streaming, etc.)
+                if (contextDisabledReason) {
+                    return contextDisabledReason
+                }
+
+                if (!question) {
+                    return 'I need some input first'
                 }
 
                 return undefined


### PR DESCRIPTION
## Problem
The current implementation uses `submissionDisabledReason` for both context addition and question submission, which doesn't allow for different validation rules between these two actions.

## Changes
- There's now two selectors: `submissionDisabledReason` and `contextDisabledReason`

## How did you test this code?
Locally