### PR TITLE
fix(ci): don't alert on ignored semgrep findings

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -9,8 +9,6 @@ name: Security
 
 permissions:
     contents: read
-    actions: read
-    security-events: write
 
 env:
     SEMGREP_ENABLE_VERSION_CHECK: 'false'
@@ -52,15 +50,7 @@ jobs:
                     --error \
                     --metrics=off \
                     --verbose \
-                    --sarif-output semgrep-python.sarif \
                     common/ ee/ posthog/ products/
-
-            - name: Upload results
-              if: ${{ !cancelled() }}
-              uses: github/codeql-action/upload-sarif@v4
-              with:
-                  sarif_file: semgrep-python.sarif
-                  category: semgrep-python
 
     semgrep-go:
         runs-on: ubuntu-latest
@@ -83,15 +73,7 @@ jobs:
                     --error \
                     --metrics=off \
                     --verbose \
-                    --sarif-output semgrep-go.sarif \
                     livestream/
-
-            - name: Upload results
-              if: ${{ !cancelled() }}
-              uses: github/codeql-action/upload-sarif@v4
-              with:
-                  sarif_file: semgrep-go.sarif
-                  category: semgrep-go
 
     semgrep-rust:
         runs-on: ubuntu-latest
@@ -116,15 +98,7 @@ jobs:
                     --error \
                     --metrics=off \
                     --verbose \
-                    --sarif-output semgrep-rust.sarif \
                     cli/ rust/
-
-            - name: Upload results
-              if: ${{ !cancelled() }}
-              uses: github/codeql-action/upload-sarif@v4
-              with:
-                  sarif_file: semgrep-rust.sarif
-                  category: semgrep-rust
 
     semgrep-js:
         runs-on: ubuntu-latest
@@ -145,15 +119,7 @@ jobs:
                     --error \
                     --metrics=off \
                     --verbose \
-                    --sarif-output semgrep-js.sarif \
                     frontend/ plugin-server/
-
-            - name: Upload results
-              if: ${{ !cancelled() }}
-              uses: github/codeql-action/upload-sarif@v4
-              with:
-                  sarif_file: semgrep-js.sarif
-                  category: semgrep-js
 
     # scans GitHub Actions and other repo-wide config
     semgrep-general:
@@ -180,7 +146,6 @@ jobs:
                     --error \
                     --metrics=off \
                     --verbose \
-                    --sarif-output semgrep-general.sarif \
                     --exclude ./cli/ \
                     --exclude ./common/ \
                     --exclude ./ee/ \
@@ -191,13 +156,6 @@ jobs:
                     --exclude ./products/ \
                     --exclude ./rust/ \
                     .
-
-            - name: Upload results
-              if: ${{ !cancelled() }}
-              uses: github/codeql-action/upload-sarif@v4
-              with:
-                  sarif_file: semgrep-general.sarif
-                  category: semgrep-general
 
     semgrep_checks:
         needs: [semgrep-python, semgrep-go, semgrep-rust, semgrep-js, semgrep-general]


### PR DESCRIPTION
Currently, when semgrep detects a valid finding, it also alerts on ignored findings. This is due to a semgrep bug that exists only when outputting in sarif format. Now, PR authors will need to open the failed Semgrep GH Action and inspect the logs to find the error.
