### PR TITLE
fix(docker): pin libxmlsec1 version to prevent version mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,8 +165,8 @@ RUN apt-get update && \
     "build-essential" \
     "git" \
     "libpq-dev" \
-    "libxmlsec1" \
-    "libxmlsec1-dev" \
+    "libxmlsec1=1.2.37-2" \
+    "libxmlsec1-dev=1.2.37-2" \
     "libffi-dev" \
     "zlib1g-dev" \
     "pkg-config" \
@@ -174,7 +174,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies using cache mount for faster rebuilds
-RUN --mount=type=cache,target=/root/.cache/uv \
+# Cache ID includes libxmlsec1 version to bust cache when system library changes
+RUN --mount=type=cache,id=uv-libxmlsec1.2.37-2,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-dev --no-install-project --no-binary-package lxml --no-binary-package xmlsec
@@ -244,8 +245,8 @@ RUN apt-get update && \
     "chromium" \
     "chromium-driver" \
     "libpq-dev" \
-    "libxmlsec1" \
-    "libxmlsec1-dev" \
+    "libxmlsec1=1.2.37-2" \
+    "libxmlsec1-dev=1.2.37-2" \
     "libxml2" \
     "gettext-base" \
     "ffmpeg=7:5.1.7-0+deb12u1" \


### PR DESCRIPTION
## Problem

CI builds are failing with:
```
xmlsec.Error: (19, 'xmlsec library version mismatch.')
```

This happens during `collectstatic` in the **build stage** when Python tries to import `xmlsec`.

## Root Cause

The `xmlsec` Python package is built from source (`--no-binary-package xmlsec` in Dockerfile) and stores the version of `libxmlsec1` it was compiled against. At import time, it checks if the runtime library version matches.

The issue is the **Depot/BuildKit cache mount** (`--mount=type=cache,target=/root/.cache/uv`). This cache persists across builds, so even with `--no-binary-package xmlsec`, if a previously compiled wheel exists in the cache from a build with a different `libxmlsec1` version, that old wheel gets reused.

## Solution

1. **Pin `libxmlsec1` version** to `1.2.37-2` (Debian bookworm stable) in both build and runtime stages
2. **Bust the uv cache** by adding a cache ID that includes the libxmlsec1 version: `id=uv-libxmlsec1.2.37-2`. This creates a fresh cache without any old compiled wheels.

## Changes

- Pin `libxmlsec1=1.2.37-2` and `libxmlsec1-dev=1.2.37-2` in build stage (line 168-169)
- Pin `libxmlsec1=1.2.37-2` and `libxmlsec1-dev=1.2.37-2` in runtime stage (line 248-249)  
- Add cache ID `id=uv-libxmlsec1.2.37-2` to uv cache mount (line 178)

## Test plan

- [ ] CI build passes
- [ ] `collectstatic` completes successfully
- [ ] Docker image builds on both amd64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)