### PR TITLE
fix: Convert to schedule timezone on activity retry

### DIFF
--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -199,7 +199,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
 
             if description.schedule.spec.time_zone_name and description.schedule.spec.time_zone_name != "UTC":
                 # Details is always in UTC, we must re-convert it to the schedule's timezone
-                start_at = start_at.astimezone(description.schedule.spec.time_zone_name)
+                start_at = start_at.astimezone(zoneinfo.ZoneInfo(description.schedule.spec.time_zone_name))
 
         frequency = dt.timedelta(seconds=inputs.frequency_seconds)
 

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -172,8 +172,10 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
             settings.TEMPORAL_CLIENT_KEY,
         )
 
-        details = temporalio.activity.info().heartbeat_details
+        schedule_handle = client.get_schedule_handle(inputs.schedule_id)
+        description = await schedule_handle.describe()
 
+        details = temporalio.activity.info().heartbeat_details
         if details:
             # If we receive details from a previous run, it means we were restarted for some reason.
             # Let's not double-backfill and instead wait for any outstanding runs.
@@ -195,9 +197,10 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
 
             start_at = dt.datetime.fromisoformat(last_activity_details.last_batch_data_interval_end)
 
-        schedule_handle = client.get_schedule_handle(inputs.schedule_id)
+            if description.schedule.spec.time_zone_name and description.schedule.spec.time_zone_name != "UTC":
+                # Details is always in UTC, we must re-convert it to the schedule's timezone
+                start_at = start_at.astimezone(description.schedule.spec.time_zone_name)
 
-        description = await schedule_handle.describe()
         frequency = dt.timedelta(seconds=inputs.frequency_seconds)
 
         if start_at is not None:


### PR DESCRIPTION
## Problem

We have a function `adjust_bound_datetime_to_schedule_time_zone` intended to resolve the problem of a backfill input not matching a schedule's timezone. In this case, we always prefer the schedule's timezone, assuming that as the source of truth.

Consider the way we resolve inputs for daily backfills: We simply replace the timezone for the schedule's timezone. This is fine for when the backfill is just starting: Since backfills are always at midnight, and we assume the input is midnight in _some timezone_, we can just replace that for the schedule's timezone and move on. For example an input of "2025-01-01T00:00:00+00:00" for a schedule in CET timezone would become "2025-01-01T00:00:00+01:00". 

Continuing, later in the code we convert this input back into UTC. Continuing with the example, "2025-01-01T00:00:00+01:00" becomes "2024-12-31T23:00:00+00:00". Since these times are equivalent, so far so good.

The problem comes when the backfill activity fails: We send the converted timestamp as temporal heartbeat details and use that to recover from a failure. In the retry, we once again run `adjust_bound_datetime_to_schedule_time_zone` to adjust the timezone, *but this timestamp was already converted UTC*, so if the schedule is not in UTC, we will end up "double correcting": The "2024-12-31T23:00:00+00:00" in the details is now replaced to "2024-12-31T23:00:00+01:00" which is then converted to UTC and drifted back one hour to "2024-12-31T22:00:00+01:00".

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

When receiving a timestamp from activity details, cast it to the schedule's timezone, thus undoing the UTC cast, and letting everything proceed as it should.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
