### PR TITLE
refactor(flags): Standardize tombstone counter labels across Python and Rust

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1247,7 +1247,7 @@ def _evaluate_flags_with_fallback(
         # My plan is to roll this out, let it bake for a bit, monitor if this tombstone metric is hit, and then remove this fallback.
         # TODO remove this fallback once we're confident that the proxying works great.
         TOMBSTONE_COUNTER.labels(
-            namespace="feature_flag",
+            namespace="feature_flags",
             operation="proxy_to_flags_service",
             component="python_fallback",
         ).inc()

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1247,7 +1247,9 @@ def _evaluate_flags_with_fallback(
         # My plan is to roll this out, let it bake for a bit, monitor if this tombstone metric is hit, and then remove this fallback.
         # TODO remove this fallback once we're confident that the proxying works great.
         TOMBSTONE_COUNTER.labels(
-            namespace="feature_flag", operation="proxy_to_flags_service", component="python_fallback"
+            namespace="feature_flag",
+            operation="proxy_to_flags_service",
+            component="python_fallback",
         ).inc()
         logger.warning(f"Failed to proxy to flags service, falling back to Python: {e}")
 

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -32,7 +32,7 @@ KLUDGES_COUNTER = Counter(
 
 TOMBSTONE_COUNTER = Counter(
     "posthog_tombstone_total",
-    "Rare anomalous events that should almost never occur. Used to track edge cases, cleanup operations finding stale data, and other scenarios that indicate potential bugs or race conditions.",
+    "Rare anomalous events that should almost never occur. Used to track edge cases, cleanup operations finding stale data, and other scenarios that indicate potential bugs or race conditions. Details (team_id, flag_id, etc.) are logged separately to avoid high-cardinality labels.",
     labelnames=["namespace", "operation", "component"],
 )
 

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -294,9 +294,11 @@ def cleanup_stale_expiry_tracking() -> int:
     removed = cleanup_generic(FLAGS_HYPERCACHE_MANAGEMENT_CONFIG)
 
     if removed > 0:
-        TOMBSTONE_COUNTER.labels(namespace="flags", operation="stale_expiry_tracking", component="flags_cache").inc(
-            removed
-        )
+        TOMBSTONE_COUNTER.labels(
+            namespace="flags",
+            operation="stale_expiry_tracking",
+            component="flags_cache",
+        ).inc(removed)
 
     return removed
 

--- a/posthog/storage/team_metadata_cache.py
+++ b/posthog/storage/team_metadata_cache.py
@@ -367,7 +367,9 @@ def cleanup_stale_expiry_tracking() -> int:
 
     if removed > 0:
         TOMBSTONE_COUNTER.labels(
-            namespace="team_metadata", operation="stale_expiry_tracking", component="team_metadata_cache"
+            namespace="team_metadata",
+            operation="stale_expiry_tracking",
+            component="team_metadata_cache",
         ).inc(removed)
 
     return removed

--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -353,9 +353,9 @@ impl HyperCacheReader {
         inc(
             TOMBSTONE_COUNTER_NAME,
             &[
-                ("failure_type".to_string(), "hypercache_miss".to_string()),
                 ("namespace".to_string(), self.config.namespace.clone()),
-                ("value".to_string(), self.config.value.clone()),
+                ("operation".to_string(), "hypercache_miss".to_string()),
+                ("component".to_string(), self.config.value.clone()),
             ],
             1,
         );
@@ -424,12 +424,12 @@ impl HyperCacheReader {
                         inc(
                             TOMBSTONE_COUNTER_NAME,
                             &[
+                                ("namespace".to_string(), self.config.namespace.clone()),
                                 (
-                                    "failure_type".to_string(),
+                                    "operation".to_string(),
                                     "hypercache_fallback_miss".to_string(),
                                 ),
-                                ("namespace".to_string(), self.config.namespace.clone()),
-                                ("value".to_string(), self.config.value.clone()),
+                                ("component".to_string(), self.config.value.clone()),
                             ],
                             1,
                         );

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -168,11 +168,12 @@ impl FeatureFlagList {
                             e
                         );
                         // Also track as a tombstone - invalid data in postgres should never happen
+                        // Details (team_id, flag_key) are logged above to avoid high-cardinality labels
                         counter!(
                             TOMBSTONE_COUNTER,
-                            "failure_type" => "flag_filter_deserialization_error",
-                            "team_id" => row.team_id.to_string(),
-                            "flag_key" => row.key.clone(),
+                            "namespace" => "feature_flags",
+                            "operation" => "flag_filter_deserialization_error",
+                            "component" => "feature_flag_list",
                         )
                         .increment(1);
 

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -486,17 +486,17 @@ pub fn log_dependency_graph_construction_errors(
     team_id: common_types::TeamId,
 ) {
     for error in errors {
-        let (failure_type, flag_id) = match error {
-            GraphError::MissingDependency(id) => ("flag_dependency_missing", id),
-            GraphError::CycleDetected(id) => ("flag_dependency_cycle", id),
+        let failure_type = match error {
+            GraphError::MissingDependency(_) => "flag_dependency_missing",
+            GraphError::CycleDetected(_) => "flag_dependency_cycle",
         };
 
         inc(
             TOMBSTONE_COUNTER,
             &[
-                ("failure_type".to_string(), failure_type.to_string()),
-                ("team_id".to_string(), team_id.to_string()),
-                ("flag_id".to_string(), flag_id.to_string()),
+                ("namespace".to_string(), "feature_flags".to_string()),
+                ("operation".to_string(), failure_type.to_string()),
+                ("component".to_string(), "graph_utils".to_string()),
             ],
             1,
         );


### PR DESCRIPTION
## Problem

In our Grafana dashboard, I noticed the tombstone panel had an entry like `posthog//flag_dependency_missing`. That's because the Tombstone metrics in Rust don't match the schema of the metrics in Python.

## Changes

- Use consistent label names: `namespace`, `operation`, `component`
- Remove high-cardinality labels (`team_id`, `flag_id`) from metrics
- Log details separately to avoid cardinality issues
- Update `TOMBSTONE_COUNTER` description to document this approach

## How did you test this code?

Unit Tests

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
