### PR TITLE
feat(web-analytics): incompatible filters warning for new query engine

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -3,7 +3,7 @@ import { Form } from 'kea-forms'
 import { useState } from 'react'
 
 import { IconFilter, IconGlobe, IconPhone, IconPlus } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonInput, LemonSelect, Popover, Tooltip } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonDivider, LemonInput, LemonSelect, Popover, Tooltip } from '@posthog/lemon-ui'
 
 import { baseModifier } from 'lib/components/AppShortcuts/shortcuts'
 import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
@@ -51,6 +51,7 @@ const CondensedWebAnalyticsFilterBar = ({ tabs }: { tabs: JSX.Element }): JSX.El
     return (
         <>
             <WebAnalyticsFiltersV2MigrationBanner />
+            <IncompatibleFiltersWarning />
             <FilterBar
                 top={tabs}
                 left={
@@ -90,37 +91,41 @@ export const WebAnalyticsFilters = ({ tabs }: { tabs: JSX.Element }): JSX.Elemen
     }
 
     return (
-        <FilterBar
-            top={tabs}
-            left={
-                <>
-                    <ReloadAll iconOnly />
-                    <DateFilter allowTimePrecision dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} />
+        <>
+            <IncompatibleFiltersWarning />
+            <FilterBar
+                top={tabs}
+                left={
+                    <>
+                        <ReloadAll iconOnly />
+                        <DateFilter allowTimePrecision dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} />
 
-                    <WebAnalyticsDomainSelector />
-                    <WebAnalyticsDeviceToggle />
-                    <LiveUserCount
-                        docLink="https://posthog.com/docs/web-analytics/faq#i-am-online-but-the-online-user-count-is-not-reflecting-my-user"
-                        dataAttr="web-analytics-live-user-count"
-                    />
-                </>
-            }
-            right={
-                <>
-                    <WebAnalyticsCompareFilter />
+                        <WebAnalyticsDomainSelector />
+                        <WebAnalyticsDeviceToggle />
+                        <LiveUserCount
+                            docLink="https://posthog.com/docs/web-analytics/faq#i-am-online-but-the-online-user-count-is-not-reflecting-my-user"
+                            dataAttr="web-analytics-live-user-count"
+                        />
+                    </>
+                }
+                right={
+                    <>
+                        <WebAnalyticsCompareFilter />
 
-                    <WebConversionGoal />
-                    <TableSortingIndicator />
+                        <WebConversionGoal />
+                        <TableSortingIndicator />
 
-                    <WebVitalsPercentileToggle />
-                    <PathCleaningToggle value={isPathCleaningEnabled} onChange={setIsPathCleaningEnabled} />
+                        <WebVitalsPercentileToggle />
+                        <PathCleaningToggle value={isPathCleaningEnabled} onChange={setIsPathCleaningEnabled} />
 
-                    <WebAnalyticsAIFilters>
-                        <WebPropertyFilters />
-                    </WebAnalyticsAIFilters>
-                </>
-            }
-        />
+                        <WebAnalyticsAIFilters>
+                            <WebPropertyFilters />
+                        </WebAnalyticsAIFilters>
+                    </>
+                }
+            />
+        </>
+
     )
 }
 
@@ -510,5 +515,33 @@ const AddSuggestedAuthorizedUrlList = (): JSX.Element => {
                 Add authorized URL
             </LemonButton>
         </div>
+    )
+}
+
+const IncompatibleFiltersWarning = (): JSX.Element | null => {
+    const { hasIncompatibleFilters, incompatibleFilters, preAggregatedEnabled } = useValues(webAnalyticsLogic)
+    const { removeIncompatibleFilters } = useActions(webAnalyticsLogic)
+
+    if (!preAggregatedEnabled || !hasIncompatibleFilters) {
+        return null
+    }
+
+    const filterNames = incompatibleFilters.map((filter) => filter.key).join(', ')
+
+    return (
+        <LemonBanner type="warning" className="mb-2">
+            <div className="flex items-center justify-between w-full">
+                <div>
+                    <div className="font-semibold">Some filters are slowing down your queries</div>
+                    <div className="text-sm mt-0.5">
+                        The following filters are not supported by the new query engine and are causing your queries to
+                        slow down: <strong>{filterNames}</strong>
+                    </div>
+                </div>
+                <LemonButton type="primary" size="small" onClick={removeIncompatibleFilters}>
+                    Remove unsupported filters
+                </LemonButton>
+            </div>
+        </LemonBanner>
     )
 }

--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -125,7 +125,6 @@ export const WebAnalyticsFilters = ({ tabs }: { tabs: JSX.Element }): JSX.Elemen
                 }
             />
         </>
