### PR TITLE
feat: allow materializing insight query endpoints with raw results

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -829,8 +829,13 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
                 column_name = split_arr[0]
                 ch_type = split_arr[1]
 
+                # Skip array types from conversion - they are already properly typed by ClickHouse
+                # and attempting to convert them causes errors like:
+                # "Illegal type Array(DateTime) of argument of function toTimezone"
+                is_array_type = ch_type.lower().startswith("array(")
+
                 # Does the clickhouse type exist in our mapping of types to convert?
-                if any(uat.lower() in ch_type.lower() for uat in arrow_type_conversion.keys()):
+                if any(uat.lower() in ch_type.lower() for uat in arrow_type_conversion.keys()) and not is_array_type:
                     # Find which type we need to convert
                     call_tuples = [
                         call_tuple
@@ -851,16 +856,33 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger):
         select_fields: list[ast.Expr] = []
         for column_name, ch_type, call_tuple in query_typings:
             if call_tuple:
-                await logger.adebug(
-                    f"Converting {column_name} of type {ch_type} to be wrapped with {call_tuple[0]}(..)"
-                )
+                is_array = ch_type.lower().startswith("array(")
 
-                select_fields.append(
-                    ast.Alias(
-                        expr=ast.Call(name=call_tuple[0], args=[ast.Field(chain=[column_name]), *call_tuple[1]]),
-                        alias=column_name,
+                if is_array:
+                    await logger.adebug(
+                        f"Converting {column_name} of type {ch_type} using arrayMap with {call_tuple[0]}(..)"
                     )
-                )
+                    # Use arrayMap to apply the conversion function to each array element
+                    lambda_expr = ast.Lambda(
+                        args=["x"],
+                        expr=ast.Call(name=call_tuple[0], args=[ast.Field(chain=["x"]), *call_tuple[1]]),
+                    )
+                    select_fields.append(
+                        ast.Alias(
+                            expr=ast.Call(name="arrayMap", args=[lambda_expr, ast.Field(chain=[column_name])]),
+                            alias=column_name,
+                        )
+                    )
+                else:
+                    await logger.adebug(
+                        f"Converting {column_name} of type {ch_type} to be wrapped with {call_tuple[0]}(..)"
+                    )
+                    select_fields.append(
+                        ast.Alias(
+                            expr=ast.Call(name=call_tuple[0], args=[ast.Field(chain=[column_name]), *call_tuple[1]]),
+                            alias=column_name,
+                        )
+                    )
             else:
                 select_fields.append(ast.Field(chain=[column_name]))
 
@@ -958,6 +980,40 @@ def _transform_date_and_datetimes(batch: pa.RecordBatch, types: list[tuple[str, 
             new_fields.append(field)
             continue
 
+        # Handle array/list types (e.g., Array(DateTime))
+        if pa.types.is_list(field.type):
+            if "datetime64" in type.lower():
+                # Array(DateTime64) -> list<timestamp(us, UTC)>
+                new_element_type = pa.timestamp("us", tz="UTC")
+                new_list_type = pa.list_(new_element_type)
+                new_field = field.with_type(new_list_type)
+                # Cast list<uint64> -> list<int64> -> list<timestamp>
+                list_int64 = pc.cast(column, pa.list_(pa.int64()))
+                list_timestamp_s = pc.cast(list_int64, pa.list_(pa.timestamp("s")))
+                new_column = pc.cast(list_timestamp_s, new_list_type)
+            elif "datetime" in type.lower():
+                # Array(DateTime) -> list<timestamp(us, UTC)>
+                new_element_type = pa.timestamp("us", tz="UTC")
+                new_list_type = pa.list_(new_element_type)
+                new_field = field.with_type(new_list_type)
+                # Cast list<uint32> -> list<int64> -> list<timestamp(s)> -> list<timestamp(us, UTC)>
+                list_int64 = pc.cast(column, pa.list_(pa.int64()))
+                list_timestamp_s = pc.cast(list_int64, pa.list_(pa.timestamp("s")))
+                new_column = pc.cast(list_timestamp_s, new_list_type)
+            else:
+                # Array(Date) -> list<date32>
+                new_element_type = pa.date32()
+                new_list_type = pa.list_(new_element_type)
+                new_field = field.with_type(new_list_type)
+                # Cast list<uint16> -> list<int32> -> list<date32>
+                list_int32 = pc.cast(column, pa.list_(pa.int32()))
+                new_column = pc.cast(list_int32, new_list_type)
+
+            new_fields.append(new_field)
+            new_columns.append(new_column)
+            continue
+
+        # Handle scalar types
         if "datetime64" in type.lower() and pa.types.is_timestamp(field.type):
             new_field: pa.Field = field.with_type(pa.timestamp("us", tz="UTC"))
             new_column = pc.cast(column, new_field.type)

--- a/products/endpoints/backend/materialization.py
+++ b/products/endpoints/backend/materialization.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+from posthog.schema import HogQLQuery, HogQLQueryModifiers
+
+from posthog.hogql.printer import to_printed_hogql
+from posthog.hogql.timings import HogQLTimings
+
+from posthog.hogql_queries.query_runner import get_query_runner
+from posthog.models.team import Team
+
+
+def convert_insight_query_to_hogql(query: dict[str, Any], team: Team) -> dict[str, Any]:
+    query_kind = query.get("kind")
+
+    if query_kind == "HogQLQuery":
+        return query
+
+    query_runner = get_query_runner(
+        query=query,
+        team=team,
+        timings=HogQLTimings(),
+        modifiers=HogQLQueryModifiers(),
+    )
+
+    combined_query_ast = query_runner.to_query()
+
+    hogql_string = to_printed_hogql(combined_query_ast, team=team, modifiers=query_runner.modifiers)
+
+    return HogQLQuery(query=hogql_string, modifiers=query_runner.modifiers).model_dump()

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -191,21 +191,31 @@ class Endpoint(CreatedMetaFields, UpdatedMetaFields, UUIDTModel):
     def can_materialize(self) -> tuple[bool, str]:
         """Check if endpoint can be materialized.
 
-        Only HogQLQuery can be materialized.
-
         Returns: (can_materialize: bool, reason: str)
         """
         query_kind = self.query.get("kind")
 
-        if query_kind != "HogQLQuery":
-            return False, f"Only HogQLQuery can be materialized. Query type '{query_kind}' is not supported."
+        MATERIALIZABLE_QUERY_TYPES = {
+            "HogQLQuery",
+            "TrendsQuery",
+            "FunnelsQuery",
+            "LifecycleQuery",
+            "RetentionQuery",
+            "PathsQuery",
+            "StickinessQuery",
+        }
+
+        if query_kind not in MATERIALIZABLE_QUERY_TYPES:
+            supported = ", ".join(sorted(MATERIALIZABLE_QUERY_TYPES))
+            return False, f"Query type '{query_kind}' cannot be materialized. Supported types: {supported}"
 
         if self.query.get("variables"):
             return False, "Queries with variables cannot be materialized."
 
-        hogql_query = self.query.get("query")
-        if not hogql_query or not isinstance(hogql_query, str):
-            return False, "Query is empty or invalid."
+        if query_kind == "HogQLQuery":
+            hogql_query = self.query.get("query")
+            if not hogql_query or not isinstance(hogql_query, str):
+                return False, "Query is empty or invalid."
 
         return True, ""
 

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -254,6 +254,7 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         self.assertIsNotNone(endpoint.saved_query)
         saved_query = endpoint.saved_query
         assert saved_query is not None
+        assert saved_query.query is not None
         self.assertEqual(saved_query.query["kind"], "HogQLQuery")
         self.assertIsInstance(saved_query.query["query"], str)
 
@@ -291,6 +292,7 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         self.assertIsNotNone(endpoint.saved_query)
         saved_query = endpoint.saved_query
         assert saved_query is not None
+        assert saved_query.query is not None
         self.assertEqual(saved_query.query["kind"], "HogQLQuery")
 
     def test_can_materialize_retention_query(self):
@@ -335,6 +337,7 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         self.assertIsNotNone(endpoint.saved_query)
         saved_query = endpoint.saved_query
         assert saved_query is not None
+        assert saved_query.query is not None
         self.assertEqual(saved_query.query["kind"], "HogQLQuery")
 
     def test_can_materialize_paths_query(self):
@@ -371,6 +374,7 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         self.assertIsNotNone(endpoint.saved_query)
         saved_query = endpoint.saved_query
         assert saved_query is not None
+        assert saved_query.query is not None
         self.assertEqual(saved_query.query["kind"], "HogQLQuery")
 
     def test_materialization_status_in_response(self):

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 import pytest
-from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
 from unittest import mock
 
 from django.utils import timezone
@@ -11,8 +11,9 @@ from asgiref.sync import sync_to_async
 from rest_framework import status
 from rest_framework.response import Response
 
-from posthog.schema import DataWarehouseSyncInterval
+from posthog.schema import DataWarehouseSyncInterval, PathsFilter, PathsQuery, PathType, RetentionQuery
 
+from posthog.constants import RETENTION_FIRST_EVER_OCCURRENCE, TREND_FILTER_TYPE_EVENTS
 from posthog.settings.temporal import DATA_MODELING_TASK_QUEUE
 from posthog.sync import database_sync_to_async
 
@@ -219,14 +220,20 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         # The API wraps validation errors in a generic message
         self.assertIn("Failed to update endpoint", response.json()["detail"])
 
-    def test_cannot_materialize_non_hogql_query(self):
-        """Test that only HogQL queries can be materialized."""
+    def test_can_materialize_lifecycle_query(self):
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user1",
+        )
+        flush_persons_and_events()
+
         endpoint = Endpoint.objects.create(
-            name="test_trends_query",
+            name="test_lifecycle_query",
             team=self.team,
             query={
-                "kind": "TrendsQuery",
-                "series": [{"kind": "EventsNode", "event": "$pageview", "math": "total"}],
+                "kind": "LifecycleQuery",
+                "series": [{"kind": "EventsNode", "event": "$pageview"}],
                 "dateRange": {"date_from": "-7d"},
                 "interval": "day",
             },
@@ -237,14 +244,134 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
             f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
             {
                 "is_materialized": True,
-                "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_12HOUR,
             },
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        # The API wraps validation errors in a generic message
-        self.assertIn("Failed to update endpoint", response.json()["detail"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        endpoint.refresh_from_db()
+        self.assertIsNotNone(endpoint.saved_query)
+        saved_query = endpoint.saved_query
+        assert saved_query is not None
+        self.assertEqual(saved_query.query["kind"], "HogQLQuery")
+        self.assertIsInstance(saved_query.query["query"], str)
+
+    def test_can_materialize_stickiness_query(self):
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user1",
+        )
+        flush_persons_and_events()
+
+        endpoint = Endpoint.objects.create(
+            name="test_stickiness_query",
+            team=self.team,
+            query={
+                "kind": "StickinessQuery",
+                "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                "dateRange": {"date_from": "-7d"},
+                "interval": "day",
+            },
+            created_by=self.user,
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_12HOUR,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        endpoint.refresh_from_db()
+        self.assertIsNotNone(endpoint.saved_query)
+        saved_query = endpoint.saved_query
+        assert saved_query is not None
+        self.assertEqual(saved_query.query["kind"], "HogQLQuery")
+
+    def test_can_materialize_retention_query(self):
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user1",
+        )
+        flush_persons_and_events()
+
+        endpoint = Endpoint.objects.create(
+            name="test_retention_query",
+            team=self.team,
+            query=RetentionQuery(
+                dateRange={"date_from": "2025-01-01", "date_to": "2025-01-08"},
+                retentionFilter={
+                    "period": "Day",
+                    "totalIntervals": 7,
+                    "retentionType": RETENTION_FIRST_EVER_OCCURRENCE,
+                    "targetEntity": {
+                        "id": "$user_signed_up",
+                        "name": "$user_signed_up",
+                        "type": TREND_FILTER_TYPE_EVENTS,
+                    },
+                    "returningEntity": {"id": "$pageview", "name": "$pageview", "type": "events"},
+                },
+            ).model_dump(),
+            created_by=self.user,
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_12HOUR,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        endpoint.refresh_from_db()
+        self.assertIsNotNone(endpoint.saved_query)
+        saved_query = endpoint.saved_query
+        assert saved_query is not None
+        self.assertEqual(saved_query.query["kind"], "HogQLQuery")
+
+    def test_can_materialize_paths_query(self):
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user1",
+        )
+        flush_persons_and_events()
+
+        endpoint = Endpoint.objects.create(
+            name="test_paths_query",
+            team=self.team,
+            query=PathsQuery(
+                pathsFilter=PathsFilter(
+                    includeEventTypes=[PathType.FIELD_PAGEVIEW, PathType.FIELD_SCREEN],
+                    excludeEvents=["logout", "https://example.com"],  # URL should be filtered out
+                )
+            ).model_dump(),
+            created_by=self.user,
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_12HOUR,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        endpoint.refresh_from_db()
+        self.assertIsNotNone(endpoint.saved_query)
+        saved_query = endpoint.saved_query
+        assert saved_query is not None
+        self.assertEqual(saved_query.query["kind"], "HogQLQuery")
 
     def test_materialization_status_in_response(self):
         """Test that materialization status is included in endpoint response."""


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Right now we only allow materializing a HogQL based endpoint. That's annoying because most value will be in insights.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- convert an insight-based query into a HogQL, then store that when materializing

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
- tests and locally
<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
i guess - but not sure if we want to put Beta product updates in the changelog?