### PR TITLE
feat(logs): stop merging resource attributes and attributes

### DIFF
--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -88,7 +88,6 @@ impl KafkaLogRow {
                 )
             })
             .collect();
-        attributes.extend(resource_attributes.clone());
 
         let instrumentation_scope = match scope {
             Some(s) => format!("{}@{}", s.name, s.version),

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -76,7 +76,7 @@ impl KafkaLogRow {
 
         let resource_attributes = extract_resource_attributes(resource);
 
-        let mut attributes: HashMap<String, String> = record
+        let attributes: HashMap<String, String> = record
             .attributes
             .into_iter()
             .map(|kv| {
@@ -94,8 +94,8 @@ impl KafkaLogRow {
             None => "".to_string(),
         };
 
-        let event_name = extract_string_from_map(&attributes, "event.name");
-        let service_name = extract_string_from_map(&attributes, "service.name");
+        let event_name = record.event_name;
+        let service_name = extract_string_from_map(&resource_attributes, "service.name");
 
         // Trace/span IDs
         let trace_id = extract_trace_id(&record.trace_id);
@@ -121,7 +121,7 @@ impl KafkaLogRow {
             body,
             severity_text,
             severity_number,
-            resource_attributes: resource_attributes.into_iter().collect(),
+            resource_attributes,
             instrumentation_scope,
             event_name,
             service_name,
@@ -221,9 +221,9 @@ fn convert_severity_number_to_text(severity_number: i32) -> String {
     }
 }
 
-fn extract_resource_attributes(resource: Option<Resource>) -> Vec<(String, String)> {
+fn extract_resource_attributes(resource: Option<Resource>) -> HashMap<String, String> {
     let Some(resource) = resource else {
-        return Vec::new();
+        return HashMap::new();
     };
 
     resource


### PR DESCRIPTION
DO NOT MERGE UNTIL #43291 IS LIVE

## Problem

as a quick hack to make things easier we merged resource attributes into attributes

however, we need treat these different and need to separate them

the queries and frontend are already pulling from resource_attributes and filtering duplicates out from attributes, so last step is to stop writing the resource attributes into attributes

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
