### PR TITLE
fix(workflows): fixes scrolling for slack blocks

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
+++ b/frontend/src/lib/components/CyclotronJob/CyclotronJobInputs.tsx
@@ -157,6 +157,7 @@ function JsonConfigField(props: {
                                 scrollbar: {
                                     vertical: 'hidden',
                                     verticalScrollbarSize: 0,
+                                    alwaysConsumeMouseWheel: false,
                                 },
                             }}
                             globals={props.templating ? (props.sampleGlobalsWithInputs ?? undefined) : undefined}


### PR DESCRIPTION
## Problem

When editing Slack node configurations in the workflow editor, users couldn't scroll through the expanded JSON blocks field. The editor would expand to show the JSON content but scrolling within the nested editor was not working properly due to scroll event handling conflicts with the parent container.

bug report: https://x.com/LouisKnightWebb/status/1998404643559190579

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

 `alwaysConsumeMouseWheel: false` allows scroll events to properly bubble up to parent containers
  when the editor reaches its scroll limits. Without this setting, the editor was consuming all mouse
  wheel events, preventing the parent ScrollableShadows container from handling overflow scrolling. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![2025-12-09 17 11 39](https://github.com/user-attachments/assets/bd13dfc5-bf82-487c-a777-0ae94d8eacfd)

- tested it orks for workflows
- tested it still works for destinations

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
