### PR TITLE
fix(workflows): Allow entering spaces 

### DIFF
--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -76,6 +76,13 @@ function initEditor(
     if (editorProps?.language === 'liquid') {
         initLiquidLanguage(monaco)
     }
+
+    editor.onKeyDown((evt) => {
+        if (evt.keyCode === monaco.KeyCode.Space) {
+            evt.stopPropagation()
+        }
+    })
+
     if (options.tabFocusMode || editorProps.onPressUpNoValue) {
         editor.onKeyDown((evt) => {
             if (options.tabFocusMode) {

--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -81,51 +81,41 @@ function initEditor(
         if (evt.keyCode === monaco.KeyCode.Space) {
             evt.stopPropagation()
         }
-        if (options.tabFocusMode || editorProps.onPressUpNoValue) {
-            if (options.tabFocusMode) {
 
-    if (options.tabFocusMode || editorProps.onPressUpNoValue) {
-        editor.onKeyDown((evt) => {
-            if (options.tabFocusMode) {
-                if (evt.keyCode === monaco.KeyCode.Tab && !evt.metaKey && !evt.ctrlKey) {
-                    const selection = editor.getSelection()
-                    if (
-                        selection &&
-                        (selection.startColumn !== selection.endColumn ||
-                            selection.startLineNumber !== selection.endLineNumber)
-                    ) {
-                        return
-                    }
-                    evt.preventDefault()
-                    evt.stopPropagation()
-
-                    const element: HTMLElement | null = evt.target?.parentElement?.parentElement?.parentElement ?? null
-                    if (!element) {
-                        return
-                    }
-                    const nextElement = evt.shiftKey
-                        ? findPreviousFocusableElement(element)
-                        : findNextFocusableElement(element)
-
-                    if (nextElement && 'focus' in nextElement) {
-                        nextElement.focus()
-                    }
-                }
-            }
-            if (editorProps.onPressUpNoValue) {
+        if (options.tabFocusMode) {
+            if (evt.keyCode === monaco.KeyCode.Tab && !evt.metaKey && !evt.ctrlKey) {
+                const selection = editor.getSelection()
                 if (
-                    evt.keyCode === monaco.KeyCode.UpArrow &&
-                    !evt.metaKey &&
-                    !evt.ctrlKey &&
-                    editor.getValue() === ''
+                    selection &&
+                    (selection.startColumn !== selection.endColumn ||
+                        selection.startLineNumber !== selection.endLineNumber)
                 ) {
-                    evt.preventDefault()
-                    evt.stopPropagation()
-                    editorProps.onPressUpNoValue()
+                    return
+                }
+                evt.preventDefault()
+                evt.stopPropagation()
+
+                const element: HTMLElement | null = evt.target?.parentElement?.parentElement?.parentElement ?? null
+                if (!element) {
+                    return
+                }
+                const nextElement = evt.shiftKey
+                    ? findPreviousFocusableElement(element)
+                    : findNextFocusableElement(element)
+
+                if (nextElement && 'focus' in nextElement) {
+                    nextElement.focus()
                 }
             }
-        })
-    }
+        }
+        if (editorProps.onPressUpNoValue) {
+            if (evt.keyCode === monaco.KeyCode.UpArrow && !evt.metaKey && !evt.ctrlKey && editor.getValue() === '') {
+                evt.preventDefault()
+                evt.stopPropagation()
+                editorProps.onPressUpNoValue()
+            }
+        }
+    })
 }
 
 export function CodeEditor({

--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -81,7 +81,8 @@ function initEditor(
         if (evt.keyCode === monaco.KeyCode.Space) {
             evt.stopPropagation()
         }
-    })
+        if (options.tabFocusMode || editorProps.onPressUpNoValue) {
+            if (options.tabFocusMode) {
 
     if (options.tabFocusMode || editorProps.onPressUpNoValue) {
         editor.onKeyDown((evt) => {


### PR DESCRIPTION
## Problem

Pressing space in workspace text inputs doesn't do anything, see: https://posthog.slack.com/archives/C06GG249PR6/p1765453958043689

## Changes

Preventing space events from bubbling up past the monaco editor so they can't be swallowed by some other handler. Not a root cause fix, unfortunately.

From looking through (and commenting out) keydown handlers, it seems like the culprit is not in our code, but possibly in a dependency. Gemini suggests that it might be react-draggable.