### PR TITLE
fix: use persons_db by default for local development

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -153,10 +153,10 @@ pub struct Config {
     #[envconfig(default = "postgres://posthog:posthog@localhost:5432/posthog")]
     pub read_database_url: String,
 
-    #[envconfig(default = "")]
+    #[envconfig(default = "postgres://posthog:posthog@localhost:5432/posthog_persons")]
     pub persons_write_database_url: String,
 
-    #[envconfig(default = "")]
+    #[envconfig(default = "postgres://posthog:posthog@localhost:5432/posthog_persons")]
     pub persons_read_database_url: String,
 
     #[envconfig(default = "1000")]


### PR DESCRIPTION
## Problem

The feature flags service was failing to evaluate cohort-based flags when running locally because the `persons_write_database_url` and `persons_read_database_url` config values defaulted to empty strings. This meant the service couldn't connect to the persons database to check cohort membership.

## Changes

- Changed defaults from feature flags service to use the `persons_db` when running locally