### PR TITLE
fix(flags): Add expiry tracking verification to HyperCache verify commands

### DIFF
--- a/posthog/management/commands/_base_hypercache_command.py
+++ b/posthog/management/commands/_base_hypercache_command.py
@@ -283,6 +283,7 @@ class BaseHyperCacheCommand(BaseCommand):
                 "cache_miss": 0,
                 "cache_match": 0,
                 "cache_mismatch": 0,
+                "expiry_missing": 0,
                 "error": 0,
                 "fixed": 0,
                 "fix_failed": 0,
@@ -336,7 +337,7 @@ class BaseHyperCacheCommand(BaseCommand):
         Verify a batch of teams against their cached data.
 
         This method handles batch loading (if available) and delegates verification
-        to the subclass's verify_team() method.
+        to the subclass's verify_team() method. Also checks expiry tracking.
         """
         # Batch-load data if the HyperCache supports it
         config = self.get_hypercache_config()
@@ -346,6 +347,13 @@ class BaseHyperCacheCommand(BaseCommand):
                 batch_data = config.hypercache.batch_load_fn(teams)
             except Exception as e:
                 self.stdout.write(self.style.WARNING(f"Batch load failed, falling back to individual loads: {e}"))
+
+        # Batch-check expiry tracking (pipelined for efficiency)
+        expiry_status: dict[str | int, bool] = {}
+        try:
+            expiry_status = self._batch_check_expiry_tracking(teams, config)
+        except Exception as e:
+            self.stdout.write(self.style.WARNING(f"Expiry tracking check failed, skipping: {e}"))
 
         for team in teams:
             stats["total"] += 1
@@ -361,6 +369,13 @@ class BaseHyperCacheCommand(BaseCommand):
             # Handle result
             if result["status"] == "match":
                 stats["cache_match"] += 1
+
+                # Check expiry tracking for teams with valid cache data
+                identifier = config.hypercache.get_cache_identifier(team)
+                if expiry_status and not expiry_status.get(identifier, True):
+                    stats["expiry_missing"] += 1
+                    self._handle_expiry_issue(team, stats, mismatches, fix, config)
+
             elif result["status"] == "miss":
                 stats["cache_miss"] += 1
                 self._handle_cache_issue(team, result, stats, mismatches, fix)
@@ -412,6 +427,89 @@ class BaseHyperCacheCommand(BaseCommand):
             self.stdout.write(self.style.ERROR(f"  ✗ Error fixing cache for team {team.id} ({team.name}): {e}"))
             return False
 
+    def _batch_check_expiry_tracking(
+        self,
+        teams: list[Team],
+        config: HyperCacheManagementConfig,
+    ) -> dict[str | int, bool]:
+        """
+        Check if teams are tracked in the expiry sorted set using pipelining.
+
+        Uses Redis ZSCORE in a pipeline to efficiently check multiple teams
+        in a single network round trip per batch.
+
+        Args:
+            teams: List of Team objects to check
+            config: HyperCache management config
+
+        Returns:
+            Dict mapping team identifier (api_token or id) to True/False
+        """
+        if not config.hypercache.expiry_sorted_set_key:
+            # No expiry tracking configured - treat all teams as tracked
+            return {config.hypercache.get_cache_identifier(team): True for team in teams}
+
+        from posthog.redis import get_client
+
+        redis_client = get_client(config.hypercache.redis_url)
+        results: dict[str | int, bool] = {}
+        batch_size = 5000  # Match REDIS_PIPELINE_BATCH_SIZE from hypercache_manager
+
+        for i in range(0, len(teams), batch_size):
+            batch = teams[i : i + batch_size]
+            pipeline = redis_client.pipeline(transaction=False)
+            identifiers: list[str | int] = []
+
+            for team in batch:
+                identifier = config.hypercache.get_cache_identifier(team)
+                identifiers.append(identifier)
+                pipeline.zscore(config.hypercache.expiry_sorted_set_key, str(identifier))
+
+            scores = pipeline.execute()
+
+            for identifier, score in zip(identifiers, scores):
+                # ZSCORE returns None if member doesn't exist
+                results[identifier] = score is not None
+
+        return results
+
+    def _handle_expiry_issue(
+        self,
+        team: Team,
+        stats: dict[str, int],
+        mismatches: list[dict],
+        fix: bool,
+        config: HyperCacheManagementConfig,
+    ):
+        """Handle a team missing from expiry tracking."""
+        issue_detail: dict = {
+            "team_id": team.id,
+            "team_name": team.name,
+            "issue": "EXPIRY_MISSING",
+            "details": "Cache exists but not tracked in expiry sorted set",
+        }
+
+        if fix:
+            issue_detail["fixed"] = self._fix_expiry(team, stats, config)
+
+        mismatches.append(issue_detail)
+
+    def _fix_expiry(self, team: Team, stats: dict[str, int], config: HyperCacheManagementConfig) -> bool:
+        """Fix expiry tracking by updating cache (which re-tracks expiry)."""
+        try:
+            success = config.update_fn(team)
+            if success:
+                stats["fixed"] += 1
+                self.stdout.write(self.style.SUCCESS(f"  ✓ Fixed expiry tracking for team {team.id} ({team.name})"))
+            else:
+                stats["fix_failed"] += 1
+                self.stdout.write(self.style.ERROR(f"  ✗ Failed to fix expiry for team {team.id} ({team.name})"))
+            return success
+        except Exception as e:
+            stats["fix_failed"] += 1
+            self.stdout.write(self.style.ERROR(f"  ✗ Error fixing expiry for team {team.id} ({team.name}): {e}"))
+            return False
+
     def _print_verification_results(self, stats: dict, mismatches: list[dict], verbose: bool, fix: bool):
         """Print verification results."""
         config = self.get_hypercache_config()
@@ -431,6 +529,12 @@ class BaseHyperCacheCommand(BaseCommand):
         self.stdout.write(
             f"Cache misses:         {stats['cache_miss']} ({self.format_percentage(stats['cache_miss'], stats['total'])})"
         )
+        if stats.get("expiry_missing", 0) > 0:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Expiry missing:       {stats['expiry_missing']} ({self.format_percentage(stats['expiry_missing'], stats['total'])})"
+                )
+            )
         if stats["error"] > 0:
             self.stdout.write(
                 self.style.ERROR(
@@ -474,7 +578,8 @@ class BaseHyperCacheCommand(BaseCommand):
 
         self.stdout.write("\n" + "=" * 70)
 
-        if stats["cache_match"] == stats["total"]:
+        all_verified = stats["cache_match"] == stats["total"] and stats.get("expiry_missing", 0) == 0
+        if all_verified:
             self.stdout.write(self.style.SUCCESS(f"\n✓ All {cache_name} caches verified successfully!\n"))
         else:
             if fix:

--- a/posthog/management/commands/test/test_base_hypercache_command.py
+++ b/posthog/management/commands/test/test_base_hypercache_command.py
@@ -495,8 +495,8 @@ class TestExpiryTrackingVerification(BaseTest):
         assert stats["expiry_missing"] == 0
         assert len(mismatches) == 0
 
-    def test_fix_expiry_calls_update_fn(self):
-        """Test that _fix_expiry calls the update_fn to refresh cache and track expiry."""
+    def test_fix_team_cache_calls_update_fn(self):
+        """Test that _fix_team_cache calls the update_fn to refresh cache and track expiry."""
         mock_config = create_mock_config_with_expiry()
 
         command = ConcreteHyperCacheCommand(mock_config=mock_config)
@@ -504,14 +504,14 @@ class TestExpiryTrackingVerification(BaseTest):
 
         stats = {"fixed": 0, "fix_failed": 0}
 
-        result = command._fix_expiry(self.team, stats, mock_config)
+        result = command._fix_team_cache(self.team, stats, "expiry tracking", mock_config)
 
         assert result is True
         assert stats["fixed"] == 1
         mock_config.update_fn.assert_called_once_with(self.team)
 
-    def test_fix_expiry_handles_update_fn_failure(self):
-        """Test that _fix_expiry handles update_fn returning False."""
+    def test_fix_team_cache_handles_update_fn_failure(self):
+        """Test that _fix_team_cache handles update_fn returning False."""
         mock_config = create_mock_config_with_expiry()
         mock_config.update_fn.return_value = False
 
@@ -520,13 +520,13 @@ class TestExpiryTrackingVerification(BaseTest):
 
         stats = {"fixed": 0, "fix_failed": 0}
 
-        result = command._fix_expiry(self.team, stats, mock_config)
+        result = command._fix_team_cache(self.team, stats, "expiry tracking", mock_config)
 
         assert result is False
         assert stats["fix_failed"] == 1
 
-    def test_fix_expiry_handles_exception(self):
-        """Test that _fix_expiry handles exceptions from update_fn."""
+    def test_fix_team_cache_handles_exception(self):
+        """Test that _fix_team_cache handles exceptions from update_fn."""
         mock_config = create_mock_config_with_expiry()
         mock_config.update_fn.side_effect = Exception("Redis error")
 
@@ -535,7 +535,7 @@ class TestExpiryTrackingVerification(BaseTest):
 
         stats = {"fixed": 0, "fix_failed": 0}
 
-        result = command._fix_expiry(self.team, stats, mock_config)
+        result = command._fix_team_cache(self.team, stats, "expiry tracking", mock_config)
 
         assert result is False
         assert stats["fix_failed"] == 1

--- a/posthog/management/commands/test/test_base_hypercache_command.py
+++ b/posthog/management/commands/test/test_base_hypercache_command.py
@@ -113,6 +113,7 @@ def create_mock_config():
     """Create a properly structured mock config for testing."""
     mock_config = MagicMock()
     mock_config.hypercache.batch_load_fn = None
+    mock_config.hypercache.expiry_sorted_set_key = None  # Disable expiry tracking by default
     mock_config.cache_display_name = "test cache"
     return mock_config
 
@@ -136,6 +137,7 @@ class TestVerifyTeamErrorHandling(BaseTest):
             "cache_miss": 0,
             "cache_match": 0,
             "cache_mismatch": 0,
+            "expiry_missing": 0,
             "error": 0,
             "fixed": 0,
             "fix_failed": 0,
@@ -178,6 +180,7 @@ class TestVerifyTeamErrorHandling(BaseTest):
             "cache_miss": 0,
             "cache_match": 0,
             "cache_mismatch": 0,
+            "expiry_missing": 0,
             "error": 0,
             "fixed": 0,
             "fix_failed": 0,
@@ -210,6 +213,7 @@ class TestVerifyTeamErrorHandling(BaseTest):
             "cache_miss": 0,
             "cache_match": 0,
             "cache_mismatch": 0,
+            "expiry_missing": 0,
             "error": 0,
             "fixed": 0,
             "fix_failed": 0,
@@ -352,3 +356,274 @@ class TestRunVerificationErrorHandling(BaseTest):
             assert "Failed to update cache metrics" in output
             # Verification should still have completed
             assert "Verification Results" in output
+
+
+def create_mock_config_with_expiry(expiry_sorted_set_key: str = "test_expiry_set"):
+    """Create a mock config with expiry tracking enabled."""
+    mock_config = MagicMock()
+    mock_config.hypercache.batch_load_fn = None
+    mock_config.hypercache.expiry_sorted_set_key = expiry_sorted_set_key
+    mock_config.hypercache.redis_url = "redis://test"
+    mock_config.hypercache.get_cache_identifier = lambda team: team.api_token
+    mock_config.cache_display_name = "test cache"
+    mock_config.update_fn = MagicMock(return_value=True)
+    return mock_config
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test", TEST=True)
+class TestExpiryTrackingVerification(BaseTest):
+    """Test expiry tracking verification functionality."""
+
+    def test_batch_check_expiry_returns_all_true_when_no_expiry_key_configured(self):
+        """Test that _batch_check_expiry_tracking returns all True when expiry tracking is disabled."""
+        mock_config = create_mock_config()  # No expiry_sorted_set_key
+
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        result = command._batch_check_expiry_tracking([self.team], mock_config)
+
+        # All teams should be considered "tracked" when expiry tracking is disabled
+        assert len(result) == 1
+        assert all(v is True for v in result.values())
+
+    def test_batch_check_expiry_uses_pipelining(self):
+        """Test that _batch_check_expiry_tracking uses Redis pipelining."""
+        mock_config = create_mock_config_with_expiry()
+
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        with patch("posthog.redis.get_client") as mock_get_client:
+            mock_redis = MagicMock()
+            mock_pipeline = MagicMock()
+            mock_pipeline.execute.return_value = [1234567890.0]  # Score indicates team is tracked
+            mock_redis.pipeline.return_value = mock_pipeline
+            mock_get_client.return_value = mock_redis
+
+            result = command._batch_check_expiry_tracking([self.team], mock_config)
+
+            # Pipeline should have been created and executed
+            mock_redis.pipeline.assert_called_once_with(transaction=False)
+            mock_pipeline.zscore.assert_called_once()
+            mock_pipeline.execute.assert_called_once()
+
+            # Team should be marked as tracked (score was not None)
+            assert result[self.team.api_token] is True
+
+    def test_batch_check_expiry_returns_false_for_missing_teams(self):
+        """Test that _batch_check_expiry_tracking returns False for teams not in sorted set."""
+        mock_config = create_mock_config_with_expiry()
+
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        with patch("posthog.redis.get_client") as mock_get_client:
+            mock_redis = MagicMock()
+            mock_pipeline = MagicMock()
+            mock_pipeline.execute.return_value = [None]  # None indicates team is not tracked
+            mock_redis.pipeline.return_value = mock_pipeline
+            mock_get_client.return_value = mock_redis
+
+            result = command._batch_check_expiry_tracking([self.team], mock_config)
+
+            # Team should be marked as NOT tracked (score was None)
+            assert result[self.team.api_token] is False
+
+    def test_expiry_missing_incremented_when_team_not_in_sorted_set(self):
+        """Test that expiry_missing stat is incremented when team is not in expiry sorted set."""
+        mock_config = create_mock_config_with_expiry()
+
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        stats = {
+            "total": 0,
+            "cache_miss": 0,
+            "cache_match": 0,
+            "cache_mismatch": 0,
+            "expiry_missing": 0,
+            "error": 0,
+            "fixed": 0,
+            "fix_failed": 0,
+        }
+        mismatches: list[dict[str, Any]] = []
+
+        with patch("posthog.redis.get_client") as mock_get_client:
+            mock_redis = MagicMock()
+            mock_pipeline = MagicMock()
+            mock_pipeline.execute.return_value = [None]  # Team not in sorted set
+            mock_redis.pipeline.return_value = mock_pipeline
+            mock_get_client.return_value = mock_redis
+
+            command._verify_teams_batch([self.team], stats, mismatches, verbose=False, fix=False)
+
+        assert stats["cache_match"] == 1  # Cache data is valid
+        assert stats["expiry_missing"] == 1  # But expiry tracking is missing
+        assert len(mismatches) == 1
+        assert mismatches[0]["issue"] == "EXPIRY_MISSING"
+
+    def test_expiry_missing_not_incremented_when_team_in_sorted_set(self):
+        """Test that expiry_missing is not incremented when team is properly tracked."""
+        mock_config = create_mock_config_with_expiry()
+
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        stats = {
+            "total": 0,
+            "cache_miss": 0,
+            "cache_match": 0,
+            "cache_mismatch": 0,
+            "expiry_missing": 0,
+            "error": 0,
+            "fixed": 0,
+            "fix_failed": 0,
+        }
+        mismatches: list[dict[str, Any]] = []
+
+        with patch("posthog.redis.get_client") as mock_get_client:
+            mock_redis = MagicMock()
+            mock_pipeline = MagicMock()
+            mock_pipeline.execute.return_value = [1234567890.0]  # Team is tracked
+            mock_redis.pipeline.return_value = mock_pipeline
+            mock_get_client.return_value = mock_redis
+
+            command._verify_teams_batch([self.team], stats, mismatches, verbose=False, fix=False)
+
+        assert stats["cache_match"] == 1
+        assert stats["expiry_missing"] == 0
+        assert len(mismatches) == 0
+
+    def test_fix_expiry_calls_update_fn(self):
+        """Test that _fix_expiry calls the update_fn to refresh cache and track expiry."""
+        mock_config = create_mock_config_with_expiry()
+
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        stats = {"fixed": 0, "fix_failed": 0}
+
+        result = command._fix_expiry(self.team, stats, mock_config)
+
+        assert result is True
+        assert stats["fixed"] == 1
+        mock_config.update_fn.assert_called_once_with(self.team)
+
+    def test_fix_expiry_handles_update_fn_failure(self):
+        """Test that _fix_expiry handles update_fn returning False."""
+        mock_config = create_mock_config_with_expiry()
+        mock_config.update_fn.return_value = False
+
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        stats = {"fixed": 0, "fix_failed": 0}
+
+        result = command._fix_expiry(self.team, stats, mock_config)
+
+        assert result is False
+        assert stats["fix_failed"] == 1
+
+    def test_fix_expiry_handles_exception(self):
+        """Test that _fix_expiry handles exceptions from update_fn."""
+        mock_config = create_mock_config_with_expiry()
+        mock_config.update_fn.side_effect = Exception("Redis error")
+
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        stats = {"fixed": 0, "fix_failed": 0}
+
+        result = command._fix_expiry(self.team, stats, mock_config)
+
+        assert result is False
+        assert stats["fix_failed"] == 1
+
+    def test_expiry_check_failure_continues_verification(self):
+        """Test that failure in expiry check doesn't stop verification."""
+        mock_config = create_mock_config_with_expiry()
+
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        stats = {
+            "total": 0,
+            "cache_miss": 0,
+            "cache_match": 0,
+            "cache_mismatch": 0,
+            "expiry_missing": 0,
+            "error": 0,
+            "fixed": 0,
+            "fix_failed": 0,
+        }
+        mismatches: list[dict[str, Any]] = []
+
+        with patch("posthog.redis.get_client") as mock_get_client:
+            mock_get_client.side_effect = ConnectionError("Redis unavailable")
+
+            command._verify_teams_batch([self.team], stats, mismatches, verbose=False, fix=False)
+
+        # Verification should still have completed
+        assert stats["cache_match"] == 1
+        assert stats["expiry_missing"] == 0  # Expiry check was skipped
+        output = command.stdout.getvalue()
+        assert "Expiry tracking check failed" in output
+
+    def test_print_verification_results_shows_expiry_missing(self):
+        """Test that verification results include expiry_missing count."""
+        mock_config = MagicMock(spec=HyperCacheManagementConfig)
+        mock_config.cache_display_name = "test cache"
+
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        stats = {
+            "total": 10,
+            "cache_miss": 0,
+            "cache_match": 10,
+            "cache_mismatch": 0,
+            "expiry_missing": 3,
+            "error": 0,
+            "fixed": 0,
+            "fix_failed": 0,
+        }
+
+        command._print_verification_results(stats, mismatches=[], verbose=False, fix=False)
+
+        output = command.stdout.getvalue()
+        assert "Expiry missing:" in output
+        assert "3" in output
+        assert "30.0%" in output
+
+    def test_verification_success_requires_no_expiry_missing(self):
+        """Test that verification only shows success when expiry_missing is 0."""
+        mock_config = MagicMock(spec=HyperCacheManagementConfig)
+        mock_config.cache_display_name = "test cache"
+
+        command = ConcreteHyperCacheCommand(mock_config=mock_config)
+        command.stdout = StringIO()  # type: ignore[assignment]
+
+        # All caches match, but some have expiry issues
+        stats = {
+            "total": 10,
+            "cache_miss": 0,
+            "cache_match": 10,
+            "cache_mismatch": 0,
+            "expiry_missing": 2,
+            "error": 0,
+            "fixed": 0,
+            "fix_failed": 0,
+        }
+        mismatches = [
+            {"team_id": 1, "team_name": "Test1", "issue": "EXPIRY_MISSING", "details": "test"},
+            {"team_id": 2, "team_name": "Test2", "issue": "EXPIRY_MISSING", "details": "test"},
+        ]
+
+        command._print_verification_results(stats, mismatches=mismatches, verbose=False, fix=False)
+
+        output = command.stdout.getvalue()
+        # Should NOT show success message
+        assert "All test cache caches verified successfully" not in output
+        # Should show issues found
+        assert "Found issues" in output


### PR DESCRIPTION
## Problem

Add verification that teams exist in the expiry sorted set, not just that their cache data is valid. Teams with valid cache but missing from the expiry sorted set won't be refreshed by the hourly job.

This applies to both `verify_team_metadata_cache` and `verify_flags_cache` since both inherit from BaseHyperCacheCommand and have expiry tracking.

## Changes

- Add `_batch_check_expiry_tracking()` using Redis pipelining (`ZSCORE`)
- Add `expiry_missing` stat and `EXPIRY_MISSING` issue type
- With `--fix`, calls `update_fn` to refresh cache and re-track expiry
- Update success condition to require no expiry issues

## How did you test this code?

Unit Tests
Manual Testing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
