### PR TITLE
fix(batch-exports): Add start timeout to BigQuery queries

### DIFF
--- a/posthog/batch_exports/debug/debugger.py
+++ b/posthog/batch_exports/debug/debugger.py
@@ -495,28 +495,28 @@ class BatchExportsDebugger:
         match self.batch_export.destination.type:
             case BatchExportDestination.Destination.DATABRICKS:
                 console.print("[bold green]Getting Databricks client...[/bold green]")
-                inputs = cast(DatabricksBatchExportInputs, self.batch_export_inputs)
+                databricks_inputs = cast(DatabricksBatchExportInputs, self.batch_export_inputs)
                 assert self.batch_export.destination.integration is not None
                 integration = DatabricksIntegration(self.batch_export.destination.integration)
                 client = DatabricksClient(
                     server_hostname=integration.server_hostname,
-                    http_path=inputs.http_path,
+                    http_path=databricks_inputs.http_path,
                     client_id=integration.client_id,
                     client_secret=integration.client_secret,
-                    catalog=inputs.catalog,
-                    schema=inputs.schema,
+                    catalog=databricks_inputs.catalog,
+                    schema=databricks_inputs.schema,
                 )
                 async with client.connect() as databricks_client:
                     yield databricks_client
             case BatchExportDestination.Destination.BIGQUERY:
                 console.print("[bold green]Getting BigQuery client...[/bold green]")
