### PR TITLE
chore(flags): Add periodic metric reporting for cohort cache

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2772,6 +2772,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2975,6 +2981,7 @@ dependencies = [
  "limiters",
  "md5",
  "metrics",
+ "metrics-util",
  "moka",
  "once_cell",
  "opentelemetry 0.22.0",
@@ -4903,12 +4910,16 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2670b8badcc285d486261e2e9f1615b506baff91427b61bd336a472b65bbf5ed"
 dependencies = [
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.13.1",
+ "indexmap 1.9.3",
  "metrics",
  "num_cpus",
+ "ordered-float",
  "quanta 0.12.2",
+ "radix_trie",
  "sketches-ddsketch",
 ]
 
@@ -5092,6 +5103,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nix"
@@ -6414,6 +6434,16 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -81,6 +81,7 @@ httpmock = "0.7.0"
 itoa = "1.0.15"
 metrics = "0.22.0"
 metrics-exporter-prometheus = "0.14.0"
+metrics-util = "0.16.0"
 once_cell = "1.18.0"
 opentelemetry = { version = "0.22.0", features = ["trace"] }
 opentelemetry-otlp = "0.15.0"

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -72,3 +72,5 @@ assert-json-diff = { workspace = true }
 reqwest = { workspace = true }
 futures = "0.3.30"
 test-case = "3.3.1"
+tokio = { workspace = true, features = ["test-util"] }
+metrics-util = { workspace = true }

--- a/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
+++ b/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
@@ -589,4 +589,109 @@ mod tests {
 
         Ok(())
     }
+
+    /// Tests that start_monitoring reports metrics at the configured interval.
+    ///
+    /// Uses tokio's test-util to pause time for deterministic testing.
+    /// Uses metrics-util's DebuggingRecorder to verify actual metrics are reported.
+    /// Inserts cache entries to verify metrics reflect actual cache state changes.
+    #[tokio::test]
+    async fn test_start_monitoring_reports_metrics_at_interval() -> Result<(), anyhow::Error> {
+        use crate::cohorts::cohort_models::Cohort;
+        use crate::metrics::consts::{COHORT_CACHE_ENTRIES_GAUGE, COHORT_CACHE_SIZE_BYTES_GAUGE};
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+        use std::sync::OnceLock;
+
+        // Install a global debugging recorder once per test process
+        static SNAPSHOTTER: OnceLock<Snapshotter> = OnceLock::new();
+        let snapshotter = SNAPSHOTTER.get_or_init(|| {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            drop(recorder.install());
+            snapshotter
+        });
+
+        // Helper to get current gauge value for a metric
+        let get_gauge_value = |metric_name: &str| -> Option<f64> {
+            snapshotter
+                .snapshot()
+                .into_vec()
+                .into_iter()
+                .find(|(key, _, _, _)| key.key().name() == metric_name)
+                .and_then(|(_, _, _, value)| {
+                    if let DebugValue::Gauge(v) = value {
+                        Some(v.into_inner())
+                    } else {
+                        None
+                    }
+                })
+        };
+
+        // Create context before pausing time (needs real time for DB connection)
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            Some(1024 * 1024),
+            None,
+        ));
+
+        // Pause time for deterministic testing
+        tokio::time::pause();
+
+        // Spawn the actual start_monitoring method
+        let cohort_cache_clone = cohort_cache.clone();
+        let monitor_handle = tokio::spawn(async move {
+            cohort_cache_clone.start_monitoring(30).await;
+        });
+
+        // First tick is immediate - empty cache
+        sleep(Duration::from_millis(1)).await;
+        assert_eq!(
+            get_gauge_value(COHORT_CACHE_SIZE_BYTES_GAUGE),
+            Some(0.0),
+            "Empty cache should report 0 bytes"
+        );
+        assert_eq!(
+            get_gauge_value(COHORT_CACHE_ENTRIES_GAUGE),
+            Some(0.0),
+            "Empty cache should report 0 entries"
+        );
+
+        // Insert a cache entry directly
+        let test_cohort = Cohort {
+            id: 1,
+            name: Some("Test Cohort".to_string()),
+            description: None,
+            team_id: 1,
+            deleted: false,
+            filters: Some(serde_json::json!({"properties": []})),
+            query: None,
+            version: Some(1),
+            pending_version: None,
+            count: None,
+            is_calculating: false,
+            is_static: false,
+            errors_calculating: 0,
+            groups: serde_json::json!({}),
+            created_by_id: None,
+        };
+        cohort_cache.cache.insert(1, vec![test_cohort]).await;
+        // Moka caches update internal stats lazily - sync ensures stats are current
+        cohort_cache.cache.run_pending_tasks().await;
+
+        // Advance time by 30 seconds - should reflect the new cache entry
+        sleep(Duration::from_secs(30)).await;
+        assert!(
+            get_gauge_value(COHORT_CACHE_SIZE_BYTES_GAUGE).unwrap() > 0.0,
+            "Cache with entry should report non-zero bytes"
+        );
+        assert_eq!(
+            get_gauge_value(COHORT_CACHE_ENTRIES_GAUGE),
+            Some(1.0),
+            "Cache with one entry should report 1 entry"
+        );
+
+        monitor_handle.abort();
+        Ok(())
+    }
 }

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -277,6 +277,12 @@ pub struct Config {
     #[envconfig(default = "30")]
     pub db_monitor_interval_secs: u64,
 
+    // How often to report cohort cache metrics (seconds)
+    // - Decrease for more granular monitoring (e.g., 10-15)
+    // - Increase to reduce metric volume (e.g., 60-120)
+    #[envconfig(default = "30")]
+    pub cohort_cache_monitor_interval_secs: u64,
+
     // Pool utilization percentage that triggers warnings (0.0-1.0)
     // - Lower values (e.g., 0.7) provide earlier warnings
     // - Higher values (e.g., 0.9) reduce alert noise
@@ -557,6 +563,7 @@ impl Config {
             persons_reader_statement_timeout_ms: 5000,
             writer_statement_timeout_ms: 5000,
             db_monitor_interval_secs: 30,
+            cohort_cache_monitor_interval_secs: 30,
             db_pool_warn_utilization: 0.8,
             billing_limiter_cache_ttl_secs: 5,
             health_check_interval_secs: 30,

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -126,6 +126,15 @@ where
         db_monitor.start_monitoring().await;
     });
 
