### PR TITLE
fix(hogql): Handle Python boolean values in property filters

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -86,6 +86,11 @@ class AggregationFinder(TraversingVisitor):
 
 
 def _handle_bool_values(value: ValueT, expr: ast.Expr, property: Property, team: Team) -> ValueT | bool:
+    if value is True:
+        value = "true"
+    elif value is False:
+        value = "false"
+
     if value != "true" and value != "false":
         return value
     if property.type == "person":

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -246,6 +246,35 @@ class TestProperty(BaseTest):
                 "properties.unknown_prop = 'true'"  # We don't have a type for unknown_prop, so string comparison it is
             ),
         )
+        # Python boolean True (not string "true") should also work
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "event", "key": "boolean_prop", "value": True},
+                team=self.team,
+            ),
+            self._parse_expr("properties.boolean_prop = true"),
+        )
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "event", "key": "string_prop", "value": True},
+                team=self.team,
+            ),
+            self._parse_expr("properties.string_prop = 'true'"),
+        )
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "event", "key": "boolean_prop", "value": False},
+                team=self.team,
+            ),
+            self._parse_expr("properties.boolean_prop = false"),
+        )
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "event", "key": "unknown_prop", "value": True},
+                team=self.team,
+            ),
+            self._parse_expr("properties.unknown_prop = 'true'"),
+        )
 
     def test_property_to_expr_event_list(self):
         # positive


### PR DESCRIPTION
## Summary
- Fixes a bug where filtering on properties with Python boolean values (e.g., `$ai_is_error = true`) would fail with a ClickHouse type mismatch error
- The error was: `There is no supertype for types String, UInt8 because some of them are String/FixedString/Enum and some of them are not`

## Problem
When users filter on boolean properties, the value can arrive as either:
- String `"true"`/`"false"` - already handled correctly
- Python boolean `True`/`False` - was **not** handled, passing through unchanged

User was hitting an error here when filtering for `true`

<img width="1322" height="770" alt="image" src="https://github.com/user-attachments/assets/307182be-0b93-4c87-85a1-a2af24987f80" />

Workaround is for user to filter for `"true"` since `$ai_is_error` is `Nullable(String)` materialized.

<img width="1305" height="424" alt="image" src="https://github.com/user-attachments/assets/af7eee5d-bbe3-42d7-9258-715c64990e66" />

For properties stored as String-typed materialized columns (like `mat_$ai_is_error`), Python booleans were converted to ClickHouse `1`/`0` (UInt8), causing type mismatches.

## Solution
Normalize Python booleans to their string representation at the start of `_handle_bool_values()`, allowing the existing property type lookup to determine the correct final type:
- If property is `Boolean` type → returns `True`/`False` (correct for bool columns)
- If property is `String` type or unknown → returns `"true"`/`"false"` (correct for string columns)

## Test plan
- [x] Added tests for Python boolean values in `test_property_to_expr_boolean`
- [ ] Tests pass in CI
