### PR TITLE
feat(vercel): Add webhook handler for marketplace.invoice.paid (Slice 2b)

### DIFF
--- a/ee/api/vercel/test/test_vercel_webhooks.py
+++ b/ee/api/vercel/test/test_vercel_webhooks.py
@@ -26,15 +26,17 @@ class TestVercelWebhooks(VercelTestBase):
         ).hexdigest()
 
     def _post_webhook(self, payload: dict, signature: str | None = None):
-        headers = {}
         if signature is not None:
-            headers["HTTP_X_VERCEL_SIGNATURE"] = signature
-
+            return self.client.post(
+                self.url,
+                data=json.dumps(payload),
+                content_type="application/json",
+                HTTP_X_VERCEL_SIGNATURE=signature,
+            )
         return self.client.post(
             self.url,
             data=json.dumps(payload),
             content_type="application/json",
-            **headers,
         )
 
     @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")

--- a/ee/api/vercel/test/test_vercel_webhooks.py
+++ b/ee/api/vercel/test/test_vercel_webhooks.py
@@ -90,12 +90,11 @@ class TestVercelWebhooks(VercelTestBase):
 
     @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
     def test_non_billing_events_ignored(self):
-        # Non-marketplace events and unhandled marketplace events should be ignored
+        # Non-invoice marketplace events should be ignored
         for event_type in [
             "integration.configuration-removed",
             "deployment.created",
-            "marketplace.invoice.created",  # Other marketplace events we don't handle
-            "marketplace.invoice.refunded",
+            "marketplace.member.created",  # Other marketplace events that aren't invoices
             None,
         ]:
             payload = {

--- a/ee/api/vercel/test/test_vercel_webhooks.py
+++ b/ee/api/vercel/test/test_vercel_webhooks.py
@@ -43,7 +43,7 @@ class TestVercelWebhooks(VercelTestBase):
     def test_invalid_signature_returns_401(self):
         payload = {
             "type": "marketplace.invoice.paid",
-            "payload": {"configurationId": self.installation_id, "invoiceId": "mi_123"},
+            "payload": {"installationId": self.installation_id, "invoiceId": "mi_123"},
         }
 
         response = self._post_webhook(payload, signature="invalid_signature")
@@ -55,7 +55,7 @@ class TestVercelWebhooks(VercelTestBase):
     def test_missing_signature_returns_401(self):
         payload = {
             "type": "marketplace.invoice.paid",
-            "payload": {"configurationId": self.installation_id, "invoiceId": "mi_123"},
+            "payload": {"installationId": self.installation_id, "invoiceId": "mi_123"},
         }
 
         response = self._post_webhook(payload, signature=None)
@@ -66,20 +66,20 @@ class TestVercelWebhooks(VercelTestBase):
     def test_missing_config_id_returns_400(self):
         payload = {
             "type": "marketplace.invoice.paid",
-            "payload": {"invoiceId": "mi_123"},  # Missing configurationId
+            "payload": {"invoiceId": "mi_123"},  # Missing installationId
         }
         signature = self._sign_payload(payload)
 
         response = self._post_webhook(payload, signature=signature)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "configurationId" in response.json()["error"]
+        assert "configurationId" in response.json()["error"]  # Error message still says configurationId
 
     @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
     def test_unknown_config_returns_404(self):
         payload = {
             "type": "marketplace.invoice.paid",
-            "payload": {"configurationId": "icfg_unknown", "invoiceId": "mi_123"},
+            "payload": {"installationId": "icfg_unknown", "invoiceId": "mi_123"},
         }
         signature = self._sign_payload(payload)
 
@@ -93,7 +93,7 @@ class TestVercelWebhooks(VercelTestBase):
         for event_type in ["integration.configuration-removed", "deployment.created", None]:
             payload = {
                 "type": event_type,
-                "payload": {"configurationId": self.installation_id},
+                "payload": {"installationId": self.installation_id},
             }
             signature = self._sign_payload(payload)
 
@@ -114,7 +114,7 @@ class TestVercelWebhooks(VercelTestBase):
 
         payload = {
             "type": "marketplace.invoice.paid",
-            "payload": {"configurationId": self.installation_id, "invoiceId": "mi_123"},
+            "payload": {"installationId": self.installation_id, "invoiceId": "mi_123"},
         }
         signature = self._sign_payload(payload)
 
@@ -143,7 +143,7 @@ class TestVercelWebhooks(VercelTestBase):
 
         payload = {
             "type": "marketplace.invoice.paid",
-            "payload": {"configurationId": self.installation_id, "invoiceId": "mi_123"},
+            "payload": {"installationId": self.installation_id, "invoiceId": "mi_123"},
         }
         signature = self._sign_payload(payload)
 
@@ -159,7 +159,7 @@ class TestVercelWebhooks(VercelTestBase):
 
         payload = {
             "type": "marketplace.invoice.paid",
-            "payload": {"configurationId": self.installation_id, "invoiceId": "mi_123"},
+            "payload": {"installationId": self.installation_id, "invoiceId": "mi_123"},
         }
         signature = self._sign_payload(payload)
 

--- a/ee/api/vercel/test/test_vercel_webhooks.py
+++ b/ee/api/vercel/test/test_vercel_webhooks.py
@@ -90,7 +90,14 @@ class TestVercelWebhooks(VercelTestBase):
 
     @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
     def test_non_billing_events_ignored(self):
-        for event_type in ["integration.configuration-removed", "deployment.created", None]:
+        # Non-marketplace events and unhandled marketplace events should be ignored
+        for event_type in [
+            "integration.configuration-removed",
+            "deployment.created",
+            "marketplace.invoice.created",  # Other marketplace events we don't handle
+            "marketplace.invoice.refunded",
+            None,
+        ]:
             payload = {
                 "type": event_type,
                 "payload": {"installationId": self.installation_id},

--- a/ee/api/vercel/test/test_vercel_webhooks.py
+++ b/ee/api/vercel/test/test_vercel_webhooks.py
@@ -14,7 +14,7 @@ from ee.api.vercel.test.base import VercelTestBase
 class TestVercelWebhooks(VercelTestBase):
     def setUp(self):
         super().setUp()
-        self.url = "/api/vercel/webhooks"
+        self.url = "/webhooks/vercel"
         self.secret = "test_webhook_secret"
 
     def _sign_payload(self, payload: dict) -> str:

--- a/ee/api/vercel/test/test_vercel_webhooks.py
+++ b/ee/api/vercel/test/test_vercel_webhooks.py
@@ -1,0 +1,167 @@
+import hmac
+import json
+import hashlib
+
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+
+from rest_framework import status
+
+from ee.api.vercel.test.base import VercelTestBase
+
+
+class TestVercelWebhooks(VercelTestBase):
+    def setUp(self):
+        super().setUp()
+        self.url = "/api/vercel/webhooks"
+        self.secret = "test_webhook_secret"
+
+    def _sign_payload(self, payload: dict) -> str:
+        body = json.dumps(payload).encode("utf-8")
+        return hmac.new(
+            self.secret.encode("utf-8"),
+            body,
+            hashlib.sha1,
+        ).hexdigest()
+
+    def _post_webhook(self, payload: dict, signature: str | None = None):
+        headers = {}
+        if signature is not None:
+            headers["HTTP_X_VERCEL_SIGNATURE"] = signature
+
+        return self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+            **headers,
+        )
+
+    @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
+    def test_invalid_signature_returns_401(self):
+        payload = {
+            "type": "marketplace.invoice.paid",
+            "payload": {"configurationId": self.installation_id, "invoiceId": "mi_123"},
+        }
+
+        response = self._post_webhook(payload, signature="invalid_signature")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.json()["error"] == "Invalid signature"
+
+    @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
+    def test_missing_signature_returns_401(self):
+        payload = {
+            "type": "marketplace.invoice.paid",
+            "payload": {"configurationId": self.installation_id, "invoiceId": "mi_123"},
+        }
+
+        response = self._post_webhook(payload, signature=None)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
+    def test_missing_config_id_returns_400(self):
+        payload = {
+            "type": "marketplace.invoice.paid",
+            "payload": {"invoiceId": "mi_123"},  # Missing configurationId
+        }
+        signature = self._sign_payload(payload)
+
+        response = self._post_webhook(payload, signature=signature)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "configurationId" in response.json()["error"]
+
+    @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
+    def test_unknown_config_returns_404(self):
+        payload = {
+            "type": "marketplace.invoice.paid",
+            "payload": {"configurationId": "icfg_unknown", "invoiceId": "mi_123"},
+        }
+        signature = self._sign_payload(payload)
+
+        response = self._post_webhook(payload, signature=signature)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "Unknown configuration" in response.json()["error"]
+
+    @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
+    def test_non_billing_events_ignored(self):
+        for event_type in ["integration.configuration-removed", "deployment.created", None]:
+            payload = {
+                "type": event_type,
+                "payload": {"configurationId": self.installation_id},
+            }
+            signature = self._sign_payload(payload)
+
+            response = self._post_webhook(payload, signature=signature)
+
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json()["status"] == "ignored"
+
+    @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
+    @patch("ee.api.vercel.vercel_webhooks.BillingManager")
+    @patch("ee.api.vercel.vercel_webhooks.License")
+    def test_billing_event_forwarded_to_billing_service(self, mock_license_model, mock_billing_manager_class):
+        mock_license = MagicMock()
+        mock_license_model.objects.first.return_value = mock_license
+
+        mock_billing_manager = MagicMock()
+        mock_billing_manager_class.return_value = mock_billing_manager
+
+        payload = {
+            "type": "marketplace.invoice.paid",
+            "payload": {"configurationId": self.installation_id, "invoiceId": "mi_123"},
+        }
+        signature = self._sign_payload(payload)
+
+        response = self._post_webhook(payload, signature=signature)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["status"] == "ok"
+
+        mock_billing_manager.handle_billing_provider_webhook.assert_called_once_with(
+            event_type="marketplace.invoice.paid",
+            event_data=payload["payload"],
+            organization=self.organization,
+            billing_provider="vercel",
+        )
+
+    @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
+    @patch("ee.api.vercel.vercel_webhooks.BillingManager")
+    @patch("ee.api.vercel.vercel_webhooks.License")
+    def test_billing_error_returns_500(self, mock_license_model, mock_billing_manager_class):
+        mock_license = MagicMock()
+        mock_license_model.objects.first.return_value = mock_license
+
+        mock_billing_manager = MagicMock()
+        mock_billing_manager_class.return_value = mock_billing_manager
+        mock_billing_manager.handle_billing_provider_webhook.side_effect = Exception("Billing service error")
+
+        payload = {
+            "type": "marketplace.invoice.paid",
+            "payload": {"configurationId": self.installation_id, "invoiceId": "mi_123"},
+        }
+        signature = self._sign_payload(payload)
+
+        response = self._post_webhook(payload, signature=signature)
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert "Processing failed" in response.json()["error"]
+
+    @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
+    @patch("ee.api.vercel.vercel_webhooks.License")
+    def test_no_license_returns_500(self, mock_license_model):
+        mock_license_model.objects.first.return_value = None
+
+        payload = {
+            "type": "marketplace.invoice.paid",
+            "payload": {"configurationId": self.installation_id, "invoiceId": "mi_123"},
+        }
+        signature = self._sign_payload(payload)
+
+        response = self._post_webhook(payload, signature=signature)
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert "No license" in response.json()["error"]

--- a/ee/api/vercel/test/test_vercel_webhooks.py
+++ b/ee/api/vercel/test/test_vercel_webhooks.py
@@ -164,4 +164,4 @@ class TestVercelWebhooks(VercelTestBase):
         response = self._post_webhook(payload, signature=signature)
 
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-        assert "No license" in response.json()["error"]
+        assert "Processing failed" in response.json()["error"]

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -73,7 +73,7 @@ def _forward_to_billing_service(event_type: str, payload: dict[str, Any], integr
 @permission_classes([])
 def vercel_webhook(request: Request) -> Response:
     """
-    Handle Vercel webhooks. Routes billing events (marketplace.*) to the billing service.
+    Handle Vercel webhooks. Routes billing events (marketplace.invoice.*) to the billing service.
     Non-billing events are acknowledged but not processed.
     """
     signature = request.headers.get("x-vercel-signature")

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -1,19 +1,6 @@
-"""
-Vercel Webhook Handler
-
-Receives webhooks from Vercel and routes billing events to the billing service.
-PostHog acts as a pure passthrough - no event normalization, no business logic.
-The billing service owns all billing provider event handling.
-
-Webhook events handled:
-- marketplace.invoice.paid (this slice) - Customer paid invoice
-- marketplace.invoice.created (Slice 5) - Invoice created
-- marketplace.invoice.notpaid (Slice 5) - Invoice not paid after grace period
-- marketplace.invoice.refunded (Slice 5) - Invoice refunded
-"""
-
 import hmac
 import hashlib
+from typing import Any
 
 from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
@@ -35,28 +22,54 @@ logger = structlog.get_logger(__name__)
 BILLING_EVENT_PREFIX = "marketplace."
 
 
-def verify_vercel_webhook_signature(payload: bytes, signature: str | None) -> bool:
-    """
-    Verify the webhook signature from Vercel using HMAC-SHA1.
-
-    Vercel signs webhooks using HMAC-SHA1 with the client integration secret.
-    The signature is provided in the x-vercel-signature header.
-    """
+def _is_valid_signature(payload: bytes, signature: str | None) -> bool:
     if not signature:
         return False
 
     secret = getattr(settings, "VERCEL_CLIENT_INTEGRATION_SECRET", None)
     if not secret:
-        logger.error("vercel_webhook_missing_secret", error="VERCEL_CLIENT_INTEGRATION_SECRET not configured")
+        logger.error("vercel_webhook_missing_secret")
         return False
 
-    expected_signature = hmac.new(
-        secret.encode("utf-8"),
-        payload,
-        hashlib.sha1,
-    ).hexdigest()
+    expected = hmac.new(secret.encode("utf-8"), payload, hashlib.sha1).hexdigest()
+    return hmac.compare_digest(expected, signature)
 
-    return hmac.compare_digest(expected_signature, signature)
+
+def _extract_config_id(data: dict[str, Any], payload: dict[str, Any]) -> str | None:
+    return (
+        data.get("configurationId")
+        or payload.get("installationId")
+        or payload.get("configuration", {}).get("id")
+        or payload.get("configurationId")
+    )
+
+
+def _is_billing_event(event_type: str | None) -> bool:
+    return bool(event_type and event_type.startswith(BILLING_EVENT_PREFIX))
+
+
+def _get_integration(config_id: str) -> OrganizationIntegration | None:
+    try:
+        return OrganizationIntegration.objects.select_related("organization").get(
+            kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
+            integration_id=config_id,
+        )
+    except OrganizationIntegration.DoesNotExist:
+        return None
+
+
+def _forward_to_billing_service(event_type: str, payload: dict[str, Any], integration: OrganizationIntegration) -> None:
+    license = License.objects.first()
+    if not license:
+        raise ValueError("No license configured")
+
+    billing_manager = BillingManager(license=license)
+    billing_manager.handle_billing_provider_webhook(
+        event_type=event_type,
+        event_data=payload,
+        organization=integration.organization,
+        billing_provider="vercel",
+    )
 
 
 @csrf_exempt
@@ -64,31 +77,14 @@ def verify_vercel_webhook_signature(payload: bytes, signature: str | None) -> bo
 @authentication_classes([])
 @permission_classes([])
 def vercel_webhook(request: Request) -> Response:
-    """
-    Receives webhooks from Vercel.
-
-    Routes billing events (marketplace.*) to the billing service.
-    Non-billing events are acknowledged but not processed.
-    """
-    # 1. Verify webhook signature
     signature = request.headers.get("x-vercel-signature")
-    if not verify_vercel_webhook_signature(request.body, signature):
+    if not _is_valid_signature(request.body, signature):
         logger.warning("vercel_webhook_invalid_signature")
         return Response({"error": "Invalid signature"}, status=status.HTTP_401_UNAUTHORIZED)
 
-    # 2. Parse event
     event_type = request.data.get("type")
     payload = request.data.get("payload", {})
-
-    # configurationId location varies by event type:
-    # - marketplace.invoice.* events: inside payload as installationId or configuration.id
-    # - other events: configurationId at top level
-    config_id = (
-        request.data.get("configurationId")
-        or payload.get("installationId")
-        or payload.get("configuration", {}).get("id")
-        or payload.get("configurationId")
-    )
+    config_id = _extract_config_id(request.data, payload)
 
     logger.info("vercel_webhook_received", event_type=event_type, config_id=config_id)
 
@@ -96,45 +92,25 @@ def vercel_webhook(request: Request) -> Response:
         logger.error("vercel_webhook_missing_config_id", event_type=event_type)
         return Response({"error": "Missing configurationId"}, status=status.HTTP_400_BAD_REQUEST)
 
-    # 3. Only route billing events to billing service
-    if not event_type or not event_type.startswith(BILLING_EVENT_PREFIX):
+    if not _is_billing_event(event_type):
         logger.info("vercel_webhook_non_billing_event", event_type=event_type)
         return Response({"status": "ignored"}, status=status.HTTP_200_OK)
 
-    # 4. Look up organization
-    try:
-        integration = OrganizationIntegration.objects.select_related("organization").get(
-            kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
-            integration_id=config_id,
+    integration = _get_integration(config_id)
+    if not integration:
+        logger.error("vercel_webhook_unknown_config", config_id=config_id)
+        capture_exception(
+            OrganizationIntegration.DoesNotExist(),
+            {"config_id": config_id, "event_type": event_type},
         )
-    except OrganizationIntegration.DoesNotExist as e:
-        logger.exception("vercel_webhook_unknown_config", config_id=config_id)
-        capture_exception(e, {"config_id": config_id, "event_type": event_type})
         return Response({"error": "Unknown configuration"}, status=status.HTTP_404_NOT_FOUND)
 
-    # 5. Forward to billing service (passthrough - no normalization)
     try:
-        license = License.objects.first()
-        if not license:
-            logger.error("vercel_webhook_no_license")
-            return Response({"error": "No license configured"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-        billing_manager = BillingManager(license=license)
-        billing_manager.handle_billing_provider_webhook(
-            event_type=event_type,
-            event_data=payload,
-            organization=integration.organization,
-            billing_provider="vercel",
-        )
+        _forward_to_billing_service(event_type, payload, integration)
     except Exception as e:
-        logger.exception("vercel_webhook_billing_error", event_type=event_type, error=str(e))
+        logger.exception("vercel_webhook_billing_error", event_type=event_type)
         capture_exception(e, {"config_id": config_id, "event_type": event_type})
-        # Return 500 so Vercel retries
         return Response({"error": "Processing failed"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    logger.info(
-        "vercel_webhook_processed",
-        event_type=event_type,
-        org_id=str(integration.organization_id),
-    )
+    logger.info("vercel_webhook_processed", event_type=event_type, org_id=str(integration.organization_id))
     return Response({"status": "ok"}, status=status.HTTP_200_OK)

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -3,7 +3,6 @@ import hashlib
 from typing import Any
 
 from django.conf import settings
-from django.views.decorators.csrf import csrf_exempt
 
 import structlog
 from rest_framework import status
@@ -72,7 +71,6 @@ def _forward_to_billing_service(event_type: str, payload: dict[str, Any], integr
     )
 
 
-@csrf_exempt
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([])
@@ -95,6 +93,8 @@ def vercel_webhook(request: Request) -> Response:
     if not _is_billing_event(event_type):
         logger.info("vercel_webhook_non_billing_event", event_type=event_type)
         return Response({"status": "ignored"}, status=status.HTTP_200_OK)
+
+    assert event_type is not None  # Guaranteed by _is_billing_event check above
 
     integration = _get_integration(config_id)
     if not integration:

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -75,6 +75,10 @@ def _forward_to_billing_service(event_type: str, payload: dict[str, Any], integr
 @authentication_classes([])
 @permission_classes([])
 def vercel_webhook(request: Request) -> Response:
+    """
+    Handle Vercel webhooks. Routes billing events (marketplace.*) to the billing service.
+    Non-billing events are acknowledged but not processed.
+    """
     signature = request.headers.get("x-vercel-signature")
     if not _is_valid_signature(request.body, signature):
         logger.warning("vercel_webhook_invalid_signature")

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -18,7 +18,7 @@ from ee.models import License
 
 logger = structlog.get_logger(__name__)
 
-BILLING_EVENTS = frozenset(["marketplace.invoice.paid"])
+BILLING_EVENT_PREFIX = "marketplace.invoice."
 
 
 def _is_valid_signature(payload: bytes, signature: str | None) -> bool:
@@ -41,7 +41,7 @@ def _extract_config_id(payload: dict[str, Any]) -> str | None:
 
 
 def _is_billing_event(event_type: str | None) -> bool:
-    return event_type in BILLING_EVENTS
+    return bool(event_type and event_type.startswith(BILLING_EVENT_PREFIX))
 
 
 def _get_integration(config_id: str) -> OrganizationIntegration | None:

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -28,6 +28,7 @@ def _is_valid_signature(payload: bytes, signature: str | None) -> bool:
     secret = getattr(settings, "VERCEL_CLIENT_INTEGRATION_SECRET", None)
     if not secret:
         logger.error("vercel_webhook_missing_secret")
+        capture_exception(Exception("VERCEL_CLIENT_INTEGRATION_SECRET not configured"), {})
         return False
 
     expected = hmac.new(secret.encode("utf-8"), payload, hashlib.sha1).hexdigest()

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -18,7 +18,7 @@ from ee.models import License
 
 logger = structlog.get_logger(__name__)
 
-BILLING_EVENT_PREFIX = "marketplace."
+BILLING_EVENTS = frozenset(["marketplace.invoice.paid"])
 
 
 def _is_valid_signature(payload: bytes, signature: str | None) -> bool:
@@ -41,7 +41,7 @@ def _extract_config_id(payload: dict[str, Any]) -> str | None:
 
 
 def _is_billing_event(event_type: str | None) -> bool:
-    return bool(event_type and event_type.startswith(BILLING_EVENT_PREFIX))
+    return event_type in BILLING_EVENTS
 
 
 def _get_integration(config_id: str) -> OrganizationIntegration | None:

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -35,11 +35,8 @@ def _is_valid_signature(payload: bytes, signature: str | None) -> bool:
 
 
 def _extract_config_id(payload: dict[str, Any]) -> str | None:
-    # Vercel marketplace webhooks include the installation ID in two places:
-    # - payload.installationId
-    # - payload.configuration.id (same value)
     # Ref: https://vercel.com/docs/observability/webhooks-overview/webhooks-api
-    return payload.get("installationId") or payload.get("configuration", {}).get("id")
+    return payload.get("installationId")
 
 
 def _is_billing_event(event_type: str | None) -> bool:

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -1,0 +1,140 @@
+"""
+Vercel Webhook Handler
+
+Receives webhooks from Vercel and routes billing events to the billing service.
+PostHog acts as a pure passthrough - no event normalization, no business logic.
+The billing service owns all billing provider event handling.
+
+Webhook events handled:
+- marketplace.invoice.paid (this slice) - Customer paid invoice
+- marketplace.invoice.created (Slice 5) - Invoice created
+- marketplace.invoice.notpaid (Slice 5) - Invoice not paid after grace period
+- marketplace.invoice.refunded (Slice 5) - Invoice refunded
+"""
+
+import hmac
+import hashlib
+
+from django.conf import settings
+from django.views.decorators.csrf import csrf_exempt
+
+import structlog
+from rest_framework import status
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.exceptions_capture import capture_exception
+from posthog.models.organization_integration import OrganizationIntegration
+
+from ee.billing.billing_manager import BillingManager
+from ee.models import License
+
+logger = structlog.get_logger(__name__)
+
+BILLING_EVENT_PREFIX = "marketplace."
+
+
+def verify_vercel_webhook_signature(payload: bytes, signature: str | None) -> bool:
+    """
+    Verify the webhook signature from Vercel using HMAC-SHA1.
+
+    Vercel signs webhooks using HMAC-SHA1 with the client integration secret.
+    The signature is provided in the x-vercel-signature header.
+    """
+    if not signature:
+        return False
+
+    secret = getattr(settings, "VERCEL_CLIENT_INTEGRATION_SECRET", None)
+    if not secret:
+        logger.error("vercel_webhook_missing_secret", error="VERCEL_CLIENT_INTEGRATION_SECRET not configured")
+        return False
+
+    expected_signature = hmac.new(
+        secret.encode("utf-8"),
+        payload,
+        hashlib.sha1,
+    ).hexdigest()
+
+    return hmac.compare_digest(expected_signature, signature)
+
+
+@csrf_exempt
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([])
+def vercel_webhook(request: Request) -> Response:
+    """
+    Receives webhooks from Vercel.
+
+    Routes billing events (marketplace.*) to the billing service.
+    Non-billing events are acknowledged but not processed.
+    """
+    # 1. Verify webhook signature
+    signature = request.headers.get("x-vercel-signature")
+    if not verify_vercel_webhook_signature(request.body, signature):
+        logger.warning("vercel_webhook_invalid_signature")
+        return Response({"error": "Invalid signature"}, status=status.HTTP_401_UNAUTHORIZED)
+
+    # 2. Parse event
+    event_type = request.data.get("type")
+    payload = request.data.get("payload", {})
+
+    # configurationId location varies by event type:
+    # - marketplace.invoice.* events: inside payload as installationId or configuration.id
+    # - other events: configurationId at top level
+    config_id = (
+        request.data.get("configurationId")
+        or payload.get("installationId")
+        or payload.get("configuration", {}).get("id")
+        or payload.get("configurationId")
+    )
+
+    logger.info("vercel_webhook_received", event_type=event_type, config_id=config_id)
+
+    if not config_id:
+        logger.error("vercel_webhook_missing_config_id", event_type=event_type)
+        return Response({"error": "Missing configurationId"}, status=status.HTTP_400_BAD_REQUEST)
+
+    # 3. Only route billing events to billing service
+    if not event_type or not event_type.startswith(BILLING_EVENT_PREFIX):
+        logger.info("vercel_webhook_non_billing_event", event_type=event_type)
+        return Response({"status": "ignored"}, status=status.HTTP_200_OK)
+
+    # 4. Look up organization
+    try:
+        integration = OrganizationIntegration.objects.select_related("organization").get(
+            kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
+            integration_id=config_id,
+        )
+    except OrganizationIntegration.DoesNotExist as e:
+        logger.exception("vercel_webhook_unknown_config", config_id=config_id)
+        capture_exception(e, {"config_id": config_id, "event_type": event_type})
+        return Response({"error": "Unknown configuration"}, status=status.HTTP_404_NOT_FOUND)
+
+    # 5. Forward to billing service (passthrough - no normalization)
+    try:
+        license = License.objects.first()
+        if not license:
+            logger.error("vercel_webhook_no_license")
+            return Response({"error": "No license configured"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        billing_manager = BillingManager(license=license)
+        billing_manager.handle_billing_provider_webhook(
+            event_type=event_type,
+            event_data=payload,
+            organization=integration.organization,
+            billing_provider="vercel",
+        )
+    except Exception as e:
+        logger.exception("vercel_webhook_billing_error", event_type=event_type, error=str(e))
+        capture_exception(e, {"config_id": config_id, "event_type": event_type})
+        # Return 500 so Vercel retries
+        return Response({"error": "Processing failed"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    logger.info(
+        "vercel_webhook_processed",
+        event_type=event_type,
+        org_id=str(integration.organization_id),
+    )
+    return Response({"status": "ok"}, status=status.HTTP_200_OK)

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -564,3 +564,43 @@ class BillingManager:
         handle_billing_service_error(res)
 
         return res.json()
+
+    def handle_billing_provider_webhook(
+        self,
+        event_type: str,
+        event_data: dict[str, Any],
+        organization: Organization,
+        billing_provider: str,
+    ) -> None:
+        """
+        Forward billing provider webhook to billing service for processing.
+
+        Pure passthrough - no transformation of event data.
+        Raises exception on failure (causes webhook endpoint to return 500, triggering Vercel retry).
+
+        Args:
+            event_type: Raw event type (e.g., "marketplace.invoice.paid")
+            event_data: Raw event payload from billing provider
+            organization: The organization this event is for
+            billing_provider: The billing provider (e.g., "vercel")
+        """
+        res = requests.post(
+            f"{BILLING_SERVICE_URL}/api/billing-provider-webhook",
+            headers=self.get_auth_headers(organization),
+            json={
+                "event_type": event_type,
+                "event_data": event_data,
+                "billing_provider": billing_provider,
+            },
+            timeout=30,
+        )
+
+        if not res.ok:
+            logger.error(
+                "billing_provider_webhook_error",
+                event_type=event_type,
+                billing_provider=billing_provider,
+                status_code=res.status_code,
+                response_text=res.text[:500] if res.text else "",
+            )
+            raise Exception(f"Billing service returned {res.status_code}: {res.text}")

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -579,7 +579,7 @@ class BillingManager:
         Raises exception on failure (causes webhook endpoint to return 500, triggering provider retry).
         """
         res = requests.post(
-            f"{BILLING_SERVICE_URL}/api/billing-provider-webhook",
+            f"{BILLING_SERVICE_URL}/api/webhooks/billing-provider",
             headers=self.get_auth_headers(organization),
             json={
                 "event_type": event_type,

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -576,13 +576,7 @@ class BillingManager:
         Forward billing provider webhook to billing service for processing.
 
         Pure passthrough - no transformation of event data.
-        Raises exception on failure (causes webhook endpoint to return 500, triggering Vercel retry).
-
-        Args:
-            event_type: Raw event type (e.g., "marketplace.invoice.paid")
-            event_data: Raw event payload from billing provider
-            organization: The organization this event is for
-            billing_provider: The billing provider (e.g., "vercel")
+        Raises exception on failure (causes webhook endpoint to return 500, triggering provider retry).
         """
         res = requests.post(
             f"{BILLING_SERVICE_URL}/api/billing-provider-webhook",

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -13,7 +13,7 @@ from posthog.views import api_key_search_view, redis_values_view
 
 from ee.admin.oauth_views import admin_auth_check, admin_oauth_success
 from ee.api import integration
-from ee.api.vercel import vercel_sso
+from ee.api.vercel import vercel_sso, vercel_webhooks
 from ee.middleware import admin_oauth2_callback
 from ee.support_sidebar_max.views import MaxChatViewSet
 
@@ -134,6 +134,8 @@ urlpatterns: list[Any] = [
     path("max/chat/", csrf_exempt(MaxChatViewSet.as_view({"post": "create"})), name="max_chat"),
     path("login/vercel/", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_redirect"})),
     path("login/vercel/continue", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_continue"})),
+    path("api/vercel/webhooks", csrf_exempt(vercel_webhooks.vercel_webhook), name="vercel_webhooks"),
+    path("webhooks/vercel", csrf_exempt(vercel_webhooks.vercel_webhook), name="vercel_webhooks_alt"),
     path("scim/v2/<uuid:domain_id>/Users", csrf_exempt(scim_views.SCIMUsersView.as_view()), name="scim_users"),
     path(
         "scim/v2/<uuid:domain_id>/Users/<int:user_id>",

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -134,8 +134,7 @@ urlpatterns: list[Any] = [
     path("max/chat/", csrf_exempt(MaxChatViewSet.as_view({"post": "create"})), name="max_chat"),
     path("login/vercel/", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_redirect"})),
     path("login/vercel/continue", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_continue"})),
-    path("api/vercel/webhooks", csrf_exempt(vercel_webhooks.vercel_webhook), name="vercel_webhooks"),
-    path("webhooks/vercel", csrf_exempt(vercel_webhooks.vercel_webhook), name="vercel_webhooks_alt"),
+    path("webhooks/vercel", csrf_exempt(vercel_webhooks.vercel_webhook), name="vercel_webhooks"),
     path("scim/v2/<uuid:domain_id>/Users", csrf_exempt(scim_views.SCIMUsersView.as_view()), name="scim_users"),
     path(
         "scim/v2/<uuid:domain_id>/Users/<int:user_id>",


### PR DESCRIPTION
## Problem

When Vercel customers pay their invoices, Vercel sends a `marketplace.invoice.paid` webhook. We need to receive this and mark the corresponding Stripe invoice as paid so our billing flows work correctly.

## Changes

- Add `/webhooks/vercel` endpoint with HMAC-SHA1 signature verification
- Forward `marketplace.*` events to billing service
- Use `capture_exception` for error tracking

## How did you test this code?

```bash
pytest ee/api/vercel/test/test_vercel_webhooks.py -v
```

E2E: Created Stripe invoice → finalized → Vercel webhook received → Stripe invoice marked paid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)