### PR TITLE
fix(replay): try to fix css issue in iframe (gated)

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -316,7 +316,7 @@ export const FEATURE_FLAGS = {
     REMOTE_CONFIG: 'remote-config', // owner: #team-platform-features
     REPLAY_FILTERS_REDESIGN: 'replay-filters-redesign', // owner: @ksvat #team-replay
     REPLAY_NEW_DETECTED_URL_COLLECTIONS: 'replay-new-detected-url-collections', // owner: @ksvat #team-replay multivariate=true
-    REPLAY_WAIT_FOR_FULL_SNAPSHOT_PLAYBACK: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay
+    REPLAY_KILLSWITCH_UI_RESIZING: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay
     REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW: 'replay-x-llm-analytics-conversation-view', // owner: @pauldambra #team-replay
     SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE: 'schedule-feature-flag-variants-update', // owner: @gustavo #team-feature-flags
     SCHEMA_MANAGEMENT: 'schema-management', // owner: @aspicer

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -316,7 +316,7 @@ export const FEATURE_FLAGS = {
     REMOTE_CONFIG: 'remote-config', // owner: #team-platform-features
     REPLAY_FILTERS_REDESIGN: 'replay-filters-redesign', // owner: @ksvat #team-replay
     REPLAY_NEW_DETECTED_URL_COLLECTIONS: 'replay-new-detected-url-collections', // owner: @ksvat #team-replay multivariate=true
-    REPLAY_KILLSWITCH_UI_RESIZING: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay
+    REPLAY_WAIT_FOR_IFRAME_READY: 'replay-wait-for-full-snapshot-playback', // owner: @ksvat #team-replay
     REPLAY_X_LLM_ANALYTICS_CONVERSATION_VIEW: 'replay-x-llm-analytics-conversation-view', // owner: @pauldambra #team-replay
     SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE: 'schedule-feature-flag-variants-update', // owner: @gustavo #team-feature-flags
     SCHEMA_MANAGEMENT: 'schema-management', // owner: @aspicer

--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
@@ -8,6 +8,8 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import { Handler, viewportResizeDimension } from '@posthog/rrweb-types'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 
 export const PlayerFrame = (): JSX.Element => {
@@ -18,6 +20,9 @@ export const PlayerFrame = (): JSX.Element => {
     const frameRef = useRef<HTMLDivElement | null>(null)
     const containerRef = useRef<HTMLDivElement | null>(null)
     const containerDimensions = useSize(containerRef)
+
+    // Feature flag to enable UI resizing fixes (killswitch to disable if needed)
+    const enableResizingFix = useFeatureFlag(FEATURE_FLAGS.REPLAY_KILLSWITCH_UI_RESIZING)
 
     // Define callbacks before they're used in effects
     const updatePlayerDimensions = useCallback(
@@ -35,6 +40,11 @@ export const PlayerFrame = (): JSX.Element => {
 
             const parentDimensions = frameRef.current.parentElement.getBoundingClientRect()
 
+            // Skip calculation if parent dimensions aren't ready yet (can happen during initial layout)
+            if (enableResizingFix && (parentDimensions.width === 0 || parentDimensions.height === 0)) {
+                return
+            }
+
             const scale = Math.min(
                 parentDimensions.width / replayDimensions.width,
                 parentDimensions.height / replayDimensions.height,
@@ -45,7 +55,7 @@ export const PlayerFrame = (): JSX.Element => {
 
             setScale(scale)
         },
-        [player, setScale]
+        [player, setScale, enableResizingFix]
     )
 
     const windowResize = useCallback((): void => {
@@ -68,11 +78,23 @@ export const PlayerFrame = (): JSX.Element => {
         player.replayer.on('resize', updatePlayerDimensions as Handler)
         window.addEventListener('resize', windowResize)
 
+        // Force an initial resize calculation after the browser has completed layout
+        // This fixes a race condition where dimensions are calculated before CSS layout is complete
+        let rafId: number | undefined
+        if (enableResizingFix) {
+            rafId = requestAnimationFrame(() => {
+                windowResize()
+            })
+        }
+
         return () => {
             player.replayer.off('resize', updatePlayerDimensions as Handler)
             window.removeEventListener('resize', windowResize)
+            if (rafId !== undefined) {
+                cancelAnimationFrame(rafId)
+            }
         }
-    }, [player, updatePlayerDimensions, windowResize])
+    }, [player, updatePlayerDimensions, windowResize, enableResizingFix])
 
     // Recalculate the player size when the player changes dimensions
     useEffect(() => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1199,13 +1199,13 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                         // Force rrweb to rebuild/repaint now that the document is ready
                         // This ensures stylesheets are processed as inline <style> tags
                         // instead of external <link> tags which fail due to CSP
-                        if (replayer.replayer && values.currentTimestamp !== undefined) {
+                        if (replayer && values.currentTimestamp !== undefined && values.sessionPlayerData.start) {
                             const currentTime = values.currentTimestamp - values.sessionPlayerData.start.valueOf()
                             // Trigger a micro-seek to force rrweb to rebuild with the ready document
-                            replayer.replayer.pause(currentTime)
+                            replayer.pause(currentTime)
                             setTimeout(() => {
-                                if (replayer.replayer) {
-                                    replayer.replayer.pause(currentTime)
+                                if (replayer) {
+                                    replayer.pause(currentTime)
                                 }
                             }, 0)
                         }

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -24,7 +24,6 @@ import { EventType, IncrementalSource, eventWithTime } from '@posthog/rrweb-type
 
 import api from 'lib/api'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs, now } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { clamp, downloadFile, findLastIndex, objectsEqual, uuid } from 'lib/utils'
@@ -1270,21 +1269,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             if (values.currentSegment?.windowId !== undefined) {
                 const allSnapshots = values.sessionPlayerData.snapshotsByWindowId[values.currentSegment?.windowId] ?? []
                 const newSnapshots = allSnapshots.slice(currentEvents.length)
-
-                // Check if we have a full snapshot before adding incremental mutations
-                // This prevents the white screen bug where incremental mutations arrive before the full snapshot
-                // flag to test this in prod on select teams/recordings without affecting everyone
-                if (
-                    values.featureFlags[FEATURE_FLAGS.REPLAY_WAIT_FOR_FULL_SNAPSHOT_PLAYBACK] &&
-                    newSnapshots.length > 0
-                ) {
-                    const hasFullSnapshot = allSnapshots.some((e) => e.type === EventType.FullSnapshot)
-
-                    if (!hasFullSnapshot) {
-                        // We have new snapshots but no full snapshot anywhere yet - wait for it
-                        return
-                    }
-                }
 
                 eventsToAdd.push(...newSnapshots)
             }


### PR DESCRIPTION
## Problem

We now have 2 tickets that "look" like crossOrigin CSS issues.... but both arent quite that

Ticket 1: https://posthoghelp.zendesk.com/agent/tickets/41248 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/48179)
Ticket 2: https://posthoghelp.zendesk.com/agent/tickets/44080 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46979)

Theory: 
 1. When the player first mounts, and begins playing "messed up CSS" version, the iframe document is still readyState: "loading" (confirmed with console logs)
  2. rrweb hasn't finished processing CSS data yet, so it creates external <link rel="stylesheet"> tags as fallbacks
  3. These external links fail to load due to CSP restrictions in the sandboxed iframe (sandbox="allow-same-origin")
  4. On remount (after Inspect DOM), the iframe is fully loaded, so rrweb creates inline <style> tags instead, which work

  Evidence:
  - Initial load: 47 <style> tags + 11 <link> tags (broken)
  - After remount (open/close "inspect dom"): 58 <style> tags + 0 <link> tags (working)


## Changes

 Wait for the iframe document to finish loading (DOMContentLoaded event) before setting up the player. This ensures rrweb processes all CSS as inline <style> tags on
  first mount.

  Gated behind feature flag REPLAY_WAIT_FOR_IFRAME_READY for safe rollout.
## How did you test this code?

have to test in prod because the issue does not repro locally (json downloaded), hence flag


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
