### PR TITLE
Expose Redis7 service on port 6479 on hobby

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -30,6 +30,8 @@ services:
             service: redis7
         volumes:
             - redis7-data:/data
+        ports:
+            - '6479:6379'
 
     clickhouse:
         #


### PR DESCRIPTION
saw errors on self-hosted killing plugin server referencing this port

other compose files set this

so 🍤 

manually applied this and plugin server started

