### PR TITLE
test(funnels): simplify funnel actor utils for tests

### DIFF
--- a/posthog/hogql_queries/insights/funnels/test/breakdown_cases.py
+++ b/posthog/hogql_queries/insights/funnels/test/breakdown_cases.py
@@ -43,7 +43,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
     class TestFunnelBreakdown(APIBaseTest):
         def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
             actors = get_actors_legacy_filters(
-                filter._data,
+                filter,
                 self.team,
                 funnel_step=funnel_step,
                 funnel_step_breakdown=breakdown_value,
@@ -2743,7 +2743,7 @@ def funnel_breakdown_group_test_factory(funnel_order_type: FunnelOrderType):
     class TestFunnelBreakdownGroup(APIBaseTest):
         def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
             actors = get_actors_legacy_filters(
-                filter._data,
+                filter,
                 self.team,
                 funnel_step=funnel_step,
                 funnel_step_breakdown=breakdown_value,

--- a/posthog/hogql_queries/insights/funnels/test/conversion_time_cases.py
+++ b/posthog/hogql_queries/insights/funnels/test/conversion_time_cases.py
@@ -7,20 +7,21 @@ from posthog.schema import FunnelsQuery
 
 from posthog.constants import INSIGHT_FUNNELS, FunnelOrderType
 from posthog.hogql_queries.insights.funnels.funnels_query_runner import FunnelsQueryRunner
-from posthog.hogql_queries.insights.funnels.test.test_utils import PseudoFunnelActors
+from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors_legacy_filters
 from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
-from posthog.models.filters import Filter
 from posthog.test.test_journeys import journeys_for
 
 
 def funnel_conversion_time_test_factory(funnel_order_type: FunnelOrderType):
     class TestFunnelConversionTime(APIBaseTest):
         def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
-            filter = Filter(data=filter, team=self.team)
-            person_filter = filter.shallow_clone({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
-            _, serialized_result, _ = PseudoFunnelActors(person_filter, self.team).get_actors()
-
-            return [val["id"] for val in serialized_result]
+            actors = get_actors_legacy_filters(
+                filter._data,
+                self.team,
+                funnel_step=funnel_step,
+                funnel_step_breakdown=breakdown_value,
+            )
+            return [actor[0] for actor in actors]
 
         def test_funnel_with_multiple_incomplete_tries(self):
             filters = {

--- a/posthog/hogql_queries/insights/funnels/test/conversion_time_cases.py
+++ b/posthog/hogql_queries/insights/funnels/test/conversion_time_cases.py
@@ -16,7 +16,7 @@ def funnel_conversion_time_test_factory(funnel_order_type: FunnelOrderType):
     class TestFunnelConversionTime(APIBaseTest):
         def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
             actors = get_actors_legacy_filters(
-                filter._data,
+                filter,
                 self.team,
                 funnel_step=funnel_step,
                 funnel_step_breakdown=breakdown_value,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_persons.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_persons.py
@@ -40,7 +40,7 @@ COUNT_COLUMN = 1
 PERSON_ID_COLUMN = 2
 
 
-def get_actors(
+def get_actors_legacy_filters(
     filters: dict[str, Any],
     team: Team,
     funnel_step: Optional[int] = None,
@@ -192,7 +192,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
 
         self.assertEqual(35, len(results))
 
@@ -211,7 +211,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=3)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=3)
 
         self.assertEqual(5, len(results))
 
@@ -230,7 +230,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=-2)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=-2)
 
         self.assertEqual(20, len(results))
 
@@ -249,7 +249,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=-3)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=-3)
 
         self.assertEqual(10, len(results))
 
@@ -291,11 +291,11 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
         }
 
         # fetch first 100 people
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
         self.assertEqual(100, len(results))
 
         # fetch next 100 people (just 10 remaining)
-        results = get_actors(filters, self.team, funnel_step=1, offset=100)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1, offset=100)
         self.assertEqual(10, len(results))
 
     @also_test_with_materialized_columns(["$browser"])
