### PR TITLE
chore(workflows): improve ux in workflow testing tab

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -58,6 +58,7 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
         nextActionId,
         eventPanelOpen,
         eventSelectorOpen,
+        lastSearchedEventName,
     } = useValues(hogFlowEditorTestLogic(logicProps))
     const {
         submitTestInvocation,
@@ -206,9 +207,17 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                                                         <div className="mb-2 text-center">
                                                             <LemonButton
                                                                 type="primary"
-                                                                onClick={() =>
-                                                                    loadSampleGlobals({ extendedSearch: true })
-                                                                }
+                                                                onClick={() => {
+                                                                    if (shouldLoadSampleGlobals) {
+                                                                        loadSampleGlobals({ extendedSearch: true })
+                                                                    } else {
+                                                                        // For non-event triggers, reload with the last searched event name
+                                                                        loadSampleEventByName(
+                                                                            lastSearchedEventName || '$pageview',
+                                                                            true
+                                                                        )
+                                                                    }
+                                                                }}
                                                                 loading={sampleGlobalsLoading}
                                                             >
                                                                 Try searching last 30 days (slower)

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -51,6 +51,7 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
         sampleGlobalsLoading,
         sampleGlobalsError,
         noMatchingEvents,
+        canTryExtendedSearch,
         isTestInvocationSubmitting,
         testResult,
         shouldLoadSampleGlobals,
@@ -197,9 +198,24 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                                     <div>
                                         <div className="bg-surface-secondary">
                                             {sampleGlobalsError && (
-                                                <LemonBanner type="info" className="mb-2">
-                                                    {sampleGlobalsError}
-                                                </LemonBanner>
+                                                <div>
+                                                    <LemonBanner type="info" className="mb-2">
+                                                        {sampleGlobalsError}
+                                                    </LemonBanner>
+                                                    {canTryExtendedSearch && (
+                                                        <div className="mb-2 text-center">
+                                                            <LemonButton
+                                                                type="primary"
+                                                                onClick={() =>
+                                                                    loadSampleGlobals({ extendedSearch: true })
+                                                                }
+                                                                loading={sampleGlobalsLoading}
+                                                            >
+                                                                Try searching last 30 days (slower)
+                                                            </LemonButton>
+                                                        </div>
+                                                    )}
+                                                </div>
                                             )}
                                             <div className="flex gap-2 items-center">
                                                 <ProfilePicture name={display} />

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -51,7 +51,6 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
         sampleGlobalsLoading,
         sampleGlobalsError,
         noMatchingEvents,
-        canTryExtendedSearch,
         isTestInvocationSubmitting,
         testResult,
         shouldLoadSampleGlobals,
@@ -198,24 +197,9 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                                     <div>
                                         <div className="bg-surface-secondary">
                                             {sampleGlobalsError && (
-                                                <div>
-                                                    <LemonBanner type="info" className="mb-2">
-                                                        {sampleGlobalsError}
-                                                    </LemonBanner>
-                                                    {canTryExtendedSearch && (
-                                                        <div className="mb-2 text-center">
-                                                            <LemonButton
-                                                                type="primary"
-                                                                onClick={() =>
-                                                                    loadSampleGlobals({ extendedSearch: true })
-                                                                }
-                                                                loading={sampleGlobalsLoading}
-                                                            >
-                                                                Try searching last 30 days (slower)
-                                                            </LemonButton>
-                                                        </div>
-                                                    )}
-                                                </div>
+                                                <LemonBanner type="info" className="mb-2">
+                                                    {sampleGlobalsError}
+                                                </LemonBanner>
                                             )}
                                             <div className="flex gap-2 items-center">
                                                 <ProfilePicture name={display} />

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
 import { IconInfo, IconPlayFilled, IconRedo, IconTestTube } from '@posthog/icons'
 import {
@@ -45,8 +45,6 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
     const { workflow, selectedNode } = useValues(hogFlowEditorLogic)
     const { setSelectedNodeId } = useActions(hogFlowEditorLogic)
     const { logicProps } = useValues(workflowLogic)
-    const [eventPanelOpen, setEventPanelOpen] = useState<string[]>(['event'])
-    const [eventSelectorOpen, setEventSelectorOpen] = useState(false)
 
     const {
         sampleGlobals,
@@ -57,9 +55,18 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
         testResult,
         shouldLoadSampleGlobals,
         nextActionId,
+        eventPanelOpen,
+        eventSelectorOpen,
     } = useValues(hogFlowEditorTestLogic(logicProps))
-    const { submitTestInvocation, setTestResult, loadSampleGlobals, loadSampleEventByName, setSampleGlobals } =
-        useActions(hogFlowEditorTestLogic(logicProps))
+    const {
+        submitTestInvocation,
+        setTestResult,
+        loadSampleGlobals,
+        loadSampleEventByName,
+        setSampleGlobals,
+        setEventPanelOpen,
+        setEventSelectorOpen,
+    } = useActions(hogFlowEditorTestLogic(logicProps))
 
     const display = asDisplay(sampleGlobals?.person)
     const url = urls.personByDistinctId(sampleGlobals?.event?.distinct_id || '')
@@ -67,11 +74,6 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
     useEffect(() => {
         setTestResult(null)
     }, [selectedNode?.id, setTestResult])
-
-    // Ensure event panel is open when component mounts or becomes visible
-    useEffect(() => {
-        setEventPanelOpen(['event'])
-    }, [])
 
     if (!selectedNode) {
         return (
@@ -245,7 +247,6 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                                                                 onChange={(_, value) => {
                                                                     if (typeof value === 'string') {
                                                                         loadSampleEventByName(value)
-                                                                        setEventSelectorOpen(false)
                                                                     }
                                                                 }}
                                                                 allowNonCapturedEvents

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorPanelTest.tsx
@@ -212,10 +212,11 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                                                                         loadSampleGlobals({ extendedSearch: true })
                                                                     } else {
                                                                         // For non-event triggers, reload with the last searched event name
-                                                                        loadSampleEventByName(
-                                                                            lastSearchedEventName || '$pageview',
-                                                                            true
-                                                                        )
+                                                                        loadSampleEventByName({
+                                                                            eventName:
+                                                                                lastSearchedEventName || '$pageview',
+                                                                            extendedSearch: true,
+                                                                        })
                                                                     }
                                                                 }}
                                                                 loading={sampleGlobalsLoading}
@@ -271,7 +272,7 @@ export function HogFlowEditorPanelTest(): JSX.Element | null {
                                                                 value={sampleGlobals?.event?.event || ''}
                                                                 onChange={(_, value) => {
                                                                     if (typeof value === 'string') {
-                                                                        loadSampleEventByName(value)
+                                                                        loadSampleEventByName({ eventName: value })
                                                                     }
                                                                 }}
                                                                 allowNonCapturedEvents

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
@@ -198,7 +198,7 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                             kind: NodeKind.EventsQuery,
                             fixedProperties: [values.matchingFilters],
                             select: ['*', 'person'],
-                            after: '-30d',
+                            after: '-7d',
                             limit: 10, // Get 10 events to cycle through
                             orderBy: ['timestamp DESC'],
                             modifiers: {
@@ -213,7 +213,7 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                             // No matching events found, fall back to example event
                             const exampleGlobals = createExampleEvent(values.workflow.team_id, values.workflow.name)
                             actions.setSampleGlobalsError(
-                                'No events match these filters in the last 30 days. Using an example $pageview event instead.'
+                                'No events match these filters in the last 7 days. Using an example $pageview event instead.'
                             )
                             actions.setNoMatchingEvents(true)
                             return exampleGlobals
@@ -263,7 +263,7 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                                 },
                             ],
                             select: ['*', 'person'],
-                            after: '-30d',
+                            after: '-7d',
                             limit: 1,
                             orderBy: ['timestamp DESC'],
                             modifiers: {
@@ -281,7 +281,7 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                                 eventName
                             )
                             actions.setSampleGlobalsError(
-                                `No "${eventName}" events found in the last 30 days. Using an example event instead.`
+                                `No "${eventName}" events found in the last 7 days. Using an example event instead.`
                             )
                             return exampleGlobals
                         }

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
@@ -438,6 +438,9 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
         loadSampleGlobalsSuccess: () => {
             actions.setTestInvocationValue('globals', JSON.stringify(values.sampleGlobals, null, 2))
         },
