### PR TITLE
fix(slack): Reject mentions from external workspaces in Slack Connect

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -33,6 +33,19 @@ def handle_app_mention(event: dict, slack_team_id: str) -> None:
     if not thread_ts:
         return
 
+    # Security: In Slack Connect channels, users from external workspaces can mention our bot.
+    # We must reject these to prevent data leakage to unauthorized users.
+    # `user_team` is only present when the user is from a different workspace than where the app is installed.
+    user_team = event.get("user_team")
+    if user_team and user_team != slack_team_id:
+        logger.warning(
+            "slack_app_mention_from_external_workspace",
+            user_team=user_team,
+            app_workspace=slack_team_id,
+            user=event.get("user"),
+        )
+        return
+
     logger.info(
         "slack_app_mention_received",
         channel=channel,


### PR DESCRIPTION
## Problem

In Slack Connect channels, users from external workspaces can mention our bot. Without this check, they could access data from a PostHog project they have no authorization for.

## Changes

We now check if `user_team` differs from the workspace where the app is installed and reject such requests.