### PR TITLE
feat: allow decimals in goal lines

### DIFF
--- a/frontend/src/lib/components/GoalLinesList.tsx
+++ b/frontend/src/lib/components/GoalLinesList.tsx
@@ -43,11 +43,18 @@ export function GoalLinesList({ goalLines, updateGoalLine, removeGoalLine }: Goa
                         onChange={(value) => updateGoalLine(goalLineIndex, 'label', value)}
                     />
                     <LemonInput
+                        type="number"
+                        step="any"
                         placeholder="Value"
                         className="grow"
-                        value={value.toString()}
-                        inputMode="decimal"
-                        onChange={(value) => updateGoalLine(goalLineIndex, 'value', parseFloat(value))}
+                        value={value}
+                        onChange={(value) =>
+                            updateGoalLine(
+                                goalLineIndex,
+                                'value',
+                                value !== undefined && !Number.isNaN(value) ? value : 0
+                            )
+                        }
                     />
                     <LemonSegmentedButton
                         value={position ?? 'end'}

--- a/frontend/src/lib/components/GoalLinesList.tsx
+++ b/frontend/src/lib/components/GoalLinesList.tsx
@@ -46,8 +46,8 @@ export function GoalLinesList({ goalLines, updateGoalLine, removeGoalLine }: Goa
                         placeholder="Value"
                         className="grow"
                         value={value.toString()}
-                        inputMode="numeric"
-                        onChange={(value) => updateGoalLine(goalLineIndex, 'value', parseInt(value))}
+                        inputMode="decimal"
+                        onChange={(value) => updateGoalLine(goalLineIndex, 'value', parseFloat(value))}
                     />
                     <LemonSegmentedButton
                         value={position ?? 'end'}

--- a/frontend/src/queries/nodes/DataVisualization/displayLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/displayLogic.ts
@@ -55,15 +55,7 @@ export const displayLogic = kea<displayLogicType>([
                 updateGoalLine: (state, { goalLineIndex, key, value }) => {
                     const goalLines = [...state]
 
-                    if (key === 'value') {
-                        if (Number.isNaN(value)) {
-                            goalLines[goalLineIndex][key] = 0
-                        } else {
-                            goalLines[goalLineIndex][key] = parseFloat(value.toString())
-                        }
-                    } else {
-                        goalLines[goalLineIndex][key] = value
-                    }
+                    goalLines[goalLineIndex] = { ...goalLines[goalLineIndex], [key]: value }
 
                     return goalLines
                 },

--- a/frontend/src/queries/nodes/DataVisualization/displayLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/displayLogic.ts
@@ -59,7 +59,7 @@ export const displayLogic = kea<displayLogicType>([
                         if (Number.isNaN(value)) {
                             goalLines[goalLineIndex][key] = 0
                         } else {
-                            goalLines[goalLineIndex][key] = parseInt(value.toString())
+                            goalLines[goalLineIndex][key] = parseFloat(value.toString())
                         }
                     } else {
                         goalLines[goalLineIndex][key] = value

--- a/frontend/src/scenes/insights/EditorFilters/goalLinesLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/goalLinesLogic.ts
@@ -38,11 +38,7 @@ export const goalLinesLogic = kea<goalLinesLogicType>([
                 updateGoalLine: (state, { goalLineIndex, key, value }) => {
                     const goalLines = [...state]
                     if (key === 'value') {
-                        if (Number.isNaN(value)) {
-                            goalLines[goalLineIndex][key] = 0
-                        } else {
-                            goalLines[goalLineIndex][key] = parseFloat(value.toString())
-                        }
+                        goalLines[goalLineIndex][key] = value as number
                     } else {
                         // @ts-expect-error not sure why it thinks this is an error but it clearly isn't
                         goalLines[goalLineIndex][key] = value

--- a/frontend/src/scenes/insights/EditorFilters/goalLinesLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/goalLinesLogic.ts
@@ -41,7 +41,7 @@ export const goalLinesLogic = kea<goalLinesLogicType>([
                         if (Number.isNaN(value)) {
                             goalLines[goalLineIndex][key] = 0
                         } else {
-                            goalLines[goalLineIndex][key] = parseInt(value.toString(), 10)
+                            goalLines[goalLineIndex][key] = parseFloat(value.toString())
                         }
                     } else {
                         // @ts-expect-error not sure why it thinks this is an error but it clearly isn't


### PR DESCRIPTION
## Problem

Users cannot set goal line values less than 1 (e.g., 0.5, 0.25) in insights charts. The frontend input was using `parseInt()` which truncated decimal values to integers, even though the backend API already supports float values.

## Changes

- Changed goal line input from text with `parseInt()` to `type="number"` with `step="any"` to allow decimal values
- Updated value handling in `GoalLinesList.tsx` to properly pass numeric values
- Simplified logic in `goalLinesLogic.ts` and `displayLogic.ts` to accept float values

**Files changed:**
- `frontend/src/lib/components/GoalLinesList.tsx`
- `frontend/src/scenes/insights/EditorFilters/goalLinesLogic.ts`
- `frontend/src/queries/nodes/DataVisualization/displayLogic.ts`

## How did you test this code?

- Manually tested entering decimal values (0.5, 0.25, etc.) in goal line input
- Verified goal lines render correctly on charts with decimal values
- Confirmed clearing input defaults to 0

## Changelog: (features only) Is this feature complete?

Yes

https://github.com/posthog/posthog/issues/31978