### PR TITLE
feat(capture): trigger readiness probe fails as soon as k8s preStop begins in mirror

### DIFF
--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -210,11 +210,15 @@ where
         config.is_mirror_deploy,
         config.log_level
     );
-    axum::serve(
+
+    if let Err(e) = axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
     )
     .with_graceful_shutdown(shutdown)
     .await
-    .unwrap()
+    {
+        tracing::error!("HTTP server graceful shutdown failed: {}", e);
+    }
+    tracing::info!("HTTP server graceful shutdown completed");
 }


### PR DESCRIPTION
## Problem
Envoy metrics are showing dropped connections from `capture` (upstream) pods during deploys, even though we've increased `preStop` and `terminationGracePeriodSeconds` substantially in the mirror deploy, and tested this. Traffic is still flowing to the pods when the endpoints should be  removed prior to an initial `SIGTERM` from k8s being issued to outgoing pods.

We need to ensure capture pods are being removed from the deploy endpoint slice by k8s ASAP during `preStop`. To speed this along, we will make `capture` pods aware the `preStop` lifecycle stage has begun, and to start signaling not-ready on their `_readiness` endpoints immediately.

If we handle `preStop` correctly, when the `SIGTERM` is issued, the Axum graceful shutdown handler will only need to finish serving in-flight requests, and should not have additional requests queued up.

_Note: the initial PR affects mirror deploy only, and is paired with a k8s spec change. If this has the desired effect, I'll do something a bit more clever prior to merging `capture` changes_

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Expect a sentinel file to be touched in `capture` pod's `/tmp` dir, indicating k8s `preStop` has begun
* Trigger `_readiness` endpoint to return `SERVICE_UNAVAILABLE` when this is found
* Let typical graceful shutdown occur in Axum once k8s `SIGTERM` is issued to the pod

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; smoke test in mirror on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
