### PR TITLE
fix(data-warehouse): If a ff is undefined, then it means its off

### DIFF
--- a/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
@@ -44,7 +44,7 @@ function getSourceDisplayStatus(
         }
     }
     // regardless of release status, those failing the feature flag should see an unreleased source
-    if (featureFlag === false) {
+    if (!featureFlag) {
         return {
             status: 'coming_soon',
             descriptionEl: unreleasedDescriptionEl,


### PR DESCRIPTION
## Problem
- We're showing warehouse sources as available even if the flag is turned off

## Changes
- Treat `undefined` feature flags as disabled 
