### PR TITLE
fix: move data warehouse tree into scene

### DIFF
--- a/frontend/src/layout/panel-layout/DatabaseTree/DatabaseTree.tsx
+++ b/frontend/src/layout/panel-layout/DatabaseTree/DatabaseTree.tsx
@@ -2,15 +2,17 @@ import { ViewLinkModal } from 'scenes/data-warehouse/ViewLinkModal'
 import { DatabaseSearchField } from 'scenes/data-warehouse/editor/sidebar/DatabaseSearchField'
 import { QueryDatabase } from 'scenes/data-warehouse/editor/sidebar/QueryDatabase'
 
-import { PanelLayoutPanel } from '../PanelLayoutPanel'
 import { SyncMoreNotice } from './SyncMoreNotice'
 
 export function DatabaseTree(): JSX.Element {
     return (
-        <PanelLayoutPanel searchField={<DatabaseSearchField placeholder="Search warehouse" />}>
-            <QueryDatabase />
+        <div className="flex flex-col gap-2 p-3 z-20 border-r border-primary group/colorful-product-icons colorful-product-icons-true">
+            <DatabaseSearchField placeholder="Search warehouse" />
+            <div className="-mx-2 grow">
+                <QueryDatabase />
+            </div>
             <SyncMoreNotice />
             <ViewLinkModal />
-        </PanelLayoutPanel>
+        </div>
     )
 }

--- a/frontend/src/layout/panel-layout/DatabaseTree/SyncMoreNotice.tsx
+++ b/frontend/src/layout/panel-layout/DatabaseTree/SyncMoreNotice.tsx
@@ -24,7 +24,7 @@ export const SyncMoreNotice = (): JSX.Element | null => {
     }
 
     return (
-        <LemonBanner type="info" className="m-2 h-[265px] min-h-[auto] z-10">
+        <LemonBanner type="info" className="h-[265px] min-h-[auto] z-10">
             <div
                 data-attr="sql-editor-source-empty-state"
                 className="p-4 text-center flex flex-col justify-center items-center relative"

--- a/frontend/src/layout/panel-layout/PanelLayout.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayout.tsx
@@ -4,7 +4,6 @@ import { useActions, useMountedLogic, useValues } from 'kea'
 import { cn } from 'lib/utils/css-classes'
 
 import { navigation3000Logic } from '../navigation-3000/navigationLogic'
-import { DatabaseTree } from './DatabaseTree/DatabaseTree'
 import { PanelLayoutNavBar } from './PanelLayoutNavBar'
 import { PROJECT_TREE_KEY, ProjectTree } from './ProjectTree/ProjectTree'
 import { projectTreeLogic } from './ProjectTree/projectTreeLogic'
@@ -157,7 +156,6 @@ export function PanelLayout(): JSX.Element {
                     {activePanelIdentifier === 'Shortcuts' && (
                         <ProjectTree root="shortcuts://" searchPlaceholder="Search your shortcuts" />
                     )}
-                    {activePanelIdentifier === 'Database' && <DatabaseTree />}
                     {activePanelIdentifier === 'DataManagement' && (
                         <ProjectTree root="data://" searchPlaceholder="Search data tools" />
                     )}

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -200,12 +200,8 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
             identifier: 'Database',
             label: 'Data warehouse',
             icon: <IconDatabaseBolt />,
-            onClick: (e?: React.KeyboardEvent) => {
-                if (!e || e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {
-                    handlePanelTriggerClick('Database')
-                }
-            },
-            showChevron: true,
+            to: urls.sqlEditor(),
+            onClick: () => handleStaticNavbarItemClick(urls.sqlEditor(), true),
             collapsedTooltip: ['Open data warehouse', 'Close data warehouse'],
             documentationUrl: 'https://posthog.com/docs/data-warehouse/sql',
         },

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -7,14 +7,7 @@ import { removeProjectIdIfPresent } from 'lib/utils/router-utils'
 import { navigation3000Logic } from '../navigation-3000/navigationLogic'
 import type { panelLayoutLogicType } from './panelLayoutLogicType'
 
-export type PanelLayoutNavIdentifier =
-    | 'Project'
-    | 'Products'
-    | 'People'
-    | 'Games'
-    | 'Shortcuts'
-    | 'DataManagement'
-    | 'Database'
+export type PanelLayoutNavIdentifier = 'Project' | 'Products' | 'People' | 'Games' | 'Shortcuts' | 'DataManagement'
 export type PanelLayoutTreeRef = React.RefObject<LemonTreeRef> | null
 export type PanelLayoutMainContentRef = React.RefObject<HTMLElement> | null
 export const PANEL_LAYOUT_DEFAULT_WIDTH: number = 245

--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
@@ -7,6 +7,7 @@ import { useRef, useState } from 'react'
 
 import { SceneExport } from 'scenes/sceneTypes'
 
+import { DatabaseTree } from '~/layout/panel-layout/DatabaseTree/DatabaseTree'
 import { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { variableModalLogic } from '~/queries/nodes/DataVisualization/Components/Variables/variableModalLogic'
@@ -125,17 +126,20 @@ export function EditorScene({ tabId }: { tabId?: string }): JSX.Element {
                             <BindLogic logic={variableModalLogic} props={{ key: dataVisualizationLogicProps.key }}>
                                 <BindLogic logic={outputPaneLogic} props={{ tabId }}>
                                     <BindLogic logic={multitabEditorLogic} props={{ tabId, monaco, editor }}>
-                                        <div
-                                            data-attr="editor-scene"
-                                            className="EditorScene w-full h-[calc(var(--scene-layout-rect-height)-var(--scene-layout-header-height))] flex flex-row overflow-hidden"
-                                            ref={ref}
-                                        >
-                                            <QueryWindow
-                                                tabId={tabId || ''}
-                                                onSetMonacoAndEditor={(monaco, editor) =>
-                                                    setMonacoAndEditor([monaco, editor])
-                                                }
-                                            />
+                                        <div className="grid grid-cols-[var(--project-panel-width)_1fr] gap-0">
+                                            <DatabaseTree />
+                                            <div
+                                                data-attr="editor-scene"
+                                                className="EditorScene w-full h-[calc(var(--scene-layout-rect-height)-var(--scene-layout-header-height))] flex flex-row overflow-hidden"
+                                                ref={ref}
+                                            >
+                                                <QueryWindow
+                                                    tabId={tabId || ''}
+                                                    onSetMonacoAndEditor={(monaco, editor) =>
+                                                        setMonacoAndEditor([monaco, editor])
+                                                    }
+                                                />
+                                            </div>
                                         </div>
                                         <ViewLinkModal />
                                     </BindLogic>

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import type { editor as importedEditor } from 'monaco-editor'
 import { useMemo } from 'react'
 
-import { IconBook, IconDownload, IconInfo, IconPlayFilled, IconSidebarClose } from '@posthog/icons'
+import { IconBook, IconDownload, IconInfo, IconPlayFilled } from '@posthog/icons'
 import { LemonDivider, Spinner } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -13,7 +13,6 @@ import { IconCancel } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
-import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { NodeKind } from '~/queries/schema/schema-general'
 
@@ -46,9 +45,6 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
         changesToSave,
         inProgressViewEdits,
     } = useValues(multitabEditorLogic)
-
-    const { activePanelIdentifier } = useValues(panelLayoutLogic)
-    const { setActivePanelIdentifier } = useActions(panelLayoutLogic)
 
     const { setQueryInput, runQuery, setError, setMetadata, setMetadataLoading, saveAsView, saveDraft, updateView } =
         useActions(multitabEditorLogic)
@@ -97,17 +93,6 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId }: QueryWindowProps): 
                 </div>
             )}
             <div className="flex flex-row justify-start align-center w-full pl-2 pr-2 bg-white dark:bg-black border-b">
