### PR TITLE
fix: Cancel running runs on batch export delete

### DIFF
--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -36,7 +36,7 @@ from posthog.batch_exports.service import (
     BatchExportWithNoEndNotAllowedError,
     backfill_export,
     cancel_running_batch_export_run,
-    disable_and_delete_export,
+    delete_batch_export,
     fetch_earliest_backfill_start_at,
     pause_batch_export,
     sync_batch_export,
@@ -744,7 +744,7 @@ class BatchExportViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.ModelVi
         since we are deleting, we assume that we can recover from this state by finishing the delete operation by calling
         instance.save().
         """
-        disable_and_delete_export(instance)
+        delete_batch_export(instance)
 
     @action(methods=["GET"], detail=False, required_scopes=["INTERNAL"])
     def test(self, request: request.Request, *args, **kwargs) -> response.Response:

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -468,28 +468,56 @@ def unpause_batch_export(
     backfill_export(temporal, batch_export_id, batch_export.team_id, start_at, end_at)
 
 
-def disable_and_delete_export(instance: BatchExport):
-    """Mark a BatchExport as deleted and delete its Temporal Schedule (including backfills)."""
+def delete_batch_export(instance: BatchExport):
+    """Delete a batch export.
+
+    This process involves:
+    * First, pausing the batch export so no new runs are scheduled.
+    * Second, canceling any running backfills.
+    * Third, canceling any running runs.
+    * Fourth and finally, deleting the Temporal Schedule.
+
+    The first step is necessary to avoid new runs being scheduled while we execute all
+    other steps.
+    """
     temporal = sync_connect()
 
     instance.deleted = True
+
+    try:
+        pause_batch_export(temporal, instance.id, note=f"Pausing due to delete request by team {instance.team_id}")
+    except BatchExportServiceRPCError:
+        logger.exception(
+            "Failed to pause batch export before deletion",
+            batch_export_id=instance.id,
+        )
 
     for backfill in running_backfills_for_batch_export(instance.id):
         try:
             async_to_sync(cancel_running_batch_export_backfill)(temporal, backfill)
         except Exception:
             logger.exception(
-                "Failed to delete backfill %s for batch export %s, but will continue on with delete",
-                backfill.id,
-                instance.id,
+                "Failed to cancel backfill",
+                backfill_id=backfill.id,
+                batch_export_id=instance.id,
+            )
+
+    for run in running_runs_for_batch_export(instance.id):
+        try:
+            cancel_running_batch_export_run(temporal, run)
+        except Exception:
+            logger.exception(
+                "Failed to cancel run",
+                run_id=run.id,
+                back_export_id=instance.id,
             )
 
     try:
         batch_export_delete_schedule(temporal, str(instance.pk))
     except BatchExportServiceScheduleNotFound as e:
         logger.warning(
-            "The Schedule %s could not be deleted as it was not found",
-            e.schedule_id,
+            "Schedule not found during delete",
+            schedule_id=e.schedule_id,
         )
 
     instance.save()
@@ -510,6 +538,13 @@ def running_backfills_for_batch_export(batch_export_id: UUID):
     """Return an iterator over running batch export backfills."""
     return BatchExportBackfill.objects.filter(
         batch_export_id=batch_export_id, status=BatchExportBackfill.Status.RUNNING
+    ).select_related("batch_export")
+
+
+def running_runs_for_batch_export(batch_export_id: UUID):
+    """Return an iterator over running batch export runs."""
+    return BatchExportRun.objects.filter(
+        batch_export_id=batch_export_id, status=BatchExportRun.Status.RUNNING
     ).select_related("batch_export")
 
 

--- a/posthog/management/commands/migrate_team.py
+++ b/posthog/management/commands/migrate_team.py
@@ -5,7 +5,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
 from posthog.batch_exports.models import BATCH_EXPORT_INTERVALS
-from posthog.batch_exports.service import backfill_export, disable_and_delete_export, sync_batch_export
+from posthog.batch_exports.service import backfill_export, delete_batch_export, sync_batch_export
 from posthog.models import BatchExport, BatchExportBackfill, BatchExportDestination, BatchExportRun, Team
 from posthog.temporal.common.client import sync_connect
 
@@ -106,7 +106,7 @@ class Command(BaseCommand):
                     raise CommandError("Didn't receive 'y', exiting")
                 print()  # noqa: T201
 
-                disable_and_delete_export(existing_export)
+                delete_batch_export(existing_export)
                 is_existing_export = False
                 display("Deleted existing batch export and backfill")
         except BatchExport.DoesNotExist:

--- a/products/batch_exports/backend/tests/temporal/test_run_updates.py
+++ b/products/batch_exports/backend/tests/temporal/test_run_updates.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 from asgiref.sync import sync_to_async
 from flaky import flaky
 
-from posthog.batch_exports.service import disable_and_delete_export, sync_batch_export
+from posthog.batch_exports.service import delete_batch_export, sync_batch_export
 from posthog.models import BatchExport, BatchExportDestination, BatchExportRun, Organization, Team
 
 from products.batch_exports.backend.temporal.batch_exports import (
@@ -76,7 +76,7 @@ def batch_export(destination, team):
 
     yield batch_export
 
-    disable_and_delete_export(batch_export)
+    delete_batch_export(batch_export)
     batch_export.delete()
 
 


### PR DESCRIPTION
## Problem

Deleting a batch export does not cancel running runs. It probably should as the act of deleting something sets the expectation it shouldn't run anymore.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Cancel ongoing runs when a batch export is deleted.
Also, small refactor of the delete function.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
