### PR TITLE
perf: update pytest configs to use '-n auto'

### DIFF
--- a/ee/hogai/eval/pytest.ini
+++ b/ee/hogai/eval/pytest.ini
@@ -6,5 +6,5 @@ env =
     TEST=1
     IN_EVAL_TESTING=1
 DJANGO_SETTINGS_MODULE = posthog.settings
-addopts = -p no:warnings --reuse-db -s -rfEp
+addopts = -p no:warnings --reuse-db -s -rfEp -n auto
 asyncio_mode = auto

--- a/ee/pytest.ini
+++ b/ee/pytest.ini
@@ -3,7 +3,7 @@ env =
     DEBUG=1
     TEST=1
 DJANGO_SETTINGS_MODULE = posthog.settings
-addopts = -p no:warnings --reuse-db
+addopts = -p no:warnings --reuse-db -n auto
 
 markers =
     ee

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -70,7 +70,7 @@
       
       
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_events_json_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_events_json_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
       SETTINGS kafka_skip_broken_messages = 100
   
@@ -90,7 +90,7 @@
       metric_name String,
       count Int64
   )
-  ENGINE=Kafka(msk_cluster, kafka_topic_list = 'clickhouse_app_metrics2_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ENGINE=Kafka(msk_cluster, kafka_topic_list = 'clickhouse_app_metrics2_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -111,7 +111,7 @@
       error_type String,
       error_details String CODEC(ZSTD(3))
   )
-  ENGINE=Kafka(msk_cluster, kafka_topic_list = 'clickhouse_app_metrics_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ENGINE=Kafka(msk_cluster, kafka_topic_list = 'clickhouse_app_metrics_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -141,7 +141,7 @@
       inserted_at DateTime64(3, 'UTC'),
       embeddings Array(Float64) -- We could experiment with quantization, but if we do we can use a new column, for now we'll eat the inefficiency
        -- Unused, I think, but the above has it, so
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_error_tracking_issue_fingerprint_embeddings_test', kafka_group_name = 'clickhouse_error_tracking_fingerprint_embeddings', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_error_tracking_issue_fingerprint_embeddings_test_gw1', kafka_group_name = 'clickhouse_error_tracking_fingerprint_embeddings', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -156,7 +156,7 @@
       is_deleted Int8,
       version Int64
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_error_tracking_issue_fingerprint_test', kafka_group_name = 'clickhouse-error-tracking-issue-fingerprint-overrides', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_error_tracking_issue_fingerprint_test_gw1', kafka_group_name = 'clickhouse-error-tracking-issue-fingerprint-overrides', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -182,7 +182,7 @@
       error VARCHAR,
       tags Array(VARCHAR)
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'events_dead_letter_queue_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'events_dead_letter_queue_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
    SETTINGS kafka_skip_broken_messages=1000
   '''
 # ---
@@ -257,7 +257,7 @@
       
       
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_events_json_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_events_json_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
       SETTINGS kafka_skip_broken_messages = 100
   
@@ -295,7 +295,7 @@
       
       
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_events_json_test', kafka_group_name = 'group1_recent', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_events_json_test_gw1', kafka_group_name = 'group1_recent', kafka_format = 'JSONEachRow')
   
       SETTINGS kafka_skip_broken_messages = 100,  kafka_num_consumers = 2, kafka_thread_per_consumer = 1
   
@@ -312,7 +312,7 @@
       team_id Int64,
       group_properties VARCHAR
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_groups_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_groups_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -337,7 +337,7 @@
       pointer_target_fixed Bool,
       current_url VARCHAR,
       type LowCardinality(String)
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_heatmap_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_heatmap_events_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -352,7 +352,7 @@
       details VARCHAR CODEC(ZSTD(3)),
       timestamp DateTime64(6, 'UTC')
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_ingestion_warnings_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_ingestion_warnings_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -381,7 +381,7 @@
       -- The actual log message.
       message String
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'log_entries_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'log_entries_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -438,7 +438,7 @@
   unload_event_end Float64,
   unload_event_start Float64
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_performance_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_performance_events_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -455,7 +455,7 @@
       is_deleted Int8,
       version UInt64
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -470,7 +470,7 @@
       is_deleted Int8,
       version Int64
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_distinct_id_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_distinct_id_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -484,7 +484,7 @@
       team_id Int64,
       _sign Nullable(Int8),
       is_deleted Nullable(Int8)
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_unique_id_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_unique_id_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -499,19 +499,19 @@
       is_deleted Int8,
       version Int64
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_distinct_id_test', kafka_group_name = 'clickhouse-person-distinct-id-overrides', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_distinct_id_test_gw1', kafka_group_name = 'clickhouse-person-distinct-id-overrides', kafka_format = 'JSONEachRow')
   
   '''
 # ---
 # name: test_create_kafka_table_with_different_kafka_host[kafka_person_overrides]
   '''
   
-      CREATE TABLE IF NOT EXISTS `posthog_test`.`kafka_person_overrides`
+      CREATE TABLE IF NOT EXISTS `posthog_test_gw1`.`kafka_person_overrides`
       ON CLUSTER 'posthog'
   
       ENGINE = Kafka(
           'kafka:9092', -- Kafka hosts
-          'clickhouse_person_override_test', -- Kafka topic
+          'clickhouse_person_override_test_gw1', -- Kafka topic
           'clickhouse-person-overrides', -- Kafka consumer group id
           'JSONEachRow' -- Specify that we should pass Kafka messages as JSON
       )
@@ -531,7 +531,7 @@
           -- set as a default value in the `person_overrides` table.
           -- created_at,
           version
-      FROM `posthog_test`.`person_overrides`
+      FROM `posthog_test_gw1`.`person_overrides`
   
   '''
 # ---
@@ -550,7 +550,7 @@
       message VARCHAR,
       instance_id UUID
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'plugin_log_entries_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'plugin_log_entries_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -570,7 +570,7 @@
       content String, -- The actual text content that was embedded
       embedding Array(Float64) -- The embedding itself
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_document_embeddings_test', kafka_group_name = 'clickhouse_document_embeddings', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_document_embeddings_test_gw1', kafka_group_name = 'clickhouse_document_embeddings', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -606,7 +606,7 @@
       created_at DateTime64(6, 'UTC')
       
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_recording_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_recording_events_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -636,7 +636,7 @@
       snapshot_source LowCardinality(Nullable(String)),
       snapshot_library Nullable(String),
       retention_period_days Nullable(Int64),
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_replay_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_replay_events_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -667,7 +667,7 @@
   , _partition UInt64
   
   )