+        loadSampleEventByNameSuccess: () => {
+            actions.setTestInvocationValue('globals', JSON.stringify(values.sampleGlobals, null, 2))
+        },
         setSampleGlobals: () => {
             actions.setTestInvocationValue('globals', JSON.stringify(values.sampleGlobals, null, 2))
         },

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
@@ -128,6 +128,8 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
         cancelSampleGlobalsLoading: true,
         receiveExampleGlobals: (globals: object | null) => ({ globals }),
         setNextActionId: (nextActionId: string | null) => ({ nextActionId }),
+        setEventPanelOpen: (eventPanelOpen: string[]) => ({ eventPanelOpen }),
+        setEventSelectorOpen: (eventSelectorOpen: boolean) => ({ eventSelectorOpen }),
     }),
     reducers({
         testResult: [
@@ -179,6 +181,19 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                         return previousGlobals
                     }
                 },
+            },
+        ],
+        eventPanelOpen: [
+            ['event'] as string[],
+            {
+                setEventPanelOpen: (_, { eventPanelOpen }) => eventPanelOpen,
+            },
+        ],
+        eventSelectorOpen: [
+            false as boolean,
+            {
+                setEventSelectorOpen: (_, { eventSelectorOpen }) => eventSelectorOpen,
+                loadSampleEventByNameSuccess: () => false, // Close selector after loading
             },
         ],
     }),

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
@@ -438,9 +438,6 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
         loadSampleGlobalsSuccess: () => {
             actions.setTestInvocationValue('globals', JSON.stringify(values.sampleGlobals, null, 2))
         },
