### PR TITLE
fix(capture-logs): use zstandard(1) instead of default

### DIFF
--- a/rust/capture-logs/src/kafka.rs
+++ b/rust/capture-logs/src/kafka.rs
@@ -198,7 +198,7 @@ impl KafkaSink {
         let mut writer = Writer::with_codec(
             &schema,
             Vec::new(),
-            Codec::Zstandard(ZstandardSettings::default()),
+            Codec::Zstandard(ZstandardSettings::new(1)),
         );
 
         for row in &rows {


### PR DESCRIPTION

## Problem
docs suggest the default level is 3 and we're using a lot of cpu time compressing

level 1 is probably more suitable for capture for raw speed

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
change zstd level from default to level1
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
