### PR TITLE
fix(workflows): add preheader, replyTo address fields to native email

### DIFF
--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -28,7 +28,7 @@ export type EmailEditorMode = 'full' | 'preview'
  * native_email-template: editor for creating reusable templates, with only subject and preheader, and email content fields
  */
 export type EmailTemplaterType = 'email' | 'native_email' | 'native_email_template'
-type EmailMetaFieldKey = 'from' | 'preheader' | 'to' | 'subject'
+type EmailMetaFieldKey = 'from' | 'to' | 'replyTo' | 'subject' | 'preheader'
 type EmailMetaField = {
     key: EmailMetaFieldKey
     label: string
@@ -39,13 +39,19 @@ type EmailMetaField = {
 
 const EMAIL_META_FIELDS = {
     FROM: { key: 'from', label: 'From', optional: false },
+    TO: { key: 'to', label: 'To', optional: false },
+    REPLY_TO: {
+        key: 'replyTo',
+        label: 'Reply-To',
+        optional: true,
+        helpText: 'Optional reply-to email address. You can comma separate multiple reply-to addresses.',
+    },
     PREHEADER: {
         key: 'preheader',
         label: 'Preheader',
         optional: true,
         helpText: 'This is the preview text that appears below the subject line in an inbox.',
     },
-    TO: { key: 'to', label: 'To', optional: false },
     SUBJECT: { key: 'subject', label: 'Subject', optional: false },
 } as const
 
@@ -54,6 +60,7 @@ const EMAIL_TYPE_SUPPORTED_FIELDS: Record<EmailTemplaterType, EmailMetaField[]> 
     native_email: [
         EMAIL_META_FIELDS.FROM,
         EMAIL_META_FIELDS.TO,
+        EMAIL_META_FIELDS.REPLY_TO,
         EMAIL_META_FIELDS.SUBJECT,
         EMAIL_META_FIELDS.PREHEADER,
     ],

--- a/plugin-server/src/cdp/services/messaging/email.service.test.ts
+++ b/plugin-server/src/cdp/services/messaging/email.service.test.ts
@@ -330,7 +330,7 @@ describe('EmailService', () => {
             await service.ses.verifyDomainIdentity({ Domain: 'posthog-test.com' }).promise()
             invocation.queueParameters = createEmailParams({
                 from: { integrationId: 1, email: 'test@posthog-test.com' },
-                html: '<body>Test content</body>',
+                html: '<tbody>Test email content</tbody>',
             })
             const result = await service.executeSendEmail(invocation)
             expect(result.error).toBeUndefined()
@@ -342,7 +342,7 @@ describe('EmailService', () => {
             await service.ses.verifyDomainIdentity({ Domain: 'posthog-test.com' }).promise()
             invocation.queueParameters = createEmailParams({
                 from: { integrationId: 1, email: 'test@posthog-test.com' },
-                html: '<tbody>Test content</tbody>',
+                html: '<tbody>Test email content</tbody>',
                 preheader: 'This is a preview text',
             })
             const result = await service.executeSendEmail(invocation)

--- a/plugin-server/src/cdp/services/messaging/email.service.test.ts
+++ b/plugin-server/src/cdp/services/messaging/email.service.test.ts
@@ -289,5 +289,66 @@ describe('EmailService', () => {
                 }
             `)
         })
+
+        it('should not include replyTo if not in params', async () => {
+            await service.ses.verifyDomainIdentity({ Domain: 'posthog-test.com' }).promise()
+            invocation.queueParameters = createEmailParams({
+                from: { integrationId: 1, email: 'test@posthog-test.com' },
+            })
+            const result = await service.executeSendEmail(invocation)
+            expect(result.error).toBeUndefined()
+            expect(sendEmailSpy.mock.calls[0][0].ReplyToAddresses).toBeUndefined()
+        })
+
+        it('should include single replyTo address if in params', async () => {
+            await service.ses.verifyDomainIdentity({ Domain: 'posthog-test.com' }).promise()
+            invocation.queueParameters = createEmailParams({
+                from: { integrationId: 1, email: 'test@posthog-test.com' },
+                replyTo: 'Customer Service <reply@example.com>',
+            })
+            const result = await service.executeSendEmail(invocation)
+            expect(result.error).toBeUndefined()
+            expect(sendEmailSpy.mock.calls[0][0].ReplyToAddresses).toEqual(['Customer Service <reply@example.com>'])
+        })
+
+        it('should split multiple comma-separated replyTo addresses', async () => {
+            await service.ses.verifyDomainIdentity({ Domain: 'posthog-test.com' }).promise()
+            invocation.queueParameters = createEmailParams({
+                from: { integrationId: 1, email: 'test@posthog-test.com' },
+                replyTo: 'reply1@example.com, reply2@example.com, Customer Service <reply3@example.com>',
+            })
+            const result = await service.executeSendEmail(invocation)
+            expect(result.error).toBeUndefined()
+            expect(sendEmailSpy.mock.calls[0][0].ReplyToAddresses).toEqual([
+                'reply1@example.com',
+                'reply2@example.com',
+                'Customer Service <reply3@example.com>',
+            ])
+        })
+
+        it('should not include preheader span if not in params', async () => {
+            await service.ses.verifyDomainIdentity({ Domain: 'posthog-test.com' }).promise()
+            invocation.queueParameters = createEmailParams({
+                from: { integrationId: 1, email: 'test@posthog-test.com' },
+                html: '<body>Test content</body>',
+            })
+            const result = await service.executeSendEmail(invocation)
+            expect(result.error).toBeUndefined()
+            const htmlData = sendEmailSpy.mock.calls[0][0].Message.Body.Html.Data
+            expect(htmlData).not.toContain('<tbody><span')
+        })
+
+        it('should include preheader at top of HTML if in params', async () => {
+            await service.ses.verifyDomainIdentity({ Domain: 'posthog-test.com' }).promise()
+            invocation.queueParameters = createEmailParams({
+                from: { integrationId: 1, email: 'test@posthog-test.com' },
+                html: '<tbody>Test content</tbody>',
+                preheader: 'This is a preview text',
+            })
+            const result = await service.executeSendEmail(invocation)
+            expect(result.error).toBeUndefined()
+            const htmlData = sendEmailSpy.mock.calls[0][0].Message.Body.Html.Data
+            expect(htmlData).toMatch(/<tbody><span style=\".*\">This is a preview text<\/span>/)
+        })
     })
 })

--- a/plugin-server/src/cdp/services/messaging/email.service.ts
+++ b/plugin-server/src/cdp/services/messaging/email.service.ts
@@ -162,8 +162,11 @@ export class EmailService {
             Tags: [{ Name: 'ph_id', Value: trackingCode }],
         }
 
-        if (params.replyTo) {
-            sendEmailParams.ReplyToAddresses = params.replyTo.split(',').map((addr) => addr.trim())
+        if (params.replyTo && params.replyTo.trim()) {
+            sendEmailParams.ReplyToAddresses = params.replyTo
+                .split(',')
+                .map((addr) => addr.trim())
+                .filter((addr) => addr.length > 0)
         }
 
         try {

--- a/plugin-server/src/cdp/services/messaging/helpers/preheader.ts
+++ b/plugin-server/src/cdp/services/messaging/helpers/preheader.ts
@@ -1,0 +1,17 @@
+export const addPreheaderToEmail = (html: string, preheader: string): string => {
+    const preheaderHtml = `<span style=display:none !important;
+           visibility:hidden;
+           mso-hide:all;
+           font-size:1px;
+           color:#ffffff;
+           line-height:1px;
+           max-height:0px;
+           max-width:0px;
+           opacity:0;
+           overflow:hidden;>
+        ${preheader}
+    </span>`
+
+    // Insert preheader right after opening <body> tag
+    return html.replace('<body>', `<body>${preheaderHtml}`)
+}

--- a/plugin-server/src/cdp/services/messaging/helpers/preheader.ts
+++ b/plugin-server/src/cdp/services/messaging/helpers/preheader.ts
@@ -1,17 +1,4 @@
 export const addPreheaderToEmail = (html: string, preheader: string): string => {
-    const preheaderHtml = `<span style=display:none !important;
-           visibility:hidden;
-           mso-hide:all;
-           font-size:1px;
-           color:#ffffff;
-           line-height:1px;
-           max-height:0px;
-           max-width:0px;
-           opacity:0;
-           overflow:hidden;>
-        ${preheader}
-    </span>`
-
-    // Insert preheader right after opening <body> tag
-    return html.replace('<body>', `<body>${preheaderHtml}`)
+    const preheaderHtml = `<span style="display:none !important;visibility:hidden;mso-hide:all;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">${preheader}</span>`
+    return html.replace('<tbody>', `<tbody>${preheaderHtml}`)
 }

--- a/plugin-server/src/cdp/templates/_destinations/email/email.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/email/email.template.ts
@@ -34,6 +34,7 @@ export const template: HogFunctionTemplate = {
                     email: '',
                     name: '',
                 },
+                replyTo: '',
                 subject: '',
                 preheader: '',
                 text: 'Hello from PostHog!',

--- a/plugin-server/src/schema/cyclotron.ts
+++ b/plugin-server/src/schema/cyclotron.ts
@@ -73,12 +73,14 @@ export const CyclotronInvocationQueueParametersEmailSchema = z.object({
         email: z.string(),
         name: z.string().optional(),
     }),
+    replyTo: z.string().optional(),
     from: z.object({
         email: z.string(),
         name: z.string().optional(),
         integrationId: z.number(),
     }),
     subject: z.string(),
+    preheader: z.string().optional(),
     text: z.string(),
     html: z.string(),
 })


### PR DESCRIPTION
## Problem

Some useful fields are not yet included in the email UX / in request to SES

## Changes

Add UX for reply-to on the native email form, pass preheader properly

<img width="591" height="310" alt="Screenshot 2025-12-12 at 3 20 40 PM" src="https://github.com/user-attachments/assets/e2d5e687-0ebd-49e7-8edb-8a4019736137" />

## How did you test this code?

- Validated locally against AWS dev
Preheader:
<img width="1217" height="67" alt="Screenshot 2025-12-12 at 3 10 43 PM" src="https://github.com/user-attachments/assets/4dc70cb3-b6ce-4610-96b5-ae7adfd76495" />
<img width="1227" height="349" alt="Screenshot 2025-12-12 at 3 11 07 PM" src="https://github.com/user-attachments/assets/f669134b-7c84-401c-bb84-d7984c241e6a" />

Reply-to:
<img width="604" height="222" alt="Screenshot 2025-12-12 at 3 21 52 PM" src="https://github.com/user-attachments/assets/63ba49d8-c80e-4e4c-902e-ec789311d0fc" />


- added tests for mail delivery logic