-
     )
 }
 

--- a/frontend/src/scenes/web-analytics/constants.ts
+++ b/frontend/src/scenes/web-analytics/constants.ts
@@ -16,7 +16,7 @@ export const WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_EVENT_PROPERTIES = [
     '$pathname',
     'metadata.loggedIn',
     'metadata.backend',
-] as const
+]
 
 export const WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_SESSION_PROPERTIES = [
     '$entry_pathname',
@@ -27,7 +27,7 @@ export const WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_SESSION_PROPERTIES = [
     '$entry_utm_term',
     '$entry_utm_content',
     '$channel_type',
-] as const
+]
 
 export const WEB_ANALYTICS_PRE_AGGREGATED_PROPERTY_ALLOW_LIST = {
     [TaxonomicFilterGroupType.EventProperties]: WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_EVENT_PROPERTIES,

--- a/frontend/src/scenes/web-analytics/constants.ts
+++ b/frontend/src/scenes/web-analytics/constants.ts
@@ -1,0 +1,92 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
+
+export const WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_EVENT_PROPERTIES = [
+    '$host',
+    '$device_type',
+    '$browser',
+    '$os',
+    '$referring_domain',
+    '$geoip_country_code',
+    '$geoip_city_name',
+    '$geoip_subdivision_1_code',
+    '$geoip_subdivision_1_name',
+    '$geoip_time_zone',
+    '$pathname',
+    'metadata.loggedIn',
+    'metadata.backend',
+] as const
+
+export const WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_SESSION_PROPERTIES = [
+    '$entry_pathname',
+    '$end_pathname',
+    '$entry_utm_source',
+    '$entry_utm_medium',
+    '$entry_utm_campaign',
+    '$entry_utm_term',
+    '$entry_utm_content',
+    '$channel_type',
+] as const
+
+export const WEB_ANALYTICS_PRE_AGGREGATED_PROPERTY_ALLOW_LIST = {
+    [TaxonomicFilterGroupType.EventProperties]: WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_EVENT_PROPERTIES,
+    [TaxonomicFilterGroupType.SessionProperties]: WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_SESSION_PROPERTIES,
+}
+
+export const PROPERTY_CURRENT_URL = '$current_url' as const
+export const PROPERTY_HOST = '$host' as const
+export const PROPERTY_PATHNAME = '$pathname' as const
+
+export const hasURLSearchParams = (filter: AnyPropertyFilter): boolean => {
+    if (filter.key !== PROPERTY_CURRENT_URL || filter.type !== PropertyFilterType.Event) {
+        return false
+    }
+
+    try {
+        const urlValue = Array.isArray(filter.value) ? filter.value[0] : filter.value
+        if (typeof urlValue === 'string') {
+            const url = new URL(urlValue)
+            return !!(url.search && url.search !== '?')
+        }
+    } catch {
+        return true
+    }
+
+    return false
+}
+
+export const convertCurrentURLFilter = (
+    filter: AnyPropertyFilter
+): { key: string; value: string; operator: PropertyOperator; type: PropertyFilterType.Event }[] | null => {
+    if (filter.key !== PROPERTY_CURRENT_URL || filter.type !== PropertyFilterType.Event) {
+        return null
+    }
+
+    try {
+        const urlValue = Array.isArray(filter.value) ? filter.value[0] : filter.value
+        if (typeof urlValue === 'string') {
+            const url = new URL(urlValue)
+            if (!url.search || url.search === '?') {
+                return [
+                    {
+                        key: PROPERTY_HOST,
+                        value: url.host,
+                        operator: filter.operator,
+                        type: PropertyFilterType.Event,
+                    },
+                    {
+                        key: PROPERTY_PATHNAME,
+                        value: url.pathname,
+                        operator: filter.operator,
+                        type: PropertyFilterType.Event,
+                    },
+                ]
+            }
+        }
+    } catch {
+        // URL parsing failed
+    }
+
+    return null
+}

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -103,6 +103,13 @@ import {
     personPropertiesToPathClean,
     sessionPropertiesToPathClean,
 } from './common'
+import {
+    PROPERTY_HOST,
+    WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_EVENT_PROPERTIES,
+    WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_SESSION_PROPERTIES,
+    convertCurrentURLFilter,
+    hasURLSearchParams,
+} from './constants'
 import { webAnalyticsHealthLogic } from './health'
 import { getDashboardItemId, getNewInsightUrlFactory } from './insightsUtils'
 import { webAnalyticsFilterLogic } from './webAnalyticsFilterLogic'
@@ -168,6 +175,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         ],
     })),
     actions({
+        removeIncompatibleFilters: true,
         setGraphsTab: (tab: string) => ({ tab }),
         setSourceTab: (tab: string) => ({ tab }),
         setDeviceTab: (tab: string) => ({ tab }),
@@ -461,6 +469,40 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     currentTeam?.modifiers?.useWebAnalyticsPreAggregatedTables
                 )
             },
