### PR TITLE
fix(flags): HyperCache expiry tracking mismatch

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -140,17 +140,6 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     return result
 
 
-def _track_cache_expiry(team: Team | int, ttl_seconds: int) -> None:
-    """
-    Track cache expiration in Redis sorted set for efficient expiry queries.
-
-    Args:
-        team: Team object or team ID
-        ttl_seconds: TTL in seconds from now
-    """
-    track_cache_expiry(FLAGS_CACHE_EXPIRY_SORTED_SET, team, ttl_seconds, redis_url=settings.FLAGS_REDIS_URL)
-
-
 # HyperCache instance for feature-flags service
 # Use dedicated flags cache alias if available, otherwise defaults to default cache
 flags_hypercache = HyperCache(
@@ -214,7 +203,7 @@ def update_flags_cache(team: Team | int, ttl: int | None = None) -> bool:
     else:
         # Track expiration in sorted set for efficient queries
         ttl_seconds = ttl if ttl is not None else settings.FLAGS_CACHE_TTL
-        _track_cache_expiry(team, ttl_seconds)
+        track_cache_expiry(FLAGS_CACHE_EXPIRY_SORTED_SET, team_id, ttl_seconds, redis_url=settings.FLAGS_REDIS_URL)
 
     return success
 

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -226,6 +226,9 @@ def clear_flags_cache(team: Team | int, kinds: list[str] | None = None) -> None:
     flags_hypercache.clear_cache(team, kinds=kinds)
 
     # Remove from expiry tracking sorted set
+    # Note: When team is an int, we use it directly as the identifier. This works
+    # because flags_hypercache is ID-based (token_based=False). For token-based
+    # caches, callers must pass a Team object to derive the correct identifier.
     try:
         redis_client = get_client(flags_hypercache.redis_url)
         identifier = flags_hypercache.get_cache_identifier(team) if isinstance(team, Team) else team

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -543,40 +543,10 @@ class TestGetTeamsWithExpiringCaches(BaseTest):
         mock_get_client.return_value = mock_redis
         mock_redis.zrangebyscore.return_value = []
 
-        # Create config with explicit FLAGS_REDIS_URL (simulating production setup)
-        test_redis_url = "redis://localhost:6379/1"
-        test_config = FLAGS_HYPERCACHE_MANAGEMENT_CONFIG.cache_expiry_config(test_redis_url)
+        get_teams_with_expiring_caches(FLAGS_HYPERCACHE_MANAGEMENT_CONFIG, ttl_threshold_hours=24)
 
-        get_teams_with_expiring_caches(test_config, ttl_threshold_hours=24)
-
-        # Verify get_client was called with FLAGS_REDIS_URL, not default REDIS_URL
-        mock_get_client.assert_called_once_with(test_redis_url)
-
-    @override_settings(FLAGS_REDIS_URL="redis://localhost:6379/1")
-    @patch("posthog.storage.cache_expiry_manager.get_client")
-    def test_track_cache_expiry_uses_correct_redis_url(self, mock_get_client):
-        """Test that track_cache_expiry uses FLAGS_REDIS_URL when passed.
-
-        This is a regression test for a bug where expiry tracking was using
-        the default Redis database (0) instead of the dedicated flags cache database (1).
-        """
-        from posthog.models.feature_flag.flags_cache import FLAGS_CACHE_EXPIRY_SORTED_SET
-        from posthog.storage.cache_expiry_manager import track_cache_expiry
-
-        # Mock Redis client
-        mock_redis = MagicMock()
-        mock_get_client.return_value = mock_redis
-
-        # Call track_cache_expiry with FLAGS_REDIS_URL (as update_flags_cache does)
-        track_cache_expiry(
-            FLAGS_CACHE_EXPIRY_SORTED_SET, self.team.id, ttl_seconds=3600, redis_url="redis://localhost:6379/1"
-        )
-
-        # Verify get_client was called with FLAGS_REDIS_URL
-        mock_get_client.assert_called_once_with("redis://localhost:6379/1")
-
-        # Verify zadd was called to track the expiry
-        self.assertEqual(mock_redis.zadd.call_count, 1)
+        # Verify get_client was called with the hypercache's redis_url
+        mock_get_client.assert_called_once_with(FLAGS_HYPERCACHE_MANAGEMENT_CONFIG.hypercache.redis_url)
 
 
 @override_settings(FLAGS_REDIS_URL="redis://test:6379/0")
@@ -586,7 +556,10 @@ class TestBatchOperations(BaseTest):
     @patch("posthog.models.feature_flag.flags_cache.refresh_expiring_caches")
     def test_refresh_expiring_caches(self, mock_refresh):
         """Test refreshing expiring caches calls generic function."""
-        from posthog.models.feature_flag.flags_cache import FLAGS_CACHE_EXPIRY_CONFIG, refresh_expiring_flags_caches
+        from posthog.models.feature_flag.flags_cache import (
+            FLAGS_HYPERCACHE_MANAGEMENT_CONFIG,
+            refresh_expiring_flags_caches,
+        )
 
         mock_refresh.return_value = (2, 0)  # successful, failed
 
@@ -597,7 +570,7 @@ class TestBatchOperations(BaseTest):
         self.assertEqual(failed, 0)
 
         # Should call generic refresh_expiring_caches with correct config
-        mock_refresh.assert_called_once_with(FLAGS_CACHE_EXPIRY_CONFIG, 24, settings.FLAGS_CACHE_REFRESH_LIMIT)
+        mock_refresh.assert_called_once_with(FLAGS_HYPERCACHE_MANAGEMENT_CONFIG, 24, settings.FLAGS_CACHE_REFRESH_LIMIT)
 
     @patch("posthog.storage.cache_expiry_manager.get_client")
     def test_cleanup_stale_expiry_tracking(self, mock_get_client):
@@ -631,8 +604,8 @@ class TestBatchOperations(BaseTest):
         # Should call zrem with the stale team ID
         mock_redis.zrem.assert_called_once_with(FLAGS_CACHE_EXPIRY_SORTED_SET, str(team2_id))
 
-    @patch("posthog.storage.cache_expiry_manager.get_client")
-    @patch("posthog.storage.cache_expiry_manager.time")
+    @patch("posthog.storage.hypercache.get_client")
+    @patch("posthog.storage.hypercache.time")
     def test_warm_without_stagger_tracks_expiry_with_default_ttl(self, mock_time, mock_get_client):
         """Test that expiry tracking happens even when stagger_ttl=False (uses batch path)."""
         from posthog.models.feature_flag.flags_cache import (

--- a/posthog/storage/cache_expiry_manager.py
+++ b/posthog/storage/cache_expiry_manager.py
@@ -1,14 +1,14 @@
 """
 Generic cache expiry management for Redis-backed caches.
 
-This module provides a shared abstraction for managing cache expiration tracking
-across different cache types (flags, team metadata, etc.). Each cache type can
-define a CacheExpiryConfig that specifies how to query and refresh that cache.
+This module provides shared functions for managing cache expiration tracking
+across different HyperCache types (flags, team metadata, etc.).
 """
 
+from __future__ import annotations
+
 import time
-from collections.abc import Callable
-from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import structlog
 
@@ -17,74 +17,14 @@ from posthog.models.team.team import Team
 from posthog.redis import get_client
 from posthog.storage.hypercache_manager import push_hypercache_teams_processed_metrics
 
+if TYPE_CHECKING:
+    from posthog.storage.hypercache_manager import HyperCacheManagementConfig
+
 logger = structlog.get_logger(__name__)
 
 
-@dataclass
-class CacheExpiryConfig:
-    """
-    Configuration for managing cache expiration tracking.
-
-    Each cache type (flags, team metadata, etc.) should define one of these
-    configs to specify how its cache expiry is tracked and refreshed.
-
-    Most properties are derived from cache_name to reduce boilerplate.
-    """
-
-    # Required properties
-    cache_name: str  # Canonical cache name (e.g., "flags", "team_metadata")
-    query_field: str  # Team model field to query by ("id" or "api_token")
-    identifier_type: type  # Type to convert identifiers to (int or str)
-    update_fn: Callable[[Team], bool]  # Function to refresh cache for a team
-    namespace: str  # Cache namespace for metrics labeling (e.g., "feature_flags", "team_metadata")
-    redis_url: str | None = None  # Optional Redis URL for dedicated cache (e.g., FLAGS_REDIS_URL)
-
-    # Derived properties
-    @property
-    def sorted_set_key(self) -> str:
-        """Redis sorted set key for tracking expiry timestamps."""
-        return f"{self.cache_name}_cache_expiry"
-
-    @property
-    def log_prefix(self) -> str:
-        """Prefix for log messages (e.g., "flags caches", "team metadata caches")."""
-        return f"{self.cache_name.replace('_', ' ')} caches"
-
-
-def track_cache_expiry(
-    sorted_set_key: str,
-    identifier: str | int,
-    ttl_seconds: int,
-    redis_url: str | None = None,
-) -> None:
-    """
-    Track cache expiration in Redis sorted set for efficient expiry queries.
-
-    This is a generic version that works with any sorted set key.
-    Cache-specific modules (flags_cache.py, team_metadata_cache.py) may have
-    their own wrappers that call this function.
-
-    Args:
-        sorted_set_key: Redis sorted set key for tracking expiry
-        identifier: The identifier to store in the sorted set. Use team.id for
-                   ID-based caches, or team.api_token for token-based caches.
-        ttl_seconds: TTL in seconds from now
-        redis_url: Optional Redis URL for dedicated cache (e.g., FLAGS_REDIS_URL)
-    """
-    try:
-        redis_client = get_client(redis_url)
-        expiry_timestamp = int(time.time()) + ttl_seconds
-
-        # Store identifier with expiry timestamp as score for efficient range queries
-        redis_client.zadd(sorted_set_key, {str(identifier): expiry_timestamp})
-    except Exception as e:
-        # Don't fail the cache update if expiry tracking fails
-        logger.warning("Failed to track cache expiry", identifier=identifier, error=str(e))
-        capture_exception(e)
-
-
 def get_teams_with_expiring_caches(
-    config: CacheExpiryConfig, ttl_threshold_hours: int = 24, limit: int = 5000
+    config: HyperCacheManagementConfig, ttl_threshold_hours: int = 24, limit: int = 5000
 ) -> list[Team]:
     """
     Get teams whose caches are expiring soon using sorted set for efficient lookup.
@@ -93,37 +33,44 @@ def get_teams_with_expiring_caches(
     This is O(log N + M) where M is the number of expiring teams, vs O(N) for SCAN.
 
     Args:
-        config: Cache configuration specifying which cache to check
+        config: HyperCache management config specifying which cache to check
         ttl_threshold_hours: Refresh caches expiring within this many hours
         limit: Maximum number of teams to return (default 5000, prevents unbounded results)
 
     Returns:
         List of Team objects whose caches need refresh (up to limit)
     """
+    hypercache = config.hypercache
+
+    if not hypercache.expiry_sorted_set_key:
+        logger.warning(f"No expiry sorted set configured for {config.log_prefix}")
+        return []
+
     try:
-        redis_client = get_client(config.redis_url)
+        redis_client = get_client(hypercache.redis_url)
 
         # Query sorted set for teams expiring within threshold
         threshold_timestamp = time.time() + (ttl_threshold_hours * 3600)
 
         # Get identifiers of teams expiring before threshold (score is expiration timestamp)
-        # Use LIMIT to prevent unbounded results that could cause memory spikes
         expiring_identifiers = redis_client.zrangebyscore(
-            config.sorted_set_key, "-inf", threshold_timestamp, start=0, num=limit
+            hypercache.expiry_sorted_set_key, "-inf", threshold_timestamp, start=0, num=limit
         )
-
-        # Decode bytes to strings and convert to appropriate type
-        expiring_identifiers = [
-            config.identifier_type(identifier.decode("utf-8") if isinstance(identifier, bytes) else identifier)
-            for identifier in expiring_identifiers
-        ]
 
         if not expiring_identifiers:
             logger.info(f"No {config.log_prefix} expiring soon")
             return []
 
-        # Build query filter dynamically based on config
-        filter_kwargs = {f"{config.query_field}__in": expiring_identifiers}
+        # Decode bytes to strings and convert to appropriate type based on token_based
+        query_field = "api_token" if hypercache.token_based else "id"
+        identifier_type = str if hypercache.token_based else int
+        decoded_identifiers = [
+            identifier_type(identifier.decode("utf-8") if isinstance(identifier, bytes) else identifier)
+            for identifier in expiring_identifiers
+        ]
+
+        # Build query filter dynamically based on token_based setting
+        filter_kwargs = {f"{query_field}__in": decoded_identifiers}
         teams = list(Team.objects.filter(**filter_kwargs).select_related("organization", "project"))
 
         logger.info(
@@ -141,7 +88,7 @@ def get_teams_with_expiring_caches(
 
 
 def refresh_expiring_caches(
-    config: CacheExpiryConfig, ttl_threshold_hours: int = 24, limit: int = 5000
+    config: HyperCacheManagementConfig, ttl_threshold_hours: int = 24, limit: int = 5000
 ) -> tuple[int, int]:
     """
     Refresh caches that are expiring soon to prevent cache misses.
@@ -151,12 +98,8 @@ def refresh_expiring_caches(
     2. Refreshes each cache by calling the configured update function
     3. Returns success/failure counts
 
-    Processes teams in batches (default 5000). If more teams are expiring than the limit,
-    subsequent runs will process the next batch. This prevents memory spikes and timeouts
-    from trying to refresh all teams at once.
-
     Args:
-        config: Cache configuration specifying which cache to refresh
+        config: HyperCache management config specifying which cache to refresh
         ttl_threshold_hours: Refresh caches expiring within this many hours
         limit: Maximum number of teams to refresh per run (default 5000)
 
@@ -205,7 +148,7 @@ def refresh_expiring_caches(
     return successful, failed
 
 
-def cleanup_stale_expiry_tracking(config: CacheExpiryConfig) -> int:
+def cleanup_stale_expiry_tracking(config: HyperCacheManagementConfig) -> int:
     """
     Remove stale entries from the expiry tracking sorted set.
 
@@ -213,33 +156,41 @@ def cleanup_stale_expiry_tracking(config: CacheExpiryConfig) -> int:
     that no longer have caches. This cleanup job removes those stale entries.
 
     Args:
-        config: Cache configuration specifying which cache to clean up
+        config: HyperCache management config specifying which cache to clean up
 
     Returns:
         Number of stale entries removed
     """
+    hypercache = config.hypercache
+
+    if not hypercache.expiry_sorted_set_key:
+        logger.warning(f"No expiry sorted set configured for {config.log_prefix}")
+        return 0
+
     try:
-        redis_client = get_client(config.redis_url)
+        redis_client = get_client(hypercache.redis_url)
 
         # Get all entries from the sorted set
-        all_identifiers = redis_client.zrange(config.sorted_set_key, 0, -1)
+        all_identifiers = redis_client.zrange(hypercache.expiry_sorted_set_key, 0, -1)
 
         if not all_identifiers:
             logger.info(f"No {config.log_prefix} expiry entries to check")
             return 0
 
-        # Decode to appropriate type
-        all_identifiers = [
-            config.identifier_type(identifier.decode("utf-8") if isinstance(identifier, bytes) else identifier)
+        # Decode to appropriate type based on token_based setting
+        query_field = "api_token" if hypercache.token_based else "id"
+        identifier_type = str if hypercache.token_based else int
+        decoded_identifiers = [
+            identifier_type(identifier.decode("utf-8") if isinstance(identifier, bytes) else identifier)
             for identifier in all_identifiers
         ]
 
         # Query for valid teams
-        filter_kwargs = {f"{config.query_field}__in": all_identifiers}
-        valid_identifiers = set(Team.objects.filter(**filter_kwargs).values_list(config.query_field, flat=True))
+        filter_kwargs = {f"{query_field}__in": decoded_identifiers}
+        valid_identifiers = set(Team.objects.filter(**filter_kwargs).values_list(query_field, flat=True))
 
         # Find stale entries (in sorted set but not in database)
-        stale_identifiers = [identifier for identifier in all_identifiers if identifier not in valid_identifiers]
+        stale_identifiers = [identifier for identifier in decoded_identifiers if identifier not in valid_identifiers]
 
         if not stale_identifiers:
             logger.info(f"No stale {config.log_prefix} expiry entries found")
@@ -249,12 +200,12 @@ def cleanup_stale_expiry_tracking(config: CacheExpiryConfig) -> int:
         stale_identifiers_str = [str(identifier) for identifier in stale_identifiers]
 
         # Remove stale entries
-        removed = redis_client.zrem(config.sorted_set_key, *stale_identifiers_str)
+        removed = redis_client.zrem(hypercache.expiry_sorted_set_key, *stale_identifiers_str)
 
         logger.info(
             f"Cleaned up stale {config.log_prefix} expiry entries",
             removed=removed,
-            total_checked=len(all_identifiers),
+            total_checked=len(decoded_identifiers),
         )
 
         return removed

--- a/posthog/storage/cache_expiry_manager.py
+++ b/posthog/storage/cache_expiry_manager.py
@@ -8,17 +8,13 @@ across different HyperCache types (flags, team metadata, etc.).
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING
 
 import structlog
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models.team.team import Team
 from posthog.redis import get_client
-from posthog.storage.hypercache_manager import push_hypercache_teams_processed_metrics
-
-if TYPE_CHECKING:
-    from posthog.storage.hypercache_manager import HyperCacheManagementConfig
+from posthog.storage.hypercache_manager import HyperCacheManagementConfig, push_hypercache_teams_processed_metrics
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -119,6 +119,15 @@ class HyperCache:
         else:
             return Team.objects.get(id=key)
 
+    def get_cache_identifier(self, team: Team) -> str | int:
+        """
+        Get the identifier used for cache keys and expiry tracking.
+
+        For token-based caches, returns api_token. For ID-based caches, returns team.id.
+        This ensures consistency between cache keys and expiry tracking entries.
+        """
+        return team.api_token if self.token_based else team.id
+
     def get_cache_key(self, key: KeyType) -> str:
         if self.token_based:
             if isinstance(key, Team):

--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -418,8 +418,15 @@ def warm_caches(
                         from posthog.storage.cache_expiry_manager import track_cache_expiry
 
                         actual_ttl = ttl_seconds if ttl_seconds is not None else config.hypercache.cache_ttl
+
+                        # For token-based caches, use API token as identifier; otherwise use team ID
+                        expiry_identifier = team.api_token if config.hypercache.token_based else team.id
+
                         track_cache_expiry(
-                            config.expiry_sorted_set_key, team, actual_ttl, redis_url=config.hypercache.redis_url
+                            config.expiry_sorted_set_key,
+                            expiry_identifier,
+                            actual_ttl,
+                            redis_url=config.hypercache.redis_url,
                         )
                     else:
                         # Fall back to regular update (will load individually and track expiry)

--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -419,12 +419,9 @@ def warm_caches(
 
                         actual_ttl = ttl_seconds if ttl_seconds is not None else config.hypercache.cache_ttl
 
-                        # For token-based caches, use API token as identifier; otherwise use team ID
-                        expiry_identifier = team.api_token if config.hypercache.token_based else team.id
-
                         track_cache_expiry(
                             config.expiry_sorted_set_key,
-                            expiry_identifier,
+                            config.hypercache.get_cache_identifier(team),
                             actual_ttl,
                             redis_url=config.hypercache.redis_url,
                         )

--- a/posthog/storage/team_metadata_cache.py
+++ b/posthog/storage/team_metadata_cache.py
@@ -279,9 +279,6 @@ TEAM_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
     cache_name="team_metadata",
 )
 
-# Derive cache expiry config from hypercache management config (eliminates duplication)
-TEAM_CACHE_EXPIRY_CONFIG = TEAM_HYPERCACHE_MANAGEMENT_CONFIG.cache_expiry_config()
-
 
 def clear_team_metadata_cache(team: Team | str | int, kinds: list[str] | None = None) -> None:
     """
@@ -330,7 +327,7 @@ def get_teams_with_expiring_caches(ttl_threshold_hours: int = 24, limit: int = 5
     Returns:
         List of Team objects whose caches need refresh (up to limit)
     """
-    return get_teams_generic(TEAM_CACHE_EXPIRY_CONFIG, ttl_threshold_hours, limit)
+    return get_teams_generic(TEAM_HYPERCACHE_MANAGEMENT_CONFIG, ttl_threshold_hours, limit)
 
 
 def refresh_expiring_caches(ttl_threshold_hours: int = 24, limit: int = 5000) -> tuple[int, int]:
@@ -353,8 +350,7 @@ def refresh_expiring_caches(ttl_threshold_hours: int = 24, limit: int = 5000) ->
     Returns:
         Tuple of (successful_refreshes, failed_refreshes)
     """
-    # Metrics are now tracked in cache_expiry_manager.py using consolidated counters
-    return refresh_generic(TEAM_CACHE_EXPIRY_CONFIG, ttl_threshold_hours, limit)
+    return refresh_generic(TEAM_HYPERCACHE_MANAGEMENT_CONFIG, ttl_threshold_hours, limit)
 
 
 def cleanup_stale_expiry_tracking() -> int:
@@ -367,7 +363,7 @@ def cleanup_stale_expiry_tracking() -> int:
     Returns:
         Number of stale entries removed
     """
-    removed = cleanup_generic(TEAM_CACHE_EXPIRY_CONFIG)
+    removed = cleanup_generic(TEAM_HYPERCACHE_MANAGEMENT_CONFIG)
 
     if removed > 0:
         TOMBSTONE_COUNTER.labels(

--- a/posthog/storage/test/test_hypercache_manager.py
+++ b/posthog/storage/test/test_hypercache_manager.py
@@ -23,6 +23,7 @@ def create_test_hypercache(
     namespace: str = "test_namespace",
     value: str = "test_value",
     token_based: bool = False,
+    expiry_sorted_set_key: str = "test_cache_expiry",
 ) -> HyperCache:
     """Create a test HyperCache with minimal setup."""
 
@@ -34,6 +35,7 @@ def create_test_hypercache(
         value=value,
         load_fn=load_fn,
         token_based=token_based,
+        expiry_sorted_set_key=expiry_sorted_set_key,
     )
 
 
@@ -290,7 +292,7 @@ class TestInvalidateAllCaches(BaseTest):
         invalidate_all_caches(config)
 
         # Should delete the expiry sorted set
-        mock_redis.delete.assert_called_with(config.expiry_sorted_set_key)
+        mock_redis.delete.assert_called_with(config.hypercache.expiry_sorted_set_key)
 
     @patch("posthog.storage.hypercache_manager.get_client")
     def test_returns_zero_on_error(self, mock_get_client):

--- a/posthog/storage/test/test_team_metadata_cache.py
+++ b/posthog/storage/test/test_team_metadata_cache.py
@@ -7,6 +7,8 @@ from typing import Any
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
+
 from posthog.models.team.team import Team
 from posthog.storage.team_metadata_cache import (
     TEAM_METADATA_FIELDS,
@@ -290,3 +292,61 @@ class TestGetTeamsWithExpiringCaches(BaseTest):
         result = get_teams_with_expiring_caches(ttl_threshold_hours=24)
 
         self.assertEqual(len(result), 0)
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test:6379/0")
+class TestWarmCachesExpiryTracking(BaseTest):
+    """
+    Test that warm_caches uses the correct identifier for expiry tracking.
+
+    This is a regression test for a bug where warm_caches used team IDs for
+    expiry tracking, but the team_metadata cache is token-based and expects
+    API tokens. This caused a mismatch between cache entries and expiry tracking.
+    """
+
+    @patch("posthog.storage.cache_expiry_manager.get_client")
+    @patch("posthog.storage.cache_expiry_manager.time")
+    def test_warm_caches_uses_api_token_for_token_based_cache(self, mock_time, mock_get_client):
+        """
+        Verify that warm_caches uses API token (not team ID) for token-based caches.
+
+        The team_metadata cache is token-based (token_based=True), so expiry
+        tracking should use the API token as the identifier, not the team ID.
+        """
+        from posthog.storage.hypercache_manager import warm_caches
+        from posthog.storage.team_metadata_cache import TEAM_CACHE_EXPIRY_SORTED_SET, TEAM_HYPERCACHE_MANAGEMENT_CONFIG
+
+        mock_time.time.return_value = 1000000
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        # Call warm_caches for this team
+        warm_caches(
+            TEAM_HYPERCACHE_MANAGEMENT_CONFIG,
+            stagger_ttl=False,
+            batch_size=1,
+            team_ids=[self.team.id],
+        )
+
+        # Verify zadd was called with the API TOKEN, not team ID
+        mock_redis.zadd.assert_called()
+        call_args = mock_redis.zadd.call_args
+
+        # First arg is the sorted set key
+        self.assertEqual(call_args[0][0], TEAM_CACHE_EXPIRY_SORTED_SET)
+
+        # Second arg is a dict with identifier -> timestamp
+        # The identifier should be the API token, NOT the team ID
+        identifier_dict = call_args[0][1]
+        self.assertIn(
+            self.team.api_token,
+            identifier_dict,
+            f"Expected API token '{self.team.api_token}' as identifier, "
+            f"but got: {list(identifier_dict.keys())}. "
+            "This indicates warm_caches is using the wrong identifier type for token-based caches.",
+        )
+        self.assertNotIn(
+            str(self.team.id),
+            identifier_dict,
+            f"Found team ID '{self.team.id}' as identifier, but token-based caches should use API tokens.",
+        )

--- a/posthog/storage/test/test_team_metadata_cache.py
+++ b/posthog/storage/test/test_team_metadata_cache.py
@@ -304,8 +304,8 @@ class TestWarmCachesExpiryTracking(BaseTest):
     API tokens. This caused a mismatch between cache entries and expiry tracking.
     """
 
-    @patch("posthog.storage.cache_expiry_manager.get_client")
-    @patch("posthog.storage.cache_expiry_manager.time")
+    @patch("posthog.storage.hypercache.get_client")
+    @patch("posthog.storage.hypercache.time")
     def test_warm_caches_uses_api_token_for_token_based_cache(self, mock_time, mock_get_client):
         """
         Verify that warm_caches uses API token (not team ID) for token-based caches.


### PR DESCRIPTION
## Problem

The `team_metadata` cache had a mismatch between cache entries (230K) and expiry tracking (80K) due to inconsistent identifier usage:
- `warm_caches` used team IDs via generic `track_cache_expiry`
- `update_team_metadata_cache` used API tokens via local `_track_cache_expiry`

This caused the expiry sorted set to contain a mix of IDs and tokens, breaking expiry management.

## Changes

- **Fix identifier mismatch**: Make `identifier` parameter explicit in `track_cache_expiry` (no default), ensuring token-based caches use tokens and ID-based caches use IDs consistently
- **Centralize identifier derivation**: Add `get_cache_identifier(team)` to HyperCache as single source of truth
- **Automate expiry tracking**: Move expiry tracking into `HyperCache.set_cache_value()` so callers can't forget it
- **Simplify config**: Eliminate redundant `CacheExpiryConfig` in favor of `HyperCacheManagementConfig`

Net result: -25 lines, and a class of bugs eliminated by design.

## How did you test this code?

- Added regression test verifying `warm_caches` uses correct identifier type (API tokens for token-based caches)
- Existing unit tests pass
- Manual testing