### PR TITLE
fix: Use a consistent order when selecting rows to insert

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -456,6 +456,8 @@ class PostgreSQLClient:
             for field in merge_key
         )
 
+        order_by = sql.SQL(",").join(sql.Identifier(field[0]) for field in merge_key)
+
         or_separator = sql.SQL(" OR ")
         update_condition = or_separator.join(
             sql.SQL("EXCLUDED.{stage_field} > final.{final_field}").format(
@@ -480,12 +482,14 @@ class PostgreSQLClient:
             """\
         INSERT INTO {final_table} AS final ({field_names})
         SELECT {field_names} FROM {stage_table}
+        ORDER BY {order_by}
         ON CONFLICT ({conflict_fields}) DO UPDATE SET
             {update_clause}
         WHERE ({update_condition})
         """
         ).format(
             final_table=final_table_identifier,
+            order_by=order_by,
             conflict_fields=conflict_fields,
             stage_table=stage_table_identifier,
             merge_condition=merge_condition,


### PR DESCRIPTION
## Problem

Rarely, merge queries from multiple postgresql batch exports can cause deadlocks.

It is frequently recommended (for example, in the [postgresql documentation](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-DEADLOCKS)) to acquire locks in a consistent order to minimize the potential of deadlocks. This can be achieved by ordering the values when selecting them for merging. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Order values when merging by merge_key. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
