### PR TITLE
fix(ducklake): remove core_nightly extension installation

### DIFF
--- a/posthog/ducklake/common.py
+++ b/posthog/ducklake/common.py
@@ -62,7 +62,6 @@ def configure_connection(
     config: dict[str, str] | None = None,
     *,
     install_extension: bool = False,
-    use_core_nightly: bool = False,
 ) -> None:
     """Configure DuckDB connection with DuckLake extension and S3 settings.
 
@@ -70,16 +69,12 @@ def configure_connection(
         conn: DuckDB connection
         config: Configuration dict (uses get_config() if None)
         install_extension: Whether to install the DuckLake extension
-        use_core_nightly: Whether to install from core_nightly (for production)
     """
     if config is None:
         config = get_config()
 
     if install_extension:
-        if use_core_nightly:
-            conn.sql("INSTALL ducklake FROM core_nightly")
-        else:
-            conn.sql("INSTALL ducklake")
+        conn.sql("INSTALL ducklake")
     conn.sql("LOAD ducklake")
 
     # Configure S3 access - supports both IRSA (production) and explicit credentials (dev)

--- a/posthog/temporal/ducklake/compaction_workflow.py
+++ b/posthog/temporal/ducklake/compaction_workflow.py
@@ -36,8 +36,8 @@ async def run_ducklake_compaction(input: DucklakeCompactionInput) -> dict:
     conn = duckdb.connect()
 
     try:
-        # Configure S3 access and install DuckLake extension (from core_nightly for production)
-        configure_connection(conn, config, install_extension=True, use_core_nightly=True)
+        # Configure S3 access and install DuckLake extension
+        configure_connection(conn, config, install_extension=True)
 
         # Attach the DuckLake catalog
         attach_catalog(conn, config, alias="ducklake")


### PR DESCRIPTION
## Summary

- Removes the `use_core_nightly` parameter from `configure_connection()`
- The `ducklake` extension is now a core extension in DuckDB 1.4.x

## Problem

The ducklake compaction workflow was failing with:

```
HTTP Error: Failed to download extension "ducklake" at URL 
"http://nightly-extensions.duckdb.org/v1.4.2/linux_arm64/ducklake.duckdb_extension.gz" (HTTP 404)
```

The `core_nightly` repository doesn't have the `ducklake` extension for all platforms (e.g., `linux_arm64`).

## Solution

Since DuckDB 1.4.x, `ducklake` is a standard core extension and should be installed with just `INSTALL ducklake` - no need to specify a repository.

## Test plan

- [x] Verify no other code references `use_core_nightly`
- [ ] Deploy and confirm compaction workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)