### PR TITLE
feat(capture): variable graceful shutdown window for capture deployments

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
+            - 'eli.r/capture-graceful-shutdown-delay'
 
 jobs:
     build:

--- a/rust/capture/src/main.rs
+++ b/rust/capture/src/main.rs
@@ -19,7 +19,7 @@ use capture::server::serve;
 
 common_alloc::used!();
 
-const GRACEFUL_SHUTDOWN_INTERVAL_MS: u64 = 3;
+const GRACEFUL_SHUTDOWN_INTERVAL_SECS: u64 = 3;
 const GRACEFUL_SHUTDOWN_INTERVAL_POLL_MS: u64 = 500;
 
 async fn shutdown() {
@@ -42,7 +42,7 @@ async fn shutdown() {
 
     loop {
         tokio::select! {
-            _ = tokio::time::sleep_until(start + Duration::from_secs(GRACEFUL_SHUTDOWN_INTERVAL_MS)) => {
+            _ = tokio::time::sleep_until(start + Duration::from_secs(GRACEFUL_SHUTDOWN_INTERVAL_SECS)) => {
                 tracing::info!("Graceful shutdown timeout reached (3s), shutting down now");
                 break;
             }

--- a/rust/capture/src/metrics_middleware.rs
+++ b/rust/capture/src/metrics_middleware.rs
@@ -14,7 +14,7 @@ use axum::{
 use metrics::gauge;
 
 // Global atomic counter for active connections
-static ACTIVE_CONNECTIONS: AtomicUsize = AtomicUsize::new(0);
+pub static ACTIVE_CONNECTIONS: AtomicUsize = AtomicUsize::new(0);
 
 // Guard to ensure connection count is decremented even on panic
 struct ConnectionGuard;


### PR DESCRIPTION
## Problem
We want to ensure we await in-flight requests when a production pod is signaled for shutdown. We can use a combo of a static time limit based on resp time tail and our existing active connections counter to sleep prior to shutdown completion in `capture` deployments.

We can test this in `capture-mirrored` deploy prior to rollout.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add variable graceful shutdown window to ensure in-flight requests complete
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
