### PR TITLE
fix(livestream): Fix session recording memory leaks and reduce Kafka timeout issues

### DIFF
--- a/livestream/configs/configs.example.yml
+++ b/livestream/configs/configs.example.yml
@@ -2,7 +2,8 @@ debug: true
 kafka:
     brokers: 'localhost:9092,localhost:9093'
     topic: 'topic'
-    session_recording_topic: 'session_recording_snapshot_item_events'  # defaults to this value
+    session_recording_enabled: false  # set to true to enable session recording stats
+    session_recording_topic: 'session_recording_snapshot_item_events'  # defaults to this value when enabled
     # session_recording_brokers: 'localhost:9094'  # optional, defaults to brokers
     group_id: 'livestream-dev'
 mmdb:

--- a/livestream/configs/configs.example.yml
+++ b/livestream/configs/configs.example.yml
@@ -2,7 +2,7 @@ debug: true
 kafka:
     brokers: 'localhost:9092,localhost:9093'
     topic: 'topic'
-    session_recording_enabled: false  # set to true to enable session recording stats
+    session_recording_enabled: true  # set to false to disable session recording stats
     session_recording_topic: 'session_recording_snapshot_item_events'  # defaults to this value when enabled
     # session_recording_brokers: 'localhost:9094'  # optional, defaults to brokers
     group_id: 'livestream-dev'

