### PR TITLE
feat(workflows): Add reason for warning log to allow users to debug their failing webhook triggers

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
@@ -175,7 +175,7 @@ describe('SourceWebhooksConsumer', () => {
                 })
                 expect(getLogs()).toEqual([
                     expect.stringContaining('Function completed'),
-                    'Responded with response status - 400',
+                    'Responded with response status - 400, reason: {"error":"\\"event\\" could not be parsed correctly"}',
                 ])
             })
 
@@ -349,7 +349,7 @@ describe('SourceWebhooksConsumer', () => {
                 await waitForBackgroundTasks()
                 expect(getLogs()).toEqual([
                     expect.stringContaining('[Action:trigger] Function completed in'),
-                    '[Action:trigger] Responded with response status - 400',
+                    '[Action:trigger] Responded with response status - 400, reason: {"error":"\\"distinct_id\\" could not be parsed correctly"}',
                 ])
                 expect(getMetrics()).toEqual([
                     expect.objectContaining({ metric_kind: 'failure', metric_name: 'trigger_failed', count: 1 }),

--- a/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
@@ -227,7 +227,15 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase {
             const customHttpResponse = getCustomHttpResponse(functionResult)
             if (customHttpResponse) {
                 const level = customHttpResponse.status >= 400 ? 'warn' : 'info'
-                addLog(level, `Responded with response status - ${customHttpResponse.status}`)
+                if (level === 'warn') {
+                    const bodyStr =
+                        typeof customHttpResponse.body === 'string'
+                            ? customHttpResponse.body
+                            : JSON.stringify(customHttpResponse.body)
+                    addLog(level, `Responded with response status - ${customHttpResponse.status}, reason: ${bodyStr}`)
+                } else {
+                    addLog(level, `Responded with response status - ${customHttpResponse.status}`)
+                }
             }
 
             const capturedPostHogEvent = functionResult.capturedPostHogEvents[0]
@@ -360,7 +368,22 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase {
                 const customHttpResponse = getCustomHttpResponse(result)
                 if (customHttpResponse) {
                     const level = customHttpResponse.status >= 400 ? 'warn' : 'info'
-                    result.logs.push(logEntry(level, `Responded with response status - ${customHttpResponse.status}`))
+                    if (level === 'warn') {
+                        const bodyStr =
+                            typeof customHttpResponse.body === 'string'
+                                ? customHttpResponse.body
+                                : JSON.stringify(customHttpResponse.body)
+                        result.logs.push(
+                            logEntry(
+                                level,
+                                `Responded with response status - ${customHttpResponse.status}, reason: ${bodyStr}`
+                            )
+                        )
+                    } else {
+                        result.logs.push(
+                            logEntry(level, `Responded with response status - ${customHttpResponse.status}`)
+                        )
+                    }
                 }
             }
         } catch (error) {


### PR DESCRIPTION
## Problem

Before:
<img width="1013" height="116" alt="image" src="https://github.com/user-attachments/assets/c733da90-57b2-4f94-bf5c-0484e6487149" />

Currently we log a 400 warning, but give no information to our users on what exactly is wrong, even though we generate helpful error bodies in our backend.

## Changes

Add the body with error details to warning logs

After:
<img width="1154" height="116" alt="image" src="https://github.com/user-attachments/assets/1a54531c-33ee-47d5-ba54-bb48cc5d96f8" />


## How did you test this code?

Updated automated test and tested manually