### PR TITLE
fix(signals): Improve video validation field updates

### DIFF
--- a/ee/hogai/session_summaries/session/templates/video-validation/validation-prompt.djt
+++ b/ee/hogai/session_summaries/session/templates/video-validation/validation-prompt.djt
@@ -39,14 +39,14 @@ For each validated event (those with moment_ids in validation results):
 1.1. Compare the visual observation against the original event description
 1.2. Identify clear contradictions:
    - ✓ "Exception occurred" vs. video shows normal page load
-   - ✓ "Blocking error" vs. video shows user continuing successfully  
+   - ✓ "Blocking error" vs. video shows user continuing successfully
    - ✓ "Failed to load" vs. video shows content appearing
    - ✗ User found workaround (still an issue, just non-blocking)
    - ✗ Slow loading (not an exception unless it failed completely)
 
 1.3. Determine the actual event type:
    - If video shows normal interaction → exception: null
-   - If video shows error but user continued → exception: "non-blocking"  
+   - If video shows error but user continued → exception: "non-blocking"
    - If video confirms blocking error → exception: "blocking" (no change)
 
 # Step 2: Update Event Descriptions
@@ -65,7 +65,7 @@ For events requiring updates based on Step 1:
       - Keep descriptions concise (4-8 words)
    - If the current description is accurate:
       - Extend it with the additional info you got
-   
+
    Inaccurate description examples - to replace:
    - "Blocking store path exception rendered Error tracking unusable" → "Clicked into Error tracking feature"
    - "Failed API call prevented dashboard load" → "Viewed analytics dashboard"
@@ -94,7 +94,7 @@ After updating individual events, reconsider each affected segment:
    - Remove references to errors that didn't occur
    - Focus on what user actually accomplished
    - Keep summaries concise (1-2 sentences, up to 15 words)
-   
+
    Examples:
    - "Error tracking page threw blocking exception, user abandoned" → "User explored error tracking and surveys features"
    - "Dashboard failed to load properly" → "User successfully reviewed analytics dashboard"
@@ -136,11 +136,25 @@ Based on all event and segment updates:
 </critical_guidelines>
 
 <output_format>
-Return a YAML object containing only the fields that require updates.
+Return a YAML list of objects containing only the fields that require updates.
+
+Each object must have exactly two keys:
+- `path`: the exact field path from the fields_to_update list above
+- `new_value`: the updated value (can be a string or null)
+
+Example output format:
+```yaml
+- path: key_actions.0.events.0.description
+  new_value: User clicked the dashboard button
+- path: key_actions.0.events.0.exception
+  new_value: null
+- path: session_outcome.success
+  new_value: true
+```
 
 IMPORTANT:
-- Use exact field paths from eligible_update_fields
-- Include field `path` and `new_value`, if it should be changed based on visual observations.
+- Return a YAML list, even if only one field needs updating
+- Use exact field paths from the fields_to_update list
 - Only include fields that are actually changing
 - Ensure all string values are properly escaped
 </output_format>

--- a/ee/hogai/session_summaries/session/video_validation.py
+++ b/ee/hogai/session_summaries/session/video_validation.py
@@ -16,6 +16,7 @@ from glom import (
 
 from posthog.models.user import User
 
+from ee.hogai.session_summaries import ExceptionToRetry
 from ee.hogai.session_summaries.constants import (
     EXPIRES_AFTER_DAYS,
     FAILED_MOMENTS_MIN_RATIO,
@@ -279,7 +280,7 @@ class SessionSummaryVideoValidator:
                 session_id=self.session_id,
                 signals_type="session-summaries",
             )
-            return None
+            raise ExceptionToRetry()
         updates_result = load_yaml_from_raw_llm_content(raw_content=updates_content, final_validation=True)
         # Validate that updates_result is a list
         if not isinstance(updates_result, list):
@@ -288,7 +289,7 @@ class SessionSummaryVideoValidator:
                 session_id=self.session_id,
                 signals_type="session-summaries",
             )
-            return None
+            raise ExceptionToRetry()
         updates_result = cast(list[dict[str, str]], updates_result)
         return updates_result
 


### PR DESCRIPTION
## Problem

This error seems caused by the video validation step resulting in an incorrect format of field updates, as generated by the LLM. Not strictly a hallucination, this is likely just a matter of lacking examples of the intended format. It just currently sometimes generates dicts instead of a list.

This error [has affected 4 users yesterday (+ you Alex)](https://us.posthog.com/project/2/error_tracking/019aca0c-43b9-7600-8ca2-6601fd0b3704?timestamp=2025-12-05T08:36:20.484000-08:00).

## Changes

This adds examples to steer the LLM, and adds protections against wrong output to be sure.

## How did you test this code?

I've ran summarization with video validation locally with this changed. Proper testing would require LLM evals for this step, which is a much greater effort.