### PR TITLE
chore(ph-ai): updated usage report queries ph-ai

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -595,6 +595,7 @@
                        (SELECT actor_id AS actor_id,
                                count() AS event_count,
                                groupUniqArray(distinct_id) AS event_distinct_ids,
+                               max(timestamp) AS last_seen,
                                actor_id AS id
                         FROM
                           (SELECT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS actor_id,


### PR DESCRIPTION
## Problem

Session summarization gets back to main agent with report, in this flow we don't have a different workflow to tag "unbillable" for so we need to just filter out at the tool call level.

## Changes

* added `arrayMap` for ease of future extension, maintaining existing additional `args.kind` filter for `search` tool calls.
  * excluded `summarize_sessions` tool call traces 
* updated `/usage` query

## How did you test this code?

- [x] unit tests
- [x] manual tests
- [x] ran query in metabase US/EU
- [x] spot-checked to-be-filtered-out traces 
