### PR TITLE
feat(dp): Add RevenueCat as a Data Pipeline source

### DIFF
--- a/posthog/temporal/data_imports/pipelines/helpers.py
+++ b/posthog/temporal/data_imports/pipelines/helpers.py
@@ -33,3 +33,5 @@ def incremental_type_to_initial_value(field_type: IncrementalFieldType) -> int |
         return date(1970, 1, 1)
     if field_type == IncrementalFieldType.ObjectID:
         return "000000000000000000000000"
+    if field_type == IncrementalFieldType.String:
+        return ""

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -207,7 +207,8 @@ class RedshiftSourceConfig(config.Config):
 
 @config.config
 class RevenueCatSourceConfig(config.Config):
-    pass
+    revenuecat_api_key: str
+    revenuecat_project_id: str
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/revenuecat/revenuecat.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/revenuecat.py
@@ -1,0 +1,244 @@
+import dataclasses
+from collections.abc import Iterator
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.revenuecat.settings import (
+    DEFAULT_LIMIT,
+    REVENUECAT_API_BASE_URL,
+    TIMESTAMP_FIELDS,
+)
+
+
+class RevenueCatRetryableError(Exception):
+    """Exception raised when RevenueCat API returns a retryable error (e.g. rate limit, 5xx)."""
+
+    pass
+
+
+@dataclasses.dataclass
+class RevenueCatResource:
+    path: str
+
+
+@dataclasses.dataclass
+class RevenueCatNestedResource:
+    path: str
+    parent_path: str
+    parent_id_field: str
+    nested_parent_param: str
+
+
+def _convert_ms_to_seconds(item: dict) -> dict:
+    for field in TIMESTAMP_FIELDS:
+        if field in item and isinstance(item[field], int):
+            item[field] = item[field] // 1000
+    return item
+
+
+@retry(
+    retry=retry_if_exception_type(RevenueCatRetryableError),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _fetch_page(
+    url: str,
+    headers: dict[str, str],
+    params: dict[str, str | int],
+    logger: FilteringBoundLogger,
+) -> tuple[list[dict], str | None]:
+    """
+    Fetch a single page from RevenueCat API with retry logic.
+    Retries on rate limits (429), conflicts (423), and server errors (5xx).
+    """
+    logger.debug(f"RevenueCat: fetching from {url} with params {params}")
+
+    response = requests.get(url, headers=headers, params=params)
+
+    if response.status_code == 423:
+        logger.warning(f"RevenueCat: request conflict (423), will retry...")
+        raise RevenueCatRetryableError(f"Request conflict: {response.status_code} - {response.text}")
+
+    if response.status_code == 429:
+        logger.warning(f"RevenueCat: rate limited (429), will retry...")
+        raise RevenueCatRetryableError(f"Rate limited: {response.status_code} - {response.text}")
+
+    if response.status_code >= 500:
+        logger.warning(f"RevenueCat: server error ({response.status_code}), will retry...")
+        raise RevenueCatRetryableError(f"Server error: {response.status_code} - {response.text}")
+
+    response.raise_for_status()
+
+    data = response.json()
+    return data.get("items", []), data.get("next_page")
+
+
+def _paginate(
+    url: str,
+    headers: dict[str, str],
+    logger: FilteringBoundLogger,
+    starting_after: str | None = None,
+) -> Iterator[dict]:
+    params: dict[str, str | int] = {"limit": DEFAULT_LIMIT}
+
+    if starting_after:
+        params["starting_after"] = starting_after
+        logger.debug(f"RevenueCat: using incremental sync, starting_after={starting_after}")
+
+    while True:
+        items, next_page = _fetch_page(url, headers, params, logger)
+
+        yield from items
+
+        if not next_page:
+            break
+
+        url = next_page
+        params = {}
+
+
+def get_rows(
+    api_key: str,
+    project_id: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: str | None = None,
+) -> Iterator[dict]:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": "PostHog-DataPipelines",
+    }
+
+    resources: dict[str, RevenueCatResource | RevenueCatNestedResource] = {
+        "Apps": RevenueCatResource(path=f"/projects/{project_id}/apps"),
+        "CustomerActiveEntitlements": RevenueCatNestedResource(
+            path=f"/projects/{project_id}/customers/{{customer_id}}/active_entitlements",
+            parent_path=f"/projects/{project_id}/customers",
+            parent_id_field="id",
+            nested_parent_param="customer_id",
+        ),
+        "CustomerAliases": RevenueCatNestedResource(
+            path=f"/projects/{project_id}/customers/{{customer_id}}/aliases",
+            parent_path=f"/projects/{project_id}/customers",
+            parent_id_field="id",
+            nested_parent_param="customer_id",
+        ),
+        "CustomerPurchases": RevenueCatNestedResource(
+            path=f"/projects/{project_id}/customers/{{customer_id}}/purchases",
+            parent_path=f"/projects/{project_id}/customers",
+            parent_id_field="id",
+            nested_parent_param="customer_id",
+        ),
+        "CustomerSubscriptions": RevenueCatNestedResource(
+            path=f"/projects/{project_id}/customers/{{customer_id}}/subscriptions",
+            parent_path=f"/projects/{project_id}/customers",
+            parent_id_field="id",
+            nested_parent_param="customer_id",
+        ),
+        "Customers": RevenueCatResource(path=f"/projects/{project_id}/customers"),
+        "EntitlementProducts": RevenueCatNestedResource(
+            path=f"/projects/{project_id}/entitlements/{{entitlement_id}}/products",
+            parent_path=f"/projects/{project_id}/entitlements",
+            parent_id_field="id",
+            nested_parent_param="entitlement_id",
+        ),
+        "Entitlements": RevenueCatResource(path=f"/projects/{project_id}/entitlements"),
+        "OfferingPackages": RevenueCatNestedResource(
+            path=f"/projects/{project_id}/offerings/{{offering_id}}/packages",
+            parent_path=f"/projects/{project_id}/offerings",
+            parent_id_field="id",
+            nested_parent_param="offering_id",
+        ),
+        "Offerings": RevenueCatResource(path=f"/projects/{project_id}/offerings"),
+        "Products": RevenueCatResource(path=f"/projects/{project_id}/products"),
+    }
+
+    resource = resources.get(endpoint)
+    if not resource:
+        raise ValueError(f"Unknown RevenueCat endpoint: {endpoint}")
+
+    if isinstance(resource, RevenueCatNestedResource):
+        logger.debug(f"RevenueCat: iterating nested resource {endpoint} (full refresh)")
+
+        for parent in _paginate(f"{REVENUECAT_API_BASE_URL}{resource.parent_path}", headers, logger):
+            parent_id = parent[resource.parent_id_field]
+            child_url = f"{REVENUECAT_API_BASE_URL}{resource.path.format(**{resource.nested_parent_param: parent_id})}"
+
+            for child in _paginate(child_url, headers, logger):
+                item = {
+                    **child,
+                    resource.nested_parent_param: parent_id,
+                }
+                yield _convert_ms_to_seconds(item)
+    else:
+        starting_after = None
+        if should_use_incremental_field and db_incremental_field_last_value:
+            starting_after = db_incremental_field_last_value
+            logger.debug(f"RevenueCat: incremental sync for {endpoint}, starting_after={starting_after}")
+        else:
+            logger.debug(f"RevenueCat: full refresh for {endpoint}")
+
+        for item in _paginate(
+            f"{REVENUECAT_API_BASE_URL}{resource.path}",
+            headers,
+            logger,
+            starting_after=starting_after,
+        ):
+            if endpoint == "Customers":
+                item = {
+                    **item,
+                    "created_at": item.get("first_seen_at"),
+                }  # Customers is the only endpoint without a created_at field, adding it for partitioning
+
+            yield _convert_ms_to_seconds(item)
+
+
+def validate_revenuecat_credentials(api_key: str, project_id: str) -> bool:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": "PostHog-DataPipelines",
+    }
+
+    response = requests.get(
+        f"{REVENUECAT_API_BASE_URL}/projects/{project_id}/customers",
+        headers=headers,
+        params={"limit": 1},
+    )
+
+    return response.status_code == 200
+
+
+def revenuecat_source(
+    api_key: str,
+    project_id: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: str | None = None,
+) -> SourceResponse:
+    return SourceResponse(
+        items=lambda: get_rows(
+            api_key=api_key,
+            project_id=project_id,
+            endpoint=endpoint,
+            logger=logger,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+        ),
+        primary_keys=["id"],
+        name=endpoint,
+        column_hints=None,
+        sort_mode="asc",
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime",
+        partition_format="week",
+        partition_keys=["created_at"],
+    )

