### PR TITLE
feat: Better handle multivariate flags on `sync_feature_flags`

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -148,6 +148,10 @@ export const WEBHOOK_SERVICES: Record<string, string> = {
 
 // NOTE: Run `dev:sync-flags` locally to sync these flags into your local project
 // or if you're running flox + mprocs you can also run the `sync-feature-flags` process
+//
+// If this is a multivariate flag, please add the `multivariate=true` tag at the end of your comment
+// if you want the script to properly create a multivariate flag. You can also specify the different
+// variant keys separated by commas, e.g. `multivariate=control,test,something_else`
 export const FEATURE_FLAGS = {
     // Eternal feature flags, shouldn't be removed, helpful for debugging/maintenance reasons
     BILLING_FORECASTING_ISSUES: 'billing-forecasting-issues', // owner: #team-billing, see `Billing.tsx`, used to raise a warning when billing is having problems
@@ -296,10 +300,10 @@ export const FEATURE_FLAGS = {
     REMOTE_CONFIG: 'remote-config', // owner: #team-platform-features
     REPLAY_DISCARD_RAW_SNAPSHOTS: 'replay-discard-raw-snapshots', // owner: @pauldambra #team-replay
     REPLAY_FILTERS_REDESIGN: 'replay-filters-redesign', // owner: @ksvat #team-replay
-    REPLAY_NEW_DETECTED_URL_COLLECTIONS: 'replay-new-detected-url-collections', // owner: @ksvat #team-replay multivariate
+    REPLAY_NEW_DETECTED_URL_COLLECTIONS: 'replay-new-detected-url-collections', // owner: @ksvat #team-replay multivariate=true
     REPLAY_WAIT_FOR_FULL_SNAPSHOT_PLAYBACK: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay
     REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW: 'replay-x-llm-analytics-conversation-view', // owner: @pauldambra #team-replay
-    REPLAY_YIELDING_PROCESSING: 'replay-yielding-processing', // owner: @pauldambra #team-replay multivariate: worker, yielding, worker_and_yielding
+    REPLAY_YIELDING_PROCESSING: 'replay-yielding-processing', // owner: @pauldambra #team-replay multivariate=worker,yielding,worker_and_yielding
     SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE: 'schedule-feature-flag-variants-update', // owner: @gustavo #team-feature-flags
     SCHEMA_MANAGEMENT: 'schema-management', // owner: @aspicer
     SEEKBAR_PREVIEW_SCRUBBING: 'seekbar-preview-scrubbing', // owner: @pauldambra #team-replay
@@ -311,7 +315,7 @@ export const FEATURE_FLAGS = {
     SURVEYS_EXPERIMENTS_CROSS_SELL: 'surveys-experiments-cross-sell', // owner: @adboio #team-surveys
     SURVEYS_FF_CROSS_SELL: 'surveys-ff-cross-sell', // owner: @adboio #team-surveys
     SURVEYS_FUNNELS_CROSS_SELL: 'survey-funnels-cross-sell', // owner: @adboio #team-surveys
-    SURVEYS_INSIGHT_BUTTON_EXPERIMENT: 'ask-users-why-ai-vs-quickcreate', // owner: @adboio #team-surveys multivariate
+    SURVEYS_INSIGHT_BUTTON_EXPERIMENT: 'ask-users-why-ai-vs-quickcreate', // owner: @adboio #team-surveys multivariate=true
     SWITCH_SUBSCRIPTION_PLAN: 'switch-subscription-plan', // owner: @a-lider #team-platform-features
     TASK_SUMMARIES: 'task-summaries', // owner: #team-llm-analytics
     TASKS: 'tasks', // owner: #team-llm-analytics

--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
     help = "Add and enable all feature flags in frontend/src/lib/constants.tsx for all projects"
 
     def handle(self, *args, **options):
-        flags: dict[str, str] = {}
+        flags: dict[str, str | list[str]] = {}
         with open("frontend/src/lib/constants.tsx", encoding="utf_8") as f:
             lines = f.readlines()
             parsing_flags = False
@@ -43,7 +43,7 @@ class Command(BaseCommand):
                                 if len(variant_keys) == 1 and variant_keys[0] == "true":
                                     flags[flag] = ["control", "test"]
                                 else:
-                                    flags[flag] = variant_keys
+                                    flags[flag] = cast(list[str], variant_keys)
                             else:
                                 flags[flag] = "boolean"
                         except IndexError:
@@ -64,7 +64,9 @@ class Command(BaseCommand):
                     ff.deleted = False
                     ff.active = is_enabled
                     ff.save()
-                    print(f"Undeleted feature flag '{flag} for team {team.id} {' - ' + team.name if team.name else ''}")
+                    print(
+                        f"Undeleted feature flag '{flag}' for team {team.id} {' - ' + team.name if team.name else ''}"
+                    )
                 elif flag not in existing_flags:
                     if isinstance(flag_type, list):
                         FeatureFlag.objects.create(

--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -1,10 +1,11 @@
 # ruff: noqa: T201 allow print statements
 
+import re
 from typing import cast
 
 from django.core.management.base import BaseCommand
 
-from posthog.models import FeatureFlag, Project, User
+from posthog.models import FeatureFlag, Team, User
 
 # These flags won't be enabled when syncing feature flags
 # Turn these on for flags that heavily change the behavior and that you wouldn't like
@@ -36,38 +37,38 @@ class Command(BaseCommand):
                     else:
                         try:
                             flag = line.split("'")[1]
-                            if flag.endswith("_EXPERIMENT") or "multivariate" in line:
-                                flags[flag] = "multivariate"
+                            multivariate_match = re.search(r"multivariate=([^\s/]+)", line)
+                            if multivariate_match:
+                                variant_keys = [key.strip() for key in multivariate_match.group(1).split(",")]
+                                if len(variant_keys) == 1 and variant_keys[0] == "true":
+                                    flags[flag] = ["control", "test"]
+                                else:
+                                    flags[flag] = variant_keys
                             else:
                                 flags[flag] = "boolean"
                         except IndexError:
                             pass
-
                 elif "export const FEATURE_FLAGS" in line:
                     parsing_flags = True
 
         first_user = cast(User, User.objects.first())
-        for project in Project.objects.all():
-            existing_flags = FeatureFlag.objects.filter(team__project_id=project.id).values_list("key", flat=True)
-            deleted_flags = FeatureFlag.objects.filter(team__project_id=project.id, deleted=True).values_list(
-                "key", flat=True
-            )
+        for team in Team.objects.all():
+            existing_flags = FeatureFlag.objects.filter(team=team).values_list("key", flat=True)
+            deleted_flags = FeatureFlag.objects.filter(team=team, deleted=True).values_list("key", flat=True)
             for flag in flags.keys():
                 flag_type = flags[flag]
                 is_enabled = flag not in INACTIVE_FLAGS
 
                 if flag in deleted_flags:
-                    ff = FeatureFlag.objects.filter(team__project_id=project.id, key=flag)[0]
+                    ff = FeatureFlag.objects.filter(team=team, key=flag)[0]
                     ff.deleted = False
                     ff.active = is_enabled
                     ff.save()
-                    print(
-                        f"Undeleted feature flag '{flag} for project {project.id} {' - ' + project.name if project.name else ''}"
-                    )
+                    print(f"Undeleted feature flag '{flag} for team {team.id} {' - ' + team.name if team.name else ''}")
                 elif flag not in existing_flags:
-                    if flag_type == "multivariate":
+                    if isinstance(flag_type, list):
                         FeatureFlag.objects.create(
-                            team=project.teams.first(),
+                            team=team,
                             rollout_percentage=100,
                             name=flag,
                             key=flag,
@@ -78,22 +79,18 @@ class Command(BaseCommand):
                                 "multivariate": {
                                     "variants": [
                                         {
-                                            "key": "control",
-                                            "name": "Control",
-                                            "rollout_percentage": 0,
-                                        },
-                                        {
-                                            "key": "test",
-                                            "name": "Test",
-                                            "rollout_percentage": 100,
-                                        },
+                                            "key": key,
+                                            "name": key.capitalize(),
+                                            "rollout_percentage": 100 if index == len(flag_type) - 1 else 0,
+                                        }
+                                        for index, key in enumerate(flag_type)
                                     ]
                                 },
                             },
                         )
                     else:
                         FeatureFlag.objects.create(
-                            team=project.teams.first(),
+                            team=team,
                             rollout_percentage=100,
                             name=flag,
                             key=flag,
@@ -101,6 +98,7 @@ class Command(BaseCommand):
                             active=is_enabled,
                             filters={"groups": [{"properties": [], "rollout_percentage": 100}], "payloads": {}},
                         )
+
                     print(
-                        f"Created feature flag '{flag} for project {project.id} {' - ' + project.name if project.name else ''}"
+                        f"Created feature flag '{flag} for team {team.id} {' - ' + team.name if team.name else ''}{f' (multivariate: {', '.join(flag_type)})' if isinstance(flag_type, list) else ''}"
                     )


### PR DESCRIPTION
We now create the feature flags from `contants.tsx` respecting the multivariate flags
and also accepting options (for example what multivariate flags we should use)