### PR TITLE
chore(product tours): disable billing for internal product tour targeting flags

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -13,7 +13,7 @@ from statshog.defaults.django import statsd
 
 from posthog.api.survey import get_surveys_count, get_surveys_opt_in
 from posthog.api.utils import get_project_id, get_token, on_permitted_recording_domain
-from posthog.constants import SURVEY_TARGETING_FLAG_PREFIX
+from posthog.constants import PRODUCT_TOUR_TARGETING_FLAG_PREFIX, SURVEY_TARGETING_FLAG_PREFIX
 from posthog.database_healthcheck import DATABASE_FOR_FLAG_MATCHING
 from posthog.exceptions import (
     RequestParsingError,
@@ -568,7 +568,10 @@ def _record_feature_flag_metrics(
     ).inc()
 
     # Handle billing analytics
-    if not all(flag.startswith(SURVEY_TARGETING_FLAG_PREFIX) for flag in feature_flags.keys()):
+    if not all(
+        flag.startswith(SURVEY_TARGETING_FLAG_PREFIX) or flag.startswith(PRODUCT_TOUR_TARGETING_FLAG_PREFIX)
+        for flag in feature_flags.keys()
+    ):
         if settings.DECIDE_BILLING_SAMPLING_RATE and random() < settings.DECIDE_BILLING_SAMPLING_RATE:
             count = int(1 / settings.DECIDE_BILLING_SAMPLING_RATE)
             increment_request_count(team.id, count)

--- a/rust/feature-flags/src/flags/flag_analytics.rs
+++ b/rust/feature-flags/src/flags/flag_analytics.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub const SURVEY_TARGETING_FLAG_PREFIX: &str = "survey-targeting-";
+pub const PRODUCT_TOUR_TARGETING_FLAG_PREFIX: &str = "product-tour-targeting-";
+
 const CACHE_BUCKET_SIZE: u64 = 60 * 2; // duration in seconds
 
 pub fn get_team_request_key(team_id: i32, request_type: FlagRequestType) -> String {

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -1,7 +1,10 @@
 use crate::{
     api::{errors::FlagError, types::FlagsResponse},
     flags::{
-        flag_analytics::{increment_request_count, SURVEY_TARGETING_FLAG_PREFIX},
+        flag_analytics::{
+            increment_request_count, PRODUCT_TOUR_TARGETING_FLAG_PREFIX,
+            SURVEY_TARGETING_FLAG_PREFIX,
+        },
         flag_models::FeatureFlagList,
         flag_request::FlagRequestType,
     },
@@ -36,7 +39,7 @@ pub async fn check_limits(
 /// Records usage metrics for feature flag requests.
 ///
 /// Only increments billing counters if there are billable flags present.
-/// Survey targeting flags (prefixed with "survey-targeting-") are not billable.
+/// Survey and product tour targeting flags are not billable.
 pub async fn record_usage(
     context: &RequestContext,
     filtered_flags: &FeatureFlagList,
@@ -64,18 +67,19 @@ pub async fn record_usage(
 
 /// Checks if the flag list contains any billable flags.
 ///
-/// Returns true if there are any flags that are both active and NOT survey targeting flags.
-/// Survey targeting flags (those starting with "survey-targeting-") and disabled flags are free
-/// and don't count toward billing.
+/// Returns true if there are any flags that are both active and NOT survey or
+/// product tour targeting flags.
 fn contains_billable_flags(filtered_flags: &FeatureFlagList) -> bool {
     filtered_flags.flags.iter().any(is_billable_flag)
 }
 
 /// Determines if a flag is billable based on its key and active status.
 ///
-/// Returns true for active regular feature flags, false for survey targeting flags or disabled flags.
+/// Returns true for active regular feature flags, false for survey/product tour targeting flags or disabled flags.
 fn is_billable_flag(flag: &crate::flags::flag_models::FeatureFlag) -> bool {
-    flag.active && !flag.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)
+    flag.active
+        && !flag.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)
+        && !flag.key.starts_with(PRODUCT_TOUR_TARGETING_FLAG_PREFIX)
 }
 
 /// Helper function to determine if usage should be recorded
@@ -235,5 +239,77 @@ mod tests {
 
         // Should NOT record usage when only disabled and survey flags are present
         assert!(!should_record_usage(&flag_list));
+    }
+
+    #[test]
+    fn test_should_record_usage_only_product_tour_flags() {
+        let tour_flag1 = create_test_flag(&format!("{PRODUCT_TOUR_TARGETING_FLAG_PREFIX}tour1"));
+        let tour_flag2 = create_test_flag(&format!("{PRODUCT_TOUR_TARGETING_FLAG_PREFIX}tour2"));
+
+        let flag_list = FeatureFlagList {
+            flags: vec![tour_flag1, tour_flag2],
+        };
+
+        // Should NOT record usage when only product tour flags are present
+        assert!(!should_record_usage(&flag_list));
+    }
+
+    #[test]
+    fn test_should_record_usage_product_tour_mixed_with_regular_flags() {
+        let tour_flag = create_test_flag(&format!("{PRODUCT_TOUR_TARGETING_FLAG_PREFIX}tour1"));
+        let regular_flag = create_test_flag("regular_flag");
+
+        let flag_list = FeatureFlagList {
+            flags: vec![tour_flag, regular_flag],
+        };
+
+        // Should record usage when there's at least one regular flag, even with product tour flags
+        assert!(should_record_usage(&flag_list));
+    }
+
+    #[test]
+    fn test_should_record_usage_disabled_product_tour_flag() {
+        let mut disabled_tour_flag =
+            create_test_flag(&format!("{PRODUCT_TOUR_TARGETING_FLAG_PREFIX}tour1"));
+        disabled_tour_flag.active = false;
+
+        let flag_list = FeatureFlagList {
+            flags: vec![disabled_tour_flag],
+        };
+
+        // Should NOT record usage for disabled product tour flags
+        assert!(!should_record_usage(&flag_list));
+    }
+
+    #[test]
+    fn test_should_record_usage_only_survey_and_product_tour_flags() {
+        let survey_flag = create_test_flag(&format!("{SURVEY_TARGETING_FLAG_PREFIX}survey1"));
+        let tour_flag = create_test_flag(&format!("{PRODUCT_TOUR_TARGETING_FLAG_PREFIX}tour1"));
+
+        let flag_list = FeatureFlagList {
+            flags: vec![survey_flag, tour_flag],
+        };
+
+        // Should NOT record usage when only survey and product tour flags are present
+        assert!(!should_record_usage(&flag_list));
+    }
+
+    #[test]
+    fn test_should_record_usage_product_tour_flag_key_edge_cases() {
+        // Test flag that contains the prefix but doesn't start with it
+        let flag_with_prefix_inside = create_test_flag(&format!(
+            "prefix-{PRODUCT_TOUR_TARGETING_FLAG_PREFIX}middle"
+        ));
+        // Test flag that starts with prefix but has extra content
+        let tour_flag_with_suffix = create_test_flag(&format!(
+            "{PRODUCT_TOUR_TARGETING_FLAG_PREFIX}tour-with-suffix"
+        ));
+
+        let flag_list = FeatureFlagList {
+            flags: vec![flag_with_prefix_inside, tour_flag_with_suffix],
+        };
+
+        // Should record usage: first flag doesn't START with prefix, second does start with prefix
+        assert!(should_record_usage(&flag_list));
     }
 }


### PR DESCRIPTION
## Problem

similar to surveys - we don't want to bill for internal targeting flags on product tours

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

disables billing, i think, need review from FF team pls <3

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->