### PR TITLE
feat(persons): Batch update personless processing

### DIFF
--- a/plugin-server/src/ingestion/analytics/preprocessing-pipeline.ts
+++ b/plugin-server/src/ingestion/analytics/preprocessing-pipeline.ts
@@ -1,5 +1,7 @@
 import { Message } from 'node-rdkafka'
 
+import { processPersonlessDistinctIdsBatchStep } from '~/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep'
+
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { Hub } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restriction-manager'
@@ -11,7 +13,6 @@ import { BatchPipelineBuilder } from '../pipelines/builders/batch-pipeline-build
 import { PipelineConfig } from '../pipelines/result-handling-pipeline'
 import { createPostTeamPreprocessingSubpipeline } from './post-team-preprocessing-subpipeline'
 import { createPreTeamPreprocessingSubpipeline } from './pre-team-preprocessing-subpipeline'
-import { processPersonlessDistinctIdsBatchStep } from '~/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep'
 
 export interface PreprocessingPipelineConfig {
     hub: Hub
@@ -106,10 +107,7 @@ export function createPreprocessingPipeline<
                             .pipeBatch(prefetchPersonsStep(personsStore, hub.PERSONS_PREFETCH_ENABLED))
                             // Batch insert personless distinct IDs after prefetch (uses prefetch cache)
                             .pipeBatch(
-                                processPersonlessDistinctIdsBatchStep(
-                                    personsStore,
-                                    hub.PERSONS_PREFETCH_ENABLED
-                                )
+                                processPersonlessDistinctIdsBatchStep(personsStore, hub.PERSONS_PREFETCH_ENABLED)
                             )
                     )
                     .handleIngestionWarnings(kafkaProducer)

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
@@ -1,0 +1,84 @@
+import { LRUCache } from 'lru-cache'
+import { Counter } from 'prom-client'
+
+import { PipelineResult, ok } from '~/ingestion/pipelines/results'
+import { IncomingEventWithTeam } from '~/types'
+
+import { ONE_HOUR } from '../../../config/constants'
+import { PersonsStore } from '../persons/persons-store'
+
+type ProcessPersonlessDistinctIdsBatchStepInput = { eventWithTeam: IncomingEventWithTeam }
+
+export const personlessDistinctIdCacheOperationsCounter = new Counter({
+    name: 'personless_distinct_id_cache_operations_total',
+    help: 'Number of cache hits and misses for the personless distinct ID inserted cache',
+    labelNames: ['operation'],
+})
+
+// Tracks whether we know we've already inserted a `posthog_personlessdistinctid` for the given
+// (team_id, distinct_id) pair. If we have, then we can skip the INSERT attempt.
+const PERSONLESS_DISTINCT_ID_INSERTED_CACHE = new LRUCache<string, boolean>({
+    max: 100_000,
+    ttl: ONE_HOUR * 4,
+    updateAgeOnGet: true,
+})
+
+/**
+ * Batch step that inserts personless distinct IDs for events where processPerson=false
+ * and no person exists. This runs after prefetchPersonsStep so the person check cache
+ * is already populated.
+ *
+ * The batch insert results (is_merged flags) are stored in the personsStore cache
+ * and consumed by processPersonlessStep to determine force_upgrade.
+ */
+export function processPersonlessDistinctIdsBatchStep<T extends ProcessPersonlessDistinctIdsBatchStepInput>(
+    personsStore: PersonsStore,
+    enabled: boolean
+) {
+    return async function processPersonlessDistinctIdsBatchStep(events: T[]): Promise<PipelineResult<T>[]> {
+        if (enabled) {
+            // Deduplicate personless events within the batch first, then check cache
+            const seenInBatch = new Set<string>()
+            let cacheHits = 0
+            const personlessEntries: { teamId: number; distinctId: string }[] = []
+
+            for (const e of events) {
+                if (e.eventWithTeam.event.properties?.$process_person_profile !== false) {
+                    continue
+                }
+                const cacheKey = `${e.eventWithTeam.team.id}|${e.eventWithTeam.event.distinct_id}`
+
+                // Skip if already seen in this batch
+                if (seenInBatch.has(cacheKey)) {
+                    continue
+                }
+                seenInBatch.add(cacheKey)
+
+                if (PERSONLESS_DISTINCT_ID_INSERTED_CACHE.get(cacheKey)) {
+                    cacheHits++
+                } else {
+                    personlessEntries.push({
+                        teamId: e.eventWithTeam.team.id,
+                        distinctId: e.eventWithTeam.event.distinct_id,
+                    })
+                }
+            }
+
+            if (cacheHits > 0) {
+                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'hit' }, cacheHits)
+            }
+
+            if (personlessEntries.length > 0) {
+                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'miss' }, personlessEntries.length)
+
+                await personsStore.processPersonlessDistinctIdsBatch(personlessEntries)
+
+                // Update LRU cache for all entries we just inserted
+                for (const entry of personlessEntries) {
+                    PERSONLESS_DISTINCT_ID_INSERTED_CACHE.set(`${entry.teamId}|${entry.distinctId}`, true)
+                }
+            }
+        }
+        return events.map((event) => ok(event))
+    }
+}

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonlessStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonlessStep.ts
@@ -1,38 +1,20 @@
-import { LRUCache } from 'lru-cache'
 import { DateTime } from 'luxon'
