### PR TITLE
fix(email): skip curly brace escape when using native email

### DIFF
--- a/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
@@ -179,7 +179,9 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
 
                 const finalValues: EmailTemplate = {
                     ...formValues,
-                    html: escapeHTMLStringCurlies(htmlData.html),
+                    html: ['native_email', 'native_email_template'].includes(props.type)
+                        ? htmlData.html
+                        : escapeHTMLStringCurlies(htmlData.html),
                     text: textData.text,
                     design: htmlData.design,
                 }
@@ -276,7 +278,9 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
                         templating: values.templatingEngine,
                         email: {
                             ...currentValues,
-                            html: escapeHTMLStringCurlies(htmlData.html),
+                            html: ['native_email', 'native_email_template'].includes(props.type)
+                                ? htmlData.html
+                                : escapeHTMLStringCurlies(htmlData.html),
                             text: textData.text,
                             design: htmlData.design,
                         },

--- a/plugin-server/src/cdp/templates/_destinations/email/email.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/email/email.template.ts
@@ -27,7 +27,7 @@ export const template: HogFunctionTemplate = {
             required: true,
             default: {
                 to: {
-                    email: '',
+                    email: '{{ person.properties.email }}',
                     name: '',
                 },
                 from: {

--- a/plugin-server/src/cdp/templates/_destinations/email/email.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/email/email.template.ts
@@ -27,7 +27,7 @@ export const template: HogFunctionTemplate = {
             required: true,
             default: {
                 to: {
-                    email: '{{ person.properties.email }}',
+                    email: '',
                     name: '',
                 },
                 from: {


### PR DESCRIPTION
## Problem

Users have reported rendering discrepancies between the email editor vs. what shows up in gmail

[We have this `escapeHTMLStringCurlies` function](https://github.com/PostHog/posthog/blob/master/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx#L313-L340) which was added when the editor was first introduced with the Mailgun destination: https://github.com/PostHog/posthog/pull/24137

I suspect this was in place due to the html data getting mangled in transit to mailgun

But for the native email use cases, this actually breaks CSS as the escape sequences remain, breaking the editor's CSS reset:

<img width="1390" height="834" alt="image" src="https://github.com/user-attachments/assets/54157bd5-2e17-4893-a2b6-3aa74a0a596e" />

⬆️ Paragraph / text blocks are the most obvious discrepancy, with the default user-agent `margin-block` and `margin-inline`  values of 1rem styles taking effect instead of what was shown in the preview

## Changes

Skipping the escape sequence step for native email ensures the rendered HTML matches the email editor preview

<img width="1206" height="668" alt="image" src="https://github.com/user-attachments/assets/a7707df3-1478-41be-9035-cc94ade79ba4" />


## How did you test this code?

Validated valid HTML in postgres and proper rendering emails in maildev
