### PR TITLE
fix(integrations): allow for mappings to show after deleting them all without destination filter UX

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -722,10 +722,9 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             },
         ],
         useMapping: [
-            (s) => [s.hogFunction, s.mappingTemplates],
-            (hogFunction: HogFunctionType | null, mappingTemplates: HogFunctionMappingType[]) => {
-                return Array.isArray(hogFunction?.mappings) || mappingTemplates.length > 0
-            },
+            (s) => [s.hogFunction, s.template],
+            // If the function has mappings, or the template has mapping templates, we use mappings
+            (hogFunction, template) => Array.isArray(hogFunction?.mappings) || template?.mapping_templates?.length,
         ],
         defaultFormState: [
             (s) => [s.template, s.hogFunction],

--- a/frontend/src/scenes/hog-functions/mapping/HogFunctionMappings.tsx
+++ b/frontend/src/scenes/hog-functions/mapping/HogFunctionMappings.tsx
@@ -199,7 +199,7 @@ export function HogFunctionMappings(): JSX.Element | null {
         }
     }, [configuration.mappings?.length])
 
-    if (!useMapping) {
+    if (!useMapping && mappingTemplates.length === 0) {
         return null
     }
 

--- a/frontend/src/scenes/hog-functions/mapping/HogFunctionMappings.tsx
+++ b/frontend/src/scenes/hog-functions/mapping/HogFunctionMappings.tsx
@@ -199,7 +199,7 @@ export function HogFunctionMappings(): JSX.Element | null {
         }
     }, [configuration.mappings?.length])
 
-    if (!useMapping && mappingTemplates.length === 0) {
+    if (!useMapping && (!configuration.mappings || configuration.mappings?.length === 0)) {
         return null
     }
 

--- a/frontend/src/scenes/hog-functions/mapping/HogFunctionMappings.tsx
+++ b/frontend/src/scenes/hog-functions/mapping/HogFunctionMappings.tsx
@@ -199,7 +199,7 @@ export function HogFunctionMappings(): JSX.Element | null {
         }
     }, [configuration.mappings?.length])
 
-    if (!useMapping && (!configuration.mappings || configuration.mappings?.length === 0)) {
+    if (!useMapping) {
         return null
     }
 


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/42035 made a good fix for an edge case but this affects the filter UX for destinations whose templates now have mappings and didn't before.

## Changes

Tweak the logic here to show the mappings section IF the template has mappings, but not affect the overall `useMapping` flag which changes the filters UX and other things in the config page.

## How did you test this code?

Reproduced customer hogfunction locally and ensured filters show up as intended for this state

<img width="958" height="429" alt="image" src="https://github.com/user-attachments/assets/f8a88a2d-2076-47a2-ab25-060aad9e021f" />
<img width="1143" height="635" alt="Screenshot 2025-12-09 at 10 53 57 AM" src="https://github.com/user-attachments/assets/feab3067-57df-4c44-a52c-51fbab9901ae" />