@@ -316,15 +316,15 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             "breakdown": "$browser",
         }
 
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
         # self.assertCountEqual([val[0]["id"] for val in results], [person1.uuid, person2.uuid])
         self.assertCountEqual([results[0][0], results[1][0]], [person1.uuid, person2.uuid])
 
-        results = get_actors(filters, self.team, funnel_step=1, funnel_step_breakdown=["Chrome"])
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1, funnel_step_breakdown=["Chrome"])
         # self.assertCountEqual([val[0]["id"] for val in results], [person1.uuid])
         self.assertCountEqual([results[0][0]], [person1.uuid])
 
-        results = get_actors(filters, self.team, funnel_step=1, funnel_step_breakdown=["Safari"])
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1, funnel_step_breakdown=["Safari"])
         # self.assertCountEqual([val[0]["id"] for val in results], [person2.uuid])
         self.assertCountEqual([results[0][0]], [person2.uuid])
 
@@ -345,15 +345,15 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             "breakdown": ["$browser", "$browser_version"],
         }
 
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
         # self.assertCountEqual([val[0]["id"] for val in results], [person1.uuid, person2.uuid])
         self.assertCountEqual([results[0][0], results[1][0]], [person1.uuid, person2.uuid])
 
-        results = get_actors(filters, self.team, funnel_step=1, funnel_step_breakdown=["Chrome", "95"])
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1, funnel_step_breakdown=["Chrome", "95"])
         # self.assertCountEqual([val[0]["id"] for val in results], [person1.uuid])
         self.assertCountEqual([results[0][0]], [person1.uuid])
 
-        results = get_actors(filters, self.team, funnel_step=1, funnel_step_breakdown=["Safari", "14"])
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1, funnel_step_breakdown=["Safari", "14"])
         # self.assertCountEqual([val[0]["id"] for val in results], [person2.uuid])
         self.assertCountEqual([results[0][0]], [person2.uuid])
 
@@ -375,15 +375,15 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             "breakdown": "$country",
         }
 
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
         # self.assertCountEqual([val[0]["id"] for val in results], [person1.uuid, person2.uuid])
         self.assertCountEqual([results[0][0], results[1][0]], [person1.uuid, person2.uuid])
 
-        results = get_actors(filters, self.team, funnel_step=1, funnel_step_breakdown=["EE"])
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1, funnel_step_breakdown=["EE"])
         # self.assertCountEqual([val[0]["id"] for val in results], [person2.uuid])
         self.assertCountEqual([results[0][0]], [person2.uuid])
 
-        results = get_actors(filters, self.team, funnel_step=1, funnel_step_breakdown=["PL"])
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1, funnel_step_breakdown=["PL"])
         # self.assertCountEqual([val[0]["id"] for val in results], [person1.uuid])
         self.assertCountEqual([results[0][0]], [person1.uuid])
 
@@ -418,7 +418,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             "breakdown": [cohort.pk],
         }
 
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
         self.assertEqual(results[0][0], person.uuid)
 
     @snapshot_clickhouse_queries
@@ -463,7 +463,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=1, include_recordings=True)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1, include_recordings=True)
         # self.assertEqual(results[0]["id"], p1.uuid)
         self.assertEqual(results[0][0], p1.uuid)
         self.assertEqual(
@@ -486,7 +486,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=2, include_recordings=True)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=2, include_recordings=True)
         # self.assertEqual(results[0]["id"], p1.uuid)
         self.assertEqual(results[0][0], p1.uuid)
         self.assertEqual(
@@ -520,7 +520,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=-3, include_recordings=True)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=-3, include_recordings=True)
         # self.assertEqual(results[0]["id"], p1.uuid)
         self.assertEqual(results[0][0], p1.uuid)
         self.assertEqual(
@@ -579,7 +579,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             "breakdown": "$browser",
         }
 
