### PR TITLE
feat(logs): implement cursor-based pagination

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2232,7 +2232,7 @@ const api = {
         }: {
             query: Omit<LogsQuery, 'kind'>
             signal?: AbortSignal
-        }): Promise<{ results: LogMessage[]; hasMore: boolean }> {
+        }): Promise<{ results: LogMessage[]; hasMore: boolean; nextCursor?: string }> {
             return new ApiRequest().logsQuery().create({ signal, data: { query } })
         },
         async sparkline({ query, signal }: { query: Omit<LogsQuery, 'kind'>; signal?: AbortSignal }): Promise<any[]> {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4668,6 +4668,10 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "nextCursor": {
+                    "description": "Cursor for fetching the next page of results",
+                    "type": "string"
+                },
                 "next_allowed_client_refresh": {
                     "format": "date-time",
                     "type": "string"
@@ -17741,6 +17745,10 @@
         "LogsQuery": {
             "additionalProperties": false,
             "properties": {
+                "after": {
+                    "description": "Cursor for fetching the next page of results",
+                    "type": "string"
+                },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
                 },
@@ -17823,6 +17831,10 @@
                 "modifiers": {
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
+                },
+                "nextCursor": {
+                    "description": "Cursor for fetching the next page of results",
+                    "type": "string"
                 },
                 "offset": {
                     "$ref": "#/definitions/integer"
@@ -24530,6 +24542,10 @@
                         "modifiers": {
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
+                        },
+                        "nextCursor": {
+                            "description": "Cursor for fetching the next page of results",
+                            "type": "string"
                         },
                         "offset": {
                             "$ref": "#/definitions/integer"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2604,6 +2604,8 @@ export interface LogsQuery extends DataNode<LogsQueryResponse> {
     filterGroup: PropertyGroupFilter
     serviceNames: string[]
     liveLogsCheckpoint?: string
+    /** Cursor for fetching the next page of results */
+    after?: string
 }
 
 export interface LogsQueryResponse extends AnalyticsQueryResponseBase {
@@ -2612,6 +2614,8 @@ export interface LogsQueryResponse extends AnalyticsQueryResponseBase {
     limit?: integer
     offset?: integer
     columns?: string[]
+    /** Cursor for fetching the next page of results */
+    nextCursor?: string
 }
 
 export interface SessionEventsItem {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7250,6 +7250,7 @@ class CachedLogsQueryResponse(BaseModel):
     last_refresh: AwareDatetime
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    nextCursor: str | None = Field(default=None, description="Cursor for fetching the next page of results")
     next_allowed_client_refresh: AwareDatetime
     offset: int | None = None
     query_metadata: dict[str, Any] | None = None
@@ -10102,6 +10103,7 @@ class LogsQueryResponse(BaseModel):
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    nextCursor: str | None = Field(default=None, description="Cursor for fetching the next page of results")
     offset: int | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -11568,6 +11570,7 @@ class QueryResponseAlternative70(BaseModel):
     hogql: str | None = Field(default=None, description="Generated HogQL query.")
     limit: int | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    nextCursor: str | None = Field(default=None, description="Cursor for fetching the next page of results")
     offset: int | None = None
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
@@ -14617,6 +14620,7 @@ class LogsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    after: str | None = Field(default=None, description="Cursor for fetching the next page of results")
     dateRange: DateRange
     filterGroup: PropertyGroupFilter
     kind: Literal["LogsQuery"] = "LogsQuery"

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -1,3 +1,5 @@
+import json
+import base64
 import datetime as dt
 
 from rest_framework import status, viewsets
@@ -27,6 +29,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             return Response({"error": "No query provided"}, status=status.HTTP_400_BAD_REQUEST)
 
         live_logs_checkpoint = query_data.get("liveLogsCheckpoint", None)
+        after_cursor = query_data.get("after", None)
         date_range = self.get_model(query_data.get("dateRange"), DateRange)
         requested_limit = min(query_data.get("limit", 1000), 2000)
         logs_query_params = {
@@ -40,6 +43,8 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         }
         if live_logs_checkpoint:
             logs_query_params["liveLogsCheckpoint"] = live_logs_checkpoint
+        if after_cursor:
+            logs_query_params["after"] = after_cursor
         query = LogsQuery(**logs_query_params)
 
         def results_generator(query: LogsQuery, logs_query_params: dict):
@@ -116,6 +121,13 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
                 response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
                 yield from response.results
                 return
+
+            # if we have a cursor, skip the time slicing optimization
+            # the cursor marks a continuation point in a single query, not across time slices
+            if after_cursor:
+                response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+                yield from response.results
+                return
             # if we're searching more than 20 minutes, first fetch the first 3 minutes of logs and see if that hits the limit
             if date_range_length > dt.timedelta(minutes=20):
                 recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=3), query.orderBy)
@@ -152,7 +164,20 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         results = list(results_generator(query, logs_query_params))
         has_more = len(results) > requested_limit
         results = results[:requested_limit]  # Rm the +1 we used to check for another page
-        return Response({"query": query, "results": results, "hasMore": has_more}, status=200)
+
+        # Generate cursor for next page
+        next_cursor = None
+        if has_more and results:
+            last_result = results[-1]
+            cursor_data = {
+                "timestamp": last_result["timestamp"].isoformat(),
+                "uuid": last_result["uuid"],
+            }
+            next_cursor = base64.b64encode(json.dumps(cursor_data).encode("utf-8")).decode("utf-8")
+
+        return Response(
+            {"query": query, "results": results, "hasMore": has_more, "nextCursor": next_cursor}, status=200
+        )
 
     @action(detail=False, methods=["POST"], required_scopes=["logs:read"])
     def sparkline(self, request: Request, *args, **kwargs) -> Response:

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -267,10 +267,10 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
                 cursor_uuid = cursor["uuid"]
             except (KeyError, ValueError, json.JSONDecodeError) as e:
                 raise ValueError(f"Invalid cursor format: {e}")
-            # For DESC (latest first): get rows where (timestamp, uuid) < cursor
             # For ASC (earliest first): get rows where (timestamp, uuid) > cursor
-            op = "<" if self.query.orderBy != "earliest" else ">"
-            ts_op = "<=" if self.query.orderBy != "earliest" else ">="
+            # For DESC (latest first, default): get rows where (timestamp, uuid) < cursor
+            op = ">" if self.query.orderBy == "earliest" else "<"
+            ts_op = ">=" if self.query.orderBy == "earliest" else "<="
             # The logs table is partitioned by timestamp, not (timestamp, uuid).
             # ClickHouse only prunes partitions when the WHERE clause directly matches
             # the partition key. A tuple comparison like (timestamp, uuid) < (x, y)

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -261,9 +261,12 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
             )
 
         if self.query.after:
-            cursor = json.loads(base64.b64decode(self.query.after).decode("utf-8"))
-            cursor_ts = dt.datetime.fromisoformat(cursor["timestamp"])
-            cursor_uuid = cursor["uuid"]
+            try:
+                cursor = json.loads(base64.b64decode(self.query.after).decode("utf-8"))
+                cursor_ts = dt.datetime.fromisoformat(cursor["timestamp"])
+                cursor_uuid = cursor["uuid"]
+            except (KeyError, ValueError, json.JSONDecodeError) as e:
+                raise ValueError(f"Invalid cursor format: {e}")
             # For DESC (latest first): get rows where (timestamp, uuid) < cursor
             # For ASC (earliest first): get rows where (timestamp, uuid) > cursor
             op = "<" if self.query.orderBy != "earliest" else ">"

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -89,7 +89,7 @@ function LogsViewerContent({
             setCursorToLogId(linkToLogId, logs)
             containerRef.current?.focus()
         }
-    }, [linkToLogId, logsCount, setCursorToLogId])
+    }, [linkToLogId, logsCount, logs, setCursorToLogId])
 
     const tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime'> = {
         formatDate: 'YYYY-MM-DD',

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -37,7 +37,6 @@ export function LogsViewer({
     return (
         <BindLogic logic={logsViewerLogic} props={{ tabId, logs, orderBy }}>
             <LogsViewerContent
-                logs={logs}
                 loading={loading}
                 totalLogsCount={totalLogsCount}
                 hasMoreLogsToLoad={hasMoreLogsToLoad}
@@ -51,7 +50,6 @@ export function LogsViewer({
 }
 
 interface LogsViewerContentProps {
-    logs: ParsedLogMessage[]
     loading: boolean
     totalLogsCount?: number
     hasMoreLogsToLoad?: boolean
@@ -62,7 +60,6 @@ interface LogsViewerContentProps {
 }
 
 function LogsViewerContent({
-    logs,
     loading,
     totalLogsCount,
     hasMoreLogsToLoad,
@@ -71,7 +68,7 @@ function LogsViewerContent({
     onRefresh,
     onLoadMore,
 }: LogsViewerContentProps): JSX.Element {
-    const { wrapBody, prettifyJson, pinnedLogsArray, isFocused, getCursorLogId, linkToLogId } =
+    const { wrapBody, prettifyJson, pinnedLogsArray, isFocused, getCursorLogId, linkToLogId, logs, logsCount } =
         useValues(logsViewerLogic)
     const { setFocused, moveCursorDown, moveCursorUp, toggleExpandLog, resetCursor, setCursorToLogId } =
         useActions(logsViewerLogic)
@@ -81,18 +78,18 @@ function LogsViewerContent({
 
     // Reset cursor when logs are cleared (e.g., new query starts)
     useEffect(() => {
-        if (logs.length === 0) {
+        if (logsCount === 0) {
             resetCursor()
         }
-    }, [logs.length, resetCursor])
+    }, [logsCount, resetCursor])
 
     // Position cursor at linked log when deep linking (URL -> cursor)
     useEffect(() => {
-        if (linkToLogId && logs.length > 0) {
+        if (linkToLogId && logsCount > 0) {
             setCursorToLogId(linkToLogId, logs)
             containerRef.current?.focus()
         }
-    }, [linkToLogId, logs, setCursorToLogId])
+    }, [linkToLogId, logsCount, setCursorToLogId])
 
     const tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime'> = {
         formatDate: 'YYYY-MM-DD',
@@ -101,10 +98,10 @@ function LogsViewerContent({
 
     useKeyboardHotkeys(
         {
-            arrowdown: { action: () => moveCursorDown(logs.length), disabled: !isFocused },
-            j: { action: () => moveCursorDown(logs.length), disabled: !isFocused },
-            arrowup: { action: () => moveCursorUp(logs.length), disabled: !isFocused },
-            k: { action: () => moveCursorUp(logs.length), disabled: !isFocused },
+            arrowdown: { action: () => moveCursorDown(logsCount), disabled: !isFocused },
+            j: { action: () => moveCursorDown(logsCount), disabled: !isFocused },
+            arrowup: { action: () => moveCursorUp(logsCount), disabled: !isFocused },
+            k: { action: () => moveCursorUp(logsCount), disabled: !isFocused },
             enter: {
                 action: () => {
                     if (cursorLogId) {

--- a/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
@@ -21,7 +21,7 @@ export const LogsViewerToolbar = ({
     orderBy,
     onChangeOrderBy,
 }: LogsViewerToolbarProps): JSX.Element => {
-    const { wrapBody, prettifyJson } = useValues(logsViewerLogic)
+    const { wrapBody, prettifyJson, logsCount } = useValues(logsViewerLogic)
     const { setWrapBody, setPrettifyJson } = useActions(logsViewerLogic)
 
     return (
@@ -53,7 +53,9 @@ export const LogsViewerToolbar = ({
             </div>
             <div className="flex items-center gap-4">
                 {totalLogsCount !== undefined && totalLogsCount > 0 && (
-                    <span className="text-muted text-xs">{humanFriendlyNumber(totalLogsCount)} logs</span>
+                    <span className="text-muted text-xs">
+                        {humanFriendlyNumber(logsCount)} of {humanFriendlyNumber(totalLogsCount)} logs
+                    </span>
                 )}
                 <span className="text-muted text-xs flex items-center gap-1">
                     <KeyboardShortcut arrowup />

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -32,7 +32,7 @@ const DEFAULT_HIGHLIGHTED_LOG_ID = null as string | null
 const DEFAULT_ORDER_BY = 'latest' as LogsQuery['orderBy']
 const DEFAULT_WRAP_BODY = true
 const DEFAULT_PRETTIFY_JSON = true
-const DEFAULT_LOGS_PAGE_SIZE: number = 100
+const DEFAULT_LOGS_PAGE_SIZE: number = 250
 const DEFAULT_INITIAL_LOGS_LIMIT = null as number | null
 const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
 const DEFAULT_LIVE_TAIL_POLL_INTERVAL_MS = 1000
@@ -260,6 +260,7 @@ export const logsLogic = kea<logsLogicType>([
         pollForNewLogs: true,
         setLogs: (logs: LogMessage[]) => ({ logs }),
         setSparkline: (sparkline: any[]) => ({ sparkline }),
+        setNextCursor: (nextCursor: string | null) => ({ nextCursor }),
         expireLiveTail: () => true,
         setLiveTailExpired: (liveTailExpired: boolean) => ({ liveTailExpired }),
         addLogsToSparkline: (logs: LogMessage[]) => logs,
@@ -441,6 +442,13 @@ export const logsLogic = kea<logsLogicType>([
                 clearLogs: () => true,
             },
         ],
+        nextCursor: [
+            null as string | null,
+            {
+                setNextCursor: (_, { nextCursor }) => nextCursor,
+                clearLogs: () => null,
+            },
+        ],
         expandedLogIds: [
             new Set<string>(),
             {
@@ -483,6 +491,7 @@ export const logsLogic = kea<logsLogicType>([
                     })
                     actions.setLogsAbortController(null)
                     actions.setHasMoreLogsToLoad(!!response.hasMore)
+                    actions.setNextCursor(response.nextCursor ?? null)
                     parseLogAttributes(response.results)
                     return response.results
                 },
@@ -491,40 +500,27 @@ export const logsLogic = kea<logsLogicType>([
                     const signal = logsController.signal
                     actions.cancelInProgressLogs(logsController)
 
-                    let dateRange: DateRange
-
-                    if (values.orderBy === 'earliest') {
-                        if (!values.newestLogTimestamp) {
-                            return values.logs
-                        }
-                        dateRange = {
-                            date_from: values.newestLogTimestamp,
-                            date_to: values.utcDateRange.date_to,
-                        }
-                    } else {
-                        if (!values.oldestLogTimestamp) {
-                            return values.logs
-                        }
-                        dateRange = {
-                            date_from: values.utcDateRange.date_from,
-                            date_to: values.oldestLogTimestamp,
-                        }
+                    if (!values.nextCursor) {
+                        return values.logs
                     }
+
                     await breakpoint(300)
                     const response = await api.logs.query({
                         query: {
                             limit: limit ?? values.logsPageSize,
                             orderBy: values.orderBy,
-                            dateRange,
+                            dateRange: values.utcDateRange,
                             searchTerm: values.searchTerm,
                             filterGroup: values.filterGroup as PropertyGroupFilter,
                             severityLevels: values.severityLevels,
                             serviceNames: values.serviceNames,
+                            after: values.nextCursor,
                         },
                         signal,
                     })
                     actions.setLogsAbortController(null)
                     actions.setHasMoreLogsToLoad(!!response.hasMore)
+                    actions.setNextCursor(response.nextCursor ?? null)
                     parseLogAttributes(response.results)
                     return [...values.logs, ...response.results]
                 },
@@ -710,32 +706,6 @@ export const logsLogic = kea<logsLogicType>([
                     .filter((series) => series.values.reduce((a, b) => a + b) > 0)
 
                 return { data, labels, dates }
-            },
-        ],
-        oldestLogTimestamp: [
-            (s) => [s.logs],
-            (logs): string | null => {
-                if (!logs.length) {
-                    return null
-                }
-                const oldest = logs.reduce((min, log) => {
-                    const logTime = dayjs(log.timestamp)
-                    return !min || logTime.isBefore(dayjs(min)) ? log.timestamp : min
-                }, logs[0].timestamp)
-                return oldest
-            },
-        ],
-        newestLogTimestamp: [
-            (s) => [s.logs],
-            (logs): string | null => {
-                if (!logs.length) {
-                    return null
-                }
-                const newest = logs.reduce((max, log) => {
-                    const logTime = dayjs(log.timestamp)
-                    return !max || logTime.isAfter(dayjs(max)) ? log.timestamp : max
-                }, logs[0].timestamp)
-                return newest
             },
         ],
         totalLogsMatchingFilters: [


### PR DESCRIPTION
## Problem

Logs pagination used timestamp-based filtering (`date_to = oldest_log_timestamp`) to fetch subsequent pages. This approach could miss logs when multiple entries share the exact same timestamp but were excluded by the limit, or cause duplicates when timestamps overlap between pages.

## Changes

**Cursor-based pagination using `(timestamp, uuid)` composite key:**

- Backend returns a `nextCursor` (base64-encoded `{timestamp, uuid}`) when more results exist
- Frontend passes `after` cursor parameter for subsequent pages
- Query uses tuple comparison `(timestamp, uuid) < cursor` for deterministic ordering
- Added explicit `timestamp <= cursor_ts` bound to guarantee ClickHouse partition pruning (table is partitioned by `toDate(timestamp)`, not the tuple)
- Skips time-slicing optimization when cursor is present (cursor already narrows the search)

**Frontend fixes:**
- Fixed Kea `propsChanged` pattern in `logsViewerLogic` so log updates trigger re-renders properly
- Removed `oldestLogTimestamp`/`newestLogTimestamp` selectors (no longer needed)
- Display "X of Y logs" in toolbar showing loaded vs total
- Increased default page size from 100 to 250

## How did you test this code?

- Manual testing: loaded logs, scrolled to trigger pagination, verified log counts match and no gaps appear
- Verified cursor is correctly generated and decoded across pages
- Tested both `latest` (DESC) and `earliest` (ASC) ordering
- Confirmed partition pruning by reviewing generated query structure:

### Partition Pruning Results:

- Without bound:
<img width="1031" height="656" alt="image" src="https://github.com/user-attachments/assets/a1965f0d-bbe3-4ac6-8494-9ff996ad02c8" />

- With bound ( fewer parts + granules )
<img width="1316" height="813" alt="image" src="https://github.com/user-attachments/assets/86e74084-fc46-4232-b502-1804fa92a6b4" />


Metric | Tuple only | Explicit + Tuple | Improvement
-- | -- | -- | --
MinMax Parts | 10/29 | 8/30 | 2 fewer parts
Partition Parts | 10/10 | 8/8 | 2 fewer parts
PrimaryKey Parts | 10/10 | 8/8 | 2 fewer parts
Granules | 46 | 43 | 3 fewer granules


