### PR TITLE
fix: Correctly apply limit when getting traces

### DIFF
--- a/posthog/hogql_queries/ai/traces_query_runner.py
+++ b/posthog/hogql_queries/ai/traces_query_runner.py
@@ -74,8 +74,8 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
         """Execute a separate query to get relevant trace IDs and their time range."""
         with self.timings.measure("traces_query_trace_ids_execute"), tags_context(product=Product.LLM_ANALYTICS):
             # Calculate max number of events needed with current offset and limit
-            limit_value = self.query.limit if self.query.limit else 100
-            offset_value = self.query.offset if self.query.offset else 0
+            limit_value = self.paginator.limit
+            offset_value = self.paginator.offset
             pagination_limit = limit_value + offset_value + 1
 
             # Determine ordering based on randomOrder parameter


### PR DESCRIPTION
## Problem

Continuation of https://github.com/PostHog/posthog/pull/42316.

## Changes

Makes sure we correctly apply the query limit when fetching trace IDs for traces export.

All trace IDs to export are pulled into a tuple for the query. I think the 10k export limit added in the previous PR is still sensible to avoid consuming too much memory with the query? If we want to increase the limit in future I guess we may need to look at other approaches that don't rely on having all trace IDs in memory.

https://github.com/PostHog/posthog/blob/832616ff8ae28b68d5922d84d828157ff3c0b988/posthog/hogql_queries/ai/traces_query_runner.py#L182