### PR TITLE
fix: Drop support for HogQL filters

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
@@ -222,7 +222,6 @@ export function BatchExportConfiguration(): JSX.Element {
                                                                   TaxonomicFilterGroupType.EventProperties,
                                                                   TaxonomicFilterGroupType.EventFeatureFlags,
                                                                   TaxonomicFilterGroupType.PersonProperties,
-                                                                  TaxonomicFilterGroupType.HogQLExpression,
                                                               ]
                                                             : []
                                                     }

--- a/products/batch_exports/backend/temporal/spmc.py
+++ b/products/batch_exports/backend/temporal/spmc.py
@@ -12,7 +12,7 @@ from django.conf import settings
 import pyarrow as pa
 import temporalio.common
 
-from posthog.schema import EventPropertyFilter, HogQLPropertyFilter, HogQLQueryModifiers, MaterializationMode
+from posthog.schema import EventPropertyFilter, HogQLQueryModifiers, MaterializationMode
 
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
@@ -1011,8 +1011,6 @@ def compose_filters_clause(
                 UpdatePropertiesToPersonProperties().visit(expr)
                 exprs.append(expr)
 
-            case "hogql":
-                exprs.append(property_to_expr(HogQLPropertyFilter(**filter), team=team))
             case s:
                 raise TypeError(f"Unknown filter type: '{s}'")
 

--- a/products/batch_exports/backend/tests/temporal/test_spmc.py
+++ b/products/batch_exports/backend/tests/temporal/test_spmc.py
@@ -329,14 +329,6 @@ def test_use_distributed_events_recent_table(test_data: dict[str, typing.Any]):
             """and(ifNull(greaterOrEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_properties, %(hogql_val_0)s), \'\'), \'null\'), \'^"|"$\', \'\'), 0.0), 0), ifNull(lessOrEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_properties, %(hogql_val_1)s), \'\'), \'null\'), \'^"|"$\', \'\'), 1.0), 0))""",
             {"hogql_val_0": "$created_at", "hogql_val_1": "$created_at"},
         ),
-        # HogQL
-        (
-            [
-                {"key": "toInt(properties.$browser_version) * 10 = 1", "type": "hogql", "value": None},
-            ],
-            """ifNull(equals(multiply(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), \'\'), \'null\'), \'^"|"$\', \'\'), %(hogql_val_1)s), 10), 1), 0)""",
-            {"hogql_val_0": "$browser_version", "hogql_val_1": "Int64"},
-        ),
     ],
     ids=[
         "events0",
@@ -347,7 +339,6 @@ def test_use_distributed_events_recent_table(test_data: dict[str, typing.Any]):
         "person1",
         "person2",
         "person3",
-        "hogql0",
     ],
 )
 def test_compose_filters_clause(


### PR DESCRIPTION
## Problem

HogQL filters do not work at the moment (see: https://github.com/PostHog/posthog/pull/42961).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Dropping support for them until we have a chance to revisit them.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
