### PR TITLE
chore: fix pycharm/jetbrains test runner

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ env =
     DEBUG=1
     TEST=1
 DJANGO_SETTINGS_MODULE = posthog.settings
-addopts = -p no:warnings --reuse-db --ignore=posthog/user_scripts --ignore=services/llm-gateway --reruns 2 --reruns-delay 1
+addopts = -p no:warnings --reuse-db --ignore=posthog/user_scripts --ignore=services/llm-gateway
 
 markers =
     ee


### PR DESCRIPTION
## Problem

These command-line options don't seem to be supported by the JetBrains test runner, I got

```
_jb_pytest_runner.py: error: unrecognized arguments: --reruns --reruns-delay 1 /some/test_file.py
```

## Changes

Remove them

## How did you test this code?

I can run tests from PyCharm again

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
