### PR TITLE
fix: Catch non-retryable error in internal stage activity

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -65,8 +65,6 @@ NON_RETRYABLE_ERROR_TYPES = (
     # Raised when attempting to run a batch export without required BigQuery permissions.
     # Our own version of `Forbidden`.
     "MissingRequiredPermissionsError",
-    # Invalid filter used.
-    "InvalidFilterError",
 )
 
 LOGGER = get_write_only_logger(__name__)

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -74,8 +74,6 @@ NON_RETRYABLE_ERROR_TYPES: list[str] = [
     # Raised when we hit our self-imposed long running operation timeout.
     # We don't want to continually retry as it could consume a lot of compute resources in the user's account.
     "DatabricksOperationTimeoutError",
-    # Invalid filter used.
-    "InvalidFilterError",
 ]
 
 DatabricksField = tuple[str, str]

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -109,8 +109,6 @@ NON_RETRYABLE_ERROR_TYPES = (
     "PostgreSQLIncompatibleSchemaError",
     # Raised when a transaction fails to complete after a certain number of retries.
     "PostgreSQLTransactionError",
-    # Invalid filter used.
-    "InvalidFilterError",
 )
 
 

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -115,8 +115,6 @@ NON_RETRYABLE_ERROR_TYPES = (
     "UndefinedFunction",
     # Unretryable error raised by S3 client when using `copy_into_redshift_activity_from_stage`.
     "ClientError",
-    # Invalid filter used.
-    "InvalidFilterError",
 )
 
 

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -65,8 +65,6 @@ NON_RETRYABLE_ERROR_TYPES = (
     "InvalidS3EndpointError",
     # Invalid file_format input
     "UnsupportedFileFormatError",
-    # Invalid filter used.
-    "InvalidFilterError",
 )
 
 FILE_FORMAT_EXTENSIONS = {

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -104,8 +104,6 @@ NON_RETRYABLE_ERROR_TYPES = (
     "SnowflakeQueryServerTimeoutError",
     # Raised when either the warehouse does not exist or we are missing 'USAGE' permissions on it
     "SnowflakeWarehouseUsageError",
-    # Invalid filter used.
-    "InvalidFilterError",
 )
 
 

--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -150,6 +150,7 @@ async def execute_batch_export_using_internal_stage(
                 initial_interval=dt.timedelta(seconds=initial_retry_interval_seconds),
                 maximum_interval=dt.timedelta(seconds=maximum_retry_interval_seconds),
                 maximum_attempts=maximum_attempts,
+                non_retryable_error_types=["InvalidFilterError"],
             ),
         )
 


### PR DESCRIPTION
## Problem

#43038 introduced a non-retryable error for filters, but this error is raised not in the main activity but the internal stage activity.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Make `InvalidFilterError` non-retryable in internal stage activity, not main activity.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
