### PR TITLE
feat(product tours): add smart URL defaults to product tours

### DIFF
--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -1,15 +1,27 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
+import { useEffect, useMemo } from 'react'
 
-import { LemonButton, LemonDivider, LemonInput, LemonSelect, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
+import {
+    LemonButton,
+    LemonDivider,
+    LemonInput,
+    LemonInputSelect,
+    LemonSelect,
+    LemonSwitch,
+    LemonTag,
+} from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { FeatureFlagReleaseConditions } from 'scenes/feature-flags/FeatureFlagReleaseConditions'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
+import { SurveyMatchTypeLabels } from 'scenes/surveys/constants'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { PropertyDefinitionType, SurveyMatchType } from '~/types'
 
 import { EditInToolbarButton } from './components/EditInToolbarButton'
 import { productTourLogic } from './productTourLogic'
@@ -18,6 +30,31 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
     const { productTour, productTourLoading, productTourForm, targetingFlagFilters, isProductTourFormSubmitting } =
         useValues(productTourLogic({ id }))
     const { editingProductTour, setProductTourFormValue, submitProductTourForm } = useActions(productTourLogic({ id }))
+
+    // Load recent URLs from property definitions
+    const { options } = useValues(propertyDefinitionsModel)
+    const { loadPropertyValues } = useActions(propertyDefinitionsModel)
+    const urlOptions = options['$current_url']
+
+    useEffect(() => {
+        if (urlOptions?.status !== 'loading' && urlOptions?.status !== 'loaded') {
+            loadPropertyValues({
+                endpoint: undefined,
+                type: PropertyDefinitionType.Event,
+                propertyKey: '$current_url',
+                newInput: '',
+                eventNames: [],
+                properties: [],
+            })
+        }
+    }, [urlOptions?.status, loadPropertyValues])
+
+    const urlMatchTypeOptions = useMemo(() => {
+        return Object.entries(SurveyMatchTypeLabels).map(([key, label]) => ({
+            label,
+            value: key as SurveyMatchType,
+        }))
+    }, [])
 
     if (!productTour) {
         return <LemonSkeleton />
@@ -77,7 +114,7 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                         </p>
                         <div className="flex gap-2">
                             <LemonSelect
-                                value={conditions.urlMatchType || 'contains'}
+                                value={conditions.urlMatchType || SurveyMatchType.Contains}
                                 onChange={(value) => {
                                     setProductTourFormValue('content', {
                                         ...productTourForm.content,
@@ -87,25 +124,40 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                                         },
                                     })
                                 }}
-                                options={[
-                                    { label: 'Contains', value: 'contains' },
-                                    { label: 'Exact match', value: 'exact' },
-                                    { label: 'Regex', value: 'regex' },
-                                ]}
+                                options={urlMatchTypeOptions}
                             />
-                            <LemonInput
+                            <LemonInputSelect
                                 className="flex-1"
-                                value={conditions.url || ''}
-                                onChange={(value) => {
+                                mode="single"
+                                value={conditions.url ? [conditions.url] : []}
+                                onChange={(val) => {
                                     setProductTourFormValue('content', {
                                         ...productTourForm.content,
                                         conditions: {
                                             ...conditions,
-                                            url: value,
+                                            url: val[0] || undefined,
                                         },
                                     })
                                 }}
+                                onInputChange={(newInput) => {
+                                    loadPropertyValues({
+                                        type: PropertyDefinitionType.Event,
+                                        endpoint: undefined,
+                                        propertyKey: '$current_url',
+                                        newInput: newInput.trim(),
+                                        eventNames: [],
+                                        properties: [],
+                                    })
+                                }}
                                 placeholder="e.g. /dashboard or https://example.com/app"
+                                allowCustomValues
+                                loading={urlOptions?.status === 'loading'}
+                                options={(urlOptions?.values || []).map(({ name }) => ({
+                                    key: String(name),
+                                    label: String(name),
+                                    value: String(name),
+                                }))}
+                                data-attr="product-tour-url-input"
                             />
                         </div>
                     </div>

--- a/frontend/src/scenes/product-tours/ProductTourView.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourView.tsx
@@ -11,6 +11,7 @@ import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { FeatureFlagReleaseConditions } from 'scenes/feature-flags/FeatureFlagReleaseConditions'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
+import { SurveyMatchTypeLabels } from 'scenes/surveys/constants'
 
 import {
     ScenePanel,
@@ -33,18 +34,13 @@ import {
     PropertyOperator,
     StepOrderValue,
     StepOrderVersion,
+    SurveyMatchType,
 } from '~/types'
 
 import { EditInToolbarButton } from './components/EditInToolbarButton'
 import { ProductTourStatsSummary } from './components/ProductTourStatsSummary'
 import { productTourLogic } from './productTourLogic'
 import { getProductTourStatus, isProductTourRunning, productToursLogic } from './productToursLogic'
-
-const UrlMatchTypeLabels: Record<string, string> = {
-    contains: 'contains',
-    exact: 'exactly matches',
-    regex: 'matches regex',
-}
 
 export function ProductTourView({ id }: { id: string }): JSX.Element {
     const { productTour, productTourLoading, tourStats, tourStatsLoading, dateRange, targetingFlagFilters } = useValues(
@@ -63,6 +59,7 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
 
     const status = getProductTourStatus(productTour)
     const isRunning = isProductTourRunning(productTour)
+    const hasUrlCondition = !!productTour.content?.conditions?.url
 
     return (
         <SceneContent>
@@ -118,6 +115,7 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
                             <LemonButton
                                 type="primary"
                                 size="small"
+                                disabledReason={!hasUrlCondition ? 'Set a URL pattern before launching' : undefined}
                                 onClick={() => {
                                     LemonDialog.open({
                                         title: 'Launch this product tour?',
@@ -400,8 +398,8 @@ function TargetingSummary({
             </span>
             {hasUrl && (
                 <div className="flex flex-col font-medium gap-1">
-                    <div className="flex flex-row">
-                        <span>URL {UrlMatchTypeLabels[conditions.urlMatchType || 'contains']}:</span>{' '}
+                    <div className="flex flex-row gap-1">
+                        <span>URL {SurveyMatchTypeLabels[conditions.urlMatchType || SurveyMatchType.Contains]}:</span>
                         <LemonTag>{conditions.url}</LemonTag>
                     </div>
                 </div>

--- a/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
@@ -108,6 +108,11 @@ export function ProductToursTable(): JSX.Element {
                                             {!tour.start_date && (
                                                 <LemonButton
                                                     fullWidth
+                                                    disabledReason={
+                                                        !tour.content?.conditions?.url
+                                                            ? 'Set a URL pattern before launching'
+                                                            : undefined
+                                                    }
                                                     onClick={() => {
                                                         LemonDialog.open({
                                                             title: 'Launch this product tour?',

--- a/frontend/src/toolbar/product-tours/utils.ts
+++ b/frontend/src/toolbar/product-tours/utils.ts
@@ -2,6 +2,7 @@ import { domToJpeg } from 'modern-screenshot'
 
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { TOOLBAR_ID, elementToQuery } from '~/toolbar/utils'
+import { SurveyMatchType } from '~/types'
 
 export interface ElementInfo {
     selector: string
@@ -138,5 +139,32 @@ export function getPageContext(): { url: string; title: string } {
     return {
         url: window.location.href,
         title: document.title,
+    }
+}
+
+/**
+ * Get smart URL defaults for a new product tour based on the current page URL.
+ *
+ * Logic:
+ * - If on root domain (path is "/" or empty), use "exact" match with the full URL
+ * - If on a path, use "contains" match with just the pathname
+ */
+export function getSmartUrlDefaults(): { url: string; urlMatchType: SurveyMatchType } {
+    const { pathname, origin } = window.location
+
+    // Check if we're on the root path
+    const isRootPath = pathname === '/' || pathname === ''
+
+    if (isRootPath) {
+        // For root domain, use exact match with full URL (without trailing slash for consistency)
+        return {
+            url: origin,
+            urlMatchType: SurveyMatchType.Exact,
+        }
+    }
+    // For paths, use contains match with the pathname
+    return {
+        url: pathname,
+        urlMatchType: SurveyMatchType.Contains,
     }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3278,7 +3278,7 @@ export interface ProductTourContent {
     appearance?: Record<string, any>
     conditions?: {
         url?: string
-        urlMatchType?: 'exact' | 'contains' | 'regex'
+        urlMatchType?: SurveyMatchType
         selector?: string
     }
     /** History of step order changes for funnel analysis */


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
