### PR TITLE
chore(ci): use dedicated Depot project for AI evals image

### DIFF
--- a/.github/workflows/cd-ai-evals-image.yml
+++ b/.github/workflows/cd-ai-evals-image.yml
@@ -57,6 +57,7 @@ jobs:
               id: build
               uses: depot/build-push-action@2583627a84956d07561420dcc1d0eb1f2af3fac0 # v1
               with:
+                  project: c1f2m5s6zd
                   file: ./Dockerfile.ai-evals
                   buildx-fallback: false # the fallback is so slow it's better to just fail
                   push: true


### PR DESCRIPTION
Gives the AI evals build its own cache space instead of sharing with the main PostHog image.

**Why:** Different base images (`ubuntu-dind` vs `unit:python`) and dependency trees mean no cache sharing benefit anyway, and frequent main builds could evict AI evals layers.