### PR TITLE
refactor: Remove logs from old migrations

### DIFF
--- a/posthog/migrations/0219_migrate_tags_v2.py
+++ b/posthog/migrations/0219_migrate_tags_v2.py
@@ -9,11 +9,6 @@ from posthog.models.tag import tagify
 
 
 def forwards(apps, schema_editor):
-    import structlog
-
-    logger = structlog.get_logger(__name__)
-    logger.info("posthog/0219_migrate_tags_v2_start")
-
     Tag = apps.get_model("posthog", "Tag")
     TaggedItem = apps.get_model("posthog", "TaggedItem")
     Insight = apps.get_model("posthog", "Insight")
@@ -33,20 +28,12 @@ def forwards(apps, schema_editor):
     )
 
     for insight_page in insight_paginator.page_range:
-        logger.info(
-            "insight_tag_batch_get_start",
-            limit=batch_size,
-            offset=(insight_page - 1) * batch_size,
-        )
         insights = iter(insight_paginator.get_page(insight_page))
         for tags, team_id, insight_id in insights:
             unique_tags = {tagify(t) for t in tags if isinstance(t, str) and t.strip() != ""}
             for tag in unique_tags:
                 temp_tag = Tag(name=tag, team_id=team_id)
                 createables.append((temp_tag, TaggedItem(insight_id=insight_id, tag_id=temp_tag.id)))
-
-    logger.info("insight_tag_get_end", tags_count=len(createables))
-    num_insight_tags = len(createables)
 
     # Collect dashboard tags and taggeditems
     dashboard_paginator = Paginator(
@@ -59,11 +46,6 @@ def forwards(apps, schema_editor):
     )
 
     for dashboard_page in dashboard_paginator.page_range:
-        logger.info(
-            "dashboard_tag_batch_get_start",
-            limit=batch_size,
-            offset=(dashboard_page - 1) * batch_size,
-        )
         dashboards = iter(dashboard_paginator.get_page(dashboard_page))
         for tags, team_id, dashboard_id in dashboards:
             unique_tags = {tagify(t) for t in tags if isinstance(t, str) and t.strip() != ""}
@@ -76,8 +58,6 @@ def forwards(apps, schema_editor):
                     )
                 )
 
-    logger.info("dashboard_tag_get_end", tags_count=len(createables) - num_insight_tags)
-
     # Consistent ordering to make independent runs non-deterministic
     createables = sorted(createables, key=lambda pair: pair[0].name)
 
@@ -85,12 +65,10 @@ def forwards(apps, schema_editor):
     # about which tags were ignored and created, so we must take care of this manually.
     tags_to_create = [tag for (tag, _) in createables]
     Tag.objects.bulk_create(tags_to_create, ignore_conflicts=True, batch_size=batch_size)
-    logger.info("tags_bulk_created")
 
     # Associate tag ids with tagged_item objects in batches. Best case scenario all tags are new. Worst case
     # scenario, all tags already exist and get is made for every tag.
     for offset in range(0, len(tags_to_create), batch_size):
-        logger.info("tagged_item_batch_create_start", limit=batch_size, offset=offset)
         batch = tags_to_create[offset : (offset + batch_size)]
 
         # Find tags that were created, and not already existing
@@ -111,8 +89,6 @@ def forwards(apps, schema_editor):
             ignore_conflicts=True,
             batch_size=batch_size,
         )
-
-    logger.info("posthog/0219_migrate_tags_v2_end")
 
 
 def reverse(apps, schema_editor):

--- a/posthog/migrations/0552_turn_off_all_action_webhooks.py
+++ b/posthog/migrations/0552_turn_off_all_action_webhooks.py
@@ -30,15 +30,11 @@ def disable_all_action_webhooks(apps, schema_editor):
         # Bulk update when we reach batch_size
         if len(actions_to_update) >= batch_size:
             Action.objects.bulk_update(actions_to_update, ["post_to_slack"])
-            print(f"Processed {processed_count} actions")  # noqa: T201
             actions_to_update = []
 
     # Handle any remaining items
     if actions_to_update:
         Action.objects.bulk_update(actions_to_update, ["post_to_slack"])
