### PR TITLE
fix: pass PERSON_PROPERTIES_UPDATE_ALL to batch person writer

### DIFF
--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -163,6 +163,7 @@ export class IngestionConsumer {
             maxConcurrentUpdates: this.hub.PERSON_BATCH_WRITING_MAX_CONCURRENT_UPDATES,
             maxOptimisticUpdateRetries: this.hub.PERSON_BATCH_WRITING_MAX_OPTIMISTIC_UPDATE_RETRIES,
             optimisticUpdateRetryInterval: this.hub.PERSON_BATCH_WRITING_OPTIMISTIC_UPDATE_RETRY_INTERVAL_MS,
+            updateAllProperties: this.hub.PERSON_PROPERTIES_UPDATE_ALL,
         })
 
         this.groupStore = new BatchWritingGroupStore(this.hub, {

--- a/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -87,6 +87,8 @@ export interface BatchWritingPersonsStoreOptions {
     dbWriteMode: PersonBatchWritingDbWriteMode
     maxOptimisticUpdateRetries: number
     optimisticUpdateRetryInterval: number
+    /** When true, all property changes trigger person updates (disables batch-level filtering) */
+    updateAllProperties: boolean
 }
 
 const DEFAULT_OPTIONS: BatchWritingPersonsStoreOptions = {
@@ -94,6 +96,7 @@ const DEFAULT_OPTIONS: BatchWritingPersonsStoreOptions = {
     maxConcurrentUpdates: 10,
     maxOptimisticUpdateRetries: 5,
     optimisticUpdateRetryInterval: 50,
+    updateAllProperties: false,
 }
 
 interface CacheMetrics {
@@ -168,8 +171,8 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
             return 'no_change'
         }
 
-        // If force_update is set (from $identify, $set events), bypass filtering and always write
-        if (update.force_update) {
+        // If force_update is set (from $identify, $set events) or updateAllProperties is enabled, bypass filtering
+        if (update.force_update || this.options.updateAllProperties) {
             return 'changed'
         }
 

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -114,6 +114,7 @@ exports[`EventPipelineRunner runEventPipeline() runs steps 1`] = `
           "maxConcurrentUpdates": 10,
           "maxOptimisticUpdateRetries": 5,
           "optimisticUpdateRetryInterval": 50,
+          "updateAllProperties": false,
         },
         "personCheckCache": {},
         "personRepository": {


### PR DESCRIPTION
## Problem

env var PERSON_PROPERTIES_UPDATE_ALL was not being passed to the Person batch Writer

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
