### PR TITLE
feat(error-tracking): Emphasize root cause fix in AI prompt

### DIFF
--- a/products/error_tracking/frontend/components/ExceptionCard/FixModal.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/FixModal.tsx
@@ -47,7 +47,7 @@ The final output should be:
 PostHog issue: ${issueUrl}
 `
         }
-        return `Please help me fix this error. Here's the stack trace:
+        return `Please help me fix the root cause of this error. Here's the stack trace:
 
 \`\`\`
 ${stacktraceText}


### PR DESCRIPTION
## Problem

I've found a lot of value in the automated AI fixing prompt in error tracking, but have noticed LLM take "fix this error" a bit too shallow - yes, catching the exception ignores the error, but I want the actual cause to be fixed (which is a deeper issue).

## Changes

Proposing to update the error tracking "Fix" mode prompt to explicitly request fixing the "root cause" of the error rather than just "the error". This helps ensure coding assistants focus on identifying and addressing underlying issues rather than applying surface-level fixes. But this is just a proposal, let me know what your experience is!
