### PR TITLE
feat: Add pinned filters to session recordings playlist

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -4,6 +4,7 @@ import { router } from 'kea-router'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { NotFound } from 'lib/components/NotFound'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
+import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { isEventFilter } from 'lib/components/UniversalFilters/utils'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
@@ -176,6 +177,26 @@ export function Group({ tabId }: { tabId?: string }): JSX.Element {
                                         <SessionRecordingsPlaylist
                                             logicKey={`groups-recordings-${groupKey}-${groupTypeIndex}`}
                                             updateSearchParams
+                                            pinnedFilters={{
+                                                type: FilterLogicalOperator.And,
+                                                values: [
+                                                    {
+                                                        type: FilterLogicalOperator.And,
+                                                        values: [
+                                                            {
+                                                                type: 'events',
+                                                                name: 'All events',
+                                                                properties: [
+                                                                    {
+                                                                        key: `$group_${groupTypeIndex} = '${groupKey}'`,
+                                                                        type: 'hogql',
+                                                                    },
+                                                                ],
+                                                            } as ActionFilter,
+                                                        ],
+                                                    },
+                                                ],
+                                            }}
                                             filters={{
                                                 duration: [
                                                     {
@@ -185,26 +206,7 @@ export function Group({ tabId }: { tabId?: string }): JSX.Element {
                                                         operator: PropertyOperator.GreaterThan,
                                                     },
                                                 ],
-                                                filter_group: {
-                                                    type: FilterLogicalOperator.And,
-                                                    values: [
-                                                        {
-                                                            type: FilterLogicalOperator.And,
-                                                            values: [
-                                                                {
-                                                                    type: 'events',
-                                                                    name: 'All events',
-                                                                    properties: [
-                                                                        {
-                                                                            key: `$group_${groupTypeIndex} = '${groupKey}'`,
-                                                                            type: 'hogql',
-                                                                        },
-                                                                    ],
-                                                                } as ActionFilter,
-                                                            ],
-                                                        },
-                                                    ],
-                                                },
+                                                filter_group: { ...DEFAULT_UNIVERSAL_GROUP_FILTER },
                                             }}
                                             onFiltersChange={(filters) => {
                                                 const eventFilters =

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -666,7 +666,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                             posthog.captureException(new Error('Invalid filters provided'), {
                                 filters,
                             })
-                            return getDefaultFilters(props.personUUID)
+                            return getDefaultFilters(props.personUUID, props.pinnedFilters)
                         }
 
                         // Always set pinned filters last, so they are not overwritten by the others
@@ -681,10 +681,10 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                         }
                     } catch (e) {
                         posthog.captureException(e)
-                        return getDefaultFilters(props.personUUID)
+                        return getDefaultFilters(props.personUUID, props.pinnedFilters)
                     }
                 },
-                resetFilters: () => getDefaultFilters(props.personUUID),
+                resetFilters: () => getDefaultFilters(props.personUUID, props.pinnedFilters),
             },
         ],
         showFilters: [
@@ -1413,7 +1413,9 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
         ] => {
             const params: ReplayURLSearchParamTypes = objectClean({
                 ...router.values.searchParams,
-                filters: objectsEqual(values.filters, getDefaultFilters(props.personUUID)) ? undefined : values.filters,
+                filters: objectsEqual(values.filters, getDefaultFilters(props.personUUID, props.pinnedFilters))
+                    ? undefined
+                    : values.filters,
                 sessionRecordingId: values.selectedRecordingId ?? undefined,
             })
 


### PR DESCRIPTION
## Problem
Folks accidentally (or not) remove group filters when watching replays in group profile and have a hard time setting them back up (the way is to use a SQL filter, which is not super intuitive).

Let's add a "pinned filter" concept that once passed in cannot be dropped.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Did the changes in the playlist logic + groups tab.

@PostHog/team-replay wanted to check this with you all before spending more time in the solution. Right now the UX is not great, as we _apparently_ drop the filters even though they are still applied.

If you think this is the way to go, I can spend some time working that out.


https://www.loom.com/share/048cf847d81d48e99b5b00adf7f7b48c

In the Loom I'm "trying" to remove the filter, but the API requests always have it, even though the UI doesn't.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
