### PR TITLE
fix(livestream): Omit empty error field from request logs

### DIFF
--- a/livestream/main.go
+++ b/livestream/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"net/http"
 	"os"
@@ -117,7 +118,42 @@ func main() {
 	e := echo.New()
 
 	// Middleware
-	e.Use(middleware.Logger())
+	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+		LogLatency:       true,
+		LogRemoteIP:      true,
+		LogHost:          true,
+		LogMethod:        true,
+		LogURI:           true,
+		LogUserAgent:     true,
+		LogStatus:        true,
+		LogError:         true,
+		LogContentLength: true,
+		LogResponseSize:  true,
+		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
+			// Build log entry, omitting error field when empty to avoid
+			// Grafana/Loki incorrectly categorizing successful requests as errors
+			logEntry := map[string]interface{}{
+				"time":          v.StartTime.Format(time.RFC3339Nano),
+				"id":            c.Response().Header().Get(echo.HeaderXRequestID),
+				"remote_ip":     v.RemoteIP,
+				"host":          v.Host,
+				"method":        v.Method,
+				"uri":           v.URI,
+				"user_agent":    v.UserAgent,
+				"status":        v.Status,
+				"latency":       v.Latency.Nanoseconds(),
+				"latency_human": v.Latency.String(),
+				"bytes_in":      v.ContentLength,
+				"bytes_out":     v.ResponseSize,
+			}
+			if v.Error != nil {
+				logEntry["error"] = v.Error.Error()
+			}
+			jsonBytes, _ := json.Marshal(logEntry)
+			log.Println(string(jsonBytes))
+			return nil
+		},
+	}))
 	e.Use(middleware.Recover())
 	e.Use(middleware.GzipWithConfig(middleware.GzipConfig{
 		Level: 9, // Set the compression level to maximum

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -118,6 +118,7 @@ func main() {
 	e := echo.New()
 
 	// Middleware
+	e.Use(middleware.RequestID())
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 		LogLatency:       true,
 		LogRemoteIP:      true,
@@ -149,8 +150,13 @@ func main() {
 			if v.Error != nil {
 				logEntry["error"] = v.Error.Error()
 			}
-			jsonBytes, _ := json.Marshal(logEntry)
-			log.Println(string(jsonBytes))
+			jsonBytes, err := json.Marshal(logEntry)
+			if err != nil {
+				log.Printf("failed to marshal log entry: %v", err)
+				return nil
+			}
+			// Write directly to stdout without log prefix since JSON already has time field
+			os.Stdout.Write(append(jsonBytes, '\n'))
 			return nil
 		},
 	}))


### PR DESCRIPTION
## Problem

The default Echo logger middleware always includes an `error` field in JSON logs:

```json
{"time":"...","status":200,"error":"","latency":...}
```

Even though the `error` field is empty for successful requests, Grafana/Loki detects the presence of the `error` key and incorrectly categorizes these as error logs.

## Solution

Replace `middleware.Logger()` with `middleware.RequestLoggerWithConfig` using a custom `LogValuesFunc` that only includes the `error` field when there's actually an error.

**Before (200 response):**
```json
{"time":"...","status":200,"error":"","latency":...}
```

**After (200 response):**
```json
{"time":"...","status":200,"latency":...}
```

**After (401 response with error):**
```json
{"time":"...","status":401,"error":"code=401, message=wrong token","latency":...}
```

## Test plan

- [x] Code compiles
- [x] All tests pass
- [ ] Verify in Grafana that successful requests no longer appear in error streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)