### PR TITLE
fix(llma): Add organization context to feature flag checks for summarization

### DIFF
--- a/products/llm_analytics/backend/api/summarization.py
+++ b/products/llm_analytics/backend/api/summarization.py
@@ -156,15 +156,25 @@ class LLMAnalyticsSummarizationViewSet(TeamAndOrgViewSetMixin, viewsets.GenericV
 
         # Include person properties for cohort-based targeting and
         # groups/group_properties for organization-level targeting (including Early Access Features)
-        flag_kwargs = {
-            "person_properties": {"email": user.email},
-            "groups": {"organization": organization_id},
-            "group_properties": {"organization": {"id": organization_id}},
-        }
+        person_properties = {"email": user.email}
+        groups = {"organization": organization_id}
+        group_properties = {"organization": {"id": organization_id}}
 
         if not (
-            posthoganalytics.feature_enabled(SUMMARIZATION_FEATURE_FLAG, distinct_id, **flag_kwargs)
-            or posthoganalytics.feature_enabled(EARLY_ADOPTERS_FEATURE_FLAG, distinct_id, **flag_kwargs)
+            posthoganalytics.feature_enabled(
+                SUMMARIZATION_FEATURE_FLAG,
+                distinct_id,
+                person_properties=person_properties,
+                groups=groups,
+                group_properties=group_properties,
+            )
+            or posthoganalytics.feature_enabled(
+                EARLY_ADOPTERS_FEATURE_FLAG,
+                distinct_id,
+                person_properties=person_properties,
+                groups=groups,
+                group_properties=group_properties,
+            )
         ):
             raise exceptions.PermissionDenied("LLM trace summarization is not enabled for this user")
 

--- a/products/llm_analytics/backend/api/summarization.py
+++ b/products/llm_analytics/backend/api/summarization.py
@@ -150,18 +150,21 @@ class LLMAnalyticsSummarizationViewSet(TeamAndOrgViewSetMixin, viewsets.GenericV
         if settings.DEBUG:
             return
 
-        # Check feature flag using user's distinct_id and person properties
-        # Person properties are needed for cohort-based feature flag evaluation
-        distinct_id = str(request.user.distinct_id)
-        person_properties = {"email": request.user.email}
+        user = cast(User, request.user)
+        distinct_id = str(user.distinct_id)
+        organization_id = str(self.team.organization_id)
+
+        # Include person properties for cohort-based targeting and
+        # groups/group_properties for organization-level targeting (including Early Access Features)
+        flag_kwargs = {
+            "person_properties": {"email": user.email},
+            "groups": {"organization": organization_id},
+            "group_properties": {"organization": {"id": organization_id}},
+        }
 
         if not (
-            posthoganalytics.feature_enabled(
-                SUMMARIZATION_FEATURE_FLAG, distinct_id, person_properties=person_properties
-            )
-            or posthoganalytics.feature_enabled(
-                EARLY_ADOPTERS_FEATURE_FLAG, distinct_id, person_properties=person_properties
-            )
+            posthoganalytics.feature_enabled(SUMMARIZATION_FEATURE_FLAG, distinct_id, **flag_kwargs)
+            or posthoganalytics.feature_enabled(EARLY_ADOPTERS_FEATURE_FLAG, distinct_id, **flag_kwargs)
         ):
             raise exceptions.PermissionDenied("LLM trace summarization is not enabled for this user")
 


### PR DESCRIPTION
## Problem

Users who opt into the `llm-analytics-early-adopters` Early Access Feature are not getting access to trace summarization. The feature flag check was missing organization context needed for Early Access Feature enrollment evaluation.

## Changes

- Add `groups` and `group_properties` parameters to `posthoganalytics.feature_enabled()` calls in the summarization endpoint
- Aligns with best practices used by other similar features (session summaries, CRM)
- Add tests verifying feature flag is called with correct organization context

## How did you test this code?

- Added unit tests for feature flag evaluation with organization context
- All 13 tests pass in `test_summarization.py`

## Changelog: (features only) Is this feature complete?

No - bug fix only