### PR TITLE
fix(insights): better UX when 'filter test accounts' option is not allowed

### DIFF
--- a/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
+++ b/frontend/src/lib/components/TestAccountFiltersSwitch.tsx
@@ -20,8 +20,12 @@ export function TestAccountFilterSwitch({ checked, onChange, ...props }: TestAcc
         <LemonSwitch
             id="test-account-filter"
             bordered
-            disabledReason={!hasFilters ? "You haven't set any internal test filters" : null}
             {...props}
+            disabledReason={
+                !hasFilters
+                    ? "You haven't set any internal test filters. Click the gear icon to configure."
+                    : props.disabledReason
+            }
             checked={checked}
             onChange={onChange}
             label={


### PR DESCRIPTION
## Problem

Filter out test accounts toggle is not working when there are no configured rules.
The toggle should be disabled instead of not allowing it to be set as active.

## Changes

Disable the toggle, and show a descriptive message.

<img width="571" height="101" alt="Screenshot 2025-12-11 at 14 40 21" src="https://github.com/user-attachments/assets/1f488622-2bda-4ecb-b0e1-f8d4bb7206b4" />

On hover:
<img width="562" height="112" alt="Screenshot 2025-12-11 at 14 40 28" src="https://github.com/user-attachments/assets/8c10cc45-a6c0-438d-b090-6e90fd5be7db" />


## How did you test this code?

Manually
