### PR TITLE
Update python.tsx to fix end quotes

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/error-tracking/python.tsx
+++ b/frontend/src/scenes/onboarding/sdks/error-tracking/python.tsx
@@ -11,7 +11,7 @@ export function PythonInstructions(): JSX.Element {
                 automatically capture Django errors.
             </p>
             <CodeSnippet language={Language.Python}>
-                MIDDLEWARE += ["posthog.integrations.django.PosthogContextMiddleware”]
+                MIDDLEWARE += ["posthog.integrations.django.PosthogContextMiddleware"]
             </CodeSnippet>
             <PythonSetupSnippet enableExceptionAutocapture />
             <h4>Optional: Capture exceptions manually</h4>


### PR DESCRIPTION
As reported here (https://github.com/PostHog/posthog/issues/41950) the closing quote was different than the opening causing the snippet to fail if copy-pasted

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
