### PR TITLE
fix(filters): Handle properly hovering on side icon on LemonButton

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -296,6 +296,7 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
 
                 workingButton = (
                     <div
+                        onMouseEnter={buttonProps.onMouseEnter}
                         className={clsx(
                             `LemonButtonWithSideAction LemonButtonWithSideAction--${type}`,
                             fullWidth && 'LemonButtonWithSideAction--full-width'


### PR DESCRIPTION
## Problem

Hovering the side icon on the filters selector does not show the edit icon
https://posthoghelp.zendesk.com/agent/tickets/44157 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46597)

<img width="479" height="441" alt="Screenshot 2025-12-09 at 15 21 19" src="https://github.com/user-attachments/assets/57a04d1b-7f56-4d8a-b952-0241f027ebf8" />


## Changes

Add an event handler to listen when the side icon is hovered

## How did you test this code?

Manually
