### PR TITLE
fix: project menu gets fit-content, unified components into Menus.tsx

### DIFF
--- a/frontend/src/layout/navigation/EnvironmentSwitcher.tsx
+++ b/frontend/src/layout/navigation/EnvironmentSwitcher.tsx
@@ -10,8 +10,8 @@ import { UploadedLogo } from 'lib/lemon-ui/UploadedLogo'
 import { IconBlank } from 'lib/lemon-ui/icons'
 import { ButtonGroupPrimitive, ButtonPrimitive, ButtonPrimitiveProps } from 'lib/ui/Button/ButtonPrimitives'
 import { Combobox } from 'lib/ui/Combobox/Combobox'
-import { DropdownMenuOpenIndicator } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { Label } from 'lib/ui/Label/Label'
+import { MenuOpenIndicator, MenuSeparator } from 'lib/ui/Menus/Menus'
 import {
     PopoverPrimitive,
     PopoverPrimitiveContent,
@@ -75,7 +75,7 @@ export function EnvironmentSwitcherOverlay({
                     <Label intent="menu" className="px-2 mt-2">
                         Current project
                     </Label>
-                    <div className="-mx-1 my-1 h-px bg-border-primary shrink-0" />
+                    <MenuSeparator />
 
                     <Combobox.Group value={[projectName]}>
                         <ButtonGroupPrimitive fullWidth className="[&>span]:contents">
@@ -171,7 +171,7 @@ export function EnvironmentSwitcherOverlay({
                         <Label intent="menu" className="px-2 mt-2">
                             Other projects
                         </Label>
-                        <div className="-mx-1.5 my-1 h-px bg-border-primary shrink-0" />
+                        <MenuSeparator className="-mx-1.5" />
                     </>
                 )
             }
@@ -275,7 +275,7 @@ export function EnvironmentSwitcherOverlay({
                     ) : (
                         <span className="truncate">{currentProject?.name ?? 'Project'}</span>
                     )}
-                    {!iconOnly && <DropdownMenuOpenIndicator />}
+                    {!iconOnly && <MenuOpenIndicator />}
                 </ButtonPrimitive>
             </PopoverPrimitiveTrigger>
             <PopoverPrimitiveContent align="start" className="w-[300px] sm:w-[500px] max-w-[300px] sm:max-w-[500px]">

--- a/frontend/src/lib/components/Account/AccountMenu.tsx
+++ b/frontend/src/lib/components/Account/AccountMenu.tsx
@@ -33,7 +33,6 @@ import {
     DropdownMenuContent,
     DropdownMenuGroup,
     DropdownMenuItem,
-    DropdownMenuOpenIndicator,
     DropdownMenuSeparator,
     DropdownMenuSub,
     DropdownMenuSubContent,
@@ -41,6 +40,7 @@ import {
     DropdownMenuTrigger,
 } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { Label } from 'lib/ui/Label/Label'
+import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -83,7 +83,7 @@ function ThemeMenu(): JSX.Element {
                     Color theme
                     <div className="ml-auto flex items-center gap-1">
                         <LemonTag>{themeMode}</LemonTag>
-                        <DropdownMenuOpenIndicator intent="sub" />
+                        <MenuOpenIndicator intent="sub" className="ml-auto" />
                     </div>
                 </ButtonPrimitive>
             </DropdownMenuSubTrigger>
@@ -263,7 +263,7 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                             <ButtonPrimitive menuItem>
                                 <IconBlank />
                                 Other organizations
-                                <DropdownMenuOpenIndicator intent="sub" />
+                                <MenuOpenIndicator intent="sub" />
                             </ButtonPrimitive>
                         </DropdownMenuSubTrigger>
                         <DropdownMenuSubContent className="min-w-[var(--project-panel-width)]">
@@ -372,7 +372,7 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                                     <IconCake />
                                     Game center
                                     <div className="ml-auto">
-                                        <DropdownMenuOpenIndicator intent="sub" />
+                                        <MenuOpenIndicator intent="sub" className="ml-auto" />
                                     </div>
                                 </ButtonPrimitive>
                             </DropdownMenuSubTrigger>

--- a/frontend/src/lib/components/Account/OrgCombobox.tsx
+++ b/frontend/src/lib/components/Account/OrgCombobox.tsx
@@ -6,6 +6,7 @@ import { UploadedLogo } from 'lib/lemon-ui/UploadedLogo'
 import { IconBlank } from 'lib/lemon-ui/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Combobox } from 'lib/ui/Combobox/Combobox'
+import { DropdownMenuSeparator } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { Label } from 'lib/ui/Label/Label'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -32,7 +33,7 @@ export function OrgCombobox({ allowCreate = true }: { allowCreate?: boolean }): 
                 <Label intent="menu" className="px-2">
                     Current organization
                 </Label>
-                <div className="-mx-1 my-1 h-px bg-border-primary shrink-0" />
+                <DropdownMenuSeparator />
 
                 <Combobox.Empty>No organizations found</Combobox.Empty>
 
@@ -62,40 +63,45 @@ export function OrgCombobox({ allowCreate = true }: { allowCreate?: boolean }): 
                     </Combobox.Group>
                 )}
 
-                <Label intent="menu" className="px-2 mt-2">
-                    Other organizations
-                </Label>
-                <div className="-mx-1 my-1 h-px bg-border-primary shrink-0" />
-
-                {otherOrganizations.map((otherOrganization) => (
-                    <Combobox.Group value={[otherOrganization.name]} key={otherOrganization.id}>
-                        <Combobox.Item key={otherOrganization.id} asChild>
-                            <ButtonPrimitive
-                                menuItem
-                                onClick={() => updateCurrentOrganization(otherOrganization.id)}
-                                tooltip={`Switch to organization: ${otherOrganization.name}`}
-                                tooltipPlacement="right"
-                                data-attr="tree-navbar-organization-dropdown-other-organization-button"
-                            >
-                                <IconBlank />
-                                <UploadedLogo
-                                    size="xsmall"
-                                    name={otherOrganization.name}
-                                    entityId={otherOrganization.id}
-                                    mediaId={otherOrganization.logo_media_id}
-                                />
-                                <span className="truncate max-w-full">{otherOrganization.name}</span>
-                                <div className="ml-auto">
-                                    <AccessLevelIndicator organization={otherOrganization} />
-                                </div>
-                            </ButtonPrimitive>
-                        </Combobox.Item>
-                    </Combobox.Group>
-                ))}
+                {otherOrganizations.length > 0 ? (
+                    <>
+                        <Label intent="menu" className="px-2 mt-2">
+                            Other organizations
+                        </Label>
+                        <DropdownMenuSeparator />
+                        {otherOrganizations.map((otherOrganization) => (
+                            <Combobox.Group value={[otherOrganization.name]} key={otherOrganization.id}>
+                                <Combobox.Item key={otherOrganization.id} asChild>
+                                    <ButtonPrimitive
+                                        menuItem
+                                        onClick={() => updateCurrentOrganization(otherOrganization.id)}
+                                        tooltip={`Switch to organization: ${otherOrganization.name}`}
+                                        tooltipPlacement="right"
+                                        data-attr="tree-navbar-organization-dropdown-other-organization-button"
+                                    >
+                                        <IconBlank />
+                                        <UploadedLogo
+                                            size="xsmall"
+                                            name={otherOrganization.name}
+                                            entityId={otherOrganization.id}
+                                            mediaId={otherOrganization.logo_media_id}
+                                        />
+                                        <span className="truncate max-w-full">{otherOrganization.name}</span>
+                                        <div className="ml-auto">
+                                            <AccessLevelIndicator organization={otherOrganization} />
+                                        </div>
+                                    </ButtonPrimitive>
+                                </Combobox.Item>
+                            </Combobox.Group>
+                        ))}
+                    </>
+                ) : (
+                    <Combobox.Empty>No other organizations found</Combobox.Empty>
+                )}
 
                 {preflight?.can_create_org && allowCreate && (
                     <>
-                        <div className="-mx-1 my-1 h-px bg-border-primary shrink-0" />
+                        <DropdownMenuSeparator />
                         <Combobox.Item asChild>
                             <ButtonPrimitive
                                 menuItem

--- a/frontend/src/lib/components/Account/OrganizationMenu.tsx
+++ b/frontend/src/lib/components/Account/OrganizationMenu.tsx
@@ -3,7 +3,7 @@ import { useValues } from 'kea'
 import { OrgCombobox } from 'lib/components/Account/OrgCombobox'
 import { UploadedLogo } from 'lib/lemon-ui/UploadedLogo/UploadedLogo'
 import { ButtonPrimitive, ButtonPrimitiveProps } from 'lib/ui/Button/ButtonPrimitives'
-import { DropdownMenuOpenIndicator } from 'lib/ui/DropdownMenu/DropdownMenu'
+import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
 import {
     PopoverPrimitive,
     PopoverPrimitiveContent,
@@ -51,7 +51,7 @@ export function OrganizationMenu({
                                 <span className="truncate font-semibold">
                                     {currentOrganization ? currentOrganization.name : 'Select organization'}
                                 </span>
-                                <DropdownMenuOpenIndicator />
+                                <MenuOpenIndicator />
                             </>
                         )}
                     </ButtonPrimitive>

--- a/frontend/src/lib/components/Account/ProjectMenu.tsx
+++ b/frontend/src/lib/components/Account/ProjectMenu.tsx
@@ -9,8 +9,9 @@ import { IconBlank } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonGroupPrimitive, ButtonPrimitive, ButtonPrimitiveProps } from 'lib/ui/Button/ButtonPrimitives'
 import { Combobox } from 'lib/ui/Combobox/Combobox'
-import { DropdownMenuOpenIndicator } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { Label } from 'lib/ui/Label/Label'
+import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
+import { MenuSeparator } from 'lib/ui/Menus/Menus'
 import {
     PopoverPrimitive,
     PopoverPrimitiveContent,
@@ -72,20 +73,17 @@ export function ProjectMenu({
                     ) : (
                         <span className="truncate">{currentTeam.name ?? 'Project'}</span>
                     )}
-                    {!iconOnly && <DropdownMenuOpenIndicator />}
+                    {!iconOnly && <MenuOpenIndicator className="ml-auto" />}
                 </ButtonPrimitive>
             </PopoverPrimitiveTrigger>
-            <PopoverPrimitiveContent
-                align="start"
-                className="w-[var(--project-panel-inner-width)] max-w-[var(--project-panel-inner-width)]"
-            >
+            <PopoverPrimitiveContent align="start" className="min-w-[var(--radix-popper-anchor-width)] max-w-fit">
                 <Combobox>
                     <Combobox.Search placeholder="Filter projects..." />
                     <Combobox.Content>
                         <Label intent="menu" className="px-2">
                             Current project
                         </Label>
-                        <div className="my-1 h-px bg-border-primary shrink-0" />
+                        <MenuSeparator />
 
                         <Combobox.Empty>No projects found</Combobox.Empty>
 
@@ -129,7 +127,7 @@ export function ProjectMenu({
                                     <Label intent="menu" className="px-2 mt-2">
                                         Other projects
                                     </Label>
-                                    <div className="my-1 h-px bg-border-primary shrink-0" />
+                                    <MenuSeparator />
                                 </>
                             )}
 
@@ -182,7 +180,7 @@ export function ProjectMenu({
                                     </Combobox.Group>
                                 )
                             })}
-                        <div className="my-1 h-px bg-border-primary shrink-0" />
+                        <MenuSeparator />
                         {preflight?.can_create_org && (
                             <Combobox.Item
                                 asChild

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneAddToNotebookDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneAddToNotebookDropdownMenu.tsx
@@ -1,12 +1,8 @@
 import { IconPlusSmall } from '@posthog/icons'
 
 import { ButtonPrimitive, ButtonPrimitiveProps } from 'lib/ui/Button/ButtonPrimitives'
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuOpenIndicator,
-    DropdownMenuTrigger,
-} from 'lib/ui/DropdownMenu/DropdownMenu'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from 'lib/ui/DropdownMenu/DropdownMenu'
+import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
 import { NotebookNodeType } from 'scenes/notebooks/types'
 
 import { NodeKind } from '~/queries/schema/schema-general'
@@ -34,7 +30,7 @@ export function SceneAddToNotebookDropdownMenu({
                 >
                     <IconPlusSmall />
                     Add to notebook
-                    <DropdownMenuOpenIndicator />
+                    <MenuOpenIndicator className="ml-auto" />
                 </ButtonPrimitive>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" matchTriggerWidth className="min-w-none max-w-none">

--- a/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu.tsx
+++ b/frontend/src/lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu.tsx
@@ -6,9 +6,9 @@ import {
     DropdownMenuContent,
     DropdownMenuGroup,
     DropdownMenuItem,
-    DropdownMenuOpenIndicator,
     DropdownMenuTrigger,
 } from 'lib/ui/DropdownMenu/DropdownMenu'
+import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
 
 import { ExportContext, ExporterFormat, OnlineExportContext } from '~/types'
 
@@ -40,7 +40,7 @@ export function SceneExportDropdownMenu({ dropdownMenuItems }: SceneExportDropdo
                 <ButtonPrimitive menuItem>
                     <IconDownload />
                     Export
-                    <DropdownMenuOpenIndicator className="ml-auto" />
+                    <MenuOpenIndicator className="ml-auto" />
                 </ButtonPrimitive>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" matchTriggerWidth>

--- a/frontend/src/lib/components/Scenes/SceneFile.tsx
+++ b/frontend/src/lib/components/Scenes/SceneFile.tsx
@@ -8,9 +8,9 @@ import {
     DropdownMenuContent,
     DropdownMenuGroup,
     DropdownMenuItem,
-    DropdownMenuOpenIndicator,
     DropdownMenuTrigger,
 } from 'lib/ui/DropdownMenu/DropdownMenu'
+import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
 
 import { PROJECT_TREE_KEY } from '~/layout/panel-layout/ProjectTree/ProjectTree'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
@@ -35,7 +35,7 @@ export function SceneFile({ dataAttrKey }: { dataAttrKey: string }): JSX.Element
                     <ButtonPrimitive variant="panel" menuItem data-attr={`${dataAttrKey}-file-dropdown-menu-trigger`}>
                         <IconFolderOpen />
                         {splitPath(projectTreeRefEntry.path).slice(0, -1).join('/')}
-                        <DropdownMenuOpenIndicator className="ml-auto" />
+                        <MenuOpenIndicator className="ml-auto" />
                     </ButtonPrimitive>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" matchTriggerWidth>

--- a/frontend/src/lib/ui/Combobox/Combobox.stories.tsx
+++ b/frontend/src/lib/ui/Combobox/Combobox.stories.tsx
@@ -5,7 +5,7 @@ import { IconGear, IconPlusSmall } from '@posthog/icons'
 import { Link } from 'lib/lemon-ui/Link'
 
 import { ButtonGroupPrimitive, ButtonPrimitive } from '../Button/ButtonPrimitives'
-import { DropdownMenuOpenIndicator } from '../DropdownMenu/DropdownMenu'
+import { MenuOpenIndicator, MenuSeparator } from '../Menus/Menus'
 import {
     PopoverPrimitive,
     PopoverPrimitiveContent,
@@ -42,7 +42,7 @@ function RenderCombobox(): JSX.Element {
 
                 {/* Groups with no value are "static" and don't affect Empty state */}
                 <Combobox.Group>
-                    <div className="-mx-1 my-1 h-px bg-border-primary shrink-0" />
+                    <MenuSeparator />
                 </Combobox.Group>
 
                 <Combobox.Group value={['Banana']}>
@@ -51,7 +51,7 @@ function RenderCombobox(): JSX.Element {
                         <ButtonPrimitive menuItem>Searchable: Banana</ButtonPrimitive>
                     </Combobox.Item>
                 </Combobox.Group>
-                <div className="-mx-1 my-1 h-px bg-border-primary shrink-0" />
+                <MenuSeparator />
 
                 <Combobox.Group value={['projectName']}>
                     <ButtonGroupPrimitive fullWidth className="[&>span]:contents">
@@ -130,7 +130,7 @@ export function InPopover(): JSX.Element {
                 <PopoverPrimitiveTrigger asChild>
                     <ButtonPrimitive data-attr="environment-switcher-button" size="sm">
                         Trigger popover
-                        <DropdownMenuOpenIndicator />
+                        <MenuOpenIndicator className="ml-auto" />
                     </ButtonPrimitive>
                 </PopoverPrimitiveTrigger>
                 <PopoverPrimitiveContent align="start">

--- a/frontend/src/lib/ui/ContextMenu/ContextMenu.tsx
+++ b/frontend/src/lib/ui/ContextMenu/ContextMenu.tsx
@@ -8,6 +8,8 @@ import { IconCheckCircle } from '@posthog/icons'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { cn } from 'lib/utils/css-classes'
 
+import { MenuSeparator } from '../Menus/Menus'
+
 const ContextMenu = ContextMenuPrimitive.Root
 
 const ContextMenuTrigger = ContextMenuPrimitive.Trigger
@@ -166,11 +168,9 @@ const ContextMenuSeparator = React.forwardRef<
     React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
 >(
     ({ className, ...props }, ref): JSX.Element => (
-        <ContextMenuPrimitive.Separator
-            ref={ref}
-            className={cn('-mx-1 my-1 h-px bg-border-primary', className)}
-            {...props}
-        />
+        <ContextMenuPrimitive.Separator ref={ref} asChild {...props}>
+            <MenuSeparator className={className} />
+        </ContextMenuPrimitive.Separator>
     )
 )
 ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName

--- a/frontend/src/lib/ui/DropdownMenu/DropdownMenu.tsx
+++ b/frontend/src/lib/ui/DropdownMenu/DropdownMenu.tsx
@@ -1,12 +1,13 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import * as React from 'react'
 
-import { IconCheck, IconChevronRight } from '@posthog/icons'
+import { IconCheck } from '@posthog/icons'
 
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { cn } from 'lib/utils/css-classes'
 
 import { Label } from '../Label/Label'
+import { MenuSeparator } from '../Menus/Menus'
 
 /* -------------------------------------------------------------------------- */
 /*                           Button Context & Hook                            */
@@ -203,35 +204,12 @@ const DropdownMenuSeparator = React.forwardRef<
     React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
 >(
     ({ className, ...props }, ref): JSX.Element => (
-        <DropdownMenuPrimitive.Separator
-            ref={ref}
-            className={cn('-mx-1 my-1 h-px bg-border-primary', className)}
-            {...props}
-        />
+        <DropdownMenuPrimitive.Separator ref={ref} {...props} asChild>
+            <MenuSeparator className={className} />
+        </DropdownMenuPrimitive.Separator>
     )
 )
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
-
-interface DropdownMenuOpenIndicatorProps extends React.HTMLAttributes<HTMLOrSVGElement> {
-    intent?: 'default' | 'sub'
-}
-const DropdownMenuOpenIndicator = ({
-    className,
-    intent = 'default',
-    ...props
-}: DropdownMenuOpenIndicatorProps): JSX.Element => {
-    return (
-        <IconChevronRight
-            className={cn(
-                'ml-auto size-3 text-secondary rotate-90 group-data-[state=open]/button-primitive:rotate-270 transition-transform duration-200 prefers-reduced-motion:transition-none',
-                intent === 'sub' && 'rotate-0 group-data-[state=open]/button-primitive:rotate-0',
-                className
-            )}
-            {...props}
-        />
-    )
-}
-DropdownMenuOpenIndicator.displayName = 'DropdownMenuOpenIndicator'
 
 const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>): JSX.Element => {
     return <span className={cn('ml-auto text-xs tracking-widest opacity-60', className)} {...props} />
@@ -255,5 +233,4 @@ export {
     DropdownMenuSubContent,
     DropdownMenuSubTrigger,
     DropdownMenuTrigger,
-    DropdownMenuOpenIndicator,
 }

--- a/frontend/src/lib/ui/Menus/Menus.tsx
+++ b/frontend/src/lib/ui/Menus/Menus.tsx
@@ -1,0 +1,35 @@
+import { forwardRef } from 'react'
+
+import { IconChevronRight } from '@posthog/icons'
+
+import { cn } from 'lib/utils/css-classes'
+
+/* -------------------------------------------------------------------------- */
+/*                           Menu Separator                                 */
+/* -------------------------------------------------------------------------- */
+export const MenuSeparator = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ className, ...props }, ref) => {
+        return <div ref={ref} className={cn('my-1 h-px bg-border-primary shrink-0 -mx-1', className)} {...props} />
+    }
+)
+MenuSeparator.displayName = 'MenuSeparator'
+
+/* -------------------------------------------------------------------------- */
+/*                           Menu Open Indicator                             */
+/* -------------------------------------------------------------------------- */
+interface MenuOpenIndicatorProps extends React.HTMLAttributes<HTMLOrSVGElement> {
+    intent?: 'default' | 'sub'
+}
+export const MenuOpenIndicator = ({ className, intent = 'default', ...props }: MenuOpenIndicatorProps): JSX.Element => {
+    return (
+        <IconChevronRight
+            className={cn(
+                'ml-auto size-3 text-secondary rotate-90 group-data-[state=open]/button-primitive:rotate-270 transition-transform duration-200 prefers-reduced-motion:transition-none',
+                intent === 'sub' && 'rotate-0 group-data-[state=open]/button-primitive:rotate-0',
+                className
+            )}
+            {...props}
+        />
+    )
+}
+MenuOpenIndicator.displayName = 'MenuOpenIndicator'

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ScenePanel/IssueAssigneeSelect.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ScenePanel/IssueAssigneeSelect.tsx
@@ -1,5 +1,5 @@
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import { DropdownMenuOpenIndicator } from 'lib/ui/DropdownMenu/DropdownMenu'
+import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
 
 import { ErrorTrackingIssueAssignee } from '~/queries/schema/schema-general'
 
@@ -24,7 +24,7 @@ export const IssueAssigneeSelect = ({
                             <AssigneeIconDisplay assignee={anyAssignee} size="small" />
                             <AssigneeLabelDisplay assignee={anyAssignee} className="ml-1" size="small" />
                         </div>
-                        {!disabled && <DropdownMenuOpenIndicator />}
+                        {!disabled && <MenuOpenIndicator className="ml-auto" />}
                     </ButtonPrimitive>
                 )}
             </AssigneeSelect>


### PR DESCRIPTION
## Problem
* Project menu has a max-width + truncate, and this isn't ideal for users/orgs with long project names... they'd have to wait for the tooltip to show the full name and that's just wasted time
* Dropdown menus/Context/ Popovers were rolling their own `dividers` or using the `dropdown menu divider` (pulling a component from unrelated file)
* Dropdown menus/Context/ Popovers were  using the `dropdown menu open indicator` (pulling a component from unrelated file)
* Org dropdown had empty "Other orgs" when no other orgs available


## Changes
* [Project menu] Remove max-width, add min-width = trigger allowing long names to show naturally
* Moved dropdown divider to own file `Menus.tsx` and get all components that used to import from there
* Moved dropdown menu open indicator to `Menus.tsx` and get all components that used to import from there
* Org dropdown now hides "Other orgs" when no other orgs available

<img width="563" height="314" alt="image" src="https://github.com/user-attachments/assets/00429405-1b5b-461e-a6fe-c717e33ec67d" />

![2025-12-11 11 04 33](https://github.com/user-attachments/assets/458964cf-0900-4990-9d3c-3fada7b02b45)


## How did you test this code?
Locally