### PR TITLE
fix: Avoid flaky snapshots by fixing date

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.stories.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.stories.tsx
@@ -7,6 +7,9 @@ import { InsightDetails as InsightDetailsComponent } from './InsightDetails'
 const meta: Meta = {
     title: 'Components/Cards/Insight Details',
     component: InsightDetailsComponent,
+    parameters: {
+        mockDate: '2025-12-10',
+    },
 }
 export default meta
 


### PR DESCRIPTION
This snapshot is flaking the last few days because it refers to a specific date in the past in the json files and we've just crossed an year boundary. Let's fix it to a specific date (this month) to avoid this from happening again next year