### PR TITLE
fix: breakdowns layout

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightViz.scss
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.scss
@@ -205,10 +205,20 @@
     }
 
     .InsightVizDisplay {
+        display: flex;
+        flex-direction: column;
         height: 100%;
     }
 
+    .InsightVizDisplay__content {
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+        min-height: 0;
+    }
+
     .TrendsInsight {
-        min-height: 100%;
+        flex: 1;
+        min-height: 0;
     }
 }

--- a/products/error_tracking/frontend/components/Breakdowns/BreakdownsChart.tsx
+++ b/products/error_tracking/frontend/components/Breakdowns/BreakdownsChart.tsx
@@ -32,7 +32,7 @@ export function BreakdownsChart(): JSX.Element {
     }
 
     return (
-        <div className="ErrorTracking__breakdowns p-3 h-full">
+        <div className="ErrorTracking__breakdowns p-3 flex-1 min-h-0">
             <Query query={query} context={{ ignoreActionsInSeriesLabels: true }} />
         </div>
     )

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -153,12 +153,12 @@ const LeftHandColumn = (): JSX.Element => {
                 width: desiredSize ?? '30%',
                 minWidth: 320,
             }}
-            className="flex flex-col relative bg-surface-primary"
+            className="flex flex-col h-full relative bg-surface-primary"
         >
             <TabsPrimitive
                 value={category}
                 onValueChange={(value) => setCategory(value as ErrorTrackingIssueSceneCategory)}
-                className="flex flex-col min-h-0"
+                className="flex flex-col flex-1 min-h-0"
             >
                 <div>
                     <ScrollableShadows direction="horizontal" className="border-b" hideScrollbars>
@@ -187,10 +187,12 @@ const LeftHandColumn = (): JSX.Element => {
                 <TabsPrimitiveContent value="exceptions" className="h-full min-h-0">
                     <ExceptionsTab />
                 </TabsPrimitiveContent>
-                <TabsPrimitiveContent value="breakdowns">
-                    <BreakdownsSearchBar />
-                    <MiniBreakdowns />
-                    <BreakdownsChart />
+                <TabsPrimitiveContent value="breakdowns" className="flex-1 min-h-0">
+                    <div className="flex flex-col h-full">
+                        <BreakdownsSearchBar />
+                        <MiniBreakdowns />
+                        <BreakdownsChart />
+                    </div>
                 </TabsPrimitiveContent>
                 {hasTasks && (
                     <TabsPrimitiveContent value="autofix">

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -188,11 +188,7 @@ const LeftHandColumn = (): JSX.Element => {
                     <ExceptionsTab />
                 </TabsPrimitiveContent>
                 <TabsPrimitiveContent value="breakdowns" className="flex-1 min-h-0">
-                    <div className="flex flex-col h-full">
-                        <BreakdownsSearchBar />
-                        <MiniBreakdowns />
-                        <BreakdownsChart />
-                    </div>
+                    <BreakdownsTab />
                 </TabsPrimitiveContent>
                 {hasTasks && (
                     <TabsPrimitiveContent value="autofix">
@@ -239,6 +235,15 @@ const ExceptionsTab = (): JSX.Element => {
                     }}
                 />
             </Metadata>
+        </div>
+    )
+}
+const BreakdownsTab = (): JSX.Element => {
+    return (
+        <div className="flex flex-col h-full">
+            <BreakdownsSearchBar />
+            <MiniBreakdowns />
+            <BreakdownsChart />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

Breakdowns chart still does not look right. It doesn't scale well with the screen height.

## Changes

Fixed it

<img width="3024" height="1656" alt="image" src="https://github.com/user-attachments/assets/df69f528-2eca-43e2-a897-3ab7d6fbe7c5" />
