### PR TITLE
fix(surveys): a couple query optimizations

### DIFF
--- a/frontend/src/scenes/surveys/surveysLogic.tsx
+++ b/frontend/src/scenes/surveys/surveysLogic.tsx
@@ -240,8 +240,8 @@ export const surveysLogic = kea<surveysLogicType>([
         },
         surveysResponsesCount: {
             __default: {} as { [key: string]: number },
-            loadResponsesCount: async () => {
-                const surveysResponsesCount = await api.surveys.getResponsesCount()
+            loadResponsesCount: async (surveyIds: string) => {
+                const surveysResponsesCount = await api.surveys.getResponsesCount(surveyIds)
                 return surveysResponsesCount
             },
         },
@@ -307,10 +307,14 @@ export const surveysLogic = kea<surveysLogicType>([
         },
         setSurveysFilters: () => {
             actions.loadSurveys()
-            actions.loadResponsesCount()
         },
         loadSurveysSuccess: () => {
             actions.loadCurrentTeam()
+
+            if (values.data.surveys.length > 0) {
+                const surveyIds = values.data.surveys.map((s) => s.id).join(',')
+                actions.loadResponsesCount(surveyIds)
+            }
 
             if (values.data.surveys.some((survey) => survey.start_date)) {
                 activationLogic.findMounted()?.actions.markTaskAsCompleted(ActivationTask.LaunchSurvey)
@@ -437,6 +441,5 @@ export const surveysLogic = kea<surveysLogicType>([
     })),
     afterMount(({ actions }) => {
         actions.loadSurveys()
-        actions.loadResponsesCount()
     }),
 ])

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1548,7 +1548,7 @@ class _Printer(Visitor[str]):
                     survey_id = node.args[0]
                     if not isinstance(survey_id, ast.Constant):
                         raise QueryError("uniqueSurveySubmissionsFilter first argument must be a constant")
-                    return filter_survey_sent_events_by_unique_submission(survey_id.value)
+                    return filter_survey_sent_events_by_unique_submission(survey_id.value, self.context.team_id)
 
                 relevant_clickhouse_name = func_meta.clickhouse_name
                 if "{}" in relevant_clickhouse_name:

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -2509,7 +2509,7 @@ class TestPrinter(BaseTest):
                 "select uuid from events where uniqueSurveySubmissionsFilter('survey123')",
                 settings=HogQLGlobalSettings(max_execution_time=10),
             )
-            mock_filter_survey_sent_events_by_unique_submission.assert_called_once_with("survey123")
+            mock_filter_survey_sent_events_by_unique_submission.assert_called_once_with("survey123", self.team.pk)
             self.assertIn("MOCKED SQL FOR UNIQUE SURVEY SUBMISSIONS FILTER", printed)
 
     def test_override_timezone(self):

--- a/posthog/models/surveys/util.py
+++ b/posthog/models/surveys/util.py
@@ -72,10 +72,10 @@ def _build_multiple_choice_query(id_based_key: str, index_based_key: str) -> str
     )"""
 
 
-def filter_survey_sent_events_by_unique_submission(survey_id: str) -> str:
+def filter_survey_sent_events_by_unique_submission(survey_id: str, team_id: int | None = None) -> str:
     """
     Generates a SQL condition string to filter 'survey sent' events, ensuring uniqueness based on submission ID,
-    using an optimized approach with argMax(). Usage with uniqueSurveySubmissionsFilter(survey_id).
+    using an optimized approach with argMax(). Usage with uniqueSurveySubmissionsFilter(survey_id, team_id).
 
     This handles two scenarios for identifying relevant 'survey sent' events:
     1. Events recorded before the introduction of `$survey_submission_id` (submission_id is empty/null):
@@ -85,6 +85,7 @@ def filter_survey_sent_events_by_unique_submission(survey_id: str) -> str:
 
     Args:
         survey_id: The ID of the survey to filter events for.
+        team_id: Optional team ID to filter events
 
     Returns:
         A SQL condition string (part of a WHERE clause) filtering event UUIDs.
@@ -99,12 +100,17 @@ def filter_survey_sent_events_by_unique_submission(survey_id: str) -> str:
         f"CASE WHEN COALESCE({submission_id_col}, '') = '' THEN toString(uuid) ELSE {submission_id_col} END"
     )
 