-import { Counter } from 'prom-client'
 
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { ONE_HOUR } from '../../../config/constants'
 import { PipelineResult, ok } from '../../../ingestion/pipelines/results'
 import { Person, Team } from '../../../types'
 import { uuidFromDistinctId } from '../person-uuid'
 import { PersonsStore } from '../persons/persons-store'
 
-export const personlessDistinctIdCacheOperationsCounter = new Counter({
-    name: 'personless_distinct_id_cache_operations_total',
-    help: 'Number of cache hits and misses for the personless distinct ID inserted cache',
-    labelNames: ['operation'],
-})
-
-// Tracks whether we know we've already inserted a `posthog_personlessdistinctid` for the given
-// (team_id, distinct_id) pair. If we have, then we can skip the INSERT attempt.
-const PERSONLESS_DISTINCT_ID_INSERTED_CACHE = new LRUCache<string, boolean>({
-    max: 100_000,
-    ttl: ONE_HOUR * 4,
-    updateAgeOnGet: true,
-})
-
 /**
  * Pipeline step that handles personless event processing checks.
  *
  * This step runs when processPerson=false, and performs:
- * 1. Database fetch for existing person
- * 2. Insert into posthog_personlessdistinctid tracking table
- * 3. Merge detection via race condition handling
- * 4. force_upgrade flag calculation
- * 5. Returns person (real or fake) with potential force_upgrade flag
+ * 1. Database fetch for existing person (from cache, populated by prefetchPersonsStep)
+ * 2. Check batch results for is_merged flag (populated by processPersonlessDistinctIdsBatchStep)
+ * 3. force_upgrade flag calculation
+ * 4. Returns person (real or fake) with potential force_upgrade flag
  *
  * The caller should check person.force_upgrade to decide if full person processing is needed.
  */
