### PR TITLE
feat(persons): Truly batch person updates

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -100,6 +100,18 @@ describe('BatchWritingPersonStore', () => {
             createPerson: jest.fn().mockResolvedValue([person, []]),
             updatePerson: jest.fn().mockResolvedValue([person, [], false]),
             updatePersonAssertVersion: jest.fn().mockResolvedValue([person.version + 1, []]),
+            updatePersonsBatch: jest.fn().mockImplementation((updates) => {
+                // Return a map with success for each update
+                const results = new Map()
+                for (const update of updates) {
+                    results.set(update.uuid, {
+                        success: true,
+                        version: update.version + 1,
+                        kafkaMessage: { topic: 'test', messages: [] },
+                    })
+                }
+                return Promise.resolve(results)
+            }),
             deletePerson: jest.fn().mockResolvedValue([]),
             addDistinctId: jest.fn().mockResolvedValue([]),
             moveDistinctIds: jest.fn().mockResolvedValue({ success: true, messages: [], distinctIdsMoved: [] }),
@@ -193,12 +205,15 @@ describe('BatchWritingPersonStore', () => {
 
         await personStore.flush()
 
-        expect(mockRepo.updatePerson).toHaveBeenCalledWith(
-            expect.objectContaining({
-                properties: { test: 'test' },
-            }),
-            expect.anything(),
-            'updatePersonNoAssert'
+        // In NO_ASSERT mode, we use batch updates
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    uuid: person.uuid,
+                    properties_to_unset: ['value_to_unset'],
+                }),
+            ])
         )
     })
 
@@ -225,12 +240,16 @@ describe('BatchWritingPersonStore', () => {
 
         await personStore.flush()
 
-        expect(mockRepo.updatePerson).toHaveBeenCalledWith(
-            expect.objectContaining({
-                properties: { test: 'test', prop_to_toggle: 'new_value' },
-            }),
-            expect.anything(),
-            'updatePersonNoAssert'
+        // In NO_ASSERT mode, we use batch updates
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    uuid: person.uuid,
+                    properties_to_set: { test: 'test', prop_to_toggle: 'new_value' },
+                    properties_to_unset: [],
+                }),
+            ])
         )
     })
 
@@ -257,12 +276,15 @@ describe('BatchWritingPersonStore', () => {
 
         await personStore.flush()
 
-        expect(mockRepo.updatePerson).toHaveBeenCalledWith(
-            expect.objectContaining({
-                properties: { test: 'test' },
-            }),
-            expect.anything(),
-            'updatePersonNoAssert'
+        // In NO_ASSERT mode, we use batch updates
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    uuid: person.uuid,
+                    properties_to_unset: ['prop_to_toggle'],
+                }),
+            ])
         )
     })
 
@@ -303,10 +325,10 @@ describe('BatchWritingPersonStore', () => {
         // Add a person update to cache
         await personStore.updatePersonWithPropertiesDiffForUpdate(person, { new_value: 'new_value' }, [], {}, 'test')
 
-        // Flush should call updatePerson (NO_ASSERT default mode)
+        // Flush should call updatePersonsBatch (NO_ASSERT default mode uses batch updates)
         await personStore.flush()
 
-        expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
         expect(mockRepo.updatePersonAssertVersion).not.toHaveBeenCalled()
     })
 
