### PR TITLE
feat(logs): show resource attributes and log attributes in the frontend

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -255,7 +255,7 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse]):
                 hex(trace_id),
                 hex(span_id),
                 body,
-                attributes,
+                mapFilter((k, v) -> not(has(resource_attributes, k)), attributes),
                 timestamp,
                 observed_timestamp,
                 severity_text,

--- a/products/logs/frontend/AttributeBreakdowns.tsx
+++ b/products/logs/frontend/AttributeBreakdowns.tsx
@@ -3,20 +3,22 @@ import { useValues } from 'kea'
 import { IconMinusSquare, IconPlusSquare } from '@posthog/icons'
 import { LemonButton, LemonTable } from '@posthog/lemon-ui'
 
-import { PropertyOperator } from '~/types'
+import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { attributeBreakdownLogic } from './attributeBreakdownLogic'
 
 export const AttributeBreakdowns = ({
     attribute,
+    type,
     addFilter,
     tabId,
 }: {
     attribute: string
-    addFilter: (key: string, value: string, operator?: PropertyOperator) => void
+    type: PropertyFilterType
+    addFilter: (key: string, value: string, operator?: PropertyOperator, type?: PropertyFilterType) => void
     tabId: string
 }): JSX.Element => {
-    const logic = attributeBreakdownLogic({ attribute, tabId })
+    const logic = attributeBreakdownLogic({ attribute, type, tabId })
     const { attributeValues, logCount, breakdowns } = useValues(logic)
 
     const dataSource = Object.entries(breakdowns)
@@ -45,14 +47,14 @@ export const AttributeBreakdowns = ({
                                 <LemonButton
                                     tooltip="Add as filter"
                                     size="xsmall"
-                                    onClick={() => addFilter(attribute, record.value)}
+                                    onClick={() => addFilter(attribute, record.value, PropertyOperator.Exact, type)}
                                 >
                                     <IconPlusSquare />
                                 </LemonButton>
                                 <LemonButton
                                     tooltip="Exclude as filter"
                                     size="xsmall"
-                                    onClick={() => addFilter(attribute, record.value, PropertyOperator.IsNot)}
+                                    onClick={() => addFilter(attribute, record.value, PropertyOperator.IsNot, type)}
                                 >
                                     <IconMinusSquare />
                                 </LemonButton>

--- a/products/logs/frontend/LogsScene.stories.tsx
+++ b/products/logs/frontend/LogsScene.stories.tsx
@@ -12,58 +12,68 @@ import { urls } from 'scenes/urls'
 import { mswDecorator } from '~/mocks/browser'
 import { MockSignature } from '~/mocks/utils'
 import { LogMessage, LogSeverityLevel } from '~/queries/schema/schema-general'
+import { PropertyFilterType } from '~/types'
 
 const delayIfNotTestRunner = async (): Promise<void> => {
     await new Promise((resolve) => setTimeout(resolve, inStorybookTestRunner() ? 0 : 200 + Math.random() * 1000))
 }
 
-const keysAndValues: Record<string, string[]> = {
-    'service.name': [
-        'posthog-web',
-        'posthog-feature-flags',
-        'posthog-surveys',
-        'posthog-web-django',
-        'cdp-behavioural-events-consumer',
-        'cdp-events-consumer',
-        'cdp-legacy-events-consumer',
-        'capture',
-    ],
-    'k8s.namespace.name': ['posthog', 'internal', 'billing'],
-    'k8s.pod.name': [
-        'posthog-web',
-        'posthog-feature-flags',
-        'posthog-surveys',
-        'posthog-web-django',
-        'cdp-behavioural-events-consumer',
-        'cdp-events-consumer',
-        'cdp-legacy-events-consumer',
-        'capture',
-    ],
-    'k8s.container.restart_count': ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
-    'k8s.node.name': [
-        'node-1',
-        'node-2',
-        'node-3',
-        'node-4',
-        'node-5',
-        'node-6',
-        'node-7',
-        'node-8',
-        'node-9',
-        'node-10',
-    ],
-    'log.iostream': ['stdout', 'stderr'],
+const attributeExamples: Record<
+    PropertyFilterType.LogAttribute | PropertyFilterType.LogResourceAttribute,
+    Record<string, string[]>
+> = {
+    [PropertyFilterType.LogResourceAttribute]: {
+        'service.name': [
+            'posthog-web',
+            'posthog-feature-flags',
+            'posthog-surveys',
+            'posthog-web-django',
+            'cdp-behavioural-events-consumer',
+            'cdp-events-consumer',
+            'cdp-legacy-events-consumer',
+            'capture',
+        ],
+        'k8s.namespace.name': ['posthog', 'internal', 'billing'],
+        'k8s.pod.name': [
+            'posthog-web',
+            'posthog-feature-flags',
+            'posthog-surveys',
+            'posthog-web-django',
+            'cdp-behavioural-events-consumer',
+            'cdp-events-consumer',
+            'cdp-legacy-events-consumer',
+            'capture',
+        ],
+        'k8s.container.restart_count': ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
+        'k8s.node.name': [
+            'node-1',
+            'node-2',
+            'node-3',
+            'node-4',
+            'node-5',
+            'node-6',
+            'node-7',
+            'node-8',
+            'node-9',
+            'node-10',
+        ],
+    },
+    [PropertyFilterType.LogAttribute]: {
+        'log.iostream': ['stdout', 'stderr'],
+        duration: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
+        method: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD'],
+    },
 }
 
 const EXAMPLES: Record<
     string,
     {
-        attributes: Record<string, string>
+        resource_attributes: Record<string, string>
         logs: { message: string; level: LogSeverityLevel; attributes?: Record<string, string> }[]
     }
 > = {
     'posthog-web': {
-        attributes: {
+        resource_attributes: {
             'k8s.namespace.name': 'posthog',
             'service.name': 'posthog-web',
             'k8s.pod.name': 'posthog-web',
@@ -87,7 +97,7 @@ const EXAMPLES: Record<
         ],
     },
     'cdp-events-consumer': {
-        attributes: {
+        resource_attributes: {
             'k8s.namespace.name': 'posthog',
             'service.name': 'cdp-events-consumer',
             'k8s.pod.name': 'cdp-events-consumer',
@@ -114,7 +124,7 @@ const EXAMPLES: Record<
     },
 }
 
-// Make a deterministic log of all messages. We basicallty want to create a tonne of logs over an example time period with some deterministic randomness to it.
+// Make a deterministic log of all messages. We basically want to create a tonne of logs over an example time period with some deterministic randomness to it.
 
 const generateLogs = (): LogMessage[] => {
     const results: LogMessage[] = []
@@ -134,12 +144,9 @@ const generateLogs = (): LogMessage[] => {
                     uuid: uuid(),
                     trace_id: uuid(),
                     span_id: uuid(),
-                    resource_attributes: 'any',
+                    resource_attributes: example.resource_attributes,
                     body: log.message,
-                    attributes: {
-                        ...example.attributes,
-                        ...log.attributes,
-                    },
+                    attributes: { ...log.attributes },
                     timestamp: currentTime.toISOString(),
                     observed_timestamp: currentTime.toISOString(),
                     severity_text: log.level,
@@ -181,7 +188,10 @@ const getLogs = async (
         if (endDate && endDate.isBefore(dayjs(log.timestamp))) {
             return false
         }
-        if (body.query?.serviceNames?.length && !body.query?.serviceNames.includes(log.attributes['service.name'])) {
+        if (
+            body.query?.serviceNames?.length &&
+            !body.query?.serviceNames.includes(log.resource_attributes['service.name'])
+        ) {
             return false
         }
         if (severityLevels.length && !severityLevels.includes(log.severity_text.toLowerCase())) {
@@ -284,11 +294,15 @@ const sparklineMock: MockSignature = async (req, res, ctx) => {
     return res(ctx.json(results))
 }
 
-const attributesMock: MockSignature = async (_req, res, ctx) => {
+const attributesMock: MockSignature = async (req, res, ctx) => {
     await delayIfNotTestRunner()
-    const results = Object.keys(keysAndValues).map((key) => ({
+    const type = (req.url.searchParams.get('attribute_type') ?? 'log_attribute') as
+        | PropertyFilterType.LogAttribute
+        | PropertyFilterType.LogResourceAttribute
+    const results = Object.keys(attributeExamples[type]).map((key) => ({
         id: key,
         name: key,
+        type: type,
     }))
     return res(ctx.json(results))
 }
@@ -296,7 +310,10 @@ const attributesMock: MockSignature = async (_req, res, ctx) => {
 const valuesMock: MockSignature = async (req, res, ctx) => {
     await delayIfNotTestRunner()
     const key = req.url.searchParams.get('key') ?? ''
-    const results = (keysAndValues[key] ?? []).map((value) => ({
+    const type = (req.url.searchParams.get('attribute_type') ?? 'log_attribute') as
+        | PropertyFilterType.LogAttribute
+        | PropertyFilterType.LogResourceAttribute
+    const results = (attributeExamples[type][key] ?? []).map((value) => ({
         id: value,
         name: value,
     }))

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -31,7 +31,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { LogMessage, ProductKey } from '~/queries/schema/schema-general'
-import { PropertyOperator } from '~/types'
+import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { LogTag } from 'products/logs/frontend/components/LogTag'
 import { LogsSparkline } from 'products/logs/frontend/components/LogsSparkline'
@@ -369,8 +369,18 @@ const ExpandedLog = ({ log }: { log: LogMessage }): JSX.Element => {
     const { expandedAttributeBreaksdowns, tabId } = useValues(logsLogic)
     const { addFilter, toggleAttributeBreakdown } = useActions(logsLogic)
 
-    const attributes = { ...log.resource_attributes, ...log.attributes }
-    const rows = Object.entries(attributes).map(([key, value]) => ({ key, value }))
+    const rows = [
+        ...Object.entries(log.resource_attributes).map(([key, value]) => ({
+            key,
+            value,
+            type: PropertyFilterType.LogResourceAttribute,
+        })),
+        ...Object.entries(log.attributes).map(([key, value]) => ({
+            key,
+            value,
+            type: PropertyFilterType.LogAttribute,
+        })),
+    ]
 
     return (
         <LemonTable
@@ -385,14 +395,14 @@ const ExpandedLog = ({ log }: { log: LogMessage }): JSX.Element => {
                             <LemonButton
                                 tooltip="Add as filter"
                                 size="xsmall"
-                                onClick={() => addFilter(record.key, record.value)}
+                                onClick={() => addFilter(record.key, record.value, PropertyOperator.Exact, record.type)}
                             >
                                 <IconPlusSquare />
                             </LemonButton>
                             <LemonButton
                                 tooltip="Exclude as filter"
                                 size="xsmall"
-                                onClick={() => addFilter(record.key, record.value, PropertyOperator.IsNot)}
+                                onClick={() => addFilter(record.key, record.value, PropertyOperator.IsNot, record.type)}
                             >
                                 <IconMinusSquare />
                             </LemonButton>

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -446,7 +446,12 @@ const ExpandedLog = ({ log }: { log: LogMessage }): JSX.Element => {
                 showRowExpansionToggle: false,
                 isRowExpanded: (record) => expandedAttributeBreaksdowns.includes(record.key),
                 expandedRowRender: (record) => (
-                    <AttributeBreakdowns attribute={record.key} addFilter={addFilter} tabId={tabId} />
+                    <AttributeBreakdowns
+                        attribute={record.key}
+                        type={record.type}
+                        addFilter={addFilter}
+                        tabId={tabId}
+                    />
                 ),
             }}
         />

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -369,7 +369,7 @@ const ExpandedLog = ({ log }: { log: LogMessage }): JSX.Element => {
     const { expandedAttributeBreaksdowns, tabId } = useValues(logsLogic)
     const { addFilter, toggleAttributeBreakdown } = useActions(logsLogic)
 
-    const attributes = log.attributes
+    const attributes = { ...log.resource_attributes, ...log.attributes }
     const rows = Object.entries(attributes).map(([key, value]) => ({ key, value }))
 
     return (

--- a/products/logs/frontend/attributeBreakdownLogic.tsx
+++ b/products/logs/frontend/attributeBreakdownLogic.tsx
@@ -26,7 +26,7 @@ export const attributeBreakdownLogic = kea<attributeBreakdownLogicType>([
             (s) => [s.logs],
             (logs): string[] => {
                 let attributesKey: 'attributes' | 'resource_attributes' = 'attributes'
-                if (props.type == PropertyFilterType.LogResourceAttribute) {
+                if (props.type === PropertyFilterType.LogResourceAttribute) {
                     attributesKey = 'resource_attributes'
                 }
                 return logs

--- a/products/logs/frontend/attributeBreakdownLogic.tsx
+++ b/products/logs/frontend/attributeBreakdownLogic.tsx
@@ -1,16 +1,19 @@
 import { connect, kea, key, path, props, selectors } from 'kea'
 
+import { PropertyFilterType } from '~/types'
+
 import type { attributeBreakdownLogicType } from './attributeBreakdownLogicType'
 import { logsLogic } from './logsLogic'
 
 export interface AttributeBreakdownLogicProps {
     attribute: string
+    type: PropertyFilterType
     tabId: string
 }
 
 export const attributeBreakdownLogic = kea<attributeBreakdownLogicType>([
     props({} as AttributeBreakdownLogicProps),
-    key((props) => `${props.tabId}-${props.attribute}`),
+    key((props) => `${props.tabId}-${props.type}-${props.attribute}`),
     path((key) => ['products', 'logs', 'frontend', 'logsAttributeBreakdownsLogic', key]),
 
     connect((props: AttributeBreakdownLogicProps) => ({
@@ -21,8 +24,15 @@ export const attributeBreakdownLogic = kea<attributeBreakdownLogicType>([
         logCount: [(s) => [s.logs], (logs): number => logs.length],
         attributeValues: [
             (s) => [s.logs],
-            (logs): string[] =>
-                logs.filter((l) => props.attribute in l.attributes).map((l) => l.attributes[props.attribute]),
+            (logs): string[] => {
+                let attributesKey: 'attributes' | 'resource_attributes' = 'attributes'
+                if (props.type == PropertyFilterType.LogResourceAttribute) {
+                    attributesKey = 'resource_attributes'
+                }
+                return logs
+                    .filter((l) => props.attribute in l[attributesKey])
+                    .map((l) => l[attributesKey][props.attribute])
+            },
         ],
         breakdowns: [
             (s) => [s.attributeValues],

--- a/products/logs/frontend/components/LogsViewer/ExpandedLogContent.tsx
+++ b/products/logs/frontend/components/LogsViewer/ExpandedLogContent.tsx
@@ -47,15 +47,17 @@ export function ExpandedLogContent({ log, logIndex }: ExpandedLogContentProps): 
     const expandedBreakdownsForThisLog = expandedAttributeBreakdowns[log.uuid] || []
 
     const rows = [
-        ...Object.entries(log.resource_attributes).map(([key, value]) => ({
+        ...Object.entries(log.resource_attributes).map(([key, value], index) => ({
             key,
             value,
             type: PropertyFilterType.LogResourceAttribute,
+            index,
         })),
-        ...Object.entries(log.attributes).map(([key, value]) => ({
+        ...Object.entries(log.attributes).map(([key, value], index) => ({
             key,
             value,
             type: PropertyFilterType.LogAttribute,
+            index,
         })),
     ]
 

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -5,7 +5,7 @@ import { TZLabelProps } from 'lib/components/TZLabel'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { cn } from 'lib/utils/css-classes'
 
-import { PropertyOperator } from '~/types'
+import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { VirtualizedLogsList } from 'products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList'
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
@@ -27,7 +27,7 @@ export interface LogsViewerProps {
     onChangeOrderBy: (orderBy: LogsOrderBy) => void
     onRefresh?: () => void
     onLoadMore?: () => void
-    onAddFilter?: (key: string, value: string, operator?: PropertyOperator) => void
+    onAddFilter?: (key: string, value: string, operator?: PropertyOperator, type?: PropertyFilterType) => void
 }
 
 export function LogsViewer({

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -5,7 +5,7 @@ import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
-import { PropertyOperator } from '~/types'
+import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
 
@@ -25,7 +25,7 @@ export interface LogsViewerLogicProps {
     tabId: string
     logs: ParsedLogMessage[]
     orderBy: LogsOrderBy
-    onAddFilter?: (key: string, value: string, operator?: PropertyOperator) => void
+    onAddFilter?: (key: string, value: string, operator?: PropertyOperator, type?: PropertyFilterType) => void
 }
 
 export const logsViewerLogic = kea<logsViewerLogicType>([
@@ -67,7 +67,12 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         setLogs: (logs: ParsedLogMessage[]) => ({ logs }),
 
         // Filter actions (emits to parent via props callback)
-        addFilter: (key: string, value: string, operator?: PropertyOperator) => ({ key, value, operator }),
+        addFilter: (key: string, value: string, operator?: PropertyOperator, type?: PropertyFilterType) => ({
+            key,
+            value,
+            operator,
+            type,
+        }),
 
         // Attribute breakdowns (per-log)
         toggleAttributeBreakdown: (logId: string, attributeKey: string) => ({ logId, attributeKey }),
@@ -235,8 +240,8 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
                 actions.resetCursor()
             }
         },
-        addFilter: ({ key, value, operator }) => {
-            props.onAddFilter?.(key, value, operator)
+        addFilter: ({ key, value, operator, type }) => {
+            props.onAddFilter?.(key, value, operator, type)
         },
         toggleExpandLog: ({ logId }) => {
             // If cursor is at attribute level, check if we just collapsed the row it's in


### PR DESCRIPTION
## Problem

as a simplification in the early days we merges resource_attributes and attributes together - this is part of the work of splitting them back out

in the logs query we filter out attributes that exist in resource attributes, and then in the frontend we merge both attributes together (todo in the future: display them differently?)

## Changes

add "type" to the attribute

## How did you test this code?

locally, updated storybook
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
