### PR TITLE
chore: Add comment explaining that Person display properties need to be materialized

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -72,6 +72,7 @@ from posthog.utils import convert_property_value, format_query_params_absolute_u
 
 DEFAULT_PAGE_LIMIT = 100
 # Sync with .../lib/constants.tsx and .../ingestion/webhook-formatter.ts
+# and make sure that they are materialized on prod!
 PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
     "email",
     "Email",

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -11,6 +11,7 @@ from typing import Optional
 from django.core import exceptions
 from django.core.management.base import BaseCommand
 
+from posthog.api.person import PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
 from posthog.demo.matrix import Matrix, MatrixManager
 from posthog.demo.products.hedgebox import HedgeboxMatrix
 from posthog.demo.products.spikegpt import SpikeGPTMatrix
@@ -303,13 +304,7 @@ class Command(BaseCommand):
 
         person_properties = {
             *PERSON_PROPERTIES_ADAPTED_FROM_EVENT,
-            "email",
-            "Email",
-            "name",
-            "Name",
-            "username",
-            "Username",
-            "UserName",
+            *PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES,
         }
         for prop in person_properties.copy():
             if prop.startswith("$initial_"):


### PR DESCRIPTION
## Problem

We have a bunch of unmaterialized properties in the person query

## Changes

We should at least warn people adding more properties that they need to materialise them first. I'd like to solve this in a more systematic way in the future, but hey this is a tiny PR 

## How did you test this code?

n/a

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
