### PR TITLE
fix(signals): Validate session ids both from filters and explicit list.

### DIFF
--- a/ee/hogai/tools/replay/summarize_sessions.py
+++ b/ee/hogai/tools/replay/summarize_sessions.py
@@ -158,11 +158,7 @@ class SummarizeSessionsTool(MaxTool):
             summaries_content, session_group_summary_id = await self._summarize_sessions(
                 session_ids=session_ids,
                 summary_title=summary_title,
-                session_ids_source=(
-                    "filters"
-                    if isinstance(recordings_filters_or_explicit_session_ids, MaxRecordingUniversalFilters)
-                    else "explicit"
-                ),
+                session_ids_source=llm_provided_session_ids_source,
             )
             # Build messages artifact for group summaries (with "Open report" button)
             content, artifact = None, None

--- a/ee/hogai/tools/replay/summarize_sessions.py
+++ b/ee/hogai/tools/replay/summarize_sessions.py
@@ -100,13 +100,11 @@ class SummarizeSessionsTool(MaxTool):
             llm_provided_session_ids = await database_sync_to_async(
                 self._get_session_ids_with_filters, thread_sensitive=False
             )(recordings_query)
-            llm_provided_session_ids_source = "filters"
+            llm_provided_session_ids_source: Literal["filters", "explicit"] = "filters"
         # If explicit session IDs - use them directly
         elif isinstance(recordings_filters_or_explicit_session_ids, list):
-            llm_provided_session_ids, llm_provided_session_ids_source = (
-                recordings_filters_or_explicit_session_ids,
-                "explicit",
-            )
+            llm_provided_session_ids = recordings_filters_or_explicit_session_ids
+            llm_provided_session_ids_source = "explicit"
         # If unexpected type - raise an error
         else:
             msg = (  # type: ignore[unreachable]


### PR DESCRIPTION
## Problem
- Generated filters sometimes return session ids for sessions that have no events
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Check session ids no matter how they were provided - through filter or explicitly

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
