### PR TITLE
fix(batch-exports): Additionally check for queries in `system.processes` table

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -540,37 +540,38 @@ class ClickHouseClient:
         async with self.aget_query(query, query_parameters=query_parameters, query_id=query_id) as response:
             return await response.content.read()
 
-    async def acheck_query_in_process_list(self, query_id: str) -> bool:
-        """Check if a query is running in the ClickHouse process list.
-
-        Arguments:
-            query_id: The ID of the query to check.
-
-        Returns:
-            True if the query is running, False otherwise.
-        """
-        query = """
-                SELECT count() > 0 AS is_running
-                FROM clusterAllReplicas({{cluster_name:String}}, system.processes)
-                WHERE query_id = {{query_id:String}}
-                FORMAT JSONEachRow
-                """
-
-        resp = await self.read_query(
-            query,
-            query_parameters={"query_id": query_id, "cluster_name": settings.CLICKHOUSE_CLUSTER},
-            query_id=f"{query_id}-CHECK",
-        )
-        result = json.loads(resp)["is_running"]
-        assert result == 1 or result == 0
-        return bool(result)
-
     async def acheck_query(
         self,
         query_id: str,
         raise_on_error: bool = True,
     ) -> ClickHouseQueryStatus:
         """Check the status of a query in ClickHouse.
+
+        This method first checks the query log to see if the query has finished, failed, or is still running.
+        If it's not found in the query log for whatever reason (we've seen this happen many times in production), it
+        checks the process list to see if the query is still running.
+
+        Arguments:
+            query_id: The ID of the query to check.
+            raise_on_error: Whether to raise an exception if the query has
+                failed.
+        """
+        try:
+            return await self.acheck_query_in_query_log(query_id, raise_on_error=raise_on_error)
+        except ClickHouseQueryNotFound:
+            is_running = await self.acheck_query_in_process_list(query_id)
+            if is_running:
+                return ClickHouseQueryStatus.RUNNING
+            else:
+                self.logger.warning("Expected query not found in query log or process list", query_id=query_id)
+                raise
+
+    async def acheck_query_in_query_log(
+        self,
+        query_id: str,
+        raise_on_error: bool = True,
+    ) -> ClickHouseQueryStatus:
+        """Check the status of a query in the ClickHouse query log.
 
         Arguments:
             query_id: The ID of the query to check.
@@ -582,7 +583,7 @@ class ClickHouseClient:
                 FROM clusterAllReplicas({{cluster_name:String}}, system.query_log)
                 WHERE query_id = {{query_id:String}}
                     AND event_date >= yesterday() AND event_time >= now() - interval 24 hour
-                    FORMAT JSONEachRow \
+                FORMAT JSONEachRow
                 """
 
         resp = await self.read_query(
@@ -592,7 +593,6 @@ class ClickHouseClient:
         )
 
         if not resp:
-            self.logger.warning("Query not found in query log", query_id=query_id)
             raise ClickHouseQueryNotFound(query, query_id)
 
         lines = resp.split(b"\n")
@@ -624,8 +624,32 @@ class ClickHouseClient:
         elif "QueryStart" in events:
             return ClickHouseQueryStatus.RUNNING
         else:
-            self.logger.warning("Expected event not found in query log", query_id=query_id, events=events)
             raise ClickHouseQueryNotFound(query, query_id)
