### PR TITLE
fix: move pytest reruns from pytest.ini to CI workflows

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -814,6 +814,7 @@ jobs:
                       --splits ${{ matrix.concurrency }} --group ${{ matrix.group }} \
                       --durations=1000 --durations-min=1.0 --store-durations \
                       --splitting-algorithm=duration_based_chunks \
+                      --reruns 2 --reruns-delay 1 \
                       $PYTEST_ARGS
                   exit_code=$?
                   set -e
@@ -843,6 +844,7 @@ jobs:
               run: |
                   pytest posthog/api/test/test_decide.py::TestDecideUsesReadReplica \
                       --durations=1000 --durations-min=1.0 \
+                      --reruns 2 --reruns-delay 1 \
                       $PYTEST_ARGS
 
             - name: Run Temporal tests
@@ -859,6 +861,7 @@ jobs:
                       --splits ${{ matrix.concurrency }} --group ${{ matrix.group }} \
                       --durations=100 --durations-min=1.0 --store-durations \
                       --splitting-algorithm=duration_based_chunks \
+                      --reruns 2 --reruns-delay 1 \
                       $PYTEST_ARGS
                   exit_code=$?
                   set -e
@@ -1104,7 +1107,7 @@ jobs:
 
             - name: Run async migrations tests
               run: |
-                  pytest -m "async_migrations"
+                  pytest -m "async_migrations" --reruns 2 --reruns-delay 1
 
     calculate-running-time:
         name: Calculate running time

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ env =
     DEBUG=1
     TEST=1
 DJANGO_SETTINGS_MODULE = posthog.settings
-addopts = -p no:warnings --reuse-db --ignore=posthog/user_scripts --ignore=services/llm-gateway --reruns 2 --reruns-delay 1
+addopts = -p no:warnings --reuse-db --ignore=posthog/user_scripts --ignore=services/llm-gateway
 
 markers =
     ee


### PR DESCRIPTION
**Problem**
The `--reruns` flag in pytest.ini breaks PyCharm's test runner which doesn't have pytest-rerunfailures installed:
```
_jb_pytest_runner.py: error: unrecognized arguments: --reruns --reruns-delay 1
```

**Solution**
Move reruns config from pytest.ini to ci-backend.yml where flakiness protection matters most.