### PR TITLE
fix: do not crash on malformed inputs

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -256,8 +256,8 @@ function renderContentItem(item: MultiModalContentItem, searchQuery?: string): J
         return <HighlightedJSONViewer src={item} name={null} collapsed={5} searchQuery={searchQuery} />
     }
 
-    if (item.type === 'text' && 'text' in item) {
-        return searchQuery?.trim() && typeof item.text === 'string' ? (
+    if (item.type === 'text' && 'text' in item && typeof item.text === 'string') {
+        return searchQuery?.trim() ? (
             <SearchHighlight string={item.text} substring={searchQuery} className="whitespace-pre-wrap" />
         ) : (
             <span className="whitespace-pre-wrap">{item.text}</span>


### PR DESCRIPTION
Fixes an issue where something that looked like one of our expected formats but had a malformed `text` field crashed the app. [Ticket here](https://posthoghelp.zendesk.com/agent/tickets/44378).

