### PR TITLE
SUPPORT SUPERDAY - Update SidePanelSupport.tsx

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import React from 'react'
 
-import { IconFeatures, IconHelmet, IconMap, IconWarning } from '@posthog/icons'
+import { IconBug, IconFeatures, IconHelmet, IconMap, IconWarning } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { SupportForm } from 'lib/components/Support/SupportForm'
@@ -468,6 +468,17 @@ export function SidePanelSupport(): JSX.Element {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to="https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&template=bug_report.yml"
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
@abigailbramble 

Added a new button to Report a Bug which links to GitHub and uses the existing Bug Report template

## Problem
This is an engineering task for Rodrigo Heinzen's Support Superday. The task was to add a "Report a bug" button in the support panel.

## Changes
Added a `LemonButton` to `SidePanelSupport.tsx` following the same design principles as the button to Suggest a Feature. The button will take to the Report a Bug template in PostHog's Github page.

<img width="1016" height="1806" alt="image" src="https://github.com/user-attachments/assets/0ade798a-9118-4b06-af74-f8ba36b22fbd" />
<img width="3426" height="892" alt="image" src="https://github.com/user-attachments/assets/a910e339-349e-45bd-9084-b960f01b37ba" />


## How did you test this code?

1. Deployed PostHog locally following Flox setup as described here: https://posthog.com/handbook/engineering/developing-locally
2. Checked the panel for any typos and whether the URL destination worked.

Did not implement tests due to Superday Time constraints