### PR TITLE
fix(llma): Use server-side evaluation for feature flag checks

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -500,6 +500,7 @@
                        (SELECT actor_id AS actor_id,
                                count() AS event_count,
                                groupUniqArray(distinct_id) AS event_distinct_ids,
+                               max(timestamp) AS last_seen,
                                actor_id AS id
                         FROM
                           (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,

--- a/products/llm_analytics/backend/api/summarization.py
+++ b/products/llm_analytics/backend/api/summarization.py
@@ -167,6 +167,8 @@ class LLMAnalyticsSummarizationViewSet(TeamAndOrgViewSetMixin, viewsets.GenericV
                 person_properties=person_properties,
                 groups=groups,
                 group_properties=group_properties,
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
             )
             or posthoganalytics.feature_enabled(
                 EARLY_ADOPTERS_FEATURE_FLAG,
@@ -174,6 +176,8 @@ class LLMAnalyticsSummarizationViewSet(TeamAndOrgViewSetMixin, viewsets.GenericV
                 person_properties=person_properties,
                 groups=groups,
                 group_properties=group_properties,
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
             )
         ):
             raise exceptions.PermissionDenied("LLM trace summarization is not enabled for this user")

--- a/products/llm_analytics/backend/api/test/test_summarization.py
+++ b/products/llm_analytics/backend/api/test/test_summarization.py
@@ -359,3 +359,6 @@ class TestSummarizationAPI(APIBaseTest):
         self.assertEqual(call_kwargs["group_properties"], {"organization": {"id": str(self.team.organization_id)}})
         self.assertIn("person_properties", call_kwargs)
         self.assertEqual(call_kwargs["person_properties"], {"email": self.user.email})
+        # Server-side evaluation to access Early Access Feature enrollment properties
+        self.assertEqual(call_kwargs["only_evaluate_locally"], False)
+        self.assertEqual(call_kwargs["send_feature_flag_events"], False)

--- a/products/llm_analytics/backend/api/test/test_translate.py
+++ b/products/llm_analytics/backend/api/test/test_translate.py
@@ -212,10 +212,10 @@ class TestTranslateAPI(APIBaseTest):
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        mock_feature_enabled.assert_called_once_with(
-            LLM_ANALYTICS_TRANSLATION,
-            str(self.user.distinct_id),
-        )
+        assert mock_feature_enabled.call_count == 2
+        call_kwargs = mock_feature_enabled.call_args_list[0][1]
+        assert call_kwargs["only_evaluate_locally"] is False
+        assert call_kwargs["send_feature_flag_events"] is False
 
     @patch("products.llm_analytics.backend.api.translate.settings")
     @patch("products.llm_analytics.backend.api.translate.posthoganalytics.feature_enabled")
@@ -256,7 +256,8 @@ class TestTranslateAPI(APIBaseTest):
         )
 
         assert response.status_code == status.HTTP_200_OK
-        mock_feature_enabled.assert_called_once_with(
-            LLM_ANALYTICS_TRANSLATION,
-            str(self.user.distinct_id),
-        )
+        assert mock_feature_enabled.call_count == 1
+        call_args = mock_feature_enabled.call_args
+        assert call_args[0][0] == LLM_ANALYTICS_TRANSLATION
+        assert call_args[1]["only_evaluate_locally"] is False
+        assert call_args[1]["send_feature_flag_events"] is False

--- a/products/llm_analytics/backend/api/translate.py
+++ b/products/llm_analytics/backend/api/translate.py
@@ -5,6 +5,8 @@ Endpoint:
 - POST /api/environments/:id/llm_analytics/translate/ - Translate text
 """
 
+from typing import cast
+
 from django.conf import settings
 
 import structlog
@@ -14,13 +16,18 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.models import User
 from posthog.rate_limit import (
     LLMAnalyticsTranslationBurstThrottle,
     LLMAnalyticsTranslationDailyThrottle,
     LLMAnalyticsTranslationSustainedThrottle,
 )
 
-from products.llm_analytics.backend.translation.constants import DEFAULT_TARGET_LANGUAGE, LLM_ANALYTICS_TRANSLATION
+from products.llm_analytics.backend.translation.constants import (
+    DEFAULT_TARGET_LANGUAGE,
+    EARLY_ADOPTERS_FEATURE_FLAG,
+    LLM_ANALYTICS_TRANSLATION,
+)
 from products.llm_analytics.backend.translation.llm import translate_text
 
 logger = structlog.get_logger(__name__)
@@ -64,9 +71,33 @@ class LLMAnalyticsTranslateViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
         if settings.DEBUG:
             return
 
-        if not posthoganalytics.feature_enabled(
-            LLM_ANALYTICS_TRANSLATION,
-            str(request.user.distinct_id),
+        user = cast(User, request.user)
+        distinct_id = str(user.distinct_id)
+        organization_id = str(self.team.organization_id)
+
+        person_properties = {"email": user.email}
+        groups = {"organization": organization_id}
+        group_properties = {"organization": {"id": organization_id}}
+
+        if not (
+            posthoganalytics.feature_enabled(
+                LLM_ANALYTICS_TRANSLATION,
+                distinct_id,
+                person_properties=person_properties,
+                groups=groups,
+                group_properties=group_properties,
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+            or posthoganalytics.feature_enabled(
+                EARLY_ADOPTERS_FEATURE_FLAG,
+                distinct_id,
+                person_properties=person_properties,
+                groups=groups,
+                group_properties=group_properties,
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
         ):
             raise exceptions.PermissionDenied("LLM trace translation is not enabled for this user")
 

--- a/products/llm_analytics/backend/translation/constants.py
+++ b/products/llm_analytics/backend/translation/constants.py
@@ -3,8 +3,9 @@
 import json
 from pathlib import Path
 
-# Feature flag
+# Feature flags
 LLM_ANALYTICS_TRANSLATION = "llm-analytics-translation"
+EARLY_ADOPTERS_FEATURE_FLAG = "llm-analytics-early-adopters"
 
 # Load supported languages from shared JSON file
 _LANGUAGES_JSON_PATH = Path(__file__).parent.parent.parent / "shared" / "supported_languages.json"


### PR DESCRIPTION
## Problem

Users enrolled in the `llm-analytics-early-adopters` Early Access Feature were getting "LLM trace summarization is not enabled for this user" errors in production.

When `personal_api_key` is set, posthog-python evaluates flags locally using only the passed `person_properties`. Early Access Features set `$feature_enrollment/*` properties on the Person, but these weren't being passed.

## Changes

- Add `only_evaluate_locally=False` to force server-side evaluation, which has access to all person properties including `$feature_enrollment/*`
- Follows the pattern used by `PostHogFeatureFlagPermission` in `posthog/permissions.py`
- Also adds early adopter access to translation endpoint for consistency

## How did you test this code?

- Ran existing unit tests: `pytest products/llm_analytics/backend/api/test/test_summarization.py` (13 passed)
- Ran translation tests: `pytest products/llm_analytics/backend/api/test/test_translate.py` (13 passed)
- Updated tests to verify new call signatures

## Changelog: (features only) Is this feature complete?

No - bug fix, not a feature