### PR TITLE
fix(experiments): Fix shared metrics links

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -205,29 +205,23 @@ export function SharedMetricModal({
                                 ]}
                                 footer={
                                     <div className="flex items-center justify-center m-2">
-                                        <LemonButton
-                                            to={`${urls.experiments()}?tab=shared-metrics`}
-                                            size="xsmall"
-                                            type="tertiary"
-                                        >
+                                        <Link to={`${urls.experiments()}?tab=shared-metrics`} target="_blank">
                                             See all shared metrics
-                                        </LemonButton>
+                                        </Link>
                                     </div>
                                 }
                             />
                         </>
                     ) : (
-                        <LemonBanner
-                            className="w-full"
-                            type="info"
-                            action={{
-                                children: 'New shared metric',
-                                to: urls.experimentsSharedMetric('new'),
-                            }}
-                        >
-                            {compatibleSharedMetrics.length > 0
-                                ? 'All of your shared metrics are already in this experiment.'
-                                : "You don't have any shared metrics that match the experiment type. Shared metrics let you create reusable metrics that you can quickly add to any experiment."}
+                        <LemonBanner className="w-full" type="info">
+                            <div className="mb-2">
+                                {compatibleSharedMetrics.length > 0
+                                    ? 'All of your shared metrics are already in this experiment.'
+                                    : "You don't have any shared metrics that match the experiment type. Shared metrics let you create reusable metrics that you can quickly add to any experiment."}
+                            </div>
+                            <Link to={urls.experimentsSharedMetric('new')} target="_blank">
+                                New shared metric
+                            </Link>
                         </LemonBanner>
                     )}
                 </div>


### PR DESCRIPTION
## Problem
Users complain that when clicking on `New shared metric` and `See all  shared metrics`, they are taken to the shared metrics UI in the same tab and lose all their progress in the create experiment form.

## Changes
Make sure these links open in a new tab.