### PR TITLE
fix(integrations): show last refreshed at on oauth integrations

### DIFF
--- a/frontend/src/lib/integrations/IntegrationView.tsx
+++ b/frontend/src/lib/integrations/IntegrationView.tsx
@@ -7,6 +7,7 @@ import { LemonBanner, LemonButton, LemonDivider, Spinner } from '@posthog/lemon-
 import api from 'lib/api'
 import { TZLabel } from 'lib/components/TZLabel'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
+import { dayjs } from 'lib/dayjs'
 import { IntegrationScopesWarning } from 'lib/integrations/IntegrationScopesWarning'
 import { IconBranch, IconOpenInNew } from 'lib/lemon-ui/icons'
 

--- a/frontend/src/lib/integrations/IntegrationView.tsx
+++ b/frontend/src/lib/integrations/IntegrationView.tsx
@@ -75,7 +75,7 @@ export function IntegrationView({
                                     <>
                                         <LemonDivider vertical />
                                         <div className="flex items-center gap-1 text-xs">
-                                            Last refreshed <TZLabel time={refreshedAtTimestamp} />
+                                            Last refreshed <TZLabel time={dayjs.unix(refreshedAtTimestamp)} />
                                         </div>
                                     </>
                                 )}

--- a/frontend/src/lib/integrations/IntegrationView.tsx
+++ b/frontend/src/lib/integrations/IntegrationView.tsx
@@ -32,7 +32,7 @@ export function IntegrationView({
 
     const isGitHub = integration.kind === 'github'
     const repositories = isGitHub ? getGitHubRepositories(integration.id) : []
-    const refreshedAtTimestamp = integration.config?.refreshed_at || null
+    const refreshedAtTimestamp = integration.config?.refreshed_at || dayjs().unix()
 
     useEffect(() => {
         if (isGitHub) {
@@ -75,7 +75,7 @@ export function IntegrationView({
                                 {refreshedAtTimestamp && (
                                     <>
                                         <LemonDivider vertical />
-                                        <div className="flex items-center gap-1 text-xs">
+                                        <div className="flex items-baseline gap-1 text-xs text-secondary">
                                             Last refreshed <TZLabel time={dayjs.unix(refreshedAtTimestamp)} />
                                         </div>
                                     </>

--- a/frontend/src/lib/integrations/IntegrationView.tsx
+++ b/frontend/src/lib/integrations/IntegrationView.tsx
@@ -2,9 +2,10 @@ import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
 import { IconTrash } from '@posthog/icons'
-import { LemonBanner, LemonButton, Spinner } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonDivider, Spinner } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { TZLabel } from 'lib/components/TZLabel'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
 import { IntegrationScopesWarning } from 'lib/integrations/IntegrationScopesWarning'
 import { IconBranch, IconOpenInNew } from 'lib/lemon-ui/icons'
@@ -30,6 +31,7 @@ export function IntegrationView({
 
     const isGitHub = integration.kind === 'github'
     const repositories = isGitHub ? getGitHubRepositories(integration.id) : []
+    const refreshedAtTimestamp = integration.config?.refreshed_at || null
 
     useEffect(() => {
         if (isGitHub) {
@@ -62,12 +64,22 @@ export function IntegrationView({
                             </span>
                         </div>
                         {integration.created_by ? (
-                            <UserActivityIndicator
-                                at={integration.created_at}
-                                by={integration.created_by}
-                                prefix="Updated"
-                                className="text-secondary"
-                            />
+                            <div className="flex items-center">
+                                <UserActivityIndicator
+                                    at={integration.created_at}
+                                    by={integration.created_by}
+                                    prefix="Created"
+                                    className="text-secondary"
+                                />
+                                {refreshedAtTimestamp && (
+                                    <>
+                                        <LemonDivider vertical />
+                                        <div className="flex items-center gap-1 text-xs">
+                                            Last refreshed <TZLabel time={refreshedAtTimestamp} />
+                                        </div>
+                                    </>
+                                )}
+                            </div>
                         ) : null}
                         {isGitHub && (
                             <div className="mt-1">


### PR DESCRIPTION
## Problem

In https://github.com/PostHog/posthog/pull/40828 we made the auto-refresher clear out old errors on the integration if it later succeeds.

This was a good change as it prevented confusion when an integration has self-repaired but still looks broken in the UI

[Recently we had a customer](https://posthoghelp.zendesk.com/agent/tickets/42997) who was confused as errors in destination logs made it seem like they  still needed to repair something, but no "Reconnect" button is showing on their integration.

## Changes

Make it clear how recently an oauth integration successfully refreshed to increase confidence in current integration status

## How did you test this code?
<img width="566" height="99" alt="image" src="https://github.com/user-attachments/assets/362ef605-24b4-4f44-9b3f-93b61687654f" />

