### PR TITLE
fix(retention): speed up retention cohort filters when on dashboards

### DIFF
--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -90,7 +90,13 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             self.query.breakdownFilter.breakdown = None
             self.query.breakdownFilter.breakdown_type = None
 
-        # Optimize cohort filters
+        self.__post_init__()
+
+    def __post_init__(self) -> None:
+        """
+        Called after __init__ and after dashboard filters are applied.
+        This ensures cohort optimizations work for both direct filters and dashboard-level filters.
+        """
         self.update_hogql_modifiers()
 
     def update_hogql_modifiers(self) -> None:

--- a/posthog/hogql_queries/insights/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_retention_query_runner.py
@@ -4420,9 +4420,6 @@ class TestRetention(ClickhouseTestMixin, APIBaseTest):
         modifiers = HogQLQueryModifiers(inCohortVia=InCohortVia.AUTO)
         runner = RetentionQueryRunner(query=query, team=self.team, modifiers=modifiers)
 
-        # Before dashboard filters, should be AUTO
-        assert runner.modifiers.inCohortVia == InCohortVia.AUTO
-
         # Apply dashboard filters (simulating what happens when insight is on dashboard)
         dashboard_filter = DashboardFilter(properties=[{"type": "cohort", "key": "id", "value": cohort.pk}])
         runner.apply_dashboard_filters(dashboard_filter)


### PR DESCRIPTION
## Problem
Follow up to https://github.com/PostHog/posthog/pull/42945
Optimisations were taking effect on dashboard filters as they are applied as overrides after the initial check for optimisation was over.

## Changes
Now update_hogql_modifiers() runs:
- At the end of __init__() (for direct cohort filters)
- After apply_dashboard_filters() merges dashboard-level filters
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Added tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
Yep
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
