### PR TITLE
feat: show active recordings on the live page

### DIFF
--- a/docker/livestream/configs-dev.yml
+++ b/docker/livestream/configs-dev.yml
@@ -3,6 +3,7 @@ kafka:
     brokers: 'kafka:9092'
     topic: 'events_plugin_ingestion'
     group_id: 'livestream-dev'
+    session_recording_enabled: true
 mmdb:
     path: 'GeoLite2-City.mmdb'
 jwt:

--- a/docker/livestream/configs-hobby.yml
+++ b/docker/livestream/configs-hobby.yml
@@ -3,5 +3,6 @@ kafka:
     brokers: 'kafka:9092'
     topic: 'events_plugin_ingestion'
     group_id: 'livestream'
+    session_recording_enabled: true
 mmdb:
     path: 'GeoLite2-City.mmdb'

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -337,6 +337,7 @@ export const FEATURE_FLAGS = {
     NEW_TAB_PROJECT_EXPLORER: 'new-tab-project-explorer', // owner: #team-platform-ux
     SURVEY_HEADLINE_SUMMARY: 'survey-headline-summary', // owner: @adboio #team-surveys
     SURVEYS_ERROR_TRACKING_CROSS_SELL: 'surveys-in-error-tracking', // owner: @adboio #team-surveys
+    LIVE_EVENTS_ACTIVE_RECORDINGS: 'live-events-active-recordings', // owner: @pauldambra #team-replay
 } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/frontend/src/scenes/activity/live/LiveEventsTable.tsx
+++ b/frontend/src/scenes/activity/live/LiveEventsTable.tsx
@@ -1,13 +1,14 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 
-import { IconPauseFilled, IconPlayFilled } from '@posthog/icons'
-import { IconRefresh } from '@posthog/icons'
+import { IconPauseFilled, IconPlayFilled, IconRefresh, IconVideoCamera } from '@posthog/icons'
 import { LemonButton, LemonTabs, Spinner, Tooltip } from '@posthog/lemon-ui'
 
+import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TZLabel } from 'lib/components/TZLabel'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { liveEventsTableLogic } from 'scenes/activity/live/liveEventsTableLogic'
@@ -92,7 +93,7 @@ export function LiveEventsTable(): JSX.Element {
                 }}
             />
             <div className="mb-4 flex w-full justify-between items-center">
-                <div className="flex justify-center">
+                <div className="flex gap-2">
                     <Tooltip title="Estimate of users active in the last 30 seconds." placement="right">
                         <div className="flex justify-center items-center bg-surface-primary px-3 py-2 rounded border border-primary text-xs font-medium text-secondary gap-x-2.5">
                             <span className="relative flex h-2.5 w-2.5">
@@ -102,6 +103,7 @@ export function LiveEventsTable(): JSX.Element {
                                         stats?.users_on_product != null && 'animate-ping'
                                     )}
                                     // Unfortunately we can't use the `opacity-50` class, because we use Tailwind's
+
                                     // `important: true` and because of that Tailwind's `opacity` completely overrides
                                     // the animation (see https://github.com/tailwindlabs/tailwindcss/issues/9225)
                                     // eslint-disable-next-line react/forbid-dom-props
@@ -114,6 +116,24 @@ export function LiveEventsTable(): JSX.Element {
                             </span>
                         </div>
                     </Tooltip>
+                    <FlaggedFeature flag={FEATURE_FLAGS.LIVE_EVENTS_ACTIVE_RECORDINGS}>
+                        <Tooltip
+                            title={
+                                stats?.active_recordings == null
+                                    ? 'Unable to retrieve active recordings count.'
+                                    : 'Session recordings currently in progress.'
+                            }
+                            placement="right"
+                        >
+                            <div className="flex justify-center items-center bg-surface-primary px-3 py-2 rounded border border-primary text-xs font-medium text-secondary gap-x-2.5">
+                                <IconVideoCamera className="w-4 h-4" />
+                                <span className="text-sm cursor-default">
+                                    Active session recordings:{' '}
+                                    <b>{stats?.active_recordings == null ? '?' : stats.active_recordings}</b>
+                                </span>
+                            </div>
+                        </Tooltip>
+                    </FlaggedFeature>
                 </div>
 
                 <div className="flex gap-2">

--- a/frontend/src/scenes/activity/live/liveEventsTableLogic.tsx
+++ b/frontend/src/scenes/activity/live/liveEventsTableLogic.tsx
@@ -16,6 +16,11 @@ import type { liveEventsTableLogicType } from './liveEventsTableLogicType'
 
 const ERROR_TOAST_ID = 'live-stream-error'
 
+export interface LiveStats {
+    users_on_product: number | null
+    active_recordings: number | null
+}
+
 export interface LiveEventsTableProps {
     showLiveStreamErrorToast?: boolean
     tabId?: string
@@ -81,7 +86,7 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
             },
         ],
         stats: [
-            { users_on_product: null },
+            { users_on_product: null, active_recordings: null } as LiveStats,
             {
                 setStats: (_, { stats }) => stats,
             },


### PR DESCRIPTION
we can now show the current active session recordings on the live activity page

so let's do it



# when it is disabled

![Screenshot 2025-12-09 at 09.43.58.png](https://app.graphite.com/user-attachments/assets/db1f9601-d005-4eba-bf62-72b883f2febc.png)

# when it is not working

![Screenshot 2025-12-09 at 09.50.19.png](https://app.graphite.com/user-attachments/assets/cc338010-558a-4267-af35-7702b742d566.png)

# when it is active

(ugh, it's not working on my machine right now, but i can see the count is available in prod :see_no_evil:)