### PR TITLE
feat(workflows): Stop tracking destination lag metrics for workflow-triggered-function-invocation, track ingestion-to-destination lag

### DIFF
--- a/plugin-server/src/cdp/services/hogflows/hogflow-functions.service.ts
+++ b/plugin-server/src/cdp/services/hogflows/hogflow-functions.service.ts
@@ -95,6 +95,9 @@ export class HogFlowFunctionsService {
         invocation: CyclotronJobInvocationHogFunction,
         hogExecutorOptions?: HogExecutorExecuteAsyncOptions
     ): Promise<CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction>> {
-        return this.hogFunctionExecutor.executeWithAsyncFunctions(invocation, hogExecutorOptions)
+        return this.hogFunctionExecutor.executeWithAsyncFunctions(invocation, {
+            ...hogExecutorOptions,
+            skipE2eLagMetrics: true,
+        })
     }
 }

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
@@ -2,7 +2,7 @@ import { Histogram } from 'prom-client'
 
 import { PluginEvent, ProcessedPluginEvent, RetryError, StorageExtension } from '@posthog/plugin-scaffold'
 
-import { destinationE2eLagMsSummary } from '~/main/ingestion-queues/metrics'
+import { destinationE2eLagMsSummary, destinationIngestedToProcessedLagMs } from '~/main/ingestion-queues/metrics'
 
 import { Hub } from '../../types'
 import { PostgresUse } from '../../utils/db/postgres'
