### PR TITLE
chore(ci): Switch to AWS OIDC ECR publish

### DIFF
--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -11,7 +11,7 @@ inputs:
     push-image:
         required: false
         default: 'false'
-        description: Whether to push the built image - requires aws-access-key and aws-access-secret
+        description: Whether to push the built image - requires aws-role-to-assume
     aws-role-to-assume:
         required: false
         description: AWS role to assume for ECR access (required when push-image is true)

--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -12,12 +12,9 @@ inputs:
         required: false
         default: 'false'
         description: Whether to push the built image - requires aws-access-key and aws-access-secret
-    aws-access-key:
+    aws-role-to-assume:
         required: false
-        description: AWS key to log into ECR (required when push-image is true)
-    aws-access-secret:
-        required: false
-        description: AWS secret to log into ECR (required when push-image is true)
+        description: AWS role to assume for ECR access (required when push-image is true)
     dockerhub-username:
         required: false
         description: Dockerhub username for pushing image
@@ -58,10 +55,9 @@ runs:
 
         - name: Configure AWS credentials
           if: ${{ inputs.push-image == 'true' }}
-          uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+          uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
           with:
-              aws-access-key-id: ${{ inputs.aws-access-key }}
-              aws-secret-access-key: ${{ inputs.aws-access-secret }}
+              role-to-assume: ${{ inputs.aws-role-to-assume }}
               aws-region: us-east-1
 
         - name: Login to DockerHub

--- a/.github/workflows/cd-ai-evals-image.yml
+++ b/.github/workflows/cd-ai-evals-image.yml
@@ -44,10 +44,9 @@ jobs:
               uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+              uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
               with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
                   aws-region: us-east-1
 
             - name: Login to Amazon ECR

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -44,10 +44,9 @@ jobs:
               uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+              uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
               with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
                   aws-region: us-east-1
 
             - name: Login to Amazon ECR

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -48,8 +48,7 @@ jobs:
               with:
                   actions-id-token-request-url: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
                   push-image: ${{ github.repository == 'PostHog/posthog' }} # Don't push on forks due to lack of credentials
-                  aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-access-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
                   pr-number: ${{ github.event.number }}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Stop using AWS IAM credentials to do the ECR publish and instead use a OIDC-backed role for this.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
