### PR TITLE
fix(csv-exporter): Handle list breakdown properties in CSV export

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -232,6 +232,9 @@ def _convert_response_to_csv_data(data: Any, breakdown_filter: Optional[dict] = 
                     prop_name = breakdowns[idx].get("property") if idx < len(breakdowns) else None
                     if not prop_name:
                         continue
+                    # Convert list property names to string (e.g., HogQL expressions)
+                    if isinstance(prop_name, list):
+                        prop_name = ", ".join(str(p) for p in prop_name)
                     formatted_val = str(val) if val is not None else ""
                     if formatted_val == BREAKDOWN_OTHER_STRING_LABEL:
                         formatted_val = BREAKDOWN_OTHER_DISPLAY


### PR DESCRIPTION
When breakdown property is a list (e.g., HogQL expressions like ['prop1', 'prop2']), convert it to a comma-separated string before using as dictionary key.

This fixes: TypeError: unhashable type: 'list'
https://us.posthog.com/project/2/error_tracking/019a4f89-3166-76b0-adcc-106838615be1?timestamp=2025-12-08%2004%3A13%3A45.553000-08%3A00&searchQuery=unhashable%20type%3A

The error occurred because BreakdownFilter.breakdown can be str | list[str | int] | int, and when it's a list, using it directly as a dictionary key fails since lists are not hashable in Python.