-        results = get_actors(filters, self.team, funnel_step=1, funnel_step_breakdown=["test'123"])
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1, funnel_step_breakdown=["test'123"])
         self.assertCountEqual([results[0][0]], [person1.uuid])
 
     def test_first_time_math_basic(self):
@@ -626,7 +626,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             "breakdown": "$browser",
         }
 
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
         self.assertCountEqual([results[0][0]], [person1.uuid])
 
         filters = {
@@ -641,7 +641,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
         self.assertEqual(len(results), 0)
 
     def test_first_time_math_multiple_ids(self):
@@ -700,7 +700,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
         self.assertEqual(len(results), 1)
         self.assertCountEqual(set(results[0][1]["distinct_ids"]), {"person1", "anon1"})
 
@@ -718,7 +718,7 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             "breakdown": "$browser",
         }
 
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
         self.assertEqual(len(results), 2)
         self.assertCountEqual(set(results[0][1]["distinct_ids"]), {"person1", "anon1"})
         self.assertCountEqual(set(results[1][1]["distinct_ids"]), {"person2", "anon2"})

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_strict.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_strict.py
@@ -19,9 +19,8 @@ from posthog.hogql_queries.insights.funnels.test.breakdown_cases import (
     funnel_breakdown_test_factory,
 )
 from posthog.hogql_queries.insights.funnels.test.conversion_time_cases import funnel_conversion_time_test_factory
-from posthog.hogql_queries.insights.funnels.test.test_utils import PseudoFunnelActors
+from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors_legacy_filters
 from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
-from posthog.models.filters import Filter
 from posthog.models.instance_setting import override_instance_config
 from posthog.test.test_journeys import journeys_for
 
@@ -181,11 +180,13 @@ class TestFunnelStrictSteps(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
 
     def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
-        filter = Filter(data=filter, team=self.team)
-        person_filter = filter.shallow_clone({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
-        _, serialized_result, _ = PseudoFunnelActors(person_filter, self.team).get_actors()
-
-        return [val["id"] for val in serialized_result]
+        actors = get_actors_legacy_filters(
+            filter._data,
+            self.team,
+            funnel_step=funnel_step,
+            funnel_step_breakdown=breakdown_value,
+        )
+        return [actor[0] for actor in actors]
 
     def test_basic_strict_funnel(self):
         filters = {

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_strict.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_strict.py
@@ -181,7 +181,7 @@ class TestFunnelStrictSteps(ClickhouseTestMixin, APIBaseTest):
 
     def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
         actors = get_actors_legacy_filters(
-            filter._data,
+            filter,
             self.team,
             funnel_step=funnel_step,
             funnel_step_breakdown=breakdown_value,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_strict_persons.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_strict_persons.py
@@ -13,7 +13,7 @@ from posthog.test.base import (
 from django.utils import timezone
 
 from posthog.constants import INSIGHT_FUNNELS
-from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors
+from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors_legacy_filters
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
 from posthog.test.test_journeys import journeys_for
 
@@ -58,7 +58,7 @@ class TestFunnelStrictStepsPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
 
         self.assertEqual(35, len(results))
 
@@ -78,7 +78,7 @@ class TestFunnelStrictStepsPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=2)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=2)
 
         self.assertEqual(10, len(results))
 
@@ -98,7 +98,7 @@ class TestFunnelStrictStepsPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=-2)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=-2)
 
         self.assertEqual(25, len(results))
 
@@ -119,7 +119,7 @@ class TestFunnelStrictStepsPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=3)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=3)
 
         self.assertEqual(0, len(results))
 
@@ -184,7 +184,7 @@ class TestFunnelStrictStepsPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=1, include_recordings=True)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1, include_recordings=True)
 
         # self.assertEqual(results[0]["id"], p1.uuid)
         self.assertEqual(results[0][0], p1.uuid)
