### PR TITLE
chore(geoip): Ignore local ips to denoise logs

### DIFF
--- a/posthog/geoip.py
+++ b/posthog/geoip.py
@@ -1,3 +1,4 @@
+import ipaddress
 from typing import Optional
 
 from django.contrib.gis.geoip2 import GeoIP2
@@ -44,14 +45,14 @@ def get_geoip_properties(ip_address: Optional[str]) -> dict[str, str]:
         $geoip_postal_code
         $geoip_time_zone
     """
-    if (
-        not ip_address
-        or not geoip
-        or ip_address == "127.0.0.1"
-        or ip_address.startswith("192.168.")
-        or ip_address.startswith("10.")
-    ):
-        # Local addresses would otherwise throw "The address 127.0.0.1 is not in the database." below
+    if not ip_address or not geoip:
+        return {}
+
+    try:
+        ip = ipaddress.ip_address(ip_address)
+        if ip.is_private or ip.is_loopback:
+            return {}
+    except ValueError:
         return {}
 
     try:

--- a/posthog/geoip.py
+++ b/posthog/geoip.py
@@ -44,7 +44,7 @@ def get_geoip_properties(ip_address: Optional[str]) -> dict[str, str]:
         $geoip_postal_code
         $geoip_time_zone
     """
-    if not ip_address or not geoip or ip_address == "127.0.0.1" or ip_address.startswith("192.168."):
+    if not ip_address or not geoip or ip_address == "127.0.0.1" or ip_address.startswith("192.168.") or ip_address.startswith("10."):
         # Local addresses would otherwise throw "The address 127.0.0.1 is not in the database." below
         return {}
 

--- a/posthog/geoip.py
+++ b/posthog/geoip.py
@@ -44,7 +44,13 @@ def get_geoip_properties(ip_address: Optional[str]) -> dict[str, str]:
         $geoip_postal_code
         $geoip_time_zone
     """
-    if not ip_address or not geoip or ip_address == "127.0.0.1" or ip_address.startswith("192.168.") or ip_address.startswith("10."):
+    if (
+        not ip_address
+        or not geoip
+        or ip_address == "127.0.0.1"
+        or ip_address.startswith("192.168.")
+        or ip_address.startswith("10.")
+    ):
         # Local addresses would otherwise throw "The address 127.0.0.1 is not in the database." below
         return {}
 

--- a/posthog/helpers/tests/test_geoip.py
+++ b/posthog/helpers/tests/test_geoip.py
@@ -13,6 +13,7 @@ uk_ip = "31.28.64.3"
 us_ip_v6 = "2600:6c52:7a00:11c:1b6:b7b0:ea19:6365"
 localhost_ip = "127.0.0.1"
 local_network_ip = "192.168.97.2"
+cluster_network_ip = "10.95.0.17"
 mexico_ip = "187.188.10.252"
 australia_ip_2 = "13.106.122.3"
 
@@ -58,6 +59,11 @@ class TestGeoIPError(TestCase):
 
     def test_geoip_on_local_network_ip_returns_successfully(self):
         properties = get_geoip_properties(local_network_ip)
+
+        self.assertEqual(properties, {})
+
+    def test_geoip_on_cluster_network_ip_returns_successfully(self):
+        properties = get_geoip_properties(cluster_network_ip)
 
         self.assertEqual(properties, {})
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

I noticed a lot of `geoIP computation error: The address 10.x.y.z is not in the database.` errors coming from internal health checks in our logs. This doesn't feel like very valuable information

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- don't try to resolve a geo location for IPs from the 10.0.0.0/8 ip space

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
