### PR TITLE
chore: Remove hub use in pipelines

### DIFF
--- a/plugin-server/src/ingestion/analytics/event-subpipeline.ts
+++ b/plugin-server/src/ingestion/analytics/event-subpipeline.ts
@@ -4,6 +4,7 @@ import { HogTransformerService } from '../../cdp/hog-transformations/hog-transfo
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, PipelineEvent, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
+import { EventPipelineRunnerOptions } from '../../worker/ingestion/event-pipeline/runner'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
@@ -23,18 +24,9 @@ export interface EventSubpipelineInput {
 }
 
 export interface EventSubpipelineConfig {
-    options: {
+    options: EventPipelineRunnerOptions & {
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: string
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: string
-        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
-        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
-        PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
-        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
-        PERSON_MERGE_ASYNC_ENABLED: boolean
-        PERSON_MERGE_ASYNC_TOPIC: string
-        PERSON_MERGE_SYNC_BATCH_SIZE: number
-        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
-        PERSON_PROPERTIES_UPDATE_ALL: boolean
     }
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager

--- a/plugin-server/src/ingestion/analytics/heatmap-subpipeline.ts
+++ b/plugin-server/src/ingestion/analytics/heatmap-subpipeline.ts
@@ -2,6 +2,7 @@ import { HogTransformerService } from '../../cdp/hog-transformations/hog-transfo
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, PipelineEvent, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
+import { EventPipelineRunnerOptions } from '../../worker/ingestion/event-pipeline/runner'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
@@ -20,16 +21,7 @@ export interface HeatmapSubpipelineInput {
 }
 
 export interface HeatmapSubpipelineConfig {
-    options: {
-        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
-        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
-        PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
-        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
-        PERSON_MERGE_ASYNC_ENABLED: boolean
-        PERSON_MERGE_ASYNC_TOPIC: string
-        PERSON_MERGE_SYNC_BATCH_SIZE: number
-        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
-        PERSON_PROPERTIES_UPDATE_ALL: boolean
+    options: EventPipelineRunnerOptions & {
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: string
     }
     teamManager: TeamManager

--- a/plugin-server/src/ingestion/analytics/heatmap-subpipeline.ts
+++ b/plugin-server/src/ingestion/analytics/heatmap-subpipeline.ts
@@ -1,6 +1,8 @@
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
 import { KafkaProducerWrapper } from '../../kafka/producer'
-import { EventHeaders, Hub, PipelineEvent, Team } from '../../types'
+import { EventHeaders, PipelineEvent, Team } from '../../types'
+import { TeamManager } from '../../utils/team-manager'
+import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { createDisablePersonProcessingStep } from '../event-processing/disable-person-processing-step'
@@ -18,7 +20,20 @@ export interface HeatmapSubpipelineInput {
 }
 
 export interface HeatmapSubpipelineConfig {
-    hub: Hub
+    options: {
+        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
+        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
+        PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
+        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
+        PERSON_MERGE_ASYNC_ENABLED: boolean
+        PERSON_MERGE_ASYNC_TOPIC: string
+        PERSON_MERGE_SYNC_BATCH_SIZE: number
+        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
+        PERSON_PROPERTIES_UPDATE_ALL: boolean
+        CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: string
+    }
+    teamManager: TeamManager
+    groupTypeManager: GroupTypeManager
     hogTransformer: HogTransformerService
     personsStore: PersonsStore
     kafkaProducer: KafkaProducerWrapper
@@ -28,16 +43,25 @@ export function createHeatmapSubpipeline<TInput extends HeatmapSubpipelineInput,
     builder: StartPipelineBuilder<TInput, TContext>,
     config: HeatmapSubpipelineConfig
 ): PipelineBuilder<TInput, void, TContext> {
-    const { hub, hogTransformer, personsStore, kafkaProducer } = config
+    const { options, teamManager, groupTypeManager, hogTransformer, personsStore, kafkaProducer } = config
 
     return builder
         .pipe(createDisablePersonProcessingStep())
-        .pipe(createNormalizeEventStep(hub))
-        .pipe(createEventPipelineRunnerHeatmapStep(hub, hogTransformer, personsStore))
+        .pipe(createNormalizeEventStep(options.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE))
+        .pipe(
+            createEventPipelineRunnerHeatmapStep(
+                options,
+                kafkaProducer,
+                teamManager,
+                groupTypeManager,
+                hogTransformer,
+                personsStore
+            )
+        )
         .pipe(
             createExtractHeatmapDataStep({
                 kafkaProducer,
-                CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: hub.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
+                CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: options.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
             })
         )
         .pipe(createSkipEmitEventStep())

--- a/plugin-server/src/ingestion/analytics/per-distinct-id-pipeline.ts
+++ b/plugin-server/src/ingestion/analytics/per-distinct-id-pipeline.ts
@@ -5,6 +5,7 @@ import { KafkaProducerWrapper } from '../../kafka/producer'
 import { Team } from '../../types'
 import { PromiseScheduler } from '../../utils/promise-scheduler'
 import { TeamManager } from '../../utils/team-manager'
+import { EventPipelineRunnerOptions } from '../../worker/ingestion/event-pipeline/runner'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { BatchPipelineBuilder } from '../pipelines/builders/batch-pipeline-builders'
@@ -21,18 +22,9 @@ export type PerDistinctIdPipelineInput = EventSubpipelineInput &
     ClientIngestionWarningSubpipelineInput
 
 export interface PerDistinctIdPipelineConfig {
-    options: {
+    options: EventPipelineRunnerOptions & {
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: string
         CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: string
-        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
-        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
-        PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
-        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
-        PERSON_MERGE_ASYNC_ENABLED: boolean
-        PERSON_MERGE_ASYNC_TOPIC: string
-        PERSON_MERGE_SYNC_BATCH_SIZE: number
-        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
-        PERSON_PROPERTIES_UPDATE_ALL: boolean
     }
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager

--- a/plugin-server/src/ingestion/analytics/pre-team-preprocessing-subpipeline.ts
+++ b/plugin-server/src/ingestion/analytics/pre-team-preprocessing-subpipeline.ts
@@ -1,6 +1,8 @@
 import { Message } from 'node-rdkafka'
 
-import { EventHeaders, Hub, IncomingEvent, IncomingEventWithTeam } from '../../types'
+import { TeamManager } from '~/utils/team-manager'
+
+import { EventHeaders, IncomingEvent, IncomingEventWithTeam } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restriction-manager'
 import {
     createApplyEventRestrictionsStep,
@@ -24,7 +26,7 @@ export interface PreTeamPreprocessingSubpipelineOutput {
 }
 
 export interface PreTeamPreprocessingSubpipelineConfig {
-    hub: Hub
+    teamManager: TeamManager
     eventIngestionRestrictionManager: EventIngestionRestrictionManager
     overflowEnabled: boolean
     overflowTopic: string
@@ -35,7 +37,8 @@ export function createPreTeamPreprocessingSubpipeline<TInput extends PreTeamPrep
     builder: StartPipelineBuilder<TInput, TContext>,
     config: PreTeamPreprocessingSubpipelineConfig
 ): PipelineBuilder<TInput, TInput & PreTeamPreprocessingSubpipelineOutput, TContext> {
-    const { hub, eventIngestionRestrictionManager, overflowEnabled, overflowTopic, preservePartitionLocality } = config
+    const { teamManager, eventIngestionRestrictionManager, overflowEnabled, overflowTopic, preservePartitionLocality } =
+        config
 
     return builder
         .pipe(createParseHeadersStep())
@@ -48,6 +51,6 @@ export function createPreTeamPreprocessingSubpipeline<TInput extends PreTeamPrep
         )
         .pipe(createParseKafkaMessageStep())
         .pipe(createDropExceptionEventsStep())
-        .pipe(createResolveTeamStep(hub))
+        .pipe(createResolveTeamStep(teamManager))
         .pipe(createValidateHistoricalMigrationStep())
 }

--- a/plugin-server/src/ingestion/analytics/preprocessing-pipeline.ts
+++ b/plugin-server/src/ingestion/analytics/preprocessing-pipeline.ts
@@ -61,7 +61,7 @@ export function createPreprocessingPipeline<
                 // to avoid buffering due to reordering.
                 b.sequentially((b) =>
                     createPreTeamPreprocessingSubpipeline(b, {
-                        hub,
+                        teamManager: hub.teamManager,
                         eventIngestionRestrictionManager,
                         overflowEnabled,
                         overflowTopic,

--- a/plugin-server/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
+++ b/plugin-server/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
@@ -6,7 +6,11 @@ import { HogTransformerService } from '../../cdp/hog-transformations/hog-transfo
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, ISOTimestamp, PipelineEvent, PreIngestionEvent, ProjectId, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
-import { EventPipelineHeatmapResult, EventPipelineRunner } from '../../worker/ingestion/event-pipeline/runner'
+import {
+    EventPipelineHeatmapResult,
+    EventPipelineRunner,
+    EventPipelineRunnerOptions,
+} from '../../worker/ingestion/event-pipeline/runner'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
@@ -67,17 +71,7 @@ const createTestPreIngestionEvent = (overrides: Partial<PreIngestionEvent> = {})
 }
 
 describe('event-pipeline-runner-heatmap-step', () => {
-    let mockConfig: {
-        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
-        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
-        PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
-        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
-        PERSON_MERGE_ASYNC_ENABLED: boolean
-        PERSON_MERGE_ASYNC_TOPIC: string
-        PERSON_MERGE_SYNC_BATCH_SIZE: number
-        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
-        PERSON_PROPERTIES_UPDATE_ALL: boolean
-    }
+    let mockConfig: EventPipelineRunnerOptions
     let mockKafkaProducer: KafkaProducerWrapper
     let mockTeamManager: TeamManager
     let mockGroupTypeManager: GroupTypeManager

--- a/plugin-server/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
+++ b/plugin-server/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.test.ts
@@ -3,8 +3,11 @@ import { v4 } from 'uuid'
 
 import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
-import { EventHeaders, Hub, ISOTimestamp, PipelineEvent, PreIngestionEvent, ProjectId, Team } from '../../types'
+import { KafkaProducerWrapper } from '../../kafka/producer'
+import { EventHeaders, ISOTimestamp, PipelineEvent, PreIngestionEvent, ProjectId, Team } from '../../types'
+import { TeamManager } from '../../utils/team-manager'
 import { EventPipelineHeatmapResult, EventPipelineRunner } from '../../worker/ingestion/event-pipeline/runner'
+import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { PipelineResultType, dlq, drop, ok } from '../pipelines/results'
@@ -64,7 +67,20 @@ const createTestPreIngestionEvent = (overrides: Partial<PreIngestionEvent> = {})
 }
 
 describe('event-pipeline-runner-heatmap-step', () => {
-    let mockHub: Hub
+    let mockConfig: {
+        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
+        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
+        PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
+        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
+        PERSON_MERGE_ASYNC_ENABLED: boolean
+        PERSON_MERGE_ASYNC_TOPIC: string
+        PERSON_MERGE_SYNC_BATCH_SIZE: number
+        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
+        PERSON_PROPERTIES_UPDATE_ALL: boolean
+    }
+    let mockKafkaProducer: KafkaProducerWrapper
+    let mockTeamManager: TeamManager
+    let mockGroupTypeManager: GroupTypeManager
     let mockHogTransformer: HogTransformerService
     let mockPersonsStore: PersonsStore
     let mockGroupStore: GroupStoreForBatch
@@ -76,7 +92,20 @@ describe('event-pipeline-runner-heatmap-step', () => {
     beforeEach(() => {
         jest.clearAllMocks()
 
-        mockHub = {} as Hub
+        mockConfig = {
+            SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
+            TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: 0,
+            PIPELINE_STEP_STALLED_LOG_TIMEOUT: 30000,
+            PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 100,
+            PERSON_MERGE_ASYNC_ENABLED: false,
+            PERSON_MERGE_ASYNC_TOPIC: '',
+            PERSON_MERGE_SYNC_BATCH_SIZE: 1,
+            PERSON_JSONB_SIZE_ESTIMATE_ENABLE: 0,
+            PERSON_PROPERTIES_UPDATE_ALL: false,
+        }
+        mockKafkaProducer = {} as KafkaProducerWrapper
+        mockTeamManager = {} as TeamManager
+        mockGroupTypeManager = {} as GroupTypeManager
         mockHogTransformer = {} as HogTransformerService
         mockPersonsStore = {} as PersonsStore
         mockGroupStore = {} as GroupStoreForBatch
@@ -106,7 +135,14 @@ describe('event-pipeline-runner-heatmap-step', () => {
         const mockResult = ok({ lastStep: 'prepareEventStep', preparedEvent: createTestPreIngestionEvent() })
         mockEventPipelineRunner.runHeatmapPipeline.mockResolvedValue(mockResult)
 
-        const step = createEventPipelineRunnerHeatmapStep(mockHub, mockHogTransformer, mockPersonsStore)
+        const step = createEventPipelineRunnerHeatmapStep(
+            mockConfig,
+            mockKafkaProducer,
+            mockTeamManager,
+            mockGroupTypeManager,
+            mockHogTransformer,
+            mockPersonsStore
+        )
 
         const input = {
             normalizedEvent: mockEvent,
@@ -119,7 +155,10 @@ describe('event-pipeline-runner-heatmap-step', () => {
         const result = await step(input)
 
         expect(EventPipelineRunner).toHaveBeenCalledWith(
-            mockHub,
+            mockConfig,
+            mockKafkaProducer,
+            mockTeamManager,
+            mockGroupTypeManager,
             mockEvent,
             mockHogTransformer,
             mockPersonsStore,
@@ -139,7 +178,14 @@ describe('event-pipeline-runner-heatmap-step', () => {
         const mockResult = drop<EventPipelineHeatmapResult>('heatmap_processing_failed')
         mockEventPipelineRunner.runHeatmapPipeline.mockResolvedValue(mockResult)
 
-        const step = createEventPipelineRunnerHeatmapStep(mockHub, mockHogTransformer, mockPersonsStore)
+        const step = createEventPipelineRunnerHeatmapStep(
+            mockConfig,
+            mockKafkaProducer,
+            mockTeamManager,
+            mockGroupTypeManager,
+            mockHogTransformer,
+            mockPersonsStore
+        )
 
         const input = {
             normalizedEvent: mockEvent,
@@ -161,7 +207,14 @@ describe('event-pipeline-runner-heatmap-step', () => {
         const mockResult = dlq<EventPipelineHeatmapResult>('heatmap_error', mockError)
         mockEventPipelineRunner.runHeatmapPipeline.mockResolvedValue(mockResult)
 
-        const step = createEventPipelineRunnerHeatmapStep(mockHub, mockHogTransformer, mockPersonsStore)
+        const step = createEventPipelineRunnerHeatmapStep(
+            mockConfig,
+            mockKafkaProducer,
+            mockTeamManager,
+            mockGroupTypeManager,
+            mockHogTransformer,
+            mockPersonsStore
+        )
 
         const input = {
             normalizedEvent: mockEvent,
@@ -184,7 +237,14 @@ describe('event-pipeline-runner-heatmap-step', () => {
         const mockResult = ok({ lastStep: 'prepareEventStep', preparedEvent: createTestPreIngestionEvent() })
         mockEventPipelineRunner.runHeatmapPipeline.mockResolvedValue(mockResult)
 
-        const step = createEventPipelineRunnerHeatmapStep(mockHub, mockHogTransformer, mockPersonsStore)
+        const step = createEventPipelineRunnerHeatmapStep(
+            mockConfig,
+            mockKafkaProducer,
+            mockTeamManager,
+            mockGroupTypeManager,
+            mockHogTransformer,
+            mockPersonsStore
+        )
 
         const input = {
             normalizedEvent: mockEvent,
@@ -197,7 +257,10 @@ describe('event-pipeline-runner-heatmap-step', () => {
         await step(input)
 
         expect(EventPipelineRunner).toHaveBeenCalledWith(
-            mockHub,
+            mockConfig,
+            mockKafkaProducer,
+            mockTeamManager,
+            mockGroupTypeManager,
             mockEvent,
             mockHogTransformer,
             mockPersonsStore,

--- a/plugin-server/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
+++ b/plugin-server/src/ingestion/event-processing/event-pipeline-runner-heatmap-step.ts
@@ -4,7 +4,7 @@ import { HogTransformerService } from '../../cdp/hog-transformations/hog-transfo
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, PipelineEvent, PreIngestionEvent, Team } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
-import { EventPipelineRunner } from '../../worker/ingestion/event-pipeline/runner'
+import { EventPipelineRunner, EventPipelineRunnerOptions } from '../../worker/ingestion/event-pipeline/runner'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
@@ -24,17 +24,7 @@ export type EventPipelineRunnerHeatmapStepResult<TInput> = TInput & {
 }
 
 export function createEventPipelineRunnerHeatmapStep<TInput extends EventPipelineRunnerHeatmapStepInput>(
-    config: {
-        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
-        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
-        PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
-        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
-        PERSON_MERGE_ASYNC_ENABLED: boolean
-        PERSON_MERGE_ASYNC_TOPIC: string
-        PERSON_MERGE_SYNC_BATCH_SIZE: number
-        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
-        PERSON_PROPERTIES_UPDATE_ALL: boolean
-    },
+    config: EventPipelineRunnerOptions,
     kafkaProducer: KafkaProducerWrapper,
     teamManager: TeamManager,
     groupTypeManager: GroupTypeManager,

--- a/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.test.ts
+++ b/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.test.ts
@@ -2,9 +2,12 @@ import { Message } from 'node-rdkafka'
 import { v4 } from 'uuid'
 
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
-import { Hub, PipelineEvent, ProjectId, Team, TimestampFormat } from '../../types'
+import { KafkaProducerWrapper } from '../../kafka/producer'
+import { PipelineEvent, ProjectId, Team, TimestampFormat } from '../../types'
+import { TeamManager } from '../../utils/team-manager'
 import { castTimestampOrNow } from '../../utils/utils'
 import { EventPipelineResult, EventPipelineRunner } from '../../worker/ingestion/event-pipeline/runner'
+import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { PipelineResult, PipelineResultType, ok } from '../pipelines/results'
@@ -73,7 +76,20 @@ const createTestEventPipelineResult = (): EventPipelineResult => ({
 })
 
 describe('event-pipeline-runner-v1-step', () => {
-    let mockHub: Hub
+    let mockConfig: {
+        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
+        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
+        PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
+        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
+        PERSON_MERGE_ASYNC_ENABLED: boolean
+        PERSON_MERGE_ASYNC_TOPIC: string
+        PERSON_MERGE_SYNC_BATCH_SIZE: number
+        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
+        PERSON_PROPERTIES_UPDATE_ALL: boolean
+    }
+    let mockKafkaProducer: KafkaProducerWrapper
+    let mockTeamManager: TeamManager
+    let mockGroupTypeManager: GroupTypeManager
     let mockHogTransformer: HogTransformerService
     let mockPersonsStore: PersonsStore
     let mockGroupStore: GroupStoreForBatch
@@ -86,7 +102,20 @@ describe('event-pipeline-runner-v1-step', () => {
     beforeEach(() => {
         jest.clearAllMocks()
 
-        mockHub = {} as Hub
+        mockConfig = {
+            SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
+            TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: 0,
+            PIPELINE_STEP_STALLED_LOG_TIMEOUT: 30000,
+            PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 100,
+            PERSON_MERGE_ASYNC_ENABLED: false,
+            PERSON_MERGE_ASYNC_TOPIC: '',
+            PERSON_MERGE_SYNC_BATCH_SIZE: 1,
+            PERSON_JSONB_SIZE_ESTIMATE_ENABLE: 0,
+            PERSON_PROPERTIES_UPDATE_ALL: false,
+        }
+        mockKafkaProducer = {} as KafkaProducerWrapper
+        mockTeamManager = {} as TeamManager
+        mockGroupTypeManager = {} as GroupTypeManager
         mockHogTransformer = {} as HogTransformerService
         mockPersonsStore = {} as PersonsStore
         mockGroupStore = {} as GroupStoreForBatch
@@ -131,7 +160,14 @@ describe('event-pipeline-runner-v1-step', () => {
             const mockPipelineResult: PipelineResult<EventPipelineResult> = ok(mockResult, [ackPromise])
             mockEventPipelineRunner.runEventPipeline.mockResolvedValue(mockPipelineResult)
 
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,
@@ -144,7 +180,10 @@ describe('event-pipeline-runner-v1-step', () => {
 
             const result = await step(input)
             expect(EventPipelineRunner).toHaveBeenCalledWith(
-                mockHub,
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
                 mockEvent,
                 mockHogTransformer,
                 mockPersonsStore,
@@ -165,7 +204,14 @@ describe('event-pipeline-runner-v1-step', () => {
             ;(retriableError as any).isRetriable = true
             mockEventPipelineRunner.runEventPipeline.mockRejectedValue(retriableError)
 
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,
@@ -184,7 +230,14 @@ describe('event-pipeline-runner-v1-step', () => {
             ;(nonRetriableError as any).isRetriable = false
             mockEventPipelineRunner.runEventPipeline.mockRejectedValue(nonRetriableError)
 
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,
@@ -202,7 +255,14 @@ describe('event-pipeline-runner-v1-step', () => {
             const errorWithoutRetriable = new Error('Error without isRetriable')
             mockEventPipelineRunner.runEventPipeline.mockRejectedValue(errorWithoutRetriable)
 
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,
@@ -225,7 +285,14 @@ describe('event-pipeline-runner-v1-step', () => {
             const mockPipelineResult: PipelineResult<EventPipelineResult> = ok(mockResult, sideEffects)
             mockEventPipelineRunner.runEventPipeline.mockResolvedValue(mockPipelineResult)
 
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,
@@ -250,7 +317,14 @@ describe('event-pipeline-runner-v1-step', () => {
             const mockPipelineResult: PipelineResult<EventPipelineResult> = ok(mockResult)
             mockEventPipelineRunner.runEventPipeline.mockResolvedValue(mockPipelineResult)
 
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,
@@ -275,7 +349,14 @@ describe('event-pipeline-runner-v1-step', () => {
             const mockPipelineResult: PipelineResult<EventPipelineResult> = ok(mockResult)
             mockEventPipelineRunner.runEventPipeline.mockResolvedValue(mockPipelineResult)
 
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,
@@ -289,7 +370,10 @@ describe('event-pipeline-runner-v1-step', () => {
             await step(input)
             expect(EventPipelineRunner).toHaveBeenCalledTimes(1)
             expect(EventPipelineRunner).toHaveBeenCalledWith(
-                mockHub,
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
                 mockEvent,
                 mockHogTransformer,
                 mockPersonsStore,
@@ -303,7 +387,14 @@ describe('event-pipeline-runner-v1-step', () => {
             const mockPipelineResult: PipelineResult<EventPipelineResult> = ok(mockResult)
             mockEventPipelineRunner.runEventPipeline.mockResolvedValue(mockPipelineResult)
 
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,
@@ -328,7 +419,14 @@ describe('event-pipeline-runner-v1-step', () => {
         })
 
         it('should pass processPerson=false and forceDisablePersonProcessing=true to runEventPipeline', async () => {
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,
@@ -344,7 +442,14 @@ describe('event-pipeline-runner-v1-step', () => {
         })
 
         it('should pass processPerson=true and forceDisablePersonProcessing=false to runEventPipeline', async () => {
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,
@@ -360,7 +465,14 @@ describe('event-pipeline-runner-v1-step', () => {
         })
 
         it('should pass processPerson=false and forceDisablePersonProcessing=false to runEventPipeline', async () => {
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,
@@ -376,7 +488,14 @@ describe('event-pipeline-runner-v1-step', () => {
         })
 
         it('should pass processPerson=true and forceDisablePersonProcessing=true to runEventPipeline', async () => {
-            const step = createEventPipelineRunnerV1Step(mockHub, mockHogTransformer, mockPersonsStore)
+            const step = createEventPipelineRunnerV1Step(
+                mockConfig,
+                mockKafkaProducer,
+                mockTeamManager,
+                mockGroupTypeManager,
+                mockHogTransformer,
+                mockPersonsStore
+            )
             const input: EventPipelineRunnerInput = {
                 message: mockMessage,
                 event: mockEvent,

--- a/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.test.ts
+++ b/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.test.ts
@@ -6,7 +6,11 @@ import { KafkaProducerWrapper } from '../../kafka/producer'
 import { PipelineEvent, ProjectId, Team, TimestampFormat } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
 import { castTimestampOrNow } from '../../utils/utils'
-import { EventPipelineResult, EventPipelineRunner } from '../../worker/ingestion/event-pipeline/runner'
+import {
+    EventPipelineResult,
+    EventPipelineRunner,
+    EventPipelineRunnerOptions,
+} from '../../worker/ingestion/event-pipeline/runner'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
@@ -76,17 +80,7 @@ const createTestEventPipelineResult = (): EventPipelineResult => ({
 })
 
 describe('event-pipeline-runner-v1-step', () => {
-    let mockConfig: {
-        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
-        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
-        PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
-        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
-        PERSON_MERGE_ASYNC_ENABLED: boolean
-        PERSON_MERGE_ASYNC_TOPIC: string
-        PERSON_MERGE_SYNC_BATCH_SIZE: number
-        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
-        PERSON_PROPERTIES_UPDATE_ALL: boolean
-    }
+    let mockConfig: EventPipelineRunnerOptions
     let mockKafkaProducer: KafkaProducerWrapper
     let mockTeamManager: TeamManager
     let mockGroupTypeManager: GroupTypeManager

--- a/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
+++ b/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
@@ -1,9 +1,11 @@
 import { Message } from 'node-rdkafka'
 
 import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
-import { EventHeaders, Hub, IncomingEventWithTeam } from '../../types'
-import { EventPipelineRunner } from '../../worker/ingestion/event-pipeline/runner'
-import { EventPipelineResult } from '../../worker/ingestion/event-pipeline/runner'
+import { KafkaProducerWrapper } from '../../kafka/producer'
+import { EventHeaders, IncomingEventWithTeam } from '../../types'
+import { TeamManager } from '../../utils/team-manager'
+import { EventPipelineResult, EventPipelineRunner } from '../../worker/ingestion/event-pipeline/runner'
+import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { PipelineResult, isOkResult, ok } from '../pipelines/results'
@@ -22,7 +24,20 @@ export type EventPipelineRunnerStepResult = EventPipelineResult & {
 }
 
 export function createEventPipelineRunnerV1Step(
-    hub: Hub,
+    config: {
+        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
+        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
+        PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
+        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
+        PERSON_MERGE_ASYNC_ENABLED: boolean
+        PERSON_MERGE_ASYNC_TOPIC: string
+        PERSON_MERGE_SYNC_BATCH_SIZE: number
+        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
+        PERSON_PROPERTIES_UPDATE_ALL: boolean
+    },
+    kafkaProducer: KafkaProducerWrapper,
+    teamManager: TeamManager,
+    groupTypeManager: GroupTypeManager,
     hogTransformer: HogTransformerService,
     personsStore: PersonsStore
 ): ProcessingStep<EventPipelineRunnerInput, EventPipelineRunnerStepResult> {
@@ -40,7 +55,10 @@ export function createEventPipelineRunnerV1Step(
         } = input
 
         const runner = new EventPipelineRunner(
-            hub,
+            config,
+            kafkaProducer,
+            teamManager,
+            groupTypeManager,
             event,
             hogTransformer,
             personsStore,

--- a/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
+++ b/plugin-server/src/ingestion/event-processing/event-pipeline-runner-v1-step.ts
@@ -4,7 +4,11 @@ import { HogTransformerService } from '../../cdp/hog-transformations/hog-transfo
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, IncomingEventWithTeam } from '../../types'
 import { TeamManager } from '../../utils/team-manager'
-import { EventPipelineResult, EventPipelineRunner } from '../../worker/ingestion/event-pipeline/runner'
+import {
+    EventPipelineResult,
+    EventPipelineRunner,
+    EventPipelineRunnerOptions,
+} from '../../worker/ingestion/event-pipeline/runner'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { GroupStoreForBatch } from '../../worker/ingestion/groups/group-store-for-batch.interface'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
@@ -24,17 +28,7 @@ export type EventPipelineRunnerStepResult = EventPipelineResult & {
 }
 
 export function createEventPipelineRunnerV1Step(
-    config: {
-        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
-        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
-        PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
-        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
-        PERSON_MERGE_ASYNC_ENABLED: boolean
-        PERSON_MERGE_ASYNC_TOPIC: string
-        PERSON_MERGE_SYNC_BATCH_SIZE: number
-        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
-        PERSON_PROPERTIES_UPDATE_ALL: boolean
-    },
+    config: EventPipelineRunnerOptions,
     kafkaProducer: KafkaProducerWrapper,
     teamManager: TeamManager,
     groupTypeManager: GroupTypeManager,

--- a/plugin-server/src/ingestion/event-processing/normalize-event-step.test.ts
+++ b/plugin-server/src/ingestion/event-processing/normalize-event-step.test.ts
@@ -30,7 +30,7 @@ const createTestTeam = (overrides: Partial<Team> = {}): Team => ({
 })
 
 describe('normalizeEventStep wrapper', () => {
-    const mockHub = { TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: 0 }
+    const timestampComparisonLoggingSampleRate = 0
     const team = createTestTeam()
 
     describe('distinctId conversion', () => {
@@ -47,7 +47,7 @@ describe('normalizeEventStep wrapper', () => {
                 uuid: uuid,
             }
 
-            const step = createNormalizeEventStep(mockHub)
+            const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
             const input = {
                 event,
                 headers: createTestEventHeaders(),
@@ -77,7 +77,7 @@ describe('normalizeEventStep wrapper', () => {
                 uuid: uuid,
             }
 
-            const step = createNormalizeEventStep(mockHub)
+            const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
             const input = {
                 event,
                 headers: createTestEventHeaders(),
@@ -109,7 +109,7 @@ describe('normalizeEventStep wrapper', () => {
             // No properties field
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -140,7 +140,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -173,7 +173,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -211,7 +211,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -254,7 +254,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -306,7 +306,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -364,7 +364,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -420,7 +420,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -461,7 +461,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -495,7 +495,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -529,7 +529,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -561,7 +561,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -593,7 +593,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -631,7 +631,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -668,7 +668,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),
@@ -699,7 +699,7 @@ describe('normalizeEventStep wrapper', () => {
             uuid: uuid,
         }
 
-        const step = createNormalizeEventStep(mockHub)
+        const step = createNormalizeEventStep(timestampComparisonLoggingSampleRate)
         const input = {
             event,
             headers: createTestEventHeaders(),

--- a/plugin-server/src/ingestion/event-processing/normalize-event-step.ts
+++ b/plugin-server/src/ingestion/event-processing/normalize-event-step.ts
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon'
 
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { EventHeaders, Hub, PipelineEvent, Team } from '../../types'
+import { EventHeaders, PipelineEvent, Team } from '../../types'
 import { normalizeEventStep } from '../../worker/ingestion/event-pipeline/normalizeEventStep'
 import { PipelineResult, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
@@ -10,7 +10,7 @@ import { ProcessingStep } from '../pipelines/steps'
 export function createNormalizeEventStep<
     TInput extends { event: PipelineEvent; headers: EventHeaders; team: Team; processPerson: boolean },
 >(
-    hub: Pick<Hub, 'TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE'>
+    timestampComparisonLoggingSampleRate: number
 ): ProcessingStep<TInput, Omit<TInput, 'event'> & { normalizedEvent: PipelineEvent; timestamp: DateTime }> {
     return async function normalizeEventStepWrapper(
         input: TInput
@@ -26,7 +26,7 @@ export function createNormalizeEventStep<
             pluginEvent,
             input.processPerson,
             input.headers,
-            hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE
+            timestampComparisonLoggingSampleRate
         )
 
         return ok({

--- a/plugin-server/src/ingestion/ingestion-consumer.test.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.test.ts
@@ -191,9 +191,9 @@ describe('IngestionConsumer', () => {
         const team2Id = await createTeam(hub.db.postgres, team.organization_id)
         team2 = (await getTeam(hub, team2Id))!
 
-        jest.mocked(createEventPipelineRunnerV1Step).mockImplementation((hub, hogTransformer, personsStore) => {
+        jest.mocked(createEventPipelineRunnerV1Step).mockImplementation((...args) => {
             const original = jest.requireActual('./event-processing/event-pipeline-runner-v1-step')
-            return original.createEventPipelineRunnerV1Step(hub, hogTransformer, personsStore)
+            return original.createEventPipelineRunnerV1Step(...args)
         })
 
         ingester = await createIngestionConsumer(hub)

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -215,7 +215,21 @@ export class IngestionConsumer {
         this.perDistinctIdPipeline = createPerDistinctIdPipeline(
             newBatchPipelineBuilder<PerDistinctIdPipelineInput, { message: Message; team: Team }>(),
             {
-                hub: this.hub,
+                options: {
+                    CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: this.hub.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,
+                    CLICKHOUSE_HEATMAPS_KAFKA_TOPIC: this.hub.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
+                    SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: this.hub.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,
+                    TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: this.hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE,
+                    PIPELINE_STEP_STALLED_LOG_TIMEOUT: this.hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT,
+                    PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: this.hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+                    PERSON_MERGE_ASYNC_ENABLED: this.hub.PERSON_MERGE_ASYNC_ENABLED,
+                    PERSON_MERGE_ASYNC_TOPIC: this.hub.PERSON_MERGE_ASYNC_TOPIC,
+                    PERSON_MERGE_SYNC_BATCH_SIZE: this.hub.PERSON_MERGE_SYNC_BATCH_SIZE,
+                    PERSON_JSONB_SIZE_ESTIMATE_ENABLE: this.hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+                    PERSON_PROPERTIES_UPDATE_ALL: this.hub.PERSON_PROPERTIES_UPDATE_ALL,
+                },
+                teamManager: this.hub.teamManager,
+                groupTypeManager: this.hub.groupTypeManager,
                 hogTransformer: this.hogTransformer,
                 personsStore: this.personsStore,
                 kafkaProducer: this.kafkaProducer!,

--- a/plugin-server/src/worker/ingestion/event-pipeline/dropOldEventsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/dropOldEventsStep.ts
@@ -2,13 +2,13 @@ import { DateTime } from 'luxon'
 
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
+import { KafkaProducerWrapper } from '../../../kafka/producer'
 import { Team } from '../../../types'
 import { parseEventTimestamp } from '../timestamps'
 import { captureIngestionWarning } from '../utils'
-import { EventPipelineRunner } from './runner'
 
 export async function dropOldEventsStep(
-    runner: EventPipelineRunner,
+    kafkaProducer: KafkaProducerWrapper,
     event: PluginEvent,
     team: Team
 ): Promise<PluginEvent | null> {
@@ -25,7 +25,7 @@ export async function dropOldEventsStep(
     // If the event is older than the threshold, drop it
     if (ageInSeconds > team.drop_events_older_than_seconds) {
         await captureIngestionWarning(
-            runner.hub.db.kafkaProducer,
+            kafkaProducer,
             team.id,
             'event_dropped_too_old',
             {

--- a/plugin-server/src/worker/ingestion/event-pipeline/prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/prepareEventStep.ts
@@ -3,15 +3,19 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 import { PreIngestionEvent, Team } from '~/types'
 
 import { AI_EVENT_TYPES, processAiEvent } from '../../../ingestion/ai-costs/process-ai-event'
+import { KafkaProducerWrapper } from '../../../kafka/producer'
 import { logger } from '../../../utils/logger'
 import { captureException } from '../../../utils/posthog'
+import { GroupStoreForBatch } from '../groups/group-store-for-batch.interface'
+import { EventsProcessor } from '../process-event'
 import { parseEventTimestamp } from '../timestamps'
 import { captureIngestionWarning } from '../utils'
 import { invalidTimestampCounter } from './metrics'
-import { EventPipelineRunner } from './runner'
 
 export async function prepareEventStep(
-    runner: EventPipelineRunner,
+    kafkaProducer: KafkaProducerWrapper,
+    eventsProcessor: EventsProcessor,
+    groupStoreForBatch: GroupStoreForBatch,
     event: PluginEvent,
     processPerson: boolean,
     team: Team
@@ -21,7 +25,7 @@ export async function prepareEventStep(
     const invalidTimestampCallback = function (type: string, details: Record<string, any>) {
         invalidTimestampCounter.labels(type).inc()
 
-        tsParsingIngestionWarnings.push(captureIngestionWarning(runner.hub.db.kafkaProducer, team_id, type, details))
+        tsParsingIngestionWarnings.push(captureIngestionWarning(kafkaProducer, team_id, type, details))
     }
 
     if (AI_EVENT_TYPES.has(event.event)) {
@@ -35,14 +39,14 @@ export async function prepareEventStep(
         }
     }
 
-    const preIngestionEvent = await runner.eventsProcessor.processEvent(
+    const preIngestionEvent = await eventsProcessor.processEvent(
         String(event.distinct_id),
         event,
         team,
         parseEventTimestamp(event, invalidTimestampCallback),
         uuid!, // it will throw if it's undefined,
         processPerson,
-        runner.groupStoreForBatch
+        groupStoreForBatch
     )
     await Promise.all(tsParsingIngestionWarnings)
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -65,7 +65,7 @@ export class EventPipelineRunner {
     mergeMode: MergeMode
 
     constructor(
-        private config: {
+        private options: {
             SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
             TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
             PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
@@ -77,8 +77,8 @@ export class EventPipelineRunner {
             PERSON_PROPERTIES_UPDATE_ALL: boolean
         },
         private kafkaProducer: KafkaProducerWrapper,
-        private teamManager: TeamManager,
-        private groupTypeManager: GroupTypeManager,
+        teamManager: TeamManager,
+        groupTypeManager: GroupTypeManager,
         private originalEvent: PipelineEvent,
         private hogTransformer: HogTransformerService | null = null,
         private personsStore: PersonsStore,
@@ -88,13 +88,13 @@ export class EventPipelineRunner {
         this.eventsProcessor = new EventsProcessor(
             teamManager,
             groupTypeManager,
-            this.config.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP
+            options.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP
         )
         this.mergeMode = determineMergeMode(
-            this.config.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
-            this.config.PERSON_MERGE_ASYNC_ENABLED,
-            this.config.PERSON_MERGE_ASYNC_TOPIC,
-            this.config.PERSON_MERGE_SYNC_BATCH_SIZE
+            options.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+            options.PERSON_MERGE_ASYNC_ENABLED,
+            options.PERSON_MERGE_ASYNC_TOPIC,
+            options.PERSON_MERGE_SYNC_BATCH_SIZE
         )
     }
 
@@ -240,7 +240,7 @@ export class EventPipelineRunner {
 
         const normalizeResult = await this.runStep<[PluginEvent, DateTime], typeof normalizeEventStep>(
             normalizeEventStep,
-            [transformedEvent, processPerson, this.headers, this.config.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE],
+            [transformedEvent, processPerson, this.headers, this.options.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE],
             team.id,
             true,
             kafkaAcks,
@@ -341,8 +341,8 @@ export class EventPipelineRunner {
                 [
                     this.kafkaProducer,
                     this.mergeMode,
-                    this.config.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
-                    this.config.PERSON_PROPERTIES_UPDATE_ALL,
+                    this.options.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+                    this.options.PERSON_PROPERTIES_UPDATE_ALL,
                     event,
                     team,
                     timestamp,
@@ -396,14 +396,14 @@ export class EventPipelineRunner {
         const timer = new Date()
         const sendException = false
         const timeout = timeoutGuard(
-            `Event pipeline step stalled. Timeout warning after ${this.config.PIPELINE_STEP_STALLED_LOG_TIMEOUT} sec! step=${step.name} team_id=${teamId} distinct_id=${this.originalEvent.distinct_id}`,
+            `Event pipeline step stalled. Timeout warning after ${this.options.PIPELINE_STEP_STALLED_LOG_TIMEOUT} sec! step=${step.name} team_id=${teamId} distinct_id=${this.originalEvent.distinct_id}`,
             () => ({
                 step: step.name,
                 teamId: teamId,
                 event_name: this.originalEvent.event,
                 distinctId: this.originalEvent.distinct_id,
             }),
-            this.config.PIPELINE_STEP_STALLED_LOG_TIMEOUT * 1000,
+            this.options.PIPELINE_STEP_STALLED_LOG_TIMEOUT * 1000,
             sendException,
             this.reportStalled.bind(this, step.name)
         )
@@ -429,14 +429,14 @@ export class EventPipelineRunner {
         const timer = new Date()
         const sendException = false
         const timeout = timeoutGuard(
-            `Event pipeline step stalled. Timeout warning after ${this.config.PIPELINE_STEP_STALLED_LOG_TIMEOUT} sec! step=${step.name} team_id=${teamId} distinct_id=${this.originalEvent.distinct_id}`,
+            `Event pipeline step stalled. Timeout warning after ${this.options.PIPELINE_STEP_STALLED_LOG_TIMEOUT} sec! step=${step.name} team_id=${teamId} distinct_id=${this.originalEvent.distinct_id}`,
             () => ({
                 step: step.name,
                 teamId: teamId,
                 event_name: this.originalEvent.event,
                 distinctId: this.originalEvent.distinct_id,
             }),
-            this.config.PIPELINE_STEP_STALLED_LOG_TIMEOUT * 1000,
+            this.options.PIPELINE_STEP_STALLED_LOG_TIMEOUT * 1000,
             sendException,
             this.reportStalled.bind(this, step.name)
         )

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -51,6 +51,18 @@ export type EventPipelineHeatmapResult = RunnerResult<{
 
 export type EventPipelinePipelineResult = PipelineResult<EventPipelineResult>
 
+export interface EventPipelineRunnerOptions {
+    SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
+    TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
+    PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
+    PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
+    PERSON_MERGE_ASYNC_ENABLED: boolean
+    PERSON_MERGE_ASYNC_TOPIC: string
+    PERSON_MERGE_SYNC_BATCH_SIZE: number
+    PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
+    PERSON_PROPERTIES_UPDATE_ALL: boolean
+}
+
 class StepErrorNoRetry extends Error {
     step: string
     args: any[]
@@ -65,17 +77,7 @@ export class EventPipelineRunner {
     mergeMode: MergeMode
 
     constructor(
-        private options: {
-            SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
-            TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: number
-            PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
-            PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
-            PERSON_MERGE_ASYNC_ENABLED: boolean
-            PERSON_MERGE_ASYNC_TOPIC: string
-            PERSON_MERGE_SYNC_BATCH_SIZE: number
-            PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
-            PERSON_PROPERTIES_UPDATE_ALL: boolean
-        },
+        private options: EventPipelineRunnerOptions,
         private kafkaProducer: KafkaProducerWrapper,
         teamManager: TeamManager,
         groupTypeManager: GroupTypeManager,

--- a/plugin-server/src/worker/ingestion/persons/person-merge-types.ts
+++ b/plugin-server/src/worker/ingestion/persons/person-merge-types.ts
@@ -150,33 +150,33 @@ export function createDefaultSyncMergeMode(): MergeMode {
 /**
  * Helper function to determine merge mode based on hub configuration
  */
-export function determineMergeMode(hub: {
-    PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: number
-    PERSON_MERGE_ASYNC_ENABLED: boolean
-    PERSON_MERGE_ASYNC_TOPIC: string
-    PERSON_MERGE_SYNC_BATCH_SIZE: number
-}): MergeMode {
+export function determineMergeMode(
+    personMergeMoveDistinctIdLimit: number,
+    personMergeAsyncEnabled: boolean,
+    personMergeAsyncTopic: string,
+    personMergeSyncBatchSize: number
+): MergeMode {
     // If async merge is enabled and topic is configured, use async mode for over-limit merges
-    if (hub.PERSON_MERGE_ASYNC_ENABLED && hub.PERSON_MERGE_ASYNC_TOPIC && hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT > 0) {
+    if (personMergeAsyncEnabled && personMergeAsyncTopic && personMergeMoveDistinctIdLimit > 0) {
         return {
             type: 'ASYNC',
-            topic: hub.PERSON_MERGE_ASYNC_TOPIC,
-            limit: hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+            topic: personMergeAsyncTopic,
+            limit: personMergeMoveDistinctIdLimit,
         }
     }
 
     // If no async and we have a limit, use limit mode (reject over-limit merges)
-    if (hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT > 0) {
+    if (personMergeMoveDistinctIdLimit > 0) {
         return {
             type: 'LIMIT',
-            limit: hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+            limit: personMergeMoveDistinctIdLimit,
         }
     }
 
-    if (hub.PERSON_MERGE_SYNC_BATCH_SIZE > 0) {
+    if (personMergeSyncBatchSize > 0) {
         return {
             type: 'SYNC',
-            batchSize: hub.PERSON_MERGE_SYNC_BATCH_SIZE,
+            batchSize: personMergeSyncBatchSize,
         }
     }
 

--- a/plugin-server/tests/main/ingestion-queues/run-ingestion-pipeline.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/run-ingestion-pipeline.test.ts
@@ -71,7 +71,26 @@ describe('workerTasks.runEventPipeline()', () => {
             hub.clickhouseGroupRepository
         )
         await expect(
-            new EventPipelineRunner(hub, event, null, personsStore, groupStoreForBatch).runEventPipeline(event, team)
+            new EventPipelineRunner(
+                {
+                    SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: hub.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,
+                    TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE,
+                    PIPELINE_STEP_STALLED_LOG_TIMEOUT: hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT,
+                    PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+                    PERSON_MERGE_ASYNC_ENABLED: hub.PERSON_MERGE_ASYNC_ENABLED,
+                    PERSON_MERGE_ASYNC_TOPIC: hub.PERSON_MERGE_ASYNC_TOPIC,
+                    PERSON_MERGE_SYNC_BATCH_SIZE: hub.PERSON_MERGE_SYNC_BATCH_SIZE,
+                    PERSON_JSONB_SIZE_ESTIMATE_ENABLE: hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+                    PERSON_PROPERTIES_UPDATE_ALL: hub.PERSON_PROPERTIES_UPDATE_ALL,
+                },
+                hub.kafkaProducer,
+                hub.teamManager,
+                hub.groupTypeManager,
+                event,
+                null,
+                personsStore,
+                groupStoreForBatch
+            ).runEventPipeline(event, team)
         ).rejects.toEqual(new DependencyUnavailableError(errorMessage, 'Postgres', new Error(errorMessage)))
         pgQueryMock.mockRestore()
     })

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -115,7 +115,26 @@ describe('processEvent', () => {
             hub.groupRepository,
             hub.clickhouseGroupRepository
         )
-        const runner = new EventPipelineRunner(hub, pluginEvent, null, personsStoreForBatch, groupStoreForBatch)
+        const runner = new EventPipelineRunner(
+            {
+                SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: hub.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,
+                TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE,
+                PIPELINE_STEP_STALLED_LOG_TIMEOUT: hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT,
+                PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+                PERSON_MERGE_ASYNC_ENABLED: hub.PERSON_MERGE_ASYNC_ENABLED,
+                PERSON_MERGE_ASYNC_TOPIC: hub.PERSON_MERGE_ASYNC_TOPIC,
+                PERSON_MERGE_SYNC_BATCH_SIZE: hub.PERSON_MERGE_SYNC_BATCH_SIZE,
+                PERSON_JSONB_SIZE_ESTIMATE_ENABLE: hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+                PERSON_PROPERTIES_UPDATE_ALL: hub.PERSON_PROPERTIES_UPDATE_ALL,
+            },
+            hub.kafkaProducer,
+            hub.teamManager,
+            hub.groupTypeManager,
+            pluginEvent,
+            null,
+            personsStoreForBatch,
+            groupStoreForBatch
+        )
         const res = await runner.runEventPipeline(pluginEvent, team)
         if (isOkResult(res)) {
             // Create the event
@@ -252,7 +271,26 @@ describe('processEvent', () => {
             hub.groupRepository,
             hub.clickhouseGroupRepository
         )
-        const runner = new EventPipelineRunner(hub, event, null, personsStoreForBatch, groupStoreForBatch)
+        const runner = new EventPipelineRunner(
+            {
+                SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: hub.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,
+                TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE,
+                PIPELINE_STEP_STALLED_LOG_TIMEOUT: hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT,
+                PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+                PERSON_MERGE_ASYNC_ENABLED: hub.PERSON_MERGE_ASYNC_ENABLED,
+                PERSON_MERGE_ASYNC_TOPIC: hub.PERSON_MERGE_ASYNC_TOPIC,
+                PERSON_MERGE_SYNC_BATCH_SIZE: hub.PERSON_MERGE_SYNC_BATCH_SIZE,
+                PERSON_JSONB_SIZE_ESTIMATE_ENABLE: hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+                PERSON_PROPERTIES_UPDATE_ALL: hub.PERSON_PROPERTIES_UPDATE_ALL,
+            },
+            hub.kafkaProducer,
+            hub.teamManager,
+            hub.groupTypeManager,
+            event,
+            null,
+            personsStoreForBatch,
+            groupStoreForBatch
+        )
         const res = await runner.runEventPipeline(event, team)
         if (isOkResult(res)) {
             // Create the event

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -56,6 +56,12 @@ exports[`EventPipelineRunner runEventPipeline() runs steps 1`] = `
     "processPersonsStep",
     [
       {
+        "limit": 100,
+        "type": "LIMIT",
+      },
+      0,
+      false,
+      {
         "distinct_id": "my_id",
         "event": "default event",
         "ip": null,
@@ -126,6 +132,30 @@ exports[`EventPipelineRunner runEventPipeline() runs steps 1`] = `
   [
     "prepareEventStep",
     [
+      {
+        "groupTypeManager": {},
+        "skipUpdateEventAndPropertiesStep": false,
+        "teamManager": {},
+      },
+      {
+        "databaseOperationCounts": {},
+        "db": {
+          "kafkaProducer": {},
+        },
+        "groupCache": {
+          "cache": {},
+          "fetchPromises": {},
+          "metrics": {
+            "cacheHits": 0,
+            "cacheMisses": 0,
+          },
+        },
+        "options": {
+          "maxConcurrentUpdates": 10,
+          "maxOptimisticUpdateRetries": 5,
+          "optimisticUpdateRetryInterval": 50,
+        },
+      },
       {
         "distinct_id": "my_id",
         "event": "default event",

--- a/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
@@ -7,7 +7,7 @@ import { closeHub, createHub } from '../../../../src/utils/db/hub'
 import { UUIDT } from '../../../../src/utils/utils'
 import { createEvent } from '../../../../src/worker/ingestion/create-event'
 import { prepareEventStep } from '../../../../src/worker/ingestion/event-pipeline/prepareEventStep'
-import { EventPipelineRunner } from '../../../../src/worker/ingestion/event-pipeline/runner'
+import { BatchWritingGroupStoreForBatch } from '../../../../src/worker/ingestion/groups/batch-writing-group-store'
 import { PostgresPersonRepository } from '../../../../src/worker/ingestion/persons/repositories/postgres-person-repository'
 import { EventsProcessor } from '../../../../src/worker/ingestion/process-event'
 import { resetTestDatabase } from '../../../helpers/sql'
@@ -57,8 +57,9 @@ const teamTwo: Team = {
 }
 
 describe('prepareEventStep()', () => {
-    let runner: Pick<EventPipelineRunner, 'hub' | 'eventsProcessor'>
     let hub: Hub
+    let eventsProcessor: EventsProcessor
+    let groupStoreForBatch: BatchWritingGroupStoreForBatch
 
     beforeEach(async () => {
         await resetTestDatabase()
@@ -86,10 +87,16 @@ describe('prepareEventStep()', () => {
             return teamId === 2 ? teamTwo : null
         })
 
-        runner = {
-            hub,
-            eventsProcessor: new EventsProcessor(hub),
-        }
+        eventsProcessor = new EventsProcessor(
+            hub.teamManager,
+            hub.groupTypeManager,
+            hub.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP
+        )
+        groupStoreForBatch = new BatchWritingGroupStoreForBatch(
+            hub.db,
+            hub.groupRepository,
+            hub.clickhouseGroupRepository
+        )
     })
 
     afterEach(async () => {
@@ -97,7 +104,14 @@ describe('prepareEventStep()', () => {
     })
 
     it('goes to `createEventStep` for normal events', async () => {
-        const response = await prepareEventStep(runner as EventPipelineRunner, pluginEvent, false, teamTwo)
+        const response = await prepareEventStep(
+            hub.kafkaProducer,
+            eventsProcessor,
+            groupStoreForBatch,
+            pluginEvent,
+            false,
+            teamTwo
+        )
 
         expect(response).toEqual({
             distinctId: 'my_id',
@@ -122,7 +136,9 @@ describe('prepareEventStep()', () => {
         }
 
         const response = await prepareEventStep(
-            runner as EventPipelineRunner,
+            hub.kafkaProducer,
+            eventsProcessor,
+            groupStoreForBatch,
             pluginEvent,
             false,
             teamWithAnonymization
@@ -145,7 +161,14 @@ describe('prepareEventStep()', () => {
     // Tests combo of prepareEvent + createEvent
     it('extracts elements_chain from properties', async () => {
         const event: PluginEvent = { ...pluginEvent, ip: null, properties: { $elements_chain: 'random string', a: 1 } }
-        const preppedEvent = await prepareEventStep(runner as EventPipelineRunner, event, false, teamTwo)
+        const preppedEvent = await prepareEventStep(
+            hub.kafkaProducer,
+            eventsProcessor,
+            groupStoreForBatch,
+            event,
+            false,
+            teamTwo
+        )
         const chEvent = createEvent(preppedEvent, person, false, false, null)
 
         expect(chEvent.elements_chain).toEqual('random string')
@@ -162,7 +185,14 @@ describe('prepareEventStep()', () => {
                 $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: 'text' }],
             },
         }
-        const preppedEvent = await prepareEventStep(runner as EventPipelineRunner, event, false, teamTwo)
+        const preppedEvent = await prepareEventStep(
+            hub.kafkaProducer,
+            eventsProcessor,
+            groupStoreForBatch,
+            event,
+            false,
+            teamTwo
+        )
         const chEvent = createEvent(preppedEvent, person, false, false, null)
 
         expect(chEvent.elements_chain).toEqual('random string')
@@ -176,7 +206,14 @@ describe('prepareEventStep()', () => {
             ip: null,
             properties: { a: 1, $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: 'text' }] },
         }
-        const preppedEvent = await prepareEventStep(runner as EventPipelineRunner, event, false, teamTwo)
+        const preppedEvent = await prepareEventStep(
+            hub.kafkaProducer,
+            eventsProcessor,
+            groupStoreForBatch,
+            event,
+            false,
+            teamTwo
+        )
         const chEvent = createEvent(preppedEvent, person, false, false, null)
 
         expect(chEvent.elements_chain).toEqual('div:nth-child="1"nth-of-type="2"text="text"')

--- a/plugin-server/tests/worker/ingestion/event-pipeline/processPersonsStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/processPersonsStep.test.ts
@@ -10,13 +10,11 @@ import { closeHub, createHub } from '../../../../src/utils/db/hub'
 import { UUIDT } from '../../../../src/utils/utils'
 import { normalizeEventStep } from '../../../../src/worker/ingestion/event-pipeline/normalizeEventStep'
 import { processPersonsStep } from '../../../../src/worker/ingestion/event-pipeline/processPersonsStep'
-import { EventPipelineRunner } from '../../../../src/worker/ingestion/event-pipeline/runner'
+import { createDefaultSyncMergeMode } from '../../../../src/worker/ingestion/persons/person-merge-types'
 import { PostgresPersonRepository } from '../../../../src/worker/ingestion/persons/repositories/postgres-person-repository'
-import { EventsProcessor } from '../../../../src/worker/ingestion/process-event'
 import { createOrganization, createTeam, fetchPostgresPersons, getTeam, resetTestDatabase } from '../../../helpers/sql'
 
 describe('processPersonsStep()', () => {
-    let runner: Pick<EventPipelineRunner, 'hub' | 'eventsProcessor'>
     let hub: Hub
 
     let uuid: string
@@ -28,13 +26,9 @@ describe('processPersonsStep()', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub()
-        runner = {
-            hub: hub,
-            eventsProcessor: new EventsProcessor(hub),
-        }
-        const organizationId = await createOrganization(runner.hub.db.postgres)
-        teamId = await createTeam(runner.hub.db.postgres, organizationId)
-        team = (await getTeam(runner.hub, teamId))!
+        const organizationId = await createOrganization(hub.db.postgres)
+        teamId = await createTeam(hub.db.postgres, organizationId)
+        team = (await getTeam(hub, teamId))!
         uuid = new UUIDT().toString()
 
         pluginEvent = {
@@ -60,13 +54,20 @@ describe('processPersonsStep()', () => {
 
     it('creates person', async () => {
         const processPerson = true
+        const personsStore = new BatchWritingPersonsStore(
+            new PostgresPersonRepository(hub.db.postgres),
+            hub.kafkaProducer
+        )
         const result = await processPersonsStep(
-            runner as EventPipelineRunner,
+            hub.kafkaProducer,
+            createDefaultSyncMergeMode(),
+            hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+            hub.PERSON_PROPERTIES_UPDATE_ALL,
             pluginEvent,
             team,
             timestamp,
             processPerson,
-            new BatchWritingPersonsStore(new PostgresPersonRepository(runner.hub.db.postgres), runner.hub.kafkaProducer)
+            personsStore
         )
 
         expect(result.type).toBe(PipelineResultType.OK)
@@ -88,7 +89,7 @@ describe('processPersonsStep()', () => {
             await kafkaAck
 
             // Check PG state
-            const persons = await fetchPostgresPersons(runner.hub.db, teamId)
+            const persons = await fetchPostgresPersons(hub.db, teamId)
             expect(persons).toEqual([resPerson])
         }
     })
@@ -105,14 +106,21 @@ describe('processPersonsStep()', () => {
         }
 
         const processPerson = true
-        const [normalizedEvent, timestamp] = await normalizeEventStep(event, processPerson)
+        const [normalizedEvent, normalizedTimestamp] = await normalizeEventStep(event, processPerson)
+        const personsStore = new BatchWritingPersonsStore(
+            new PostgresPersonRepository(hub.db.postgres),
+            hub.kafkaProducer
+        )
         const result = await processPersonsStep(
-            runner as EventPipelineRunner,
+            hub.kafkaProducer,
+            createDefaultSyncMergeMode(),
+            hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+            hub.PERSON_PROPERTIES_UPDATE_ALL,
             normalizedEvent,
             team,
-            timestamp,
+            normalizedTimestamp,
             processPerson,
-            new BatchWritingPersonsStore(new PostgresPersonRepository(runner.hub.db.postgres), runner.hub.kafkaProducer)
+            personsStore
         )
 
         expect(result.type).toBe(PipelineResultType.OK)
@@ -150,7 +158,7 @@ describe('processPersonsStep()', () => {
             await kafkaAck
 
             // Check PG state
-            const persons = await fetchPostgresPersons(runner.hub.db, teamId)
+            const persons = await fetchPostgresPersons(hub.db, teamId)
             expect(persons).toEqual([resPerson])
         }
     })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -25,7 +25,7 @@ import * as metrics from '../../../../src/worker/ingestion/event-pipeline/metric
 import { prepareEventStep } from '../../../../src/worker/ingestion/event-pipeline/prepareEventStep'
 import { processPersonlessStep } from '../../../../src/worker/ingestion/event-pipeline/processPersonlessStep'
 import { processPersonsStep } from '../../../../src/worker/ingestion/event-pipeline/processPersonsStep'
-import { EventPipelineRunner } from '../../../../src/worker/ingestion/event-pipeline/runner'
+import { EventPipelineRunner, EventPipelineRunnerOptions } from '../../../../src/worker/ingestion/event-pipeline/runner'
 import { PersonMergeLimitExceededError } from '../../../../src/worker/ingestion/persons/person-merge-types'
 import { PostgresPersonRepository } from '../../../../src/worker/ingestion/persons/repositories/postgres-person-repository'
 
@@ -202,18 +202,19 @@ describe('EventPipelineRunner', () => {
             hub.groupRepository,
             hub.clickhouseGroupRepository
         )
+        const options: EventPipelineRunnerOptions = {
+            SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: hub.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,
+            TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE,
+            PIPELINE_STEP_STALLED_LOG_TIMEOUT: hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT,
+            PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+            PERSON_MERGE_ASYNC_ENABLED: hub.PERSON_MERGE_ASYNC_ENABLED,
+            PERSON_MERGE_ASYNC_TOPIC: hub.PERSON_MERGE_ASYNC_TOPIC,
+            PERSON_MERGE_SYNC_BATCH_SIZE: hub.PERSON_MERGE_SYNC_BATCH_SIZE,
+            PERSON_JSONB_SIZE_ESTIMATE_ENABLE: hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+            PERSON_PROPERTIES_UPDATE_ALL: hub.PERSON_PROPERTIES_UPDATE_ALL,
+        }
         runner = new TestEventPipelineRunner(
-            {
-                SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: hub.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,
-                TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE,
-                PIPELINE_STEP_STALLED_LOG_TIMEOUT: hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT,
-                PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
-                PERSON_MERGE_ASYNC_ENABLED: hub.PERSON_MERGE_ASYNC_ENABLED,
-                PERSON_MERGE_ASYNC_TOPIC: hub.PERSON_MERGE_ASYNC_TOPIC,
-                PERSON_MERGE_SYNC_BATCH_SIZE: hub.PERSON_MERGE_SYNC_BATCH_SIZE,
-                PERSON_JSONB_SIZE_ESTIMATE_ENABLE: hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
-                PERSON_PROPERTIES_UPDATE_ALL: hub.PERSON_PROPERTIES_UPDATE_ALL,
-            },
+            options,
             hub.kafkaProducer,
             hub.teamManager,
             hub.groupTypeManager,
@@ -332,30 +333,31 @@ describe('EventPipelineRunner', () => {
                     new PostgresPersonRepository(hub.db.postgres),
                     hub.kafkaProducer
                 )
-                const groupStoreForBatch = new BatchWritingGroupStoreForBatch(
+                const heatmapGroupStoreForBatch = new BatchWritingGroupStoreForBatch(
                     hub.db,
                     hub.groupRepository,
                     hub.clickhouseGroupRepository
                 )
+                const heatmapOptions: EventPipelineRunnerOptions = {
+                    SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: hub.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,
+                    TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE,
+                    PIPELINE_STEP_STALLED_LOG_TIMEOUT: hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT,
+                    PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+                    PERSON_MERGE_ASYNC_ENABLED: hub.PERSON_MERGE_ASYNC_ENABLED,
+                    PERSON_MERGE_ASYNC_TOPIC: hub.PERSON_MERGE_ASYNC_TOPIC,
+                    PERSON_MERGE_SYNC_BATCH_SIZE: hub.PERSON_MERGE_SYNC_BATCH_SIZE,
+                    PERSON_JSONB_SIZE_ESTIMATE_ENABLE: hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+                    PERSON_PROPERTIES_UPDATE_ALL: hub.PERSON_PROPERTIES_UPDATE_ALL,
+                }
                 runner = new TestEventPipelineRunner(
-                    {
-                        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: hub.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,
-                        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE,
-                        PIPELINE_STEP_STALLED_LOG_TIMEOUT: hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT,
-                        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
-                        PERSON_MERGE_ASYNC_ENABLED: hub.PERSON_MERGE_ASYNC_ENABLED,
-                        PERSON_MERGE_ASYNC_TOPIC: hub.PERSON_MERGE_ASYNC_TOPIC,
-                        PERSON_MERGE_SYNC_BATCH_SIZE: hub.PERSON_MERGE_SYNC_BATCH_SIZE,
-                        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
-                        PERSON_PROPERTIES_UPDATE_ALL: hub.PERSON_PROPERTIES_UPDATE_ALL,
-                    },
+                    heatmapOptions,
                     hub.kafkaProducer,
                     hub.teamManager,
                     hub.groupTypeManager,
                     heatmapEvent,
                     undefined,
                     personsStore,
-                    groupStoreForBatch,
+                    heatmapGroupStoreForBatch,
                     undefined // headers
                 )
 

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -186,12 +186,21 @@ describe('EventPipelineRunner', () => {
             teamManager: {
                 fetchTeam: jest.fn(() => Promise.resolve(team)),
             },
+            groupTypeManager: {},
             db: {
                 kafkaProducer: mockProducer,
                 fetchPerson: jest.fn(),
             },
             eventsToDropByToken: createEventsToDropByToken('drop_token:drop_id,drop_token_all:*'),
+            SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
             TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: 0.0,
+            PIPELINE_STEP_STALLED_LOG_TIMEOUT: 30000,
+            PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: 100,
+            PERSON_MERGE_ASYNC_ENABLED: false,
+            PERSON_MERGE_ASYNC_TOPIC: '',
+            PERSON_MERGE_SYNC_BATCH_SIZE: 1,
+            PERSON_JSONB_SIZE_ESTIMATE_ENABLE: 0,
+            PERSON_PROPERTIES_UPDATE_ALL: false,
         }
 
         personsStoreForBatch = new BatchWritingPersonsStore(
@@ -204,7 +213,20 @@ describe('EventPipelineRunner', () => {
             hub.clickhouseGroupRepository
         )
         runner = new TestEventPipelineRunner(
-            hub,
+            {
+                SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: hub.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,
+                TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE,
+                PIPELINE_STEP_STALLED_LOG_TIMEOUT: hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT,
+                PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+                PERSON_MERGE_ASYNC_ENABLED: hub.PERSON_MERGE_ASYNC_ENABLED,
+                PERSON_MERGE_ASYNC_TOPIC: hub.PERSON_MERGE_ASYNC_TOPIC,
+                PERSON_MERGE_SYNC_BATCH_SIZE: hub.PERSON_MERGE_SYNC_BATCH_SIZE,
+                PERSON_JSONB_SIZE_ESTIMATE_ENABLE: hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+                PERSON_PROPERTIES_UPDATE_ALL: hub.PERSON_PROPERTIES_UPDATE_ALL,
+            },
+            hub.kafkaProducer,
+            hub.teamManager,
+            hub.groupTypeManager,
             pluginEvent,
             undefined,
             personsStoreForBatch,
@@ -326,7 +348,20 @@ describe('EventPipelineRunner', () => {
                     hub.clickhouseGroupRepository
                 )
                 runner = new TestEventPipelineRunner(
-                    hub,
+                    {
+                        SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: hub.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,
+                        TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE: hub.TIMESTAMP_COMPARISON_LOGGING_SAMPLE_RATE,
+                        PIPELINE_STEP_STALLED_LOG_TIMEOUT: hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT,
+                        PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: hub.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+                        PERSON_MERGE_ASYNC_ENABLED: hub.PERSON_MERGE_ASYNC_ENABLED,
+                        PERSON_MERGE_ASYNC_TOPIC: hub.PERSON_MERGE_ASYNC_TOPIC,
+                        PERSON_MERGE_SYNC_BATCH_SIZE: hub.PERSON_MERGE_SYNC_BATCH_SIZE,
+                        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+                        PERSON_PROPERTIES_UPDATE_ALL: hub.PERSON_PROPERTIES_UPDATE_ALL,
+                    },
+                    hub.kafkaProducer,
+                    hub.teamManager,
+                    hub.groupTypeManager,
                     heatmapEvent,
                     undefined,
                     personsStore,


### PR DESCRIPTION
## Problem

The EventPipelineRunner class and related pipeline step functions have tight coupling to the `Hub` object, making them difficult to test in isolation and obscuring their actual dependencies. This coupling also makes it harder to understand what configuration and services each component actually needs. This is an important step to move ingestion out of the hub


## Changes

Refactored the event ingestion pipeline to use explicit dependency injection instead of passing the `Hub` object:

- **`EventPipelineRunner`**: Now accepts an explicit `options` object with only the properties it needs (`SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP`, `PERSON_MERGE_*` settings, etc.) plus individual dependencies (`kafkaProducer`, `teamManager`, `groupTypeManager`, `personsStore`, `groupStoreForBatch`)
- **Pipeline step functions**: Updated to accept explicit parameters instead of accessing `runner.hub`:
  - `prepareEventStep(kafkaProducer, eventsProcessor, groupStoreForBatch, event, processPerson, team)`
  - `processPersonsStep(kafkaProducer, mergeMode, measurePersonJsonbSize, personPropertiesUpdateAll, event, team, timestamp, processPerson, personsStore)`
  - `normalizeEventStep` and other steps similarly updated
- **`EventsProcessor`**: Constructor now takes `(teamManager, groupTypeManager, skipUpdateEventAndPropertiesStep)` instead of `Hub`
- **Pipeline configs**: `PerDistinctIdPipelineConfig`, `HeatmapSubpipelineConfig`, `EventSubpipelineConfig` now use an `options` object pattern to group related configuration
- **Test files**: Updated to create explicit mocks for individual dependencies rather than mocking the entire `Hub` object

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
