### PR TITLE
feat(logs): enhance cursor pagination and time-slicing optimization

### DIFF
--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -40,7 +40,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             try:
                 cursor = json.loads(base64.b64decode(after_cursor).decode("utf-8"))
                 cursor_ts = dt.datetime.fromisoformat(cursor["timestamp"])
-                if order_by == "earliest":
+                if order_by == OrderBy3.EARLIEST or order_by == "earliest":
                     # For "earliest" ordering, we're looking for logs AFTER the cursor
                     date_range = DateRange(
                         date_from=cursor_ts.isoformat(),

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -387,11 +387,18 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
             # For DESC (latest first, default): get rows where (timestamp, uuid) < cursor
             op = ">" if self.query.orderBy == "earliest" else "<"
             ts_op = ">=" if self.query.orderBy == "earliest" else "<="
-            # The logs table is partitioned by timestamp, not (timestamp, uuid).
-            # ClickHouse only prunes partitions when the WHERE clause directly matches
-            # the partition key. A tuple comparison like (timestamp, uuid) < (x, y)
-            # won't trigger pruning even though it logically implies timestamp <= x.
-            # So we add an explicit scalar bound to guarantee partition pruning fires.
+            # The logs table is sorted by (team_id, time_bucket, ..., timestamp) where
+            # time_bucket = toStartOfDay(timestamp). ClickHouse only prunes efficiently when
+            # the WHERE clause matches the sorting key. A tuple comparison like
+            # (timestamp, uuid) < (x, y) won't trigger pruning.
+            # We add explicit scalar bounds on both time_bucket and timestamp to ensure
+            # ClickHouse can use the primary index and skip irrelevant parts.
+            exprs.append(
+                parse_expr(
+                    f"time_bucket {ts_op} toStartOfDay({{cursor_ts}})",
+                    placeholders={"cursor_ts": ast.Constant(value=cursor_ts)},
+                )
+            )
             exprs.append(
                 parse_expr(
                     f"timestamp {ts_op} {{cursor_ts}}",


### PR DESCRIPTION
## Problem

Cursor pagination was slow because:
1. Time-slicing was skipped entirely for page 2+
2. No time_bucket bound meant ClickHouse couldn't use the primary key efficiently

## Changes

- Narrow date range to cursor timestamp when paginating (enables time-slicing)
- Add time_bucket bound for better primary key pruning

## How did you test this code?

EXPLAIN indexes = 1 confirms time_bucket is now in the PrimaryKey condition.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._