### PR TITLE
feat(endpoints): add OpenAPI spec generation route

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -500,6 +500,7 @@
                        (SELECT actor_id AS actor_id,
                                count() AS event_count,
                                groupUniqArray(distinct_id) AS event_distinct_ids,
+                               max(timestamp) AS last_seen,
                                actor_id AS id
                         FROM
                           (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11419,6 +11419,10 @@
                 "variables": {
                     "description": "A map for overriding HogQL query variables, where the key is the variable name and the value is the variable value. Variable must be set on the endpoint's query between curly braces (i.e. {variable.from_date}) For example: {\"from_date\": \"1970-01-01\"}",
                     "type": "object"
+                },
+                "version": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Specific endpoint version to execute. If not provided, the latest version is used."
                 }
             },
             "type": "object"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1689,6 +1689,8 @@ export interface EndpointRunRequest {
      *   The query executed will return the count of $identify events, instead of $pageview's
      */
     query_override?: Record<string, any>
+    /** Specific endpoint version to execute. If not provided, the latest version is used. */
+    version?: integer
 }
 
 export interface EndpointLastExecutionTimesRequest {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -9284,6 +9284,9 @@ class EndpointRunRequest(BaseModel):
             ' {variable.from_date}) For example: {"from_date": "1970-01-01"}'
         ),
     )
+    version: int | None = Field(
+        default=None, description="Specific endpoint version to execute. If not provided, the latest version is used."
+    )
 
 
 class EntityNode(BaseModel):

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -2,6 +2,7 @@ import re
 from datetime import timedelta
 from typing import Union, cast
 
+from django.conf import settings
 from django.core.cache import cache
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -73,7 +74,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
     # NOTE: Do we need to override the scopes for the "create"
     scope_object = "endpoint"
     # Special case for query - these are all essentially read actions
-    scope_object_read_actions = ["retrieve", "list", "run", "versions", "version_detail"]
+    scope_object_read_actions = ["retrieve", "list", "run", "versions", "version_detail", "openapi_spec"]
     scope_object_write_actions: list[str] = ["create", "destroy", "update"]
     lookup_field = "name"
     queryset = Endpoint.objects.all()
@@ -804,3 +805,163 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             }
 
         return Response(result)
