### PR TITLE
fix(batch-exports): Cancel batch export query if not found in query log

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -602,6 +602,22 @@ class ClickHouseClient:
             self.logger.warning("Expected event not found in query log", query_id=query_id, events=events)
             raise ClickHouseQueryNotFound(query, query_id)
 
+    async def acancel_query(self, query_id: str) -> None:
+        """Cancel a running query in ClickHouse.
+
+        Arguments:
+            query_id: The ID of the query to cancel.
+        """
+        query = f"KILL QUERY ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' WHERE query_id = {{{{query_id:String}}}}"
+
+        await self.execute_query(
+            query,
+            query_parameters={"query_id": query_id},
+            query_id=f"{query_id}-KILL",
+        )
+
+        self.logger.info("Cancelled query", query_id=query_id)
+
     async def stream_query_as_jsonl(
         self,
         query,

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from posthog.clickhouse.query_tagging import QueryTags
 from posthog.temporal.common.clickhouse import (
+    ClickHouseError,
     ClickHouseMemoryLimitExceededError,
     ClickHouseQueryNotFound,
     ClickHouseQueryStatus,
@@ -98,7 +99,7 @@ async def test_acancel_query(clickhouse_client):
 
     await clickhouse_client.acancel_query(long_running_query_id)
 
-    with pytest.raises(Exception):
+    with pytest.raises(ClickHouseError):
         await query_task
 
     max_wait_time = 5.0

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from posthog.clickhouse.query_tagging import QueryTags
 from posthog.temporal.common.clickhouse import (
     ClickHouseMemoryLimitExceededError,
+    ClickHouseQueryNotFound,
     ClickHouseQueryStatus,
     add_log_comment_param,
     encode_clickhouse_data,
@@ -100,8 +101,6 @@ async def test_acancel_query(clickhouse_client):
     with pytest.raises(Exception):
         await query_task
 
-    await asyncio.sleep(1)
-
     max_wait_time = 5.0
     poll_interval = 0.5
     elapsed_time = 0.0
@@ -111,7 +110,7 @@ async def test_acancel_query(clickhouse_client):
         try:
             status = await clickhouse_client.acheck_query(long_running_query_id, raise_on_error=False)
             break
-        except Exception:
+        except ClickHouseQueryNotFound:
             await asyncio.sleep(poll_interval)
             elapsed_time += poll_interval
 

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -82,7 +82,7 @@ def test_clickhouse_memory_limit_exceeded_error(clickhouse_client):
                 pass
 
 
-async def test_acancel_query(clickhouse_client):
+async def test_acancel_query(clickhouse_client, django_db_setup):
     """Test that acancel_query successfully cancels a long-running query."""
     long_running_query_id = f"test-long-running-query-{uuid.uuid4()}"
     long_running_query = "SELECT sleep(300)"

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -1,4 +1,5 @@
 import uuid
+import asyncio
 import datetime as dt
 
 import pytest
@@ -7,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from posthog.clickhouse.query_tagging import QueryTags
 from posthog.temporal.common.clickhouse import (
     ClickHouseMemoryLimitExceededError,
+    ClickHouseQueryStatus,
     add_log_comment_param,
     encode_clickhouse_data,
 )
@@ -76,3 +78,41 @@ def test_clickhouse_memory_limit_exceeded_error(clickhouse_client):
         with pytest.raises(ClickHouseMemoryLimitExceededError):
             with clickhouse_client.post_query("SELECT 1", query_parameters={}, query_id=None):
                 pass
+
+
+async def test_acancel_query(clickhouse_client):
+    """Test that acancel_query successfully cancels a long-running query."""
+    long_running_query_id = f"test-long-running-query-{uuid.uuid4()}"
+    long_running_query = "SELECT sleep(300)"
+
+    async def run_query():
+        await clickhouse_client.execute_query(
+            long_running_query,
+            query_id=long_running_query_id,
+        )
+
+    query_task = asyncio.create_task(run_query())
+
+    await asyncio.sleep(1)
+
+    await clickhouse_client.acancel_query(long_running_query_id)
+
+    with pytest.raises(Exception):
+        await query_task
+
+    await asyncio.sleep(1)
+
+    max_wait_time = 5.0
+    poll_interval = 0.5
+    elapsed_time = 0.0
+
+    status = None
+    while elapsed_time < max_wait_time:
+        try:
+            status = await clickhouse_client.acheck_query(long_running_query_id, raise_on_error=False)
+            break
+        except Exception:
+            await asyncio.sleep(poll_interval)
+            elapsed_time += poll_interval
+
+    assert status == ClickHouseQueryStatus.ERROR

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -488,18 +488,26 @@ async def _write_batch_export_record_batches_to_internal_stage(
                     query_id=str(query_id),
                 )
                 # Sometimes we can't find the query in the query log, so make sure we retry a few times
+                num_attempts = 5
                 check_query = make_retryable_with_exponential_backoff(
                     client.acheck_query,
-                    max_attempts=5,
+                    max_attempts=num_attempts,
                     max_retry_delay=1,
                     retryable_exceptions=(ClickHouseQueryNotFound,),
                 )
 
-                status = await check_query(str(query_id), raise_on_error=True)
-
-                while status == ClickHouseQueryStatus.RUNNING:
-                    await asyncio.sleep(10)
+                try:
                     status = await check_query(str(query_id), raise_on_error=True)
+                    while status == ClickHouseQueryStatus.RUNNING:
+                        await asyncio.sleep(10)
+                        status = await check_query(str(query_id), raise_on_error=True)
+                except ClickHouseQueryNotFound:
+                    logger.exception(
+                        f"Query not found in query log after {num_attempts} attempts",
+                        query_id=str(query_id),
+                    )
+                    await client.acancel_query(str(query_id))
+                    raise
 
             except Exception as e:
                 logger.exception(

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -506,7 +506,10 @@ async def _write_batch_export_record_batches_to_internal_stage(
                         f"Query not found in query log after {num_attempts} attempts",
                         query_id=str(query_id),
                     )
-                    await client.acancel_query(str(query_id))
+                    try:
+                        await client.acancel_query(str(query_id))
+                    except Exception as cancel_error:
+                        logger.warning("Failed to cancel query", query_id=str(query_id), error=str(cancel_error))
                     raise
 
             except Exception as e:


### PR DESCRIPTION
## Problem

Sometimes we cannot find the batch export query in the query log and when we retry the batch export, we can end up with multiple queries running at once.

## Changes

Cancel the existing query if not found in the query log.

This may not work as intended, if the same mechanism preventing us finding the query in the first place affects our ability to cancel the query

## How did you test this code?

Added a test to test the new cancel query functionality.

