### PR TITLE
fix: make survey's multiple question chart to be based on respondends

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -671,7 +671,11 @@ export function LineGraph_({
                         formatter: (value: number, context) => {
                             if (value !== 0 && inSurveyView && showValuesOnSeries) {
                                 const dataset = context.dataset as any
-                                const total = dataset.data?.reduce((sum: number, val: number) => sum + val, 0) || 1
+                                // Use totalResponses if provided (for per-respondent %), otherwise sum of values
+                                const total =
+                                    dataset.totalResponses ??
+                                    dataset.data?.reduce((sum: number, val: number) => sum + val, 0) ??
+                                    1
                                 const percentage = ((value / total) * 100).toFixed(1)
                                 return `${value} (${percentage}%)`
                             }

--- a/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
@@ -16,6 +16,7 @@ const barColor = CHART_INSIGHTS_COLORS[2]
 
 interface Props {
     responseData: ChoiceQuestionResponseData[]
+    totalResponses: number
 }
 
 interface ProcessedData {
@@ -23,7 +24,7 @@ interface ProcessedData {
     openEndedResponses: ChoiceQuestionResponseData[]
 }
 
-export function MultipleChoiceQuestionViz({ responseData }: Props): JSX.Element | null {
+export function MultipleChoiceQuestionViz({ responseData, totalResponses }: Props): JSX.Element | null {
     const { chartData, openEndedResponses } = useMemo((): ProcessedData => {
         const predefinedResponses = responseData.filter((d) => d.isPredefined)
         const nonPredefinedResponses = responseData.filter((d) => !d.isPredefined)
@@ -79,6 +80,7 @@ export function MultipleChoiceQuestionViz({ responseData }: Props): JSX.Element 
                                 backgroundColor: barColor,
                                 borderColor: barColor,
                                 hoverBackgroundColor: barColor,
+                                totalResponses,
                             },
                         ]}
                         labels={chartData.map((d) => d.label)}

--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -175,7 +175,10 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
                         question.type === SurveyQuestionType.MultipleChoice) &&
                         (demoData.type === SurveyQuestionType.SingleChoice ||
                             demoData.type === SurveyQuestionType.MultipleChoice) && (
-                            <MultipleChoiceQuestionViz responseData={demoData.data} />
+                            <MultipleChoiceQuestionViz
+                                responseData={demoData.data}
+                                totalResponses={demoData.totalResponses}
+                            />
                         )}
                     {question.type === SurveyQuestionType.Open && demoData.type === SurveyQuestionType.Open && (
                         <OpenQuestionViz question={question} responseData={demoData.data} />
@@ -233,7 +236,10 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
                         question.type === SurveyQuestionType.MultipleChoice) &&
                         (processedData.type === SurveyQuestionType.SingleChoice ||
                             processedData.type === SurveyQuestionType.MultipleChoice) && (
-                            <MultipleChoiceQuestionViz responseData={processedData.data} />
+                            <MultipleChoiceQuestionViz
+                                responseData={processedData.data}
+                                totalResponses={processedData.totalResponses}
+                            />
                         )}
                     {question.type === SurveyQuestionType.Open && processedData.type === SurveyQuestionType.Open && (
                         <OpenQuestionViz question={question} responseData={processedData.data} />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4248,6 +4248,8 @@ export type GraphDataset = ChartDataset<ChartType> &
         /** Action/event filter defition */
         action?: ActionFilter | null
         yAxisID?: string
+        /** Total number of respondents for survey questions (for per-respondent percentage calculation) */
+        totalResponses?: number
     }
 
 export type GraphPoint = InteractionItem & { dataset: GraphDataset }


### PR DESCRIPTION
## Problem

When displaying survey results for multiple choice questions, the percentage calculations were incorrect for multi-select questions. The percentages were being calculated based on the sum of all selections rather than the total number of respondents, leading to misleading statistics.

## Changes

Updated the percentage calculation in survey visualizations to use the total number of respondents rather than the sum of values when available (industry standard).

This ensures that for multi-select questions, percentages reflect the proportion of respondents who selected each option, rather than the proportion of total selections.

Before:

![CleanShot 2025-12-11 at 15.54.40@2x.jpg](https://app.graphite.com/user-attachments/assets/a1ed264f-46bc-4830-8b94-a7008904157f.jpg)

After:

![CleanShot 2025-12-11 at 15.53.55@2x.jpg](https://app.graphite.com/user-attachments/assets/1d148098-518e-4977-8b92-3a1e5015efb7.jpg)

## How did you test this code?

Tested with various survey configurations including single-choice and multiple-choice questions. Verified that percentage calculations now correctly show the proportion of respondents who selected each option rather than the proportion of total selections.

## Changelog
No