-  ENGINE=Distributed('posthog', 'posthog_test', 'sharded_app_metrics2', rand())
+  ENGINE=Distributed('posthog', 'posthog_test_gw0', 'sharded_app_metrics2', rand())
   
   '''
 # ---
@@ -714,7 +714,7 @@
   , _partition UInt64
   
   )
-  ENGINE=Distributed('posthog', 'posthog_test', 'sharded_app_metrics', rand())
+  ENGINE=Distributed('posthog', 'posthog_test_gw0', 'sharded_app_metrics', rand())
   
   '''
 # ---
@@ -837,7 +837,7 @@
   , _partition UInt64
   , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64(), _timestamp_ms DateTime64
       
-  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test', 'events_recent', sipHash64(distinct_id))
+  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test_gw0', 'events_recent', sipHash64(distinct_id))
   
   '''
 # ---
@@ -861,7 +861,7 @@
   , _offset UInt64
   , _partition UInt64
   
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_posthog_document_embeddings', cityHash64(document_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw1', 'sharded_posthog_document_embeddings', cityHash64(document_id))
   
   '''
 # ---
@@ -915,7 +915,7 @@
   _timestamp,
   _offset,
   _partition
-  FROM posthog_test.kafka_error_tracking_issue_fingerprint_embeddings
+  FROM posthog_test_gw1.kafka_error_tracking_issue_fingerprint_embeddings
   
   '''
 # ---
@@ -958,7 +958,7 @@
   _timestamp,
   _offset,
   _partition
-  FROM posthog_test.kafka_error_tracking_issue_fingerprint_overrides
+  FROM posthog_test_gw1.kafka_error_tracking_issue_fingerprint_overrides
   WHERE version > 0 -- only store updated rows, not newly inserted ones
   
   '''
