### PR TITLE
feat(capture): expose Hyper server loop directly to control/observe graceful shutdown

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
+            - 'eli.r/capture-hyper-cfg'
 
 jobs:
     build:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1567,6 +1567,8 @@ dependencies = [
  "flate2",
  "futures",
  "health",
+ "hyper 1.6.0",
+ "hyper-util",
  "limiters",
  "lz-str",
  "metrics",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -77,6 +77,8 @@ futures-util = { version = "0.3.31" }
 governor = { version = "0.5.1", features = ["dashmap"] }
 http = { version = "1.1.0" }
 http-body-util = "0.1.0"
+hyper = { version = "1.5", features = ["server", "http1", "http2"] }
+hyper-util = { version = "0.1", features = ["tokio", "server", "server-auto", "server-graceful"] }
 httpmock = "0.7.0"
 itoa = "1.0.15"
 metrics = "0.22.0"

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -17,6 +17,8 @@ bytes = { workspace = true }
 envconfig = { workspace = true }
 flate2 = { workspace = true }
 health = { path = "../common/health" }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
 common-alloc = { path = "../common/alloc" }
 common-continuous-profiling = { path = "../common/continuous_profiling" }
 common-redis = { path = "../common/redis" }

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -119,6 +119,12 @@ pub struct Config {
     // if set in env, will configure a request timeout on the server's Axum router
     pub request_timeout_seconds: Option<u64>,
 
+    // graceful shutdown timeout for in-flight connections
+    // default is less than k8s term grace period, higher than
+    // deploy p99.99 resp times for all services (even replay)
+    #[envconfig(default = "10")]
+    pub shutdown_graceful_timeout_seconds: u64,
+
     #[envconfig(nested = true)]
     pub continuous_profiling: ContinuousProfilingConfig,
 }

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -85,6 +85,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     healthcheck_strategy: HealthStrategy::All,
     ai_max_sum_of_parts_bytes: 26_214_400, // 25MB default
     request_timeout_seconds: Some(10),
+    shutdown_graceful_timeout_seconds: 5, // short timeout for tests
     continuous_profiling: ContinuousProfilingConfig {
         continuous_profiling_enabled: false,
         pyroscope_server_address: String::new(),


### PR DESCRIPTION
## Problem
We want more app level control over graceful shutdown of `capture`'s Axum server during deploy cutovers.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Expose underlying Hyper server builder plumbing
* Control graceful shutdown timeout and observe actual behavior of Hyper-managed connections on shutdown

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, CI, mirror deploy smoke test
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
