### PR TITLE
chore(security): scan GitHub Actions with Semgrep

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -172,6 +172,7 @@ jobs:
                     --config "p/owasp-top-ten" \
                     --config "p/security-audit" \
                     --config "p/trailofbits" \
+                    --config "p/github-actions" \
                     --exclude-rule dockerfile.security.no-sudo-in-dockerfile.no-sudo-in-dockerfile \
                     --exclude-rule trailofbits.yaml.github-actions.aws-secret-key.aws-secret-key \
                     --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport \


### PR DESCRIPTION
We now scan our GitHub Actions workflows with Semgrep's [github-actions ruleset](https://semgrep.dev/p/github-actions). This ruleset includes a [rule](https://semgrep.dev/playground/r/yaml.github-actions.security.pull-request-target-code-checkout.pull-request-target-code-checkout?editorMode=advanced) to check that we never check out a user-controlled branch while also using `pull_request_target`. This dangerous combination can allow for arbitrary code execution, which was the cause of our recent [npm incident](https://posthog.com/blog/nov-24-shai-hulud-attack-post-mortem).

Importantly, once this is merged we no longer need Team Security to review all GitHub Actions changes.