-        loadSampleEventByNameSuccess: () => {
-            actions.setTestInvocationValue('globals', JSON.stringify(values.sampleGlobals, null, 2))
-        },
         setSampleGlobals: () => {
             actions.setTestInvocationValue('globals', JSON.stringify(values.sampleGlobals, null, 2))
         },

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
@@ -120,15 +120,11 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
     actions({
         setTestResult: (testResult: HogflowTestResult | null) => ({ testResult }),
         setTestResultMode: (mode: 'raw' | 'diff') => ({ mode }),
-        loadSampleGlobals: (payload?: { eventId?: string; extendedSearch?: boolean }) => ({
-            eventId: payload?.eventId,
-            extendedSearch: payload?.extendedSearch,
-        }),
-        loadSampleEventByName: (eventName: string, extendedSearch?: boolean) => ({ eventName, extendedSearch }),
+        loadSampleGlobals: (payload?: { eventId?: string }) => ({ eventId: payload?.eventId }),
+        loadSampleEventByName: (eventName: string) => ({ eventName }),
         setSampleGlobals: (globals?: string | null) => ({ globals }),
         setSampleGlobalsError: (error: string | null) => ({ error }),
         setNoMatchingEvents: (noMatchingEvents: boolean) => ({ noMatchingEvents }),
-        setCanTryExtendedSearch: (canTryExtendedSearch: boolean) => ({ canTryExtendedSearch }),
         cancelSampleGlobalsLoading: true,
         receiveExampleGlobals: (globals: object | null) => ({ globals }),
         setNextActionId: (nextActionId: string | null) => ({ nextActionId }),
@@ -160,13 +156,6 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
             {
                 loadSampleGlobals: () => false,
                 setNoMatchingEvents: (_, { noMatchingEvents }) => noMatchingEvents,
-            },
-        ],
-        canTryExtendedSearch: [
-            false as boolean,
-            {
-                loadSampleGlobals: () => false,
-                setCanTryExtendedSearch: (_, { canTryExtendedSearch }) => canTryExtendedSearch,
             },
         ],
         fetchCancelled: [
@@ -213,21 +202,18 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
         sampleGlobals: [
             null as CyclotronJobInvocationGlobals | null,
             {
-                loadSampleGlobals: async ({ extendedSearch }) => {
+                loadSampleGlobals: async () => {
                     if (!values.shouldLoadSampleGlobals) {
                         return null
                     }
 
                     try {
-                        // Use 30 days for extended search, 7 days normally
-                        const timeRange = extendedSearch ? '-30d' : '-7d'
-
                         // Fetch multiple events so we can cycle through them
                         const query: EventsQuery = {
                             kind: NodeKind.EventsQuery,
                             fixedProperties: [values.matchingFilters],
                             select: ['*', 'person'],
-                            after: timeRange,
+                            after: '-7d',
                             limit: 10, // Get 10 events to cycle through
                             orderBy: ['timestamp DESC'],
                             modifiers: {
@@ -239,30 +225,17 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                         const response = await performQuery(query)
 
                         if (!response?.results?.[0]) {
-                            // No matching events found
+                            // No matching events found, fall back to example event
                             const exampleGlobals = createExampleEvent(values.workflow.team_id, values.workflow.name)
+                            actions.setSampleGlobalsError(
+                                'No events match these filters in the last 7 days. Using an example $pageview event instead.'
+                            )
                             actions.setNoMatchingEvents(true)
-
-                            if (extendedSearch) {
-                                // Extended search (30 days) also failed
-                                actions.setSampleGlobalsError(
-                                    'No events match these filters in the last 30 days. Using an example $pageview event instead.'
-                                )
-                                actions.setCanTryExtendedSearch(false)
-                            } else {
-                                // First search (7 days) failed, allow extended search
-                                actions.setSampleGlobalsError(
-                                    'No events match these filters in the last 7 days. Using an example $pageview event instead.'
-                                )
-                                actions.setCanTryExtendedSearch(true)
-                            }
-
                             return exampleGlobals
                         }
 
                         // Found matching events
                         actions.setNoMatchingEvents(false)
-                        actions.setCanTryExtendedSearch(false)
 
                         // Pick a different event than the current one if possible
                         let resultIndex = 0
@@ -288,14 +261,9 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                         return null
                     }
                 },
-                loadSampleEventByName: async ({
-                    eventName,
-                    extendedSearch,
-                }): Promise<CyclotronJobInvocationGlobals | null> => {
+                loadSampleEventByName: async ({ eventName }): Promise<CyclotronJobInvocationGlobals | null> => {
                     // Load a specific event by name (for non-event triggers)
                     try {
-                        const timeRange = extendedSearch ? '-30d' : '-7d'
-
                         const query: EventsQuery = {
                             kind: NodeKind.EventsQuery,
                             fixedProperties: [
@@ -310,7 +278,7 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                                 },
                             ],
                             select: ['*', 'person'],
-                            after: timeRange,
+                            after: '-7d',
                             limit: 1,
                             orderBy: ['timestamp DESC'],
                             modifiers: {
@@ -321,15 +289,14 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                         const response = await performQuery(query)
 
                         if (!response?.results?.[0]) {
-                            // No matching events found
-                            const timePeriod = extendedSearch ? '30' : '7'
+                            // No matching events found, create an example event with this name
                             const exampleGlobals = createExampleEvent(
                                 values.workflow.team_id,
                                 values.workflow.name,
                                 eventName
                             )
                             actions.setSampleGlobalsError(
-                                `No "${eventName}" events found in the last ${timePeriod} days. Using an example event instead.`
+                                `No "${eventName}" events found in the last 7 days. Using an example event instead.`
                             )
                             return exampleGlobals
                         }
@@ -493,11 +460,10 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
             // Just mark as cancelled - we'll ignore any results that come back
         },
         setSelectedNodeId: () => {
-            // When we switch back to a trigger node, reset the flags
+            // When we switch back to a trigger node, reset the no matching events flag
             // so we can try loading again
             if (values.noMatchingEvents) {
                 actions.setNoMatchingEvents(false)
-                actions.setCanTryExtendedSearch(false)
             }
         },
     })),


### PR DESCRIPTION
## Problem

Folks do not understand that they need to load a sample event (that will then match their filters) so they trigger the testing action and it usually fails because properties are missing that they have set to be there in their filters. 

## Changes

![2025-12-11 11 38 22](https://github.com/user-attachments/assets/be183c19-ba87-4951-b8e6-17cd073bce52)

- When an event-trigger is set we now load the example events automatically in the testing tab
- We load a maximum of 10 events so folks could cycle through to test different versions of the same event 
- when no matching event was found in the last 7d user can choose to search the last 30d
- When no event trigger is selected folks can still load example events to test individual steps (before it was not possible)

## How did you test this code?

- local dev
