### PR TITLE
chore: Expand kafka-dedup buckets

### DIFF
--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -57,7 +57,9 @@ pub async fn index() -> &'static str {
 /// Setup metrics recorder with optimized histogram buckets for kafka-deduplicator
 /// Using fewer buckets to reduce cardinality
 fn setup_kafka_deduplicator_metrics() -> PrometheusHandle {
-    const BUCKETS: &[f64] = &[0.001, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 100.0, 500.0, 5000.0];
+    const BUCKETS: &[f64] = &[
+        0.001, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+    ];
     // similarity scores are all in the range [0.0, 1.0] so we want
     // granular bucket ranges for higher fidelity metrics
     const SIMILARITY_BUCKETS: &[f64] = &[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
@@ -80,6 +82,11 @@ fn setup_kafka_deduplicator_metrics() -> PrometheusHandle {
         100.0 * 1024.0 * 1024.0 * 1024.0,
     ];
 
+    // Buckets for counting unique items (UUIDs, timestamps)
+    const COUNT_BUCKETS: &[f64] = &[
+        1.0, 2.0, 5.0, 10.0, 50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0,
+    ];
+
     PrometheusBuilder::new()
         .set_buckets(BUCKETS)
         .unwrap()
@@ -96,6 +103,16 @@ fn setup_kafka_deduplicator_metrics() -> PrometheusHandle {
         .set_buckets_for_metric(
             Matcher::Suffix("checkpoint_size_bytes".to_string()),
             CHECKPOINT_SIZE_BYTES_BUCKETS,
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Suffix("unique_uuids".to_string()),
+            COUNT_BUCKETS,
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Suffix("unique_timestamps".to_string()),
+            COUNT_BUCKETS,
         )
         .unwrap()
         .install_recorder()

--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -105,10 +105,7 @@ fn setup_kafka_deduplicator_metrics() -> PrometheusHandle {
             CHECKPOINT_SIZE_BYTES_BUCKETS,
         )
         .unwrap()
-        .set_buckets_for_metric(
-            Matcher::Suffix("unique_uuids".to_string()),
-            COUNT_BUCKETS,
-        )
+        .set_buckets_for_metric(Matcher::Suffix("unique_uuids".to_string()), COUNT_BUCKETS)
         .unwrap()
         .set_buckets_for_metric(
             Matcher::Suffix("unique_timestamps".to_string()),


### PR DESCRIPTION
## Problem

We need broader buckets for kafka-deduplicator

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
