### PR TITLE
chore(web-analytics): Allow customization if DataTable empty state icon

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -864,6 +864,7 @@ export function DataTable({
                                         <InsightEmptyState
                                             heading={context?.emptyStateHeading}
                                             detail={context?.emptyStateDetail}
+                                            icon={context?.emptyStateIcon}
                                         />
                                     )
                                 }

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -27,6 +27,7 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     insightProps?: InsightLogicProps<Q>
     emptyStateHeading?: string
     emptyStateDetail?: string | JSX.Element
+    emptyStateIcon?: JSX.Element
     renderEmptyStateAsSkeleton?: boolean
     rowProps?: (record: unknown) => Omit<HTMLProps<HTMLTableRowElement>, 'key'>
     /**

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -54,16 +54,18 @@ import { insightVizDataLogic } from '../insightVizDataLogic'
 export function InsightEmptyState({
     heading = 'There are no matching events for this query',
     detail = 'Try changing the date range, or pick another action, event or breakdown.',
+    icon = <IconArchive className="text-5xl mb-2 text-tertiary" />,
 }: {
     heading?: string
     detail?: string | JSX.Element
+    icon?: JSX.Element
 }): JSX.Element {
     return (
         <div
             data-attr="insight-empty-state"
             className="flex flex-col flex-1 rounded p-4 w-full items-center justify-center text-center text-balance"
         >
-            <IconArchive className="text-5xl mb-2 text-tertiary" />
+            {icon}
             <h2 className="text-xl leading-tight">{heading}</h2>
             <p className="text-sm text-tertiary">{detail}</p>
         </div>


### PR DESCRIPTION
## Problem
Data Table empty state doesn't allow users to customize the displayed icon. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Allow users to pass an optional icon prop to the Data Table empty state and pass that down

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
