### PR TITLE
feat(capture): add explicit _readiness probe behavior tied to shutdown signal

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
+            - 'eli.r/capture-coord-readiness-contour'
 
 jobs:
     build:

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -119,6 +119,11 @@ pub struct Config {
     // if set in env, will configure a request timeout on the server's Axum router
     pub request_timeout_seconds: Option<u64>,
 
+    // time to wait after SIGTERM before starting graceful shutdown, allowing
+    // readiness probe to fail and load balancer to stop routing new traffic
+    #[envconfig(default = "5")]
+    pub shutdown_readiness_drain_seconds: u64,
+
     #[envconfig(nested = true)]
     pub continuous_profiling: ContinuousProfilingConfig,
 }

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -2,6 +2,7 @@
 use std::fs::read;
 use std::io::Write;
 use std::path::Path;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -995,6 +996,7 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
             verbose_sample_percent,
             26_214_400, // 25MB default for AI endpoint
             Some(10),   // request_timeout_seconds
+            Arc::new(AtomicBool::new(false)),
         ),
         sink,
     )

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -85,6 +85,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     healthcheck_strategy: HealthStrategy::All,
     ai_max_sum_of_parts_bytes: 26_214_400, // 25MB default
     request_timeout_seconds: Some(10),
+    shutdown_readiness_drain_seconds: 0, // no drain delay in tests
     continuous_profiling: ContinuousProfilingConfig {
         continuous_profiling_enabled: false,
         pyroscope_server_address: String::new(),

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -21,6 +21,7 @@ use limiters::token_dropper::TokenDropper;
 use reqwest::multipart::{Form, Part};
 use serde_json::{json, Value};
 use std::io::Write;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -171,6 +172,7 @@ fn setup_ai_test_router() -> Router {
         0.0_f32,
         26_214_400, // 25MB default for AI endpoint
         Some(10),   // request_timeout_seconds
+        Arc::new(AtomicBool::new(false)),
     )
 }
 
@@ -1494,6 +1496,7 @@ fn setup_ai_test_router_with_capturing_sink() -> (Router, CapturingSink) {
         0.0_f32,
         26_214_400, // 25MB default for AI endpoint
         Some(10),   // request_timeout_seconds
+        Arc::new(AtomicBool::new(false)),
     );
 
     (router, sink_clone)
@@ -2369,6 +2372,7 @@ fn setup_ai_test_router_with_token_dropper(token_dropper: TokenDropper) -> (Rout
         0.0_f32,
         26_214_400,
         Some(10),
+        Arc::new(AtomicBool::new(false)),
     );
 
     (router, sink_clone)
@@ -2566,6 +2570,7 @@ fn setup_ai_test_router_with_llm_quota_limited(token: &str) -> (Router, Capturin
         0.0_f32,
         26_214_400,
         Some(10),
+        Arc::new(AtomicBool::new(false)),
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -2,6 +2,7 @@
 mod integration_utils;
 use integration_utils::DEFAULT_CONFIG;
 
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -139,6 +140,7 @@ async fn setup_router_with_limits(
         0.0,         // verbose_sample_percent
         26_214_400,  // ai_max_sum_of_parts_bytes (25MB)
         Some(10),    // request_timeout_seconds
+        Arc::new(AtomicBool::new(false)),
     );
 
     (app, sink)
@@ -1139,6 +1141,7 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
         0.0,
         26_214_400,
         Some(10), // request_timeout_seconds
+        Arc::new(AtomicBool::new(false)),
     );
 
     let client = TestClient::new(app);
@@ -1216,6 +1219,7 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
         0.0,
         26_214_400,
         Some(10), // request_timeout_seconds
+        Arc::new(AtomicBool::new(false)),
     );
 
     let client = TestClient::new(app);
@@ -1297,6 +1301,7 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
         0.0,
         26_214_400,
         Some(10), // request_timeout_seconds
+        Arc::new(AtomicBool::new(false)),
     );
 
     let client = TestClient::new(app);
@@ -1715,6 +1720,7 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
         0.0,
         26_214_400,
         Some(10), // request_timeout_seconds
+        Arc::new(AtomicBool::new(false)),
     );
 
     let client = TestClient::new(app);


### PR DESCRIPTION
## Problem
We see bursts of closed connections in Envoy across deploy boundaries in `capture` deployments. The root metric surfaced in Envoy is `envoy_cluster_upstream_cx_destroy_remote_with_active_rq` which means our app is closing connections out while Envoy awaits a response to an in-flight request.

The reason could be that capture does not properly trigger changes to the `_readiness` endpoint before taking down the listener entirely and triggering shutdown. In this scenario, Envoy is still sending connections to outgoing pods right during a deploy cutover, right up until the pod listener is dropped.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement a simple `_readiness` status change when k8s signals (SIGTERM/SIGKILL) to shut down the pod
* Sleep for a configurable window prior to completing shutdown so k8s LB (and Envoy) have time to figure this out before the app stops listening and attempts to finish in-flights

Let's see what effect this has in mirror, and iterate from there. Handling readiness probes properly is good practice anyway.

**Q: Why didn't you reuse the HealthRegistry for this?**
I considered it but didn't want unrelated global changes in app health to bleed over into the `_readiness` probe behavior until I've seen this act strictly on deploy cutovers.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and CI; will smoke test in mirror deploy & eval results prior to merge
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
