### PR TITLE
feat: use input component instead of select for sampling option

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -374,7 +374,7 @@ function EventTriggerOptions(): JSX.Element | null {
 function Sampling(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
-    const [value, setValue] = useState<number>(
+    const [value, setValue] = useState<number | undefined>(
         typeof currentTeam?.session_recording_sample_rate === 'string'
             ? Math.floor(parseFloat(currentTeam?.session_recording_sample_rate) * 100)
             : 100
@@ -390,29 +390,24 @@ function Sampling(): JSX.Element {
                     resourceType={AccessControlResourceType.SessionRecording}
                     minAccessLevel={AccessControlLevel.Editor}
                 >
-                    <LemonField
-                        name="sampling"
-                        label="Sampling"
-                        help="Choose how many sessions to record. 100% = record every session, 50% = record roughly half."
-                    >
-                        {({ error }) => (
-                            <LemonInput
-                                type="number"
-                                onChange={(v) => {
-                                    setValue(v ? v : 100)
-                                    updateCurrentTeam({ session_recording_sample_rate: v?.toString() })
-                                }}
-                                min={0}
-                                max={100}
-                                status={error ? 'danger' : 'default'}
-                                suffix={<>%</>}
-                                value={value}
-                                onPressEnter={() =>
-                                    updateCurrentTeam({ session_recording_sample_rate: value.toString() })
-                                }
-                            />
-                        )}
-                    </LemonField>
+                    <LemonInput
+                        type="number"
+                        onChange={(value) => {
+                            setValue(value)
+                            setTimeout(function () {
+                                const returnRate = value ? value / 100 : 1.0
+                                updateCurrentTeam({ session_recording_sample_rate: returnRate.toString() })
+                            }, 2000)
+                        }}
+                        min={0}
+                        max={100}
+                        suffix={<>%</>}
+                        value={value}
+                        onPressEnter={() => {
+                            const returnRate = value ? value / 100 : 1.0
+                            updateCurrentTeam({ session_recording_sample_rate: returnRate.toString() })
+                        }}
+                    />
                 </AccessControlAction>
             </div>
             <p>Choose how many sessions to record. 100% = record every session, 50% = record roughly half.</p>

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -1,6 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
-
+import { useCallback, useState } from 'react'
 import { IconInfo, IconPlus } from '@posthog/icons'
 import {
     LemonBanner,
@@ -380,6 +379,11 @@ function Sampling(): JSX.Element {
             : 100
     )
 
+    const updateSampling = useCallback((): void => {
+        const returnRate = typeof value == 'number' ? value / 100 : 0
+        updateCurrentTeam({ session_recording_sample_rate: returnRate.toString() })
+    }, [])
+
     return (
         <>
             <div className="flex flex-row justify-between mt-2">
@@ -399,18 +403,9 @@ function Sampling(): JSX.Element {
                             max={100}
                             suffix={<>%</>}
                             value={value}
-                            onPressEnter={() => {
-                                const returnRate = value ? value / 100 : 1.0
-                                updateCurrentTeam({ session_recording_sample_rate: returnRate.toString() })
-                            }}
+                            onPressEnter={updateSampling}
                         />
-                        <LemonButton
-                            type="secondary"
-                            onClick={() => {
-                                const returnRate = value ? value / 100 : 1.0
-                                updateCurrentTeam({ session_recording_sample_rate: returnRate.toString() })
-                            }}
-                        >
+                        <LemonButton type="secondary" onClick={updateSampling}>
                             Update
                         </LemonButton>
                     </div>

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -1,8 +1,7 @@
 import { useActions, useValues } from 'kea'
-import { Form } from 'kea-forms'
 import { useState } from 'react'
 
-import { IconCheck, IconCircleDashed, IconInfo, IconPencil, IconPlus, IconTrash, IconX } from '@posthog/icons'
+import { IconInfo, IconPlus } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -31,6 +31,7 @@ import { TriggersSummary } from 'lib/components/Triggers/TriggersSummary'
 import { UrlConfig } from 'lib/components/Triggers/UrlConfig'
 import { FeatureFlagTrigger, Trigger, TriggerType } from 'lib/components/Triggers/types'
 import { SESSION_REPLAY_MINIMUM_DURATION_OPTIONS } from 'lib/constants'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { IconCancel } from 'lib/lemon-ui/icons'
 import { isNumeric } from 'lib/utils'
 import { Since } from 'scenes/settings/environment/SessionRecordingSettings'
@@ -385,7 +386,11 @@ function Sampling(): JSX.Element {
 
     const updateSampling = (): void => {
         const returnRate = typeof value == 'number' ? value / 100 : 0
-        updateCurrentTeam({ session_recording_sample_rate: returnRate.toString() })
+        if (returnRate > 1) {
+            lemonToast.error('Session recording sample rate must be between 0 to 100')
+        } else {
+            updateCurrentTeam({ session_recording_sample_rate: returnRate.toString() })
+        }
     }
 
     return (

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -408,13 +408,13 @@ function Sampling(): JSX.Element {
                             suffix={<>%</>}
                             value={value}
                             onPressEnter={updateSampling}
-                            data-attr="sampling"
+                            data-attr="sampling-setting-input"
                         />
                         <LemonButton
                             type="primary"
                             disabledReason={currentSampleRate === value && 'there was no change in sample rate'}
                             onClick={updateSampling}
-                            data-attr="update-sampling"
+                            data-attr="sampling-setting-update"
                         >
                             Update
                         </LemonButton>

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -6,6 +6,7 @@ import {
     LemonBanner,
     LemonButton,
     LemonDivider,
+    LemonInput,
     LemonLabel,
     LemonSegmentedButton,
     LemonSegmentedButtonOption,

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -374,10 +374,10 @@ function EventTriggerOptions(): JSX.Element | null {
 function Sampling(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
-    const [value, setValue] = useState<string>(
+    const [value, setValue] = useState<number>(
         typeof currentTeam?.session_recording_sample_rate === 'string'
-            ? currentTeam?.session_recording_sample_rate
-            : '100'
+            ? Math.floor(parseFloat(currentTeam?.session_recording_sample_rate) * 100)
+            : 100
     )
 
     return (
@@ -390,14 +390,29 @@ function Sampling(): JSX.Element {
                     resourceType={AccessControlResourceType.SessionRecording}
                     minAccessLevel={AccessControlLevel.Editor}
                 >
-                    <LemonInput
-                        onChange={() => {
-                            setValue(value)
-                            updateCurrentTeam({ session_recording_sample_rate: value })
-                        }}
-                        value={value}
-                        onPressEnter={() => updateCurrentTeam({ session_recording_sample_rate: value })}
-                    />
+                    <LemonField
+                        name="sampling"
+                        label="Sampling"
+                        help="Choose how many sessions to record. 100% = record every session, 50% = record roughly half."
+                    >
+                        {({ error }) => (
+                            <LemonInput
+                                type="number"
+                                onChange={(v) => {
+                                    setValue(v ? v : 100)
+                                    updateCurrentTeam({ session_recording_sample_rate: v?.toString() })
+                                }}
+                                min={0}
+                                max={100}
+                                status={error ? 'danger' : 'default'}
+                                suffix={<>%</>}
+                                value={value}
+                                onPressEnter={() =>
+                                    updateCurrentTeam({ session_recording_sample_rate: value.toString() })
+                                }
+                            />
+                        )}
+                    </LemonField>
                 </AccessControlAction>
             </div>
             <p>Choose how many sessions to record. 100% = record every session, 50% = record roughly half.</p>

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -408,11 +408,13 @@ function Sampling(): JSX.Element {
                             suffix={<>%</>}
                             value={value}
                             onPressEnter={updateSampling}
+                            data-attr="sampling"
                         />
                         <LemonButton
                             type="primary"
                             disabledReason={currentSampleRate === value && 'there was no change in sample rate'}
                             onClick={updateSampling}
+                            data-attr="update-sampling"
                         >
                             Update
                         </LemonButton>

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -1,6 +1,8 @@
 import { useActions, useValues } from 'kea'
-import { useCallback, useState } from 'react'
-import { IconInfo, IconPlus } from '@posthog/icons'
+import { Form } from 'kea-forms'
+import { useState } from 'react'
+
+import { IconCheck, IconCircleDashed, IconInfo, IconPencil, IconPlus, IconTrash, IconX } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -373,16 +375,18 @@ function EventTriggerOptions(): JSX.Element | null {
 function Sampling(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
-    const [value, setValue] = useState<number | undefined>(
+
+    const currentSampleRate =
         typeof currentTeam?.session_recording_sample_rate === 'string'
             ? Math.floor(parseFloat(currentTeam?.session_recording_sample_rate) * 100)
             : 100
-    )
 
-    const updateSampling = useCallback((): void => {
+    const [value, setValue] = useState<number | undefined>(currentSampleRate)
+
+    const updateSampling = (): void => {
         const returnRate = typeof value == 'number' ? value / 100 : 0
         updateCurrentTeam({ session_recording_sample_rate: returnRate.toString() })
-    }, [])
+    }
 
     return (
         <>
@@ -405,7 +409,11 @@ function Sampling(): JSX.Element {
                             value={value}
                             onPressEnter={updateSampling}
                         />
-                        <LemonButton type="secondary" onClick={updateSampling}>
+                        <LemonButton
+                            type="primary"
+                            disabledReason={currentSampleRate === value && 'there was no change in sample rate'}
+                            onClick={updateSampling}
+                        >
                             Update
                         </LemonButton>
                     </div>

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -374,6 +374,11 @@ function EventTriggerOptions(): JSX.Element | null {
 function Sampling(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
+    const [value, setValue] = useState<string>(
+        typeof currentTeam?.session_recording_sample_rate === 'string'
+            ? currentTeam?.session_recording_sample_rate
+            : '100'
+    )
 
     return (
         <>
@@ -385,106 +390,13 @@ function Sampling(): JSX.Element {
                     resourceType={AccessControlResourceType.SessionRecording}
                     minAccessLevel={AccessControlLevel.Editor}
                 >
-                    <LemonSelect
-                        onChange={(v) => {
-                            updateCurrentTeam({ session_recording_sample_rate: v })
+                    <LemonInput
+                        onChange={() => {
+                            setValue(value)
+                            updateCurrentTeam({ session_recording_sample_rate: value })
                         }}
-                        dropdownMatchSelectWidth={false}
-                        options={[
-                            {
-                                label: '100% (no sampling)',
-                                value: '1.00',
-                            },
-                            {
-                                label: '95%',
-                                value: '0.95',
-                            },
-                            {
-                                label: '90%',
-                                value: '0.90',
-                            },
-                            {
-                                label: '85%',
-                                value: '0.85',
-                            },
-                            {
-                                label: '80%',
-                                value: '0.80',
-                            },
-                            {
-                                label: '75%',
-                                value: '0.75',
-                            },
-                            {
-                                label: '70%',
-                                value: '0.70',
-                            },
-                            {
-                                label: '65%',
-                                value: '0.65',
-                            },
-                            {
-                                label: '60%',
-                                value: '0.60',
-                            },
-                            {
-                                label: '55%',
-                                value: '0.55',
-                            },
-                            {
-                                label: '50%',
-                                value: '0.50',
-                            },
-                            {
-                                label: '45%',
-                                value: '0.45',
-                            },
-                            {
-                                label: '40%',
-                                value: '0.40',
-                            },
-                            {
-                                label: '35%',
-                                value: '0.35',
-                            },
-                            {
-                                label: '30%',
-                                value: '0.30',
-                            },
-                            {
-                                label: '25%',
-                                value: '0.25',
-                            },
-                            {
-                                label: '20%',
-                                value: '0.20',
-                            },
-                            {
-                                label: '15%',
-                                value: '0.15',
-                            },
-                            {
-                                label: '10%',
-                                value: '0.10',
-                            },
-                            {
-                                label: '5%',
-                                value: '0.05',
-                            },
-                            {
-                                label: '1%',
-                                value: '0.01',
-                            },
-                            {
-                                label: '0% (replay disabled)',
-                                value: '0.00',
-                            },
-                        ]}
-                        value={
-                            typeof currentTeam?.session_recording_sample_rate === 'string'
-                                ? currentTeam?.session_recording_sample_rate
-                                : '1.00'
-                        }
+                        value={value}
+                        onPressEnter={() => updateCurrentTeam({ session_recording_sample_rate: value })}
                     />
                 </AccessControlAction>
             </div>

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -390,24 +390,30 @@ function Sampling(): JSX.Element {
                     resourceType={AccessControlResourceType.SessionRecording}
                     minAccessLevel={AccessControlLevel.Editor}
                 >
-                    <LemonInput
-                        type="number"
-                        onChange={(value) => {
-                            setValue(value)
-                            setTimeout(function () {
+                    <div className="flex flex-row gap-x-2">
+                        <LemonInput
+                            type="number"
+                            className="[&>input::-webkit-inner-spin-button]:appearance-none"
+                            onChange={(value) => setValue(value)}
+                            min={0}
+                            max={100}
+                            suffix={<>%</>}
+                            value={value}
+                            onPressEnter={() => {
                                 const returnRate = value ? value / 100 : 1.0
                                 updateCurrentTeam({ session_recording_sample_rate: returnRate.toString() })
-                            }, 2000)
-                        }}
-                        min={0}
-                        max={100}
-                        suffix={<>%</>}
-                        value={value}
-                        onPressEnter={() => {
-                            const returnRate = value ? value / 100 : 1.0
-                            updateCurrentTeam({ session_recording_sample_rate: returnRate.toString() })
-                        }}
-                    />
+                            }}
+                        />
+                        <LemonButton
+                            type="secondary"
+                            onClick={() => {
+                                const returnRate = value ? value / 100 : 1.0
+                                updateCurrentTeam({ session_recording_sample_rate: returnRate.toString() })
+                            }}
+                        >
+                            Update
+                        </LemonButton>
+                    </div>
                 </AccessControlAction>
             </div>
             <p>Choose how many sessions to record. 100% = record every session, 50% = record roughly half.</p>


### PR DESCRIPTION
## Problem

Instead of letting users having to choose in 5% increments for replay sampling, we want users to be able to chose more granular settings

## Changes

Replacing the select component for text input on sampling settings section

Current:
<img width="1462" height="114" alt="Screenshot 2025-12-12 at 15 56 52" src="https://github.com/user-attachments/assets/93e2bbd5-7411-4d59-bb95-37bd9321f16a" />
Update:
(button disabled when value has not changed)
<img width="1462" height="106" alt="Screenshot 2025-12-15 at 15 07 40" src="https://github.com/user-attachments/assets/75fd09db-3625-44ac-b007-412b0d53e4eb" />
(button enabled)
<img width="1462" height="106" alt="Screenshot 2025-12-15 at 15 07 53" src="https://github.com/user-attachments/assets/9ee41d75-b7b0-409b-bd41-d18a328020ca" />

Toast messages:
<img width="561" height="244" alt="Screenshot 2025-12-16 at 15 38 49" src="https://github.com/user-attachments/assets/4d914a45-0338-4837-8330-3c209eb56f23" />
<img width="561" height="244" alt="Screenshot 2025-12-16 at 15 38 58" src="https://github.com/user-attachments/assets/1b968ded-c6c8-47a8-af16-432f952f0302" />



## How did you test this code?

Local testing and making sure this does not break any preexisting tests, this PR should not alter the actual sampling float data

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

Small fix on a feature, no need to update the changelog.