+    // Start cohort cache monitoring
+    let cohort_cache_clone = cohort_cache.clone();
+    let cohort_cache_monitor_interval = config.cohort_cache_monitor_interval_secs;
+    tokio::spawn(async move {
+        cohort_cache_clone
+            .start_monitoring(cohort_cache_monitor_interval)
+            .await;
+    });
+
     let feature_flags_billing_limiter = match FeatureFlagsLimiter::new(
         Duration::from_secs(config.billing_limiter_cache_ttl_secs),
         redis_client.clone(), // Limiter only reads from redis, ReadWriteClient automatically routes reads to replica


### PR DESCRIPTION
Add a background task that periodically reports cohort cache metrics (`flags_cohort_cache_size_bytes`, `flags_cohort_cache_entries`) so they stay fresh regardless of cache hit/miss patterns.

## Problem

In https://github.com/PostHog/posthog/pull/43181 we implemented memory (rather than count) based eviction of the cohort Moka cache (in-memory). However, the metrics are only updated on cache miss and we have a very high cache hit rate. Because of this, we're not getting any metrics around this.

## Changes

- Add `start_monitoring()` method to `CohortCacheManager`
- Add `cohort_cache_monitor_interval_secs` config (default 30s)
- Spawn monitoring task in `server.rs` alongside `DatabasePoolMonitor`


## How did you test this code?

Unit Tests

Manual Tests

1. Start the feature-flags service with metrics enabled

```bash
cd rust
ENABLE_METRICS=true COHORT_CACHE_MONITOR_INTERVAL_SECS=10 cargo run -p feature-flags
```

2. Create a feature flag with cohort targeting

You need a feature flag that uses cohort-based targeting.

3. Trigger flag evaluations

First request (cache miss)

```bash
curl -X POST http://127.0.0.1:3001/flags \
  -H "Content-Type: application/json" \
  -d '{"token": "<YOUR_API_TOKEN>", "distinct_id": "test-user-123"}'
```

Second request (cache hit)

```bash
curl -X POST http://127.0.0.1:3001/flags \
  -H "Content-Type: application/json" \
  -d '{"token": "<YOUR_API_TOKEN>", "distinct_id": "test-user-456"}'
```

4. Check the metrics

Wait for the monitoring interval, then check metrics

```bash
sleep 10 && curl -s http://127.0.0.1:3001/metrics | grep -E "flags_cohort_cache_(size|entries|hit|miss)"
```

Expected metrics

| Metric                        | Type    | Description                         |
|-------------------------------|---------|-------------------------------------|
| flags_cohort_cache_hit_total  | counter | Number of cache hits                |
| flags_cohort_cache_miss_total | counter | Number of cache misses              |
| flags_cohort_cache_entries    | gauge   | Number of teams with cached cohorts |
| flags_cohort_cache_size_bytes | gauge   | Total cache memory usage in bytes   |

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
