### PR TITLE
fix: decrypt payloads inside the loop when copying flags

### DIFF
--- a/posthog/api/organization_feature_flag.py
+++ b/posthog/api/organization_feature_flag.py
@@ -82,13 +82,6 @@ class OrganizationFeatureFlagView(
         successful_projects = []
         failed_projects = []
 
-        filters = flag_to_copy.get_filters()
-        if flag_to_copy.has_encrypted_payloads:
-            # Decrypt payloads before copying to ensure the new flag has unencrypted payloads
-            # that will be re-encrypted by the serializer if needed
-            encrypted_payloads = filters.get("payloads", {})
-            filters["payloads"] = get_decrypted_flag_payloads(encrypted_payloads, should_decrypt=True)
-
         for target_project_id in target_project_ids:
             # Target project does not exist
             target_team = Team.objects.filter(project_id=target_project_id).first()
@@ -174,6 +167,15 @@ class OrganizationFeatureFlagView(
                             prop["value"] = name_to_dest_cohort_id[cohort_name]
                         except (ValueError, TypeError):
                             continue
+
+            # Get fresh filters for each target project because the cohort replacement logic above
+            # mutates the filters object. This ensures each copy gets the correct cohort mappings.
+            filters = flag_to_copy.get_filters()
+            if flag_to_copy.has_encrypted_payloads:
+                # Decrypt payloads before copying to ensure the new flag has unencrypted payloads
+                # that will be re-encrypted by the serializer if needed
+                encrypted_payloads = filters.get("payloads", {})
+                filters["payloads"] = get_decrypted_flag_payloads(encrypted_payloads, should_decrypt=True)
 
             flag_data = {
                 "key": flag_to_copy.key,

--- a/posthog/api/organization_feature_flag.py
+++ b/posthog/api/organization_feature_flag.py
@@ -168,8 +168,7 @@ class OrganizationFeatureFlagView(
                         except (ValueError, TypeError):
                             continue
 
-            # Get fresh filters for each target project because the cohort replacement logic above
-            # mutates the filters object. This ensures each copy gets the correct cohort mappings.
+            # Retrieve filters per iteration since cohort replacement logic mutates the dict
             filters = flag_to_copy.get_filters()
             if flag_to_copy.has_encrypted_payloads:
                 # Decrypt payloads before copying to ensure the new flag has unencrypted payloads

--- a/posthog/api/test/test_organization_feature_flag.py
+++ b/posthog/api/test/test_organization_feature_flag.py
@@ -754,3 +754,52 @@ class TestOrganizationFeatureFlagCopy(APIBaseTest, QueryMatchingTest):
 
         decrypted_payload = get_decrypted_flag_payload(copied_flag.filters["payloads"]["true"], should_decrypt=True)
         self.assertEqual(decrypted_payload, '{"key": "secret_value"}')
+
+    def test_copy_encrypted_payloads_flag_to_multiple_projects(self):
+        """Test that copying a flag with encrypted payloads to multiple projects works correctly."""
+        from posthog.helpers.encrypted_flag_payloads import encrypt_flag_payloads, get_decrypted_flag_payload
+
+        url = f"/api/organizations/{self.organization.id}/feature_flags/copy_flags"
+
+        # Create third team for testing multiple targets
+        team_3 = Team.objects.create(organization=self.organization)
+        team_3.api_token = "phc_test_copy_token_3"
+        team_3.save()
+
+        # Create a flag with encrypted payloads
+        flag_data = {
+            "groups": [{"rollout_percentage": 100}],
+            "payloads": {"true": '{"key": "secret_value"}'},
+        }
+        encrypt_flag_payloads({"has_encrypted_payloads": True, "filters": flag_data})
+
+        encrypted_flag = FeatureFlag.objects.create(
+            team=self.team_1,
+            created_by=self.user,
+            key="encrypted-multi-flag",
+            filters=flag_data,
+            rollout_percentage=100,
+            is_remote_configuration=True,
+            has_encrypted_payloads=True,
+        )
+
+        data = {
+            "feature_flag_key": encrypted_flag.key,
+            "from_project": encrypted_flag.team_id,
+            "target_project_ids": [self.team_2.id, team_3.id],
+        }
+        response = self.client.post(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("success", response.json())
+        self.assertEqual(len(response.json()["success"]), 2)
+
+        # Verify both copied flags have correctly encrypted payloads
+        for target_team in [self.team_2, team_3]:
+            copied_flag = FeatureFlag.objects.get(key=encrypted_flag.key, team=target_team)
+            self.assertTrue(copied_flag.is_remote_configuration)
+            self.assertTrue(copied_flag.has_encrypted_payloads)
+
+            # Verify the encrypted payload can be decrypted back to the original value
+            decrypted_payload = get_decrypted_flag_payload(copied_flag.filters["payloads"]["true"], should_decrypt=True)
+            self.assertEqual(decrypted_payload, '{"key": "secret_value"}')


### PR DESCRIPTION
Follow up to #42740 to fix problem when copying flag to multiple targets.

The PR introduced this bug when moved the `get_decrypted_flag_payloads` to outside the loop of targets, 