### PR TITLE
fix(logs): fix severity text + resource attribute filter crash

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -279,18 +279,6 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
     def where(self):
         exprs: list[ast.Expr] = []
 
-        if self.query.severityLevels:
-            exprs.append(
-                parse_expr(
-                    "severity_text IN {severityLevels}",
-                    placeholders={
-                        "severityLevels": ast.Tuple(
-                            exprs=[ast.Constant(value=str(sl)) for sl in self.query.severityLevels]
-                        )
-                    },
-                )
-            )
-
         if self.query.serviceNames:
             exprs.append(
                 parse_expr(
@@ -367,6 +355,18 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
                 exprs.append(property_to_expr(log_filters, team=self.team))
 
         exprs.append(ast.Placeholder(expr=ast.Field(chain=["filters"])))
+
+        if self.query.severityLevels:
+            exprs.append(
+                parse_expr(
+                    "severity_text IN {severityLevels}",
+                    placeholders={
+                        "severityLevels": ast.Tuple(
+                            exprs=[ast.Constant(value=str(sl)) for sl in self.query.severityLevels]
+                        )
+                    },
+                )
+            )
 
         if self.query.liveLogsCheckpoint:
             exprs.append(


### PR DESCRIPTION
## Problem

we were trying to filter the log_attributes table by severity_text, but that field does not exist on log attributes

## Changes

move the severity text filter to after we generate the resource attribute filter

## How did you test this code?

locally

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
