### PR TITLE
revert(docker): undo uv optimization from #42124

### DIFF
--- a/Dockerfile.ai-evals
+++ b/Dockerfile.ai-evals
@@ -1,20 +1,13 @@
 # Same as pyproject.toml so that uv can pick it up and doesn't need to download a different Python version.
 FROM python:3.12.12-slim-bookworm AS python-base
-FROM ghcr.io/astral-sh/uv:0.9.9 AS uv
 FROM cruizba/ubuntu-dind:latest
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
-# Copy Python base and uv
+# Copy Python base
 COPY --from=python-base /usr/local /usr/local
-COPY --from=uv /uv /uvx /bin/
 
 # Set working directory
 WORKDIR /code
-
-# uv settings for Docker builds
-ENV UV_COMPILE_BYTECODE=1
-ENV UV_LINK_MODE=copy
-ENV UV_PROJECT_ENVIRONMENT=/python-runtime
 
 # Copy Docker scripts
 COPY docker/ ./docker/
@@ -31,15 +24,16 @@ RUN apt-get update && \
     "zlib1g-dev" \
     "pkg-config" \
     "netcat-openbsd" \
-    "postgresql-client" \
-    && \
-    rm -rf /var/lib/apt/lists/*
+    "postgresql-client"
 
-# Install Python dependencies using cache mount for faster rebuilds
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project --no-binary-package lxml --no-binary-package xmlsec
+# Copy uv dependencies
+COPY pyproject.toml uv.lock docker-compose.base.yml docker-compose.dev.yml ./
+
+# Install python deps
+RUN rm -rf /var/lib/apt/lists/* && \
+pip install uv==0.9.9 --no-cache-dir && \
+UV_PROJECT_ENVIRONMENT=/python-runtime uv sync --frozen --no-cache --compile-bytecode \
+--no-binary-package lxml --no-binary-package xmlsec
 
 # Copy project files
 COPY bin/ ./bin/
@@ -49,7 +43,6 @@ COPY common/hogvm common/hogvm/
 COPY posthog posthog/
 COPY products/ products/
 COPY ee ee/
-COPY docker-compose.base.yml docker-compose.dev.yml ./
 
 ENV PATH=/python-runtime/bin:$PATH \
     PYTHONPATH=/python-runtime


### PR DESCRIPTION
Reverts #42124.

Returns to `pip install uv` approach instead of `COPY --from=ghcr.io/astral-sh/uv` and removes the cache mounts/bind mounts pattern.