+        ],
+        incompatibleFilters: [
+            (s) => [s.rawWebAnalyticsFilters, s.preAggregatedEnabled],
+            (
+                rawWebAnalyticsFilters: WebAnalyticsPropertyFilters,
+                preAggregatedEnabled: boolean
+            ): WebAnalyticsPropertyFilters => {
+                if (!preAggregatedEnabled) {
+                    return []
+                }
+
+                return rawWebAnalyticsFilters.filter((filter) => {
+                    if (hasURLSearchParams(filter)) {
+                        return true
+                    }
+
+                    if (filter.type === PropertyFilterType.Event) {
+                        return !(WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_EVENT_PROPERTIES as readonly string[]).includes(
+                            filter.key
+                        )
+                    } else if (filter.type === PropertyFilterType.Session) {
+                        return !(WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_SESSION_PROPERTIES as readonly string[]).includes(
+                            filter.key
+                        )
+                    } else if (filter.type === PropertyFilterType.Person) {
+                        return true
+                    }
+                    return false
+                })
+            },
+        ],
+        hasIncompatibleFilters: [
+            (s) => [s.incompatibleFilters],
+            (incompatibleFilters: WebAnalyticsPropertyFilters) => incompatibleFilters.length > 0,
         ],
         breadcrumbs: [
             () => [],
@@ -2347,6 +2389,37 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     filter_type: 'percentile',
                     total_filter_count: values.webAnalyticsFilters.length,
                 })
+            },
+            removeIncompatibleFilters: () => {
+                let compatibleFilters = values.rawWebAnalyticsFilters.filter(
+                    (filter) =>
+                        !values.incompatibleFilters.some(
+                            (incompatible) =>
+                                incompatible.key === filter.key &&
+                                incompatible.value === filter.value &&
+                                incompatible.operator === filter.operator &&
+                                incompatible.type === filter.type
+                        )
+                )
+
+                const convertedFilters: WebAnalyticsPropertyFilters = []
+                for (const filter of compatibleFilters) {
+                    const converted = convertCurrentURLFilter(filter)
+                    if (converted) {
+                        convertedFilters.push(...converted)
+                    } else {
+                        convertedFilters.push(filter)
+                    }
+                }
+
+                const hostFilters = convertedFilters.filter((f) => f.key === PROPERTY_HOST)
+                if (hostFilters.length > 1) {
+                    const dedupedFilters = convertedFilters.filter((f) => f.key !== PROPERTY_HOST)
+                    dedupedFilters.push(hostFilters[0])
+                    actions.setWebAnalyticsFilters(dedupedFilters)
+                } else {
+                    actions.setWebAnalyticsFilters(convertedFilters)
+                }
             },
             setProductTab: ({ tab }) => {
                 if (tab === ProductTab.HEALTH) {

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -486,13 +486,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     }
 
                     if (filter.type === PropertyFilterType.Event) {
-                        return !(WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_EVENT_PROPERTIES as readonly string[]).includes(
-                            filter.key
-                        )
+                        return !WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_EVENT_PROPERTIES.includes(filter.key)
                     } else if (filter.type === PropertyFilterType.Session) {
-                        return !(WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_SESSION_PROPERTIES as readonly string[]).includes(
-                            filter.key
-                        )
+                        return !WEB_ANALYTICS_PRE_AGGREGATED_ALLOWED_SESSION_PROPERTIES.includes(filter.key)
                     } else if (filter.type === PropertyFilterType.Person) {
                         return true
                     }


### PR DESCRIPTION
## Problem

We ended up with unsupported filters, even with the toggle for the new query engine set to ON. (more context: https://posthog.slack.com/archives/C05LJK1N3CP/p1765483649024119)

Trying to reproduce it, I got two ideas where this might happen:
- When the toggle is changed, and the filters are already set
- Posthog AI can suggest it in some weird cases. 

We can't protect against all of them, so instead of just cleaning them up, let's warn the user with a banner. 

## Changes

- Added a banner to warn and prompt users to remove the unsupported filters
- Added a special condition like the Page Reports logic to parse `$current_url` filters that don't include query strings and transform then into `host + path` so they hit the optimized tables

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
