### PR TITLE
feat: Add button to remove entry from sidebar on context panel

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/menus/MenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/MenuItems.tsx
@@ -28,6 +28,7 @@ import { groupAnalyticsConfigLogic } from 'scenes/settings/environment/groupAnal
 
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
+import { editCustomProductsModalLogic } from '../../PinnedFolder/editCustomProductsModalLogic'
 import { NewMenu } from '../../menus/NewMenu'
 import { panelLayoutLogic } from '../../panelLayoutLogic'
 import { projectTreeDataLogic } from '../projectTreeDataLogic'
@@ -62,10 +63,13 @@ export function MenuItems({
     const { deleteShortcut, addShortcutItem } = useActions(projectTreeDataLogic)
     const { groupTypes } = useValues(groupAnalyticsConfigLogic)
     const { deleteGroupType } = useActions(groupAnalyticsConfigLogic)
+    const { selectedPaths: customProductsSelectedPaths } = useValues(editCustomProductsModalLogic)
+
     const projectTreeLogicProps = { key: logicKey ?? uniqueKey, root }
     const { checkedItems, checkedItemsCount, checkedItemCountNumeric, checkedItemsArray } = useValues(
         projectTreeLogic(projectTreeLogicProps)
     )
+
     const {
         createFolder,
         deleteItem,
@@ -78,6 +82,7 @@ export function MenuItems({
     } = useActions(projectTreeLogic(projectTreeLogicProps))
     const { openMoveToModal } = useActions(moveToLogic)
     const { openLinkToModal } = useActions(linkToLogic)
+    const { toggleProduct } = useActions(editCustomProductsModalLogic)
 
     const { resetPanelLayout } = useActions(panelLayoutLogic)
 
@@ -141,6 +146,7 @@ export function MenuItems({
     const isItemAFolder = item.record?.type === 'folder'
     const itemShortcutPath = joinPath([splitPath(item.record?.path).pop() ?? 'Unnamed'])
     const isItemAlreadyInShortcut = !isItemAFolder && shortcutNonFolderPaths.has(itemShortcutPath)
+
     return (
         <>
             {productMenu}
@@ -244,7 +250,7 @@ export function MenuItems({
                             Already in shortcuts panel
                         </ButtonPrimitive>
                     </MenuItem>
-                ) : (
+                ) : root !== 'custom-products://' ? (
                     <MenuItem
                         asChild
                         onClick={(e) => {
@@ -257,7 +263,31 @@ export function MenuItems({
                     >
                         <ButtonPrimitive menuItem>Add to shortcuts panel</ButtonPrimitive>
                     </MenuItem>
-                )
+                ) : null
+            ) : null}
+
+            {root === 'custom-products://' && !item.id.startsWith('shortcuts://') ? (
+                <MenuItem
+                    asChild
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        toggleProduct(item.record?.path as string)
+                    }}
+                >
+                    <ButtonPrimitive menuItem>Remove from sidebar panel</ButtonPrimitive>
+                </MenuItem>
+            ) : root === 'products://' &&
+              item.record?.path &&
+              !customProductsSelectedPaths.has(item.record?.path as string) ? (
+                <MenuItem
+                    asChild
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        toggleProduct(item.record?.path as string)
+                    }}
+                >
+                    <ButtonPrimitive menuItem>Add to sidebar panel</ButtonPrimitive>
+                </MenuItem>
             ) : null}
 
             {item.id.startsWith('project/') || item.id.startsWith('project://') ? (


### PR DESCRIPTION
Let's make it slightly easier to remove entry from the sidebar by exposing button on the context panel.
Also, on the all apps, make it easier to add that entry to the custom list.



![image.png](https://app.graphite.com/user-attachments/assets/9626d35f-58f6-4212-9680-52d1885690ac.png)

