### PR TITLE
feat(userpaths): decode URL-encoded characters in path cleaning aliases

### DIFF
--- a/frontend/src/scenes/paths-v2/pathUtils.test.ts
+++ b/frontend/src/scenes/paths-v2/pathUtils.test.ts
@@ -191,4 +191,68 @@ describe('pageUrl', () => {
         const result = pageUrl(testData, true)
         expect(result).toBe('/path')
     })
+
+    it('should decode URL-encoded characters in path cleaning aliases', () => {
+        const testData = {
+            name: '2_https://example.com/files/<id>',
+            targetLinks: [
+                {
+                    average_conversion_time: 0,
+                    index: 0,
+                    value: 0,
+                    width: 0,
+                    y0: 0,
+                    color: { r: 0, g: 0, b: 0 } as RGBColor,
+                    target: {
+                        name: '1_https://example.com/',
+                        targetLinks: [],
+                        sourceLinks: [],
+                        depth: 0,
+                        width: 0,
+                        height: 0,
+                        index: 0,
+                        value: 0,
+                        x0: 0,
+                        x1: 0,
+                        y0: 0,
+                        y1: 0,
+                        layer: 0,
+                        visible: true,
+                    },
+                    source: {
+                        name: '1_https://example.com/',
+                        targetLinks: [],
+                        sourceLinks: [],
+                        depth: 0,
+                        width: 0,
+                        height: 0,
+                        index: 0,
+                        value: 0,
+                        x0: 0,
+                        x1: 0,
+                        y0: 0,
+                        y1: 0,
+                        layer: 0,
+                        visible: true,
+                    },
+                },
+            ],
+            sourceLinks: [],
+            depth: 0,
+            width: 0,
+            height: 0,
+            index: 0,
+            value: 0,
+            x0: 0,
+            x1: 0,
+            y0: 0,
+            y1: 0,
+            layer: 0,
+            visible: true,
+        } as unknown as PathNodeData
+
+        // The URL API encodes < and > to %3C and %3E, but we should decode them back
+        const result = pageUrl(testData, true)
+        expect(result).toBe('/files/<id>')
+    })
 })

--- a/frontend/src/scenes/paths-v2/pathUtils.ts
+++ b/frontend/src/scenes/paths-v2/pathUtils.ts
@@ -103,6 +103,8 @@ export function pageUrl(d: PathNodeData, display?: boolean): string {
         if (url.hash?.includes('/')) {
             name += url.hash
         }
+        // Decode URL-encoded characters (e.g., %3C becomes <) to display path cleaning aliases correctly
+        name = decodeURIComponent(name)
     } catch {
         // discard if invalid url
     }

--- a/frontend/src/scenes/paths-v2/pathUtils.ts
+++ b/frontend/src/scenes/paths-v2/pathUtils.ts
@@ -1,5 +1,7 @@
 import { RGBColor } from 'd3'
 
+import { tryDecodeURIComponent } from 'lib/utils'
+
 import { FunnelPathsFilter, PathsFilter } from '~/queries/schema/schema-general'
 import { FunnelPathType } from '~/types'
 
@@ -104,7 +106,7 @@ export function pageUrl(d: PathNodeData, display?: boolean): string {
             name += url.hash
         }
         // Decode URL-encoded characters (e.g., %3C becomes <) to display path cleaning aliases correctly
-        name = decodeURIComponent(name)
+        name = tryDecodeURIComponent(name)
     } catch {
         // discard if invalid url
     }

--- a/frontend/src/scenes/paths/pathUtils.test.ts
+++ b/frontend/src/scenes/paths/pathUtils.test.ts
@@ -191,4 +191,68 @@ describe('pageUrl', () => {
         const result = pageUrl(testData, true)
         expect(result).toBe('/path')
     })
+
+    it('should decode URL-encoded characters in path cleaning aliases', () => {
+        const testData = {
+            name: '2_https://example.com/files/<id>',
+            targetLinks: [
+                {
+                    average_conversion_time: 0,
+                    index: 0,
+                    value: 0,
+                    width: 0,
+                    y0: 0,
+                    color: { r: 0, g: 0, b: 0 } as RGBColor,
+                    target: {
+                        name: '1_https://example.com/',
+                        targetLinks: [],
+                        sourceLinks: [],
+                        depth: 0,
+                        width: 0,
+                        height: 0,
+                        index: 0,
+                        value: 0,
+                        x0: 0,
+                        x1: 0,
+                        y0: 0,
+                        y1: 0,
+                        layer: 0,
+                        visible: true,
+                    },
+                    source: {
+                        name: '1_https://example.com/',
+                        targetLinks: [],
+                        sourceLinks: [],
+                        depth: 0,
+                        width: 0,
+                        height: 0,
+                        index: 0,
+                        value: 0,
+                        x0: 0,
+                        x1: 0,
+                        y0: 0,
+                        y1: 0,
+                        layer: 0,
+                        visible: true,
+                    },
+                },
+            ],
+            sourceLinks: [],
+            depth: 0,
+            width: 0,
+            height: 0,
+            index: 0,
+            value: 0,
+            x0: 0,
+            x1: 0,
+            y0: 0,
+            y1: 0,
+            layer: 0,
+            visible: true,
+        } as unknown as PathNodeData
+
+        // The URL API encodes < and > to %3C and %3E, but we should decode them back
+        const result = pageUrl(testData, true)
+        expect(result).toBe('/files/<id>')
+    })
 })

--- a/frontend/src/scenes/paths/pathUtils.ts
+++ b/frontend/src/scenes/paths/pathUtils.ts
@@ -1,5 +1,7 @@
 import { RGBColor } from 'd3'
 
+import { tryDecodeURIComponent } from 'lib/utils'
+
 import { FunnelPathsFilter, PathsFilter } from '~/queries/schema/schema-general'
 import { FunnelPathType } from '~/types'
 
@@ -110,7 +112,7 @@ export function pageUrl(d: PathNodeData, display?: boolean, showFullUrls?: boole
             name += url.hash
         }
         // Decode URL-encoded characters (e.g., %3C becomes <) to display path cleaning aliases correctly
-        name = decodeURIComponent(name)
+        name = tryDecodeURIComponent(name)
     } catch {
         // discard if invalid url
     }

--- a/frontend/src/scenes/paths/pathUtils.ts
+++ b/frontend/src/scenes/paths/pathUtils.ts
@@ -109,6 +109,8 @@ export function pageUrl(d: PathNodeData, display?: boolean, showFullUrls?: boole
         if (url.hash?.includes('/')) {
             name += url.hash
         }
+        // Decode URL-encoded characters (e.g., %3C becomes <) to display path cleaning aliases correctly
+        name = decodeURIComponent(name)
     } catch {
         // discard if invalid url
     }


### PR DESCRIPTION
## Problem

Zendesk ticket: https://posthoghelp.zendesk.com/agent/tickets/44351 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46632)

## Changes

Added tests and implementation to decode URL-encoded characters (e.g., %3C and %3E) in the  function, ensuring correct display of path cleaning aliases.

## How did you test this code?
Manually and with tests:
<img width="710" height="410" alt="Screenshot 2025-12-09 at 11 29 17 AM" src="https://github.com/user-attachments/assets/2e9e7905-a1bc-4514-adc3-225a12493a25" />

After:
<img width="168" height="136" alt="image" src="https://github.com/user-attachments/assets/44665cff-3c90-4b74-918c-8c6af89108f6" />
