### PR TITLE
feat: add minmax index on sharded_events.timestamp

### DIFF
--- a/posthog/clickhouse/migrations/0185_sharded_events_add_timestamp_minmax_index.py
+++ b/posthog/clickhouse/migrations/0185_sharded_events_add_timestamp_minmax_index.py
@@ -1,0 +1,18 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+ADD_MINMAX_INDEX_TIMESTAMP = """
+ALTER TABLE sharded_events
+ADD INDEX IF NOT EXISTS minmax_sharded_events_timestamp timestamp
+TYPE minmax
+GRANULARITY 1
+"""
+
+operations = [
+    run_sql_with_exceptions(
+        ADD_MINMAX_INDEX_TIMESTAMP,
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0184_sharded_events_add_distinct_id_bloom_filter_index
+0185_sharded_events_add_timestamp_minmax_index.py

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0185_sharded_events_add_timestamp_minmax_index.py
+0185_sharded_events_add_timestamp_minmax_index


### PR DESCRIPTION
## Problem

Some queries for events, event with narrow timestamp condition load a lot of data.

## Changes

Add minmax index on timestamp column. This should give some breath to ClickHouse