@@ -314,6 +314,13 @@ export class LegacyPluginExecutorService {
                 if (capturedAt) {
                     const e2eLagMs = Date.now() - new Date(capturedAt).getTime()
                     destinationE2eLagMsSummary.observe(e2eLagMs)
+                }
+                const ingestedAt = invocation.state.globals.event?.ingested_at
+                if (ingestedAt) {
+                    const ingestedToProcessedLagMs = Date.now() - new Date(ingestedAt).getTime()
+                    destinationIngestedToProcessedLagMs
+                        .labels({ destinationType: 'legacy-plugin' })
+                        .observe(ingestedToProcessedLagMs)
                 }
             }
         } catch (e) {

--- a/plugin-server/src/cdp/services/native-destination-executor.service.ts
+++ b/plugin-server/src/cdp/services/native-destination-executor.service.ts
@@ -1,6 +1,6 @@
 import { Histogram } from 'prom-client'
 
-import { destinationE2eLagMsSummary } from '~/main/ingestion-queues/metrics'
+import { destinationE2eLagMsSummary, destinationIngestedToProcessedLagMs } from '~/main/ingestion-queues/metrics'
 import { PluginsServerConfig } from '~/types'
 import { parseJSON } from '~/utils/json-parse'
 
@@ -231,6 +231,13 @@ export class NativeDestinationExecutorService {
                 if (capturedAt) {
                     const e2eLagMs = Date.now() - new Date(capturedAt).getTime()
                     destinationE2eLagMsSummary.observe(e2eLagMs)
+                }
+                const ingestedAt = invocation.state.globals.event?.ingested_at
+                if (ingestedAt) {
+                    const ingestedToProcessedLagMs = Date.now() - new Date(ingestedAt).getTime()
+                    destinationIngestedToProcessedLagMs
+                        .labels({ destinationType: 'native' })
+                        .observe(ingestedToProcessedLagMs)
                 }
             }
         } catch (e) {

--- a/plugin-server/src/cdp/services/segment-destination-executor.service.ts
+++ b/plugin-server/src/cdp/services/segment-destination-executor.service.ts
@@ -1,7 +1,7 @@
 import { Histogram } from 'prom-client'
 import { ReadableStream } from 'stream/web'
 
-import { destinationE2eLagMsSummary } from '~/main/ingestion-queues/metrics'
+import { destinationE2eLagMsSummary, destinationIngestedToProcessedLagMs } from '~/main/ingestion-queues/metrics'
 import { PluginsServerConfig } from '~/types'
 
 import { parseJSON } from '../../utils/json-parse'
@@ -319,6 +319,14 @@ export class SegmentDestinationExecutorService {
                 if (capturedAt) {
                     const e2eLagMs = Date.now() - new Date(capturedAt).getTime()
                     destinationE2eLagMsSummary.observe(e2eLagMs)
+                }
+
+                const ingestedAt = invocation.state.globals.event?.ingested_at
+                if (ingestedAt) {
+                    const ingestedToProcessedLagMs = Date.now() - new Date(ingestedAt).getTime()
+                    destinationIngestedToProcessedLagMs
+                        .labels({ destinationType: 'segment' })
+                        .observe(ingestedToProcessedLagMs)
                 }
             }
         } catch (e) {

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -87,6 +87,7 @@ export type HogFunctionInvocationGlobals = {
         elements_chain: string
         timestamp: string
         captured_at?: string | null
+        ingested_at?: string | null
 
         /* Special fields in Hog */
         url: string

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -71,6 +71,12 @@ export function convertToHogFunctionInvocationGlobals(
             : clickHouseTimestampToISO(event.captured_at)
         : null
 
+    const eventIngestedAt = event.ingested_at
+        ? DateTime.fromISO(event.ingested_at).isValid
+            ? event.ingested_at
+            : clickHouseTimestampToISO(event.ingested_at)
+        : null
+
     const context: HogFunctionInvocationGlobals = {
         project: {
             id: team.id,
@@ -85,6 +91,7 @@ export function convertToHogFunctionInvocationGlobals(
             properties,
             timestamp: eventTimestamp,
             captured_at: eventCapturedAt,
+            ingested_at: eventIngestedAt,
             url: `${projectUrl}/events/${encodeURIComponent(event.uuid)}/${encodeURIComponent(eventTimestamp)}`,
         },
         person,

--- a/plugin-server/src/main/ingestion-queues/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/metrics.ts
@@ -1,5 +1,5 @@
 // Metrics that make sense across all Kafka consumers
-import { Counter, Gauge, Summary } from 'prom-client'
+import { Counter, Gauge, Histogram, Summary } from 'prom-client'
 
 export const kafkaRebalancePartitionCount = new Gauge({
     name: 'kafka_rebalance_partition_count',
@@ -59,6 +59,13 @@ export const destinationE2eLagMsSummary = new Summary({
     name: 'destination_e2e_lag_ms',
     help: 'Time difference in ms between event capture time and destination finishing time',
     percentiles: [0.5, 0.9, 0.95, 0.99],
+})
+
+export const destinationIngestedToProcessedLagMs = new Histogram({
+    name: 'destination_ingested_to_processed_lag_ms',
+    help: 'Time difference in ms between event ingestion and destination finishing time',
+    buckets: [1000, 5000, 10000, 30000, 100000, 1000000, Infinity],
+    labelNames: ['destinationType'],
 })
 
 export const cookielessRedisErrorCounter = new Counter({

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -886,6 +886,7 @@ export interface RawClickHouseEvent extends BaseEvent {
     timestamp: ClickHouseTimestamp
     created_at: ClickHouseTimestamp
     captured_at?: ClickHouseTimestamp | null
+    ingested_at?: ClickHouseTimestamp
     properties?: string
     elements_chain: string
     person_created_at?: ClickHouseTimestamp

--- a/plugin-server/src/worker/ingestion/create-event.ts
+++ b/plugin-server/src/worker/ingestion/create-event.ts
@@ -103,6 +103,7 @@ export function createEvent(
             capturedAt !== null
                 ? castTimestampToClickhouseFormat(DateTime.fromJSDate(capturedAt), TimestampFormat.ClickHouse)
                 : null,
+        ingested_at: castTimestampToClickhouseFormat(DateTime.utc(), TimestampFormat.ClickHouse),
         person_id: person.uuid,
         person_properties: eventPersonProperties,
         person_created_at: castTimestampOrNow(person.created_at, TimestampFormat.ClickHouseSecondPrecision),


### PR DESCRIPTION
Opening this draft as basis for conversation about how to track these metrics. Interesting questions to me are:
* What buckets make sense? I picked something that seemed sensible based on the workflow e2e metrics, but that's not a great basis IMO
* What else could be causing our crazy high values? We already track `ingestion_lag_ms` (From Capture until writing to clickhouse_events_json), might be worth looking at those to make sure it's not ingestion lag (even though I'm pretty sure it's not)

## Problem

* We have crazy high values for the destination e2e lag of millions of seconds - that can't be correct
* With summary-metrics we get percentiles per-pod, which is not super ideal
* Having one big e2e metric isn't enough to track where potential issues occur

## Changes

* Stop observing a destination metric when a hogfunction is called from a workflow
* Add a new ingestion-to-destination metric that uses histogram buckets instead of Summary

## How did you test this code?

Updated automated tests
