### PR TITLE
fix(hobby): adds redis env vars for logs consumer to hobby

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -138,6 +138,8 @@ services:
             OBJECT_STORAGE_ENABLED: true
             CDP_REDIS_HOST: redis7
             CDP_REDIS_PORT: 6379
+            LOGS_REDIS_HOST: redis7
+            LOGS_REDIS_PORT: 6379
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
             CYCLOTRON_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             PERSONS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'


### PR DESCRIPTION
## Problem

A redis url recently got added as an env var to plugin-server to support logs consumers.

The default value was set to connect via 127.0.0.1 which is host external to the docker network.

Hobby deployments have all serviecs deployed within the same docker network so we don't expose redis ports externally.

We need to set env vars for hobby deployment so that it can connect to redis internally.

## Changes

Set env vars for the logs redis url for the plugin-server for hobby deployments

## How did you test this code?

Haven't tested it, tbh. Trying to fix hobby
