### PR TITLE
fix(ux): add presisted changes to isLayoutPanelVisible isLayoutPanelPinned act…

### DIFF
--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -69,21 +69,21 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
         ],
         isLayoutPanelVisible: [
             false,
-            { persist: true },
+            { persist: true, prefix: '2', separator: '.' },
             {
                 showLayoutPanel: (_, { visible }) => visible,
             },
         ],
         isLayoutPanelPinned: [
             false,
-            { persist: true },
+            { persist: true, prefix: '2', separator: '.' },
             {
                 toggleLayoutPanelPinned: (_, { pinned }) => pinned,
             },
         ],
         activePanelIdentifier: [
             '',
-            { persist: true },
+            { persist: true, prefix: '2', separator: '.' },
             {
                 setActivePanelIdentifier: (_, { identifier }) => identifier,
                 clearActivePanelIdentifier: () => '',


### PR DESCRIPTION
## Problem
After removal of data warehouse panel, some users had a persisted open panel identifer which allowed for a ghost column in the DOM

<img width="584" height="643" alt="image" src="https://github.com/user-attachments/assets/fc0c5249-4927-4214-9c04-cb338d597c61" />

## Changes
Change the persist key for the following logic `reducers` for `isLayoutPanelVisible` `isLayoutPanelPinned` & `activePanelIdentifier`, this will reset users saved preferences and the issue will go away.

## How did you test this code?
Not really