### PR TITLE
fix: project rename crash with Revenue Analytics enabled

### DIFF
--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -307,7 +307,8 @@ export const teamLogic = kea<teamLogicType>([
         ],
         customerAnalyticsConfig: [
             (s) => [s.currentTeam],
-            (currentTeam: TeamType): CustomerAnalyticsConfig => currentTeam.customer_analytics_config,
+            (currentTeam: TeamType): CustomerAnalyticsConfig =>
+                currentTeam?.customer_analytics_config ?? ({} as CustomerAnalyticsConfig),
         ],
     })),
     listeners(({ actions }) => ({

--- a/products/revenue_analytics/frontend/settings/revenueAnalyticsSettingsLogic.ts
+++ b/products/revenue_analytics/frontend/settings/revenueAnalyticsSettingsLogic.ts
@@ -199,9 +199,16 @@ export const revenueAnalyticsSettingsLogic = kea<revenueAnalyticsSettingsLogicTy
             // TODO: Check how to pass the preflight region here
             values.currentTeam?.revenue_analytics_config || createEmptyConfig(),
             {
-                updateCurrentTeam: (_, { revenue_analytics_config }) => {
+                updateCurrentTeam: (state, { revenue_analytics_config }) => {
+                    // Only update if revenue_analytics_config is explicitly provided
+                    if (revenue_analytics_config === undefined) {
+                        return state
+                    }
                     // TODO: Check how to pass the preflight region here
                     return revenue_analytics_config || createEmptyConfig()
+                },
+                loadRevenueAnalyticsConfigSuccess: (_, { revenueAnalyticsConfig }) => {
+                    return revenueAnalyticsConfig || createEmptyConfig()
                 },
             },
         ],


### PR DESCRIPTION
## Problem
Renaming a project with Revenue Analytics enabled throws TypeError: `Cannot read properties of undefined (reading 'activity_event').`
The `customerAnalyticsConfig` selector crashes when `currentTeam` is momentarily null during the post-rename `loadUser()` refresh.

Closes #43156

## Changes

Return empty config {} as fallback when currentTeam is null

## How did you test this code?
How to reproduce the bug: 
Enable `customer-analytics-roadmap` feature flag locally. 
Go to settings
Rename the project