### PR TITLE
fix: Raise non-retryable exception on string limit exceeded

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -121,8 +121,14 @@ NON_RETRYABLE_ERROR_TYPES = (
 class StringLimitExceededError(Exception):
     """Error raised when exceeding Redshift VARCHAR limit."""
 
-    def __init__(self, column: str, table: str, schema: str):
-        msg = f"Column '{column}' in '{schema}.{table}' exceeds Redshift's 'VARCHAR' limit and cannot be exported"
+    def __init__(self, column: str | None, table: str, schema: str):
+        if column:
+            msg = f"Column '{column}' "
+        else:
+            msg = f"A column "
+
+        msg += f"in '{schema}.{table}' exceeds Redshift's string limit and cannot be exported"
+
         if column in {"properties", "set", "set_once", "person_properties"}:
             msg += ". Consider switching this column to 'SUPER' type which can support longer documents compared to 'VARCHAR'"
         super().__init__(msg)
@@ -230,7 +236,6 @@ class RedshiftClient(PostgreSQLClient):
         merge_key: Fields,
         update_key: Fields,
         final_table_fields: Fields,
-        update_when_matched: Fields = (),
         stage_fields_cast_to_super: collections.abc.Container[str] | None = None,
         remove_duplicates: bool = True,
     ) -> None:
@@ -349,6 +354,7 @@ class RedshiftClient(PostgreSQLClient):
                         schema=schema,
                         stage_table=stage_table_name,
                         query="DELETE",
+                        full_query=delete_query,
                     )
                     self.external_logger.error(  # noqa: TRY400
                         "A non-retryable 'UndefinedFunction' error happened when attempting to"
@@ -363,7 +369,21 @@ class RedshiftClient(PostgreSQLClient):
                     )
                     raise
 
-                await cursor.execute(merge_query)
+                try:
+                    await cursor.execute(merge_query)
+                except psycopg.errors.InternalError_ as e:
+                    self.logger.exception(
+                        "Query failed",
+                        table=final_table_name,
+                        schema=schema,
+                        stage_table=stage_table_name,
+                        query="MERGE",
+                        full_query=merge_query,
+                    )
+                    if "String value exceeds the max size of 65535" in str(e):
+                        raise StringLimitExceededError(column=None, schema=schema, table=final_table_name) from e
+                    else:
+                        raise
 
     async def acopy_from_s3_bucket(
         self,


### PR DESCRIPTION
## Problem

Redshift's 64kb limit will always apply, and can sometimes fail batch exports. So, we should raise a non-retryable error.

Eventually, we should allow users to export the fields in `VARBYTE` type, which allows much more data.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

When merging, if the error points at exceeding varchar limit, raise non-retryable error.

I also added logging to debug this further if needed.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
