### PR TITLE
feat: Exit toolbar gracefully

### DIFF
--- a/frontend/src/lib/brand/AnimatedLogomark.tsx
+++ b/frontend/src/lib/brand/AnimatedLogomark.tsx
@@ -6,10 +6,8 @@ import { Logomark } from 'lib/brand/Logomark'
 export interface AnimatedLogomarkProps {
     /** Animate the logomark continuously (e.g. during loading states) */
     animate: boolean
-    /** Play a single animation cycle and call onAnimationComplete when done */
-    animateOnce?: boolean
-    /** Callback when a single animation cycle completes (only used with animateOnce) */
-    onAnimationComplete?: () => void
+    /** Play a single animation cycle and call the provided callback when done */
+    animateOnce?: () => void
     className?: string
 }
 
@@ -19,21 +17,16 @@ export interface AnimatedLogomarkProps {
  * When `animate` becomes false, the animation completes its current cycle before
  * stopping - it won't cut off mid-jump.
  *
- * When `animateOnce` is true, plays a single animation cycle and calls
- * `onAnimationComplete` when done.
+ * When `animateOnce` is provided, plays a single animation cycle and calls
+ * the provided callback when done.
  */
-export function AnimatedLogomark({
-    animate,
-    animateOnce,
-    onAnimationComplete,
-    className,
-}: AnimatedLogomarkProps): JSX.Element {
+export function AnimatedLogomark({ animate, animateOnce, className }: AnimatedLogomarkProps): JSX.Element {
     const ref = useRef<HTMLDivElement | null>(null)
     const [isAnimating, setIsAnimating] = useState(false)
     const shouldStopRef = useRef(false)
-    const onAnimationCompleteRef = useRef(onAnimationComplete)
+    const animateOnceRef = useRef(animateOnce)
 
-    onAnimationCompleteRef.current = onAnimationComplete
+    animateOnceRef.current = animateOnce
 
     // Track stop intent via ref so the listener always sees current value
     // without needing to be re-attached when `animate` changes
@@ -59,9 +52,9 @@ export function AnimatedLogomark({
         }
 
         const handleAnimationIteration = (): void => {
-            if (animateOnce) {
+            if (animateOnceRef.current) {
                 setIsAnimating(false)
-                onAnimationCompleteRef.current?.()
+                animateOnceRef.current()
             } else if (shouldStopRef.current) {
                 setIsAnimating(false)
             }
@@ -71,7 +64,7 @@ export function AnimatedLogomark({
         return () => {
             animatedElement.removeEventListener('animationiteration', handleAnimationIteration)
         }
-    }, [isAnimating, animateOnce])
+    }, [isAnimating])
 
     return (
         <div ref={ref} className={clsx(className, isAnimating && 'animate-logomark-jump-continuous')}>

--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -400,8 +400,7 @@ export function Toolbar(): JSX.Element | null {
                 >
                     <AnimatedLogomark
                         animate={isLoading}
-                        animateOnce={isExiting}
-                        onAnimationComplete={completeGracefulExit}
+                        animateOnce={isExiting ? completeGracefulExit : undefined}
                         className="Toolbar__logomark"
                     />
                 </ToolbarButton>

--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -196,7 +196,7 @@ function piiMaskingMenuItem(
 
 function MoreMenu(): JSX.Element {
     const { hedgehogMode, theme, posthog, piiMaskingEnabled, piiMaskingColor, piiWarning } = useValues(toolbarLogic)
-    const { setHedgehogMode, toggleTheme, setVisibleMenu, togglePiiMasking, setPiiMaskingColor } =
+    const { setHedgehogMode, toggleTheme, setVisibleMenu, togglePiiMasking, setPiiMaskingColor, startGracefulExit } =
         useActions(toolbarLogic)
 
     const [loadingSurveys, setLoadingSurveys] = useState(true)
@@ -211,8 +211,6 @@ function MoreMenu(): JSX.Element {
 
     // KLUDGE: if there is no theme, assume light mode, which shouldn't be, but seems to be, necessary
     const currentlyLightMode = !theme || theme === 'light'
-
-    const { logout } = useActions(toolbarConfigLogic)
 
     return (
         <LemonMenu
@@ -256,7 +254,7 @@ function MoreMenu(): JSX.Element {
                             window.open(HELP_URL, '_blank')?.focus()
                         },
                     },
-                    { icon: <IconX />, label: 'Close toolbar', onClick: logout },
+                    { icon: <IconX />, label: 'Close toolbar', onClick: startGracefulExit },
                 ].filter(Boolean) as LemonMenuItems
             }
             maxContentWidth={true}
@@ -333,8 +331,10 @@ export function ToolbarInfoMenu(): JSX.Element | null {
 
 export function Toolbar(): JSX.Element | null {
     const ref = useRef<HTMLDivElement | null>(null)
-    const { minimized, position, isDragging, hedgehogMode, isEmbeddedInApp, isLoading } = useValues(toolbarLogic)
-    const { setVisibleMenu, toggleMinimized, onMouseOrTouchDown, setElement, setIsBlurred } = useActions(toolbarLogic)
+    const { minimized, position, isDragging, hedgehogMode, isEmbeddedInApp, isLoading, isExiting } =
+        useValues(toolbarLogic)
+    const { setVisibleMenu, toggleMinimized, onMouseOrTouchDown, setElement, setIsBlurred, completeGracefulExit } =
+        useActions(toolbarLogic)
     const { isAuthenticated, userIntent } = useValues(toolbarConfigLogic)
     const { authenticate } = useActions(toolbarConfigLogic)
 
@@ -398,7 +398,12 @@ export function Toolbar(): JSX.Element | null {
                     title={isAuthenticated ? 'Minimize' : 'Authenticate the PostHog Toolbar'}
                     titleMinimized={isAuthenticated ? 'Expand the toolbar' : 'Authenticate the PostHog Toolbar'}
                 >
-                    <AnimatedLogomark animate={isLoading} className="Toolbar__logomark" />
+                    <AnimatedLogomark
+                        animate={isLoading}
+                        animateOnce={isExiting}
+                        onAnimationComplete={completeGracefulExit}
+                        className="Toolbar__logomark"
+                    />
                 </ToolbarButton>
                 {isAuthenticated ? (
                     <>

--- a/frontend/src/toolbar/bar/toolbarLogic.ts
+++ b/frontend/src/toolbar/bar/toolbarLogic.ts
@@ -65,6 +65,8 @@ export const toolbarLogic = kea<toolbarLogicType>([
             ['remoteWebVitalsLoading'],
         ],
         actions: [
+            toolbarConfigLogic,
+            ['logout'],
             actionsTabLogic,
             [
                 'showButtonActions',
@@ -110,6 +112,8 @@ export const toolbarLogic = kea<toolbarLogicType>([
         maybeSendNavigationMessage: true,
         togglePiiMasking: (enabled?: boolean) => ({ enabled }),
         setPiiMaskingColor: (color: string) => ({ color }),
+        startGracefulExit: true,
+        completeGracefulExit: true,
     })),
     windowValues(() => ({
         windowHeight: (window: Window) => window.innerHeight,
@@ -220,6 +224,13 @@ export const toolbarLogic = kea<toolbarLogicType>([
             { persist: true },
             {
                 setPiiMaskingColor: (_, { color }) => color,
+            },
+        ],
+        isExiting: [
+            false,
+            {
+                startGracefulExit: () => true,
+                completeGracefulExit: () => false,
             },
         ],
     })),
@@ -556,6 +567,13 @@ export const toolbarLogic = kea<toolbarLogicType>([
             if (styleElement && values.piiMaskingEnabled) {
                 styleElement.textContent = generatePiiMaskingCSS(color, values.posthog)
             }
+        },
+        startGracefulExit: () => {
+            actions.setVisibleMenu('none')
+            actions.toggleMinimized(true)
+        },
+        completeGracefulExit: () => {
+            actions.logout()
         },
     })),
     afterMount(({ actions, values, cache }) => {


### PR DESCRIPTION
## Problem

The toolbar exit can be a bit janky with some component flicker before it closes.

## Changes

We added logo animation for loading in https://github.com/PostHog/posthog/pull/42671 so rather than just calling `logout` directly, let's use the animation to exit gracefully - collapse the toolbar, animate the hog once, fade out.

## How did you test this code?

Tested locally

https://github.com/user-attachments/assets/5661af53-4006-4263-a7a2-bafe2739d37c


