### PR TITLE
fix(flags): Improve UX around disabled actions/fields

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -6,6 +6,7 @@ import React, { useContext } from 'react'
 import { IconChevronDown, IconChevronRight, IconExternal } from '@posthog/icons'
 
 import { LemonDropdown, LemonDropdownProps } from '../LemonDropdown'
+import { INTERACTIVE_CLOSE_DELAY_MS } from '../LemonInput/LemonInput'
 import { Link } from '../Link'
 import { PopoverOverlayContext, PopoverReferenceContext } from '../Popover'
 import { Spinner } from '../Spinner/Spinner'
@@ -65,6 +66,8 @@ export interface LemonButtonPropsBase
     disabled?: boolean
     /** Like plain `disabled`, except we enforce a reason to be shown in the tooltip. */
     disabledReason?: React.ReactElement | string | null | false
+    /** Whether the disabled reason tooltip is interactive (e.g., contains a link) */
+    disabledReasonInteractive?: boolean
     noPadding?: boolean
     size?: 'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large'
     'data-attr'?: string
@@ -134,6 +137,7 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                 className,
                 disabled,
                 disabledReason,
+                disabledReasonInteractive,
                 loading,
                 type = 'tertiary',
                 status = 'default',
@@ -284,6 +288,8 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                         arrowOffset={tooltipArrowOffset}
                         docLink={tooltipDocLink}
                         visible={tooltipForceMount}
+                        interactive={disabledReasonInteractive}
+                        closeDelayMs={disabledReasonInteractive ? INTERACTIVE_CLOSE_DELAY_MS : undefined}
                     >
                         {workingButton}
                     </Tooltip>

--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
@@ -47,7 +47,9 @@ interface LemonInputPropsBase
     /** @deprecated Use `disabledReason` instead and provide a reason. */
     disabled?: boolean
     /** Like plain `disabled`, except we enforce a reason to be shown in the tooltip. */
-    disabledReason?: string | null | false
+    disabledReason?: React.ReactNode | null | false
+    /** Whether the disabled reason tooltip is interactive (e.g., contains a link) */
+    disabledReasonInteractive?: boolean
     /** Whether input field is full width. Cannot be used in conjuction with `autoWidth`. */
     fullWidth?: boolean
     /** Whether input field should be as wide as its content. Cannot be used in conjuction with `fullWidth`. */
@@ -85,6 +87,12 @@ export interface LemonInputPropsNumber
 
 export type LemonInputProps = LemonInputPropsText | LemonInputPropsNumber
 