@@ -1051,7 +1051,7 @@
   , _offset UInt64
   , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64(), consumer_breadcrumbs Array(String)
       
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_events', sipHash64(distinct_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_events', sipHash64(distinct_id))
   
   '''
 # ---
@@ -1094,7 +1094,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS events_dead_letter_queue_mv ON CLUSTER 'posthog'
-  TO posthog_test.writable_events_dead_letter_queue
+  TO posthog_test_gw1.writable_events_dead_letter_queue
   AS SELECT
   id,
   event_uuid,
@@ -1114,7 +1114,7 @@
   tags,
   _timestamp,
   _offset
-  FROM posthog_test.kafka_events_dead_letter_queue
+  FROM posthog_test_gw1.kafka_events_dead_letter_queue
   
   '''
 # ---
@@ -1122,7 +1122,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS events_json_mv ON CLUSTER 'posthog'
-  TO posthog_test.writable_events
+  TO posthog_test_gw1.writable_events
   AS SELECT
   uuid,
   event,
@@ -1196,7 +1196,7 @@
           arrayEnumerate(_headers.name)
       )
   ) as consumer_breadcrumbs
-  FROM posthog_test.kafka_events_json
+  FROM posthog_test_gw1.kafka_events_json
   
   '''
 # ---
@@ -1248,7 +1248,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS events_recent_json_mv
-  TO posthog_test.writable_events_recent
+  TO posthog_test_gw1.writable_events_recent
   AS SELECT
   uuid,
   event,
@@ -1276,14 +1276,14 @@
   _timestamp_ms,
   _offset,
   _partition
-  FROM posthog_test.kafka_events_recent_json
+  FROM posthog_test_gw1.kafka_events_recent_json
   
   '''
 # ---
 # name: test_create_table_query[exchange_rate]
   '''
   
-  CREATE TABLE IF NOT EXISTS `posthog_test`.`exchange_rate` ON CLUSTER 'posthog' (
+  CREATE TABLE IF NOT EXISTS `posthog_test_gw0`.`exchange_rate` ON CLUSTER 'posthog' (
       currency String,
       date Date,
       rate Decimal64(10),
@@ -1354,7 +1354,7 @@
       _timestamp DateTime,
       _offset UInt64,
       _partition UInt64
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_heatmaps', cityHash64(concat(toString(team_id), '-', session_id, '-', toString(toDate(timestamp)))))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw1', 'sharded_heatmaps', cityHash64(concat(toString(team_id), '-', session_id, '-', toString(toDate(timestamp)))))
   
   '''
 # ---
@@ -1362,7 +1362,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS heatmaps_mv
-  TO posthog_test.writable_heatmaps
+  TO posthog_test_gw1.writable_heatmaps
   AS SELECT
       session_id,
       team_id,
@@ -1383,7 +1383,7 @@
       _timestamp,
       _offset,
       _partition
-  FROM posthog_test.kafka_heatmaps
+  FROM posthog_test_gw1.kafka_heatmaps
   
   '''
 # ---
@@ -1402,7 +1402,7 @@
   , _offset UInt64
   , _partition UInt64
   
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_ingestion_warnings', rand())
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_ingestion_warnings', rand())
   
   '''
 # ---
@@ -1410,7 +1410,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS ingestion_warnings_mv
-  TO posthog_test.writable_ingestion_warnings
+  TO posthog_test_gw1.writable_ingestion_warnings
   AS SELECT
   team_id,
   source,
@@ -1420,7 +1420,7 @@
   _timestamp,
   _offset,
   _partition
-  FROM posthog_test.kafka_ingestion_warnings
+  FROM posthog_test_gw1.kafka_ingestion_warnings
   
   '''
 # ---
@@ -1438,7 +1438,7 @@
       metric_name String,
       count Int64
   )
-  ENGINE=Kafka(msk_cluster, kafka_topic_list = 'clickhouse_app_metrics2_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ENGINE=Kafka(msk_cluster, kafka_topic_list = 'clickhouse_app_metrics2_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1459,7 +1459,7 @@
       error_type String,
       error_details String CODEC(ZSTD(3))
   )
-  ENGINE=Kafka(msk_cluster, kafka_topic_list = 'clickhouse_app_metrics_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ENGINE=Kafka(msk_cluster, kafka_topic_list = 'clickhouse_app_metrics_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1489,7 +1489,7 @@
       inserted_at DateTime64(3, 'UTC'),
       embeddings Array(Float64) -- We could experiment with quantization, but if we do we can use a new column, for now we'll eat the inefficiency
        -- Unused, I think, but the above has it, so
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_error_tracking_issue_fingerprint_embeddings_test', kafka_group_name = 'clickhouse_error_tracking_fingerprint_embeddings', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_error_tracking_issue_fingerprint_embeddings_test_gw1', kafka_group_name = 'clickhouse_error_tracking_fingerprint_embeddings', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1504,7 +1504,7 @@
       is_deleted Int8,
       version Int64
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_error_tracking_issue_fingerprint_test', kafka_group_name = 'clickhouse-error-tracking-issue-fingerprint-overrides', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_error_tracking_issue_fingerprint_test_gw1', kafka_group_name = 'clickhouse-error-tracking-issue-fingerprint-overrides', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1530,7 +1530,7 @@
       error VARCHAR,
       tags Array(VARCHAR)
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'events_dead_letter_queue_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'events_dead_letter_queue_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
    SETTINGS kafka_skip_broken_messages=1000
   '''
 # ---
