### PR TITLE
fix(e2e): un-skip fixed insight variables tests

### DIFF
--- a/playwright/e2e/product-analytics/insight-variables.spec.ts
+++ b/playwright/e2e/product-analytics/insight-variables.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test } from '../../utils/playwright-test-base'
 
 test.describe('insight variables', () => {
-    // :FIXME: This test is flaky on CI.
-    test.skip('show correctly on dashboards', async ({ page }) => {
+    test('show correctly on dashboards', async ({ page }) => {
         // Go to "Insight variables" dashboard.
         await page.goToMenuItem('dashboards')
         await page.getByText('Insight variables').click()


### PR DESCRIPTION
## Problem

This test was skipped in https://github.com/PostHog/posthog/pull/42538, but already fixed forward in https://github.com/PostHog/posthog/pull/42726.

## Changes

Un-skips the test again.

## How did you test this code?

CI run