--- a/posthog/temporal/data_imports/sources/revenuecat/settings.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/settings.py
@@ -1,0 +1,45 @@
+from products.data_warehouse.backend.types import IncrementalField, IncrementalFieldType
+
+REVENUECAT_API_BASE_URL = "https://api.revenuecat.com/v2"
+DEFAULT_LIMIT = 100
+
+TIMESTAMP_FIELDS = ["first_seen_at", "last_seen_at", "updated_at", "created_at", "expires_at", "purchase_date"]
+
+REVENUECAT_ENDPOINTS = [
+    "Apps",
+    "CustomerActiveEntitlements",
+    "CustomerAliases",
+    "CustomerPurchases",
+    "CustomerSubscriptions",
+    "Customers",
+    "EntitlementProducts",
+    "Entitlements",
+    "OfferingPackages",
+    "Offerings",
+    "Products",
+]
+
+INCREMENTAL_ENDPOINTS = {
+    "Apps",
+    "Customers",
+    "Entitlements",
+    "Offerings",
+    "Products",
+}
+
+_ID_INCREMENTAL_FIELD: list[IncrementalField] = [
+    {
+        "label": "id",
+        "type": IncrementalFieldType.String,
+        "field": "id",
+        "field_type": IncrementalFieldType.String,
+    }
+]
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    "Apps": _ID_INCREMENTAL_FIELD,
+    "Customers": _ID_INCREMENTAL_FIELD,
+    "Entitlements": _ID_INCREMENTAL_FIELD,
+    "Offerings": _ID_INCREMENTAL_FIELD,
+    "Products": _ID_INCREMENTAL_FIELD,
+}

