### PR TITLE
chore(signals): Include real distinct ID for summary generations

### DIFF
--- a/ee/hogai/session_summaries/session/video_validation.py
+++ b/ee/hogai/session_summaries/session/video_validation.py
@@ -266,11 +266,12 @@ class SessionSummaryVideoValidator:
         # Call LLM with the validation prompt
         updates_raw = await call_llm(
             input_prompt=validation_prompt,
-            user_key=self.user.id,
+            user_id=self.user.id,
             session_id=self.session_id,
             model=model_to_use,
             system_prompt=system_prompt,
             trace_id=self.trace_id or str(uuid.uuid4()),
+            user_distinct_id=self.user.distinct_id,
         )
         updates_content = get_raw_content(updates_raw)
         if not updates_content:

--- a/posthog/temporal/ai/session_summary/summarize_session.py
+++ b/posthog/temporal/ai/session_summary/summarize_session.py
@@ -217,6 +217,7 @@ async def get_llm_single_session_summary_activity(
         session_start_time_str=llm_input.session_start_time_str,
         session_duration=llm_input.session_duration,
         trace_id=temporalio.activity.info().workflow_id,
+        user_distinct_id=llm_input.user_distinct_id_to_log,
     )
     # Store the final summary in the DB
     await database_sync_to_async(_store_final_summary_in_db_from_activity, thread_sensitive=False)(
@@ -295,6 +296,7 @@ async def stream_llm_single_session_summary_activity(inputs: SingleSessionSummar
         session_start_time_str=llm_input.session_start_time_str,
         session_duration=llm_input.session_duration,
         trace_id=temporalio.activity.info().workflow_id,
+        user_distinct_id=llm_input.user_distinct_id_to_log,
     )
     async for current_summary_state_str in session_summary_generator:
         if current_summary_state_str == last_summary_state_str:


### PR DESCRIPTION
## Problem

Before: Session summarization traces aren't matched to the relevant person. This makes it massively annoying to see the generations for a person who reported an issue, as it requires knowing the Temporal workflow ID.

## Changes

After: Session summarization traces ARE matched to the relevant person.

## How did you test this code?

Summarized sessions locally.