+
+    @extend_schema(
+        description="Get OpenAPI 3.0 specification for this endpoint. Use this to generate typed SDK clients.",
+    )
+    @action(methods=["GET"], detail=True, url_path="openapi.json")
+    def openapi_spec(self, request: Request, name=None, *args, **kwargs) -> Response:
+        """Generate OpenAPI 3.0 specification for this endpoint.
+
+        Returns a spec that can be used with tools like openapi-generator,
+        @hey-api/openapi-ts, or any other OpenAPI-compatible SDK generator.
+        """
+        endpoint = get_object_or_404(Endpoint, team=self.team, name=name)
+        spec = self._generate_openapi_spec(endpoint, request)
+        return Response(spec, content_type="application/json")
+
+    def _generate_openapi_spec(self, endpoint: Endpoint, request: Request) -> dict:
+        """Generate OpenAPI 3.0 spec for a single endpoint."""
+        base_url = settings.SITE_URL or f"{request.scheme}://{request.get_host()}"
+        run_path = f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run"
+
+        # Build request body schema based on query type
+        request_schema = self._build_request_schema(endpoint)
+
+        spec = {
+            "openapi": "3.0.3",
+            "info": {
+                "title": endpoint.name,
+                "description": endpoint.description or f"PostHog Endpoint: {endpoint.name}",
+                "version": str(endpoint.current_version),
+            },
+            "servers": [{"url": base_url}],
+            "paths": {
+                run_path: {
+                    "post": {
+                        "operationId": f"run_{endpoint.name.replace('-', '_')}",
+                        "summary": f"Execute {endpoint.name}",
+                        "description": endpoint.description or f"Execute the {endpoint.name} endpoint",
+                        "security": [{"PersonalAPIKey": []}],
+                        "requestBody": {
+                            "required": False,
+                            "content": {
+                                "application/json": {
+                                    "schema": request_schema,
+                                }
+                            },
+                        },
+                        "responses": {
+                            "200": {
+                                "description": "Query results",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "results": {
+                                                    "type": "array",
+                                                    "items": {},
+                                                    "description": "Query result rows",
+                                                },
+                                                "columns": {
+                                                    "type": "array",
+                                                    "items": {"type": "string"},
+                                                    "description": "Column names (for HogQL queries)",
+                                                },
+                                                "hasMore": {
+                                                    "type": "boolean",
+                                                    "description": "Whether there are more results available",
+                                                },
+                                            },
+                                            "required": ["results"],
+                                        }
+                                    }
+                                },
+                            },
+                            "400": {"description": "Invalid request"},
+                            "401": {"description": "Authentication required"},
+                            "404": {"description": "Endpoint not found"},
+                        },
+                    }
+                }
+            },
+            "components": {
+                "securitySchemes": {
+                    "PersonalAPIKey": {
+                        "type": "http",
+                        "scheme": "bearer",
+                        "description": "Personal API Key from PostHog. Get one at /settings/user-api-keys",
+                    }
+                }
+            },
+        }
+
+        return spec
+
+    def _build_request_schema(self, endpoint: Endpoint) -> dict:
+        """Build the request body schema based on the endpoint's query type."""
+        query_kind = endpoint.query.get("kind")
+        properties: dict = {}
+        schema: dict = {
+            "type": "object",
+            "properties": properties,
+        }
+
+        if query_kind == "HogQLQuery":
+            # HogQL queries support variables
+            variables = endpoint.query.get("variables")
+            if variables:
+                variables_schema = self._build_variables_schema(variables)
+                properties["variables"] = variables_schema
+        else:
+            # Insight queries support query_override
+            properties["query_override"] = {
+                "type": "object",
+                "description": "Override query parameters (e.g., dateRange, interval)",
+                "additionalProperties": True,
+            }
+
+        # Common parameters for all query types
+        properties["filters_override"] = {
+            "type": "object",
+            "description": "Override dashboard filters",
+            "properties": {
+                "properties": {
+                    "type": "array",
+                    "items": {},
+                    "description": "Property filters to apply",
+                }
+            },
+        }
+
+        properties["refresh"] = {
+            "type": "string",
+            "enum": ["blocking", "force_blocking"],
+            "default": "blocking",
+            "description": "Refresh mode for the query",
+        }
+
+        properties["version"] = {
+            "type": "integer",
+            "description": f"Specific endpoint version to execute (1-{endpoint.current_version})",
+        }
+
+        return schema
+
+    def _build_variables_schema(self, variables: dict) -> dict:
+        """Build schema for HogQL variables."""
+        properties = {}
+
+        for var_id, var_data in variables.items():
+            code_name = var_data.get("code_name", var_id)
+            properties[code_name] = {
+                "description": f"Variable: {code_name}",
+            }
+
+        return {
+            "type": "object",
+            "description": "HogQL query variables",
+            "properties": properties,
+            "additionalProperties": True,
+        }

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -2,7 +2,6 @@ import re
 from datetime import timedelta
 from typing import Union, cast
 
-from django.conf import settings
 from django.core.cache import cache
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -62,6 +61,7 @@ from products.data_warehouse.backend.models.external_data_schema import (
     sync_frequency_to_sync_frequency_interval,
 )
 from products.endpoints.backend.models import Endpoint, EndpointVersion
+from products.endpoints.backend.openapi import generate_openapi_spec
 
 from common.hogvm.python.utils import HogVMException
 
