### PR TITLE
fix(query): fix query runner error logging

### DIFF
--- a/posthog/hogql_queries/test/test_query_runner_logging.py
+++ b/posthog/hogql_queries/test/test_query_runner_logging.py
@@ -26,7 +26,7 @@ class DummyCachedResponse(GenericCachedQueryResponse):
     errors: list[str] | None = None
 
 
-class DummyQueryRunner(QueryRunner[DummyQuery, DummyResponse, DummyCachedResponse]):
+class DummyQueryRunner(QueryRunner[DummyQuery, DummyResponse, DummyCachedResponse]):  # type: ignore
     query: DummyQuery
     response: DummyResponse
     cached_response: DummyCachedResponse

--- a/posthog/hogql_queries/test/test_query_runner_logging.py
+++ b/posthog/hogql_queries/test/test_query_runner_logging.py
@@ -1,0 +1,91 @@
+from typing import Any
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from pydantic import BaseModel
+
+from posthog.schema import GenericCachedQueryResponse
+
+from posthog.hogql_queries.query_runner import ExecutionMode, QueryRunner
+
+
+class DummyQuery(BaseModel):
+    kind: str = "DummyQuery"
+
+
+class DummyResponse(BaseModel):
+    results: str = "ok"
+    error: str | None = None
+    errors: list[str] | None = None
+
+
+class DummyCachedResponse(GenericCachedQueryResponse):
+    results: str | None = None
+    error: str | None = None
+    errors: list[str] | None = None
+
+
+class DummyQueryRunner(QueryRunner[DummyQuery, DummyResponse, DummyCachedResponse]):
+    query: DummyQuery
+    response: DummyResponse
+    cached_response: DummyCachedResponse
+
+    def __init__(
+        self,
+        *args: Any,
+        response_error: str | None = None,
+        response_errors: list[str] | None = None,
+        raise_exception: bool = False,
+        **kwargs: Any,
+    ):
+        self._response_error = response_error
+        self._response_errors = response_errors
+        self._raise_exception = raise_exception
+        super().__init__(*args, **kwargs)
+
+    def _calculate(self) -> DummyResponse:
+        if self._raise_exception:
+            raise ValueError("boom")
+        return DummyResponse(error=self._response_error, errors=self._response_errors)
+
+    def to_query(self):
+        raise NotImplementedError()
+
+    def to_actors_query(self, *args, **kwargs):
+        raise NotImplementedError()
+
+
+class TestQueryRunnerLogging(BaseTest):
+    def test_has_error_true_when_response_contains_error_string(self):
+        runner = DummyQueryRunner(query=DummyQuery(), team=self.team, response_error="bad")
+
+        with patch("posthoganalytics.capture") as capture_mock:
+            runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS, user=self.user)
+
+        props = capture_mock.call_args.kwargs["properties"]
+        self.assertTrue(props["has_error"])
+        self.assertFalse(props["cache_hit"])
+
+    def test_has_error_true_when_response_contains_errors_list(self):
+        runner = DummyQueryRunner(query=DummyQuery(), team=self.team, response_errors=["boom"])
+
+        with patch("posthoganalytics.capture") as capture_mock:
+            runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS, user=self.user)
+
+        props = capture_mock.call_args.kwargs["properties"]
+        self.assertTrue(props["has_error"])
+        self.assertFalse(props["cache_hit"])
+
+    def test_exception_still_records_has_error(self):
+        runner = DummyQueryRunner(query=DummyQuery(), team=self.team, raise_exception=True)
+
+        with patch("posthoganalytics.capture") as capture_mock:
+            with self.assertRaises(ValueError):
+                runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS, user=self.user)
+
+        self.assertEqual(capture_mock.call_count, 1)
+        props = capture_mock.call_args.kwargs["properties"]
+        self.assertTrue(props["has_error"])
+        self.assertEqual(props["error_type"], "ValueError")
+        self.assertFalse(props["cache_hit"])


### PR DESCRIPTION
## Problem

We emit a "query executed" event but the has_error property is always false/null, making it unusable for a Product analytics health dashboard.

## Changes

> - The only place that sets has_error is the success path in posthog/hogql_queries/query_runner.py (lines 1179-1224): after calculate() returns, it looks at fresh_response_dict.get("error") and emits posthoganalytics.capture("query executed", has_error=…). If calculate() throws (syntax errors, CH errors, ACL errors, etc.), we leave this block and re-raise, so no event is captured. That’s why you see zero has_error: true entries—the failures never reach the logging.
> - The cache-hit path (query_runner.py around 1030) also fires query executed but doesn’t include has_error at all, so cached failures wouldn’t surface either.
> - On top of that, most query runners raise on errors instead of populating an error field in the response; the code only checks the singular error key, not errors, so even responses that carry an errors array wouldn’t flip the flag.
>
> If you want reliable failure tracking, you’ll need to wrap the calculate() call (and possibly the cached path) in a try/except, capture a query executed event with has_error=True before re-raising, and/or also look at errors in the response.

## How did you test this code?

CI run