### PR TITLE
fix: use requestIdleCallback in replay processing

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
@@ -181,7 +181,7 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
             cache.processingCache = cache.processingCache || { snapshots: {} }
 
             const processingMode = values.featureFlags[FEATURE_FLAGS.REPLAY_YIELDING_PROCESSING]
-            const enableYielding = processingMode === 'yielding' || processingMode === 'worker_and_yielding'
+            const enableYielding = processingMode === 'worker_and_yielding'
             const discardRawSnapshots = !!values.featureFlags[FEATURE_FLAGS.REPLAY_DISCARD_RAW_SNAPSHOTS]
 
             const result = await processAllSnapshots(

--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/DecompressionWorkerManager.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/DecompressionWorkerManager.ts
@@ -2,7 +2,7 @@ import type { PostHog } from 'posthog-js'
 import snappyInit, { decompress_raw } from 'snappy-wasm'
 
 import type { DecompressionRequest, DecompressionResponse } from './decompressionWorker'
-import { yieldToMain } from './yield-scheduler'
+import { requestIdleCallback } from './yield-scheduler'
 
 interface PendingRequest {
     resolve: (data: Uint8Array) => void
@@ -18,11 +18,11 @@ interface DecompressionStats {
     totalSize: number
 }
 
-export type DecompressionMode = 'worker' | 'yielding' | 'blocking' | 'worker_and_yielding'
+export type DecompressionMode = 'worker' | 'worker_and_yielding'
 
 export function normalizeMode(mode?: string | boolean): DecompressionMode {
-    if (mode === 'worker' || mode === 'yielding' || mode === 'worker_and_yielding' || mode === 'blocking') {
-        return mode
+    if (mode === 'worker_and_yielding') {
+        return 'worker_and_yielding'
     }
     return 'worker'
 }
@@ -43,8 +43,7 @@ export class DecompressionWorkerManager {
         private readonly posthog?: PostHog
     ) {
         this.mode = normalizeMode(mode)
-        this.readyPromise =
-            this.mode === 'worker' || this.mode === 'worker_and_yielding' ? this.initWorker() : this.initSnappy()
+        this.readyPromise = this.initWorker()
     }
 
     private getErrorMessage(error: unknown): string {
@@ -146,11 +145,7 @@ export class DecompressionWorkerManager {
     }
 
     private shouldUseWorker(): boolean {
-        return (
-            (this.mode === 'worker' || this.mode === 'worker_and_yielding') &&
-            this.worker !== null &&
-            !this.workerInitFailed
-        )
+        return this.worker !== null && !this.workerInitFailed
     }
 
     private async decompressWithFallback(
@@ -236,20 +231,38 @@ export class DecompressionWorkerManager {
         const startTime = performance.now()
         const dataSize = compressedData.length
 
-        try {
-            let yieldDuration = 0
-            if (this.mode === 'yielding' || this.mode === 'worker_and_yielding') {
-                const yieldStart = performance.now()
-                await yieldToMain()
-                yieldDuration = performance.now() - yieldStart
-            }
+        if (this.mode === 'worker_and_yielding') {
+            return new Promise<Uint8Array>((resolve, reject) => {
+                const idleStart = performance.now()
+                requestIdleCallback(() => {
+                    const idleDuration = performance.now() - idleStart
+                    try {
+                        const decompressStart = performance.now()
+                        const result = decompress_raw(compressedData)
+                        const decompressDuration = performance.now() - decompressStart
+                        const totalDuration = performance.now() - startTime
+                        this.updateStats(
+                            totalDuration,
+                            dataSize,
+                            idleDuration,
+                            decompressDuration,
+                            metadata?.isParallel
+                        )
+                        resolve(result)
+                    } catch (error) {
+                        console.error('Decompression error:', error)
+                        reject(error instanceof Error ? error : new Error('Unknown decompression error'))
+                    }
+                })
+            })
+        }
 
+        try {
             const decompressStart = performance.now()
             const result = decompress_raw(compressedData)
             const decompressDuration = performance.now() - decompressStart
-
             const totalDuration = performance.now() - startTime
-            this.updateStats(totalDuration, dataSize, yieldDuration, decompressDuration, metadata?.isParallel)
+            this.updateStats(totalDuration, dataSize, undefined, decompressDuration, metadata?.isParallel)
             return result
         } catch (error) {
             console.error('Decompression error:', error)

--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/__mocks__/yield-scheduler.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/__mocks__/yield-scheduler.ts
@@ -1,5 +1,9 @@
 // Mock implementation of yield-scheduler for testing
-export async function yieldToMain(): Promise<void> {
-    // In tests, don't actually yield - just return immediately
-    return Promise.resolve()
+export const requestIdleCallback = (callback: (deadline: IdleDeadline) => void): number => {
+    // In tests, call immediately with a fake deadline that has plenty of time
+    callback({
+        didTimeout: false,
+        timeRemaining: () => 50,
+    })
+    return 0
 }

--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
@@ -20,7 +20,7 @@ import {
 } from 'scenes/session-recordings/player/snapshot-processing/patch-meta-event'
 import { SourceKey, keyForSource } from 'scenes/session-recordings/player/snapshot-processing/source-key'
 import { throttleCapture } from 'scenes/session-recordings/player/snapshot-processing/throttle-capturing'
-import { yieldToMain } from 'scenes/session-recordings/player/snapshot-processing/yield-scheduler'
+import { requestIdleCallback } from 'scenes/session-recordings/player/snapshot-processing/yield-scheduler'
 
 import {
     EncodedRecordingSnapshot,
@@ -226,7 +226,7 @@ function processSnapshot(
     pushPatchedMeta: (ts: number, winId?: number, fullSnapshot?: RecordingSnapshot) => boolean,
     sessionRecordingId: string,
     sourceKey: SourceKey
-): 'continue' | 'process' {
+): void {
     const currentTimestamp = snapshot.timestamp
 
     if (currentTimestamp === context.previousTimestamp) {
@@ -243,7 +243,7 @@ function processSnapshot(
                     sourceKey: sourceKey,
                 })
             })
-            return 'continue'
+            return
         }
     } else {
         context.seenHashes = new Set<number>()
@@ -303,7 +303,6 @@ function processSnapshot(
     context.result.push(snapshot)
     context.sourceResult.push(snapshot)
     context.previousTimestamp = currentTimestamp
-    return 'process'
 }
 
 async function processAllSnapshotsAsync(
@@ -328,71 +327,92 @@ async function processAllSnapshotsAsync(
         seenHashes: new Set<number>(),
     }
 
-    const YIELD_BATCH_SIZE = 50
+    return new Promise((resolve) => {
+        let sourceIdx = 0
+        let snapshotIndex = 0
+        let sortedSnapshots: RecordingSnapshot[] = []
+        let pushPatchedMeta: ReturnType<typeof createPushPatchedMeta> | null = null
+        let currentSourceKey: SourceKey | null = null
 
-    for (let sourceIdx = 0; sourceIdx < sources.length; sourceIdx++) {
-        const source = sources[sourceIdx]
-        const sourceKey = keyForSource(source)
+        const processChunk = (deadline: IdleDeadline): void => {
+            while (deadline.timeRemaining() > 0 && sourceIdx < sources.length) {
+                const source = sources[sourceIdx]
+                const sourceKey = keyForSource(source)
 
-        if (sourceKey in processingCache.snapshots) {
-            const cachedSnapshots = processingCache.snapshots[sourceKey]
-            for (const snapshot of cachedSnapshots) {
-                context.result.push(snapshot)
+                if (currentSourceKey !== sourceKey) {
+                    if (currentSourceKey !== null && processingCache.snapshots[currentSourceKey]) {
+                        if (discardRawSnapshots && snapshotsBySource[currentSourceKey]) {
+                            snapshotsBySource[currentSourceKey].snapshots = []
+                        }
+                    }
+
+                    currentSourceKey = sourceKey
+                    snapshotIndex = 0
+
+                    if (sourceKey in processingCache.snapshots) {
+                        const cachedSnapshots = processingCache.snapshots[sourceKey]
+                        for (const snapshot of cachedSnapshots) {
+                            context.result.push(snapshot)
+                        }
+                        sourceIdx++
+                        continue
+                    }
+
+                    if (!(sourceKey in snapshotsBySource)) {
+                        sourceIdx++
+                        continue
+                    }
+
+                    const sourceSnapshots = snapshotsBySource[sourceKey].snapshots || []
+                    if (!sourceSnapshots.length) {
+                        sourceIdx++
+                        continue
+                    }
+
+                    context.sourceResult = []
+                    sortedSnapshots = sourceSnapshots.sort((a, b) => a.timestamp - b.timestamp)
+                    context.seenHashes = new Set<number>()
+                    pushPatchedMeta = createPushPatchedMeta(
+                        context,
+                        sourceKey,
+                        viewportForTimestamp,
+                        sessionRecordingId
+                    )
+                }
+
+                while (deadline.timeRemaining() > 0 && snapshotIndex < sortedSnapshots.length) {
+                    const snapshot = sortedSnapshots[snapshotIndex]
+                    processSnapshot(
+                        snapshot,
+                        sortedSnapshots,
+                        snapshotIndex,
+                        context,
+                        pushPatchedMeta!,
+                        sessionRecordingId,
+                        sourceKey
+                    )
+                    snapshotIndex++
+                }
+
+                if (snapshotIndex >= sortedSnapshots.length) {
+                    processingCache.snapshots[sourceKey] = context.sourceResult
+                    if (discardRawSnapshots && snapshotsBySource[sourceKey]) {
+                        snapshotsBySource[sourceKey].snapshots = []
+                    }
+                    sourceIdx++
+                }
             }
-            continue
-        }
 
-        if (!(sourceKey in snapshotsBySource)) {
-            continue
-        }
-
-        const sourceSnapshots = snapshotsBySource[sourceKey].snapshots || []
-        if (!sourceSnapshots.length) {
-            continue
-        }
-
-        context.sourceResult = []
-        const sortedSnapshots = sourceSnapshots.sort((a, b) => a.timestamp - b.timestamp)
-        context.seenHashes = new Set<number>()
-        const pushPatchedMeta = createPushPatchedMeta(context, sourceKey, viewportForTimestamp, sessionRecordingId)
-
-        for (let snapshotIndex = 0; snapshotIndex < sortedSnapshots.length; snapshotIndex++) {
-            const snapshot = sortedSnapshots[snapshotIndex]
-            const action = processSnapshot(
-                snapshot,
-                sortedSnapshots,
-                snapshotIndex,
-                context,
-                pushPatchedMeta,
-                sessionRecordingId,
-                sourceKey
-            )
-
-            if (action === 'continue') {
-                continue
-            }
-
-            if (snapshotIndex % YIELD_BATCH_SIZE === 0 && snapshotIndex < sortedSnapshots.length - 1) {
-                await yieldToMain()
+            if (sourceIdx < sources.length) {
+                requestIdleCallback(processChunk)
+            } else {
+                context.result.sort((a, b) => a.timestamp - b.timestamp)
+                resolve(context.result)
             }
         }
 
-        processingCache.snapshots[sourceKey] = context.sourceResult
-
-        // Clear original snapshots after processing to free memory
-        // Once processed, we only need processingCache.snapshots[sourceKey]
-        if (discardRawSnapshots && snapshotsBySource[sourceKey]) {
-            snapshotsBySource[sourceKey].snapshots = []
-        }
-
-        if (sourceIdx < sources.length - 1) {
-            await yieldToMain()
-        }
-    }
-
-    context.result.sort((a, b) => a.timestamp - b.timestamp)
-
-    return context.result
+        requestIdleCallback(processChunk)
+    })
 }
 
 function processAllSnapshotsSync(
@@ -445,7 +465,7 @@ function processAllSnapshotsSync(
 
         for (let snapshotIndex = 0; snapshotIndex < sortedSnapshots.length; snapshotIndex++) {
             const snapshot = sortedSnapshots[snapshotIndex]
-            const action = processSnapshot(
+            processSnapshot(
                 snapshot,
                 sortedSnapshots,
                 snapshotIndex,
@@ -454,10 +474,6 @@ function processAllSnapshotsSync(
                 sessionRecordingId,
                 sourceKey
             )
-
-            if (action === 'continue') {
-                continue
-            }
         }
 
         processingCache.snapshots[sourceKey] = context.sourceResult
@@ -634,7 +650,7 @@ export const parseEncodedSnapshots = async (
     registerWindowId?: RegisterWindowIdCallback
 ): Promise<RecordingSnapshot[]> => {
     const startTime = performance.now()
-    const enableYielding = decompressionMode === 'yielding' || decompressionMode === 'worker_and_yielding'
+    const enableYielding = decompressionMode === 'worker_and_yielding'
 
     const registerFn: RegisterWindowIdCallback = registerWindowId || createWindowIdRegistry()
 
@@ -708,24 +724,18 @@ export const parseEncodedSnapshots = async (
 
     const lineCount = items.length
     const unparseableLines: string[] = []
-
     const parsedLines: RecordingSnapshot[] = []
-    const PARSE_BATCH_SIZE = 100
 
-    for (let i = 0; i < items.length; i++) {
-        const l = items[i]
+    const parseItem = (l: RecordingSnapshot | EncodedRecordingSnapshot | string): void => {
         if (!l) {
-            // blob files have an empty line at the end
-            continue
+            return
         }
         try {
-            // Raw snapshot line from API - windowId is a UUID string, or from file export with numeric windowId
             let snapshotLine:
                 | { windowId?: string; window_id?: string; data?: unknown[] }
                 | EncodedRecordingSnapshot
                 | RecordingSnapshot
             if (typeof l === 'string') {
-                // is loaded from blob v1 storage
                 snapshotLine = JSON.parse(l) as EncodedRecordingSnapshot
 
                 if (Array.isArray(snapshotLine)) {
@@ -735,13 +745,10 @@ export const parseEncodedSnapshots = async (
                     }
                 }
             } else {
-                // is loaded from file export - already has numeric windowId
                 snapshotLine = l
             }
 
-            // Check if this is already a parsed snapshot with numeric windowId
             if (isRecordingSnapshot(snapshotLine)) {
-                // is loaded from file export - already processed
                 const snap = coerceToEventWithTime(snapshotLine, sessionId)
                 const baseSnapshot: RecordingSnapshot = {
                     windowId: snapshotLine.windowId,
@@ -754,8 +761,6 @@ export const parseEncodedSnapshots = async (
                 'timestamp' in snapshotLine &&
                 typeof snapshotLine['windowId'] === 'string'
             ) {
-                // Mobile SDK format: single event with string windowId at top level
-                // The whole object is the event, not data as an array
                 const rawWindowId: string = snapshotLine['windowId']
                 const windowId = registerFn(rawWindowId)
                 const snap = coerceToEventWithTime(snapshotLine, sessionId)
@@ -766,21 +771,17 @@ export const parseEncodedSnapshots = async (
                 const chunkedSnapshots = chunkMutationSnapshot(baseSnapshot)
                 parsedLines.push(...chunkedSnapshots)
             } else {
-                // Web blob storage format: data is array of events
                 const snapshotData = snapshotLine['data'] || []
                 const rawWindowId: string = snapshotLine['window_id'] || snapshotLine['windowId'] || ''
                 const windowId = registerFn(rawWindowId)
 
                 for (const d of snapshotData) {
                     const snap = coerceToEventWithTime(d, sessionId)
-
                     const baseSnapshot: RecordingSnapshot = {
                         windowId,
                         ...snap,
                     }
-
                     const chunkedSnapshots = chunkMutationSnapshot(baseSnapshot)
-
                     parsedLines.push(...chunkedSnapshots)
                 }
             }
@@ -789,28 +790,52 @@ export const parseEncodedSnapshots = async (
                 unparseableLines.push(l)
             }
         }
-
-        if (enableYielding && (i + 1) % PARSE_BATCH_SIZE === 0 && i < items.length - 1) {
-            await yieldToMain()
-        }
     }
 
-    if (unparseableLines.length) {
-        const extra = {
-            playbackSessionId: sessionId,
-            totalLineCount: lineCount,
-            unparseableLinesCount: unparseableLines.length,
-            exampleLines: unparseableLines.slice(0, 3),
-        }
-        throttleCapture(`${sessionId}-unparseable-lines`, () => {
-            posthog.capture('session recording had unparseable lines', {
-                ...extra,
-                feature: 'session-recording-snapshot-processing',
+    const reportUnparseableLines = (): void => {
+        if (unparseableLines.length) {
+            const extra = {
+                playbackSessionId: sessionId,
+                totalLineCount: lineCount,
+                unparseableLinesCount: unparseableLines.length,
+                exampleLines: unparseableLines.slice(0, 3),
+            }
+            throttleCapture(`${sessionId}-unparseable-lines`, () => {
+                posthog.capture('session recording had unparseable lines', {
+                    ...extra,
+                    feature: 'session-recording-snapshot-processing',
+                })
             })
-        })
+        }
     }
 
-    return parsedLines
+    if (!enableYielding) {
+        for (const item of items) {
+            parseItem(item)
+        }
+        reportUnparseableLines()
+        return parsedLines
+    }
+
+    return new Promise((resolve) => {
+        let index = 0
+
+        const processChunk = (deadline: IdleDeadline): void => {
+            while (index < items.length && deadline.timeRemaining() > 0) {
+                parseItem(items[index])
+                index++
+            }
+
+            if (index < items.length) {
+                requestIdleCallback(processChunk)
+            } else {
+                reportUnparseableLines()
+                resolve(parsedLines)
+            }
+        }
+
+        requestIdleCallback(processChunk)
+    })
 }
 
 /*


### PR DESCRIPTION
we tested yielding by using `setTimeout(fn, 0)` and it didn't have great results for web vitals or time to first play

let's have one last stab at this

using requestIdleTimeout we can tell the browser to let user interaction happen before our code

let's test that and see how web vitals and time to first play are affected