### PR TITLE
fix: increase column configurator modal size for better visibility

### DIFF
--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.scss
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.scss
@@ -2,7 +2,7 @@
     .Columns {
         display: flex;
         column-gap: 1rem;
-        width: 700px;
+        width: 900px;
         padding: 0.5rem;
         background-color: var(--color-bg-primary);
         border-radius: var(--radius);

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.scss
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.scss
@@ -2,7 +2,8 @@
     .Columns {
         display: flex;
         column-gap: 1rem;
-        width: 900px;
+        width: 1200px;
+        max-width: 90vw;
         padding: 0.5rem;
         background-color: var(--color-bg-primary);
         border-radius: var(--radius);
@@ -14,7 +15,13 @@
     }
 
     .HalfColumn {
-        width: 50%;
+        &:first-child {
+            width: 40%;
+        }
+
+        &:last-child {
+            width: 60%;
+        }
 
         @media (max-width: 960px) {
             width: 100%;

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -203,7 +203,7 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                     </div>
                     <div className="HalfColumn">
                         <h4 className="secondary uppercase text-secondary">Available columns</h4>
-                        <div className="h-[480px]">
+                        <div className="h-[min(480px,60vh)]">
                             <AutoSizer>
                                 {({ height, width }: { height: number; width: number }) => (
                                     <TaxonomicFilter

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -203,7 +203,7 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                     </div>
                     <div className="HalfColumn">
                         <h4 className="secondary uppercase text-secondary">Available columns</h4>
-                        <div className="h-[360px]">
+                        <div className="h-[480px]">
                             <AutoSizer>
                                 {({ height, width }: { height: number; width: number }) => (
                                     <TaxonomicFilter


### PR DESCRIPTION
## Problem

Properties are unreadable 

After:

| Before | After |
|---------|--------|
| <img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/c32dc0af-9792-46c3-90ba-b8183b13eebc" /> | <img width="1509" height="856" alt="image" src="https://github.com/user-attachments/assets/6ccb7a30-1b10-4623-94e6-baafdd96a81f" /> |



## Changes

- Increase size

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