@@ -1605,7 +1605,7 @@
       
       
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_events_json_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_events_json_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
       SETTINGS kafka_skip_broken_messages = 100
   
@@ -1643,7 +1643,7 @@
       
       
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_events_json_test', kafka_group_name = 'group1_recent', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_events_json_test_gw1', kafka_group_name = 'group1_recent', kafka_format = 'JSONEachRow')
   
       SETTINGS kafka_skip_broken_messages = 100,  kafka_num_consumers = 2, kafka_thread_per_consumer = 1
   
@@ -1660,7 +1660,7 @@
       team_id Int64,
       group_properties VARCHAR
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_groups_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_groups_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1685,7 +1685,7 @@
       pointer_target_fixed Bool,
       current_url VARCHAR,
       type LowCardinality(String)
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_heatmap_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_heatmap_events_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1700,7 +1700,7 @@
       details VARCHAR CODEC(ZSTD(3)),
       timestamp DateTime64(6, 'UTC')
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_ingestion_warnings_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_ingestion_warnings_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1729,7 +1729,7 @@
       -- The actual log message.
       message String
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'log_entries_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'log_entries_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1786,7 +1786,7 @@
   unload_event_end Float64,
   unload_event_start Float64
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_performance_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_performance_events_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1803,7 +1803,7 @@
       is_deleted Int8,
       version UInt64
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1818,7 +1818,7 @@
       is_deleted Int8,
       version Int64
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_distinct_id_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_distinct_id_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1832,7 +1832,7 @@
       team_id Int64,
       _sign Nullable(Int8),
       is_deleted Nullable(Int8)
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_unique_id_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_unique_id_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1847,19 +1847,19 @@
       is_deleted Int8,
       version Int64
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_distinct_id_test', kafka_group_name = 'clickhouse-person-distinct-id-overrides', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_person_distinct_id_test_gw1', kafka_group_name = 'clickhouse-person-distinct-id-overrides', kafka_format = 'JSONEachRow')
   
   '''
 # ---
 # name: test_create_table_query[kafka_person_overrides]
   '''
   
-      CREATE TABLE IF NOT EXISTS `posthog_test`.`kafka_person_overrides`
+      CREATE TABLE IF NOT EXISTS `posthog_test_gw1`.`kafka_person_overrides`
       ON CLUSTER 'posthog'
   
       ENGINE = Kafka(
           'kafka:9092', -- Kafka hosts
-          'clickhouse_person_override_test', -- Kafka topic
+          'clickhouse_person_override_test_gw1', -- Kafka topic
           'clickhouse-person-overrides', -- Kafka consumer group id
           'JSONEachRow' -- Specify that we should pass Kafka messages as JSON
       )
@@ -1879,7 +1879,7 @@
           -- set as a default value in the `person_overrides` table.
           -- created_at,
           version
