### PR TITLE
refactor(funnels): simplify `_get_breakdown_select_prop`

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -400,7 +400,7 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
         ):
             return [prop_basic, ast.Alias(alias="prop", expr=ast.Field(chain=["prop_basic"]))]
         else:
-            raise ValidationError(f"Unknown breakdown attribution type ${breakdownAttributionType}")
+            raise ValidationError(f"Unknown breakdown attribution type {breakdownAttributionType}")
 
     def _get_extra_fields(
         self, source_kind: SourceTableKind, node: Optional[DataWarehouseNode] = None

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -382,18 +382,10 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
             breakdownAttributionType == BreakdownAttributionType.STEP
             and funnelsFilter.funnelOrderType != StepOrderValue.UNORDERED
         ):
-            select_columns = []
-            default_breakdown_selector = "[]" if self._query_has_array_breakdown() else "NULL"
-
-            # get prop value from each step
-            for index, _ in enumerate(self.context.query.series):
-                select_columns.append(
-                    parse_expr(f"if(step_{index} = 1, prop_basic, {default_breakdown_selector}) as prop_{index}")
-                )
-
-            final_select = parse_expr(f"prop_{funnelsFilter.breakdownAttributionValue} as prop")
-
-            return [prop_basic, *select_columns, final_select]
+            prop = parse_expr(
+                f"if(step_{funnelsFilter.breakdownAttributionValue} = 1, prop_basic, {self._default_breakdown_selector()}) as prop"
+            )
+            return [prop_basic, prop]
         elif (
             breakdownAttributionType
             in [

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -382,8 +382,9 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
             breakdownAttributionType == BreakdownAttributionType.STEP
             and funnelsFilter.funnelOrderType != StepOrderValue.UNORDERED
         ):
+            default_breakdown_selector = "[]" if self._query_has_array_breakdown() else "NULL"
             prop = parse_expr(
-                f"if(step_{funnelsFilter.breakdownAttributionValue} = 1, prop_basic, {self._default_breakdown_selector()}) as prop"
+                f"if(step_{funnelsFilter.breakdownAttributionValue} = 1, prop_basic, {default_breakdown_selector}) as prop"
             )
             return [prop_basic, prop]
         elif (

--- a/posthog/hogql_queries/insights/funnels/funnel_udf.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_udf.py
@@ -49,7 +49,7 @@ class FunnelUDFMixin:
             self.context.breakdownAttributionType == BreakdownAttributionType.STEP
             and self.context.funnelsFilter.funnelOrderType != StepOrderValue.UNORDERED
         ):
-            prop = f"prop_{self.context.funnelsFilter.breakdownAttributionValue}"
+            prop = "prop"
         else:
             prop = "prop_basic"
         if self._query_has_array_breakdown():

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -84,7 +84,7 @@
             if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
        (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
-               groupUniqArrayIf(arrayMap(x -> ifNull(x, ''), prop_1), notEmpty(prop_1)) AS prop,
+               groupUniqArrayIf(arrayMap(x -> ifNull(x, ''), prop), notEmpty(prop)) AS prop,
                arrayJoin(aggregate_funnel_array(2, 1209600, 'step_1', 'strict', prop, [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
@@ -105,9 +105,7 @@
                   if(equals(e.event, 'sign up'), 1, 0) AS step_0,
                   if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
                   [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                  if(ifNull(equals(step_0, 1), 0), prop_basic, []) AS prop_0,
-                  if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop_1,
-                  prop_1 AS prop
+                  if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_udf.ambr
@@ -1031,7 +1031,7 @@
             if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
        (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
-               groupUniqArrayIf(arrayMap(x -> ifNull(x, ''), prop_1), notEmpty(prop_1)) AS prop,
+               groupUniqArrayIf(arrayMap(x -> ifNull(x, ''), prop), notEmpty(prop)) AS prop,
                arrayJoin(aggregate_funnel_array(2, 1209600, 'step_1', 'ordered', prop, [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
                                                                                                                                                                                          and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
                                                                                                                                                                                                                          and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
@@ -1052,9 +1052,7 @@
                   if(equals(e.event, 'sign up'), 1, 0) AS step_0,
                   if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
                   [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                  if(ifNull(equals(step_0, 1), 0), prop_basic, []) AS prop_0,
-                  if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop_1,
-                  prop_1 AS prop
+                  if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,


### PR DESCRIPTION
## Problem

Code for `_get_breakdown_select_prop` is unneccesarily complex.

## Changes

- For step specific breakdown attribution, the query previously built a column for every step and then only used the one matching the selected step. For example:

    ```sql
    if(ifNull(equals(step_0, 1), 0), prop_basic, []) AS prop_0,
    if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop_1,
    prop_1 AS prop
    ```

    This is now simplified to compute only the relevant step:

    ```sql
    if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop
	```

- The breakdown attribution logic for `ALL_EVENTS` and for `STEP` with `UNORDERED` step order was effectively the same as the logic for `FIRST_TOUCH` and `LAST_TOUCH`. This duplication is removed and the shared logic now lives in one place which makes the function shorter and easier to follow.

## How did you test this code?

CI run