+// Delay for interactive tooltips to close after mouse leave.
+// This allows some grace period in case the user moves the
+// cursor out of the tooltip briefly while intending to
+// interact with it.
+export const INTERACTIVE_CLOSE_DELAY_MS = 750
+
 export const LemonInput = React.forwardRef<HTMLDivElement, LemonInputProps>(function LemonInput(
     {
         className,
@@ -106,6 +114,7 @@ export const LemonInput = React.forwardRef<HTMLDivElement, LemonInputProps>(func
         inputRef,
         disabled,
         disabledReason,
+        disabledReasonInteractive,
         badgeText,
         showFocusPulse = true,
         ...props
@@ -179,9 +188,12 @@ export const LemonInput = React.forwardRef<HTMLDivElement, LemonInputProps>(func
     }
 
     const InputComponent = autoWidth ? RawInputAutosize : 'input'
-
     return (
-        <Tooltip title={disabledReason ?? undefined}>
+        <Tooltip
+            title={disabledReason ?? undefined}
+            interactive={disabledReasonInteractive}
+            closeDelayMs={disabledReasonInteractive ? INTERACTIVE_CLOSE_DELAY_MS : undefined}
+        >
             <span
                 className={clsx(
                     'LemonInput',

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -1555,6 +1555,9 @@ function FeatureFlagRollout({
                                     onRemoveVariant={removeVariant}
                                     onDistributeEqually={distributeVariantsEqually}
                                     canEditVariant={canEditVariant}
+                                    hasExperiment={hasExperiment ?? false}
+                                    experimentId={experiment?.id}
+                                    experimentName={experiment?.name}
                                     isDraftExperiment={isDraftExperiment}
                                     onVariantChange={(index, field, value) => {
                                         const currentVariants = [...variants]

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -858,15 +858,22 @@ export function FeatureFlag({ id }: FeatureFlagLogicProps): JSX.Element {
                                     type: featureFlag.active ? 'feature_flag' : 'feature_flag_off',
                                 }}
                                 actions={
-                                    <>
-                                        <LemonButton
-                                            type="secondary"
-                                            size="small"
-                                            onClick={() => editFeatureFlag(true)}
-                                        >
-                                            Edit
-                                        </LemonButton>
-                                    </>
+                                    <AccessControlAction
+                                        resourceType={AccessControlResourceType.FeatureFlag}
+                                        minAccessLevel={AccessControlLevel.Editor}
+                                        userAccessLevel={featureFlag.user_access_level}
+                                    >
+                                        {({ disabledReason }) => (
+                                            <LemonButton
+                                                type="secondary"
+                                                size="small"
+                                                disabledReason={disabledReason}
+                                                onClick={() => editFeatureFlag(true)}
+                                            >
+                                                Edit
+                                            </LemonButton>
+                                        )}
+                                    </AccessControlAction>
                                 }
                             />
                             <LemonTabs

--- a/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
@@ -187,8 +187,8 @@ export function FeatureFlagVariantsForm({
                                 disabledReason={
                                     !canEditVariant(index)
                                         ? isDraftExperiment
-                                            ? 'Cannot modify the control variant in an experiment'
-                                            : 'Cannot modify variants in a flag with a launched experiment'
+                                            ? 'Cannot modify the control variant in an experiment.'
+                                            : 'Cannot modify variants in a flag with a launched experiment.'
                                         : undefined
                                 }
                                 value={variant.key}

--- a/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
@@ -184,7 +184,13 @@ export function FeatureFlagVariantsForm({
                                 autoCapitalize="off"
                                 autoCorrect="off"
                                 spellCheck={false}
-                                disabled={!canEditVariant(index)}
+                                disabledReason={
+                                    !canEditVariant(index)
+                                        ? isDraftExperiment
+                                            ? 'Cannot modify the control variant in an experiment'
+                                            : 'Cannot modify variants in a flag with a launched experiment'
+                                        : undefined
+                                }
                                 value={variant.key}
                                 onChange={(value) => onVariantChange?.(index, 'key', value)}
                             />

--- a/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
@@ -88,7 +88,7 @@ export function FeatureFlagVariantsForm({
         }
         return (
             <>
-                This flag is linked to {experimentLink}. Variants {action} after the experiment has been launched.
+                This flag is linked to {experimentLink}. Variant keys {action} after the experiment has been launched.
             </>
         )
     }


### PR DESCRIPTION
## Problem

When trying to edit a feature flag but the user is lacking permissions or a linked experiment prevents certain changes, user feedback has revealed that it's not clear _why_ an edit cannot be made.

## Changes

1. Users who cannot edit a flag now see the `edit` button disabled with a reason. The message makes it clear that they do not have the proper permissions to edit the flag.

2. When a flag is linked to an experiment, editing variants is disabled. The variant text input now has a hover message stating the reason why it cannot be edited.

Trying to edit a flag as a read-only user
<img width="431" height="110" alt="image" src="https://github.com/user-attachments/assets/9679056b-9a88-4cd6-a3db-f57d9dc11f85" />

Trying to change the control variant key when linked to a draft experiment
<img width="787" height="189" alt="image" src="https://github.com/user-attachments/assets/3d7b8bdb-23f3-4f6e-9c68-f0c1035ea3f3" />

Trying to edit variant keys when linked to a launched experiment
<img width="792" height="241" alt="image" src="https://github.com/user-attachments/assets/0efff586-4b04-4291-8b49-db9eeb92aaf8" />

## How did you test this code?

Manual testing, see images above