@@ -209,7 +209,7 @@ class TestFunnelStrictStepsPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=2, include_recordings=True)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=2, include_recordings=True)
 
         # self.assertEqual(results[0]["id"], p1.uuid)
         self.assertEqual(results[0][0], p1.uuid)
@@ -245,7 +245,7 @@ class TestFunnelStrictStepsPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=-3, include_recordings=True)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=-3, include_recordings=True)
 
         # self.assertEqual(results[0]["id"], p1.uuid)
         self.assertEqual(results[0][0], p1.uuid)

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
@@ -4,7 +4,7 @@ from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, snapshot_clickhouse_queries
 
 from posthog.constants import INSIGHT_FUNNELS, FunnelVizType
-from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors
+from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors_legacy_filters
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
 from posthog.test.test_journeys import journeys_for
 
@@ -59,7 +59,7 @@ class TestFunnelTrendsActors(ClickhouseTestMixin, APIBaseTest):
             last_timestamp=timestamp,
         )
 
-        results = get_actors(
+        results = get_actors_legacy_filters(
             {"funnel_to_step": 1, **filters},
             self.team,
             funnel_trends_drop_off=False,
@@ -109,7 +109,7 @@ class TestFunnelTrendsActors(ClickhouseTestMixin, APIBaseTest):
             last_timestamp=timestamp,
         )
 
-        results = get_actors(
+        results = get_actors_legacy_filters(
             filters,
             self.team,
             funnel_trends_drop_off=False,
@@ -148,7 +148,7 @@ class TestFunnelTrendsActors(ClickhouseTestMixin, APIBaseTest):
             last_timestamp=timestamp,
         )
 
-        results = get_actors(
+        results = get_actors_legacy_filters(
             filters,
             self.team,
             funnel_trends_drop_off=True,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
@@ -23,9 +23,8 @@ from posthog.hogql_queries.insights.funnels.test.breakdown_cases import (
     funnel_breakdown_test_factory,
 )
 from posthog.hogql_queries.insights.funnels.test.conversion_time_cases import funnel_conversion_time_test_factory
-from posthog.hogql_queries.insights.funnels.test.test_utils import PseudoFunnelActors
+from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors_legacy_filters
 from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
-from posthog.models.filters import Filter
 from posthog.models.property_definition import PropertyDefinition
 from posthog.test.test_journeys import journeys_for
 
@@ -535,11 +534,13 @@ class TestFunnelUnorderedStepsConversionTime(
 
 class TestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
     def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
-        filter = Filter(data=filter, team=self.team)
-        person_filter = filter.shallow_clone({"funnel_step": funnel_step, "funnel_step_breakdown": breakdown_value})
-        _, serialized_result, _ = PseudoFunnelActors(person_filter, self.team).get_actors()
-
-        return [val["id"] for val in serialized_result]
+        actors = get_actors_legacy_filters(
+            filter._data,
+            self.team,
+            funnel_step=funnel_step,
+            funnel_step_breakdown=breakdown_value,
+        )
+        return [actor[0] for actor in actors]
 
     def test_basic_unordered_funnel(self):
         filters = {

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
@@ -535,7 +535,7 @@ class TestFunnelUnorderedStepsConversionTime(
 class TestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
     def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
         actors = get_actors_legacy_filters(
-            filter._data,
+            filter,
             self.team,
             funnel_step=funnel_step,
             funnel_step_breakdown=breakdown_value,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered_persons.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered_persons.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 from posthog.constants import INSIGHT_FUNNELS
-from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors
+from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors_legacy_filters
 from posthog.test.test_journeys import journeys_for
 
 FORMAT_TIME = "%Y-%m-%d 00:00:00"
@@ -46,13 +46,13 @@ class TestFunnelUnorderedStepsPersons(ClickhouseTestMixin, APIBaseTest):
         }
 
         with self.assertRaisesMessage(ValueError, "Input should be a valid integer"):
-            get_actors(filters, self.team, funnel_step="blah")  # type: ignore
+            get_actors_legacy_filters(filters, self.team, funnel_step="blah")  # type: ignore
 
         with self.assertRaisesMessage(ValueError, "Funnel steps are 1-indexed, so step 0 doesn't exist"):
-            get_actors(filters, self.team, funnel_step=0)
+            get_actors_legacy_filters(filters, self.team, funnel_step=0)
 
         with self.assertRaisesMessage(ValueError, "The first valid drop-off argument for funnelStep is -2"):
-            get_actors(filters, self.team, funnel_step=-1)
+            get_actors_legacy_filters(filters, self.team, funnel_step=-1)
 
     def test_first_step(self):
         self._create_sample_data_multiple_dropoffs()
@@ -70,7 +70,7 @@ class TestFunnelUnorderedStepsPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=1)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=1)
 
         self.assertEqual(35, len(results))
 
@@ -90,7 +90,7 @@ class TestFunnelUnorderedStepsPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=3)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=3)
 
         self.assertEqual(5, len(results))
 
@@ -110,7 +110,7 @@ class TestFunnelUnorderedStepsPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=-2)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=-2)
 
         self.assertEqual(20, len(results))
 
@@ -130,6 +130,6 @@ class TestFunnelUnorderedStepsPersons(ClickhouseTestMixin, APIBaseTest):
             ],
         }
 