+
+    async def acheck_query_in_process_list(self, query_id: str) -> bool:
+        """Check if a query is running in the ClickHouse process list.
+
+        Arguments:
+            query_id: The ID of the query to check.
+
+        Returns:
+            True if the query is running, False otherwise.
+        """
+        query = """
+                SELECT count() > 0 AS is_running
+                FROM clusterAllReplicas({{cluster_name:String}}, system.processes)
+                WHERE query_id = {{query_id:String}}
+                FORMAT JSONEachRow
+                """
+
+        resp = await self.read_query(
+            query,
+            query_parameters={"query_id": query_id, "cluster_name": settings.CLICKHOUSE_CLUSTER},
+            query_id=f"{query_id}-CHECK",
+        )
+        result = json.loads(resp)["is_running"]
+        assert result == 1 or result == 0
+        return bool(result)
 
     async def acancel_query(self, query_id: str) -> None:
         """Cancel a running query in ClickHouse.

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -648,7 +648,11 @@ class ClickHouseClient:
             query_parameters={"query_id": query_id, "cluster_name": settings.CLICKHOUSE_CLUSTER},
             query_id=f"{query_id}-CHECK-PROCESS-LIST",
         )
-        return bool(resp)
+        if not resp:
+            return False
+
+        result = resp.decode("utf-8").strip()
+        return result == "1"
 
     async def acancel_query(self, query_id: str) -> None:
         """Cancel a running query in ClickHouse.

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from posthog.clickhouse.query_tagging import QueryTags
 from posthog.temporal.common.clickhouse import (
+    ClickHouseClient,
     ClickHouseError,
     ClickHouseMemoryLimitExceededError,
     ClickHouseQueryNotFound,
@@ -14,6 +15,79 @@ from posthog.temporal.common.clickhouse import (
     add_log_comment_param,
     encode_clickhouse_data,
 )
+
+
+async def _wait_for_query_status(
+    client: ClickHouseClient,
+    query_id: str,
+    expected_status: ClickHouseQueryStatus,
+    raise_on_error: bool = True,
+    max_wait_time: float = 5.0,
+    poll_interval: float = 0.5,
+) -> ClickHouseQueryStatus | None:
+    """Wait for a query to reach the expected status in the query log.
+
+    Returns:
+        The query status if found, None if timeout.
+    """
+    elapsed_time = 0.0
+    while elapsed_time < max_wait_time:
+        try:
+            status = await client.acheck_query_in_query_log(query_id, raise_on_error=raise_on_error)
+            if status == expected_status:
+                return status
+        except ClickHouseQueryNotFound:
+            pass
+        except ClickHouseError:
+            if raise_on_error:
+                raise
+            return ClickHouseQueryStatus.ERROR
+        await asyncio.sleep(poll_interval)
+        elapsed_time += poll_interval
+    return None
+
+
+async def _wait_for_query_in_process_list(
+    client: ClickHouseClient,
+    query_id: str,
+    expected: bool,
+    max_wait_time: float = 5.0,
+    poll_interval: float = 0.5,
+) -> bool:
+    """Wait for a query to appear or disappear from the process list.
+
+    Returns:
+        True if query is in process list, False otherwise.
+    """
+    elapsed_time = 0.0
+    while elapsed_time < max_wait_time:
+        is_running = await client.acheck_query_in_process_list(query_id)
+        if is_running == expected:
+            return is_running
+        await asyncio.sleep(poll_interval)
+        elapsed_time += poll_interval
+    return not expected
+
+
+async def _run_and_cancel_query(
+    client: ClickHouseClient,
+    query: str,
+    query_id: str,
+    wait_before_cancel: float = 0.5,
+) -> asyncio.Task:
+    """Start a long-running query and cancel it after a short delay.
+
+    Returns:
+        The task running the query (which will raise ClickHouseError when awaited).
+    """
+
+    async def run_query():
+        await client.execute_query(query, query_id=query_id)
+
+    query_task = asyncio.create_task(run_query())
+    await asyncio.sleep(wait_before_cancel)
+    await client.acancel_query(query_id)
+    return query_task
 
 
 @pytest.mark.parametrize(
@@ -84,38 +158,17 @@ def test_clickhouse_memory_limit_exceeded_error(clickhouse_client):
 
 async def test_acancel_query(clickhouse_client, django_db_setup):
     """Test that acancel_query successfully cancels a long-running query."""
-    long_running_query_id = f"test-long-running-query-{uuid.uuid4()}"
+    query_id = f"test-long-running-query-{uuid.uuid4()}"
     long_running_query = "SELECT sleep(3)"
 
-    async def run_query():
-        await clickhouse_client.execute_query(
-            long_running_query,
-            query_id=long_running_query_id,
-        )
-
-    query_task = asyncio.create_task(run_query())
-
-    await asyncio.sleep(0.5)
-
-    await clickhouse_client.acancel_query(long_running_query_id)
+    query_task = await _run_and_cancel_query(clickhouse_client, long_running_query, query_id)
 
     with pytest.raises(ClickHouseError):
         await query_task
 
-    max_wait_time = 5.0
-    poll_interval = 0.5
-    elapsed_time = 0.0
-
-    status = None
-    while elapsed_time < max_wait_time:
-        try:
-            status = await clickhouse_client.acheck_query(long_running_query_id, raise_on_error=False)
-            if status != ClickHouseQueryStatus.RUNNING:
-                break
-        except ClickHouseQueryNotFound:
-            pass
-        await asyncio.sleep(poll_interval)
-        elapsed_time += poll_interval
+    status = await _wait_for_query_status(
+        clickhouse_client, query_id, ClickHouseQueryStatus.ERROR, raise_on_error=False
+    )
 
     # ClickHouse treats cancelled queries as failed, so we expect an error status
     # Code: 394. DB::Exception: Query was cancelled. (QUERY_WAS_CANCELLED)
@@ -127,14 +180,7 @@ async def test_acheck_query_in_process_list(clickhouse_client, django_db_setup):
     query_id = f"test-process-list-query-{uuid.uuid4()}"
     long_running_query = "SELECT sleep(3)"
 
-    async def run_query():
-        await clickhouse_client.execute_query(
-            long_running_query,
-            query_id=query_id,
-        )
-
-    query_task = asyncio.create_task(run_query())
-
+    query_task = asyncio.create_task(clickhouse_client.execute_query(long_running_query, query_id=query_id))
     await asyncio.sleep(0.5)
 
     # query should be running, and therefore in the process list
@@ -147,15 +193,42 @@ async def test_acheck_query_in_process_list(clickhouse_client, django_db_setup):
     with pytest.raises(ClickHouseError):
         await query_task
 
-    max_wait_time = 5.0
-    poll_interval = 0.5
-    elapsed_time = 0.0
-
-    while elapsed_time < max_wait_time:
-        is_running = await clickhouse_client.acheck_query_in_process_list(query_id)
-        if not is_running:
-            break
-        await asyncio.sleep(poll_interval)
-        elapsed_time += poll_interval
-
+    is_running = await _wait_for_query_in_process_list(clickhouse_client, query_id, expected=False)
     assert is_running is False
+
+
+async def test_acheck_query_in_query_log_successful(clickhouse_client, django_db_setup):
+    """Test that acheck_query_in_query_log returns FINISHED for a successful query."""
+    query_id = f"test-successful-query-{uuid.uuid4()}"
+    await clickhouse_client.execute_query("SELECT 1", query_id=query_id)
+
+    status = await _wait_for_query_status(clickhouse_client, query_id, ClickHouseQueryStatus.FINISHED)
+    assert status == ClickHouseQueryStatus.FINISHED
+
+
+async def test_acheck_query_in_query_log_cancelled(clickhouse_client, django_db_setup):
+    """Test that acheck_query_in_query_log handles cancelled queries correctly based on raise_on_error."""
+    query_id = f"test-cancelled-query-{uuid.uuid4()}"
+    long_running_query = "SELECT sleep(3)"
+
+    query_task = await _run_and_cancel_query(clickhouse_client, long_running_query, query_id)
+
+    with pytest.raises(ClickHouseError):
+        await query_task
+
+    # using raise_on_error=False should return an error status
+    status = await _wait_for_query_status(
+        clickhouse_client, query_id, ClickHouseQueryStatus.ERROR, raise_on_error=False
+    )
+    assert status == ClickHouseQueryStatus.ERROR
+
+    # using raise_on_error=True should raise an exception
+    with pytest.raises(ClickHouseError):
+        await _wait_for_query_status(clickhouse_client, query_id, ClickHouseQueryStatus.ERROR, raise_on_error=True)
+
+
+async def test_acheck_query_in_query_log_not_found(clickhouse_client, django_db_setup):
+    """Test that acheck_query_in_query_log raises ClickHouseQueryNotFound for non-existent queries."""
+    non_existent_query_id = f"test-non-existent-query-{uuid.uuid4()}"
+    with pytest.raises(ClickHouseQueryNotFound):
+        await clickhouse_client.acheck_query_in_query_log(non_existent_query_id)


### PR DESCRIPTION
## Problem

Sometimes when looking up queries in the `system.query_log` table they do not appear for some reason.

## Changes

If we cannot find a query in the query log for whatever reason, fallback to using the [`system.processes` table](https://clickhouse.com/docs/operations/system-tables/processes)


## How did you test this code?

Added new tests to test the ClickHouseClient directly.
