### PR TITLE
feat(data-warehouse): integrate direct query tables with BI scene HogQL

### DIFF
--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3404,6 +3404,7 @@ export interface DatabaseSchemaSource {
     source_type: string
     prefix: string
     last_synced_at?: string
+    is_direct_query?: boolean
 }
 
 export interface DatabaseSchemaField {
@@ -3482,12 +3483,39 @@ export interface DatabaseSchemaSystemTable extends DatabaseSchemaTableCommon {
     type: 'system'
 }
 
+export interface DatabaseSchemaForeignKey {
+    column: string
+    target_table: string
+    target_column: string
+}
+
+export interface DatabaseSchemaColumnInfo {
+    name: string
+    data_type: string
+    is_nullable: boolean
+}
+
+export interface DatabaseSchemaIndexInfo {
+    name: string
+    columns: string[]
+    is_unique: boolean
+    is_primary: boolean
+}
+
+export interface DatabaseSchemaMetadata {
+    primary_key?: string[]
+    foreign_keys?: DatabaseSchemaForeignKey[]
+    columns?: DatabaseSchemaColumnInfo[]
+    indexes?: DatabaseSchemaIndexInfo[]
+}
+
 export interface DatabaseSchemaDataWarehouseTable extends DatabaseSchemaTableCommon {
     type: 'data_warehouse'
     format: string
     url_pattern: string
     schema?: DatabaseSchemaSchema
     source?: DatabaseSchemaSource
+    schema_metadata?: DatabaseSchemaMetadata
 }
 
 export interface DatabaseSchemaBatchExportTable extends DatabaseSchemaTableCommon {

--- a/frontend/src/scenes/bi/biLogic.ts
+++ b/frontend/src/scenes/bi/biLogic.ts
@@ -282,6 +282,10 @@ export const biLogic = kea<biLogicType>([
                     return ''
                 }
                 if (table && getTableDialect(table) === 'postgres') {
+                    const sourceId = getTableSourceId(table)
+                    if (sourceId && isDirectQueryTable(table)) {
+                        return `--pg:${sourceId}\n` + queryString
+                    }
                     return '--pg\n' + queryString
                 }
                 return queryString
@@ -923,4 +927,12 @@ function wrapTimeAggregation(value: string, interval: BITimeAggregation, table: 
 
 function getTableDialect(table: DatabaseSchemaTable): 'postgres' | 'clickhouse' {
     return (table as any)?.source?.source_type === 'Postgres' ? 'postgres' : 'clickhouse'
+}
+
+function getTableSourceId(table: DatabaseSchemaTable): string | null {
+    return (table as any)?.source?.id || null
+}
+
+function isDirectQueryTable(table: DatabaseSchemaTable): boolean {
+    return (table as any)?.source?.is_direct_query === true
 }

--- a/posthog/hogql/helpers/__init__.py
+++ b/posthog/hogql/helpers/__init__.py
@@ -1,3 +1,12 @@
+import re
+from typing import NamedTuple
+
+
+class PostgresDialectInfo(NamedTuple):
+    uses_postgres: bool
+    source_id: str | None = None
+
+
 def uses_postgres_dialect(query: str | None) -> bool:
     """Detect whether a HogQL query is marked to use the Postgres dialect."""
 
@@ -11,3 +20,32 @@ def uses_postgres_dialect(query: str | None) -> bool:
         or stripped_query.endswith("--pg")
         or stripped_query.endswith("-- pg")
     )
+
+
+def parse_postgres_directive(query: str | None) -> PostgresDialectInfo:
+    """Parse Postgres dialect directive from a HogQL query.
+
+    Supports formats:
+    - --pg or -- pg: Regular Postgres dialect (executes against Django DB)
+    - --pg:UUID: Direct query to external Postgres source identified by UUID
+
+    Returns a PostgresDialectInfo with:
+    - uses_postgres: True if any Postgres dialect marker is present
+    - source_id: UUID of the external source if specified (indicates direct query)
+    """
+    if not query:
+        return PostgresDialectInfo(uses_postgres=False)
+
+    stripped_query = query.strip()
+
+    # Check for --pg:UUID format (direct query to external source)
+    uuid_pattern = r"--pg:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+    match = re.search(uuid_pattern, stripped_query)
+    if match:
+        return PostgresDialectInfo(uses_postgres=True, source_id=match.group(1))
+
+    # Check for regular --pg format
+    if uses_postgres_dialect(query):
+        return PostgresDialectInfo(uses_postgres=True)
+
+    return PostgresDialectInfo(uses_postgres=False)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -988,6 +988,45 @@ class DatabaseSchemaSource(BaseModel):
     prefix: str
     source_type: str
     status: str
+    is_direct_query: bool | None = None
+
+
+class DatabaseSchemaForeignKey(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    column: str
+    target_table: str
+    target_column: str
+
+
+class DatabaseSchemaColumnInfo(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    name: str
+    data_type: str
+    is_nullable: bool
+
+
+class DatabaseSchemaIndexInfo(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    name: str
+    columns: list[str]
+    is_unique: bool
+    is_primary: bool
+
+
+class DatabaseSchemaMetadata(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    primary_key: list[str] | None = None
+    foreign_keys: list[DatabaseSchemaForeignKey] | None = None
+    columns: list[DatabaseSchemaColumnInfo] | None = None
+    indexes: list[DatabaseSchemaIndexInfo] | None = None
 
 
 class DatabaseSchemaTableType(StrEnum):
@@ -9208,6 +9247,7 @@ class DatabaseSchemaDataWarehouseTable(BaseModel):
     name: str
     row_count: float | None = None
     schema_: DatabaseSchemaSchema | None = Field(default=None, alias="schema")
+    schema_metadata: DatabaseSchemaMetadata | None = None
     source: DatabaseSchemaSource | None = None
     type: Literal["data_warehouse"] = "data_warehouse"
     url_pattern: str


### PR DESCRIPTION
## Summary
- Add `--pg:source_uuid` directive parsing to identify external Postgres sources
- Register direct query tables in HogQL database for query resolution
- Create `PostgresTable` instances with proper field type mappings from schema metadata
- Execute queries against external Postgres via psycopg2
- Frontend passes source UUID with `--pg` directive for direct query tables

## Test plan
- [ ] Create a direct query Postgres data source
- [ ] Verify tables appear in BI scene list
- [ ] Click a table and verify query executes against external Postgres
- [ ] Verify field types are correctly mapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)