-        results = get_actors(filters, self.team, funnel_step=-3)
+        results = get_actors_legacy_filters(filters, self.team, funnel_step=-3)
 
         self.assertEqual(10, len(results))

--- a/posthog/hogql_queries/insights/funnels/test/test_utils.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_utils.py
@@ -6,7 +6,7 @@ from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.visitor import clone_expr
 
-from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors
+from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors_legacy_filters
 from posthog.hogql_queries.insights.funnels.utils import alias_columns_in_select
 from posthog.models.team.team import Team
 
@@ -41,7 +41,7 @@ class PseudoFunnelActors:
         self.team = team
 
     def get_actors(self):
-        actors = get_actors(
+        actors = get_actors_legacy_filters(
             self.filters,
             self.team,
             funnel_step=self.filters.get("funnel_step"),

--- a/posthog/hogql_queries/insights/funnels/test/test_utils.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_utils.py
@@ -1,14 +1,10 @@
-from typing import Any
-
 from django.test import SimpleTestCase
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.visitor import clone_expr
 
-from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors_legacy_filters
 from posthog.hogql_queries.insights.funnels.utils import alias_columns_in_select
-from posthog.models.team.team import Team
 
 
 class TestUtils(SimpleTestCase):
@@ -33,23 +29,3 @@ class TestUtils(SimpleTestCase):
         )
         assert result[2] == ast.Alias(alias="step_0", expr=ast.Field(chain=["my_table", "step_0"]))
         assert result[3] == ast.Alias(alias="step_1", expr=ast.Field(chain=["my_table", "step_1"]))
-
-
-class PseudoFunnelActors:
-    def __init__(self, person_filter: Any, team: Team):
-        self.filters = person_filter._data
-        self.team = team
-
-    def get_actors(self):
-        actors = get_actors_legacy_filters(
-            self.filters,
-            self.team,
-            funnel_step=self.filters.get("funnel_step"),
-            funnel_step_breakdown=self.filters.get("funnel_step_breakdown"),
-        )
-
-        return (
-            None,
-            [{"id": actor[0]} for actor in actors],
-            None,
-        )


### PR DESCRIPTION
## Problem

Some more simplifications of the funnel test code.

## Changes

- renames `get_actors` to `get_actors_legacy_filters`, as I'll introduce a new `get_actors` for query based funnels
- replaces `PseudoFunnelActors` with direct calls to `get_actors_legacy_filters`

## How did you test this code?

CI run