### PR TITLE
fix(cohorts): Ability to create quick surveys for static cohorts

### DIFF
--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -307,7 +307,7 @@ export function Cohorts(): JSX.Element {
                     cohortId: quickSurveyModalState.cohortId,
                     cohortName: quickSurveyModalState.cohortName,
                 }}
-                info="This survey will display to all users in this cohort."
+                info="This survey will display to all users in the cohort."
                 isOpen={quickSurveyModalState.isOpen}
                 onCancel={() => {
                     closeQuickSurveyModal()

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -21,7 +21,6 @@ import { PersonsManagementSceneTabs } from 'scenes/persons-management/PersonsMan
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
 import { QuickSurveyModal } from 'scenes/surveys/QuickSurveyModal'
-import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -155,10 +154,6 @@ export function Cohorts(): JSX.Element {
                                     <LemonButton
                                         onClick={() => {
                                             if (cohort.id === 'new') {
-                                                return
-                                            }
-                                            // Can only create survey for static cohort
-                                            if (!cohort.is_static) {
                                                 return
                                             }
                                             openQuickSurveyModal(cohort.id, cohort.name)
@@ -308,11 +303,7 @@ export function Cohorts(): JSX.Element {
                 useURLForSorting={false}
             />
             <QuickSurveyModal
-                context={{
-                    type: QuickSurveyType.COHORT,
-                    cohortId: quickSurveyModalState.cohortId,
-                    cohortName: quickSurveyModalState.cohortName,
-                }}
+                context={quickSurveyModalState.context}
                 info="This survey will display to all users in the cohort."
                 isOpen={quickSurveyModalState.isOpen}
                 onCancel={() => {

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -20,6 +20,8 @@ import { cohortsSceneLogic } from 'scenes/cohorts/cohortsSceneLogic'
 import { PersonsManagementSceneTabs } from 'scenes/persons-management/PersonsManagementSceneTabs'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
+import { QuickSurveyModal } from 'scenes/surveys/QuickSurveyModal'
+import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -33,9 +35,23 @@ export const scene: SceneExport = {
 }
 
 export function Cohorts(): JSX.Element {
-    const { cohorts, cohortsLoading, pagination, cohortFilters, shouldShowEmptyState, cohortSorting } =
-        useValues(cohortsSceneLogic)
-    const { deleteCohort, exportCohortPersons, setCohortFilters, setCohortSorting } = useActions(cohortsSceneLogic)
+    const {
+        cohorts,
+        cohortsLoading,
+        pagination,
+        cohortFilters,
+        shouldShowEmptyState,
+        cohortSorting,
+        quickSurveyModalState,
+    } = useValues(cohortsSceneLogic)
+    const {
+        deleteCohort,
+        exportCohortPersons,
+        setCohortFilters,
+        setCohortSorting,
+        openQuickSurveyModal,
+        closeQuickSurveyModal,
+    } = useActions(cohortsSceneLogic)
     const { searchParams } = useValues(router)
 
     const columns: LemonTableColumns<CohortType> = [
@@ -134,6 +150,18 @@ export function Cohorts(): JSX.Element {
                                     fullWidth
                                 >
                                     Export all columns for users
+                                </LemonButton>
+                                <LemonButton
+                                    onClick={() => {
+                                        if (cohort.id === 'new') {
+                                            return
+                                        }
+                                        openQuickSurveyModal(cohort.id, cohort.name)
+                                    }}
+                                    tooltip="Create a survey that targets the cohort"
+                                    fullWidth
+                                >
+                                    Create survey
                                 </LemonButton>
                                 <LemonDivider />
                                 <LemonButton
@@ -272,6 +300,18 @@ export function Cohorts(): JSX.Element {
                     setCohortSorting(sorting)
                 }}
                 useURLForSorting={false}
+            />
+            <QuickSurveyModal
+                context={{
+                    type: QuickSurveyType.COHORT,
+                    cohortId: quickSurveyModalState.cohortId,
+                    cohortName: quickSurveyModalState.cohortName,
+                }}
+                info="This survey will display to all users in this cohort."
+                isOpen={quickSurveyModalState.isOpen}
+                onCancel={() => {
+                    closeQuickSurveyModal()
+                }}
             />
         </SceneContent>
     )

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -151,18 +151,24 @@ export function Cohorts(): JSX.Element {
                                 >
                                     Export all columns for users
                                 </LemonButton>
-                                <LemonButton
-                                    onClick={() => {
-                                        if (cohort.id === 'new') {
-                                            return
-                                        }
-                                        openQuickSurveyModal(cohort.id, cohort.name)
-                                    }}
-                                    tooltip="Create a survey that targets the cohort"
-                                    fullWidth
-                                >
-                                    Create survey
-                                </LemonButton>
+                                {cohort.is_static && (
+                                    <LemonButton
+                                        onClick={() => {
+                                            if (cohort.id === 'new') {
+                                                return
+                                            }
+                                            // Can only create survey for static cohort
+                                            if (!cohort.is_static) {
+                                                return
+                                            }
+                                            openQuickSurveyModal(cohort.id, cohort.name)
+                                        }}
+                                        tooltip="Create a survey that targets the cohort"
+                                        fullWidth
+                                    >
+                                        Create survey
+                                    </LemonButton>
+                                )}
                                 <LemonDivider />
                                 <LemonButton
                                     status="danger"

--- a/frontend/src/scenes/cohorts/cohortsSceneLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortsSceneLogic.ts
@@ -13,6 +13,7 @@ import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { objectsEqual } from 'lib/utils'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { personsLogic } from 'scenes/persons/personsLogic'
+import { QuickSurveyType } from 'scenes/surveys/quick-create/types'
 import { urls } from 'scenes/urls'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
@@ -46,8 +47,11 @@ type QuickSurveyModalState =
       }
     | {
           isOpen: true
-          cohortId: number
-          cohortName?: string
+          context: {
+              type: QuickSurveyType.COHORT
+              cohortId: number
+              cohortName?: string
+          }
       }
 
 export const cohortsSceneLogic = kea<cohortsSceneLogicType>([
@@ -104,8 +108,11 @@ export const cohortsSceneLogic = kea<cohortsSceneLogicType>([
                 openQuickSurveyModal: (_, { cohortId, cohortName }) => {
                     return {
                         isOpen: true,
-                        cohortId,
-                        cohortName,
+                        context: {
+                            type: QuickSurveyType.COHORT,
+                            cohortId,
+                            cohortName,
+                        },
                     }
                 },
                 closeQuickSurveyModal: () => {

--- a/frontend/src/scenes/cohorts/cohortsSceneLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortsSceneLogic.ts
@@ -61,7 +61,7 @@ export const cohortsSceneLogic = kea<cohortsSceneLogicType>([
         deleteCohort: (cohort: Partial<CohortType>) => ({ cohort }),
         exportCohortPersons: (id: CohortType['id'], columns?: string[]) => ({ id, columns }),
         setCohortSorting: (sorting: Sorting | null) => ({ sorting }),
-        openQuickSurveyModal: (cohortId: number) => ({ cohortId }),
+        openQuickSurveyModal: (cohortId: number, cohortName?: string) => ({ cohortId, cohortName }),
         closeQuickSurveyModal: true,
     })),
     reducers({

--- a/frontend/src/scenes/cohorts/cohortsSceneLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortsSceneLogic.ts
@@ -40,6 +40,16 @@ const DEFAULT_COHORT_FILTERS: CohortFilters = {
 
 const COHORTS_PER_PAGE = 100
 
+type QuickSurveyModalState =
+    | {
+          isOpen: false
+      }
+    | {
+          isOpen: true
+          cohortId: number
+          cohortName?: string
+      }
+
 export const cohortsSceneLogic = kea<cohortsSceneLogicType>([
     path(['scenes', 'cohorts', 'cohortsSceneLogic']),
     tabAwareScene(),
@@ -51,6 +61,8 @@ export const cohortsSceneLogic = kea<cohortsSceneLogicType>([
         deleteCohort: (cohort: Partial<CohortType>) => ({ cohort }),
         exportCohortPersons: (id: CohortType['id'], columns?: string[]) => ({ id, columns }),
         setCohortSorting: (sorting: Sorting | null) => ({ sorting }),
+        openQuickSurveyModal: (cohortId: number) => ({ cohortId }),
+        closeQuickSurveyModal: true,
     })),
     reducers({
         cohortFilters: [
@@ -82,6 +94,23 @@ export const cohortsSceneLogic = kea<cohortsSceneLogicType>([
                     return {
                         ...state,
                         results: state.results.filter((c) => c.id !== cohort.id),
+                    }
+                },
+            },
+        ],
+        quickSurveyModalState: [
+            { isOpen: false } as QuickSurveyModalState,
+            {
+                openQuickSurveyModal: (_, { cohortId, cohortName }) => {
+                    return {
+                        isOpen: true,
+                        cohortId,
+                        cohortName,
+                    }
+                },
+                closeQuickSurveyModal: () => {
+                    return {
+                        isOpen: false,
                     }
                 },
             },

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -680,6 +680,7 @@ export enum SURVEY_CREATED_SOURCE {
     INSIGHT_CROSS_SELL = 'insight_cross_sell',
     CUSTOMER_ANALYTICS_INSIGHT = 'customer_analytics_insight',
     ERROR_TRACKING = 'error_tracking',
+    COHORTS = 'cohorts',
 }
 
 export enum SURVEY_FORM_INPUT_IDS {

--- a/frontend/src/scenes/surveys/quick-create/quickSurveyFormLogic.ts
+++ b/frontend/src/scenes/surveys/quick-create/quickSurveyFormLogic.ts
@@ -45,6 +45,7 @@ export interface QuickSurveyFormValues {
     conditions: Survey['conditions']
     appearance: Survey['appearance']
     linkedFlagId?: number | null
+    targeting_flag_filters?: Survey['targeting_flag_filters']
 }
 
 export interface QuickSurveyFormLogicProps {
@@ -140,6 +141,9 @@ export const quickSurveyFormLogic = kea<quickSurveyFormLogicType>([
                     appearance: formValues.appearance,
                     ...(formValues.linkedFlagId ? { linked_flag_id: formValues.linkedFlagId } : {}),
                     ...(shouldLaunch ? { start_date: dayjs().toISOString() } : {}),
+                    ...(formValues.targeting_flag_filters
+                        ? { targeting_flag_filters: formValues.targeting_flag_filters }
+                        : {}),
                 }
 
                 const response = await api.surveys.create(surveyData)

--- a/frontend/src/scenes/surveys/quick-create/types.ts
+++ b/frontend/src/scenes/surveys/quick-create/types.ts
@@ -8,6 +8,7 @@ export type QuickSurveyContext =
     | { type: QuickSurveyType.EXPERIMENT; experiment: Experiment }
     | { type: QuickSurveyType.ANNOUNCEMENT }
     | { type: QuickSurveyType.ERROR_TRACKING; exceptionType: string; exceptionMessage?: string | null }
+    | { type: QuickSurveyType.COHORT; cohortId: number; cohortName?: string }
 
 export interface QuickSurveyFormProps {
     context: QuickSurveyContext
@@ -21,4 +22,5 @@ export enum QuickSurveyType {
     EXPERIMENT = 'experiment',
     ANNOUNCEMENT = 'announcement',
     ERROR_TRACKING = 'error_tracking',
+    COHORT = 'cohort',
 }

--- a/frontend/src/scenes/surveys/quick-create/utils.ts
+++ b/frontend/src/scenes/surveys/quick-create/utils.ts
@@ -1,6 +1,7 @@
 import { SurveyQuestionType } from 'posthog-js'
 
 import { EventsNode } from '~/queries/schema/schema-general'
+import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { SURVEY_CREATED_SOURCE, defaultSurveyAppearance } from '../constants'
 import { toSurveyEvent } from '../utils/opportunityDetection'
@@ -82,6 +83,35 @@ export const buildLogicProps = (context: QuickSurveyContext): Omit<QuickSurveyFo
                     question: 'Hog mode is now available!',
                     description: 'You can never have too many hedgehogs.',
                     buttonText: 'Check it out 👉',
+                }
+            }
+        case QuickSurveyType.COHORT:
+            return {
+                key: `cohort-${context.cohortId}`,
+                contextType: context.type,
+                source: SURVEY_CREATED_SOURCE.COHORTS,
+                defaults: {
+                    name: `Cohort ${context.cohortName ?? context.cohortId} - Quick feedback ${randomId}`,
+                    question: 'Ask your cohort a question',
+                    targeting_flag_filters: {
+                        groups: [
+                            {
+                                properties: [
+                                    {
+                                        key: 'id',
+                                        value: context.cohortId,
+                                        type: PropertyFilterType.Cohort,
+                                        operator: PropertyOperator.In,
+                                        cohort_name: 'Static cohort',
+                                    },
+                                ],
+                                rollout_percentage: 100,
+                                variant: null,
+                            },
+                        ],
+                        multivariate: null,
+                        payloads: {},
+                    },
                 },
             }
 

--- a/frontend/src/scenes/surveys/quick-create/utils.ts
+++ b/frontend/src/scenes/surveys/quick-create/utils.ts
@@ -92,7 +92,7 @@ export const buildLogicProps = (context: QuickSurveyContext): Omit<QuickSurveyFo
                 source: SURVEY_CREATED_SOURCE.COHORTS,
                 defaults: {
                     name: `Cohort ${context.cohortName ?? context.cohortId} - Quick feedback ${randomId}`,
-                    question: 'Ask your cohort a question',
+                    question: 'Ask the cohort a question',
                     targeting_flag_filters: {
                         groups: [
                             {


### PR DESCRIPTION
## Problem

Inspired by @adboio recent efforts, I thought this would be pretty neat.

Feel free to close this though I was just curious if survey could target members of a cohort.

## Changes

Note: This is only available for static cohort for now because cohort with behavioural filters can't be used in survey targeting for now: https://posthog.com/docs/feature-flags/common-questions#why-cant-i-use-a-cohort-with-behavioral-filters-in-my-feature-flag

I briefly checked it out, it seems like there is possibility a `cohort_type` that we can use; however in https://github.com/PostHog/posthog/pull/36606 it was mentioned that it could be `null` for the older cohorts that are created.

We could also calculate whether its behavioral on the frontend, but I believe that calculation code warrants a separate PR 

https://github.com/user-attachments/assets/e2b5c2d9-293f-4f57-b530-53989392d496



## How did you test this code?

1) Go to a cohorts page
2) Click on the three dots on the right for a static cohort
3) Click on `Create Survey`
4) A modal will appear, create the survey
5) Check that the created survey is targeting the static cohort 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