-      FROM `posthog_test`.`person_overrides`
+      FROM `posthog_test_gw1`.`person_overrides`
   
   '''
 # ---
@@ -1898,7 +1898,7 @@
       message VARCHAR,
       instance_id UUID
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'plugin_log_entries_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'plugin_log_entries_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1918,7 +1918,7 @@
       content String, -- The actual text content that was embedded
       embedding Array(Float64) -- The embedding itself
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_document_embeddings_test', kafka_group_name = 'clickhouse_document_embeddings', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_document_embeddings_test_gw1', kafka_group_name = 'clickhouse_document_embeddings', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1954,7 +1954,7 @@
       created_at DateTime64(6, 'UTC')
       
       
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_recording_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_recording_events_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -1984,7 +1984,7 @@
       snapshot_source LowCardinality(Nullable(String)),
       snapshot_library Nullable(String),
       retention_period_days Nullable(Int64),
-  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_replay_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
+  ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_replay_events_test_gw1', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
 # ---
@@ -2027,7 +2027,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS log_entries_mv ON CLUSTER 'posthog'
-  TO posthog_test.log_entries
+  TO posthog_test_gw1.log_entries
   AS SELECT
   team_id,
   log_source,
@@ -2038,7 +2038,7 @@
   message,
   _timestamp,
   _offset
-  FROM posthog_test.kafka_log_entries
+  FROM posthog_test_gw1.kafka_log_entries
   
   '''
 # ---
@@ -2099,7 +2099,7 @@
   , _offset UInt64
   , _partition UInt64
   
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_performance_events', sipHash64(session_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_performance_events', sipHash64(session_id))
   
   '''
 # ---
@@ -2107,11 +2107,11 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS performance_events_mv ON CLUSTER 'posthog'
-  TO posthog_test.writeable_performance_events
+  TO posthog_test_gw1.writeable_performance_events
   AS SELECT
   uuid, session_id, window_id, pageview_id, distinct_id, timestamp, time_origin, entry_type, name, team_id, current_url, start_time, duration, redirect_start, redirect_end, worker_start, fetch_start, domain_lookup_start, domain_lookup_end, connect_start, secure_connection_start, connect_end, request_start, response_start, response_end, decoded_body_size, encoded_body_size, initiator_type, next_hop_protocol, render_blocking_status, response_status, transfer_size, largest_contentful_paint_element, largest_contentful_paint_render_time, largest_contentful_paint_load_time, largest_contentful_paint_size, largest_contentful_paint_id, largest_contentful_paint_url, dom_complete, dom_content_loaded_event, dom_interactive, load_event_end, load_event_start, redirect_count, navigation_type, unload_event_end, unload_event_start
   ,_timestamp, _offset, _partition
-  FROM posthog_test.kafka_performance_events
+  FROM posthog_test_gw1.kafka_performance_events
   
   '''
 # ---
@@ -2207,7 +2207,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS person_distinct_id_mv ON CLUSTER 'posthog'
-  TO posthog_test.person_distinct_id
+  TO posthog_test_gw1.person_distinct_id
   AS SELECT
   distinct_id,
   person_id,
@@ -2215,7 +2215,7 @@
   coalesce(_sign, if(is_deleted==0, 1, -1)) AS _sign,
   _timestamp,
   _offset
-  FROM posthog_test.kafka_person_distinct_id
+  FROM posthog_test_gw1.kafka_person_distinct_id
   
   '''
 # ---
@@ -2285,7 +2285,7 @@
 # name: test_create_table_query[person_overrides]
   '''
   