-                {activePanelIdentifier !== 'Database' ? (
-                    <LemonButton
-                        onClick={() => setActivePanelIdentifier('Database')}
-                        className="rounded-none"
-                        icon={<IconSidebarClose />}
-                        type="tertiary"
-                        size="xsmall"
-                    >
-                        Data warehouse
-                    </LemonButton>
-                ) : null}
                 <RunButton />
                 <LemonDivider vertical />
                 {isDraft && featureFlags[FEATURE_FLAGS.EDITOR_DRAFTS] && (

--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -1,11 +1,7 @@
-import { actions, kea, listeners, path, props, reducers } from 'kea'
-import { router, urlToAction } from 'kea-router'
+import { actions, kea, listeners, path, props } from 'kea'
 import posthog from 'posthog-js'
 
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
-import { urls } from 'scenes/urls'
-
-import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 
 import type { editorSceneLogicType } from './editorSceneLogicType'
 
@@ -39,22 +35,7 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
         reportAIQueryAccepted: true,
         reportAIQueryRejected: true,
         reportAIQueryPromptOpen: true,
-        setWasPanelActive: (wasPanelActive: boolean) => ({ wasPanelActive }),
     }),
-    reducers(() => ({
-        wasPanelActive: [
-            false,
-            {
-                setWasPanelActive: (_, { wasPanelActive }) => wasPanelActive,
-            },
-        ],
-        panelExplicitlyClosed: [
-            false,
-            {
-                [panelLayoutLogic.actionTypes.closePanel]: () => true,
-            },
-        ],
-    })),
     listeners(() => ({
         reportAIQueryPrompted: () => {
             posthog.capture('ai_query_prompted')
@@ -67,22 +48,6 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
         },
         reportAIQueryPromptOpen: () => {
             posthog.capture('ai_query_prompt_open')
-        },
-    })),
-    urlToAction(({ values }) => ({
-        [urls.sqlEditor()]: () => {
-            if (!values.panelExplicitlyClosed) {
-                panelLayoutLogic.actions.showLayoutPanel(true)
-                panelLayoutLogic.actions.setActivePanelIdentifier('Database')
-                panelLayoutLogic.actions.toggleLayoutPanelPinned(true)
-            }
-        },
-        '*': () => {
-            if (router.values.location.pathname !== urls.sqlEditor()) {
-                panelLayoutLogic.actions.clearActivePanelIdentifier()
-                panelLayoutLogic.actions.toggleLayoutPanelPinned(false)
-                panelLayoutLogic.actions.showLayoutPanel(false)
-            }
         },
     })),
 ])

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -111,7 +111,7 @@ export const QueryDatabase = (): JSX.Element => {
                                             'drafts',
                                             'unsaved-folder',
                                             'endpoints',
-                                        ].includes(item.record?.type) && 'font-bold',
+                                        ].includes(item.record?.type) && 'font-semibold',
                                         item.record?.type === 'column' && 'font-mono text-xs',
                                         'truncate'
                                     )}

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -12,7 +12,6 @@ import { TreeItem } from 'lib/components/DatabaseTableTree/DatabaseTableTree'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTreeRef, TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { newInternalTab } from 'lib/utils/newInternalTab'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { DataWarehouseSourceIcon, mapUrlToProvider } from 'scenes/data-warehouse/settings/DataWarehouseSourceIcon'
 import { dataWarehouseSettingsLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsLogic'
@@ -21,7 +20,6 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { FuseSearchMatch } from '~/layout/navigation-3000/sidebars/utils'
-import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import {
     DatabaseSchemaDataWarehouseTable,
     DatabaseSchemaEndpointTable,
@@ -29,13 +27,7 @@ import {
     DatabaseSchemaManagedViewTable,
     DatabaseSchemaTable,
 } from '~/queries/schema/schema-general'
-import {
-    DataWarehouseSavedQuery,
-    DataWarehouseSavedQueryDraft,
-    DataWarehouseViewLink,
-    FileSystemIconColor,
-    QueryTabState,
-} from '~/types'
+import { DataWarehouseSavedQuery, DataWarehouseSavedQueryDraft, DataWarehouseViewLink, QueryTabState } from '~/types'
 
 import { dataWarehouseJoinsLogic } from '../../external/dataWarehouseJoinsLogic'
 import { dataWarehouseViewsLogic } from '../../saved_queries/dataWarehouseViewsLogic'
@@ -969,20 +961,6 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                 }
 
                 return [
-                    {
-                        id: 'new-query',
-                        name: 'SQL editor',
-                        type: 'node',
-                        icon: iconForType('sql_editor', [
-                            'var(--color-product-data-warehouse-light)',
-                        ] as FileSystemIconColor),
-                        onClick: () => {
-                            newInternalTab(urls.sqlEditor())
-                        },
-                        record: {
-                            type: 'sql',
-                        },
-                    } as TreeDataItem,
                     createTopLevelFolderNode('sources', sourcesChildren, false, <IconPlug />),
                     ...(featureFlags[FEATURE_FLAGS.EDITOR_DRAFTS]
                         ? [createTopLevelFolderNode('drafts', draftsChildren, false)]


### PR DESCRIPTION
## Problem
Nav bar panel `data warehouse` was out of place for these reasons:
* the items in panel tree are mostly non-navigable 
* the items in the tree were pertaining solely to the SQL editor scene
* the editor scene was doing some funky stuff to make it all work (including moving the `RUN` button over)

## Changes
* Nav bar data warehouse link opens the scene
* The tree now lives in the scene as it was, non-hide-able, which makes sense i think
* removed logic for hiding/showing panel in `editorscenelogic`
* removed "SQL editor" link in their tree items as it's unnecessary
* and changed their folders from `font-bold` to the standard `font-semibold`

![2025-12-10 13 25 23](https://github.com/user-attachments/assets/ef73cc0c-7166-4a0d-b360-d16160cf8c4e)


## How did you test this code?
locally

* search still works in their tree
* copying still works in their tree
* icon colors are intact 
* navbar opens scene correctly