@@ -817,151 +817,5 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         @hey-api/openapi-ts, or any other OpenAPI-compatible SDK generator.
         """
         endpoint = get_object_or_404(Endpoint, team=self.team, name=name)
-        spec = self._generate_openapi_spec(endpoint, request)
+        spec = generate_openapi_spec(endpoint, self.team.id, request)
         return Response(spec, content_type="application/json")
-
-    def _generate_openapi_spec(self, endpoint: Endpoint, request: Request) -> dict:
-        """Generate OpenAPI 3.0 spec for a single endpoint."""
-        base_url = settings.SITE_URL or f"{request.scheme}://{request.get_host()}"
-        run_path = f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run"
-
-        # Build request body schema based on query type
-        request_schema = self._build_request_schema(endpoint)
-
-        spec = {
-            "openapi": "3.0.3",
-            "info": {
-                "title": endpoint.name,
-                "description": endpoint.description or f"PostHog Endpoint: {endpoint.name}",
-                "version": str(endpoint.current_version),
-            },
-            "servers": [{"url": base_url}],
-            "paths": {
-                run_path: {
-                    "post": {
-                        "operationId": f"run_{endpoint.name.replace('-', '_')}",
-                        "summary": f"Execute {endpoint.name}",
-                        "description": endpoint.description or f"Execute the {endpoint.name} endpoint",
-                        "security": [{"PersonalAPIKey": []}],
-                        "requestBody": {
-                            "required": False,
-                            "content": {
-                                "application/json": {
-                                    "schema": request_schema,
-                                }
-                            },
-                        },
-                        "responses": {
-                            "200": {
-                                "description": "Query results",
-                                "content": {
-                                    "application/json": {
-                                        "schema": {
-                                            "type": "object",
-                                            "properties": {
-                                                "results": {
-                                                    "type": "array",
-                                                    "items": {},
-                                                    "description": "Query result rows",
-                                                },
-                                                "columns": {
-                                                    "type": "array",
-                                                    "items": {"type": "string"},
-                                                    "description": "Column names (for HogQL queries)",
-                                                },
-                                                "hasMore": {
-                                                    "type": "boolean",
-                                                    "description": "Whether there are more results available",
-                                                },
-                                            },
-                                            "required": ["results"],
-                                        }
-                                    }
-                                },
-                            },
-                            "400": {"description": "Invalid request"},
-                            "401": {"description": "Authentication required"},
-                            "404": {"description": "Endpoint not found"},
-                        },
-                    }
-                }
-            },
-            "components": {
-                "securitySchemes": {
-                    "PersonalAPIKey": {
-                        "type": "http",
-                        "scheme": "bearer",
-                        "description": "Personal API Key from PostHog. Get one at /settings/user-api-keys",
-                    }
-                }
-            },
-        }
-
-        return spec
-
-    def _build_request_schema(self, endpoint: Endpoint) -> dict:
-        """Build the request body schema based on the endpoint's query type."""
-        query_kind = endpoint.query.get("kind")
-        properties: dict = {}
-        schema: dict = {
-            "type": "object",
-            "properties": properties,
-        }
-
-        if query_kind == "HogQLQuery":
-            # HogQL queries support variables
-            variables = endpoint.query.get("variables")
-            if variables:
-                variables_schema = self._build_variables_schema(variables)
-                properties["variables"] = variables_schema
-        else:
-            # Insight queries support query_override
-            properties["query_override"] = {
-                "type": "object",
-                "description": "Override query parameters (e.g., dateRange, interval)",
-                "additionalProperties": True,
-            }
-
-        # Common parameters for all query types
-        properties["filters_override"] = {
-            "type": "object",
-            "description": "Override dashboard filters",
-            "properties": {
-                "properties": {
-                    "type": "array",
-                    "items": {},
-                    "description": "Property filters to apply",
-                }
-            },
-        }
-
-        properties["refresh"] = {
-            "type": "string",
-            "enum": ["blocking", "force_blocking"],
-            "default": "blocking",
-            "description": "Refresh mode for the query",
-        }
-
-        properties["version"] = {
-            "type": "integer",
-            "description": f"Specific endpoint version to execute (1-{endpoint.current_version})",
-        }
-
-        return schema
-
-    def _build_variables_schema(self, variables: dict) -> dict:
-        """Build schema for HogQL variables."""
-        properties = {}
-
-        for var_id, var_data in variables.items():
-            code_name = var_data.get("code_name", var_id)
-            properties[code_name] = {
-                "description": f"Variable: {code_name}",
-            }
-
-        return {
-            "type": "object",
-            "description": "HogQL query variables",
-            "properties": properties,
-            "additionalProperties": True,
-        }

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -811,7 +811,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         """Generate OpenAPI 3.0 specification for this endpoint.
 
         Returns a spec that can be used with tools like openapi-generator,
-        @hey-api/openapi-ts, or any other OpenAPI-compatible SDK generator.
+        `@hey-api/openapi-ts`, or any other OpenAPI-compatible SDK generator.
         """
         endpoint = get_object_or_404(Endpoint, team=self.team, name=name)
         spec = generate_openapi_spec(endpoint, self.team.id, request)