@@ -43,40 +25,27 @@ export async function processPersonlessStep(
     personsStore: PersonsStore,
     forceDisablePersonProcessing: boolean = false
 ): Promise<PipelineResult<Person>> {
-    const distinctId = String(event.distinct_id)
+    const distinctId = event.distinct_id
 
     // If forceDisablePersonProcessing is true, skip all personless processing and just create a fake person
     if (forceDisablePersonProcessing) {
         return ok(createFakePerson(team.id, distinctId))
     }
 
-    // Check if a real person exists for this distinct_id
+    // Check if a real person exists for this distinct_id (from prefetch cache)
     let existingPerson = await personsStore.fetchForChecking(team.id, distinctId)
 
     if (!existingPerson) {
-        // See the comment in `mergeDistinctIds`. We are inserting a row into `posthog_personlessdistinctid`
-        // to note that this Distinct ID has been used in "personless" mode. This is necessary
-        // so that later, during a merge, we can decide whether we need to write out an override
-        // or not.
+        // Check if batch insert found this distinct_id was merged
+        // The batch step (processPersonlessDistinctIdsBatchStep) already did the INSERT
+        // and stored is_merged=true results in the personsStore cache
+        const personIsMerged = personsStore.getPersonlessBatchResult(team.id, distinctId)
 
-        const personlessDistinctIdCacheKey = `${team.id}|${distinctId}`
-        const cacheHit = PERSONLESS_DISTINCT_ID_INSERTED_CACHE.get(personlessDistinctIdCacheKey)
-        personlessDistinctIdCacheOperationsCounter.inc({ operation: cacheHit ? 'hit' : 'miss' })
-
-        if (!cacheHit) {
-            const personIsMerged = await personsStore.addPersonlessDistinctId(team.id, distinctId)
-
-            // We know the row is in PG now, and so future events for this Distinct ID can
-            // skip the PG I/O.
-            PERSONLESS_DISTINCT_ID_INSERTED_CACHE.set(personlessDistinctIdCacheKey, true)
-
-            if (personIsMerged) {
-                // If `personIsMerged` comes back `true`, it means the `posthog_personlessdistinctid`
-                // has been updated by a merge (either since we called `fetchPerson` above, plus
-                // replication lag). We need to check `fetchPerson` again (this time using the leader)
-                // so that we properly associate this event with the Person we got merged into.
-                existingPerson = await personsStore.fetchForUpdate(team.id, distinctId)
-            }
+        if (personIsMerged) {
+            // If is_merged came back true, it means the posthog_personlessdistinctid
+            // was updated by a merge. We need to fetch the person again (using the leader)
+            // so that we properly associate this event with the Person we got merged into.
+            existingPerson = await personsStore.fetchForUpdate(team.id, distinctId)
         }
     }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonlessStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonlessStep.ts
@@ -19,8 +19,8 @@ export const personlessDistinctIdCacheOperationsCounter = new Counter({
 // Tracks whether we know we've already inserted a `posthog_personlessdistinctid` for the given
 // (team_id, distinct_id) pair. If we have, then we can skip the INSERT attempt.
 const PERSONLESS_DISTINCT_ID_INSERTED_CACHE = new LRUCache<string, boolean>({
-    max: 10_000,
-    ttl: ONE_HOUR * 24, // cache up to 24h
+    max: 100_000,
+    ttl: ONE_HOUR * 4,
     updateAgeOnGet: true,
 })
 

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -117,6 +117,7 @@ describe('BatchWritingPersonStore', () => {
             moveDistinctIds: jest.fn().mockResolvedValue({ success: true, messages: [], distinctIdsMoved: [] }),
             addPersonlessDistinctId: jest.fn().mockResolvedValue(true),
             addPersonlessDistinctIdForMerge: jest.fn().mockResolvedValue(true),
+            addPersonlessDistinctIdsBatch: jest.fn().mockResolvedValue(new Map()),
             personPropertiesSize: jest.fn().mockResolvedValue(1024),
             updateCohortsAndFeatureFlagsForMerge: jest.fn().mockResolvedValue(undefined),
             inTransaction: jest.fn().mockImplementation(async (description, transaction) => {

--- a/plugin-server/src/worker/ingestion/persons/persons-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store.ts
@@ -164,6 +164,19 @@ export interface PersonsStore extends BatchWritingStore {
     prefetchPersons(teamDistinctIds: { teamId: number; distinctId: string }[]): Promise<void>
 
     /**
+     * Batch-inserts personless distinct IDs for events where no person exists.
+     * Stores is_merged results in a cache for later lookup.
+     * @param entries - A list of team IDs and distinct IDs to insert
+     */
+    processPersonlessDistinctIdsBatch(entries: { teamId: number; distinctId: string }[]): Promise<void>
+
+    /**
+     * Gets the is_merged result from batch personless insert.
+     * Returns undefined if not in batch cache.
+     */
+    getPersonlessBatchResult(teamId: number, distinctId: string): boolean | undefined
+
+    /**
      * Flushes the batch
      */
     flush(): Promise<FlushResult[]>

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
@@ -82,6 +82,7 @@ export interface PersonRepository {
 
     addPersonlessDistinctId(teamId: Team['id'], distinctId: string): Promise<boolean>
     addPersonlessDistinctIdForMerge(teamId: Team['id'], distinctId: string): Promise<boolean>
+    addPersonlessDistinctIdsBatch(entries: { teamId: number; distinctId: string }[]): Promise<Map<string, boolean>>
 
     personPropertiesSize(personId: string, teamId: number): Promise<number>
 

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-dualwrite-person-repository.ts
@@ -388,6 +388,10 @@ export class PostgresDualWritePersonRepository implements PersonRepository {
         return isMerged
     }
 
+    addPersonlessDistinctIdsBatch(_entries: { teamId: number; distinctId: string }[]): Promise<Map<string, boolean>> {
+        throw new Error('addPersonlessDistinctIdsBatch is not implemented for dual-write repository')
+    }
+
     async personPropertiesSize(personId: string, teamId: number): Promise<number> {
         return await this.primaryRepo.personPropertiesSize(personId, teamId)
     }

--- a/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
@@ -1080,6 +1080,91 @@ describe('PostgresPersonRepository', () => {
         })
     })
 
+    describe('addPersonlessDistinctIdsBatch', () => {
+        it('should insert multiple personless distinct IDs in batch', async () => {
+            const team = await getFirstTeam(hub)
+            const entries = [
+                { teamId: team.id, distinctId: 'batch-distinct-1' },
+                { teamId: team.id, distinctId: 'batch-distinct-2' },
+                { teamId: team.id, distinctId: 'batch-distinct-3' },
+            ]
+
+            const results = await repository.addPersonlessDistinctIdsBatch(entries)
+
+            // All should be not merged (new inserts)
+            expect(results.size).toBe(3)
+            expect(results.get(`${team.id}|batch-distinct-1`)).toBe(false)
+            expect(results.get(`${team.id}|batch-distinct-2`)).toBe(false)
+            expect(results.get(`${team.id}|batch-distinct-3`)).toBe(false)
+
+            // Verify records were inserted
+            const selectResult = await postgres.query(
+                PostgresUse.PERSONS_WRITE,
+                `SELECT distinct_id, is_merged FROM posthog_personlessdistinctid WHERE team_id = $1 ORDER BY distinct_id`,
+                [team.id],
+                'verifyBatchInsert'
+            )
+            expect(selectResult.rows).toHaveLength(3)
+        })
+
+        it('should handle duplicate distinct IDs in batch (deduplicates)', async () => {
+            const team = await getFirstTeam(hub)
+            const entries = [
+                { teamId: team.id, distinctId: 'dup-distinct' },
+                { teamId: team.id, distinctId: 'dup-distinct' },
+                { teamId: team.id, distinctId: 'other-distinct' },
+            ]
+
+            const results = await repository.addPersonlessDistinctIdsBatch(entries)
+
+            // Should have 2 unique entries
+            expect(results.size).toBe(2)
+            expect(results.get(`${team.id}|dup-distinct`)).toBe(false)
+            expect(results.get(`${team.id}|other-distinct`)).toBe(false)
+        })
+
+        it('should return is_merged=true for already merged distinct IDs', async () => {
+            const team = await getFirstTeam(hub)
+            const mergedDistinctId = 'already-merged-distinct'
+
+            // First, insert and mark as merged
+            await repository.addPersonlessDistinctIdForMerge(team.id, mergedDistinctId)
+
+            // Now try to batch insert including the merged one
+            const entries = [
+                { teamId: team.id, distinctId: mergedDistinctId },
+                { teamId: team.id, distinctId: 'new-distinct' },
+            ]
+
+            const results = await repository.addPersonlessDistinctIdsBatch(entries)
+
+            expect(results.size).toBe(2)
+            expect(results.get(`${team.id}|${mergedDistinctId}`)).toBe(true) // Already merged
+            expect(results.get(`${team.id}|new-distinct`)).toBe(false) // New insert
+        })
+
+        it('should handle empty batch', async () => {
+            const results = await repository.addPersonlessDistinctIdsBatch([])
+            expect(results.size).toBe(0)
+        })
+
+        it('should handle multiple teams in same batch', async () => {
+            const team1 = await getFirstTeam(hub)
+            const team2Id = await createTeam(hub.db.postgres, team1.organization_id)
+
+            const entries = [
+                { teamId: team1.id, distinctId: 'shared-distinct' },
+                { teamId: team2Id, distinctId: 'shared-distinct' },
+            ]
+
+            const results = await repository.addPersonlessDistinctIdsBatch(entries)
+
+            expect(results.size).toBe(2)
+            expect(results.get(`${team1.id}|shared-distinct`)).toBe(false)
+            expect(results.get(`${team2Id}|shared-distinct`)).toBe(false)
+        })
+    })
+
     describe('personPropertiesSize', () => {
         it('should return properties size for existing person', async () => {
             const team = await getFirstTeam(hub)

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -118,6 +118,7 @@ exports[`EventPipelineRunner runEventPipeline() runs steps 1`] = `
           },
         },
         "personUpdateCache": {},
+        "personlessBatchResults": {},
         "updateLatencyPerDistinctIdSeconds": {},
       },
     ],

--- a/plugin-server/tests/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.test.ts
@@ -1,0 +1,169 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { PipelineResultType } from '~/ingestion/pipelines/results'
+import { IncomingEventWithTeam, Team } from '~/types'
+
+import { PersonsStore } from '../../../../src/worker/ingestion/persons/persons-store'
+
+describe('processPersonlessDistinctIdsBatchStep', () => {
+    let mockPersonsStore: jest.Mocked<PersonsStore>
+    let team: Team
+    let processPersonlessDistinctIdsBatchStep: typeof import('../../../../src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep').processPersonlessDistinctIdsBatchStep
+
+    beforeEach(async () => {
+        // Reset modules to get a fresh LRU cache for each test
+        jest.resetModules()
+        const module = await import(
+            '../../../../src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep'
+        )
+        processPersonlessDistinctIdsBatchStep = module.processPersonlessDistinctIdsBatchStep
+
+        team = {
+            id: 1,
+            uuid: 'test-team-uuid',
+            organization_id: 'test-org',
+            name: 'Test Team',
+        } as Team
+
+        mockPersonsStore = {
+            processPersonlessDistinctIdsBatch: jest.fn().mockResolvedValue(undefined),
+            getPersonlessBatchResult: jest.fn().mockReturnValue(undefined),
+        } as unknown as jest.Mocked<PersonsStore>
+    })
+
+    const createEventWithTeam = (
+        distinctId: string,
+        processPerson: boolean | undefined = undefined
+    ): { eventWithTeam: IncomingEventWithTeam } => {
+        const event: PluginEvent = {
+            distinct_id: distinctId,
+            ip: null,
+            site_url: 'http://localhost',
+            team_id: team.id,
+            now: '2020-02-23T02:15:00Z',
+            timestamp: '2020-02-23T02:15:00Z',
+            event: '$pageview',
+            properties: processPerson === undefined ? {} : { $process_person_profile: processPerson },
+            uuid: `uuid-${distinctId}`,
+        }
+
+        return {
+            eventWithTeam: {
+                event,
+                team,
+                message: {} as any,
+                headers: {
+                    force_disable_person_processing: false,
+                    historical_migration: false,
+                },
+            },
+        }
+    }
+
+    describe('when enabled', () => {
+        it('should process personless events and call batch insert', async () => {
+            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+            const events = [
+                createEventWithTeam('user-1', false),
+                createEventWithTeam('user-2', false),
+                createEventWithTeam('user-3', false),
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(3)
+            expect(results.every((r) => r.type === PipelineResultType.OK)).toBe(true)
+            expect(mockPersonsStore.processPersonlessDistinctIdsBatch).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-1' },
+                { teamId: team.id, distinctId: 'user-2' },
+                { teamId: team.id, distinctId: 'user-3' },
+            ])
+        })
+
+        it('should skip non-personless events', async () => {
+            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+            const events = [
+                createEventWithTeam('user-1', true), // processPerson=true
+                createEventWithTeam('user-2', false), // processPerson=false (personless)
+                createEventWithTeam('user-3'), // processPerson=undefined (default, not personless)
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(3)
+            expect(mockPersonsStore.processPersonlessDistinctIdsBatch).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-2' },
+            ])
+        })
+
+        it('should not call batch insert when no personless events', async () => {
+            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+            const events = [createEventWithTeam('user-1', true), createEventWithTeam('user-2')]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(2)
+            expect(mockPersonsStore.processPersonlessDistinctIdsBatch).not.toHaveBeenCalled()
+        })
+
+        it('should return all events as OK even if batch insert fails', async () => {
+            mockPersonsStore.processPersonlessDistinctIdsBatch.mockRejectedValue(new Error('DB error'))
+
+            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+            const events = [createEventWithTeam('user-1', false)]
+
+            // The step should throw since we don't handle errors gracefully
+            await expect(step(events)).rejects.toThrow('DB error')
+        })
+    })
+
+    describe('when disabled', () => {
+        it('should not process any events', async () => {
+            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, false)
+            const events = [createEventWithTeam('user-1', false), createEventWithTeam('user-2', false)]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(2)
+            expect(results.every((r) => r.type === PipelineResultType.OK)).toBe(true)
+            expect(mockPersonsStore.processPersonlessDistinctIdsBatch).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('LRU cache behavior', () => {
+        it('should deduplicate entries within same batch before hitting cache', async () => {
+            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+            const events = [
+                createEventWithTeam('user-1', false),
+                createEventWithTeam('user-1', false), // Duplicate - deduped before cache/insert
+                createEventWithTeam('user-2', false),
+            ]
+
+            await step(events)
+
+            // Duplicates are removed before batch insert
+            expect(mockPersonsStore.processPersonlessDistinctIdsBatch).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-1' },
+                { teamId: team.id, distinctId: 'user-2' },
+            ])
+        })
+
+        it('should use cache to skip already-inserted distinct IDs across batches', async () => {
+            const step = processPersonlessDistinctIdsBatchStep(mockPersonsStore, true)
+
+            // First batch
+            await step([createEventWithTeam('user-1', false)])
+            expect(mockPersonsStore.processPersonlessDistinctIdsBatch).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-1' },
+            ])
+
+            mockPersonsStore.processPersonlessDistinctIdsBatch.mockClear()
+
+            // Second batch - user-1 should be cached, only user-2 should be inserted
+            await step([createEventWithTeam('user-1', false), createEventWithTeam('user-2', false)])
+            expect(mockPersonsStore.processPersonlessDistinctIdsBatch).toHaveBeenCalledWith([
+                { teamId: team.id, distinctId: 'user-2' },
+            ])
+        })
+    })
+})


### PR DESCRIPTION
## Problem

When processing personless events, each event triggered an individual INSERT into the `posthog_personlessdistinctid` table. In batches with multiple personless events, this caused N sequential database round-trips, adding latency to event processing.

## Changes

- Add processPersonlessDistinctIdsBatchStep that batch-inserts personless distinct IDs after prefetch
- Use PostgreSQL UNNEST for efficient single-query batch inserts with deduplication
- Add LRU cache to skip INSERTs for recently-seen distinct IDs
- Simplify `processPersonlessStep` to consume batch results instead of doing individual inserts
- Store is_merged results in personsStore cache for force_upgrade detection

## How did you test this code?

- Added unit tests for `processPersonlessDistinctIdsBatchStep` covering cache hits/misses, deduplication, and disabled mode
- Added unit tests for `addPersonlessDistinctIdsBatch` in postgres-person-repository covering batch inserts, duplicates, merged detection, empty batches, and multi-team batches
- Added E2E tests for multiple personless events in same batch (different users and same user scenarios)
- Existing personless processing tests continue to pass

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
