### PR TITLE
fix: Reduce keep alive timeout

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -117,7 +117,7 @@ async def get_s3_client():
         config=AioConfig(
             connect_timeout=60,
             read_timeout=300,
-            connector_args={"keepalive_timeout": 300},
+            connector_args={"keepalive_timeout": 30},
             http_session_cls=AIOHTTPSession,
         ),
     ) as s3_client:

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -78,8 +78,8 @@ def socket_factory(addr_info):
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
 
     if sys.platform == "linux":
-        # Start sending keepalive probes after 60s
-        # Ensure that any idle timeouts allow at least 60s
+        # Start sending keepalive probes after 30s
+        # Ensure that any idle timeouts allow at least 30s
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 30)
         # Send keepalive probes every 10s
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)


### PR DESCRIPTION
## Problem

There are two keepalive parameters at play:
1. aiohttp's keepalive timeout, which dictates how much should aiohttp (i.e. us) wait on idle connections before closing them.
2. the underlying socket's keepalive parameters, which dictate when should the socket start sending keepalive probes.

Notice that if the server is also internally tracking idle connections, and it detects is as idle, but it does so before aiohttp's keepalive timeout fires-off, then the server could respond with a `RST` upon us coming back trying to re-use the connection. From our perspective, this connection is not idle, but from the server's it is.

I think having a keepalive timeout of 300 may be too high and causing us to inadvertently re-use dropped connections.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Bring keepalive timeout to 30s. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