--- a/products/endpoints/backend/openapi.py
+++ b/products/endpoints/backend/openapi.py
@@ -7,7 +7,7 @@ from products.endpoints.backend.models import Endpoint
 
 def generate_openapi_spec(endpoint: Endpoint, team_id: int, request: Request) -> dict:
     """Generate OpenAPI 3.0 spec for a single endpoint."""
-    base_url = settings.SITE_URL or f"{request.scheme}://{request.get_host()}"
+    base_url = settings.SITE_URL
     run_path = f"/api/environments/{team_id}/endpoints/{endpoint.name}/run"
 
     return {

--- a/products/endpoints/backend/openapi.py
+++ b/products/endpoints/backend/openapi.py
@@ -1,0 +1,148 @@
+from django.conf import settings
+
+from rest_framework.request import Request
+
+from products.endpoints.backend.models import Endpoint
+
+
+def generate_openapi_spec(endpoint: Endpoint, team_id: int, request: Request) -> dict:
+    """Generate OpenAPI 3.0 spec for a single endpoint."""
+    base_url = settings.SITE_URL or f"{request.scheme}://{request.get_host()}"
+    run_path = f"/api/environments/{team_id}/endpoints/{endpoint.name}/run"
+
+    request_schema = _build_request_schema(endpoint)
+
+    return {
+        "openapi": "3.0.3",
+        "info": {
+            "title": endpoint.name,
+            "description": endpoint.description or f"PostHog Endpoint: {endpoint.name}",
+            "version": str(endpoint.current_version),
+        },
+        "servers": [{"url": base_url}],
+        "paths": {
+            run_path: {
+                "post": {
+                    "operationId": f"run_{endpoint.name.replace('-', '_')}",
+                    "summary": f"Execute {endpoint.name}",
+                    "description": endpoint.description or f"Execute the {endpoint.name} endpoint",
+                    "security": [{"PersonalAPIKey": []}],
+                    "requestBody": {
+                        "required": False,
+                        "content": {
+                            "application/json": {
+                                "schema": request_schema,
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Query results",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "results": {
+                                                "type": "array",
+                                                "items": {},
+                                                "description": "Query result rows",
+                                            },
+                                            "columns": {
+                                                "type": "array",
+                                                "items": {"type": "string"},
+                                                "description": "Column names (for HogQL queries)",
+                                            },
+                                            "hasMore": {
+                                                "type": "boolean",
+                                                "description": "Whether there are more results available",
+                                            },
+                                        },
+                                        "required": ["results"],
+                                    }
+                                }
+                            },
+                        },
+                        "400": {"description": "Invalid request"},
+                        "401": {"description": "Authentication required"},
+                        "404": {"description": "Endpoint not found"},
+                    },
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "PersonalAPIKey": {
+                    "type": "http",
+                    "scheme": "bearer",
+                    "description": "Personal API Key from PostHog. Get one at /settings/user-api-keys",
+                }
+            }
+        },
+    }
+
+
+def _build_request_schema(endpoint: Endpoint) -> dict:
+    """Build the request body schema based on the endpoint's query type."""
+    query_kind = endpoint.query.get("kind")
+    properties: dict = {}
+    schema: dict = {
+        "type": "object",
+        "properties": properties,
+    }
+
+    if query_kind == "HogQLQuery":
+        variables = endpoint.query.get("variables")
+        if variables:
+            variables_schema = _build_variables_schema(variables)
+            properties["variables"] = variables_schema
+    else:
+        properties["query_override"] = {
+            "type": "object",
+            "description": "Override query parameters (e.g., dateRange, interval)",
+            "additionalProperties": True,
+        }
+
+    properties["filters_override"] = {
+        "type": "object",
+        "description": "Override dashboard filters",
+        "properties": {
+            "properties": {
+                "type": "array",
+                "items": {},
+                "description": "Property filters to apply",
+            }
+        },
+    }
+
+    properties["refresh"] = {
+        "type": "string",
+        "enum": ["blocking", "force_blocking"],
+        "default": "blocking",
+        "description": "Refresh mode for the query",
+    }
+
+    properties["version"] = {
+        "type": "integer",
+        "description": f"Specific endpoint version to execute (1-{endpoint.current_version})",
+    }
+
+    return schema
+
+
+def _build_variables_schema(variables: dict) -> dict:
+    """Build schema for HogQL variables."""
+    properties = {}
+
+    for var_id, var_data in variables.items():
+        code_name = var_data.get("code_name", var_id)
+        properties[code_name] = {
+            "description": f"Variable: {code_name}",
+        }
+
+    return {
+        "type": "object",
+        "description": "HogQL query variables",
+        "properties": properties,
+        "additionalProperties": True,
+    }