--- a/livestream/configs/configs.go
+++ b/livestream/configs/configs.go
@@ -46,7 +46,7 @@ func InitConfigs(filename, configPath string) {
 	viper.AddConfigPath(configPath)
 
 	viper.SetDefault("kafka.group_id", "livestream")
-	viper.SetDefault("kafka.session_recording_enabled", false)
+	viper.SetDefault("kafka.session_recording_enabled", true)
 
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/livestream/configs/configs.go
+++ b/livestream/configs/configs.go
@@ -35,6 +35,7 @@ type Config struct {
 type KafkaConfig struct {
 	Brokers                  string `mapstructure:"brokers"`
 	Topic                    string `mapstructure:"topic"`
+	SessionRecordingEnabled  bool   `mapstructure:"session_recording_enabled"`
 	SessionRecordingTopic    string `mapstructure:"session_recording_topic"`
 	SessionRecordingBrokers  string `mapstructure:"session_recording_brokers"`
 	GroupID                  string `mapstructure:"group_id"`
@@ -45,7 +46,7 @@ func InitConfigs(filename, configPath string) {
 	viper.AddConfigPath(configPath)
 
 	viper.SetDefault("kafka.group_id", "livestream")
-	viper.SetDefault("kafka.session_recording_topic", "session_recording_snapshot_item_events")
+	viper.SetDefault("kafka.session_recording_enabled", false)
 
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -79,8 +80,13 @@ func LoadConfig() (*Config, error) {
 	if len(config.CORSAllowOrigins) == 0 {
 		config.CORSAllowOrigins = []string{"*"}
 	}
-	if config.Kafka.SessionRecordingBrokers == "" {
-		config.Kafka.SessionRecordingBrokers = config.Kafka.Brokers
+	if config.Kafka.SessionRecordingEnabled {
+		if config.Kafka.SessionRecordingTopic == "" {
+			config.Kafka.SessionRecordingTopic = "session_recording_snapshot_item_events"
+		}
+		if config.Kafka.SessionRecordingBrokers == "" {
+			config.Kafka.SessionRecordingBrokers = config.Kafka.Brokers
+		}
 	}
 
 	if config.MMDB.Path == "" {

--- a/livestream/configs/configs_test.go
+++ b/livestream/configs/configs_test.go
@@ -30,9 +30,9 @@ func TestLoadConfig(t *testing.T) {
 				Kafka: KafkaConfig{
 					Brokers:                 "localhost:9092,localhost:9093",
 					Topic:                   "topic",
-					SessionRecordingEnabled: false,
+					SessionRecordingEnabled: true,
 					SessionRecordingTopic:   "session_recording_snapshot_item_events",
-					SessionRecordingBrokers: "",
+					SessionRecordingBrokers: "localhost:9092,localhost:9093",
 					GroupID:                 "livestream-dev",
 				},
 				Postgres: PostgresConfig{

--- a/livestream/configs/configs_test.go
+++ b/livestream/configs/configs_test.go
@@ -30,8 +30,9 @@ func TestLoadConfig(t *testing.T) {
 				Kafka: KafkaConfig{
 					Brokers:                 "localhost:9092,localhost:9093",
 					Topic:                   "topic",
+					SessionRecordingEnabled: false,
 					SessionRecordingTopic:   "session_recording_snapshot_item_events",
-					SessionRecordingBrokers: "localhost:9092,localhost:9093",
+					SessionRecordingBrokers: "",
 					GroupID:                 "livestream-dev",
 				},
 				Postgres: PostgresConfig{

--- a/livestream/events/session_recording_consumer.go
+++ b/livestream/events/session_recording_consumer.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"errors"
 	"log"
 	"strconv"
@@ -32,9 +33,9 @@ func NewSessionRecordingKafkaConsumer(
 		"auto.offset.reset":          "latest",
 		"enable.auto.commit":         false,
 		"security.protocol":          securityProtocol,
-		"fetch.message.max.bytes":    1_000_000_000,
-		"fetch.max.bytes":            1_000_000_000,
-		"queued.max.messages.kbytes": 2_000_000,
+		"fetch.message.max.bytes":    10_000_000,  // 10MB - we only read headers
+		"fetch.max.bytes":            50_000_000,  // 50MB - reduced from 1GB
+		"queued.max.messages.kbytes": 100_000,     // 100MB - reduced from 2GB
 	}
 
 	consumer, err := kafka.NewConsumer(config)
@@ -49,34 +50,40 @@ func NewSessionRecordingKafkaConsumer(
 	}, nil
 }
 
-func (c *SessionRecordingKafkaConsumer) Consume() {
+func (c *SessionRecordingKafkaConsumer) Consume(ctx context.Context) {
 	if err := c.consumer.SubscribeTopics([]string{c.topic}, nil); err != nil {
 		log.Fatalf("Failed to subscribe to session recording topic: %v", err)
 	}
 
 	for {
-		msg, err := c.consumer.ReadMessage(15 * time.Second)
-		if err != nil {
-			var inErr kafka.Error
-			if errors.As(err, &inErr) {
-				if inErr.Code() == kafka.ErrTransport {
-					metrics.SessionRecordingConnectFailure.Inc()
-				} else if inErr.IsTimeout() {
-					metrics.SessionRecordingTimeoutConsume.Inc()
-					continue
+		select {
+		case <-ctx.Done():
+			log.Println("session recording consumer shutting down...")
+			return
+		default:
+			msg, err := c.consumer.ReadMessage(15 * time.Second)
+			if err != nil {
+				var inErr kafka.Error
+				if errors.As(err, &inErr) {
+					if inErr.Code() == kafka.ErrTransport {
+						metrics.SessionRecordingConnectFailure.Inc()
+					} else if inErr.IsTimeout() {
+						metrics.SessionRecordingTimeoutConsume.Inc()
+						continue
+					}
 				}
+				log.Printf("Error consuming session recording message: %v", err)
+				continue
 			}
-			log.Printf("Error consuming session recording message: %v", err)
-			continue
-		}
 
-		metrics.SessionRecordingMsgConsumed.With(prometheus.Labels{"partition": strconv.Itoa(int(msg.TopicPartition.Partition))}).Inc()
+			metrics.SessionRecordingMsgConsumed.With(prometheus.Labels{"partition": strconv.Itoa(int(msg.TopicPartition.Partition))}).Inc()
 
-		token, sessionId := parseSessionRecordingHeaders(msg.Headers)
-		if token != "" && sessionId != "" {
-			c.statsChan <- SessionRecordingEvent{Token: token, SessionId: sessionId}
-		} else {
-			metrics.SessionRecordingDroppedMessages.Inc()
+			token, sessionId := parseSessionRecordingHeaders(msg.Headers)
+			if token != "" && sessionId != "" {
+				c.statsChan <- SessionRecordingEvent{Token: token, SessionId: sessionId}
+			} else {
+				metrics.SessionRecordingDroppedMessages.Inc()
+			}
 		}
 	}
 }

--- a/livestream/events/session_recording_consumer.go
+++ b/livestream/events/session_recording_consumer.go
@@ -80,7 +80,11 @@ func (c *SessionRecordingKafkaConsumer) Consume(ctx context.Context) {
 
 			token, sessionId := parseSessionRecordingHeaders(msg.Headers)
 			if token != "" && sessionId != "" {
-				c.statsChan <- SessionRecordingEvent{Token: token, SessionId: sessionId}
+				select {
+				case c.statsChan <- SessionRecordingEvent{Token: token, SessionId: sessionId}:
+				case <-ctx.Done():
+					return
+				}
 			} else {
 				metrics.SessionRecordingDroppedMessages.Inc()
 			}

--- a/livestream/events/session_recording_consumer.go
+++ b/livestream/events/session_recording_consumer.go
@@ -61,7 +61,7 @@ func (c *SessionRecordingKafkaConsumer) Consume(ctx context.Context) {
 			log.Println("session recording consumer shutting down...")
 			return
 		default:
-			msg, err := c.consumer.ReadMessage(15 * time.Second)
+			msg, err := c.consumer.ReadMessage(1 * time.Second)
 			if err != nil {
 				var inErr kafka.Error
 				if errors.As(err, &inErr) {

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -88,14 +88,21 @@ func main() {
 	}
 
 	go func() {
+		ticker := time.NewTicker(7127 * time.Millisecond)
+		defer ticker.Stop()
 		for {
-			metrics.IncomingQueue.Set(consumer.IncomingRatio())
-			metrics.EventQueue.Set(float64(len(phEventChan)) / float64(cap(phEventChan)))
-			metrics.StatsQueue.Set(float64(len(statsChan)) / float64(cap(statsChan)))
-			metrics.SessionRecordingStatsQueue.Set(float64(len(sessionStatsChan)) / float64(cap(sessionStatsChan)))
-			metrics.SubQueue.Set(float64(len(subChan)) / float64(cap(subChan)))
-			metrics.UnSubQueue.Set(float64(len(unSubChan)) / float64(cap(unSubChan)))
-			time.Sleep(7127 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				log.Println("metrics collection shutting down...")
+				return
+			case <-ticker.C:
+				metrics.IncomingQueue.Set(consumer.IncomingRatio())
+				metrics.EventQueue.Set(float64(len(phEventChan)) / float64(cap(phEventChan)))
+				metrics.StatsQueue.Set(float64(len(statsChan)) / float64(cap(statsChan)))
+				metrics.SessionRecordingStatsQueue.Set(float64(len(sessionStatsChan)) / float64(cap(sessionStatsChan)))
+				metrics.SubQueue.Set(float64(len(subChan)) / float64(cap(subChan)))
+				metrics.UnSubQueue.Set(float64(len(unSubChan)) / float64(cap(unSubChan)))
+			}
 		}
 	}()
 


### PR DESCRIPTION
This PR addresses several issues in the session recording livestream feature introduced in #42797:

## Issues Fixed

### 1. 🔥 Reduced Kafka fetch sizes (fixes timeout issues)
Changed from **1GB to 10MB** for message max and **50MB** for fetch max. Since we only read headers from session recording messages, the excessive 1GB limits were causing:
- Memory pressure
- Potential timeouts
- Slow consumer performance

### 2. 🔧 Fixed memory leak
Added cleanup goroutine to remove empty token stores every 10 minutes. Previously, the `token→store` mapping grew indefinitely as new tokens were encountered, never being cleaned up even when sessions expired.

### 3. 🛑 Added graceful shutdown
Session recording consumer and stats keeper now accept `context.Context` and respect cancellation signals for clean shutdowns. This prevents hanging goroutines on application shutdown. HTTP server also now shuts down gracefully.

### 4. ⚙️ Made feature configurable
Added `session_recording_enabled` boolean config flag (defaults to `true`). Can be disabled if needed by setting to `false`.

### 5. 📝 Fixed Go naming conventions
Changed `SESSION_RECORDING_TTL` to `sessionRecordingTTL` - unexported constants should use camelCase in Go.

### 6. ✅ Updated tests
All tests now use context for proper cleanup and graceful shutdown. Added test for `cleanupEmptyStores()`.

## Testing

- ✅ All existing tests pass
- ✅ Added context support to all test cases
- ✅ Verified graceful shutdown behavior
- ✅ Added cleanup test coverage

cc @pauldambra - this addresses potential issues with the session recording feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)