### PR TITLE
fix: small improvements around kafka-deduplicator

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4409,7 +4409,6 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "metrics-exporter-prometheus",
- "num_cpus",
  "once_cell",
  "opentelemetry 0.22.0",
  "opentelemetry-otlp",

--- a/rust/kafka-deduplicator/Cargo.toml
+++ b/rust/kafka-deduplicator/Cargo.toml
@@ -26,7 +26,6 @@ health = { path = "../common/health" }
 itertools = "0.14"
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
-num_cpus = "1.17.0"
 once_cell = "1.21"
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }

--- a/rust/kafka-deduplicator/src/kafka/config.rs
+++ b/rust/kafka-deduplicator/src/kafka/config.rs
@@ -68,12 +68,18 @@ impl ConsumerConfigBuilder {
         self
     }
 
-    /// Enable sticky partition assignments based on the kafka client ID supplied
+    /// Enable sticky partition assignments based on the kafka client ID supplied.
+    /// Always uses cooperative-sticky strategy for consistent behavior across all pods.
+    /// When client_id is provided, also enables static membership for truly sticky assignments.
     pub fn with_sticky_partition_assignment(mut self, client_id: Option<&str>) -> Self {
+        // Always use cooperative-sticky for consistent behavior across all pods
+        self.config
+            .set("partition.assignment.strategy", "cooperative-sticky");
+
         if let Some(found_client_id) = client_id {
             self.config.set("client.id", found_client_id);
-            self.config
-                .set("partition.assignment.strategy", "cooperative-sticky");
+            // Enable static membership for truly sticky assignments
+            self.config.set("group.instance.id", found_client_id);
         }
         self
     }

--- a/rust/kafka-deduplicator/src/rocksdb/metrics_consts.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/metrics_consts.rs
@@ -41,5 +41,8 @@ pub const ROCKSDB_CHECKPOINT_OPERATIONS_COUNTER: &str = "rocksdb_checkpoint_oper
 /// Gauge for number of SST files
 pub const ROCKSDB_SST_FILES_COUNT_GAUGE: &str = "rocksdb_sst_files_count";
 
+/// Gauge for estimated number of keys in a column family
+pub const ROCKSDB_ESTIMATE_NUM_KEYS_GAUGE: &str = "rocksdb_estimate_num_keys";
+
 /// Counter for RocksDB errors
 pub const ROCKSDB_ERRORS_COUNTER: &str = "rocksdb_errors_total";


### PR DESCRIPTION
## Problem

The kafka-deduplicator needed better observability for understanding duplicate patterns and fixes for container environments.


## Changes

- Added metrics for unique UUIDs/timestamps seen during deduplication analysis
- Added rocksdb_estimate_num_keys gauge for tracking data volume
- Fixed CPU detection to respect container limits (replaced num_cpus with std::thread::available_parallelism())
- Always use cooperative-sticky partition assignment; enable static membership when client_id provided
-Reduced RocksDB background jobs from 4 to 2 to lower I/O contention

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
