### PR TITLE
fix(workflows): use captureEvent after webhook trigger

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
@@ -242,11 +242,17 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase {
             // Add all logs to the result
 
             if (capturedPostHogEvent) {
+                // For workflows, the captured event is only used as trigger data and not sent to the database.
+                // Remove the execution count property to allow workflow actions to capture events without
+                // triggering the infinite loop protection.
+                const { $hog_function_execution_count, ...cleanProperties } = capturedPostHogEvent.properties || {}
+
                 // Invoke the hogflow
                 const triggerGlobals: HogFunctionInvocationGlobals = {
                     ...invocation.state.globals,
                     event: {
                         ...capturedPostHogEvent,
+                        properties: cleanProperties,
                         uuid: new UUIDT().toString(),
                         elements_chain: '',
                         url: '',

--- a/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-source-webhooks.consumer.ts
@@ -242,7 +242,7 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase {
             // Add all logs to the result
 
             if (capturedPostHogEvent) {
-                // For workflows, the captured event is only used as trigger data and not sent to the database.
+                // For workflows, the captured event is only used as trigger data and not to actually capture the event
                 // Remove the execution count property to allow workflow actions to capture events without
                 // triggering the infinite loop protection.
                 const { $hog_function_execution_count, ...cleanProperties } = capturedPostHogEvent.properties || {}


### PR DESCRIPTION
## Problem

When using webhooks as workflow triggers, subsequent "Capture" actions within the workflow would fail with the error: "postHogCapture was called from an event that already executed this function. To prevent infinite loops, the event was not captured."

  This happened because:
  1. Webhook triggers call postHogCapture internally, which adds a $hog_function_execution_count: 1 property for infinite loop protection
  2. For workflows (unlike regular webhooks), this event is NOT captured to the database - it's only used as trigger data
  3. The execution count property was passed along to the workflow, causing any subsequent capture actions to fail with the infinite loop protection error

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

 - Modified cdp-source-webhooks.consumer.ts to strip the execution count property for workflow webhooks only
  - Added tests to verify:
    - Workflow webhook events are not captured
    - The execution count property is removed from workflow invocations
    - Regular webhooks continue to work normally with the protection in place

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- in addition to automated test it was tested locally

![2025-12-12 16 09 32](https://github.com/user-attachments/assets/af10d263-03e9-44de-8f70-67afea6a39ea)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
