### PR TITLE
fix(logs): return correct log attribute type from attributes endpoint

### DIFF
--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -265,7 +265,7 @@ FROM (
             for result in results[0][0]:
                 entry = {
                     "name": result,
-                    "propertyFilterType": "log_attribute",
+                    "propertyFilterType": "log_resource_attribute" if attribute_type == "resource" else "log_attribute",
                 }
                 r.append(entry)
         return Response({"results": r, "count": results[0][1] + offset}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Problem

this change got accidentally reverted at some point from #42822 

## Changes

return the correct attribute type for log and resource attributes

## How did you test this code?

tested locally pointing to dev clickhouse
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
