### PR TITLE
fix(ph-ai): async memory nodes

### DIFF
--- a/ee/hogai/chat_agent/graph.py
+++ b/ee/hogai/chat_agent/graph.py
@@ -72,7 +72,7 @@ class AssistantGraph(ChatAgentLoopGraph):
         )
         self._graph.add_conditional_edges(
             AssistantNodeName.MEMORY_ONBOARDING_ENQUIRY,
-            memory_onboarding_enquiry.router,
+            memory_onboarding_enquiry.arouter,
             path_map={
                 "continue": AssistantNodeName.MEMORY_ONBOARDING_FINALIZE,
                 "interrupt": AssistantNodeName.MEMORY_ONBOARDING_ENQUIRY_INTERRUPT,
@@ -116,7 +116,7 @@ class AssistantGraph(ChatAgentLoopGraph):
         self._graph.add_edge(AssistantNodeName.START, AssistantNodeName.SLASH_COMMAND_HANDLER)
         self._graph.add_conditional_edges(
             AssistantNodeName.SLASH_COMMAND_HANDLER,
-            slash_command_handler.router,  # type: ignore[arg-type]
+            slash_command_handler.arouter,
         )
 
         return self

--- a/ee/hogai/chat_agent/memory/nodes.py
+++ b/ee/hogai/chat_agent/memory/nodes.py
@@ -341,7 +341,7 @@ class MemoryOnboardingFinalizeNode(AssistantNode):
             ]
         )
         chain = prompt | self._model | StrOutputParser() | compressed_memory_parser
-        compressed_memory = cast(str, chain.invoke({"memory_content": core_memory.initial_text}, config=config))
+        compressed_memory = cast(str, await chain.ainvoke({"memory_content": core_memory.initial_text}, config=config))
         compressed_memory = compressed_memory.replace("\n", " ").strip()
         await core_memory.aset_core_memory(compressed_memory)
 

--- a/ee/hogai/chat_agent/memory/nodes.py
+++ b/ee/hogai/chat_agent/memory/nodes.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 
 from django.utils import timezone
 