--- a/posthog/temporal/data_imports/sources/revenuecat/source.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/source.py
@@ -3,11 +3,25 @@ from typing import cast
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+    SuggestedTable,
 )
 
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import RevenueCatSourceConfig
+from posthog.temporal.data_imports.sources.revenuecat.revenuecat import (
+    revenuecat_source,
+    validate_revenuecat_credentials,
+)
+from posthog.temporal.data_imports.sources.revenuecat.settings import (
+    INCREMENTAL_ENDPOINTS,
+    INCREMENTAL_FIELDS,
+    REVENUECAT_ENDPOINTS,
+)
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
@@ -22,8 +36,93 @@ class RevenueCatSource(SimpleSource[RevenueCatSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.REVENUE_CAT,
+            caption="""Enter your RevenueCat credentials to automatically pull your RevenueCat data into the PostHog Data warehouse. You will need your [RevenueCat API key](https://app.revenuecat.com/api-keys) and your [Project ID](https://app.revenuecat.com/overview).""",
+            permissionsCaption="""Your API key needs read-only permissions for the entities you want to sync.""",
             label="RevenueCat",
             iconPath="/static/services/revenuecat.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="revenuecat_api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="sk_...",
+                    ),
+                    SourceFieldInputConfig(
+                        name="revenuecat_project_id",
+                        label="Project ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="proj1ab2c3d4",
+                    ),
+                ],
+            ),
+            suggestedTables=[
+                SuggestedTable(
+                    table="App",
+                    tooltip="If you have multiple apps, you can enable this to get data for all apps.",
+                ),
+                SuggestedTable(
+                    table="Customer",
+                    tooltip="Enable this to get all your in-app customer data in PostHog.",
+                ),
+                SuggestedTable(
+                    table="Entitlement",
+                    tooltip="Enable this to get all your entitlement data in PostHog.",
+                ),
+                SuggestedTable(
+                    table="Offering",
+                    tooltip="Enable this to get all your offering data in PostHog.",
+                ),
+                SuggestedTable(
+                    table="Product",
+                    tooltip="Enable this to get all your product information in PostHog.",
+                ),
+            ],
+            betaSource=True,
+            featureFlag="dp-source-revenuecat",
+        )
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "400": "Client error.",
+            "401": "Not authenticated. Please check your API key configuration and permissions in RevenueCat, then try again.",
+            "403": "uthorization failed. Please check your API key configuration and permissions in RevenueCat, then try again.",
+            "404": "No resource was found. Please check the resource name and try again.",
+            "409": "Uniqueness constraint violation. Please check the request body and try again.",
+            "422": "The request was valid and the syntax correct, but RC was unable to process the contained instructions. Please check the request body and try again.",
+        }
+
+    def get_schemas(
+        self, config: RevenueCatSourceConfig, team_id: int, with_counts: bool = False
+    ) -> list[SourceSchema]:
+        return [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=endpoint in INCREMENTAL_ENDPOINTS,
+                supports_append=False,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+            )
+            for endpoint in REVENUECAT_ENDPOINTS
+        ]
+
+    def validate_credentials(self, config: RevenueCatSourceConfig, team_id: int) -> tuple[bool, str | None]:
+        try:
+            if validate_revenuecat_credentials(config.revenuecat_api_key, config.revenuecat_project_id):
+                return True, None
+            else:
+                return False, "Invalid RevenueCat credentials"
+        except Exception as e:
+            return False, str(e)
+
+    def source_for_pipeline(self, config: RevenueCatSourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return revenuecat_source(
+            api_key=config.revenuecat_api_key,
+            project_id=config.revenuecat_project_id,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value,
         )

--- a/products/data_warehouse/backend/types.py
+++ b/products/data_warehouse/backend/types.py
@@ -10,6 +10,8 @@ class IncrementalFieldType(StrEnum):
     DateTime = "datetime"
     Date = "date"
     Timestamp = "timestamp"
+    # RevenueCat specific
+    String = "string"
     # MongoDB specific
     ObjectID = "objectid"
 


### PR DESCRIPTION
Adds RevenueCat source to our DataPipelines sources. 

  ## Notes:
  * RevenueCat API uses millisecond timestamps which are converted to seconds for compatibility
  * Nested resources (e.g., CustomerSubscriptions) require full refresh as they need to iterate through all parent records
  * Simple resources (Apps, Customers, Entitlements, Offerings, Products) support incremental sync using ID-based cursors as they use the `starting_after` query parameter that expects an ID
  * Source is marked as beta and behind feature flag `dp-source-revenuecat` (waiting to see if we can get the rate limits up for our requests)
