### PR TITLE
fix(insights): return 400 for ExposedCHQueryError like /query

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -47,6 +47,7 @@ from posthog.clickhouse.cancel import cancel_query_on_cluster
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.constants import INSIGHT, INSIGHT_FUNNELS, INSIGHT_STICKINESS, TRENDS_STICKINESS, FunnelVizType
 from posthog.decorators import cached_by_filters
+from posthog.errors import ExposedCHQueryError
 from posthog.event_usage import groups
 from posthog.helpers.multi_property_breakdown import protect_old_clients_from_multi_property_default
 from posthog.hogql_queries.apply_dashboard_filters import (
@@ -827,8 +828,8 @@ class InsightSerializer(InsightBasicSerializer):
                     variables_override=variables_override,
                     tile_filters_override=tile_filters_override,
                 )
-            except ExposedHogQLError as e:
-                raise ValidationError(str(e))
+            except (ExposedHogQLError, ExposedCHQueryError) as e:
+                raise ValidationError(str(e), getattr(e, "code_name", None))
             except ConcurrencyLimitExceeded as e:
                 logger.warn(
                     "concurrency_limit_exceeded_api", exception=e, insight_id=insight.id, team_id=insight.team_id
@@ -1157,7 +1158,10 @@ When set, the specified dashboard's filters and date range override will be appl
             # context is used in the to_representation method to report filters used
             serializer_context.update({"dashboard": dashboard_tile.dashboard})
 
-        serialized_data = self.get_serializer(instance, context=serializer_context).data
+        try:
+            serialized_data = self.get_serializer(instance, context=serializer_context).data
+        except (ExposedHogQLError, ExposedCHQueryError) as e:
+            raise ValidationError(str(e), getattr(e, "code_name", None))
 
         if dashboard_tile is not None:
             serialized_data["color"] = dashboard_tile.color
@@ -1185,8 +1189,8 @@ When set, the specified dashboard's filters and date range override will be appl
                     result = self.calculate_trends_hogql(request)
                 else:
                     result = self.calculate_trends(request)
-        except ExposedHogQLError as e:
-            raise ValidationError(str(e))
+        except (ExposedHogQLError, ExposedCHQueryError) as e:
+            raise ValidationError(str(e), getattr(e, "code_name", None))
         except UserAccessControlError as e:
             raise ValidationError(str(e))
         except Cohort.DoesNotExist as e:
@@ -1281,8 +1285,8 @@ When set, the specified dashboard's filters and date range override will be appl
                 else:
                     funnel = self.calculate_funnel(request)
 
-        except ExposedHogQLError as e:
-            raise ValidationError(str(e))
+        except (ExposedHogQLError, ExposedCHQueryError) as e:
+            raise ValidationError(str(e), getattr(e, "code_name", None))
 
         if isinstance(funnel["result"], BaseModel):
             funnel["result"] = funnel["result"].model_dump()


### PR DESCRIPTION
## Problem

The query-django service, specifically the /insight endpoint, is returning 500s for ExposedCHQueryError. The /query endpoint catches this exception type and returns a 400. This 500s are polluting the success metrics.

<img width="1263" height="243" alt="Screenshot 2025-12-10 at 5 07 38 PM" src="https://github.com/user-attachments/assets/f998d8d3-655b-4475-bfdc-c53686c724cc" />

<img width="841" height="802" alt="Screenshot 2025-12-10 at 5 20 52 PM" src="https://github.com/user-attachments/assets/f2936ebc-c076-4851-8f10-6305a084dfb2" />


From: https://grafana.prod-us.posthog.dev/d/af63abeg2f37kb/query-django-fault-investigation

The query endpoint handles ExposedCHQueryError here:
https://github.com/PostHog/posthog/blob/master/posthog/api/query.py#L171-L172

You can see from the query-django logs that error code 386 (CHQueryErrorNoCommonType), which is converted to ExposedCHQueryError, results in a 500. 

query-django log (request_id=`c4db7c39-730a-4066-86e4-d1e2d0603586`, Timebox `{"from":"2025-12-10 21:09:04","to":"2025-12-10 21:09:46"}`):  https://grafana.prod-us.posthog.dev/goto/ZldbCSMDR?orgId=1

corresponding contour log: https://grafana.prod-us.posthog.dev/goto/4-wQjIGDg?orgId=1. Note the response_code=500 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Handle the error in the /insight endpoint's retrieve(), trend(), and funnel() methods, returning 400 (ValidationError) instead of 500.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests.


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
