### PR TITLE
fix(llma): use string value for $ai_is_error filter

### DIFF
--- a/products/llm_analytics/backend/dashboard_templates.py
+++ b/products/llm_analytics/backend/dashboard_templates.py
@@ -236,7 +236,7 @@ def get_llm_analytics_default_template() -> DashboardTemplate:
                                 "type": "event",
                                 "key": "$ai_is_error",
                                 "operator": "exact",
-                                "value": True,
+                                "value": "true",
                             }
                         ],
                         "filterTestAccounts": False,

--- a/products/llm_analytics/frontend/llmAnalyticsLogic.tsx
+++ b/products/llm_analytics/frontend/llmAnalyticsLogic.tsx
@@ -842,7 +842,7 @@ export const llmAnalyticsLogic = kea<llmAnalyticsLogicType>([
                             type: PropertyFilterType.Event,
                             key: '$ai_is_error',
                             operator: PropertyOperator.Exact,
-                            value: true,
+                            value: 'true',
                         }),
                         filterTestAccounts: shouldFilterTestAccounts,
                     },
@@ -864,7 +864,7 @@ export const llmAnalyticsLogic = kea<llmAnalyticsLogicType>([
                                             type: PropertyFilterType.Event,
                                             key: '$ai_is_error',
                                             operator: PropertyOperator.Exact,
-                                            value: true,
+                                            value: 'true',
                                         },
                                     ] as AnyPropertyFilter[],
                                 })


### PR DESCRIPTION
## Problem

The AI Errors insight on the LLM analytics dashboard fails with a ClickHouse type mismatch error:

```
DB::Exception: There is no supertype for types String, UInt8 because some of them are String/FixedString/Enum and some of them are not: while executing 'FUNCTION equals(mat_$ai_is_error :: 4, 1 :: 5) -> equals(mat_$ai_is_error, 1) Nullable(UInt8) : 6'
```

The `$ai_is_error` property is stored as a String in the materialized column, but the filter was using a boolean value (`True`/`true`) which converts to UInt8 (1), causing the type mismatch.

Related to #43290

## Changes

Changed the `$ai_is_error` filter value from boolean `true` to string `"true"` in:
- Backend dashboard template (`dashboard_templates.py`)
- Frontend logic (`llmAnalyticsLogic.tsx`) - both the query and click handler

## How did you test this code?

This is a straightforward value type change. The fix aligns with how other parts of the codebase compare `$ai_is_error` (e.g., `properties.$ai_is_error = 'true'` in SQL queries).

## Changelog: (features only) Is this feature complete?

No - this is a bug fix.