@@ -515,7 +537,10 @@ describe('BatchWritingPersonStore', () => {
     })
 
     it('should handle database errors gracefully during flush', async () => {
-        mockRepo.updatePerson = jest.fn().mockRejectedValue(new Error('Database connection failed'))
+        // Mock batch update to throw an error - all persons will fail
+        mockRepo.updatePersonsBatch = jest.fn().mockImplementation(() => {
+            throw new Error('Database connection failed')
+        })
 
         await personStore.updatePersonWithPropertiesDiffForUpdate(person, { new_value: 'new_value' }, [], {}, 'test')
 
@@ -528,15 +553,28 @@ describe('BatchWritingPersonStore', () => {
         await personStore.updatePersonWithPropertiesDiffForUpdate(person, { test: 'value1' }, [], {}, 'test1')
         await personStore.updatePersonWithPropertiesDiffForUpdate(person2, { test: 'value2' }, [], {}, 'test2')
 
-        // Mock first update to succeed, second to fail
-        let callCount = 0
-        mockRepo.updatePerson = jest.fn().mockImplementation(() => {
-            callCount++
-            if (callCount === 1) {
-                return Promise.resolve([person, []]) // success for first person
+        // Mock batch update to fail for person2 (returns error in results map)
+        mockRepo.updatePersonsBatch = jest.fn().mockImplementation((updates) => {
+            const results = new Map()
+            for (const update of updates) {
+                if (update.uuid === person.uuid) {
+                    results.set(update.uuid, {
+                        success: true,
+                        version: update.version + 1,
+                        kafkaMessage: { topic: 'test', messages: [] },
+                    })
+                } else {
+                    results.set(update.uuid, {
+                        success: false,
+                        error: new Error('Database error'),
+                    })
+                }
             }
-            throw new Error('Database error') // fail for second person
+            return Promise.resolve(results)
         })
+
+        // Mock fallback to also fail
+        mockRepo.updatePerson = jest.fn().mockRejectedValue(new Error('Database error'))
 
         await expect(personStore.flush()).rejects.toThrow('Database error')
     })
@@ -602,17 +640,33 @@ describe('BatchWritingPersonStore', () => {
 
         await personStore.flush()
 
-        expect(mockRepo.updatePerson).toHaveBeenCalledWith(
-            expect.objectContaining({
-                properties: { null_prop: null, undefined_prop: undefined, test: 'test' },
-            }),
-            expect.anything(),
-            'updatePersonNoAssert'
+        // In NO_ASSERT mode, we use batch updates
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    uuid: person.uuid,
+                    properties_to_set: expect.objectContaining({
+                        null_prop: null,
+                        undefined_prop: undefined,
+                    }),
+                }),
+            ])
         )
     })
 
     it('should handle MessageSizeTooLarge errors and capture warning', async () => {
-        // Mock NO_ASSERT update to fail with MessageSizeTooLarge
+        // Mock batch update to fail for this person, then fallback to fail with MessageSizeTooLarge
+        mockRepo.updatePersonsBatch = jest.fn().mockImplementation((updates) => {
+            const results = new Map()
+            for (const update of updates) {
+                results.set(update.uuid, {
+                    success: false,
+                    error: new Error('batch failed'),
+                })
+            }
+            return Promise.resolve(results)
+        })
         mockRepo.updatePerson = jest.fn().mockRejectedValue(new MessageSizeTooLarge('test', new Error('test')))
 
         // Add a person update to cache
@@ -621,7 +675,7 @@ describe('BatchWritingPersonStore', () => {
         // Flush should handle the error and capture warning
         await personStore.flush()
 
-        expect(mockRepo.updatePerson).toHaveBeenCalled()
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalled()
         expect(captureIngestionWarning).toHaveBeenCalledWith(
             db.kafkaProducer,
             teamId,
@@ -635,7 +689,7 @@ describe('BatchWritingPersonStore', () => {
 
     describe('dbWriteMode functionality', () => {
         describe('flush with NO_ASSERT mode', () => {
-            it('should call updatePersonNoAssert directly without retries', async () => {
+            it('should call updatePersonsBatch directly without retries', async () => {
                 const personStore = new BatchWritingPersonsStore(mockRepo, db.kafkaProducer, {
                     dbWriteMode: 'NO_ASSERT',
                 })
@@ -649,17 +703,30 @@ describe('BatchWritingPersonStore', () => {
                 )
                 await personStore.flush()
 
-                expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+                // NO_ASSERT mode uses batch updates
+                expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
                 expect(mockRepo.updatePersonAssertVersion).not.toHaveBeenCalled()
                 expect(db.postgres.transaction).not.toHaveBeenCalled()
             })
 
-            it('should fallback with NO_ASSERT mode', async () => {
+            it('should fallback with NO_ASSERT mode when batch fails', async () => {
                 const personStore = new BatchWritingPersonsStore(mockRepo, db.kafkaProducer, {
                     dbWriteMode: 'NO_ASSERT',
                     maxOptimisticUpdateRetries: 5,
                 })
 
+                // Mock batch update to fail
+                mockRepo.updatePersonsBatch = jest.fn().mockImplementation((updates) => {
+                    const results = new Map()
+                    for (const update of updates) {
+                        results.set(update.uuid, {
+                            success: false,
+                            error: new Error('Batch failed'),
+                        })
+                    }
+                    return Promise.resolve(results)
+                })
+                // Mock fallback to also fail
                 mockRepo.updatePerson = jest.fn().mockRejectedValue(new Error('Database error'))
 
                 await personStore.updatePersonWithPropertiesDiffForUpdate(
@@ -671,7 +738,8 @@ describe('BatchWritingPersonStore', () => {
                 )
 
                 await expect(personStore.flush()).rejects.toThrow('Database error')
-                expect(mockRepo.updatePerson).toHaveBeenCalledTimes(6) // 6 for update (1 fallback + 5 retries)
+                expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+                expect(mockRepo.updatePerson).toHaveBeenCalled() // Fallback was attempted
                 expect(mockRepo.updatePersonAssertVersion).not.toHaveBeenCalled()
             })
         })
@@ -791,7 +859,7 @@ describe('BatchWritingPersonStore', () => {
 
                 await Promise.all([noAssertBatch.flush(), assertVersionBatch.flush()])
 
-                expect(noAssertMockRepo.updatePerson).toHaveBeenCalledTimes(1) // NO_ASSERT mode
+                expect(noAssertMockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1) // NO_ASSERT mode uses batch
                 expect(assertVersionMockRepo.updatePersonAssertVersion).toHaveBeenCalledTimes(1) // ASSERT_VERSION mode
             })
         })
@@ -934,34 +1002,22 @@ describe('BatchWritingPersonStore', () => {
 
         expect(cache.size).toBe(1)
 
-        // Flush should consolidate these into a single DB update
+        // Flush should consolidate these into a single DB update (via batch)
         await personStore.flush()
 
-        // ISSUE: Currently this will likely result in 2 separate DB calls for the same person
-        // or only one of the updates will be applied, leading to incomplete data
-        // expect(db.updatePerson).toHaveBeenCalledTimes(1)
-
-        // The updatePerson call should have the correct properties
-        expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
-        expect(mockRepo.updatePerson).toHaveBeenCalledWith(
-            expect.objectContaining({
-                id: sharedPerson.id,
-                properties: {
-                    initial_prop: 'initial_value',
-                    prop_from_distinctId1: 'value1',
-                    prop_from_distinctId2: 'value2',
-                },
-            }),
-            // Only mutable fields should be in the update object
-            expect.objectContaining({
-                properties: {
-                    initial_prop: 'initial_value',
-                    prop_from_distinctId1: 'value1',
-                    prop_from_distinctId2: 'value2',
-                },
-                is_identified: expect.any(Boolean),
-            }),
-            'updatePersonNoAssert'
+        // In NO_ASSERT mode, we use batch updates
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: sharedPerson.id,
+                    properties_to_set: {
+                        initial_prop: 'initial_value',
+                        prop_from_distinctId1: 'value1',
+                        prop_from_distinctId2: 'value2',
+                    },
+                }),
+            ])
         )
     })
 
@@ -1015,16 +1071,18 @@ describe('BatchWritingPersonStore', () => {
 
         await personStore.flush()
 
-        expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
-        expect(mockRepo.updatePerson).toHaveBeenCalledWith(
-            expect.objectContaining({
-                properties: {
-                    existing_prop: 'existing_value',
-                    conflicting_prop: 'new_value',
-                },
-            }),
-            expect.anything(),
-            'updatePersonNoAssert'
+        // In NO_ASSERT mode, we use batch updates
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    properties_to_set: {
+                        existing_prop: 'existing_value',
+                        conflicting_prop: 'new_value',
+                    },
+                    properties_to_unset: [],
+                }),
+            ])
         )
     })
 
@@ -1077,15 +1135,17 @@ describe('BatchWritingPersonStore', () => {
 
         await personStore.flush()
 
-        expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
-        expect(mockRepo.updatePerson).toHaveBeenCalledWith(
-            expect.objectContaining({
-                properties: {
-                    existing_prop: 'existing_value',
-                },
-            }),
-            expect.anything(),
-            'updatePersonNoAssert'
+        // In NO_ASSERT mode, we use batch updates
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    properties_to_set: {
+                        existing_prop: 'existing_value',
+                    },
+                    properties_to_unset: ['conflicting_prop'],
+                }),
+            ])
         )
     })
 
@@ -1573,14 +1633,8 @@ describe('BatchWritingPersonStore', () => {
             // Flush SHOULD write to database since it's a new property
             await personStore.flush()
 
-            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
-            expect(mockRepo.updatePerson).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    properties: { name: 'John', $browser: 'Chrome' },
-                }),
-                expect.anything(),
-                'updatePersonNoAssert'
-            )
+            // In NO_ASSERT mode, we use batch updates
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
 
             // Verify metrics - should be 'changed' since new property triggers write
             expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
@@ -1612,7 +1666,8 @@ describe('BatchWritingPersonStore', () => {
             // Flush SHOULD write to database because name is not filtered
             await personStore.flush()
 
-            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+            // In NO_ASSERT mode, we use batch updates
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
 
             // Verify metrics - should be 'changed' since non-filtered property triggers write
             expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
@@ -1644,7 +1699,8 @@ describe('BatchWritingPersonStore', () => {
             // Flush SHOULD write to database because unsetting always triggers a write
             await personStore.flush()
 
-            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+            // In NO_ASSERT mode, we use batch updates
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
 
             // Verify metrics - should be 'changed' since unsetting triggers write
             expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
@@ -1678,7 +1734,8 @@ describe('BatchWritingPersonStore', () => {
             // Flush SHOULD write to database because force_update bypasses filtering
             await personStore.flush()
 
-            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+            // In NO_ASSERT mode, we use batch updates
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
 
             // Verify metrics - should be 'changed' because force_update bypasses filtering
             expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
@@ -1794,19 +1851,18 @@ describe('BatchWritingPersonStore', () => {
             // Flush SHOULD write to database because $geoip_country_name is allowed
             await personStore.flush()
 
-            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
-            expect(mockRepo.updatePerson).toHaveBeenCalledWith(
+            // In NO_ASSERT mode, we use batch updates
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith([
                 expect.objectContaining({
-                    properties: {
+                    properties_to_set: {
                         $geoip_country_name: 'United States',
                         $geoip_city_name: 'San Francisco',
                         $geoip_latitude: 37.7749,
                         $geoip_longitude: -122.4194,
                     },
                 }),
-                expect.anything(),
-                'updatePersonNoAssert'
-            )
+            ])
 
             // Verify metrics - should be 'changed' since allowed geoip property triggers write
             expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
@@ -1869,19 +1925,18 @@ describe('BatchWritingPersonStore', () => {
             // Flush SHOULD write to database because event 3 has non-filtered property
             await personStore.flush()
 
-            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
-            expect(mockRepo.updatePerson).toHaveBeenCalledWith(
+            // In NO_ASSERT mode, we use batch updates
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith([
                 expect.objectContaining({
-                    properties: {
+                    properties_to_set: {
                         $browser: 'Chrome',
                         $app_build: '200',
                         $os: 'macOS',
                         name: 'John',
                     },
                 }),
-                expect.anything(),
-                'updatePersonNoAssert'
-            )
+            ])
 
             // Verify metrics - should be 'changed' since non-filtered property triggers write
             expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
@@ -1918,18 +1973,16 @@ describe('BatchWritingPersonStore', () => {
             // Flush SHOULD write to database
             await personStore.flush()
 
-            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
-            expect(mockRepo.updatePerson).toHaveBeenCalledWith(
+            // In NO_ASSERT mode, we use batch updates
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith([
                 expect.objectContaining({
-                    properties: {
-                        test: 'test',
+                    properties_to_set: expect.objectContaining({
                         plan: 'premium',
                         subscription_status: 'active',
-                    },
+                    }),
                 }),
-                expect.anything(),
-                'updatePersonNoAssert'
-            )
+            ])
 
             // Verify metrics - should be 'changed' since custom properties trigger write
             expect(mockPersonProfileBatchUpdateOutcomeCounter.labels).toHaveBeenCalledTimes(1)
@@ -1989,20 +2042,19 @@ describe('BatchWritingPersonStore', () => {
             // Flush SHOULD write to database because $identify event set force_update=true
             await personStore.flush()
 
-            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+            // In NO_ASSERT mode, we use batch updates
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
 
             // Verify that ALL property changes from all three events are written
-            expect(mockRepo.updatePerson).toHaveBeenCalledWith(
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith([
                 expect.objectContaining({
-                    properties: expect.objectContaining({
+                    properties_to_set: expect.objectContaining({
                         $browser: 'Safari',
                         utm_source: 'facebook',
                         $geoip_city_name: 'San Francisco',
                     }),
                 }),
-                expect.anything(),
-                'updatePersonNoAssert'
-            )
+            ])
         })
 
         it('integration: chain without $identify/$set should not trigger update', async () => {
@@ -2112,15 +2164,13 @@ describe('BatchWritingPersonStore', () => {
             await personStore.updatePersonWithPropertiesDiffForUpdate(person2, { batch: '2' }, [], {}, 'distinct-2')
             await personStore.flush()
 
-            // Verify second batch wrote correctly
-            expect(mockRepo.updatePerson).toHaveBeenCalledTimes(2)
-            expect(mockRepo.updatePerson).toHaveBeenLastCalledWith(
+            // Verify second batch wrote correctly (NO_ASSERT mode uses batch updates)
+            expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(2)
+            expect(mockRepo.updatePersonsBatch).toHaveBeenLastCalledWith([
                 expect.objectContaining({
-                    properties: expect.objectContaining({ batch: '2' }),
+                    properties_to_set: expect.objectContaining({ batch: '2' }),
                 }),
-                expect.anything(),
-                'updatePersonNoAssert'
-            )
+            ])
         })
 
         it('should not share cached person data between batches', async () => {

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -177,6 +177,7 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
 
         // Check if there are any properties_to_set that should trigger an update
         const ignoredProperties: string[] = []
+
         const hasPropertyTriggeringUpdate = Object.keys(update.properties_to_set).some((key) => {
             // Check if this is a new property (not in current properties)
             const isNewProperty = !(key in update.properties)
@@ -258,158 +259,21 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
             return []
         }
 
-        const limit = pLimit(this.options.maxConcurrentUpdates)
-
         try {
-            const results = await Promise.all(
-                updateEntries.map(([cacheKey, update]) =>
-                    limit(async (): Promise<FlushResult[]> => {
-                        try {
-                            personWriteMethodAttemptCounter.inc({
-                                db_write_mode: this.options.dbWriteMode,
-                                method: this.options.dbWriteMode,
-                                outcome: 'attempt',
-                            })
+            let allKafkaMessages: FlushResult[]
 
-                            let kafkaMessages: FlushResult[] = []
-                            switch (this.options.dbWriteMode) {
-                                case 'NO_ASSERT': {
-                                    const result = await this.withMergeRetry(
-                                        update,
-                                        this.updatePersonNoAssert.bind(this),
-                                        'updatePersonNoAssert',
-                                        this.options.maxOptimisticUpdateRetries,
-                                        this.options.optimisticUpdateRetryInterval
-                                    )
-                                    kafkaMessages = result.messages.map((message) => ({
-                                        topicMessage: message,
-                                        teamId: update.team_id,
-                                        uuid: update.uuid,
-                                        distinctId: update.distinct_id,
-                                    }))
-                                    break
-                                }
-                                case 'ASSERT_VERSION': {
-                                    const result = await this.withMergeRetry(
-                                        update,
-                                        this.updatePersonAssertVersion.bind(this),
-                                        'updatePersonAssertVersion',
-                                        this.options.maxOptimisticUpdateRetries,
-                                        this.options.optimisticUpdateRetryInterval
-                                    )
-                                    kafkaMessages = result.messages.map((message) => ({
-                                        topicMessage: message,
-                                        teamId: update.team_id,
-                                        uuid: update.uuid,
-                                        distinctId: update.distinct_id,
-                                    }))
-                                    break
-                                }
-                            }
-
-                            personWriteMethodAttemptCounter.inc({
-                                db_write_mode: this.options.dbWriteMode,
-                                method: this.options.dbWriteMode,
-                                outcome: 'success',
-                            })
-
-                            return kafkaMessages
-                        } catch (error) {
-                            // If the Kafka message is too large, we can't retry, so we need to capture a warning and stop retrying
-                            if (error instanceof MessageSizeTooLarge) {
-                                await captureIngestionWarning(
-                                    this.kafkaProducer,
-                                    update.team_id,
-                                    'person_upsert_message_size_too_large',
-                                    {
-                                        personId: update.id,
-                                        distinctId: update.distinct_id,
-                                    }
-                                )
-                                personWriteMethodAttemptCounter.inc({
-                                    db_write_mode: this.options.dbWriteMode,
-                                    method: this.options.dbWriteMode,
-                                    outcome: 'error',
-                                })
-                                return []
-                            }
-
-                            if (error instanceof PersonPropertiesSizeViolationError) {
-                                await captureIngestionWarning(
-                                    this.kafkaProducer,
-                                    update.team_id,
-                                    'person_properties_size_violation',
-                                    {
-                                        personId: update.id,
-                                        distinctId: update.distinct_id,
-                                        teamId: update.team_id,
-                                        message: 'Person properties exceeds size limit and was rejected',
-                                    }
-                                )
-                                personWriteMethodAttemptCounter.inc({
-                                    db_write_mode: this.options.dbWriteMode,
-                                    method: this.options.dbWriteMode,
-                                    outcome: 'properties_size_violation',
-                                })
-                                return []
-                            }
-
-                            // Handle max retries error with the latest person update
-                            if (error instanceof MaxRetriesError) {
-                                logger.warn('⚠️', 'Falling back to direct update after max retries', {
-                                    teamId: error.latestPersonUpdate.team_id,
-                                    personId: error.latestPersonUpdate.id,
-                                    distinctId: error.latestPersonUpdate.distinct_id,
-                                })
-
-                                personFallbackOperationsCounter.inc({
-                                    db_write_mode: this.options.dbWriteMode,
-                                    fallback_reason: 'max_retries',
-                                })
-
-                                const fallbackResult = await this.updatePersonNoAssert(error.latestPersonUpdate)
-                                const fallbackMessages = fallbackResult.success ? fallbackResult.messages : []
-
-                                personWriteMethodAttemptCounter.inc({
-                                    db_write_mode: this.options.dbWriteMode,
-                                    method: 'fallback',
-                                    outcome: 'success',
-                                })
-
-                                return fallbackMessages.map((message) => ({
-                                    topicMessage: message,
-                                    teamId: error.latestPersonUpdate.team_id,
-                                    uuid: error.latestPersonUpdate.uuid,
-                                    distinctId: error.latestPersonUpdate.distinct_id,
-                                }))
-                            }
-
-                            // Re-throw any other errors
-                            throw error
-                        }
-                    }).catch((error) => {
-                        logger.error('Failed to update person after max retries and direct update fallback', {
-                            error,
-                            cacheKey,
-                            teamId: update.team_id,
-                            personId: update.id,
-                            distinctId: update.distinct_id,
-                            errorMessage: error instanceof Error ? error.message : String(error),
-                            errorStack: error instanceof Error ? error.stack : undefined,
-                        })
-
-                        personWriteMethodAttemptCounter.inc({
-                            db_write_mode: this.options.dbWriteMode,
-                            method: 'fallback',
-                            outcome: 'error',
-                        })
-                        throw error
-                    })
-                )
-            )
-
-            // Flatten all Kafka messages from all operations
-            const allKafkaMessages = results.flat()
+            switch (this.options.dbWriteMode) {
+                case 'NO_ASSERT': {
+                    // Use batch update for NO_ASSERT mode - single query for all updates
+                    allKafkaMessages = await this.flushBatchNoAssert(updateEntries)
+                    break
+                }
+                case 'ASSERT_VERSION': {
+                    // Use individual updates for ASSERT_VERSION mode (requires per-person retry logic)
+                    allKafkaMessages = await this.flushIndividualAssertVersion(updateEntries)
+                    break
+                }
+            }
 
             // Record successful flush
             const flushLatency = (performance.now() - flushStartTime) / 1000
@@ -430,6 +294,247 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
             })
             throw error
         }
+    }
+
+    /**
+     * Flush all person updates using a single batch query (NO_ASSERT mode).
+     * Falls back to individual updates for any persons that fail in the batch.
+     */
+    private async flushBatchNoAssert(updateEntries: [string, PersonUpdate][]): Promise<FlushResult[]> {
+        const updates = updateEntries.map(([_, update]) => update)
+
+        personWriteMethodAttemptCounter.inc({
+            db_write_mode: this.options.dbWriteMode,
+            method: 'batch',
+            outcome: 'attempt',
+        })
+
+        // Try batch update first
+        const batchResults = await this.personRepository.updatePersonsBatch(updates)
+
+        const allKafkaMessages: FlushResult[] = []
+        const failedUpdates: PersonUpdate[] = []
+
+        // Process batch results
+        for (const update of updates) {
+            const result = batchResults.get(update.uuid)
+            if (result?.success && result.kafkaMessage) {
+                allKafkaMessages.push({
+                    topicMessage: result.kafkaMessage,
+                    teamId: update.team_id,
+                    uuid: update.uuid,
+                    distinctId: update.distinct_id,
+                })
+                personWriteMethodAttemptCounter.inc({
+                    db_write_mode: this.options.dbWriteMode,
+                    method: 'batch',
+                    outcome: 'success',
+                })
+            } else {
+                // Track the failure and queue for individual retry
+                failedUpdates.push(update)
+
+                // Handle specific error types
+                if (result?.error instanceof PersonPropertiesSizeViolationError) {
+                    await captureIngestionWarning(
+                        this.kafkaProducer,
+                        update.team_id,
+                        'person_properties_size_violation',
+                        {
+                            personId: update.id,
+                            distinctId: update.distinct_id,
+                            teamId: update.team_id,
+                            message: 'Person properties exceeds size limit and was rejected',
+                        }
+                    )
+                    personWriteMethodAttemptCounter.inc({
+                        db_write_mode: this.options.dbWriteMode,
+                        method: 'batch',
+                        outcome: 'properties_size_violation',
+                    })
+                    // Don't retry size violations - they will never succeed
+                    failedUpdates.pop()
+                }
+            }
+        }
+
+        // Fallback to individual updates for failed persons
+        if (failedUpdates.length > 0) {
+            logger.warn('⚠️', `Batch update had ${failedUpdates.length} failures, falling back to individual updates`, {
+                failedCount: failedUpdates.length,
+                totalCount: updates.length,
+            })
+
+            personFallbackOperationsCounter.inc({
+                db_write_mode: this.options.dbWriteMode,
+                fallback_reason: 'batch_partial_failure',
+            })
+
+            const limit = pLimit(this.options.maxConcurrentUpdates)
+            const fallbackResults = await Promise.all(
+                failedUpdates.map((update) =>
+                    limit(async (): Promise<FlushResult[]> => {
+                        try {
+                            const result = await this.withMergeRetry(
+                                update,
+                                this.updatePersonNoAssert.bind(this),
+                                'updatePersonNoAssert',
+                                this.options.maxOptimisticUpdateRetries,
+                                this.options.optimisticUpdateRetryInterval
+                            )
+                            personWriteMethodAttemptCounter.inc({
+                                db_write_mode: this.options.dbWriteMode,
+                                method: 'fallback',
+                                outcome: 'success',
+                            })
+                            return result.messages.map((message) => ({
+                                topicMessage: message,
+                                teamId: update.team_id,
+                                uuid: update.uuid,
+                                distinctId: update.distinct_id,
+                            }))
+                        } catch (error) {
+                            return this.handleIndividualUpdateError(error, update)
+                        }
+                    })
+                )
+            )
+            allKafkaMessages.push(...fallbackResults.flat())
+        }
+
+        return allKafkaMessages
+    }
+
+    /**
+     * Flush all person updates using individual queries with version assertion (ASSERT_VERSION mode).
+     * This mode requires per-person retry logic for version conflicts.
+     */
+    private async flushIndividualAssertVersion(updateEntries: [string, PersonUpdate][]): Promise<FlushResult[]> {
+        const limit = pLimit(this.options.maxConcurrentUpdates)
+
+        const results = await Promise.all(
+            updateEntries.map(([cacheKey, update]) =>
+                limit(async (): Promise<FlushResult[]> => {
+                    try {
+                        personWriteMethodAttemptCounter.inc({
+                            db_write_mode: this.options.dbWriteMode,
+                            method: this.options.dbWriteMode,
+                            outcome: 'attempt',
+                        })
+
+                        const result = await this.withMergeRetry(
+                            update,
+                            this.updatePersonAssertVersion.bind(this),
+                            'updatePersonAssertVersion',
+                            this.options.maxOptimisticUpdateRetries,
+                            this.options.optimisticUpdateRetryInterval
+                        )
+
+                        personWriteMethodAttemptCounter.inc({
+                            db_write_mode: this.options.dbWriteMode,
+                            method: this.options.dbWriteMode,
+                            outcome: 'success',
+                        })
+
+                        return result.messages.map((message) => ({
+                            topicMessage: message,
+                            teamId: update.team_id,
+                            uuid: update.uuid,
+                            distinctId: update.distinct_id,
+                        }))
+                    } catch (error) {
+                        return this.handleIndividualUpdateError(error, update)
+                    }
+                }).catch((error) => {
+                    logger.error('Failed to update person after max retries and direct update fallback', {
+                        error,
+                        cacheKey,
+                        teamId: update.team_id,
+                        personId: update.id,
+                        distinctId: update.distinct_id,
+                        errorMessage: error instanceof Error ? error.message : String(error),
+                        errorStack: error instanceof Error ? error.stack : undefined,
+                    })
+
+                    personWriteMethodAttemptCounter.inc({
+                        db_write_mode: this.options.dbWriteMode,
+                        method: 'fallback',
+                        outcome: 'error',
+                    })
+                    throw error
+                })
+            )
+        )
+
+        return results.flat()
+    }
+
+    /**
+     * Handle errors from individual person update attempts.
+     * Returns FlushResult[] for recoverable errors, throws for fatal errors.
+     */
+    private async handleIndividualUpdateError(error: unknown, update: PersonUpdate): Promise<FlushResult[]> {
+        // If the Kafka message is too large, we can't retry, so we need to capture a warning and stop retrying
+        if (error instanceof MessageSizeTooLarge) {
+            await captureIngestionWarning(this.kafkaProducer, update.team_id, 'person_upsert_message_size_too_large', {
+                personId: update.id,
+                distinctId: update.distinct_id,
+            })
+            personWriteMethodAttemptCounter.inc({
+                db_write_mode: this.options.dbWriteMode,
+                method: this.options.dbWriteMode,
+                outcome: 'error',
+            })
+            return []
+        }
+
+        if (error instanceof PersonPropertiesSizeViolationError) {
+            await captureIngestionWarning(this.kafkaProducer, update.team_id, 'person_properties_size_violation', {
+                personId: update.id,
+                distinctId: update.distinct_id,
+                teamId: update.team_id,
+                message: 'Person properties exceeds size limit and was rejected',
+            })
+            personWriteMethodAttemptCounter.inc({
+                db_write_mode: this.options.dbWriteMode,
+                method: this.options.dbWriteMode,
+                outcome: 'properties_size_violation',
+            })
+            return []
+        }
+
+        // Handle max retries error with the latest person update
+        if (error instanceof MaxRetriesError) {
+            logger.warn('⚠️', 'Falling back to direct update after max retries', {
+                teamId: error.latestPersonUpdate.team_id,
+                personId: error.latestPersonUpdate.id,
+                distinctId: error.latestPersonUpdate.distinct_id,
+            })
+
+            personFallbackOperationsCounter.inc({
+                db_write_mode: this.options.dbWriteMode,
+                fallback_reason: 'max_retries',
+            })
+
+            const fallbackResult = await this.updatePersonNoAssert(error.latestPersonUpdate)
+            const fallbackMessages = fallbackResult.success ? fallbackResult.messages : []
+
+            personWriteMethodAttemptCounter.inc({
+                db_write_mode: this.options.dbWriteMode,
+                method: 'fallback',
+                outcome: 'success',
+            })
+
+            return fallbackMessages.map((message) => ({
+                topicMessage: message,
+                teamId: error.latestPersonUpdate.team_id,
+                uuid: error.latestPersonUpdate.uuid,
+                distinctId: error.latestPersonUpdate.distinct_id,
+            }))
+        }
+
+        // Re-throw any other errors
+        throw error
     }
 
     async inTransaction<T>(description: string, transaction: (tx: PersonsStoreTransaction) => Promise<T>): Promise<T> {

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -331,9 +331,6 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                     outcome: 'success',
                 })
             } else {
-                // Track the failure and queue for individual retry
-                failedUpdates.push(update)
-
                 // Handle specific error types
                 if (result?.error instanceof PersonPropertiesSizeViolationError) {
                     await captureIngestionWarning(
@@ -353,8 +350,11 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
                         outcome: 'properties_size_violation',
                     })
                     // Don't retry size violations - they will never succeed
-                    failedUpdates.pop()
+                    continue
                 }
+
+                // Queue for individual retry
+                failedUpdates.push(update)
             }
         }
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
@@ -64,6 +64,18 @@ export interface PersonRepository {
 
     updatePersonAssertVersion(personUpdate: PersonUpdate): Promise<[number | undefined, TopicMessage[]]>
 
+    /**
+     * Batch update multiple persons in a single query using UNNEST.
+     * Returns results indexed by person UUID, each containing:
+     * - success: boolean indicating if the update succeeded
+     * - version: the new version if successful
+     * - kafkaMessage: the Kafka message to send if successful
+     * - error: error details if the update failed
+     */
+    updatePersonsBatch(
+        personUpdates: PersonUpdate[]
+    ): Promise<Map<string, { success: boolean; version?: number; kafkaMessage?: TopicMessage; error?: Error }>>
+
     deletePerson(person: InternalPerson): Promise<TopicMessage[]>
 
     addDistinctId(person: InternalPerson, distinctId: string, version: number): Promise<TopicMessage[]>

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -280,7 +280,8 @@ export class PostgresPersonRepository
         })
 
         // Use UNNEST with two arrays to keep query structure constant for prepared statement reuse.
-        // This avoids creating different query plans for different batch sizes.
+        // This is more efficient than building dynamic OR conditions because PostgreSQL can
+        // prepare and cache the execution plan regardless of batch size.
         const teamIds = uniqueTeamPersons.map((p) => p.teamId)
         const distinctIds = uniqueTeamPersons.map((p) => p.distinctId)
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -957,6 +957,138 @@ export class PostgresPersonRepository
         }
     }
 
+    /**
+     * Batch update multiple persons in a single query using UNNEST.
+     * This uses a fixed query structure regardless of batch size, enabling prepared statement reuse.
+     *
+     * The method updates all mutable fields (properties, is_identified, created_at) and increments version.
+     * It does NOT assert version - it always overwrites with the provided values.
+     */
+    async updatePersonsBatch(
+        personUpdates: PersonUpdate[]
+    ): Promise<Map<string, { success: boolean; version?: number; kafkaMessage?: TopicMessage; error?: Error }>> {
+        const results = new Map<
+            string,
+            { success: boolean; version?: number; kafkaMessage?: TopicMessage; error?: Error }
+        >()
+
+        if (personUpdates.length === 0) {
+            return results
+        }
+
+        // Prepare arrays for UNNEST - one array per column we're updating/filtering on
+        const uuids: string[] = []
+        const teamIds: number[] = []
+        const properties: string[] = []
+        const propertiesLastUpdatedAt: string[] = []
+        const propertiesLastOperation: string[] = []
+        const isIdentified: boolean[] = []
+        const createdAt: string[] = []
+
+        for (const update of personUpdates) {
+            uuids.push(update.uuid)
+            teamIds.push(update.team_id)
+
+            // Calculate final properties by applying set and unset operations
+            const finalProperties = { ...update.properties }
+            Object.entries(update.properties_to_set).forEach(([key, value]) => {
+                finalProperties[key] = value
+            })
+            update.properties_to_unset.forEach((key) => {
+                delete finalProperties[key]
+            })
+
+            // sanitizeJsonbValue already returns JSON.stringify(value) for objects, so don't double-stringify
+            properties.push(sanitizeJsonbValue(finalProperties))
+            propertiesLastUpdatedAt.push(sanitizeJsonbValue(update.properties_last_updated_at))
+            propertiesLastOperation.push(sanitizeJsonbValue(update.properties_last_operation))
+            isIdentified.push(update.is_identified)
+            createdAt.push(update.created_at.toISO()!)
+        }
+
+        try {
+            // Use UNNEST to pass arrays, keeping query structure constant for prepared statement reuse
+            // Note: batch column names are prefixed with 'new_' to avoid any potential confusion with table columns
+            const { rows } = await this.postgres.query<RawPerson>(
+                PostgresUse.PERSONS_WRITE,
+                `
+                UPDATE posthog_person AS p SET
+                    properties = batch.new_properties::jsonb,
+                    properties_last_updated_at = batch.new_properties_last_updated_at::jsonb,
+                    properties_last_operation = batch.new_properties_last_operation::jsonb,
+                    is_identified = batch.new_is_identified,
+                    created_at = batch.new_created_at::timestamp with time zone,
+                    version = COALESCE(p.version, 0)::numeric + 1
+                FROM UNNEST(
+                    $1::uuid[],
+                    $2::integer[],
+                    $3::text[],
+                    $4::text[],
+                    $5::text[],
+                    $6::boolean[],
+                    $7::text[]
+                ) AS batch(batch_uuid, batch_team_id, new_properties, new_properties_last_updated_at, new_properties_last_operation, new_is_identified, new_created_at)
+                WHERE p.uuid = batch.batch_uuid AND p.team_id = batch.batch_team_id
+                RETURNING p.*
+                `,
+                [uuids, teamIds, properties, propertiesLastUpdatedAt, propertiesLastOperation, isIdentified, createdAt],
+                'updatePersonsBatch'
+            )
+
+            // Build a map of uuid -> updated person for quick lookup
+            const updatedPersonsByUuid = new Map<string, InternalPerson>()
+            for (const row of rows) {
+                const person = this.toPerson(row)
+                updatedPersonsByUuid.set(person.uuid, person)
+            }
+
+            // Process results for each input update
+            for (const update of personUpdates) {
+                const updatedPerson = updatedPersonsByUuid.get(update.uuid)
+                if (updatedPerson) {
+                    results.set(update.uuid, {
+                        success: true,
+                        version: updatedPerson.version,
+                        kafkaMessage: generateKafkaPersonUpdateMessage(updatedPerson),
+                    })
+                } else {
+                    // Person was not found/updated - likely deleted or merged
+                    results.set(update.uuid, {
+                        success: false,
+                        error: new NoRowsUpdatedError(
+                            `Person with uuid="${update.uuid}" and team_id="${update.team_id}" was not updated`
+                        ),
+                    })
+                }
+            }
+        } catch (error) {
+            // If the batch update fails due to properties size constraint, we need to handle it
+            // For now, mark all as failed - the caller can fall back to individual updates
+            if (this.isPropertiesSizeConstraintViolation(error)) {
+                for (const update of personUpdates) {
+                    results.set(update.uuid, {
+                        success: false,
+                        error: new PersonPropertiesSizeViolationError(
+                            `Batch update failed due to properties size constraint`,
+                            update.team_id,
+                            update.id
+                        ),
+                    })
+                }
+            } else {
+                // For other errors, mark all as failed with the original error
+                for (const update of personUpdates) {
+                    results.set(update.uuid, {
+                        success: false,
+                        error: error instanceof Error ? error : new Error(String(error)),
+                    })
+                }
+            }
+        }
+
+        return results
+    }
+
     async updateCohortsAndFeatureFlagsForMerge(
         teamID: Team['id'],
         sourcePersonID: InternalPerson['id'],

--- a/plugin-server/src/worker/ingestion/persons/repositories/raw-postgres-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/raw-postgres-person-repository.ts
@@ -51,6 +51,10 @@ export interface RawPostgresPersonRepository {
 
     updatePersonAssertVersion(personUpdate: PersonUpdate): Promise<[number | undefined, TopicMessage[]]>
 
+    updatePersonsBatch(
+        personUpdates: PersonUpdate[]
+    ): Promise<Map<string, { success: boolean; version?: number; kafkaMessage?: TopicMessage; error?: Error }>>
+
     deletePerson(person: InternalPerson, tx?: TransactionClient): Promise<TopicMessage[]>
 
     addDistinctId(

--- a/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state-batch.test.ts
@@ -139,6 +139,7 @@ describe('PersonState.processEvent()', () => {
         jest.spyOn(personRepository, 'fetchPerson')
         jest.spyOn(personRepository, 'createPerson')
         jest.spyOn(personRepository, 'updatePerson')
+        jest.spyOn(personRepository, 'updatePersonsBatch')
 
         defaultRetryConfig.RETRY_INTERVAL_DEFAULT = 0
     })
@@ -527,7 +528,8 @@ describe('PersonState.processEvent()', () => {
                 version: 0,
                 is_identified: false,
             })
-            expect(personRepository.updatePerson).toHaveBeenCalledTimes(1)
+            // Batch mode uses updatePersonsBatch instead of updatePerson
+            expect(personRepository.updatePersonsBatch).toHaveBeenCalledTimes(1)
             // verify Postgres persons
             const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
@@ -1011,7 +1013,8 @@ describe('PersonState.processEvent()', () => {
             )
 
             expect(personRepository.fetchPerson).toHaveBeenCalledTimes(1)
-            expect(personRepository.updatePerson).toHaveBeenCalledTimes(1)
+            // Batch mode uses updatePersonsBatch instead of updatePerson
+            expect(personRepository.updatePersonsBatch).toHaveBeenCalledTimes(1)
 
             // verify Postgres persons
             const persons = sortPersons(await fetchPostgresPersonsH())
@@ -1028,7 +1031,8 @@ describe('PersonState.processEvent()', () => {
             )
 
             await personS.updateProperties()
-            expect(personRepository.updatePerson).toHaveBeenCalledTimes(1)
+            // No additional batch call since no changes
+            expect(personRepository.updatePersonsBatch).toHaveBeenCalledTimes(1)
         })
 
         it('handles race condition when person provided has been merged', async () => {
@@ -2668,6 +2672,7 @@ describe('PersonState.processEvent()', () => {
 
             jest.spyOn(personRepository, 'fetchPerson')
             jest.spyOn(personRepository, 'updatePerson')
+            jest.spyOn(personRepository, 'updatePersonsBatch')
         })
 
         afterEach(async () => {
@@ -2743,7 +2748,8 @@ describe('PersonState.processEvent()', () => {
                 is_identified: true,
             })
 
-            expect(personRepository.updatePerson).toHaveBeenCalledTimes(1)
+            // Batch mode uses updatePersonsBatch instead of updatePerson
+            expect(personRepository.updatePersonsBatch).toHaveBeenCalledTimes(1)
             expect(hub.db.kafkaProducer.queueMessages).toHaveBeenCalledTimes(2)
             // verify Postgres persons
             const persons = sortPersons(await fetchPostgresPersonsH())


### PR DESCRIPTION
## Problem

Currently batch updates during flush run one by one, this PR allows us to batch all updates in one, when running in "NO_ASSERT" update mode

## Changes

- Added updatePersonsBatch method to PostgresPersonRepository that uses PostgreSQL's UNNEST function to update multiple persons in a single query
- The query uses a fixed structure regardless of batch size, enabling PostgreSQL prepared statement reuse for better performance
- Updated BatchWritingPersonsStore.flushBatchNoAssert to use the new batch update method instead of individual updates
- Added fallback logic: if any persons fail in the batch update, they are retried individually
- Added updatePersonsBatch to RawPostgresPersonRepository interface and PostgresDualwritePersonRepository implementation

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
