### PR TITLE
test: skip secret-dependent tests on external contributor PRs

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -37,7 +37,7 @@ env:
     # absolute wild tbh https://stackoverflow.com/a/75503402
     DISPLAY: ':99.0'
     OIDC_RSA_PRIVATE_KEY: ${{ secrets.OIDC_RSA_PRIVATE_KEY }}
-    RUNS_ON_INTERNAL_PR: ${{ github.event.pull_request.head.repo.fork == false }}
+    RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
 
 permissions:
     contents: write

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -37,6 +37,7 @@ env:
     # absolute wild tbh https://stackoverflow.com/a/75503402
     DISPLAY: ':99.0'
     OIDC_RSA_PRIVATE_KEY: ${{ secrets.OIDC_RSA_PRIVATE_KEY }}
+    RUNS_ON_INTERNAL_PR: ${{ github.event.pull_request.head.repo.fork == false }}
 
 permissions:
     contents: write

--- a/posthog/api/test/test_oauth_application.py
+++ b/posthog/api/test/test_oauth_application.py
@@ -1,3 +1,4 @@
+import pytest
 from posthog.test.base import APIBaseTest
 
 from rest_framework import status
@@ -6,6 +7,7 @@ from rest_framework.test import APIClient
 from posthog.models.oauth import OAuthApplication
 
 
+@pytest.mark.requires_secrets
 class TestOAuthApplicationMetadataView(APIBaseTest):
     public_fields = ["name", "client_id"]
 

--- a/products/growth/dags/tests/test_oauth.py
+++ b/products/growth/dags/tests/test_oauth.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+import pytest
 import unittest.mock
 from freezegun import freeze_time
 
@@ -20,6 +21,7 @@ from products.growth.dags.oauth import (
 )
 
 
+@pytest.mark.requires_secrets
 class TestOAuthTokenCleanup(TestCase):
     def setUp(self):
         self.organization = Organization.objects.create(name="Test Org")
@@ -68,6 +70,7 @@ class TestOAuthTokenCleanup(TestCase):
         self.assertTrue(OAuthAccessToken.objects.filter(id=valid_token.id).exists())
 
 
+@pytest.mark.requires_secrets
 class TestBatchDeleteFunctionality(TestCase):
     """Test the new DRY batch delete functionality."""
 

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -13,6 +13,7 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
 )
 
 
+@pytest.mark.requires_secrets
 class TestGetTaskProcessingContextActivity:
     def _create_task_with_repo(self, team, user, github_integration, repo_config):
         return Task.objects.create(

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,5 +11,6 @@ markers =
     clickhouse_only
     skip_on_multitenancy
     async_migrations
+    requires_secrets: test needs internal secrets or infra and is skipped on external PRs
 
 asyncio_mode = auto


### PR DESCRIPTION
## Problem

We have tests failing for external contributor PRs due to a missing `OIDC_RSA_PRIVATE_KEY `.

## Changes

Excludes these tests from external contributor PRs.

## How did you test this code?

```
pytest posthog/api/test/test_oauth_application.py # runs
RUNS_ON_INTERNAL_PR=true pytest posthog/api/test/test_oauth_application.py # runs
RUNS_ON_INTERNAL_PR=false pytest posthog/api/test/test_oauth_application.py # skipped
```