-      CREATE TABLE IF NOT EXISTS `posthog_test`.`person_overrides`
+      CREATE TABLE IF NOT EXISTS `posthog_test_gw0`.`person_overrides`
       ON CLUSTER 'posthog' (
           team_id INT NOT NULL,
   
@@ -2349,9 +2349,9 @@
 # name: test_create_table_query[person_overrides_mv]
   '''
   
-      CREATE MATERIALIZED VIEW IF NOT EXISTS `posthog_test`.`person_overrides_mv`
+      CREATE MATERIALIZED VIEW IF NOT EXISTS `posthog_test_gw1`.`person_overrides_mv`
       ON CLUSTER 'posthog'
-      TO `posthog_test`.`person_overrides`
+      TO `posthog_test_gw1`.`person_overrides`
       AS SELECT
           team_id,
           old_person_id,
@@ -2362,7 +2362,7 @@
           -- set as a default value in the `person_overrides` table.
           -- created_at,
           version
-      FROM `posthog_test`.`kafka_person_overrides`
+      FROM `posthog_test_gw1`.`kafka_person_overrides`
   
   '''
 # ---
@@ -2471,7 +2471,7 @@
   _timestamp,
   _offset,
   _partition
-  FROM posthog_test.kafka_posthog_document_embeddings
+  FROM posthog_test_gw1.kafka_posthog_document_embeddings
   
   '''
 # ---
@@ -2811,7 +2811,7 @@
   
       -- web vitals
       vitals_lcp AggregateFunction(argMin, Nullable(Float64), DateTime64(6, 'UTC'))
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_raw_sessions', cityHash64(session_id_v7))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_raw_sessions', cityHash64(session_id_v7))
   
   '''
 # ---
@@ -2819,7 +2819,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS raw_sessions_mv 
-  TO posthog_test.writable_raw_sessions
+  TO posthog_test_gw1.writable_raw_sessions
   AS
   
   SELECT
@@ -2896,7 +2896,7 @@
   
       -- web vitals
       argMinState(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$web_vitals_LCP_value'), ''), 'null'), '^"|"$', ''), 'Float64'), timestamp) as vitals_lcp
-  FROM posthog_test.sharded_events
+  FROM posthog_test_gw1.sharded_events
   WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7)
   GROUP BY
       team_id,
@@ -3002,7 +3002,7 @@
   
       -- Replay
       has_replay_events SimpleAggregateFunction(max, Boolean)
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_raw_sessions_v3', cityHash64(session_id_v7))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_raw_sessions_v3', cityHash64(session_id_v7))
   
   '''
 # ---
@@ -3010,7 +3010,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS raw_sessions_v3_mv
-  TO posthog_test.writable_raw_sessions_v3
+  TO posthog_test_gw1.writable_raw_sessions_v3
   AS
   
   WITH
@@ -3203,7 +3203,7 @@
       [event] as event_names,
   
       false as has_replay_events
-  FROM posthog_test.sharded_events AS source_table
+  FROM posthog_test_gw1.sharded_events AS source_table
   WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7
   AND TRUE
       
@@ -3214,7 +3214,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS raw_sessions_v3_recordings_mv
-  TO posthog_test.writable_raw_sessions_v3
+  TO posthog_test_gw1.writable_raw_sessions_v3
   AS
   
   WITH
@@ -3297,7 +3297,7 @@
   
       -- replay
       true as has_replay_events
-  FROM posthog_test.sharded_session_replay_events AS source_table
+  FROM posthog_test_gw1.sharded_session_replay_events AS source_table
   WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(session_id, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7
   AND TRUE
       
@@ -3322,7 +3322,7 @@
   , _timestamp DateTime
   , _offset UInt64
   
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_recording_events', sipHash64(distinct_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_session_recording_events', sipHash64(distinct_id))
   
   '''
 # ---
@@ -3330,7 +3330,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS session_recording_events_mv ON CLUSTER 'posthog'
-  TO posthog_test.writable_session_recording_events
+  TO posthog_test_gw1.writable_session_recording_events
   AS SELECT
   uuid,
   timestamp,
@@ -3342,7 +3342,7 @@
   created_at,
   _timestamp,
   _offset
-  FROM posthog_test.kafka_session_recording_events
+  FROM posthog_test_gw1.kafka_session_recording_events
   
   '''
 # ---
@@ -3393,7 +3393,7 @@
       _timestamp SimpleAggregateFunction(max, DateTime),
       -- retention period for this session, in days. Useful to show TTL for the recording
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
 # ---
@@ -3401,7 +3401,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS session_replay_events_mv ON CLUSTER 'posthog'
-  TO posthog_test.writable_session_replay_events (
+  TO posthog_test_gw1.writable_session_replay_events (
   `session_id` String, `team_id` Int64, `distinct_id` String,
   `min_first_timestamp` DateTime64(6, 'UTC'),
   `max_last_timestamp` DateTime64(6, 'UTC'),
@@ -3455,7 +3455,7 @@
   argMinState(snapshot_library, first_timestamp) as snapshot_library,
   max(_timestamp) as _timestamp
   ,max(retention_period_days) as retention_period_days
-  FROM posthog_test.kafka_session_replay_events
+  FROM posthog_test_gw1.kafka_session_replay_events
   group by session_id, team_id
   
   '''
@@ -3512,7 +3512,7 @@
       -- as these are used in some key queries and need to be fast
       pageview_count SimpleAggregateFunction(sum, Int64),
       autocapture_count SimpleAggregateFunction(sum, Int64),
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_sessions', sipHash64(session_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_sessions', sipHash64(session_id))
   
   '''
 # ---
@@ -3520,7 +3520,7 @@
   '''
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS sessions_mv ON CLUSTER 'posthog'
-  TO posthog_test.writable_sessions
+  TO posthog_test_gw1.writable_sessions
   AS
   
   SELECT
