### PR TITLE
feat(web-analytics): add UTM breakdowns back to page reports

### DIFF
--- a/frontend/src/scenes/web-analytics/common.ts
+++ b/frontend/src/scenes/web-analytics/common.ts
@@ -66,6 +66,11 @@ export enum TileId {
     PAGE_REPORTS_LANGUAGES = 'PR_LANGUAGES',
     PAGE_REPORTS_TOP_EVENTS = 'PR_TOP_EVENTS',
     PAGE_REPORTS_PREVIOUS_PAGE = 'PR_PREVIOUS_PAGE',
+    PAGE_REPORTS_UTM_SOURCE = 'PR_UTM_SOURCE',
+    PAGE_REPORTS_UTM_MEDIUM = 'PR_UTM_MEDIUM',
+    PAGE_REPORTS_UTM_CAMPAIGN = 'PR_UTM_CAMPAIGN',
+    PAGE_REPORTS_UTM_CONTENT = 'PR_UTM_CONTENT',
+    PAGE_REPORTS_UTM_TERM = 'PR_UTM_TERM',
 
     // Marketing Tiles
     MARKETING = 'MARKETING',
@@ -125,6 +130,11 @@ export const loadPriorityMap: Record<TileId, number> = {
     [TileId.PAGE_REPORTS_TIMEZONES]: 14,
     [TileId.PAGE_REPORTS_LANGUAGES]: 15,
     [TileId.PAGE_REPORTS_TOP_EVENTS]: 16,
+    [TileId.PAGE_REPORTS_UTM_SOURCE]: 17,
+    [TileId.PAGE_REPORTS_UTM_MEDIUM]: 18,
+    [TileId.PAGE_REPORTS_UTM_CAMPAIGN]: 19,
+    [TileId.PAGE_REPORTS_UTM_CONTENT]: 20,
+    [TileId.PAGE_REPORTS_UTM_TERM]: 21,
 
     // Marketing Tiles
     [TileId.MARKETING_OVERVIEW]: 1,
@@ -186,6 +196,11 @@ export const TILE_LABELS: Record<TileId, string> = {
     [TileId.PAGE_REPORTS_LANGUAGES]: 'Languages',
     [TileId.PAGE_REPORTS_TOP_EVENTS]: 'Top events',
     [TileId.PAGE_REPORTS_PREVIOUS_PAGE]: 'Previous page',
+    [TileId.PAGE_REPORTS_UTM_SOURCE]: 'UTM source',
+    [TileId.PAGE_REPORTS_UTM_MEDIUM]: 'UTM medium',
+    [TileId.PAGE_REPORTS_UTM_CAMPAIGN]: 'UTM campaign',
+    [TileId.PAGE_REPORTS_UTM_CONTENT]: 'UTM content',
+    [TileId.PAGE_REPORTS_UTM_TERM]: 'UTM term',
     [TileId.MARKETING]: 'Marketing',
     [TileId.MARKETING_CAMPAIGN_BREAKDOWN]: 'Campaign breakdown',
 }

--- a/frontend/src/scenes/web-analytics/pageReportsLogic.ts
+++ b/frontend/src/scenes/web-analytics/pageReportsLogic.ts
@@ -202,6 +202,11 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
                         outboundClicksQuery: undefined,
                         channelsQuery: undefined,
                         referrersQuery: undefined,
+                        utmSourceQuery: undefined,
+                        utmMediumQuery: undefined,
+                        utmCampaignQuery: undefined,
+                        utmContentQuery: undefined,
+                        utmTermQuery: undefined,
                         deviceTypeQuery: undefined,
                         browserQuery: undefined,
                         osQuery: undefined,
@@ -305,6 +310,11 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
                     // Source queries
                     channelsQuery: getQuery(TileId.SOURCES, SourceTab.CHANNEL),
                     referrersQuery: getQuery(TileId.SOURCES, SourceTab.REFERRING_DOMAIN),
+                    utmSourceQuery: getQuery(TileId.SOURCES, SourceTab.UTM_SOURCE),
+                    utmMediumQuery: getQuery(TileId.SOURCES, SourceTab.UTM_MEDIUM),
+                    utmCampaignQuery: getQuery(TileId.SOURCES, SourceTab.UTM_CAMPAIGN),
+                    utmContentQuery: getQuery(TileId.SOURCES, SourceTab.UTM_CONTENT),
+                    utmTermQuery: getQuery(TileId.SOURCES, SourceTab.UTM_TERM),
 
                     // Device queries
                     deviceTypeQuery: getQuery(TileId.DEVICES, DeviceTab.DEVICE_TYPE),
@@ -472,10 +482,10 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
                                 }
                             ),
                             createQueryTile(
-                                TileId.PAGE_REPORTS_OUTBOUND_CLICKS,
-                                'Outbound Clicks',
-                                'External links users click on this page',
-                                queries.outboundClicksQuery
+                                TileId.PAGE_REPORTS_PREVIOUS_PAGE,
+                                'Previous Pages',
+                                'Pages users visited before this page. For internal navigation, we used the previous pathname. If the user arrived from an external link, we used the referrer URL.',
+                                queries.prevPathsQuery
                             ),
                         ].filter(Boolean) as WebAnalyticsTile[],
                     },
@@ -499,10 +509,40 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
                                 queries.referrersQuery
                             ),
                             createQueryTile(
-                                TileId.PAGE_REPORTS_PREVIOUS_PAGE,
-                                'Previous Pages',
-                                'Pages users visited before this page. For internal navigation, we used the previous pathname. If the user arrived from an external link, we used the referrer URL.',
-                                queries.prevPathsQuery
+                                TileId.PAGE_REPORTS_OUTBOUND_CLICKS,
+                                'Outbound Clicks',
+                                'External links users click on this page',
+                                queries.outboundClicksQuery
+                            ),
+                            createQueryTile(
+                                TileId.PAGE_REPORTS_UTM_SOURCE,
+                                'UTM Source',
+                                'UTM source parameter showing the source of traffic to this page',
+                                queries.utmSourceQuery
+                            ),
+                            createQueryTile(
+                                TileId.PAGE_REPORTS_UTM_MEDIUM,
+                                'UTM Medium',
+                                'UTM medium parameter showing the marketing medium that brought users to this page',
+                                queries.utmMediumQuery
+                            ),
+                            createQueryTile(
+                                TileId.PAGE_REPORTS_UTM_CAMPAIGN,
+                                'UTM Campaign',
+                                'UTM campaign parameter showing the marketing campaign that brought users to this page',
+                                queries.utmCampaignQuery
+                            ),
+                            createQueryTile(
+                                TileId.PAGE_REPORTS_UTM_CONTENT,
+                                'UTM Content',
+                                'UTM content parameter showing which specific link or content brought users to this page',
+                                queries.utmContentQuery
+                            ),
+                            createQueryTile(
+                                TileId.PAGE_REPORTS_UTM_TERM,
+                                'UTM Term',
+                                'UTM term parameter showing the keywords associated with traffic to this page',
+                                queries.utmTermQuery
                             ),
                         ].filter(Boolean) as WebAnalyticsTile[],
                     },


### PR DESCRIPTION
## Problem

I've removed those in the past because the queries were conflicting but that is not the case anymore, so let's add them back :) 

## Changes

- Added utm breakdowns back
- Swaped the Previous path and outbound clicks so they are more cohesive to the context

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
