### PR TITLE
fix(cohorts): Update count from write db

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -526,10 +526,11 @@ def remove_person_from_static_cohort(person_uuid: uuid.UUID, cohort_id: int, *, 
     )
 
 
-def get_static_cohort_size(*, cohort_id: int, team_id: int) -> int:
-    count = CohortPeople.objects.filter(cohort_id=cohort_id, person__team_id=team_id).count()
-
-    return count
+def get_static_cohort_size(*, cohort_id: int, team_id: int, using_database: str | None = None) -> int:
+    qs = CohortPeople.objects.filter(cohort_id=cohort_id, person__team_id=team_id)
+    if using_database:
+        qs = qs.using(using_database)
+    return qs.count()
 
 
 def recalculate_cohortpeople(


### PR DESCRIPTION
## Problem

Static cohorts often display counts less than the actual count of records in `posthog_cohortpeople`. I suspect this is due to replication lag - we update records on the main db then read the count from the read replica. When batch inserting, the counts are typically off by a single batch insert.

Resolves https://github.com/PostHog/posthog/issues/42495

## Changes

I've added an optional `using_database` parameter to specify where we read the cohort count from. I've updated existing call sites that look like they would be affected by replication lag.

## How did you test this code?

I've added a unit test, made sure cohort creation still works as expected locally manually. This is an issue that's only reproducible in production due to differences in infrastructure (i.e., we don't run a read replica locally, and even if we did, replication lag would likely not be as much of a factor).
