### PR TITLE
Rewrite readme in pirate

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://posthog.com/docs">Docs</a> - <a href="https://posthog.com/community">Community</a> - <a href="https://posthog.com/roadmap">Roadmap</a> - <a href="https://posthog.com/why">Why PostHog?</a> - <a href="https://posthog.com/changelog">Changelog</a> - <a href="https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&template=bug_report.yml">Bug reports</a>
+  <a href="https://posthog.com/docs">Ship's Log</a> - <a href="https://posthog.com/community">Crew</a> - <a href="https://posthog.com/roadmap">Treasure Map</a> - <a href="https://posthog.com/why">Why sail with PostHog?</a> - <a href="https://posthog.com/changelog">Captain's Log</a> - <a href="https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&template=bug_report.yml">Report leaks in the hull</a>
 </p>
 
 <p align="center">
@@ -19,59 +19,59 @@
   </a>
 </p>
 
-## PostHog is an all-in-one, open source platform for building successful products
+## PostHog be an all-in-one, open source vessel fer buildin' successful products, arr!
 
-[PostHog](https://posthog.com/) provides every tool you need to build a successful product including:
+[PostHog](https://posthog.com/) provides every tool ye need to build a successful product, includin' these fine treasures:
 
-- [Product analytics](https://posthog.com/product-analytics): Autocapture or manually instrument event-based analytics to understand user behavior and analyze data with visualization or SQL.
-- [Web analytics](https://posthog.com/web-analytics): Monitor web traffic and user sessions with a GA-like dashboard. Easily monitor conversion, web vitals, and revenue.
-- [Session replays](https://posthog.com/session-replay): Watch real user sessions of interactions with your website or mobile app to diagnose issues and understand user behavior.
-- [Feature flags](https://posthog.com/feature-flags): Safely roll out features to select users or cohorts with feature flags.
-- [Experiments](https://posthog.com/experiments): Test changes and measure their statistical impact on goal metrics. Set up experiments with no-code too.
-- [Error tracking](https://posthog.com/error-tracking): Track errors, get alerts, and resolve issues to improve your product.
-- [Surveys](https://posthog.com/surveys): Ask anything with our collection of no-code survey templates, or build custom surveys with our survey builder.
-- [Data warehouse](https://posthog.com/data-warehouse): Sync data from external tools like Stripe, Hubspot, your data warehouse, and more. Query it alongside your product data.
-- [Data pipelines](https://posthog.com/cdp): Run custom filters and transformations on your incoming data. Send it to 25+ tools or any webhook in real time or batch export large amounts to your warehouse.
-- [LLM analytics](https://posthog.com/docs/llm-analytics): Capture traces, generations, latency, and cost for your LLM-powered app.
+- [Product analytics](https://posthog.com/product-analytics): Autocapture or manually chart yer event-based analytics to understand how scallywags behave and analyze data with fancy visualizations or SQL, savvy?
+- [Web analytics](https://posthog.com/web-analytics): Monitor web traffic and user sessions with a dashboard fit fer a captain. Keep an eye on conversions, web vitals, and yer doubloons.
+- [Session replays](https://posthog.com/session-replay): Spy on real user sessions of landlubbers interactin' with yer website or mobile app to diagnose issues and understand their behavior, har har!
+- [Feature flags](https://posthog.com/feature-flags): Safely hoist new features to select crew members or groups with feature flags, without sinkin' the ship.
+- [Experiments](https://posthog.com/experiments): Test changes and measure their impact on yer treasure metrics. Set up experiments with no code required, even a cabin boy could do it!
+- [Error tracking](https://posthog.com/error-tracking): Track errors, get alerts when the ship be takin' on water, and patch the holes to improve yer vessel.
+- [Surveys](https://posthog.com/surveys): Ask yer crew anything with our collection of no-code survey templates, or build custom questionnaires with our survey builder.
+- [Data warehouse](https://posthog.com/data-warehouse): Sync data from external ports like Stripe, Hubspot, yer data warehouse, and more. Query it alongside yer product data, all in one hold.
+- [Data pipelines](https://posthog.com/cdp): Run custom filters and transformations on yer incoming cargo. Send it to 25+ tools or any webhook in real time, or batch export large amounts to yer warehouse.
+- [LLM analytics](https://posthog.com/docs/llm-analytics): Capture traces, generations, latency, and cost fer yer LLM-powered vessel.
 
-Best of all, all of this is free to use with a [generous monthly free tier](https://posthog.com/pricing) for each product. Get started by signing up for [PostHog Cloud US](https://us.posthog.com/signup) or [PostHog Cloud EU](https://eu.posthog.com/signup).
+Best of all, every bit of this bounty be free to use with a [generous monthly free tier](https://posthog.com/pricing) fer each product. Set sail by signin' up fer [PostHog Cloud US](https://us.posthog.com/signup) or [PostHog Cloud EU](https://eu.posthog.com/signup), matey!
 
-## Table of Contents
+## Navigator's Chart
 
-- [PostHog is an all-in-one, open source platform for building successful products](#posthog-is-an-all-in-one-open-source-platform-for-building-successful-products)
-- [Table of Contents](#table-of-contents)
-- [Getting started with PostHog](#getting-started-with-posthog)
-  - [PostHog Cloud (Recommended)](#posthog-cloud-recommended)
-  - [Self-hosting the open-source hobby deploy (Advanced)](#self-hosting-the-open-source-hobby-deploy-advanced)
-- [Setting up PostHog](#setting-up-posthog)
-- [Learning more about PostHog](#learning-more-about-posthog)
-- [Contributing](#contributing)
+- [PostHog be an all-in-one, open source vessel fer buildin' successful products](#posthog-be-an-all-in-one-open-source-vessel-fer-buildin-successful-products-arr)
+- [Navigator's Chart](#navigators-chart)
+- [Settin' sail with PostHog](#settin-sail-with-posthog)
+  - [PostHog Cloud (Recommended fer landlubbers)](#posthog-cloud-recommended-fer-landlubbers)
+  - [Hostin' yer own ship (Advanced - fer seasoned sailors)](#hostin-yer-own-ship-advanced---fer-seasoned-sailors)
+- [Riggin' up PostHog](#riggin-up-posthog)
+- [Learnin' more about PostHog](#learnin-more-about-posthog)
+- [Joinin' the crew](#joinin-the-crew)
 - [Open-source vs. paid](#open-source-vs-paid)
-- [We’re hiring!](#were-hiring)
+- [We be hirin'!](#we-be-hirin)
 
-## Getting started with PostHog
+## Settin' sail with PostHog
 
-### PostHog Cloud (Recommended)
+### PostHog Cloud (Recommended fer landlubbers)
 
-The fastest and most reliable way to get started with PostHog is signing up for free to [PostHog Cloud](https://us.posthog.com/signup) or [PostHog Cloud EU](https://eu.posthog.com/signup). Your first 1 million events, 5k recordings, 1M flag requests, 100k exceptions, and 1500 survey responses are free every month, after which you pay based on usage.
+The fastest and most seaworthy way to get started with PostHog be signin' up fer free to [PostHog Cloud](https://us.posthog.com/signup) or [PostHog Cloud EU](https://eu.posthog.com/signup). Yer first 1 million events, 5k recordings, 1M flag requests, 100k exceptions, and 1500 survey responses be free every month, after which ye pay based on what ye plunder.
 
-### Self-hosting the open-source hobby deploy (Advanced)
+### Hostin' yer own ship (Advanced - fer seasoned sailors)
 
-If you want to self-host PostHog, you can deploy a hobby instance in one line on Linux with Docker (recommended 4GB memory):
+If ye want to captain yer own vessel and self-host PostHog, ye can deploy a hobby instance in one line on Linux with Docker (recommended 4GB memory fer smooth sailin'):
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/posthog/posthog/HEAD/bin/deploy-hobby)"
 ```
 
-Open source deployments should scale to approximately 100k events per month, after which we recommend [migrating to a PostHog Cloud](https://posthog.com/docs/migrate/migrate-to-cloud).
+Open source deployments should handle approximately 100k events per month, after which we recommend [migratin' to PostHog Cloud](https://posthog.com/docs/migrate/migrate-to-cloud) lest ye run aground.
 
-We _do not_ provide customer support or offer guarantees for open source deployments. See our [self-hosting docs](https://posthog.com/docs/self-host), [troubleshooting guide](https://posthog.com/docs/self-host/deploy/troubleshooting), and [disclaimer](https://posthog.com/docs/self-host/open-source/disclaimer) for more info.
+We _do not_ provide customer support or offer guarantees fer open source deployments, arr. See our [self-hostin' scroll](https://posthog.com/docs/self-host), [troubleshootin' guide](https://posthog.com/docs/self-host/deploy/troubleshooting), and [disclaimer](https://posthog.com/docs/self-host/open-source/disclaimer) fer more info.
 
-## Setting up PostHog
+## Riggin' up PostHog
 
-Once you've got a PostHog instance, you can set it up by installing our [JavaScript web snippet](https://posthog.com/docs/getting-started/install?tab=snippet), one of [our SDKs](https://posthog.com/docs/getting-started/install?tab=sdks), or by [using our API](https://posthog.com/docs/getting-started/install?tab=api).
+Once ye've got a PostHog instance aboard, ye can rig it up by installin' our [JavaScript web snippet](https://posthog.com/docs/getting-started/install?tab=snippet), one of [our SDKs](https://posthog.com/docs/getting-started/install?tab=sdks), or by [usin' our API](https://posthog.com/docs/getting-started/install?tab=api).
 
-We have SDKs and libraries for popular languages and frameworks like:
+We have SDKs and libraries fer popular languages and frameworks, like these fine tools:
 
 | Frontend                                              | Mobile                                                          | Backend                                             |
 | ----------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------- |
@@ -80,36 +80,36 @@ We have SDKs and libraries for popular languages and frameworks like:
 | [React](https://posthog.com/docs/libraries/react)     | [iOS](https://posthog.com/docs/libraries/ios)                   | [PHP](https://posthog.com/docs/libraries/php)       |
 | [Vue](https://posthog.com/docs/libraries/vue-js)      | [Flutter](https://posthog.com/docs/libraries/flutter)           | [Ruby](https://posthog.com/docs/libraries/ruby)     |
 
-Beyond this, we have docs and guides for [Go](https://posthog.com/docs/libraries/go), [.NET/C#](https://posthog.com/docs/libraries/dotnet), [Django](https://posthog.com/docs/libraries/django), [Angular](https://posthog.com/docs/libraries/angular), [WordPress](https://posthog.com/docs/libraries/wordpress), [Webflow](https://posthog.com/docs/libraries/webflow), and more.
+Beyond this bounty, we have scrolls and guides fer [Go](https://posthog.com/docs/libraries/go), [.NET/C#](https://posthog.com/docs/libraries/dotnet), [Django](https://posthog.com/docs/libraries/django), [Angular](https://posthog.com/docs/libraries/angular), [WordPress](https://posthog.com/docs/libraries/wordpress), [Webflow](https://posthog.com/docs/libraries/webflow), and more treasures.
 
-Once you've installed PostHog, see our [product docs](https://posthog.com/docs/product-os) for more information on how to set up [product analytics](https://posthog.com/docs/product-analytics/capture-events), [web analytics](https://posthog.com/docs/web-analytics/getting-started), [session replays](https://posthog.com/docs/session-replay/how-to-watch-recordings), [feature flags](https://posthog.com/docs/feature-flags/creating-feature-flags), [experiments](https://posthog.com/docs/experiments/creating-an-experiment), [error tracking](https://posthog.com/docs/error-tracking/installation#setting-up-exception-autocapture), [surveys](https://posthog.com/docs/surveys/installation), [data warehouse](https://posthog.com/docs/cdp/sources), and more.
+Once ye've hoisted PostHog aboard, consult our [product scrolls](https://posthog.com/docs/product-os) fer more wisdom on how to set up [product analytics](https://posthog.com/docs/product-analytics/capture-events), [web analytics](https://posthog.com/docs/web-analytics/getting-started), [session replays](https://posthog.com/docs/session-replay/how-to-watch-recordings), [feature flags](https://posthog.com/docs/feature-flags/creating-feature-flags), [experiments](https://posthog.com/docs/experiments/creating-an-experiment), [error tracking](https://posthog.com/docs/error-tracking/installation#setting-up-exception-autocapture), [surveys](https://posthog.com/docs/surveys/installation), [data warehouse](https://posthog.com/docs/cdp/sources), and more booty.
 
-## Learning more about PostHog
+## Learnin' more about PostHog
 
-Our code isn't the only thing that's open source 😳. We also open source our [company handbook](https://posthog.com/handbook) which details our [strategy](https://posthog.com/handbook/why-does-posthog-exist), [ways of working](https://posthog.com/handbook/company/culture), and [processes](https://posthog.com/handbook/team-structure).
+Our code ain't the only thing that be open source 😳. We also open source our [company handbook](https://posthog.com/handbook) which details our [strategy](https://posthog.com/handbook/why-does-posthog-exist), [ways of workin'](https://posthog.com/handbook/company/culture), and [ship's protocols](https://posthog.com/handbook/team-structure).
 
-Curious about how to make the most of PostHog? We wrote a guide to [winning with PostHog](https://posthog.com/docs/new-to-posthog/getting-hogpilled) which walks you through the basics of [measuring activation](https://posthog.com/docs/new-to-posthog/activation), [tracking retention](https://posthog.com/docs/new-to-posthog/retention), and [capturing revenue](https://posthog.com/docs/new-to-posthog/revenue).
+Curious about how to plunder the most from PostHog? We scribed a guide to [winnin' with PostHog](https://posthog.com/docs/new-to-posthog/getting-hogpilled) which walks ye through the basics of [measurin' activation](https://posthog.com/docs/new-to-posthog/activation), [trackin' retention](https://posthog.com/docs/new-to-posthog/retention), and [capturin' revenue](https://posthog.com/docs/new-to-posthog/revenue).
 
-## Contributing
+## Joinin' the crew
 
-We <3 contributions big and small:
+We <3 contributions big and small from all ye scallywags:
 
-- Vote on features or get early access to beta functionality in our [roadmap](https://posthog.com/roadmap)
-- Open a PR (see our instructions on [developing PostHog locally](https://posthog.com/handbook/engineering/developing-locally))
-- Submit a [feature request](https://github.com/PostHog/posthog/issues/new?assignees=&labels=enhancement%2C+feature&template=feature_request.yml) or [bug report](https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&template=bug_report.yml)
+- Vote on features or get early access to beta functionality in our [treasure map](https://posthog.com/roadmap)
+- Open a PR (see our instructions on [developin' PostHog locally](https://posthog.com/handbook/engineering/developing-locally))
+- Submit a [feature request](https://github.com/PostHog/posthog/issues/new?assignees=&labels=enhancement%2C+feature&template=feature_request.yml) or [bug report](https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&template=bug_report.yml) if ye spot somethin' amiss
 
 ## Open-source vs. paid
 
-This repo is available under the [MIT expat license](https://github.com/PostHog/posthog/blob/master/LICENSE), except for the `ee` directory (which has its [license here](https://github.com/PostHog/posthog/blob/master/ee/LICENSE)) if applicable.
+This here vessel be available under the [MIT expat license](https://github.com/PostHog/posthog/blob/master/LICENSE), except fer the `ee` directory (which has its [license here](https://github.com/PostHog/posthog/blob/master/ee/LICENSE)) if applicable.
 
-Need _absolutely 💯% FOSS_? Check out our [posthog-foss](https://github.com/PostHog/posthog-foss) repository, which is purged of all proprietary code and features.
+Need _absolutely 💯% FOSS_, ye say? Check out our [posthog-foss](https://github.com/PostHog/posthog-foss) repository, which be purged of all proprietary code and features.
 
-The pricing for our paid plan is completely transparent and available on [our pricing page](https://posthog.com/pricing).
+The pricin' fer our paid plan be completely transparent and available on [our pricin' page](https://posthog.com/pricing).
 
-## We're hiring!
+## We be hirin'!
 
 <img src="https://res.cloudinary.com/dmukukwp6/image/upload/v1/posthog.com/src/components/Home/images/mission-control-hog" alt="Hedgehog working on a Mission Control Center" width="350px"/>
 
-Hey! If you're reading this, you've proven yourself as a dedicated README reader.
+Ahoy! If ye be readin' this, ye've proven yerself as a dedicated README reader, savvy?
 
-You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+Ye might also make a fine addition to our crew. We be growin' fast [and would love fer ye to join us](https://posthog.com/careers) on this voyage!


### PR DESCRIPTION
## Problem

The user requested a fun, thematic update to the `README.md` file, specifically to rewrite it in pirate speak.

## Changes

The `README.md` file has been fully translated into pirate speak. Key changes include:
*   Main heading: "PostHog be an all-in-one, open source vessel fer buildin' successful products, arr!"
*   Navigation links: "Ship's Log" (Docs), "Crew" (Community), "Treasure Map" (Roadmap), "Captain's Log" (Changelog)
*   Section headings like "Table of Contents" → "Navigator's Chart", "Getting started" → "Settin' sail with PostHog", "Contributing" → "Joinin' the crew".
*   General text converted to use pirate dialect (e.g., "ye," "yer," "fer," "scallywags," "landlubbers," "doubloons," "plunder," "savvy," and nautical metaphors).
*   Links, code blocks, and structural elements remain functional.

## How did you test this code?

Manually reviewed the generated diff and the rendered `README.md` to ensure all text was converted to pirate speak and that the formatting and links remained intact.

## Changelog: (features only) Is this feature complete?

No. This is a stylistic change, not a feature.

---
[Slack Thread](https://posthog.slack.com/archives/C0A2VHCG5QR/p1765368268159769?thread_ts=1765368268.159769&cid=C0A2VHCG5QR)

<a href="https://cursor.com/background-agent?bcId=bc-1dbc08c2-2e7f-4912-8470-3bf671045cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1dbc08c2-2e7f-4912-8470-3bf671045cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