-from asgiref.sync import async_to_sync
 from langchain_core.messages import (
     AIMessage as LangchainAIMessage,
     BaseMessage,
@@ -23,15 +22,18 @@ from posthog.schema import (
     AssistantMessage,
     AssistantMessageMetadata,
     CachedEventTaxonomyQueryResponse,
+    CacheMissResponse,
     ContextMessage,
     EventTaxonomyItem,
     EventTaxonomyQuery,
     HumanMessage,
+    QueryStatusResponse,
 )
 
 from posthog.event_usage import report_user_action
 from posthog.hogql_queries.ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
 from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.sync import database_sync_to_async
 from posthog.utils import human_list
 
 from ee.hogai.artifacts.utils import unwrap_visualization_artifact_content
@@ -68,23 +70,17 @@ from .prompts import (
 
 
 class MemoryInitializerContextMixin(AssistantContextMixin):
-    def _retrieve_context(self, *, config: RunnableConfig | None = None) -> EventTaxonomyItem | None:
+    async def _aretrieve_context(self, *, config: RunnableConfig | None = None) -> EventTaxonomyItem | None:
         if config and "_mock_memory_onboarding_context" in config.get("configurable", {}):
             # Only for evals/tests (as patch() doesn't work because of evals running concurrently async)
             return config["configurable"]["_mock_memory_onboarding_context"]
         # Retrieve the origin domain.
-        runner = EventTaxonomyQueryRunner(
-            team=self._team, query=EventTaxonomyQuery(event="$pageview", properties=["$host"])
-        )
-        response = runner.run(ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS)
+        response = await self._arun_taxonomy_query("$pageview", "$host")
         if not isinstance(response, CachedEventTaxonomyQueryResponse):
             raise ValueError("Failed to query the event taxonomy.")
         # Otherwise, retrieve the app bundle ID.
         if not response.results:
-            runner = EventTaxonomyQueryRunner(
-                team=self._team, query=EventTaxonomyQuery(event="$screen", properties=["$app_namespace"])
-            )
-            response = runner.run(ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS)
+            response = await self._arun_taxonomy_query("$screen", "$app_namespace")
         if not isinstance(response, CachedEventTaxonomyQueryResponse):
             raise ValueError("Failed to query the event taxonomy.")
         if not response.results:
@@ -102,15 +98,26 @@ class MemoryInitializerContextMixin(AssistantContextMixin):
             return None
         return item
 
+    async def _arun_taxonomy_query(
+        self, event: str, property: str
+    ) -> CacheMissResponse | QueryStatusResponse | CachedEventTaxonomyQueryResponse:
+        def run_query() -> CacheMissResponse | QueryStatusResponse | CachedEventTaxonomyQueryResponse:
+            runner = EventTaxonomyQueryRunner(
+                team=self._team, query=EventTaxonomyQuery(event=event, properties=[property])
+            )
+            return runner.run(ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS)
+
+        return await database_sync_to_async(run_query, thread_sensitive=False)()
+
 
 class MemoryOnboardingShouldRunMixin(AssistantNode):
-    def should_run_onboarding_at_start(self, state: AssistantState) -> Literal["continue", "memory_onboarding"]:
+    async def should_run_onboarding_at_start(self, state: AssistantState) -> Literal["continue", "memory_onboarding"]:
         """
         Only trigger memory onboarding when explicitly requested with /init command.
         If another user has already started the onboarding process, or it has already been completed, do not trigger it again.
         If no messages are to be found in the AssistantState, do not run onboarding.
         """
-        core_memory = self.core_memory
+        core_memory = await self._aget_core_memory()
 
         if core_memory and core_memory.is_scraping_pending:
             # a user has already started the onboarding, we don't allow other users to start it concurrently until timeout is reached
@@ -130,14 +137,14 @@ class MemoryOnboardingShouldRunMixin(AssistantNode):
 
 
 class MemoryOnboardingNode(MemoryInitializerContextMixin, MemoryOnboardingShouldRunMixin):
-    def run(self, state: AssistantState, config: RunnableConfig) -> Optional[PartialAssistantState]:
-        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
-        core_memory.change_status_to_pending()
+    async def arun(self, state: AssistantState, config: RunnableConfig) -> Optional[PartialAssistantState]:
+        core_memory, _ = await CoreMemory.objects.aget_or_create(team=self._team)
+        await core_memory.achange_status_to_pending()
 
         # The team has a product description, initialize the memory with it.
         if self._team.project.product_description:
-            core_memory.append_question_to_initial_text("What does the company do?")
-            core_memory.append_answer_to_initial_text(self._team.project.product_description)
+            await core_memory.aappend_question_to_initial_text("What does the company do?")
+            await core_memory.aappend_answer_to_initial_text(self._team.project.product_description)
             return PartialAssistantState(
                 messages=[
                     AssistantMessage(
@@ -147,7 +154,7 @@ class MemoryOnboardingNode(MemoryInitializerContextMixin, MemoryOnboardingShould
                 ]
             )
 
-        retrieved_prop = self._retrieve_context(config=config)
+        retrieved_prop = await self._aretrieve_context(config=config)
 
         # No host or app bundle ID found
         if not retrieved_prop:
@@ -177,13 +184,13 @@ class MemoryInitializerNode(MemoryInitializerContextMixin, AssistantNode):
     Scrapes the product description from the given origin or app bundle IDs.
     """
 
-    def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
-        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
+    async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
+        core_memory, _ = await CoreMemory.objects.aget_or_create(team=self._team)
         if core_memory.initial_text:
             # Reset the initial text if it's not the first time /init is ran
             core_memory.initial_text = ""
-            core_memory.save()
-        retrieved_prop = self._retrieve_context(config=config)
+            await core_memory.asave()
+        retrieved_prop = await self._aretrieve_context(config=config)
         # No host or app bundle ID found, continue.
         if not retrieved_prop:
             return None
@@ -206,8 +213,8 @@ class MemoryInitializerNode(MemoryInitializerContextMixin, AssistantNode):
         if answer == SCRAPING_TERMINATION_MESSAGE:
             return PartialAssistantState(messages=[AssistantMessage(content=answer, id=str(uuid4()))])
         # Otherwise, proceed to confirmation that the memory is correct.
-        core_memory.append_question_to_initial_text("What does the company do?")
-        core_memory.append_answer_to_initial_text(answer)
+        await core_memory.aappend_question_to_initial_text("What does the company do?")
+        await core_memory.aappend_answer_to_initial_text(answer)
         return PartialAssistantState(messages=[AssistantMessage(content=answer, id=str(uuid4()))])
 
     def router(self, state: AssistantState) -> Literal["interrupt", "continue"]:
@@ -235,7 +242,7 @@ class MemoryInitializerInterruptNode(AssistantNode):
     Prompts the user to confirm or reject the scraped memory.
     """
 
-    def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
+    async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
         raise NodeInterrupt(
             AssistantMessage(
                 content=SCRAPING_VERIFICATION_MESSAGE,
@@ -257,23 +264,23 @@ class MemoryOnboardingEnquiryNode(AssistantNode):
     Prompts the user to give more information about the product, feature, business, etc.
     """
 
-    def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
+    async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         human_message = find_last_message_of_type(state.messages, HumanMessage)
         if not human_message:
             raise ValueError("No human message found.")
 
-        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
+        core_memory, _ = await CoreMemory.objects.aget_or_create(team=self._team)
         if (
             human_message.content not in [SCRAPING_CONFIRMATION_MESSAGE, SCRAPING_REJECTION_MESSAGE]
             and not human_message.content.startswith("/")  # Ignore slash commands
             and core_memory.initial_text.endswith("Answer:")
         ):
             # The user is answering to a question
-            core_memory.append_answer_to_initial_text(human_message.content)
+            await core_memory.aappend_answer_to_initial_text(human_message.content)
 
         if human_message.content == SCRAPING_REJECTION_MESSAGE:
             core_memory.initial_text = ""
-            core_memory.save()
+            await core_memory.asave()
 
         answers_left = core_memory.answers_left
         if answers_left > 0:
@@ -286,7 +293,7 @@ class MemoryOnboardingEnquiryNode(AssistantNode):
 
             if "[Done]" not in response and "===" in response:
                 question = self._format_question(response)
-                core_memory.append_question_to_initial_text(question)
+                await core_memory.aappend_question_to_initial_text(question)
                 return PartialAssistantState(onboarding_question=question)
         return PartialAssistantState(onboarding_question=None, answers_left=None)
 
@@ -301,8 +308,8 @@ class MemoryOnboardingEnquiryNode(AssistantNode):
             team=self._team,
         )
 
-    def router(self, state: AssistantState) -> Literal["continue", "interrupt"]:
-        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
+    async def arouter(self, state: AssistantState) -> Literal["continue", "interrupt"]:
+        core_memory, _ = await CoreMemory.objects.aget_or_create(team=self._team)
         if state.onboarding_question and core_memory.answers_left > 0:
             return "interrupt"
         return "continue"
@@ -324,8 +331,8 @@ class MemoryOnboardingEnquiryInterruptNode(AssistantNode):
 
 
 class MemoryOnboardingFinalizeNode(AssistantNode):
-    def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
-        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
+    async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
+        core_memory, _ = await CoreMemory.objects.aget_or_create(team=self._team)
         # Compress the question/answer memory before saving it
         prompt = ChatPromptTemplate.from_messages(
             [
@@ -336,7 +343,7 @@ class MemoryOnboardingFinalizeNode(AssistantNode):
         chain = prompt | self._model | StrOutputParser() | compressed_memory_parser
         compressed_memory = cast(str, chain.invoke({"memory_content": core_memory.initial_text}, config=config))
         compressed_memory = compressed_memory.replace("\n", " ").strip()
-        core_memory.set_core_memory(compressed_memory)
+        await core_memory.aset_core_memory(compressed_memory)
 
         context_message = ContextMessage(
             content=format_prompt_string(MEMORY_INITIALIZED_CONTEXT_PROMPT, core_memory=core_memory.initial_text),
@@ -387,8 +394,8 @@ class MemoryCollectorNode(MemoryOnboardingShouldRunMixin):
     The Memory Collector manages the core memory of the agent. Core memory is a text containing facts about a user's company and product. It helps the agent save and remember facts that could be useful for insight generation or other agentic functions requiring deeper context about the product.
     """
 
-    def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
-        if self.should_run_onboarding_at_start(state) != "continue":
+    async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
+        if await self.should_run_onboarding_at_start(state) != "continue":
             return None
 
         # Check if an interrupt had an unhandled tool, so it should go to tools first.
@@ -403,13 +410,13 @@ class MemoryCollectorNode(MemoryOnboardingShouldRunMixin):
 
         prompt = ChatPromptTemplate.from_messages(
             [("system", MEMORY_COLLECTOR_PROMPT)], template_format="mustache"
-        ) + self._construct_messages(state)
+        ) + await self._aconstruct_messages(state)
         chain = prompt | self._model | raise_memory_updated
 
         try:
-            response = chain.invoke(
+            response = await chain.ainvoke(
                 {
-                    "core_memory": self.core_memory_text,
+                    "core_memory": await self._aget_core_memory_text(),
                     "date": timezone.now().strftime("%Y-%m-%d"),
                 },
                 config=config,
@@ -429,13 +436,13 @@ class MemoryCollectorNode(MemoryOnboardingShouldRunMixin):
             model="gpt-4.1", temperature=0.3, disable_streaming=True, user=self._user, team=self._team, billable=True
         ).bind_tools(memory_collector_tools)
 
-    def _construct_messages(self, state: AssistantState) -> list[BaseMessage]:
+    async def _aconstruct_messages(self, state: AssistantState) -> list[BaseMessage]:
         node_messages = state.memory_collection_messages or []
 
         filtered_messages = filter_and_merge_messages(
             state.messages, entity_filter=(HumanMessage, AssistantMessage, ArtifactRefMessage)
         )
-        enriched_messages = async_to_sync(self.context_manager.artifacts.aenrich_messages)(filtered_messages)
+        enriched_messages = await self.context_manager.artifacts.aenrich_messages(filtered_messages)
 
         conversation: list[BaseMessage] = []
         for message in enriched_messages:
@@ -492,18 +499,18 @@ class MemoryCollectorNode(MemoryOnboardingShouldRunMixin):
 
 
 class MemoryCollectorToolsNode(AssistantNode):
-    def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
+    async def arun(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         node_messages = state.memory_collection_messages
         if not node_messages:
             raise ValueError("No memory collection messages found.")
         last_message = node_messages[-1]
         if not isinstance(last_message, LangchainAIMessage):
             raise ValueError("Last message must be an AI message.")
-        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
+        core_memory, _ = await CoreMemory.objects.aget_or_create(team=self._team)
 
         tools_parser = PydanticToolsParser(tools=memory_collector_tools)
         try:
-            tool_calls: list[Union[core_memory_append, core_memory_replace]] = tools_parser.invoke(
+            tool_calls: list[Union[core_memory_append, core_memory_replace]] = await tools_parser.ainvoke(
                 last_message, config=config
             )
         except ValidationError as e:
@@ -517,11 +524,11 @@ class MemoryCollectorToolsNode(AssistantNode):
         new_messages: list[LangchainToolMessage] = []
         for tool_call, schema in zip(last_message.tool_calls, tool_calls):
             if isinstance(schema, core_memory_append):
-                core_memory.append_core_memory(schema.memory_content)
+                await core_memory.aappend_core_memory(schema.memory_content)
                 new_messages.append(LangchainToolMessage(content="Memory appended.", tool_call_id=tool_call["id"]))
             if isinstance(schema, core_memory_replace):
                 try:
-                    core_memory.replace_core_memory(schema.original_fragment, schema.new_fragment)
+                    await core_memory.areplace_core_memory(schema.original_fragment, schema.new_fragment)
                     new_messages.append(LangchainToolMessage(content="Memory replaced.", tool_call_id=tool_call["id"]))
                 except ValueError as e:
                     new_messages.append(LangchainToolMessage(content=str(e), tool_call_id=tool_call["id"]))

--- a/ee/hogai/chat_agent/slash_commands/commands/remember/command.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/remember/command.py
@@ -1,6 +1,5 @@
 from uuid import uuid4
 
-from asgiref.sync import sync_to_async
 from langchain_core.runnables import RunnableConfig
 
 from posthog.schema import AssistantMessage, HumanMessage
@@ -40,12 +39,12 @@ class RememberCommand(SlashCommand):
                 ]
             )
 
-        await sync_to_async(self._append_to_memory)(memory_content)
+        await self._append_to_memory(memory_content)
 
         return PartialAssistantState(
             messages=[AssistantMessage(content="I'll remember that for you.", id=str(uuid4()))]
         )
 
-    def _append_to_memory(self, content: str) -> None:
-        core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
-        core_memory.append_core_memory(content)
+    async def _append_to_memory(self, content: str) -> None:
+        core_memory, _ = await CoreMemory.objects.aget_or_create(team=self._team)
+        await core_memory.aappend_core_memory(content)

--- a/ee/hogai/chat_agent/slash_commands/nodes.py
+++ b/ee/hogai/chat_agent/slash_commands/nodes.py
@@ -51,7 +51,7 @@ class SlashCommandHandlerNode(AssistantNode):
         command_instance = command_class(self._team, self._user)
         return await command_instance.execute(config, state)
 
-    def router(self, state: AssistantState) -> AssistantNodeName | list[Send]:
+    async def arouter(self, state: AssistantState) -> AssistantNodeName | list[Send]:
         """
         Route based on whether a slash command was detected.
 
@@ -71,9 +71,9 @@ class SlashCommandHandlerNode(AssistantNode):
         ]
 
         # Check if memory onboarding should run instead
-        memory_onboarding_should_run = MemoryOnboardingNode(self._team, self._user).should_run_onboarding_at_start(
-            state
-        )
+        memory_onboarding_should_run = await MemoryOnboardingNode(
+            self._team, self._user
+        ).should_run_onboarding_at_start(state)
         if memory_onboarding_should_run == "memory_onboarding":
             send_list = [Send(AssistantNodeName.MEMORY_ONBOARDING, state)]
 

--- a/ee/hogai/chat_agent/slash_commands/test/test_slash_command_handler.py
+++ b/ee/hogai/chat_agent/slash_commands/test/test_slash_command_handler.py
@@ -52,17 +52,17 @@ class TestSlashCommandHandlerNode(BaseTest):
         result = self.node._get_command(state)
         self.assertIsNone(result)
 
-    def test_router_returns_end_for_command(self):
+    async def test_router_returns_end_for_command(self):
         """Test that commands route to END (handled in arun)."""
         state = AssistantState(messages=[HumanMessage(content="/usage")])
-        result = self.node.router(state)
+        result = await self.node.arouter(state)
         self.assertEqual(result, AssistantNodeName.END)
 
-    def test_router_returns_send_list_for_non_command(self):
+    async def test_router_returns_send_list_for_non_command(self):
         """Test that non-command messages route to normal flow."""
         state = AssistantState(messages=[HumanMessage(content="Hello, how are you?")])
         with patch.object(self.node, "_team", self.team), patch.object(self.node, "_user", self.user):
-            result = self.node.router(state)
+            result = await self.node.arouter(state)
 
         self.assertIsInstance(result, list)
         send_list = cast(list[Send], result)
@@ -72,11 +72,11 @@ class TestSlashCommandHandlerNode(BaseTest):
         self.assertEqual(send_list[0].node, AssistantNodeName.ROOT)
         self.assertEqual(send_list[1].node, AssistantNodeName.MEMORY_COLLECTOR)
 
-    def test_router_returns_send_list_for_empty_messages(self):
+    async def test_router_returns_send_list_for_empty_messages(self):
         """Test that empty messages route to normal flow."""
         state = AssistantState(messages=[])
         with patch.object(self.node, "_team", self.team), patch.object(self.node, "_user", self.user):
-            result = self.node.router(state)
+            result = await self.node.arouter(state)
 
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 2)
@@ -114,10 +114,10 @@ class TestSlashCommandHandlerNode(BaseTest):
         result = self.node._get_command(state)
         self.assertEqual(result, SlashCommandName.FIELD_REMEMBER)
 
-    def test_router_returns_end_for_remember_command(self):
+    async def test_router_returns_end_for_remember_command(self):
         """Test that /remember command routes to END."""
         state = AssistantState(messages=[HumanMessage(content="/remember test fact")])
-        result = self.node.router(state)
+        result = await self.node.arouter(state)
         self.assertEqual(result, AssistantNodeName.END)
 
     def test_command_handlers_contains_feedback(self):
@@ -134,10 +134,10 @@ class TestSlashCommandHandlerNode(BaseTest):
         result = self.node._get_command(state)
         self.assertEqual(result, SlashCommandName.FIELD_FEEDBACK)
 
-    def test_router_returns_end_for_feedback_command(self):
+    async def test_router_returns_end_for_feedback_command(self):
         """Test that /feedback command routes to END."""
         state = AssistantState(messages=[HumanMessage(content="/feedback")])
-        result = self.node.router(state)
+        result = await self.node.arouter(state)
         self.assertEqual(result, AssistantNodeName.END)
 
     def test_get_command_detects_feedback_with_args(self):

--- a/ee/models/assistant.py
+++ b/ee/models/assistant.py
@@ -130,14 +130,14 @@ class CoreMemory(UUIDTModel):
     scraping_status = models.CharField(max_length=20, choices=ScrapingStatus.choices, blank=True, null=True)
     scraping_started_at = models.DateTimeField(null=True)
 
-    def change_status_to_pending(self):
+    async def achange_status_to_pending(self):
         self.scraping_started_at = timezone.now()
         self.scraping_status = CoreMemory.ScrapingStatus.PENDING
-        self.save()
+        await self.asave()
 
-    def change_status_to_skipped(self):
+    async def achange_status_to_skipped(self):
         self.scraping_status = CoreMemory.ScrapingStatus.SKIPPED
-        self.save()
+        await self.asave()
 
     @property
     def is_scraping_pending(self) -> bool:
@@ -150,35 +150,35 @@ class CoreMemory(UUIDTModel):
     def is_scraping_finished(self) -> bool:
         return self.scraping_status in [CoreMemory.ScrapingStatus.COMPLETED, CoreMemory.ScrapingStatus.SKIPPED]
 
-    def append_question_to_initial_text(self, text: str):
+    async def aappend_question_to_initial_text(self, text: str):
         if self.initial_text != "":
             self.initial_text += "\n"
         self.initial_text += "Question: " + text + "\nAnswer:"
         self.initial_text = self.initial_text.strip()
-        self.save()
+        await self.asave()
 
-    def append_answer_to_initial_text(self, text: str):
+    async def aappend_answer_to_initial_text(self, text: str):
         self.initial_text += " " + text
         self.initial_text = self.initial_text.strip()
-        self.save()
+        await self.asave()
 
-    def set_core_memory(self, text: str):
+    async def aset_core_memory(self, text: str):
         self.text = text
         self.scraping_status = CoreMemory.ScrapingStatus.COMPLETED
-        self.save()
+        await self.asave()
 
-    def append_core_memory(self, text: str):
+    async def aappend_core_memory(self, text: str):
         if self.text == "":
             self.text = text
         else:
             self.text = self.text + "\n" + text
-        self.save()
+        await self.asave()
 
-    def replace_core_memory(self, original_fragment: str, new_fragment: str):
+    async def areplace_core_memory(self, original_fragment: str, new_fragment: str):
         if original_fragment not in self.text:
             raise ValueError(f"Original fragment {original_fragment} not found in core memory")
         self.text = self.text.replace(original_fragment, new_fragment)
-        self.save()
+        await self.asave()
 
     @property
     def formatted_text(self) -> str:

--- a/ee/models/test/test_assistant.py
+++ b/ee/models/test/test_assistant.py
@@ -13,39 +13,39 @@ class TestCoreMemory(BaseTest):
         super().setUp()
         self.core_memory = CoreMemory.objects.create(team=self.team)
 
-    def test_status_changes(self):
+    async def test_status_changes(self):
         # Test pending status
-        self.core_memory.change_status_to_pending()
+        await self.core_memory.achange_status_to_pending()
         self.assertEqual(self.core_memory.scraping_status, CoreMemory.ScrapingStatus.PENDING)
         self.assertIsNotNone(self.core_memory.scraping_started_at)
 
         # Test skipped status
-        self.core_memory.change_status_to_skipped()
+        await self.core_memory.achange_status_to_skipped()
         self.assertEqual(self.core_memory.scraping_status, CoreMemory.ScrapingStatus.SKIPPED)
 
-    def test_scraping_status_properties(self):
+    async def test_scraping_status_properties(self):
         # Test pending status within time window
-        self.core_memory.change_status_to_pending()
+        await self.core_memory.achange_status_to_pending()
         self.assertTrue(self.core_memory.is_scraping_pending)
 
         # Test pending status outside time window
         self.core_memory.scraping_started_at = timezone.now() - timedelta(minutes=11)
-        self.core_memory.save()
+        await self.core_memory.asave()
         self.assertFalse(self.core_memory.is_scraping_pending)
 
         # Test finished status
         self.core_memory.scraping_status = CoreMemory.ScrapingStatus.COMPLETED
-        self.core_memory.save()
+        await self.core_memory.asave()
         self.assertTrue(self.core_memory.is_scraping_finished)
 
         self.core_memory.scraping_status = CoreMemory.ScrapingStatus.SKIPPED
-        self.core_memory.save()
+        await self.core_memory.asave()
         self.assertTrue(self.core_memory.is_scraping_finished)
 
     @freeze_time("2023-01-01 12:00:00")
-    def test_is_scraping_pending_timing(self):
+    async def test_is_scraping_pending_timing(self):
         # Set initial pending status
-        self.core_memory.change_status_to_pending()
+        await self.core_memory.achange_status_to_pending()
         initial_time = timezone.now()
 
         # Test 3 minutes after (should be true)
@@ -60,38 +60,38 @@ class TestCoreMemory(BaseTest):
         with freeze_time(initial_time + timedelta(minutes=11)):
             self.assertFalse(self.core_memory.is_scraping_pending)
 
-    def test_core_memory_operations(self):
+    async def test_core_memory_operations(self):
         # Test setting core memory
         test_text = "Test memory content"
-        self.core_memory.set_core_memory(test_text)
+        await self.core_memory.aset_core_memory(test_text)
         self.assertEqual(self.core_memory.text, test_text)
         self.assertEqual(self.core_memory.initial_text, "")
         self.assertEqual(self.core_memory.scraping_status, CoreMemory.ScrapingStatus.COMPLETED)
 
         # Test appending core memory
         append_text = "Additional content"
-        self.core_memory.append_core_memory(append_text)
+        await self.core_memory.aappend_core_memory(append_text)
         self.assertEqual(self.core_memory.text, f"{test_text}\n{append_text}")
 
         # Test replacing core memory
         original = "content"
         new = "memory"
-        self.core_memory.replace_core_memory(original, new)
+        await self.core_memory.areplace_core_memory(original, new)
         self.assertIn(new, self.core_memory.text)
         self.assertNotIn(original, self.core_memory.text)
 
         # Test replacing non-existent content
         with self.assertRaises(ValueError):
-            self.core_memory.replace_core_memory("nonexistent", "new")
+            await self.core_memory.areplace_core_memory("nonexistent", "new")
 
-    def test_formatted_text(self):
+    async def test_formatted_text(self):
         # Test formatted text with short content
         short_text = "Short text"
-        self.core_memory.set_core_memory(short_text)
+        await self.core_memory.aset_core_memory(short_text)
         self.assertEqual(self.core_memory.formatted_text, short_text)
 
         # Test formatted text with long content
         long_text = "x" * 6000
-        self.core_memory.set_core_memory(long_text)
+        await self.core_memory.aset_core_memory(long_text)
         self.assertEqual(len(self.core_memory.formatted_text), 5001)
         self.assertEqual(self.core_memory.formatted_text, long_text[:2500] + "…" + long_text[-2500:])

--- a/ee/pytest.ini
+++ b/ee/pytest.ini
@@ -9,3 +9,5 @@ markers =
     ee
     clickhouse_only
     skip_on_multitenancy
+
+asyncio_mode = auto

--- a/posthog/temporal/ai/chat_agent.py
+++ b/posthog/temporal/ai/chat_agent.py
@@ -83,9 +83,12 @@ async def process_conversation_activity(inputs: AssistantConversationRunnerWorkf
 
     team, user, conversation = await asyncio.gather(
         Team.objects.aget(id=inputs.team_id),
-        User.objects.aget(id=inputs.user_id),
+        User.objects.filter(id=inputs.user_id).select_related("current_organization").afirst(),
         Conversation.objects.aget(id=inputs.conversation_id),
     )
+
+    if not user:
+        raise ValueError(f"User with id {inputs.user_id} not found")
 
     human_message = HumanMessage.model_validate(inputs.message) if inputs.message else None
 

--- a/posthog/temporal/tests/ai/test_chat_agent_activity.py
+++ b/posthog/temporal/tests/ai/test_chat_agent_activity.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from posthog.schema import AgentMode
 
-from posthog.models import Team, User
 from posthog.temporal.ai.chat_agent import (
     AssistantConversationRunnerWorkflowInputs,
     get_conversation_stream_key,
@@ -18,47 +17,22 @@ from ee.hogai.utils.types import AssistantMode
 from ee.models import Conversation
 
 
+@pytest.mark.django_db(transaction=True)
 class TestProcessChatAgentActivity:
-    """Test the process_conversation_activity function."""
-
     @pytest.fixture
-    def mock_team(self):
-        """Mock team object."""
-        team = MagicMock(spec=Team)
-        team.id = 1
-        team.name = "Test Team"
-        return team
-
-    @pytest.fixture
-    def mock_user(self):
-        """Mock user object."""
-        user = MagicMock(spec=User)
-        user.id = 2
-        user.email = "test@example.com"
-        return user
-
-    @pytest.fixture
-    def mock_conversation(self):
-        """Mock conversation object."""
-        conversation = MagicMock(spec=Conversation)
-        conversation.id = uuid4()
-        conversation.team_id = 1
-        conversation.user_id = 2
-        return conversation
+    def conversation(self, team, user):
+        return Conversation.objects.create(team=team, user=user)
 
     @pytest.fixture
     def mock_redis_stream(self):
-        """Mock RedisStream."""
         stream = AsyncMock()
         stream.write_to_stream = AsyncMock()
         return stream
 
     @pytest.fixture
     def mock_assistant(self):
-        """Mock Assistant with streaming capability."""
         assistant = MagicMock()
 
-        # Mock the async stream to yield chunks
         async def mock_astream():
             chunks = [
                 {"type": "ai", "content": "Hello", "id": "1"},
@@ -72,12 +46,11 @@ class TestProcessChatAgentActivity:
         return assistant
 
     @pytest.fixture
-    def conversation_inputs(self):
-        """Basic conversation inputs."""
+    def conversation_inputs(self, team, user, conversation):
         return AssistantConversationRunnerWorkflowInputs(
-            team_id=1,
-            user_id=2,
-            conversation_id=uuid4(),
+            team_id=team.id,
+            user_id=user.id,
+            conversation_id=conversation.id,
             message={"content": "Hello", "type": "human"},
             is_new_conversation=True,
             trace_id="test-trace",
@@ -88,50 +61,27 @@ class TestProcessChatAgentActivity:
     async def test_process_conversation_activity_success(
         self,
         conversation_inputs,
-        mock_team,
-        mock_user,
-        mock_conversation,
         mock_redis_stream,
         mock_assistant,
     ):
-        """Test successful conversation processing."""
         with (
-            patch("posthog.temporal.ai.chat_agent.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
-            patch("posthog.temporal.ai.chat_agent.User.objects.aget", new=AsyncMock(return_value=mock_user)),
-            patch(
-                "posthog.temporal.ai.chat_agent.Conversation.objects.aget",
-                new=AsyncMock(return_value=mock_conversation),
-            ),
             patch(
                 "posthog.temporal.ai.chat_agent.ConversationRedisStream", return_value=mock_redis_stream
             ) as mock_redis_stream_class,
             patch("posthog.temporal.ai.chat_agent.ChatAgentRunner", return_value=mock_assistant),
         ):
-            # Execute the activity
             await process_conversation_activity(conversation_inputs)
 
-            # Verify database queries were made (they're patched, so we just check execution completed)
-
-            # Verify RedisStream operations
             expected_stream_key = f"{CONVERSATION_STREAM_PREFIX}{conversation_inputs.conversation_id}"
-
-            # Verify RedisStream was created with correct key
             mock_redis_stream_class.assert_called_once_with(expected_stream_key)
-
-            # Verify write_to_stream was called once
             mock_redis_stream.write_to_stream.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_process_conversation_activity_streaming_error(
         self,
         conversation_inputs,
-        mock_team,
-        mock_user,
-        mock_conversation,
         mock_redis_stream,
     ):
-        """Test error handling during streaming."""
-        # Mock Assistant to raise an error during streaming
         mock_assistant = MagicMock()
 
         async def mock_astream():
@@ -139,91 +89,64 @@ class TestProcessChatAgentActivity:
             raise Exception("Streaming error")
 
         mock_assistant.astream = mock_astream
-
-        # Mock RedisStream to raise an error during write_to_stream
         mock_redis_stream.write_to_stream = AsyncMock(side_effect=Exception("Streaming error"))
 
         with (
-            patch("posthog.temporal.ai.chat_agent.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
-            patch("posthog.temporal.ai.chat_agent.User.objects.aget", new=AsyncMock(return_value=mock_user)),
-            patch(
-                "posthog.temporal.ai.chat_agent.Conversation.objects.aget",
-                new=AsyncMock(return_value=mock_conversation),
-            ),
             patch("posthog.temporal.ai.chat_agent.ConversationRedisStream", return_value=mock_redis_stream),
             patch("posthog.temporal.ai.chat_agent.ChatAgentRunner", return_value=mock_assistant),
         ):
-            # Should raise the streaming error
             with pytest.raises(Exception, match="Streaming error"):
                 await process_conversation_activity(conversation_inputs)
 
-            # Verify write_to_stream was called once
             mock_redis_stream.write_to_stream.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_process_conversation_activity_no_message(
         self,
-        mock_team,
-        mock_user,
-        mock_conversation,
+        team,
+        user,
+        conversation,
         mock_redis_stream,
         mock_assistant,
     ):
-        """Test processing without a message."""
         inputs = AssistantConversationRunnerWorkflowInputs(
-            team_id=1,
-            user_id=2,
-            conversation_id=uuid4(),
-            message=None,  # No message
+            team_id=team.id,
+            user_id=user.id,
+            conversation_id=conversation.id,
+            message=None,
         )
 
         with (
-            patch("posthog.temporal.ai.chat_agent.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
-            patch("posthog.temporal.ai.chat_agent.User.objects.aget", new=AsyncMock(return_value=mock_user)),
-            patch(
-                "posthog.temporal.ai.chat_agent.Conversation.objects.aget",
-                new=AsyncMock(return_value=mock_conversation),
-            ),
             patch("posthog.temporal.ai.chat_agent.ConversationRedisStream", return_value=mock_redis_stream),
             patch(
                 "posthog.temporal.ai.chat_agent.ChatAgentRunner", return_value=mock_assistant
             ) as mock_assistant_create,
         ):
-            # Execute the activity
             await process_conversation_activity(inputs)
 
-            # Verify Assistant was created with None message
             mock_assistant_create.assert_called_once()
             call_args = mock_assistant_create.call_args
             assert call_args[1]["new_message"] is None
-
-            # Verify write_to_stream was called once
             mock_redis_stream.write_to_stream.assert_called_once()
 
+    @pytest.mark.asyncio
     async def test_process_conversation_activity_sets_agent_mode(
         self,
-        mock_team,
-        mock_user,
-        mock_conversation,
+        team,
+        user,
+        conversation,
         mock_redis_stream,
         mock_assistant,
     ):
-        """Ensure agent mode is forwarded to the runner."""
         inputs = AssistantConversationRunnerWorkflowInputs(
-            team_id=1,
-            user_id=2,
-            conversation_id=uuid4(),
+            team_id=team.id,
+            user_id=user.id,
+            conversation_id=conversation.id,
             message={"content": "Hello", "type": "human"},
             agent_mode=AgentMode.SESSION_REPLAY,
         )
 
         with (
-            patch("posthog.temporal.ai.chat_agent.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
-            patch("posthog.temporal.ai.chat_agent.User.objects.aget", new=AsyncMock(return_value=mock_user)),
-            patch(
-                "posthog.temporal.ai.chat_agent.Conversation.objects.aget",
-                new=AsyncMock(return_value=mock_conversation),
-            ),
             patch("posthog.temporal.ai.chat_agent.ConversationRedisStream", return_value=mock_redis_stream),
             patch(
                 "posthog.temporal.ai.chat_agent.ChatAgentRunner", return_value=mock_assistant
@@ -235,54 +158,33 @@ class TestProcessChatAgentActivity:
             mock_redis_stream.write_to_stream.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_heartbeat_callback(
-        self, conversation_inputs, mock_team, mock_user, mock_conversation, mock_redis_stream, mock_assistant
-    ):
-        """Test that heartbeat callback is throttled to avoid too many calls."""
-        # Mock activity context
+    async def test_heartbeat_callback(self, conversation_inputs, mock_redis_stream, mock_assistant):
         mock_activity = Mock()
         mock_activity.heartbeat = Mock()
         with (
-            patch("posthog.temporal.ai.chat_agent.Team.objects.aget", new=AsyncMock(return_value=mock_team)),
-            patch("posthog.temporal.ai.chat_agent.User.objects.aget", new=AsyncMock(return_value=mock_user)),
-            patch(
-                "posthog.temporal.ai.chat_agent.Conversation.objects.aget",
-                new=AsyncMock(return_value=mock_conversation),
-            ),
             patch("posthog.temporal.ai.chat_agent.ConversationRedisStream", return_value=mock_redis_stream),
             patch("posthog.temporal.ai.chat_agent.ChatAgentRunner", return_value=mock_assistant),
             patch("posthog.temporal.ai.chat_agent.activity", mock_activity),
         ):
-            # Track callback invocations
             callback_invocations = []
 
             async def mock_write_to_stream(generator, callback=None):
-                # Simulate rapid message generation
                 if callback:
                     start_time = time.time()
-                    for _ in range(20):  # 20 messages in quick succession
+                    for _ in range(20):
                         callback()
                         callback_invocations.append(time.time() - start_time)
 
             mock_redis_stream.write_to_stream = mock_write_to_stream
 
-            # Run the activity
             await process_conversation_activity(conversation_inputs)
 
-            # Check that heartbeat was called but not for every message
-            # With 20 messages at 100ms intervals (2 seconds total) and 5-second throttle,
-            # we should see at most 1 heartbeat call
             assert mock_activity.heartbeat.call_count == 20
-
-            # Verify the callback was invoked for each message
             assert len(callback_invocations) == 20
 
 
 class TestUtilityFunctions:
-    """Test utility functions."""
-
     def test_get_conversation_stream_key(self):
-        """Test get_conversation_stream_key function."""
         conversation_id = uuid4()
         expected_key = f"{CONVERSATION_STREAM_PREFIX}{conversation_id}"
 


### PR DESCRIPTION
## Problem
Memory nodes are sync and lead to deadlocks when running subagent workflows. Let's convert memory-related nodes to async to remove blocking operations.

## Changes
- Converted memory-related nodes to use async/await pattern
- Added asyncio_mode = auto to pytest.ini (this is present in the main pytest.ini but not in ee)

## How did you test this code?
Updated all tests