-        print(f"Processed {processed_count} actions")  # noqa: T201
-
-    print(f"Processed {processed_count} actions in total")  # noqa: T201
 
 
 class Migration(migrations.Migration):

--- a/posthog/migrations/0672_resave_hogFns_from_token_refresh_incident.py
+++ b/posthog/migrations/0672_resave_hogFns_from_token_refresh_incident.py
@@ -5,7 +5,7 @@ from django.db import migrations
 
 
 def resave_hog_functions(apps, schema_editor):
-    call_command("resave_hog_functions")
+    call_command("resave_hog_functions", silent=True)
 
 
 def reverse_migration(apps, schema_editor):

--- a/posthog/migrations/0731_backfill_hog_function_template_fk.py
+++ b/posthog/migrations/0731_backfill_hog_function_template_fk.py
@@ -11,22 +11,15 @@ def backfill_hog_function_template_fk(apps, schema_editor):
     HogFunction = apps.get_model("posthog", "HogFunction")
     HogFunctionTemplate = apps.get_model("posthog", "HogFunctionTemplate")
 
-    batch_size = 1000
-    total_processed = 0
-    total_updated = 0
-
     total_count = HogFunction.objects.filter(template_id__isnull=False, hog_function_template__isnull=True).count()
 
     if total_count == 0:
-        logger.info("no_records_to_update")
         return
-
-    logger.info("starting_backfill", total_records=total_count)
 
     # Use keyset pagination
     last_id = 0
-    batch_count = 0
 
+    batch_size = 1000
     while True:
         # Query for just the batch of IDs using ORM
         query = HogFunction.objects.filter(template_id__isnull=False, hog_function_template__isnull=True).order_by("id")
@@ -53,33 +46,10 @@ def backfill_hog_function_template_fk(apps, schema_editor):
                         hog_function.save(update_fields=["hog_function_template"])
                         batch_updated += 1
                     except HogFunctionTemplate.DoesNotExist:
-                        logger.warning(
-                            "no_template_found",
-                            hog_function_id=str(hog_function.id),
-                            template_id=hog_function.template_id,
-                        )
+                        continue  # Just ignore, this has finished running in prod already, don't need this
 
         # Track progress
-        batch_count += 1
-        total_processed += len(batch_ids)
-        total_updated += batch_updated
         last_id = batch_ids[-1]
-
-        # Calculate progress percentage
-        progress = (total_processed / total_count) * 100 if total_count > 0 else 100
-
-        logger.info(
-            "batch_completed",
-            batch_num=batch_count,
-            batch_size=len(batch_ids),
-            batch_updated=batch_updated,
-            processed=total_processed,
-            updated=total_updated,
-            total=total_count,
-            progress=round(progress, 2),
-        )
-
-    logger.info("backfill_completed", processed=total_processed, updated=total_updated, total_batches=batch_count)
 
 
 class Migration(migrations.Migration):

--- a/posthog/migrations/0763_migrate_team_base_currency.py
+++ b/posthog/migrations/0763_migrate_team_base_currency.py
@@ -2,10 +2,6 @@
 
 from django.db import migrations
 
-import structlog
-
-logger = structlog.get_logger(__name__)
-
 
 def migrate_revenue_base_currency(apps, schema_editor):
     """
@@ -23,19 +19,12 @@ def migrate_revenue_base_currency(apps, schema_editor):
                 team.base_currency = revenue_config.base_currency
                 team.save()
                 teams_updated += 1
-                logger.debug(
-                    "Updated team base currency from revenue config",
-                    team_id=team.id,
-                    base_currency=revenue_config.base_currency,
-                )
         except TeamRevenueAnalyticsConfig.DoesNotExist:
             # No revenue config, keep default USD
             continue
-        except Exception as e:
-            logger.error("Failed to migrate base currency for team", team_id=team.id, error=str(e), exc_info=True)
+        except Exception:
+            # Just ignore, this has finished running in prod already, don't need this
             continue
-
-    logger.info("Revenue base currency migration completed", teams_updated=teams_updated)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
These aren't really useful now that they've run and they're but noise when setting up an environment from the ground, so let's just get rid of them