### PR TITLE
fix(data-warehouse): Sort column names alphabetically in SQL editor sidebar

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -120,9 +120,11 @@ const createTableNode = (
     const tableChildren: TreeDataItem[] = []
 
     if ('fields' in table) {
-        Object.values(table.fields).forEach((field: DatabaseSchemaField) => {
-            tableChildren.push(createColumnNode(table.name, field, isSearch))
-        })
+        Object.values(table.fields)
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .forEach((field: DatabaseSchemaField) => {
+                tableChildren.push(createColumnNode(table.name, field, isSearch))
+            })
     }
 
     const tableId = `${isSearch ? 'search-' : ''}table-${table.name}`
@@ -172,9 +174,11 @@ const createViewNode = (
     const isManagedViewsetView = view.managed_viewset_kind !== null
     const isManagedView = 'type' in view && view.type === 'managed_view'
 
-    Object.values(view.columns).forEach((column: DatabaseSchemaField) => {
-        viewChildren.push(createColumnNode(view.name, column, isSearch))
-    })
+    Object.values(view.columns)
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .forEach((column: DatabaseSchemaField) => {
+            viewChildren.push(createColumnNode(view.name, column, isSearch))
+        })
 
     const viewId = `${isSearch ? 'search-' : ''}view-${view.id}`
 
@@ -206,9 +210,11 @@ const createManagedViewNode = (
 ): TreeDataItem => {
     const viewChildren: TreeDataItem[] = []
 
-    Object.values(managedView.fields).forEach((field: DatabaseSchemaField) => {
-        viewChildren.push(createColumnNode(managedView.name, field, isSearch))
-    })
+    Object.values(managedView.fields)
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .forEach((field: DatabaseSchemaField) => {
+            viewChildren.push(createColumnNode(managedView.name, field, isSearch))
+        })
 
     const managedViewId = `${isSearch ? 'search-' : ''}managed-view-${managedView.id}`
 
@@ -233,9 +239,11 @@ const createEndpointNode = (
 ): TreeDataItem => {
     const endpointChildren: TreeDataItem[] = []
 
-    Object.values(endpoint.fields).forEach((field: DatabaseSchemaField) => {
-        endpointChildren.push(createColumnNode(endpoint.name, field, isSearch))
-    })
+    Object.values(endpoint.fields)
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .forEach((field: DatabaseSchemaField) => {
+            endpointChildren.push(createColumnNode(endpoint.name, field, isSearch))
+        })
 
     const endpointId = `${isSearch ? 'search-' : ''}endpoint-${endpoint.id}`
 


### PR DESCRIPTION
## Summary
- Columns within tables, views, managed views, and endpoints in the SQL editor sidebar are now sorted alphabetically by name
- Previously columns appeared in their original order (based on how they were defined in the schema)

## Test plan
- Open the SQL editor
- Expand any table or view in the sidebar
- Verify column names are sorted alphabetically (A-Z)

🤖 Generated with [Claude Code](https://claude.com/claude-code)