### PR TITLE
fix(flags): Use weak ETags for local_evaluation endpoint

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1805,7 +1805,7 @@ class FeatureFlagViewSet(
             # Return 304 Not Modified if client's ETag matches
             if not modified and etag:
                 response = Response(status=status.HTTP_304_NOT_MODIFIED)
-                response["ETag"] = f'"{etag}"'
+                response["ETag"] = f'W/"{etag}"'
                 response["Cache-Control"] = "private, must-revalidate"
                 return response
 
@@ -1822,7 +1822,7 @@ class FeatureFlagViewSet(
 
             response = Response(response_data)
             if etag:
-                response["ETag"] = f'"{etag}"'
+                response["ETag"] = f'W/"{etag}"'
                 response["Cache-Control"] = "private, must-revalidate"
             return response
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -6629,7 +6629,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("ETag", response.headers)
-        self.assertTrue(response.headers["ETag"].startswith('"'))
+        self.assertTrue(response.headers["ETag"].startswith('W/"'))
         self.assertTrue(response.headers["ETag"].endswith('"'))
         self.assertIn("Cache-Control", response.headers)
         self.assertEqual(response.headers["Cache-Control"], "private, must-revalidate")
@@ -6851,8 +6851,8 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             "/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
         )
         etag = response1.headers["ETag"]
-        # ETag is returned with quotes, e.g., '"abc123"'
-        self.assertTrue(etag.startswith('"') and etag.endswith('"'))
+        # ETag is returned as weak ETag, e.g., 'W/"abc123"'
+        self.assertTrue(etag.startswith('W/"') and etag.endswith('"'))
 
         # Client sends ETag with quotes (standard format) - should match
         response2 = self.client.get(
@@ -6885,8 +6885,8 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             "/api/feature_flag/local_evaluation", headers={"authorization": f"Bearer {personal_api_key}"}
         )
         etag = response1.headers["ETag"]
-        # Strip quotes to get raw ETag value
-        raw_etag = etag.strip('"')
+        # Strip weak ETag prefix and quotes to get raw ETag value (W/"abc123" -> abc123)
+        raw_etag = etag.removeprefix('W/"').removesuffix('"')
 
         # Client sends ETag without quotes (non-standard but should work)
         response2 = self.client.get(


### PR DESCRIPTION
## Problem

We put in a lot of work to add etag support to our local evaluation endpoint and our SDK clients. Yet I wasn't seeing any etag cache hits in our metrics.

<img width="1172" height="543" alt="Screenshot 2025-12-05 at 2 11 34 PM" src="https://github.com/user-attachments/assets/c06b8f3f-06a3-47dd-aef5-161ec5685960" />

Digging into it, I discovered that strong ETags (e.g., `"abc123"`) are stripped by Envoy/proxy when it compresses the response body with gzip. This is correct behavior per RFC 7232, since strong ETags represent byte-for-byte equality which no longer holds after compression. I didn't notice this in my testing because I was testing locally and also verified prod by using `curl` which doesn't send the `Accept-Encoding` header by default.

Weak ETags (e.g., `W/"abc123"`) indicate semantic equivalence rather than byte-for-byte equality, so proxies preserve them through compression transformations.

## Changes

Changed the etag header to use the weak etag format (aka `W"/abc123"`)
This fixes ETag headers not being returned in production when responses are gzip-compressed by the ingress proxy.

## How did you test this code?

Manually.
Unit Tests

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
