### PR TITLE
fix: handle missing coupons overview

### DIFF
--- a/frontend/src/scenes/coupons/couponLogic.ts
+++ b/frontend/src/scenes/coupons/couponLogic.ts
@@ -43,7 +43,7 @@ export const couponLogic = kea<couponLogicType>([
     }),
     loaders(() => ({
         couponsOverview: [
-            { claimed_coupons: [] } as CouponsOverview,
+            null as CouponsOverview | null,
             {
                 loadCouponsOverview: async () => {
                     return await api.get('api/billing/coupons/overview')
@@ -60,13 +60,13 @@ export const couponLogic = kea<couponLogicType>([
             (s) => [s.couponsOverview],
             (couponsOverview) =>
                 (campaignSlug: string): ClaimedCouponInfo | null => {
-                    return couponsOverview.claimed_coupons.find((c) => c.campaign_slug === campaignSlug) || null
+                    return couponsOverview?.claimed_coupons?.find((c) => c.campaign_slug === campaignSlug) || null
                 },
         ],
         activeCoupons: [
             (s) => [s.couponsOverview],
             (couponsOverview): ClaimedCouponInfo[] => {
-                return couponsOverview.claimed_coupons.filter((c) => c.status === 'claimed')
+                return couponsOverview?.claimed_coupons?.filter((c) => c.status === 'claimed') ?? []
             },
         ],
     }),


### PR DESCRIPTION
## Problem

The couponsOverview loader had a non-null default type, so TypeScript didn't enforce null checks in selectors, causing a runtime crash when the API failed.

## Changes

Changed the loader default to null as CouponsOverview | null and added optional chaining in selectors, so TypeScript now enforces null safety.

## How did you test this code?

Manually