### PR TITLE
chore: run query again if materialization was run again in the meantime

### DIFF
--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -6,6 +6,7 @@ from django.core.cache import cache
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
+from dateutil.parser import isoparse
 from django_filters.rest_framework import DjangoFilterBackend
 from loginas.utils import is_impersonated_session
 from pydantic import BaseModel
@@ -489,6 +490,20 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         )
         return Response(result, status=response_status)
 
+    def _is_cache_stale(self, result: Response, saved_query) -> bool:
+        """Check if cached result is older than the materialization."""
+        if not isinstance(result.data, dict) or not result.data.get("is_cached"):
+            return False
+
+        last_refresh = result.data.get("last_refresh")
+        if not last_refresh or not saved_query.last_run_at:
+            return False
+
+        if isinstance(last_refresh, str):
+            last_refresh = isoparse(last_refresh)
+
+        return last_refresh < saved_query.last_run_at
+
     def _execute_materialized_endpoint(
         self, endpoint: Endpoint, data: EndpointRunRequest, request: Request
     ) -> Response:
@@ -527,9 +542,17 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             }
             tag_queries(workload=Workload.ENDPOINTS, warehouse_query=True)
 
-            return self._execute_query_and_respond(
+            result = self._execute_query_and_respond(
                 query_request_data, data.client_query_id, request, extra_result_fields=extra_fields
             )
+
+            if self._is_cache_stale(result, saved_query):
+                query_request_data["refresh"] = RefreshType.FORCE_BLOCKING
+                result = self._execute_query_and_respond(
+                    query_request_data, data.client_query_id, request, extra_result_fields=extra_fields
+                )
+
+            return result
         except Exception as e:
             capture_exception(
                 e,

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -331,6 +331,116 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         self.assertNotIn("created_by", response_data)
         self.assertNotIn("description", response_data)
 
+    def test_cache_invalidated_after_query_update(self):
+        """Test that updating endpoint query invalidates cache for materialized endpoints."""
+        initial_query = {
+            "kind": "HogQLQuery",
+            "query": "SELECT 1 as value",
+        }
+        updated_query = {
+            "kind": "HogQLQuery",
+            "query": "SELECT 2 as value",
+        }
+
+        endpoint = Endpoint.objects.create(
+            name="query_update_endpoint",
+            team=self.team,
+            query=initial_query,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR,
+            },
+            format="json",
+        )
+
+        endpoint.refresh_from_db()
+        self.assertEqual(endpoint.current_version, 1)
+        saved_query = endpoint.saved_query
+        assert saved_query is not None
+        saved_query.status = DataWarehouseSavedQuery.Status.COMPLETED
+        saved_query.last_run_at = timezone.now() - timedelta(minutes=20)
+        saved_query.table = DataWarehouseTable.objects.create(
+            team=self.team,
+            name="query_update_endpoint",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            url_pattern="s3://test-bucket/path",
+        )
+        saved_query.save()
+
+        with mock.patch("products.endpoints.backend.api.EndpointViewSet._execute_query_and_respond") as mock_execute:
+            old_cache_time = timezone.now() - timedelta(minutes=30)
+            old_cached_response = Response(
+                {
+                    "results": [[1]],
+                    "is_cached": True,
+                    "last_refresh": old_cache_time,
+                }
+            )
+            mock_execute.return_value = old_cached_response
+
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+                {},
+                format="json",
+            )
+
+            self.assertEqual(mock_execute.call_count, 2, "Old cache should be detected as stale and refreshed")
+
+        self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {"query": updated_query},
+            format="json",
+        )
+
+        endpoint.refresh_from_db()
+        self.assertEqual(endpoint.current_version, 2, "Version should be incremented after query update")
+
+        new_saved_query = endpoint.saved_query
+        assert new_saved_query is not None, "Materialization should be re-enabled after query update"
+        new_saved_query.status = DataWarehouseSavedQuery.Status.COMPLETED
+        new_saved_query.last_run_at = timezone.now()
+        new_saved_query.table = DataWarehouseTable.objects.create(
+            team=self.team,
+            name=f"query_update_endpoint_v2",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            url_pattern="s3://test-bucket/path-v2",
+        )
+        new_saved_query.save()
+
+        with mock.patch("products.endpoints.backend.api.EndpointViewSet._execute_query_and_respond") as mock_execute:
+            new_cache_time = timezone.now() - timedelta(minutes=5)
+            new_cached_response = Response(
+                {
+                    "results": [[1]],
+                    "is_cached": True,
+                    "last_refresh": new_cache_time,
+                }
+            )
+            fresh_response = Response({"results": [[2]], "is_cached": False})
+
+            mock_execute.side_effect = [new_cached_response, fresh_response]
+
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+                {},
+                format="json",
+            )
+
+            self.assertEqual(
+                mock_execute.call_count,
+                2,
+                "Cache from before query update should be stale (older than new materialization)",
+            )
+            self.assertEqual(
+                response.json()["results"], [[2]], "Should return fresh results after query update, not old cache"
+            )
+
     def test_materialized_endpoint_applies_filters_override(self):
         saved_query = DataWarehouseSavedQuery.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

if an endpoint query changes and is then materialized again because of it, the cache key stays the same because the query that we run is `select * from s3(...)`. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- check if the cache results are older than the last refresh of the materialization

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
- test test yeh man
<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
nah
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