@@ -3565,7 +3565,7 @@
   sumIf(1, event='$pageview') as pageview_count,
   sumIf(1, event='$autocapture') as autocapture_count
   
-  FROM posthog_test.sharded_events
+  FROM posthog_test_gw1.sharded_events
   WHERE `$session_id` IS NOT NULL AND `$session_id` != '' AND team_id IN (1, 2, 13610, 19279, 21173, 29929, 32050, 9910, 11775, 21129, 31490)
   GROUP BY `$session_id`, team_id
   
@@ -4769,7 +4769,7 @@
   , _partition UInt64
   
   )
-  ENGINE=Distributed('posthog', 'posthog_test', 'sharded_app_metrics2', rand())
+  ENGINE=Distributed('posthog', 'posthog_test_gw1', 'sharded_app_metrics2', rand())
   
   '''
 # ---
@@ -4795,7 +4795,7 @@
   , _partition UInt64
   
   )
-  ENGINE=Distributed('posthog', 'posthog_test', 'sharded_app_metrics', rand())
+  ENGINE=Distributed('posthog', 'posthog_test_gw1', 'sharded_app_metrics', rand())
   
   '''
 # ---
@@ -4809,7 +4809,7 @@
       person_id UUID,
       status Enum8('entered' = 1, 'left' = 2),
       last_updated DateTime64(6) DEFAULT now64()
-  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test', 'cohort_membership')
+  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test_gw1', 'cohort_membership')
   
   '''
 # ---
@@ -4828,7 +4828,7 @@
   , _offset UInt64
   , _partition UInt64
   
-  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test', 'error_tracking_issue_fingerprint_overrides')
+  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test_gw1', 'error_tracking_issue_fingerprint_overrides')
   
   '''
 # ---
@@ -4906,7 +4906,7 @@
   , _offset UInt64
   , consumer_breadcrumbs Array(String)
       
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_events', sipHash64(distinct_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_events', sipHash64(distinct_id))
   
   '''
 # ---
@@ -4937,7 +4937,7 @@
   , _offset UInt64
   
       
-  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test', 'events_dead_letter_queue')
+  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test_gw1', 'events_dead_letter_queue')
   
   '''
 # ---
@@ -4977,7 +4977,7 @@
   , _partition UInt64
   , _timestamp_ms DateTime64
       
-  ) ENGINE = Distributed('posthog_batch_exports', 'posthog_test', 'events_recent')
+  ) ENGINE = Distributed('posthog_batch_exports', 'posthog_test_gw1', 'events_recent')
   
   '''
 # ---
@@ -4995,7 +4995,7 @@
   , _timestamp DateTime
   , _offset UInt64
   
-  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test', 'groups')
+  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test_gw1', 'groups')
   
   '''
 # ---
@@ -5023,7 +5023,7 @@
       _timestamp DateTime,
       _offset UInt64,
       _partition UInt64
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_heatmaps', cityHash64(concat(toString(team_id), '-', session_id, '-', toString(toDate(timestamp)))))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw1', 'sharded_heatmaps', cityHash64(concat(toString(team_id), '-', session_id, '-', toString(toDate(timestamp)))))
   
   '''
 # ---
@@ -5042,7 +5042,7 @@
   , _offset UInt64
   , _partition UInt64
   
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_ingestion_warnings', rand())
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw1', 'sharded_ingestion_warnings', rand())
   
   '''
 # ---
@@ -5062,7 +5062,7 @@
   , _timestamp DateTime
   , _offset UInt64
   
-  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test', 'person')
+  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test_gw1', 'person')
   
   '''
 # ---
@@ -5083,7 +5083,7 @@
   , _partition UInt64
   
       
-  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test', 'person_distinct_id2')
+  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test_gw1', 'person_distinct_id2')
   
   '''
 # ---
@@ -5104,7 +5104,7 @@
   , _partition UInt64
   
       
-  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test', 'person_distinct_id_overrides')
+  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test_gw1', 'person_distinct_id_overrides')
   
   '''
 # ---
@@ -5126,7 +5126,7 @@
   , _timestamp DateTime
   , _offset UInt64
   
-  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test', 'plugin_log_entries')
+  ) ENGINE = Distributed('posthog_single_shard', 'posthog_test_gw1', 'plugin_log_entries')
   
   '''
 # ---
