### PR TITLE
chore: add perosnal api key admin inline on users django

### DIFF
--- a/posthog/admin/admins/user_admin.py
+++ b/posthog/admin/admins/user_admin.py
@@ -10,6 +10,7 @@ from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberInline
+from posthog.admin.inlines.personal_api_key_inline import PersonalAPIKeyInline
 from posthog.admin.inlines.totp_device_inline import TOTPDeviceInline
 from posthog.api.authentication import password_reset_token_generator
 from posthog.api.email_verification import EmailVerifier
@@ -26,7 +27,7 @@ class UserChangeForm(DjangoUserChangeForm):
         # an admin can provide that reset link manually – much better than sending a new password in plain text.
         password_reset_token = password_reset_token_generator.make_token(self.instance)
         self.fields["password"].help_text = (
-            "Raw passwords are not stored, so there is no way to see this user’s password, but you can send them "
+            "Raw passwords are not stored, so there is no way to see this user's password, but you can send them "
             f'<a target="_blank" href="/reset/{self.instance.uuid}/{password_reset_token}">this password reset link</a> '
             "(it only works when logged out)."
         )
@@ -47,7 +48,7 @@ class UserAdmin(DjangoUserAdmin):
     change_password_form = None  # This view is not exposed in our subclass of UserChangeForm
     change_form_template = "admin/posthog/user/change_form.html"
 
-    inlines = [OrganizationMemberInline, TOTPDeviceInline]
+    inlines = [OrganizationMemberInline, PersonalAPIKeyInline, TOTPDeviceInline]
     fieldsets = (
         (
             None,

--- a/posthog/admin/inlines/personal_api_key_inline.py
+++ b/posthog/admin/inlines/personal_api_key_inline.py
@@ -1,0 +1,17 @@
+from django.contrib import admin
+
+from posthog.models.personal_api_key import PersonalAPIKey
+
+
+class PersonalAPIKeyInline(admin.TabularInline):
+    model = PersonalAPIKey
+    extra = 0
+    fields = ("label", "mask_value", "created_at", "last_used_at", "scopes")
+    readonly_fields = ("label", "mask_value", "created_at", "last_used_at", "scopes")
+    can_delete = True
+    show_change_link = True
+    ordering = ("-created_at",)
+
+    def has_add_permission(self, request, obj=None):
+        # Prevent adding API keys through the admin (they should be created via API)
+        return False


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
make a cop's life easier

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- add personal api key inline to users admin

## How did you test this code?
it's there locally, but doesn't delete?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
nope
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
