### PR TITLE
chore: lazy developers

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -340,6 +340,7 @@ export const FEATURE_FLAGS = {
     SURVEYS_ERROR_TRACKING_CROSS_SELL: 'surveys-in-error-tracking', // owner: @adboio #team-surveys
     LIVE_EVENTS_ACTIVE_RECORDINGS: 'live-events-active-recordings', // owner: @pauldambra #team-replay
     PRODUCT_TOURS: 'product-tours-2025', // owner: @pauldambra #team-replay
+    // PLEASE KEEP THIS ALPHABETICALLY ORDERED
 } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]


### PR DESCRIPTION
## Problem

To improve maintainability and readability, developers need a clear reminder to keep the `FEATURE_FLAGS` constant alphabetically ordered when adding new flags.

## Changes

Added a comment `// PLEASE KEEP THIS ALPHABETICALLY ORDERED` at the bottom of the `FEATURE_FLAGS` object in `constants.tsx`.

## How did you test this code?

Manually verified the presence and placement of the comment in `constants.tsx`.

## Changelog: (features only) Is this feature complete?

No

---
[Slack Thread](https://posthog.slack.com/archives/C0351B1DMUY/p1765367968978069?thread_ts=1765367968.978069&cid=C0351B1DMUY)

<a href="https://cursor.com/background-agent?bcId=bc-eb51ae52-246d-4bf1-a080-78c37b7a31ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb51ae52-246d-4bf1-a080-78c37b7a31ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

