### PR TITLE
fix(heatmaps): fix cookie banner detection, which was hiding some websites in screenshots

### DIFF
--- a/posthog/tasks/heatmap_screenshot.py
+++ b/posthog/tasks/heatmap_screenshot.py
@@ -50,15 +50,33 @@ def _dismiss_cookie_banners(page: Page) -> None:
             pass
 
     # CSS-hide common cookie/consent containers and overlays
+    # Important: Only target specific container elements (div, section, aside, etc.) to avoid hiding html/body
+    # which may have cookie-related classes (e.g., <html class="supports-no-cookies">)
     css_hide = """
-    [id*="cookie" i], [class*="cookie" i],
-    [id*="consent" i], [class*="consent" i],
-    [id*="gdpr" i], [class*="gdpr" i],
-    [id*="onetrust" i], [class*="onetrust" i],
-    [id*="ot-sdk" i], [class*="ot-sdk" i],
-    [id*="sp_message" i], [class*="sp_message" i],
-    [id*="sp-consent" i], [class*="sp-consent" i],
-    [id*="quantcast" i], [class*="quantcast" i],
+    div[id*="cookie" i], div[class*="cookie" i],
+    div[id*="consent" i], div[class*="consent" i],
+    div[id*="gdpr" i], div[class*="gdpr" i],
+    div[id*="onetrust" i], div[class*="onetrust" i],
+    div[id*="ot-sdk" i], div[class*="ot-sdk" i],
+    div[id*="sp_message" i], div[class*="sp_message" i],
+    div[id*="sp-consent" i], div[class*="sp-consent" i],
+    div[id*="quantcast" i], div[class*="quantcast" i],
+    section[id*="cookie" i], section[class*="cookie" i],
+    section[id*="consent" i], section[class*="consent" i],
+    section[id*="gdpr" i], section[class*="gdpr" i],
+    section[id*="onetrust" i], section[class*="onetrust" i],
+    section[id*="ot-sdk" i], section[class*="ot-sdk" i],
+    section[id*="sp_message" i], section[class*="sp_message" i],
+    section[id*="sp-consent" i], section[class*="sp-consent" i],
+    section[id*="quantcast" i], section[class*="quantcast" i],
+    aside[id*="cookie" i], aside[class*="cookie" i],
+    aside[id*="consent" i], aside[class*="consent" i],
+    aside[id*="gdpr" i], aside[class*="gdpr" i],
+    aside[id*="onetrust" i], aside[class*="onetrust" i],
+    aside[id*="ot-sdk" i], aside[class*="ot-sdk" i],
+    aside[id*="sp_message" i], aside[class*="sp_message" i],
+    aside[id*="sp-consent" i], aside[class*="sp-consent" i],
+    aside[id*="quantcast" i], aside[class*="quantcast" i],
     iframe[src*="consent" i], iframe[src*="cookie" i], iframe[src*="onetrust" i],
     /* generic fixed overlays */
     div[style*="position:fixed" i][style*="z-index" i] {


### PR DESCRIPTION
## Problem

ticket: https://posthoghelp.zendesk.com/agent/tickets/44717 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/47839)

## Changes

We were being too eager with cookie detection. Only detect "cookie" named classes on certain elements to avoid hiding critical content

## How did you test this code?

kubectl tests locally with the user's screenshots --
Before fix: 
```BEFORE - Body: {'visibility': 'visible', 'display': 'block'}, HTML: {'visibility': 'visible', 'display': 'block'}
AFTER  - Body: {'visibility': 'hidden', 'display': 'block'}, HTML: {'visibility': 'hidden', 'display': 'none'}
✗ FAILED! Page is hidden after cookie dismissal
```


After fix: 
```BEFORE - Body: {'visibility': 'visible', 'display': 'block'}, HTML: {'visibility': 'visible', 'display': 'block'}
AFTER  - Body: {'visibility': 'visible', 'display': 'block'}, HTML: {'visibility': 'visible', 'display': 'block'}
✓ SUCCESS! Page is still visible after cookie dismissal
```
<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
