### PR TITLE
fix: make error tracking work in hobby deploy

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -490,7 +490,19 @@ services:
         ports:
             - '127.0.0.1:8333:8333' # S3 API
             - '127.0.0.1:9333:9333' # Master server (for admin UI)
-        command: server -s3 -s3.port=8333 -dir=/data
+        entrypoint:
+            - /bin/sh
+            - -c
+            - |
+                (
+                    until echo "s3.bucket.create -name posthog" | /usr/bin/weed shell -master=localhost:9333 2>/dev/null; do
+                        sleep 5
+                    done
+                    echo "Created bucket: posthog"
+                ) &
+                exec /usr/bin/weed "$$@"
+            - --
+        command: ['server', '-s3', '-s3.port=8333', '-dir=/data']
 
 networks:
     otel_network:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -321,9 +321,9 @@ services:
             KAFKA_CONSUMER_GROUP: cymbal
             KAFKA_CONSUMER_TOPIC: exceptions_ingestion
             OBJECT_STORAGE_BUCKET: posthog
-            OBJECT_STORAGE_ACCESS_KEY_ID: 'object_storage_root_user'
-            OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password'
-            OBJECT_STORAGE_ENDPOINT: 'http://objectstorage:19000'
+            OBJECT_STORAGE_ACCESS_KEY_ID: 'any'
+            OBJECT_STORAGE_SECRET_ACCESS_KEY: 'any'
+            OBJECT_STORAGE_ENDPOINT: 'http://seaweedfs:8333'
             OBJECT_STORAGE_FORCE_PATH_STYLE: 'true'
             BIND_HOST: '0.0.0.0'
             BIND_PORT: '3302'
@@ -336,7 +336,7 @@ services:
         depends_on:
             kafka:
                 condition: service_started
-            objectstorage:
+            seaweedfs:
                 condition: service_started
             db:
                 condition: service_healthy

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -307,6 +307,42 @@ services:
             - db
             - redis
 
+    cymbal:
+        image: ghcr.io/posthog/posthog/cymbal:master
+        build:
+            context: ./posthog/rust
+            args:
+                BIN: cymbal
+        restart: on-failure
+        volumes:
+            - ./share:/share
+        environment:
+            KAFKA_HOSTS: 'kafka:9092'
+            KAFKA_CONSUMER_GROUP: cymbal
+            KAFKA_CONSUMER_TOPIC: exceptions_ingestion
+            OBJECT_STORAGE_BUCKET: posthog
+            OBJECT_STORAGE_ACCESS_KEY_ID: 'object_storage_root_user'
+            OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password'
+            OBJECT_STORAGE_ENDPOINT: 'http://objectstorage:19000'
+            OBJECT_STORAGE_FORCE_PATH_STYLE: 'true'
+            BIND_HOST: '0.0.0.0'
+            BIND_PORT: '3302'
+            DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
+            PERSONS_URL: 'postgres://posthog:posthog@db:5432/posthog'
+            MAXMIND_DB_PATH: '/share/GeoLite2-City.mmdb'
+            REDIS_URL: 'redis://redis:6379/'
+            ALLOW_INTERNAL_IPS: 'true'
+            RUST_LOG: 'info'
+        depends_on:
+            kafka:
+                condition: service_started
+            objectstorage:
+                condition: service_started
+            db:
+                condition: service_healthy
+            redis:
+                condition: service_healthy
+
 volumes:
     zookeeper-data:
     zookeeper-datalog:


### PR DESCRIPTION
## Problem

Error tracking ingestion does not work in hobby deploy because there is no cymbal instance.

## Changes

Added cymbal to the docker compose.

You can test it using
```
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/ablaszkiewicz/posthog-hobby-test/refs/heads/master/bin/deploy-hobby)"
```

I tested it and it looks good!

<img width="901" height="990" alt="image" src="https://github.com/user-attachments/assets/2dca5c6c-9ab9-4331-a4d4-8e808f420322" />
