### PR TITLE
fix(customers): Fix traces node not filtering correctly for groups

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -28,7 +28,7 @@ import { getLogicKey } from './utils'
 const Component = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttributes>): JSX.Element | null => {
     const { expanded } = useValues(notebookNodeLogic)
     const { groupKey, groupTypeIndex, personId, tabId } = attributes
-    const group = groupKey && groupTypeIndex ? { groupKey, groupTypeIndex } : undefined
+    const group = groupKey && groupTypeIndex !== undefined ? { groupKey, groupTypeIndex } : undefined
     const logicKey = getLogicKey({ groupKey, personId, tabId })
 
     const logic = llmAnalyticsLogic({ logicKey, personId, group })


### PR DESCRIPTION
## Problem

The current implementation of `NotebookNodeLLMTrace.tsx` has a bug in the group condition check. When `groupTypeIndex` is `0`, it evaluates to `false` in the boolean expression, causing the group to be incorrectly set to `undefined`.

## Changes

Fixed the condition for setting the `group` variable in `NotebookNodeLLMTrace.tsx` by changing:
```javascript
const group = groupKey && groupTypeIndex ? { groupKey, groupTypeIndex } : undefined
```
to:
```javascript
const group = groupKey && groupTypeIndex !== undefined ? { groupKey, groupTypeIndex } : undefined
```

This ensures that when `groupTypeIndex` is `0` (a valid value), it's properly handled in the condition.

## How did you test this code?

Tested by verifying that notebook nodes with LLM traces correctly display when `groupTypeIndex` is set to `0`.

## Changelog: Yes