### PR TITLE
fix(product tours): make 'open in posthog' work

### DIFF
--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -6,6 +6,7 @@ import { subscriptions } from 'kea-subscriptions'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { uuid } from 'lib/utils'
+import { urls } from 'scenes/urls'
 
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
 import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
@@ -249,7 +250,7 @@ export const productToursLogic = kea<productToursLogicType>([
         ],
     }),
 
-    forms(({ actions }) => ({
+    forms(({ values, actions }) => ({
         tourForm: {
             defaults: { name: '', steps: [] } as TourForm,
             errors: ({ name }) => ({
@@ -275,14 +276,16 @@ export const productToursLogic = kea<productToursLogicType>([
                     throw new Error(error.detail || 'Failed to save tour')
                 }
 
+                const { apiURL } = values
+
                 const savedTour = await response.json()
                 lemonToast.success(id ? 'Tour updated' : 'Tour created', {
-                    button: {
-                        label: 'Open in PostHog',
-                        action: () => {
-                            // TODO: Add URL when product tours UI is available
-                        },
-                    },
+                    button: id
+                        ? {
+                              label: 'Open in PostHog',
+                              action: () => window.open(`${apiURL}${urls.productTour(id)}`, '_blank'),
+                          }
+                        : undefined,
                 })
                 actions.loadTours()
                 // Close the editing bar after successful save
@@ -293,7 +296,7 @@ export const productToursLogic = kea<productToursLogicType>([
     })),
 
     connect(() => ({
-        values: [toolbarConfigLogic, ['dataAttributes']],
+        values: [toolbarConfigLogic, ['dataAttributes', 'apiURL']],
     })),
 
     selectors({


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