+    extra_filters = ""
+    if team_id is not None:
+        extra_filters += f" AND team_id = {team_id}"
+
     query = f"""uuid IN (
         SELECT
             argMax(uuid, timestamp) -- Selects the UUID of the event with the latest timestamp within each group
         FROM events
         WHERE event = '{SurveyEventName.SENT}' -- Filter for 'survey sent' events
           AND JSONExtractString(properties, '{SurveyEventProperties.SURVEY_ID}') = '{survey_id}' -- Filter for the specific survey
+          {extra_filters}
           -- Date range filters from the outer query are intentionally NOT included here.
           -- This ensures we find the globally latest unique submission, which is then
           -- filtered by the outer query's date range.


### PR DESCRIPTION
## Problem

1. new AI summary endpoint is extremely slow - times out after 60s on the endpoint - and times out after 120s in posthog sql insight 😭 i cannot find any evidence of a query with `uniqueSurveySubmissionsFilter` ever succeeding in prod (works fine in local tho lol)
2. we call loadResponsesCount too frequently, and without filtering on survey IDs, it can be extremely slow

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

response count queries in the past week:

| p50 | p90 | p95 | p99 | max | total |
| --- | --- | --- | --- | --- | --- |
| 8986 ms | 31176 ms | 46294 ms | 80642 ms | 418725 ms | 315 |

## Changes

1. added team ID filters to uniqueSurveySubmissionsFilter to (hopefully) fix the AI summary endpoint
2. removed loadResponsesCount from the surveysLogic afterMount, and instead call it on loadSurveysSuccess _with_ a list of survey IDs
    1. this is probably only a marginal benefit, we should look into better options moving fwd, but hopefully will help a bit. lucas suggested caching response data in indexeddb and just loading behind the scenes. this won't help query performance, but i'll make for a snappier UI

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

this query consistently times out at 120s:

```sql
  SELECT count(*)
  FROM events
  WHERE event = 'survey sent'
      AND JSONExtractString(properties, '$survey_id') = '019a9dc5-745c-0000-231d-8ce32972cd72'
      AND timestamp >= '2024-01-01 00:00:00'
      AND timestamp <= now()
      AND uniqueSurveySubmissionsFilter('019a9dc5-745c-0000-231d-8ce32972cd72')
```

one suspicion i have is that uniqueSurveySubmissionsFilter is not filtering on a team ID

i can't 100% replicate this in posthog sql... BUT this query:

```sql
select *
from query_log
where query like '%019a9dc5-745c-0000-231d-8ce32972cd72%'
  and query like '%uniqueSurveySubmissionsFilter%'
  and query not like '%query_log%'
  and event_time >= '2025-12-05 00:00:00'
order by query_start_time desc
limit 20
```

reveals that these queries are reading ~49 BILLION rows

compared to this query, which does the same thing, and reads only ~27 million rows:

```sql
SELECT count(*)
FROM events
WHERE event = 'survey sent'
    AND JSONExtractString(properties, '$survey_id') = '019a9dc5-745c-0000-231d-8ce32972cd72'
    AND team_id = 2
    AND uuid IN (
        SELECT argMax(uuid, timestamp)
        FROM events
        WHERE event = 'survey sent'
            AND JSONExtractString(properties, '$survey_id') = '019a9dc5-745c-0000-231d-8ce32972cd72'
            AND team_id = 2
        GROUP BY
            CASE WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = ''
                  THEN toString(uuid)
                  ELSE JSONExtractString(properties, '$survey_submission_id')
            END
    )
```

also this query times out at 120s:

```sql
SELECT count(*)
FROM events
WHERE JSONExtractString(properties, '$survey_id') = '019a9dc5-745c-0000-231d-8ce32972cd72'
```

## How did you test this code?

- unit testing
- manual testing

i ran this locally, once against master and once against this PR:

```python
from posthog.hogql.parser import parse_select
from posthog.hogql.printer import prepare_and_print_ast
from posthog.hogql.context import HogQLContext
from posthog.models import Team

team = Team.objects.get(id=2)
ctx = HogQLContext(team_id=team.pk, enable_select_queries=True)

query = "SELECT count(*) FROM events WHERE event = 'survey sent' AND uniqueSurveySubmissionsFilter('019a9dc5-745c-0000-231d-8ce32972cd72')"
ast = parse_select(query)
sql = prepare_and_print_ast(ast, ctx, dialect="clickhouse")
print(sql[0])
```

on master, the query is:

```sql
SELECT count(*) AS `count(*)` FROM events WHERE and(equals(events.team_id, 2), equals(events.event, %(hogql_val_0)s), uuid IN (
        SELECT
            argMax(uuid, timestamp) -- Selects the UUID of the event with the latest timestamp within each group
        FROM events
        WHERE event = 'survey sent' -- Filter for 'survey sent' events
          AND JSONExtractString(properties, '$survey_id') = '019a9dc5-745c-0000-231d-8ce32972cd72' -- Filter for the specific survey
          -- Date range filters from the outer query are intentionally NOT included here.
          -- This ensures we find the globally latest unique submission, which is then
          -- filtered by the outer query's date range.
        GROUP BY CASE WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = '' THEN toString(uuid) ELSE JSONExtractString(properties, '$survey_submission_id') END -- Group events by the
effective submission identifier
    )) LIMIT 50000
```

on PR branch, the query is:

```sql
SELECT count(*) AS `count(*)` FROM events WHERE and(equals(events.team_id, 2), equals(events.event, %(hogql_val_0)s), uuid IN (
        SELECT
            argMax(uuid, timestamp) -- Selects the UUID of the event with the latest timestamp within each group
        FROM events
        WHERE event = 'survey sent' -- Filter for 'survey sent' events
          AND JSONExtractString(properties, '$survey_id') = '019a9dc5-745c-0000-231d-8ce32972cd72' -- Filter for the specific survey
           AND team_id = 2
          -- Date range filters from the outer query are intentionally NOT included here.
          -- This ensures we find the globally latest unique submission, which is then
          -- filtered by the outer query's date range.
        GROUP BY CASE WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = '' THEN toString(uuid) ELSE
JSONExtractString(properties, '$survey_submission_id') END -- Group events by the effective submission identifier
    )) LIMIT 50000
```

`team_id` was not in the subquery originally!

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->