### PR TITLE
fix(retention): massive speedup for retention cohort filters

### DIFF
--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -8,6 +8,7 @@ from posthog.schema import (
     CachedRetentionQueryResponse,
     EntityType,
     HogQLQueryModifiers,
+    InCohortVia,
     IntervalType,
     RetentionEntity,
     RetentionQuery,
@@ -88,6 +89,52 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             # Clean up old fields
             self.query.breakdownFilter.breakdown = None
             self.query.breakdownFilter.breakdown_type = None
+
+        # Optimize cohort filters
+        self.update_hogql_modifiers()
+
+    def update_hogql_modifiers(self) -> None:
+        """
+        Update HogQL modifiers to optimize cohort filtering performance.
+        Use LEFTJOIN mode instead of SUBQUERY for cohort filters to enable better query optimization.
+        """
+        if self.modifiers.inCohortVia == InCohortVia.AUTO:
+            # Check if we have cohort filters in properties
+            has_cohort_filter = False
+
+            if self.query.properties:
+                has_cohort_filter = self._has_cohort_property(self.query.properties)
+
+            # Check if we have cohort breakdown
+            if not has_cohort_filter and self.query.breakdownFilter:
+                if self.query.breakdownFilter.breakdown_type == "cohort" or (
+                    self.query.breakdownFilter.breakdowns
+                    and any(b.type == "cohort" for b in self.query.breakdownFilter.breakdowns)
+                ):
+                    has_cohort_filter = True
+
+            # Use LEFTJOIN for cohort filters to avoid slow subquery evaluation
+            if has_cohort_filter:
+                self.modifiers.inCohortVia = InCohortVia.LEFTJOIN
+
+    def _has_cohort_property(self, properties) -> bool:
+        """Recursively check if properties contain cohort filters."""
+        if isinstance(properties, list):
+            for prop in properties:
+                if self._has_cohort_property(prop):
+                    return True
+        elif isinstance(properties, dict):
+            if properties.get("type") == "cohort":
+                return True
+            # Check nested property groups
+            if "values" in properties:
+                return self._has_cohort_property(properties["values"])
+        elif hasattr(properties, "type") and properties.type == "cohort":
+            return True
+        elif hasattr(properties, "values"):
+            return self._has_cohort_property(properties.values)
+
+        return False
 
     @cached_property
     def group_type_index(self) -> int | None:


### PR DESCRIPTION
## Problem
Massive, massive speedup for retention queries with cohort filters
Fixes https://posthoghelp.zendesk.com/agent/tickets/41150 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/45767)
Original query executes for 20min+, new query with changes finishes in under 30s

Root cause - the default inCohortVia mode for retention queries was SUBQUERY, which generated inefficient SQL:
```
WHERE in(
    if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), 
    (SELECT person_id FROM cohortpeople WHERE cohort_id = X AND version = Y)
)
```

## Changes
Automatically switch retention queries with cohort filters to use LEFTJOIN mode instead of SUBQUERY mode. This generates optimized SQL:
```
LEFT JOIN (
    SELECT person_id, 1 as matched 
    FROM cohortpeople 
    WHERE cohort_id = X AND version = Y
) AS in_cohort__X 
ON person_id = in_cohort__X.person_id
WHERE equals(in_cohort__X.matched, 1)
```
- Cohort table joined once upfront instead of per-row subquery
- Simple equality check in WHERE clause
- ClickHouse can optimize join execution plan
- Significantly faster execution (~100x+ improvement for large cohorts)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Added tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
yes
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
