### PR TITLE
fix: truncate float to percentage int for replay sample rate trigger

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -869,7 +869,7 @@ export function RecordingTriggersSummary({ selectedPlatform }: { selectedPlatfor
     const hasEventTriggers = (eventTriggerConfig?.length ?? 0) > 0
     const hasFeatureFlag = !!currentTeam.session_recording_linked_flag
     const sampleRate = currentTeam.session_recording_sample_rate
-    const numericSampleRate = !!sampleRate && parseFloat(sampleRate) * 100
+    const numericSampleRate = !!sampleRate && (parseFloat(sampleRate) * 100).toFixed(0)
     const hasSampling = isNumeric(numericSampleRate) && numericSampleRate < 100
     const hasMinDuration = !!currentTeam.session_recording_minimum_duration_milliseconds
     const hasUrlBlocklist = (currentTeam.session_recording_url_blocklist_config?.length ?? 0) > 0

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -869,7 +869,7 @@ export function RecordingTriggersSummary({ selectedPlatform }: { selectedPlatfor
     const hasEventTriggers = (eventTriggerConfig?.length ?? 0) > 0
     const hasFeatureFlag = !!currentTeam.session_recording_linked_flag
     const sampleRate = currentTeam.session_recording_sample_rate
-    const numericSampleRate = !!sampleRate && (parseFloat(sampleRate) * 100).toFixed(0)
+    const numericSampleRate = !!sampleRate && Math.floor(parseFloat(sampleRate) * 100)
     const hasSampling = isNumeric(numericSampleRate) && numericSampleRate < 100
     const hasMinDuration = !!currentTeam.session_recording_minimum_duration_milliseconds
     const hasUrlBlocklist = (currentTeam.session_recording_url_blocklist_config?.length ?? 0) > 0


### PR DESCRIPTION
## Problem
<img width="500" height="208" alt="Screenshot 2025-12-09 at 19 52 19" src="https://github.com/user-attachments/assets/ad7d1d20-7d2b-43a7-b006-b9c2093e3477" />

This float point issue seems to only happen on 55% at the moment but for now adding a truncate to int works.

## Changes

Truncate the float to drop the decimals in replay sample rate number percentage
<img width="433" height="344" alt="Screenshot 2025-12-10 at 12 27 19" src="https://github.com/user-attachments/assets/3f39962b-2f37-46ed-8eed-1e90b953873b" />


## How did you test this code?

Tested locally to see the new view

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

It is a bugfix not a featureTM
