### PR TITLE
fix: validate order by from url params

### DIFF
--- a/products/error_tracking/frontend/components/IssueQueryOptions/IssueQueryOptions.tsx
+++ b/products/error_tracking/frontend/components/IssueQueryOptions/IssueQueryOptions.tsx
@@ -20,17 +20,9 @@ import { issuesDataNodeLogic } from '../../logics/issuesDataNodeLogic'
 import {
     ErrorTrackingQueryOrderBy,
     ErrorTrackingQueryRevenueEntity,
+    ORDER_BY_OPTIONS,
     issueQueryOptionsLogic,
 } from './issueQueryOptionsLogic'
-
-const labels = {
-    last_seen: 'Last seen',
-    first_seen: 'First seen',
-    occurrences: 'Occurrences',
-    users: 'Users',
-    sessions: 'Sessions',
-    revenue: 'Revenue',
-}
 
 type GroupOptions = Record<`group_${GroupTypeIndex}`, string>
 
@@ -66,23 +58,23 @@ export const IssueQueryOptions = (): JSX.Element => {
                     <LemonMenu
                         items={[
                             {
-                                label: labels['last_seen'],
+                                label: ORDER_BY_OPTIONS['last_seen'],
                                 onClick: () => setOrderBy('last_seen'),
                             },
                             {
-                                label: labels['first_seen'],
+                                label: ORDER_BY_OPTIONS['first_seen'],
                                 onClick: () => setOrderBy('first_seen'),
                             },
                             {
-                                label: labels['occurrences'],
+                                label: ORDER_BY_OPTIONS['occurrences'],
                                 onClick: () => setOrderBy('occurrences'),
                             },
                             {
-                                label: labels['users'],
+                                label: ORDER_BY_OPTIONS['users'],
                                 onClick: () => setOrderBy('users'),
                             },
                             {
-                                label: labels['sessions'],
+                                label: ORDER_BY_OPTIONS['sessions'],
                                 onClick: () => setOrderBy('sessions'),
                             },
                             hasRevenueSorting && {
@@ -193,5 +185,5 @@ const sortByLabel = (
         return `Revenue (by ${entity})`
     }
 
-    return labels[orderBy]
+    return ORDER_BY_OPTIONS[orderBy]
 }

--- a/products/error_tracking/frontend/components/IssueQueryOptions/issueQueryOptionsLogic.ts
+++ b/products/error_tracking/frontend/components/IssueQueryOptions/issueQueryOptionsLogic.ts
@@ -17,7 +17,15 @@ export type ErrorTrackingQueryRevenueEntity = ErrorTrackingQuery['revenueEntity'
 export type ErrorTrackingQueryAssignee = ErrorTrackingQuery['assignee']
 export type ErrorTrackingQueryStatus = ErrorTrackingQuery['status']
 
-const DEFAULT_ORDER_BY = 'last_seen'
+export const ORDER_BY_OPTIONS: Record<ErrorTrackingQueryOrderBy, string> = {
+    last_seen: 'Last seen',
+    first_seen: 'First seen',
+    occurrences: 'Occurrences',
+    users: 'Users',
+    sessions: 'Sessions',
+    revenue: 'Revenue',
+}
+const DEFAULT_ORDER_BY: ErrorTrackingQueryOrderBy = 'last_seen'
 const DEFAULT_ORDER_DIRECTION = 'DESC'
 const DEFAULT_REVENUE_PERIOD = 'last_30_days'
 const DEFAULT_REVENUE_ENTITY = 'person'
@@ -135,7 +143,9 @@ export const issueQueryOptionsLogic = kea<issueQueryOptionsLogicType>([
     urlToAction(({ actions, values }) => {
         const urlToAction = (_: any, params: Params): void => {
             if (params.orderBy && !equal(params.orderBy, values.orderBy)) {
-                actions.setOrderBy(params.orderBy)
+                if (params.orderBy in ORDER_BY_OPTIONS) {
+                    actions.setOrderBy(params.orderBy)
+                }
             }
             if (params.status && !equal(params.status, values.status)) {
                 actions.setStatus(params.status)


### PR DESCRIPTION
## Problem

Sometimes when navigating from other products which have different order_by options, we fail to parse it from the URL and we set the sort by column to an empty one

## Changes

Added a validation
