### PR TITLE
chore: add env to limit event list max_threads

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -273,12 +273,15 @@ def query_with_columns(
     *,
     workload: Workload = Workload.DEFAULT,
     team_id: Optional[int] = None,
+    settings: Optional[dict[str, Any]] = None,
 ) -> list[dict]:
     if columns_to_remove is None:
         columns_to_remove = []
     if columns_to_rename is None:
         columns_to_rename = {}
-    metrics, types = sync_execute(query, args, with_column_types=True, workload=workload, team_id=team_id)
+    metrics, types = sync_execute(
+        query, args, settings=settings, with_column_types=True, workload=workload, team_id=team_id
+    )
     type_names = [key for key, _type in types]
 
     rows = []

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -160,6 +160,7 @@ def query_events_list(
             query_type="events_list",
             workload=Workload.OFFLINE,
             team_id=team.pk,
+            settings={"max_threads": settings.CLICKHOUSE_EVENT_LIST_MAX_THREADS},
         ), bound_to_same_day
     else:
         return insight_query_with_columns(
@@ -174,4 +175,5 @@ def query_events_list(
             query_type="events_list",
             workload=Workload.OFFLINE,
             team_id=team.pk,
+            settings={"max_threads": settings.CLICKHOUSE_EVENT_LIST_MAX_THREADS},
         ), bound_to_same_day

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -486,3 +486,5 @@ PATCH_EVENT_LIST_MAX_OFFSET: int = get_from_env("PATCH_EVENT_LIST_MAX_OFFSET", 0
 PATCH_EVENT_LIST_MAX_OFFSET_PER_TEAM: set[int] = get_from_env(
     "PATCH_EVENT_LIST_MAX_OFFSET_PER_TEAM", default=set[int]([]), type_cast=str_to_int_set
 )
+
+CLICKHOUSE_EVENT_LIST_MAX_THREADS: int = get_from_env("CLICKHOUSE_EVENT_LIST_MAX_THREADS", 50, type_cast=int)


### PR DESCRIPTION
## Problem

Some dumb queries consume way too much CPU / IO

## Changes

limit max_threads per query