--- a/products/endpoints/backend/tests/test_endpoint.py
+++ b/products/endpoints/backend/tests/test_endpoint.py
@@ -1013,3 +1013,159 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
         response_data = response.json()
         self.assertEqual("validation_error", response_data["type"])
+
+
+class TestEndpointOpenAPISpec(ClickhouseTestMixin, APIBaseTest):
+    """Tests for the OpenAPI specification generation endpoint."""
+
+    def setUp(self):
+        super().setUp()
+        self.sample_hogql_query = {
+            "kind": "HogQLQuery",
+            "query": "SELECT count(1) FROM events",
+        }
+
+    def test_openapi_spec_basic(self):
+        """Test generating OpenAPI spec for a basic endpoint."""
+        Endpoint.objects.create(
+            name="basic-endpoint",
+            team=self.team,
+            query=self.sample_hogql_query,
+            description="A basic test endpoint",
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/basic-endpoint/openapi.json/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        spec = response.json()
+
+        self.assertEqual(spec["openapi"], "3.0.3")
+        self.assertEqual(spec["info"]["title"], "basic-endpoint")
+        self.assertEqual(spec["info"]["description"], "A basic test endpoint")
+        self.assertEqual(spec["info"]["version"], "1")
+
+        self.assertIn("servers", spec)
+        self.assertEqual(len(spec["servers"]), 1)
+
+        run_path = f"/api/environments/{self.team.id}/endpoints/basic-endpoint/run"
+        self.assertIn(run_path, spec["paths"])
+
+        post_op = spec["paths"][run_path]["post"]
+        self.assertEqual(post_op["operationId"], "run_basic_endpoint")
+        self.assertIn("requestBody", post_op)
+        self.assertIn("responses", post_op)
+        self.assertIn("200", post_op["responses"])
+
+        response_schema = post_op["responses"]["200"]["content"]["application/json"]["schema"]
+        self.assertIn("results", response_schema["properties"])
+        self.assertEqual(response_schema["properties"]["results"]["type"], "array")
+
+    def test_openapi_spec_with_variables(self):
+        """Test that HogQL endpoints with variables include variables in the schema."""
+        from posthog.models.insight_variable import InsightVariable
+
+        variable = InsightVariable.objects.create(
+            team=self.team,
+            name="Country Filter",
+            code_name="country",
+            type=InsightVariable.Type.STRING,
+            default_value="US",
+        )
+
+        query_with_variables = {
+            "kind": "HogQLQuery",
+            "query": "SELECT * FROM events WHERE properties.$country = {variables.country}",
+            "variables": {str(variable.id): {"variableId": str(variable.id), "code_name": "country", "value": "US"}},
+        }
+
+        Endpoint.objects.create(
+            name="endpoint-with-vars",
+            team=self.team,
+            query=query_with_variables,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/endpoint-with-vars/openapi.json/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        spec = response.json()
+
+        run_path = f"/api/environments/{self.team.id}/endpoints/endpoint-with-vars/run"
+        request_schema = spec["paths"][run_path]["post"]["requestBody"]["content"]["application/json"]["schema"]
+
+        self.assertIn("variables", request_schema["properties"])
+        variables_schema = request_schema["properties"]["variables"]
+        self.assertEqual(variables_schema["type"], "object")
+        self.assertIn("country", variables_schema["properties"])
+
+    def test_openapi_spec_insight_query(self):
+        """Test that insight queries include query_override in the schema."""
+        insight_query = {
+            "kind": "TrendsQuery",
+            "series": [{"kind": "EventsNode", "event": "$pageview"}],
+        }
+
+        Endpoint.objects.create(
+            name="trends-endpoint",
+            team=self.team,
+            query=insight_query,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/trends-endpoint/openapi.json/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        spec = response.json()
+
+        run_path = f"/api/environments/{self.team.id}/endpoints/trends-endpoint/run"
+        request_schema = spec["paths"][run_path]["post"]["requestBody"]["content"]["application/json"]["schema"]
+
+        self.assertIn("query_override", request_schema["properties"])
+        self.assertIn("filters_override", request_schema["properties"])
+
+    def test_openapi_spec_not_found(self):
+        """Test that requesting spec for non-existent endpoint returns 404."""
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/nonexistent/openapi.json/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_openapi_spec_security_scheme(self):
+        """Test that the spec includes proper security scheme."""
+        Endpoint.objects.create(
+            name="secure-endpoint",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/secure-endpoint/openapi.json/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        spec = response.json()
+
+        self.assertIn("components", spec)
+        self.assertIn("securitySchemes", spec["components"])
+        self.assertIn("PersonalAPIKey", spec["components"]["securitySchemes"])
+        self.assertEqual(spec["components"]["securitySchemes"]["PersonalAPIKey"]["type"], "http")
+        self.assertEqual(spec["components"]["securitySchemes"]["PersonalAPIKey"]["scheme"], "bearer")
+
+    def test_openapi_spec_version_reflects_endpoint_version(self):
+        """Test that the spec version matches the endpoint's current version."""
+        Endpoint.objects.create(
+            name="versioned-endpoint",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+            is_active=True,
+            current_version=3,
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/endpoints/versioned-endpoint/openapi.json/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        spec = response.json()
+        self.assertEqual(spec["info"]["version"], "3")


### PR DESCRIPTION
Add a new `/openapi.json` route to the Endpoints API that generates
an OpenAPI 3.0 specification for individual endpoints. This enables
customers to use standard SDK generators (openapi-generator, hey-api,
etc.) to create typed clients for their custom PostHog endpoints.

The generated spec includes:
- Endpoint metadata (name, description, version)
- Request body schema with variables (HogQL) or query_override (insights)
- Common parameters (filters_override, refresh, version)
- Response schema with results array
- Bearer token authentication scheme