-                inputs = cast(BigQueryBatchExportInputs, self.batch_export_inputs)
+                bigquery_inputs = cast(BigQueryBatchExportInputs, self.batch_export_inputs)
                 async with BigQueryClient.from_service_account_inputs(
-                    private_key=inputs.private_key,
-                    private_key_id=inputs.private_key_id,
-                    token_uri=inputs.token_uri,
-                    client_email=inputs.client_email,
-                    project_id=inputs.project_id,
+                    private_key=bigquery_inputs.private_key,
+                    private_key_id=bigquery_inputs.private_key_id,
+                    token_uri=bigquery_inputs.token_uri,
+                    client_email=bigquery_inputs.client_email,
+                    project_id=bigquery_inputs.project_id,
                 ) as bigquery_client:
                     yield bigquery_client
             case t:

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -390,7 +390,7 @@ class BigQueryClient:
             return table
 
     async def execute_query(
-        self, query: str, start_query_timeout: float = 10 * 60, poll_interval: float = 0.5
+        self, query: str, start_query_timeout: float | int = 10 * 60, poll_interval: float | int = 0.5
     ) -> RowIterator | _EmptyRowIterator:
         """Execute a query and wait for it to complete.
 

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -11,6 +11,7 @@ import collections.abc
 from django.conf import settings
 
 import pyarrow as pa
+import requests
 from google.api_core.exceptions import Forbidden, GoogleAPICallError, NotFound
 from google.cloud import bigquery
 from google.cloud.bigquery.table import RowIterator, _EmptyRowIterator
@@ -426,7 +427,7 @@ class BigQueryClient:
                     # best-effort attempt to cancel the query
                     try:
                         await asyncio.to_thread(query_job.cancel)
-                    except GoogleAPICallError as err:
+                    except (GoogleAPICallError, requests.exceptions.RequestException) as err:
                         self.external_logger.warning("Failed to cancel query when cleaning up: %s", err)
                     raise StartQueryTimeoutError(query_id, start_query_timeout)
                 await asyncio.sleep(poll_interval)

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -416,6 +416,11 @@ class BigQueryClient:
                 break
             query_duration = time.monotonic() - query_start_time
             if query_duration > start_query_timeout:
+                # Cancel the query then raise a timeout error
+                # According to Google's own docs:
+                # "It's not possible to check if a job was cancelled in the API"
+                # so we cancel it and hope for the best
+                await asyncio.to_thread(query_job.cancel)
                 assert query_job.job_id is not None
                 raise BigQueryStartQueryTimeoutError(query_job.job_id, start_query_timeout)
 

--- a/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
@@ -48,6 +48,7 @@ async def test_execute_query_pending_timeout(states_sequence: list[str], should_
                 start_query_timeout=0.05,
                 poll_interval=0.01,
             )
+        mock_query_job.cancel.assert_called_once()
     else:
         result = await client.execute_query(
             "SELECT 1",

--- a/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 from products.batch_exports.backend.temporal.destinations.bigquery_batch_export import (
     BigQueryClient,
-    BigQueryStartQueryTimeoutError,
+    StartQueryTimeoutError,
 )
 
 
@@ -41,7 +41,7 @@ async def test_execute_query_pending_timeout(states_sequence: list[str], should_
 
     if should_timeout:
         with pytest.raises(
-            BigQueryStartQueryTimeoutError, match="Query 'test-job-id' still in 'PENDING' state after 0.05 seconds"
+            StartQueryTimeoutError, match="Query 'test-job-id' still in 'PENDING' state after 0.05 seconds"
         ):
             await client.execute_query(
                 "SELECT 1",

--- a/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
@@ -41,7 +41,7 @@ async def test_execute_query_pending_timeout(states_sequence: list[str], should_
 
     if should_timeout:
         with pytest.raises(
-            StartQueryTimeoutError, match="Query 'test-job-id' still in 'PENDING' state after 0.05 seconds"
+            StartQueryTimeoutError, match="Query still in 'PENDING' state after 0.05 seconds; timing out."
         ):
             await client.execute_query(
                 "SELECT 1",

--- a/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
@@ -1,0 +1,57 @@
+import pytest
+from unittest.mock import MagicMock
+
+from products.batch_exports.backend.temporal.destinations.bigquery_batch_export import (
+    BigQueryClient,
+    BigQueryStartQueryTimeoutError,
+)
+
+
+@pytest.mark.parametrize(
+    "states_sequence,should_timeout",
+    [
+        (["PENDING", "PENDING", "RUNNING", "DONE"], False),
+        (["PENDING"] * 100, True),
+        (["RUNNING", "DONE"], False),
+    ],
+    ids=["eventually_starts", "stays_pending_times_out", "starts_immediately"],
+)
+@pytest.mark.asyncio
+async def test_execute_query_pending_timeout(states_sequence: list[str], should_timeout: bool):
+    mock_query_job = MagicMock()
+    state_iter = iter(states_sequence)
+    mock_query_job.state = next(state_iter)
+    mock_query_job.job_id = "test-job-id"
+
+    def reload_side_effect():
+        try:
+            mock_query_job.state = next(state_iter)
+        except StopIteration:
+            pass
+
+    mock_query_job.reload = reload_side_effect
+    mock_result = MagicMock(name="mock_result")
+    mock_query_job.result.return_value = mock_result
+
+    mock_sync_client = MagicMock()
+    mock_sync_client.query.return_value = mock_query_job
+    mock_sync_client.project = "test-project"
+
+    client = BigQueryClient(mock_sync_client)
+
+    if should_timeout:
+        with pytest.raises(
+            BigQueryStartQueryTimeoutError, match="Query 'test-job-id' still in 'PENDING' state after 0.05 seconds"
+        ):
+            await client.execute_query(
+                "SELECT 1",
+                start_query_timeout=0.05,
+                poll_interval=0.01,
+            )
+    else:
+        result = await client.execute_query(
+            "SELECT 1",
+            start_query_timeout=0.5,
+            poll_interval=0.01,
+        )
+        assert result == mock_result


### PR DESCRIPTION

## Problem

If a BigQuery project/account is overloaded, queries can back up and remain in a 'PENDING' state.
This means that queries can take hours to complete and we have no control over this.

## Changes

- Add a timeout for when a query remains in a 'PENDING' state for a certain period of time
- Ensure we cancel query
- Raise a non-retryable error

- Also, add a BigQuery client to the batch exports debugger

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- Ran existing BigQuery tests
- Added a unit test for the BigQueryClient (uses a mock since it's very difficult to simulate this behaviour otherwise)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

