### PR TITLE
fix(ducklake): use correct DuckLake API for table listing and compaction

### DIFF
--- a/posthog/temporal/ducklake/compaction_workflow.py
+++ b/posthog/temporal/ducklake/compaction_workflow.py
@@ -1,5 +1,6 @@
 import re
 from datetime import timedelta
+from typing import NamedTuple
 
 import structlog
 from temporalio import activity, common, workflow
@@ -12,6 +13,11 @@ logger = structlog.get_logger(__name__)
 
 # Valid SQL identifier pattern (alphanumeric and underscores only)
 TABLE_NAME_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+class TableInfo(NamedTuple):
+    schema_name: str
+    table_name: str
 
 
 @activity.defn
@@ -48,42 +54,61 @@ async def run_ducklake_compaction(input: DucklakeCompactionInput) -> dict:
         activity.heartbeat()
 
         # Get list of tables to compact
+        tables_to_compact: list[TableInfo] = []
         if input.tables:
-            tables_to_compact = input.tables
+            # Input tables should be in "schema.table" format
+            for table_spec in input.tables:
+                if "." in table_spec:
+                    schema_name, table_name = table_spec.split(".", 1)
+                    tables_to_compact.append(TableInfo(schema_name, table_name))
+                else:
+                    # Assume main schema if not specified
+                    tables_to_compact.append(TableInfo("main", table_spec))
         else:
-            # Get all tables in the ducklake catalog
+            # Get all tables with their schema names from the ducklake catalog
+            # Query the DuckLake metadata catalog to join tables with schemas
             result = conn.execute("""
-                SELECT table_name
-                FROM ducklake.information_schema.tables
-                WHERE table_schema = 'main'
+                SELECT s.schema_name, t.table_name
+                FROM ducklake_table_info('ducklake') t
+                JOIN __ducklake_metadata_ducklake.ducklake_schema s
+                    ON t.schema_id = s.schema_id
+                    AND s.end_snapshot IS NULL
             """).fetchall()
-            tables_to_compact = [row[0] for row in result]
+            tables_to_compact = [TableInfo(row[0], row[1]) for row in result]
 
-        logger.info("Tables to compact", tables=tables_to_compact)
+        logger.info("Tables to compact", tables=[(t.schema_name, t.table_name) for t in tables_to_compact])
 
         compaction_results = {}
 
-        for table in tables_to_compact:
+        for table_info in tables_to_compact:
             activity.heartbeat()
+            table_key = f"{table_info.schema_name}.{table_info.table_name}"
 
-            # Validate table name to prevent SQL injection
-            if not TABLE_NAME_PATTERN.match(table):
-                logger.warning("Skipping invalid table name", table=table)
-                compaction_results[table] = {"status": "error", "error": "Invalid table name"}
+            # Validate table and schema names to prevent SQL injection
+            if not TABLE_NAME_PATTERN.match(table_info.table_name):
+                logger.warning("Skipping invalid table name", table=table_key)
+                compaction_results[table_key] = {"status": "error", "error": "Invalid table name"}
+                continue
+            if not TABLE_NAME_PATTERN.match(table_info.schema_name):
+                logger.warning("Skipping invalid schema name", table=table_key)
+                compaction_results[table_key] = {"status": "error", "error": "Invalid schema name"}
                 continue
 
             try:
                 if input.dry_run:
-                    logger.info("Dry run - would compact table", table=table)
-                    compaction_results[table] = {"status": "dry_run"}
+                    logger.info("Dry run - would compact table", table=table_key)
+                    compaction_results[table_key] = {"status": "dry_run"}
                 else:
-                    logger.info("Compacting table", table=table)
-                    conn.execute(f"CALL ducklake.merge_adjacent_files(table => '{table}')")
-                    compaction_results[table] = {"status": "success"}
-                    logger.info("Successfully compacted table", table=table)
+                    logger.info("Compacting table", table=table_key)
+                    conn.execute(
+                        f"CALL ducklake_merge_adjacent_files('ducklake', '{table_info.table_name}', "
+                        f"schema => '{table_info.schema_name}')"
+                    )
+                    compaction_results[table_key] = {"status": "success"}
+                    logger.info("Successfully compacted table", table=table_key)
             except Exception as e:
-                logger.exception("Failed to compact table", table=table, error=str(e))
-                compaction_results[table] = {"status": "error", "error": str(e)}
+                logger.exception("Failed to compact table", table=table_key, error=str(e))
+                compaction_results[table_key] = {"status": "error", "error": str(e)}
     finally:
         conn.close()
 


### PR DESCRIPTION
## Problem

The DuckLake compaction workflow was failing with:
```
Catalog Error: Table with name tables does not exist!
Did you mean "ducklake.events"?

LINE 3:                 FROM ducklake.information_schema.tables
```

## Root Cause

Multiple issues with the DuckLake API usage:

1. **Non-existent table**: DuckLake catalogs don't have `information_schema.tables` 
2. **Wrong function name**: Code used `ducklake.merge_adjacent_files()` instead of `ducklake_merge_adjacent_files()`
3. **Missing schema handling**: Tables in PostHog are created across multiple schemas (`data_modeling_team_*`, `data_imports_team_*`), but the compaction wasn't schema-aware

## Solution

1. Use `ducklake_table_info('ducklake')` to list tables
2. Query `__ducklake_metadata_ducklake.ducklake_schema` to get schema names
3. Use correct function: `ducklake_merge_adjacent_files('ducklake', table, schema => schema_name)`
4. Track tables with `schema.table` format
5. Validate both schema and table names for SQL injection prevention

## Changes

- Added `TableInfo` named tuple to track schema + table pairs
- Updated table listing query to join with schema metadata
- Fixed `merge_adjacent_files` function call syntax
- Added schema name validation
- Input tables now support `schema.table` format (falls back to `main` schema)

## References

- [DuckLake extension docs](https://duckdb.org/docs/stable/core_extensions/ducklake)
- [merge_adjacent_files docs](https://ducklake.select/docs/stable/duckdb/maintenance/merge_adjacent_files)

## Test plan

- [ ] Workflow can list tables across all schemas
- [ ] Compaction runs with correct schema qualification
- [ ] Dry run mode works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)