@@ -5150,7 +5150,7 @@
   , _offset UInt64
   , _partition UInt64
   
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_posthog_document_embeddings', cityHash64(document_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw1', 'sharded_posthog_document_embeddings', cityHash64(document_id))
   
   '''
 # ---
@@ -5169,7 +5169,7 @@
       _timestamp DateTime64(6),
       _partition UInt64,
       _offset UInt64
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_precalculated_events', sipHash64(distinct_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw1', 'sharded_precalculated_events', sipHash64(distinct_id))
   
   '''
 # ---
@@ -5259,7 +5259,7 @@
   
       -- web vitals
       vitals_lcp AggregateFunction(argMin, Nullable(Float64), DateTime64(6, 'UTC'))
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_raw_sessions', cityHash64(session_id_v7))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_raw_sessions', cityHash64(session_id_v7))
   
   '''
 # ---
@@ -5358,7 +5358,7 @@
   
       -- Replay
       has_replay_events SimpleAggregateFunction(max, Boolean)
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_raw_sessions_v3', cityHash64(session_id_v7))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_raw_sessions_v3', cityHash64(session_id_v7))
   
   '''
 # ---
@@ -5380,7 +5380,7 @@
   , _timestamp DateTime
   , _offset UInt64
   
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_recording_events', sipHash64(distinct_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_session_recording_events', sipHash64(distinct_id))
   
   '''
 # ---
@@ -5431,7 +5431,7 @@
       _timestamp SimpleAggregateFunction(max, DateTime),
       -- retention period for this session, in days. Useful to show TTL for the recording
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
 # ---
@@ -5487,7 +5487,7 @@
       -- as these are used in some key queries and need to be fast
       pageview_count SimpleAggregateFunction(sum, Int64),
       autocapture_count SimpleAggregateFunction(sum, Int64),
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_sessions', sipHash64(session_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_sessions', sipHash64(session_id))
   
   '''
 # ---
@@ -5548,7 +5548,7 @@
   , _offset UInt64
   , _partition UInt64
   
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_performance_events', sipHash64(session_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw0', 'sharded_performance_events', sipHash64(session_id))
   
   '''
 # ---
@@ -5730,7 +5730,7 @@
 # name: test_create_table_query_replicated_and_storage[exchange_rate]
   '''
   
-  CREATE TABLE IF NOT EXISTS `posthog_test`.`exchange_rate` ON CLUSTER 'posthog' (
+  CREATE TABLE IF NOT EXISTS `posthog_test_gw1`.`exchange_rate` ON CLUSTER 'posthog' (
       currency String,
       date Date,
       rate Decimal64(10),
@@ -5893,7 +5893,7 @@
 # name: test_create_table_query_replicated_and_storage[person_overrides]
   '''
   
-      CREATE TABLE IF NOT EXISTS `posthog_test`.`person_overrides`
+      CREATE TABLE IF NOT EXISTS `posthog_test_gw1`.`person_overrides`
       ON CLUSTER 'posthog' (
           team_id INT NOT NULL,
   
@@ -7348,7 +7348,7 @@
       _timestamp SimpleAggregateFunction(max, DateTime),
       -- retention period for this session, in days. Useful to show TTL for the recording
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
+  ) ENGINE = Distributed('posthog', 'posthog_test_gw1', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
 # ---

--- a/products/mcp/python/pytest.ini
+++ b/products/mcp/python/pytest.ini
@@ -4,7 +4,7 @@ testpaths = tests
 python_files = test_*.py *_test.py
 python_classes = Test*
 python_functions = test_*
-addopts = -v --tb=short
-env = 
+addopts = -v --tb=short -n auto
+env =
     PYTHONPATH = .
 filterwarnings = ignore::DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ env =
     DEBUG=1
     TEST=1
 DJANGO_SETTINGS_MODULE = posthog.settings
-addopts = -p no:warnings --reuse-db --ignore=posthog/user_scripts --ignore=services/llm-gateway
+addopts = -p no:warnings --reuse-db --ignore=posthog/user_scripts --ignore=services/llm-gateway -n auto
 
 markers =
     ee


### PR DESCRIPTION
## Problem

Python tests take on average 21m to run

## Changes

set `-n auto` to make tests run in parallel.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
