### PR TITLE
fix(ci): balance Playwright and granian workers to reduce flakiness

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -337,7 +337,7 @@ jobs:
             - name: Start PostHog web & Celery worker
               run: |
                   python manage.py run_autoreload_celery --type=worker &> /tmp/celery.log &
-                  python -m granian --interface asgi posthog.asgi:application --host 0.0.0.0 --port 8000 --log-level debug --workers 1 &> /tmp/server.log &
+                  python -m granian --interface asgi posthog.asgi:application --host 0.0.0.0 --port 8000 --log-level debug --workers 4 &> /tmp/server.log &
 
             # Install Playwright browsers while we wait for PostHog to be ready
             - name: Install Playwright browsers
@@ -354,8 +354,8 @@ jobs:
             - name: Run Playwright tests
               id: playwright-tests
               shell: bash
-              # we can run 10 workers because we have 16 CPU
-              # we don't want to run 16 since we need to leave some for everything else
+              # Run 6 Playwright workers against 4 granian workers
+              # This balances parallelism with server capacity to avoid timeouts
               run: |
                   set +e  # Allow snapshot update retry
                   # Attempt 1: Always verify (fast path when snapshots match)
@@ -363,7 +363,7 @@ jobs:
                   # Note: Playwright's built-in retry (3x per test) handles test flakiness
                   echo "Attempt 1: Running Playwright tests"
                   set -o pipefail
-                  pnpm --filter=@posthog/playwright exec playwright test --workers=10 2>&1 | tee /tmp/playwright-output-attempt-1.log
+                  pnpm --filter=@posthog/playwright exec playwright test --workers=6 2>&1 | tee /tmp/playwright-output-attempt-1.log
                   EXIT_CODE=$?
                   set +o pipefail
 
@@ -383,7 +383,7 @@ jobs:
                       # Attempt 2: Update snapshots
                       echo "Attempt 2: Running Playwright tests with --update-snapshots"
                       set -o pipefail
-                      pnpm --filter=@posthog/playwright exec playwright test --workers=10 --update-snapshots 2>&1 | tee /tmp/playwright-output-attempt-2.log
+                      pnpm --filter=@posthog/playwright exec playwright test --workers=6 --update-snapshots 2>&1 | tee /tmp/playwright-output-attempt-2.log
                       EXIT_CODE=$?
                       set +o pipefail
 


### PR DESCRIPTION
**Problem**
Playwright E2E tests failing ~27% of the time with timeouts and blank pages. Screenshots showed the app wasn't loading at all.

**Root cause**
10 Playwright workers hitting a single granian worker - server couldn't keep up with concurrent requests, causing pages to load slowly or not at all.

**Fix**
- Granian workers: 1 → 4
- Playwright workers: 10 → 6

Ratio improves from 10:1 to 6:4, giving the server capacity to handle concurrent test requests.