### PR TITLE
feat(charts): highlight bar in stacked bars chart when holding shift

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -28,9 +28,11 @@ import {
 export function ClickToInspectActors({
     isTruncated,
     groupTypeLabel,
+    showShiftKeyHint,
 }: {
     isTruncated?: boolean
     groupTypeLabel: string
+    showShiftKeyHint?: boolean
 }): JSX.Element {
     return (
         <div className="table-subtext">
@@ -38,6 +40,14 @@ export function ClickToInspectActors({
                 <div className="table-subtext-truncated">
                     For readability, <b>not all series are displayed</b>.<br />
                 </div>
+            )}
+            {showShiftKeyHint && (
+                <>
+                    <div>
+                        Hold Shift (<kbd className="KeyboardShortcut__key">⇧</kbd>) to highlight individual bars
+                    </div>
+                    <br />
+                </>
             )}
             <div className="table-subtext-click-to-inspect">
                 <IconHandClick className="mr-1 mb-0.5" />
@@ -92,6 +102,7 @@ export function InsightTooltip({
     breakdownFilter,
     interval,
     dateRange,
+    showShiftKeyHint,
 }: InsightTooltipProps): JSX.Element {
     // Display entities as columns if multiple exist (e.g., pageview + autocapture, or multiple formulas)
     // and the insight has a breakdown or compare option enabled. This gives us space for labels
@@ -201,7 +212,11 @@ export function InsightTooltip({
                     showHeader={showHeader}
                 />
                 {!hideInspectActorsSection && (
-                    <ClickToInspectActors isTruncated={isTruncated} groupTypeLabel={groupTypeLabel} />
+                    <ClickToInspectActors
+                        isTruncated={isTruncated}
+                        groupTypeLabel={groupTypeLabel}
+                        showShiftKeyHint={showShiftKeyHint}
+                    />
                 )}
             </div>
         )
@@ -261,7 +276,11 @@ export function InsightTooltip({
                 showHeader={showHeader}
             />
             {!hideInspectActorsSection && (
-                <ClickToInspectActors isTruncated={isTruncated} groupTypeLabel={groupTypeLabel} />
+                <ClickToInspectActors
+                    isTruncated={isTruncated}
+                    groupTypeLabel={groupTypeLabel}
+                    showShiftKeyHint={showShiftKeyHint}
+                />
             )}
         </div>
     )

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -67,6 +67,8 @@ export interface InsightTooltipProps extends Omit<TooltipConfig, 'renderSeries' 
     timezone?: string | undefined
     interval?: IntervalType | null
     dateRange?: DateRange | null
+    /** Show hint about holding shift to highlight individual bars in stacked charts */
+    showShiftKeyHint?: boolean
 }
 
 export interface FormattedDateOptions {

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -5,7 +5,7 @@ import ChartDataLabels from 'chartjs-plugin-datalabels'
 import ChartjsPluginStacked100, { ExtendedChartData } from 'chartjs-plugin-stacked100'
 import chartTrendline from 'chartjs-plugin-trendline'
 import clsx from 'clsx'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useEffect } from 'react'
 
@@ -288,7 +288,10 @@ export function LineGraph_({
     const { timezone, isTrends, isFunnels, breakdownFilter, query, interval, insightData } = useValues(
         insightVizDataLogic(insightProps)
     )
-    const { theme, getTrendsColor, getTrendsHidden } = useValues(trendsDataLogic(insightProps))
+    const { theme, getTrendsColor, getTrendsHidden, hoveredDatasetIndex, isShiftPressed } = useValues(
+        trendsDataLogic(insightProps)
+    )
+    const { setHoveredDatasetIndex, setIsShiftPressed } = useActions(trendsDataLogic(insightProps))
 
     const hideTooltipOnScroll = isInsightVizNode(query) ? query.hideTooltipOnScroll : undefined
 
@@ -306,6 +309,34 @@ export function LineGraph_({
     const isPercentStackView = !!supportsPercentStackView && !!showPercentStackView
     const showAnnotations = ((isTrends && !isHorizontal) || isFunnels) && !hideAnnotations
     const isLog10 = yAxisScaleType === 'log10' // Currently log10 is the only logarithmic scale supported
+    const isHighlightBarMode = isBar && isStacked && isShiftPressed
+
+    const handleKeyDown = (e: KeyboardEvent): void => {
+        if (e.key === 'Shift') {
+            setIsShiftPressed(true)
+        }
+    }
+    const handleKeyUp = (e: KeyboardEvent): void => {
+        if (e.key === 'Shift') {
+            setIsShiftPressed(false)
+            setHoveredDatasetIndex(null)
+        }
+    }
+
+    // Track shift key for single-bar hover mode in stacked charts
+    useEffect(() => {
+        if (!isBar || !isStacked) {
+            return
+        }
+
+        window.addEventListener('keydown', handleKeyDown)
+        window.addEventListener('keyup', handleKeyUp)
+
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown)
+            window.removeEventListener('keyup', handleKeyUp)
+        }
+    }, [isBar, isStacked])
 
     // Add scrollend event on main element to hide tooltips when scrolling
     useEffect(() => {
@@ -378,7 +409,12 @@ export function LineGraph_({
 
         let backgroundColor: string | undefined = undefined
         if (isBackgroundBasedGraphType) {
-            backgroundColor = mainColor
+            // Dim non-hovered bars in stacked bar charts when shift is pressed
+            if (isHighlightBarMode && hoveredDatasetIndex !== null && index !== hoveredDatasetIndex) {
+                backgroundColor = hexToRGBA(mainColor, 0.2)
+            } else {
+                backgroundColor = mainColor
+            }
         } else if (isArea) {
             const alpha = isPercentStackView ? 1 : 0.5
             backgroundColor = hexToRGBA(mainColor, alpha)
@@ -595,9 +631,9 @@ export function LineGraph_({
 
             const tooltipOptions: Partial<TooltipOptions> = {
                 enabled: false,
-                mode: 'nearest',
+                mode: isHighlightBarMode ? 'point' : 'nearest',
                 axis: isHorizontal ? 'y' : 'x',
-                intersect: false,
+                intersect: isHighlightBarMode,
                 itemSort: (a, b) => a.label.localeCompare(b.label),
             }
 
@@ -699,6 +735,11 @@ export function LineGraph_({
                                 const dataset = processedDatasets[referenceDataPoint.datasetIndex]
                                 const date = dataset?.days?.[referenceDataPoint.dataIndex]
                                 const seriesData = createTooltipData(tooltip.dataPoints, (dp) => {
+                                    // For stacked bar charts when shift is pressed, show only the hovered bar
+                                    if (isHighlightBarMode) {
+                                        return dp.datasetIndex === referenceDataPoint.datasetIndex
+                                    }
+
                                     if (tooltipConfig?.filter) {
                                         return tooltipConfig.filter(dp)
                                     }
@@ -799,10 +840,13 @@ export function LineGraph_({
                             }
 
                             const bounds = canvas.getBoundingClientRect()
+                            const verticalBarTopOffset =
+                                isHighlightBarMode && !isHorizontal ? tooltip.caretY - tooltipEl.clientHeight / 2 : 0
                             const horizontalBarTopOffset = isHorizontal
                                 ? tooltip.caretY - tooltipEl.clientHeight / 2
                                 : 0
-                            const tooltipClientTop = bounds.top + window.pageYOffset + horizontalBarTopOffset
+                            const tooltipClientTop =
+                                bounds.top + window.pageYOffset + horizontalBarTopOffset + verticalBarTopOffset
 
                             const chartClientLeft = bounds.left + window.pageXOffset
                             const defaultOffsetLeft = Math.max(chartClientLeft, chartClientLeft + tooltip.caretX + 8)
@@ -843,8 +887,16 @@ export function LineGraph_({
                     axis: isHorizontal ? 'y' : 'x',
                     intersect: false,
                 },
-                onHover(event: ChartEvent, _: ActiveElement[], chart: Chart) {
+                onHover(event: ChartEvent, elements: ActiveElement[], chart: Chart) {
                     onChartHover(event, chart, onClick)
+
+                    // For stacked bar charts when shift is pressed, track hovered dataset to highlight only that bar
+                    if (isHighlightBarMode) {
+                        const newHoveredIdx = elements.length > 0 ? elements[0].datasetIndex : null
+                        if (hoveredDatasetIndex !== newHoveredIdx) {
+                            setHoveredDatasetIndex(newHoveredIdx)
+                        }
+                    }
                 },
                 onClick: (event: ChartEvent, _: ActiveElement[], chart: Chart) => {
                     onChartClick(event, chart, processedDatasets, onClick)
@@ -1034,6 +1086,9 @@ export function LineGraph_({
             labels,
             hideTooltip,
             getTooltip,
+            hoveredDatasetIndex,
+            setHoveredDatasetIndex,
+            isHighlightBarMode,
         ],
     })
 

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -767,6 +767,7 @@ export function LineGraph_({
                                         breakdownFilter={breakdownFilter}
                                         interval={interval}
                                         dateRange={insightData?.resolved_date_range}
+                                        showShiftKeyHint={isBar && isStacked && !isHighlightBarMode}
                                         renderSeries={(value, datum) => {
                                             const hasBreakdown =
                                                 datum.breakdown_value !== undefined && !!datum.breakdown_value

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -116,6 +116,8 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
         setBreakdownValuesLoading: (loading: boolean) => ({ loading }),
         toggleResultHidden: (dataset: IndexedTrendResult) => ({ dataset }),
         toggleAllResultsHidden: (datasets: IndexedTrendResult[], hidden: boolean) => ({ datasets, hidden }),
+        setHoveredDatasetIndex: (index: number | null) => ({ index }),
+        setIsShiftPressed: (isPressed: boolean) => ({ isPressed }),
     }),
 
     reducers({
@@ -123,6 +125,18 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
             false,
             {
                 setBreakdownValuesLoading: (_, { loading }) => loading,
+            },
+        ],
+        hoveredDatasetIndex: [
+            null as number | null,
+            {
+                setHoveredDatasetIndex: (_, { index }) => index,
+            },
+        ],
+        isShiftPressed: [
+            false,
+            {
+                setIsShiftPressed: (_, { isPressed }) => isPressed,
             },
         ],
     }),


### PR DESCRIPTION
## Problem

Having many values in a stacked bar can be hard to read and understand.
Allow highlighting a specific part of the bar by holding "shift".

https://posthog.slack.com/archives/C0368RPHLQH/p1764685989494289

## Changes

https://github.com/user-attachments/assets/9546a71b-ef40-43a6-9ea1-f9482bde8f37

## How did you test this code?

Manually

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

Yes
