### PR TITLE
feat(managed_migrations): surface helpful errors to user for invalid data sets

### DIFF
--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -25,7 +25,6 @@ impl<T, E: std::error::Error + Send + Sync + 'static> ToUserError<T> for Result<
     }
 }
 
-
 const DEFAULT_USER_ERROR_MESSAGE: &str = "An unknown error occurred";
 
 pub fn get_user_message(error: &anyhow::Error) -> String {
@@ -146,8 +145,10 @@ mod tests {
         let inner_error = anyhow::Error::from(UserError::new("specific parse error"));
         let inner_msg = get_user_message(&inner_error);
 
-        let outer_error =
-            inner_error.context(UserError::new(format!("File 'test.json' failed: {}", inner_msg)));
+        let outer_error = inner_error.context(UserError::new(format!(
+            "File 'test.json' failed: {}",
+            inner_msg
+        )));
 
         let result = get_user_message(&outer_error);
         assert_eq!(result, "File 'test.json' failed: specific parse error");

--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -25,22 +25,16 @@ impl<T, E: std::error::Error + Send + Sync + 'static> ToUserError<T> for Result<
     }
 }
 
+
 const DEFAULT_USER_ERROR_MESSAGE: &str = "An unknown error occurred";
 
-pub fn get_user_message(error: &anyhow::Error) -> &str {
-    if let Some(user_error) = error.downcast_ref::<UserError>() {
-        return &user_error.msg;
+pub fn get_user_message(error: &anyhow::Error) -> String {
+    // Get the shallowest UserError in the chain
+    // To provide the user with all the error context they need, we concatenate the user errors together at call site
+    match error.downcast_ref::<UserError>() {
+        Some(user_error) => user_error.msg.clone(),
+        None => DEFAULT_USER_ERROR_MESSAGE.to_string(),
     }
-
-    let mut source = error.source();
-    while let Some(err) = source {
-        if let Some(user_error) = err.downcast_ref::<UserError>() {
-            return &user_error.msg;
-        }
-        source = err.source();
-    }
-
-    DEFAULT_USER_ERROR_MESSAGE
 }
 
 #[derive(Error, Debug)]
@@ -133,30 +127,30 @@ mod tests {
     }
 
     #[test]
-    fn test_multiple_user_errors_in_chain() {
+    fn test_multiple_user_errors_returns_shallowest() {
         let deep_user_error = UserError::new("Deep user error");
-        let middle_user_error = UserError::new("Middle user error");
+        let shallowest_user_error = UserError::new("Shallowest user error");
 
         let error = anyhow::Error::from(deep_user_error)
             .context("Some system error")
-            .context(middle_user_error)
+            .context(shallowest_user_error)
             .context("Top level error");
 
         let result = get_user_message(&error);
-        assert_eq!(result, "Middle user error");
+        assert_eq!(result, "Shallowest user error");
     }
 
     #[test]
-    fn test_multiple_user_errors_with_root_user_error() {
-        let deep_user_error = UserError::new("Deep user error");
-        let root_user_error = UserError::new("Root user error");
+    fn test_concatenated_user_error() {
+        // Test the pattern we use: concatenate inner message when creating outer error
+        let inner_error = anyhow::Error::from(UserError::new("specific parse error"));
+        let inner_msg = get_user_message(&inner_error);
 
-        let error = anyhow::Error::from(deep_user_error)
-            .context("Some system error")
-            .context(root_user_error);
+        let outer_error =
+            inner_error.context(UserError::new(format!("File 'test.json' failed: {}", inner_msg)));
 
-        let result = get_user_message(&error);
-        assert_eq!(result, "Root user error");
+        let result = get_user_message(&outer_error);
+        assert_eq!(result, "File 'test.json' failed: specific parse error");
     }
 
     #[test]

--- a/rust/batch-import-worker/src/error/mod.rs
+++ b/rust/batch-import-worker/src/error/mod.rs
@@ -146,8 +146,7 @@ mod tests {
         let inner_msg = get_user_message(&inner_error);
 
         let outer_error = inner_error.context(UserError::new(format!(
-            "File 'test.json' failed: {}",
-            inner_msg
+            "File 'test.json' failed: {inner_msg}"
         )));
 
         let result = get_user_message(&outer_error);

--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -386,7 +386,6 @@ impl Job {
         let parsed = tokio::task::spawn_blocking(move || (m_tf)(next_chunk))
             .await?
             .map_err(|e| {
-                // Get the inner user message (specific parse error) and combine with filename
                 let inner_msg = get_user_message(&e);
                 e.context(UserError::new(format!(
                     "Parsing data in file '{}' failed: {}",
@@ -701,9 +700,7 @@ mod tests {
                 error_msg,
                 display_msg,
             } => {
-                // error_msg contains the full error chain (for developers)
                 assert!(error_msg.contains("500 Internal Server Error"));
-                // display_msg contains the user-friendly message
                 assert_eq!(display_msg, "Remote server error");
             }
             _ => panic!("expected pause"),
@@ -828,7 +825,6 @@ mod tests {
 
     #[test]
     fn test_decide_on_error_separates_developer_and_user_messages() {
-        // Create a nested error chain
         let root_error = std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid byte sequence");
         let error = anyhow::Error::from(root_error)
             .context("Failed to parse JSON")
@@ -851,7 +847,6 @@ mod tests {
                 error_msg,
                 display_msg,
             } => {
-                // Developer message should contain the full error chain
                 assert!(
                     error_msg.contains("Processing chunk"),
                     "Developer message should contain outer context: {}",
@@ -868,7 +863,6 @@ mod tests {
                     error_msg
                 );
 
-                // User message should be the simple user-friendly message
                 assert_eq!(
                     display_msg,
                     "User-friendly error message (Date range: 2023-01-01 to 2023-01-02)"

--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -825,7 +825,8 @@ mod tests {
 
     #[test]
     fn test_decide_on_error_separates_developer_and_user_messages() {
-        let root_error = std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid byte sequence");
+        let root_error =
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid byte sequence");
         let error = anyhow::Error::from(root_error)
             .context("Failed to parse JSON")
             .context("Processing chunk");

--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -849,18 +849,15 @@ mod tests {
             } => {
                 assert!(
                     error_msg.contains("Processing chunk"),
-                    "Developer message should contain outer context: {}",
-                    error_msg
+                    "Developer message should contain outer context: {error_msg}"
                 );
                 assert!(
                     error_msg.contains("Failed to parse JSON"),
-                    "Developer message should contain inner context: {}",
-                    error_msg
+                    "Developer message should contain inner context: {error_msg}"
                 );
                 assert!(
                     error_msg.contains("invalid byte sequence"),
-                    "Developer message should contain root cause: {}",
-                    error_msg
+                    "Developer message should contain root cause: {error_msg}"
                 );
 
                 assert_eq!(

--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -388,8 +388,7 @@ impl Job {
             .map_err(|e| {
                 let inner_msg = get_user_message(&e);
                 e.context(UserError::new(format!(
-                    "Parsing data in file '{}' failed: {}",
-                    key_for_error, inner_msg
+                    "Parsing data in file '{key_for_error}' failed: {inner_msg}"
                 )))
             })
             .context(format!("Processing part chunk {next_part:?}"))?;

--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     context::AppContext,
     emit::Emitter,
-    error::{extract_retry_after_from_error, get_user_message, is_rate_limited_error},
+    error::{extract_retry_after_from_error, get_user_message, is_rate_limited_error, UserError},
     job::backoff::format_backoff_messages,
     parse::{format::ParserFn, Parsed},
     source::DataSource,
@@ -54,9 +54,10 @@ fn decide_on_error(
             display_msg,
         }
     } else {
+        // Use the full error chain for developer-facing message
         let error_msg = match current_date_range {
-            Some(dr) => format!("{user_message} (Date range: {dr})"),
-            None => user_message.to_string(),
+            Some(dr) => format!("{err:#} (Date range: {dr})"),
+            None => format!("{err:#}"),
         };
         let display_msg = match current_date_range {
             Some(dr) => format!("{user_message} (Date range: {dr})"),
@@ -228,7 +229,7 @@ impl Job {
                     current_date_range.as_deref(),
                     policy,
                     current_attempt,
-                    user_facing_error_message,
+                    &user_facing_error_message,
                 ) {
                     ErrorHandlingDecision::Backoff {
                         delay,
@@ -380,9 +381,18 @@ impl Job {
 
         info!("Fetched part chunk {:?}", next_part);
         let m_tf = self.transform.clone();
+        let key_for_error = key.clone();
         // This is computationally expensive, so we run it in a blocking task
         let parsed = tokio::task::spawn_blocking(move || (m_tf)(next_chunk))
             .await?
+            .map_err(|e| {
+                // Get the inner user message (specific parse error) and combine with filename
+                let inner_msg = get_user_message(&e);
+                e.context(UserError::new(format!(
+                    "Parsing data in file '{}' failed: {}",
+                    key_for_error, inner_msg
+                )))
+            })
             .context(format!("Processing part chunk {next_part:?}"))?;
 
         info!(
@@ -691,7 +701,9 @@ mod tests {
                 error_msg,
                 display_msg,
             } => {
-                assert_eq!(error_msg, "Remote server error");
+                // error_msg contains the full error chain (for developers)
+                assert!(error_msg.contains("500 Internal Server Error"));
+                // display_msg contains the user-friendly message
                 assert_eq!(display_msg, "Remote server error");
             }
             _ => panic!("expected pause"),
@@ -812,5 +824,57 @@ mod tests {
         assert!(!should_pause_due_to_max_attempts(2, 3));
         assert!(should_pause_due_to_max_attempts(3, 3));
         assert!(should_pause_due_to_max_attempts(4, 3));
+    }
+
+    #[test]
+    fn test_decide_on_error_separates_developer_and_user_messages() {
+        // Create a nested error chain
+        let root_error = std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid byte sequence");
+        let error = anyhow::Error::from(root_error)
+            .context("Failed to parse JSON")
+            .context("Processing chunk");
+
+        let decision = decide_on_error(
+            &error,
+            Some("2023-01-01 to 2023-01-02"),
+            crate::job::backoff::BackoffPolicy::new(
+                std::time::Duration::from_secs(60),
+                2.0,
+                std::time::Duration::from_secs(3600),
+            ),
+            0,
+            "User-friendly error message",
+        );
+
+        match decision {
+            ErrorHandlingDecision::Pause {
+                error_msg,
+                display_msg,
+            } => {
+                // Developer message should contain the full error chain
+                assert!(
+                    error_msg.contains("Processing chunk"),
+                    "Developer message should contain outer context: {}",
+                    error_msg
+                );
+                assert!(
+                    error_msg.contains("Failed to parse JSON"),
+                    "Developer message should contain inner context: {}",
+                    error_msg
+                );
+                assert!(
+                    error_msg.contains("invalid byte sequence"),
+                    "Developer message should contain root cause: {}",
+                    error_msg
+                );
+
+                // User message should be the simple user-friendly message
+                assert_eq!(
+                    display_msg,
+                    "User-friendly error message (Date range: 2023-01-01 to 2023-01-02)"
+                );
+            }
+            _ => panic!("Expected Pause decision"),
+        }
     }
 }

--- a/rust/batch-import-worker/src/parse/content/amplitude.rs
+++ b/rust/batch-import-worker/src/parse/content/amplitude.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use super::TransformContext;
 use crate::cache::{group_cache::GroupChanges, GroupCache};
+use crate::parse::format::{extract_between, extract_field_name, UserFacingParseError};
 
 mod identify;
 
@@ -113,6 +114,93 @@ pub struct AmplitudeEvent {
     pub user_properties: HashMap<String, Value>,
     pub uuid: Option<String>,
     pub version_name: Option<String>,
+}
+
+/// Implement schema-specific error messages for AmplitudeEvent
+/// That we can surface to the user to let them know what's wrong with the
+/// data set they are trying to import
+impl UserFacingParseError for AmplitudeEvent {
+    fn user_facing_schema_error(err: &serde_json::Error) -> String {
+        let err_str = err.to_string();
+
+        // Handle missing required fields (though most Amplitude fields are optional)
+        if err_str.contains("missing field") {
+            if let Some(field_name) = extract_field_name(&err_str, "missing field `", "`") {
+                return format!(
+                    "Missing field '{}'. Please check that your Amplitude export includes this field.",
+                    field_name
+                );
+            }
+        }
+
+        if err_str.contains("invalid type:") {
+            let got = extract_between(&err_str, "invalid type: ", ", expected");
+            let expected = extract_between(&err_str, "expected ", " at line");
+
+            if let (Some(got), Some(expected)) = (got, expected) {
+                if err_str.contains("event_type") {
+                    return format!(
+                        "The 'event_type' field must be a string (e.g., \"event_type\": \"button_click\"), but got {}.",
+                        got
+                    );
+                }
+                if err_str.contains("user_id") {
+                    return format!(
+                        "The 'user_id' field must be a string (e.g., \"user_id\": \"user123\"), but got {}.",
+                        got
+                    );
+                }
+                if err_str.contains("device_id") {
+                    return format!(
+                        "The 'device_id' field must be a string (e.g., \"device_id\": \"device456\"), but got {}.",
+                        got
+                    );
+                }
+                if err_str.contains("event_time") {
+                    return format!(
+                        "The 'event_time' field must be a string in format 'YYYY-MM-DD HH:MM:SS' (e.g., \"event_time\": \"2023-10-15 14:30:00\"), but got {}.",
+                        got
+                    );
+                }
+                if err_str.contains("event_properties") {
+                    return format!(
+                        "The 'event_properties' field must be a JSON object (e.g., \"event_properties\": {{\"key\": \"value\"}}), but got {}.",
+                        got
+                    );
+                }
+                if err_str.contains("user_properties") {
+                    return format!(
+                        "The 'user_properties' field must be a JSON object (e.g., \"user_properties\": {{\"name\": \"John\"}}), but got {}.",
+                        got
+                    );
+                }
+                if expected.contains("i64") {
+                    return format!(
+                        "Expected an integer value but got {}. Check that numeric fields contain valid integers.",
+                        got
+                    );
+                }
+                if expected.contains("map") || expected.contains("struct") {
+                    return format!(
+                        "Expected a JSON object but got {}. This field must be a JSON object like {{\"key\": \"value\"}}.",
+                        got
+                    );
+                }
+            }
+        }
+
+        if err_str.contains("unknown field") {
+            if let Some(field_name) = extract_field_name(&err_str, "unknown field `", "`") {
+                return format!(
+                    "Unknown field '{}' in Amplitude event. This field will be ignored, but check if this is a typo.",
+                    field_name
+                );
+            }
+        }
+
+        // Generic message to fallback to if we can't determine something specific surface to the user
+        "The JSON structure doesn't match the expected Amplitude event format. Events should have 'event_type' (string), and optionally 'user_id', 'device_id', 'event_time', 'event_properties', etc.".to_string()
+    }
 }
 
 /// Detect which groups have changed properties since last seen

--- a/rust/batch-import-worker/src/parse/content/amplitude.rs
+++ b/rust/batch-import-worker/src/parse/content/amplitude.rs
@@ -127,8 +127,7 @@ impl UserFacingParseError for AmplitudeEvent {
         if err_str.contains("missing field") {
             if let Some(field_name) = extract_field_name(&err_str, "missing field `", "`") {
                 return format!(
-                    "Missing field '{}'. Please check that your Amplitude export includes this field.",
-                    field_name
+                    "Missing field '{field_name}'. Please check that your Amplitude export includes this field."
                 );
             }
         }
@@ -140,50 +139,42 @@ impl UserFacingParseError for AmplitudeEvent {
             if let (Some(got), Some(expected)) = (got, expected) {
                 if err_str.contains("event_type") {
                     return format!(
-                        "The 'event_type' field must be a string (e.g., \"event_type\": \"button_click\"), but got {}.",
-                        got
+                        "The 'event_type' field must be a string (e.g., \"event_type\": \"button_click\"), but got {got}."
                     );
                 }
                 if err_str.contains("user_id") {
                     return format!(
-                        "The 'user_id' field must be a string (e.g., \"user_id\": \"user123\"), but got {}.",
-                        got
+                        "The 'user_id' field must be a string (e.g., \"user_id\": \"user123\"), but got {got}."
                     );
                 }
                 if err_str.contains("device_id") {
                     return format!(
-                        "The 'device_id' field must be a string (e.g., \"device_id\": \"device456\"), but got {}.",
-                        got
+                        "The 'device_id' field must be a string (e.g., \"device_id\": \"device456\"), but got {got}."
                     );
                 }
                 if err_str.contains("event_time") {
                     return format!(
-                        "The 'event_time' field must be a string in format 'YYYY-MM-DD HH:MM:SS' (e.g., \"event_time\": \"2023-10-15 14:30:00\"), but got {}.",
-                        got
+                        "The 'event_time' field must be a string in format 'YYYY-MM-DD HH:MM:SS' (e.g., \"event_time\": \"2023-10-15 14:30:00\"), but got {got}."
                     );
                 }
                 if err_str.contains("event_properties") {
                     return format!(
-                        "The 'event_properties' field must be a JSON object (e.g., \"event_properties\": {{\"key\": \"value\"}}), but got {}.",
-                        got
+                        "The 'event_properties' field must be a JSON object (e.g., \"event_properties\": {{\"key\": \"value\"}}), but got {got}."
                     );
                 }
                 if err_str.contains("user_properties") {
                     return format!(
-                        "The 'user_properties' field must be a JSON object (e.g., \"user_properties\": {{\"name\": \"John\"}}), but got {}.",
-                        got
+                        "The 'user_properties' field must be a JSON object (e.g., \"user_properties\": {{\"name\": \"John\"}}), but got {got}."
                     );
                 }
                 if expected.contains("i64") {
                     return format!(
-                        "Expected an integer value but got {}. Check that numeric fields contain valid integers.",
-                        got
+                        "Expected an integer value but got {got}. Check that numeric fields contain valid integers."
                     );
                 }
                 if expected.contains("map") || expected.contains("struct") {
                     return format!(
-                        "Expected a JSON object but got {}. This field must be a JSON object like {{\"key\": \"value\"}}.",
-                        got
+                        "Expected a JSON object but got {got}. This field must be a JSON object like {{\"key\": \"value\"}}."
                     );
                 }
             }
@@ -192,8 +183,7 @@ impl UserFacingParseError for AmplitudeEvent {
         if err_str.contains("unknown field") {
             if let Some(field_name) = extract_field_name(&err_str, "unknown field `", "`") {
                 return format!(
-                    "Unknown field '{}' in Amplitude event. This field will be ignored, but check if this is a typo.",
-                    field_name
+                    "Unknown field '{field_name}' in Amplitude event. This field will be ignored, but check if this is a typo."
                 );
             }
         }

--- a/rust/batch-import-worker/src/parse/content/captured.rs
+++ b/rust/batch-import-worker/src/parse/content/captured.rs
@@ -21,7 +21,7 @@ impl UserFacingParseError for RawEvent {
                     "properties" => "Missing required field 'properties'. Each line must have a 'properties' object (can be empty: \"properties\": {}).".to_string(),
                     "distinct_id" => "Missing required field 'distinct_id'. Each event must identify a user with 'distinct_id'.".to_string(),
                     "timestamp" => "Missing required field 'timestamp'. Each event must have a timestamp (e.g., \"timestamp\": \"2024-01-01T00:00:00Z\").".to_string(),
-                    _ => format!("Missing required field '{}'. Please check that your data includes this field.", field_name),
+                    _ => format!("Missing required field '{field_name}'. Please check that your data includes this field."),
                 };
             }
         }
@@ -33,14 +33,12 @@ impl UserFacingParseError for RawEvent {
             if let (Some(got), Some(expected)) = (got, expected) {
                 if err_str.contains("`event`") || (expected == "a string" && err.column() < 20) {
                     return format!(
-                        "The 'event' field must be a string (e.g., \"event\": \"$pageview\"), but got {}.",
-                        got
+                        "The 'event' field must be a string (e.g., \"event\": \"$pageview\"), but got {got}."
                     );
                 }
                 if expected.contains("map") {
                     return format!(
-                        "Expected an object/map but got {}. The 'properties' field must be a JSON object like {{\"key\": \"value\"}}.",
-                        got
+                        "Expected an object/map but got {got}. The 'properties' field must be a JSON object like {{\"key\": \"value\"}}."
                     );
                 }
             }

--- a/rust/batch-import-worker/src/parse/content/captured.rs
+++ b/rust/batch-import-worker/src/parse/content/captured.rs
@@ -5,6 +5,51 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use super::TransformContext;
+use crate::parse::format::{extract_between, extract_field_name, UserFacingParseError};
+
+/// Implement schema-specific error messages for RawEvent (Captured format)
+/// That we can surface to the user to let them know what's wrong with the
+/// data set they are trying to import
+impl UserFacingParseError for RawEvent {
+    fn user_facing_schema_error(err: &serde_json::Error) -> String {
+        let err_str = err.to_string();
+
+        if err_str.contains("missing field") {
+            if let Some(field_name) = extract_field_name(&err_str, "missing field `", "`") {
+                return match field_name.as_str() {
+                    "event" => "Missing required field 'event'. Each line must have an 'event' field with the event name (e.g., \"event\": \"$pageview\").".to_string(),
+                    "properties" => "Missing required field 'properties'. Each line must have a 'properties' object (can be empty: \"properties\": {}).".to_string(),
+                    "distinct_id" => "Missing required field 'distinct_id'. Each event must identify a user with 'distinct_id'.".to_string(),
+                    "timestamp" => "Missing required field 'timestamp'. Each event must have a timestamp (e.g., \"timestamp\": \"2024-01-01T00:00:00Z\").".to_string(),
+                    _ => format!("Missing required field '{}'. Please check that your data includes this field.", field_name),
+                };
+            }
+        }
+
+        if err_str.contains("invalid type:") {
+            let got = extract_between(&err_str, "invalid type: ", ", expected");
+            let expected = extract_between(&err_str, "expected ", " at line");
+
+            if let (Some(got), Some(expected)) = (got, expected) {
+                if err_str.contains("`event`") || (expected == "a string" && err.column() < 20) {
+                    return format!(
+                        "The 'event' field must be a string (e.g., \"event\": \"$pageview\"), but got {}.",
+                        got
+                    );
+                }
+                if expected.contains("map") {
+                    return format!(
+                        "Expected an object/map but got {}. The 'properties' field must be a JSON object like {{\"key\": \"value\"}}.",
+                        got
+                    );
+                }
+            }
+        }
+
+        // Fallback to generic message
+        "The JSON structure doesn't match the expected Captured event format. Required fields: 'event' (string), 'distinct_id', 'timestamp', 'properties' (object).".to_string()
+    }
+}
 
 pub fn captured_parse_fn(
     context: TransformContext,

--- a/rust/batch-import-worker/src/parse/content/mixpanel.rs
+++ b/rust/batch-import-worker/src/parse/content/mixpanel.rs
@@ -51,7 +51,7 @@ impl UserFacingParseError for MixpanelEvent {
                     "event" => "Missing required field 'event'. Each Mixpanel event must have an 'event' field with the event name (e.g., \"event\": \"page_view\").".to_string(),
                     "properties" => "Missing required field 'properties'. Each Mixpanel event must have a 'properties' object containing at least the 'time' field.".to_string(),
                     "time" => "Missing required field 'time' in 'properties'. Each Mixpanel event must have a timestamp (e.g., \"properties\": {\"time\": 1697379000}).".to_string(),
-                    _ => format!("Missing required field '{}'. Please check that your Mixpanel export includes this field.", field_name),
+                    _ => format!("Missing required field '{field_name}'. Please check that your Mixpanel export includes this field."),
                 };
             }
         }
@@ -63,20 +63,17 @@ impl UserFacingParseError for MixpanelEvent {
             if let (Some(got), Some(expected)) = (got, expected) {
                 if err_str.contains("`event`") || (expected == "a string" && err.column() < 15) {
                     return format!(
-                        "The 'event' field must be a string (e.g., \"event\": \"page_view\"), but got {}.",
-                        got
+                        "The 'event' field must be a string (e.g., \"event\": \"page_view\"), but got {got}."
                     );
                 }
                 if err_str.contains("`time`") || expected.contains("i64") {
                     return format!(
-                        "The 'time' field must be a Unix timestamp (integer), but got {}. Use seconds since epoch (e.g., 1697379000).",
-                        got
+                        "The 'time' field must be a Unix timestamp (integer), but got {got}. Use seconds since epoch (e.g., 1697379000)."
                     );
                 }
                 if expected.contains("map") || expected.contains("struct") {
                     return format!(
-                        "Expected an object/map but got {}. The 'properties' field must be a JSON object like {{\"time\": 1697379000}}.",
-                        got
+                        "Expected an object/map but got {got}. The 'properties' field must be a JSON object like {{\"time\": 1697379000}}."
                     );
                 }
             }

--- a/rust/batch-import-worker/src/parse/content/mixpanel.rs
+++ b/rust/batch-import-worker/src/parse/content/mixpanel.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use super::TransformContext;
+use crate::parse::format::{extract_between, extract_field_name, UserFacingParseError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -35,6 +36,55 @@ pub struct MixpanelProperties {
     distinct_id: Option<String>,
     #[serde(flatten)]
     other: HashMap<String, Value>,
+}
+
+/// Implement schema-specific error messages for MixpanelEvent
+/// That we can surface to the user to let them know what's wrong with the
+/// data set they are trying to import
+impl UserFacingParseError for MixpanelEvent {
+    fn user_facing_schema_error(err: &serde_json::Error) -> String {
+        let err_str = err.to_string();
+
+        if err_str.contains("missing field") {
+            if let Some(field_name) = extract_field_name(&err_str, "missing field `", "`") {
+                return match field_name.as_str() {
+                    "event" => "Missing required field 'event'. Each Mixpanel event must have an 'event' field with the event name (e.g., \"event\": \"page_view\").".to_string(),
+                    "properties" => "Missing required field 'properties'. Each Mixpanel event must have a 'properties' object containing at least the 'time' field.".to_string(),
+                    "time" => "Missing required field 'time' in 'properties'. Each Mixpanel event must have a timestamp (e.g., \"properties\": {\"time\": 1697379000}).".to_string(),
+                    _ => format!("Missing required field '{}'. Please check that your Mixpanel export includes this field.", field_name),
+                };
+            }
+        }
+
+        if err_str.contains("invalid type:") {
+            let got = extract_between(&err_str, "invalid type: ", ", expected");
+            let expected = extract_between(&err_str, "expected ", " at line");
+
+            if let (Some(got), Some(expected)) = (got, expected) {
+                if err_str.contains("`event`") || (expected == "a string" && err.column() < 15) {
+                    return format!(
+                        "The 'event' field must be a string (e.g., \"event\": \"page_view\"), but got {}.",
+                        got
+                    );
+                }
+                if err_str.contains("`time`") || expected.contains("i64") {
+                    return format!(
+                        "The 'time' field must be a Unix timestamp (integer), but got {}. Use seconds since epoch (e.g., 1697379000).",
+                        got
+                    );
+                }
+                if expected.contains("map") || expected.contains("struct") {
+                    return format!(
+                        "Expected an object/map but got {}. The 'properties' field must be a JSON object like {{\"time\": 1697379000}}.",
+                        got
+                    );
+                }
+            }
+        }
+
+        // Fallback to generic message
+        "The JSON structure doesn't match the expected Mixpanel event format. Required fields: 'event' (string), 'properties' (object with 'time' as integer timestamp).".to_string()
+    }
 }
 
 // Based off sample data provided by customer.

--- a/rust/batch-import-worker/src/parse/format.rs
+++ b/rust/batch-import-worker/src/parse/format.rs
@@ -233,7 +233,6 @@ pub trait UserFacingParseError {
         format!("{} (Error at column {})", base_message, err.column())
     }
 
-    /// Returns a user-facing error message for truncated/incomplete JSON.
     fn user_facing_eof_error(err: &serde_json::Error) -> String {
         let err_str = err.to_string();
         if err_str.contains("parsing a value") && err.column() == 0 {
@@ -244,7 +243,6 @@ pub trait UserFacingParseError {
         }
     }
 
-    /// Returns a user-facing error message for JSON syntax errors.
     fn user_facing_syntax_error(err: &serde_json::Error) -> String {
         let err_str = err.to_string();
         if err_str.contains("key must be a string") {
@@ -263,19 +261,14 @@ pub trait UserFacingParseError {
         }
     }
 
-    /// Returns a user-facing error message for schema/data mismatch errors.
-    /// Override this method to provide format-specific error messages.
     fn user_facing_schema_error(err: &serde_json::Error) -> String {
         user_facing_schema_error_generic(err)
     }
 }
 
-/// Generic implementation for schema errors when types don't provide specific messages.
-/// This provides reasonable defaults for common error patterns.
 fn user_facing_schema_error_generic(err: &serde_json::Error) -> String {
     let err_str = err.to_string();
 
-    // Handle missing required fields
     if err_str.contains("missing field") {
         if let Some(field_name) = extract_field_name(&err_str, "missing field `", "`") {
             return format!(
@@ -285,7 +278,6 @@ fn user_facing_schema_error_generic(err: &serde_json::Error) -> String {
         }
     }
 
-    // Handle wrong type errors
     if err_str.contains("invalid type:") {
         let got = extract_between(&err_str, "invalid type: ", ", expected");
         let expected = extract_between(&err_str, "expected ", " at line");
@@ -314,7 +306,6 @@ fn user_facing_schema_error_generic(err: &serde_json::Error) -> String {
         }
     }
 
-    // Handle unknown field errors (if strict parsing)
     if err_str.contains("unknown field") {
         if let Some(field_name) = extract_field_name(&err_str, "unknown field `", "`") {
             return format!(
@@ -328,7 +319,6 @@ fn user_facing_schema_error_generic(err: &serde_json::Error) -> String {
     "The JSON structure doesn't match the expected format. Please check that your data matches the required schema.".to_string()
 }
 
-/// Helper functions for parsing error messages - exported for use by content modules
 pub fn extract_field_name(s: &str, prefix: &str, suffix: &str) -> Option<String> {
     let start = s.find(prefix)? + prefix.len();
     let end = s[start..].find(suffix)? + start;
@@ -381,7 +371,6 @@ mod tests {
         name: String,
     }
 
-    // Implement UserFacingParseError for TestData to use json_nd in tests
     impl UserFacingParseError for TestData {}
 
     async fn setup_test_files() -> (TempDir, FolderSource) {

--- a/rust/batch-import-worker/src/parse/format.rs
+++ b/rust/batch-import-worker/src/parse/format.rs
@@ -8,6 +8,7 @@ use rayon::prelude::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{context::AppContext, job::model::JobModel};
+use crate::error::UserError;
 
 use super::{
     content::{
@@ -212,12 +213,145 @@ pub fn newline_delim<T: Send>(
     }
 }
 
+/// Trait for types that can provide user-facing JSON parse error messages.
+/// Each event type (RawEvent, MixpanelEvent, AmplitudeEvent) implements this
+/// to provide format-specific error messages that help users fix their data.
+pub trait UserFacingParseError {
+    /// Returns a user-facing error message for any JSON parse error.
+    /// Dispatches to specific handlers based on error category.
+    /// Override `user_facing_schema_error` to customize schema mismatch messages.
+    fn user_facing_parse_error(err: &serde_json::Error) -> String {
+        use serde_json::error::Category;
+
+        let base_message = match err.classify() {
+            Category::Eof => Self::user_facing_eof_error(err),
+            Category::Syntax => Self::user_facing_syntax_error(err),
+            Category::Data => Self::user_facing_schema_error(err),
+            Category::Io => "Error reading the data. Please try again.".to_string(),
+        };
+
+        format!("{} (Error at column {})", base_message, err.column())
+    }
+
+    /// Returns a user-facing error message for truncated/incomplete JSON.
+    fn user_facing_eof_error(err: &serde_json::Error) -> String {
+        let err_str = err.to_string();
+        if err_str.contains("parsing a value") && err.column() == 0 {
+            "The line appears to be empty. Each line should contain a valid JSON object."
+                .to_string()
+        } else {
+            "The JSON appears to be truncated or incomplete. Check for missing closing braces or brackets.".to_string()
+        }
+    }
+
+    /// Returns a user-facing error message for JSON syntax errors.
+    fn user_facing_syntax_error(err: &serde_json::Error) -> String {
+        let err_str = err.to_string();
+        if err_str.contains("key must be a string") {
+            "JSON keys must be quoted strings. Use double quotes (\") not single quotes (')."
+                .to_string()
+        } else if err_str.contains("trailing comma") {
+            "Remove the trailing comma before the closing brace or bracket.".to_string()
+        } else if err_str.contains("expected `,`") {
+            "Missing comma between values or properties.".to_string()
+        } else if err_str.contains("expected `:`") {
+            "Missing colon after property name.".to_string()
+        } else if err_str.contains("expected ident") {
+            "Invalid JSON syntax. Make sure the line is valid JSON, not plain text.".to_string()
+        } else {
+            "Invalid JSON syntax. Please check for proper formatting.".to_string()
+        }
+    }
+
+    /// Returns a user-facing error message for schema/data mismatch errors.
+    /// Override this method to provide format-specific error messages.
+    fn user_facing_schema_error(err: &serde_json::Error) -> String {
+        user_facing_schema_error_generic(err)
+    }
+}
+
+/// Generic implementation for schema errors when types don't provide specific messages.
+/// This provides reasonable defaults for common error patterns.
+fn user_facing_schema_error_generic(err: &serde_json::Error) -> String {
+    let err_str = err.to_string();
+
+    // Handle missing required fields
+    if err_str.contains("missing field") {
+        if let Some(field_name) = extract_field_name(&err_str, "missing field `", "`") {
+            return format!(
+                "Missing required field '{}'. Please check that your data includes this field.",
+                field_name
+            );
+        }
+    }
+
+    // Handle wrong type errors
+    if err_str.contains("invalid type:") {
+        let got = extract_between(&err_str, "invalid type: ", ", expected");
+        let expected = extract_between(&err_str, "expected ", " at line");
+
+        if let (Some(got), Some(expected)) = (got, expected) {
+            if expected.contains("map") {
+                return format!(
+                    "Expected an object/map but got {}. This field must be a JSON object like {{\"key\": \"value\"}}.",
+                    got
+                );
+            }
+            if expected == "a string" {
+                return format!(
+                    "Expected a string value but got {}. String values must be quoted.",
+                    got
+                );
+            }
+            if expected == "an integer" || expected == "a number" {
+                return format!("Expected a number but got {}.", got);
+            }
+
+            return format!(
+                "Type mismatch: expected {} but got {}. Please check your data format.",
+                expected, got
+            );
+        }
+    }
+
+    // Handle unknown field errors (if strict parsing)
+    if err_str.contains("unknown field") {
+        if let Some(field_name) = extract_field_name(&err_str, "unknown field `", "`") {
+            return format!(
+                "Unknown field '{}'. This field is not recognized. Check for typos or remove this field.",
+                field_name
+            );
+        }
+    }
+
+    // Fallback
+    "The JSON structure doesn't match the expected format. Please check that your data matches the required schema.".to_string()
+}
+
+/// Helper functions for parsing error messages - exported for use by content modules
+pub fn extract_field_name(s: &str, prefix: &str, suffix: &str) -> Option<String> {
+    let start = s.find(prefix)? + prefix.len();
+    let end = s[start..].find(suffix)? + start;
+    Some(s[start..end].to_string())
+}
+
+pub fn extract_between(s: &str, start_marker: &str, end_marker: &str) -> Option<String> {
+    let start = s.find(start_marker)? + start_marker.len();
+    let end = s[start..].find(end_marker)? + start;
+    Some(s[start..end].to_string())
+}
+
 pub fn json_nd<T>(skip_blank_lines: bool) -> impl Fn(Vec<u8>) -> Result<Parsed<Vec<T>>, Error>
 where
-    T: DeserializeOwned + Send,
+    T: DeserializeOwned + Send + UserFacingParseError,
 {
     newline_delim(skip_blank_lines, |line| {
-        let parsed = serde_json::from_str(line).context("Failed to json parse line")?;
+        let parsed = serde_json::from_str(line)
+            .map_err(|e| {
+                let user_msg = T::user_facing_parse_error(&e);
+                anyhow::Error::from(e).context(UserError::new(user_msg))
+            })
+            .context("Failed to json parse line")?;
         Ok(parsed)
     })
 }
@@ -246,6 +380,9 @@ mod tests {
         id: i32,
         name: String,
     }
+
+    // Implement UserFacingParseError for TestData to use json_nd in tests
+    impl UserFacingParseError for TestData {}
 
     async fn setup_test_files() -> (TempDir, FolderSource) {
         let temp_dir = TempDir::new().unwrap();
@@ -314,5 +451,85 @@ mod tests {
         assert_eq!(parsed.data.len(), 1);
         // 26 "data" characters, plus the newline
         assert_eq!(parsed.consumed, 27);
+    }
+
+    #[test]
+    fn test_json_parse_error_has_user_friendly_message() {
+        use crate::error::get_user_message;
+
+        let invalid_json = b"not valid json\n".to_vec();
+        let result = json_nd::<TestData>(false)(invalid_json);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+
+        let user_message = get_user_message(&err);
+        assert!(
+            user_message.contains("Invalid JSON syntax") || user_message.contains("plain text"),
+            "Expected user message to give specific guidance, got: {}",
+            user_message
+        );
+        assert!(
+            user_message.contains("column"),
+            "Expected user message to include column info, got: {}",
+            user_message
+        );
+    }
+
+    #[test]
+    fn test_json_parse_error_preserves_underlying_error() {
+        let invalid_json = b"not valid json\n".to_vec();
+        let result = json_nd::<TestData>(false)(invalid_json);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+
+        let full_error = format!("{:#}", err);
+        assert!(
+            full_error.contains("expected value") || full_error.contains("expected ident"),
+            "Expected full error to contain serde details, got: {}",
+            full_error
+        );
+    }
+
+    #[test]
+    fn test_specific_error_messages_for_common_issues() {
+        use crate::error::get_user_message;
+
+        let truncated = b"{\"id\": 1, \"name\": \"test\n".to_vec();
+        let err = json_nd::<TestData>(false)(truncated).unwrap_err();
+        let msg = get_user_message(&err);
+        assert!(
+            msg.contains("truncated") || msg.contains("incomplete"),
+            "Truncated JSON should mention truncation: {}",
+            msg
+        );
+
+        let trailing_comma = b"{\"id\": 1,}\n".to_vec();
+        let err = json_nd::<TestData>(false)(trailing_comma).unwrap_err();
+        let msg = get_user_message(&err);
+        assert!(
+            msg.contains("trailing comma"),
+            "Trailing comma should be mentioned: {}",
+            msg
+        );
+
+        let single_quotes = b"{'id': 1}\n".to_vec();
+        let err = json_nd::<TestData>(false)(single_quotes).unwrap_err();
+        let msg = get_user_message(&err);
+        assert!(
+            msg.contains("double quotes") || msg.contains("quoted strings"),
+            "Single quotes error should suggest double quotes: {}",
+            msg
+        );
+
+        let missing_comma = b"{\"id\": 1 \"name\": \"test\"}\n".to_vec();
+        let err = json_nd::<TestData>(false)(missing_comma).unwrap_err();
+        let msg = get_user_message(&err);
+        assert!(
+            msg.contains("comma"),
+            "Missing comma should be mentioned: {}",
+            msg
+        );
     }
 }

--- a/rust/batch-import-worker/src/parse/format.rs
+++ b/rust/batch-import-worker/src/parse/format.rs
@@ -450,13 +450,11 @@ mod tests {
         let user_message = get_user_message(&err);
         assert!(
             user_message.contains("Invalid JSON syntax") || user_message.contains("plain text"),
-            "Expected user message to give specific guidance, got: {}",
-            user_message
+            "Expected user message to give specific guidance, got: {user_message}"
         );
         assert!(
             user_message.contains("column"),
-            "Expected user message to include column info, got: {}",
-            user_message
+            "Expected user message to include column info, got: {user_message}"
         );
     }
 
@@ -468,11 +466,10 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
 
-        let full_error = format!("{:#}", err);
+        let full_error = format!("{err:#}");
         assert!(
             full_error.contains("expected value") || full_error.contains("expected ident"),
-            "Expected full error to contain serde details, got: {}",
-            full_error
+            "Expected full error to contain serde details, got: {full_error}"
         );
     }
 
@@ -485,8 +482,7 @@ mod tests {
         let msg = get_user_message(&err);
         assert!(
             msg.contains("truncated") || msg.contains("incomplete"),
-            "Truncated JSON should mention truncation: {}",
-            msg
+            "Truncated JSON should mention truncation: {msg}"
         );
 
         let trailing_comma = b"{\"id\": 1,}\n".to_vec();
@@ -494,8 +490,7 @@ mod tests {
         let msg = get_user_message(&err);
         assert!(
             msg.contains("trailing comma"),
-            "Trailing comma should be mentioned: {}",
-            msg
+            "Trailing comma should be mentioned: {msg}"
         );
 
         let single_quotes = b"{'id': 1}\n".to_vec();
@@ -503,8 +498,7 @@ mod tests {
         let msg = get_user_message(&err);
         assert!(
             msg.contains("double quotes") || msg.contains("quoted strings"),
-            "Single quotes error should suggest double quotes: {}",
-            msg
+            "Single quotes error should suggest double quotes: {msg}"
         );
 
         let missing_comma = b"{\"id\": 1 \"name\": \"test\"}\n".to_vec();
@@ -512,8 +506,7 @@ mod tests {
         let msg = get_user_message(&err);
         assert!(
             msg.contains("comma"),
-            "Missing comma should be mentioned: {}",
-            msg
+            "Missing comma should be mentioned: {msg}"
         );
     }
 }

--- a/rust/batch-import-worker/src/parse/format.rs
+++ b/rust/batch-import-worker/src/parse/format.rs
@@ -272,8 +272,7 @@ fn user_facing_schema_error_generic(err: &serde_json::Error) -> String {
     if err_str.contains("missing field") {
         if let Some(field_name) = extract_field_name(&err_str, "missing field `", "`") {
             return format!(
-                "Missing required field '{}'. Please check that your data includes this field.",
-                field_name
+                "Missing required field '{field_name}'. Please check that your data includes this field."
             );
         }
     }
@@ -285,23 +284,20 @@ fn user_facing_schema_error_generic(err: &serde_json::Error) -> String {
         if let (Some(got), Some(expected)) = (got, expected) {
             if expected.contains("map") {
                 return format!(
-                    "Expected an object/map but got {}. This field must be a JSON object like {{\"key\": \"value\"}}.",
-                    got
+                    "Expected an object/map but got {got}. This field must be a JSON object like {{\"key\": \"value\"}}."
                 );
             }
             if expected == "a string" {
                 return format!(
-                    "Expected a string value but got {}. String values must be quoted.",
-                    got
+                    "Expected a string value but got {got}. String values must be quoted."
                 );
             }
             if expected == "an integer" || expected == "a number" {
-                return format!("Expected a number but got {}.", got);
+                return format!("Expected a number but got {got}.");
             }
 
             return format!(
-                "Type mismatch: expected {} but got {}. Please check your data format.",
-                expected, got
+                "Type mismatch: expected {expected} but got {got}. Please check your data format."
             );
         }
     }
@@ -309,8 +305,7 @@ fn user_facing_schema_error_generic(err: &serde_json::Error) -> String {
     if err_str.contains("unknown field") {
         if let Some(field_name) = extract_field_name(&err_str, "unknown field `", "`") {
             return format!(
-                "Unknown field '{}'. This field is not recognized. Check for typos or remove this field.",
-                field_name
+                "Unknown field '{field_name}'. This field is not recognized. Check for typos or remove this field."
             );
         }
     }

--- a/rust/batch-import-worker/src/parse/format.rs
+++ b/rust/batch-import-worker/src/parse/format.rs
@@ -7,8 +7,8 @@ use rayon::iter::IntoParallelIterator;
 use rayon::prelude::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use crate::{context::AppContext, job::model::JobModel};
 use crate::error::UserError;
+use crate::{context::AppContext, job::model::JobModel};
 
 use super::{
     content::{

--- a/rust/batch-import-worker/src/parse/mod.rs
+++ b/rust/batch-import-worker/src/parse/mod.rs
@@ -2,6 +2,7 @@ pub mod content;
 pub mod format;
 pub mod serialization;
 
+#[derive(Debug)]
 pub struct Parsed<T> {
     pub data: T,
     // How many "parts" of the chunk (bytes, rows) were consumed to create the data. This allows for offset

--- a/rust/batch-import-worker/src/source/date_range_export.rs
+++ b/rust/batch-import-worker/src/source/date_range_export.rs
@@ -900,6 +900,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_error_handling_401() {
+        use crate::error::get_user_message;
+
         let server = MockServer::start();
         let _mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/export");
@@ -914,16 +916,17 @@ mod tests {
 
         let result = source.prepare_key(key).await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Authentication failed"));
+        let err = result.unwrap_err();
+        let user_msg = get_user_message(&err);
+        assert_eq!(user_msg, "Authentication failed, check your credentials");
 
         source.cleanup_after_job().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_error_handling_500() {
+        use crate::error::get_user_message;
+
         let server = MockServer::start();
         let _mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/export");
@@ -938,10 +941,9 @@ mod tests {
 
         let result = source.prepare_key(key).await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Remote server error"));
+        let err = result.unwrap_err();
+        let user_msg = get_user_message(&err);
+        assert_eq!(user_msg, "Remote server error");
 
         source.cleanup_after_job().await.unwrap();
     }

--- a/rust/batch-import-worker/src/source/s3.rs
+++ b/rust/batch-import-worker/src/source/s3.rs
@@ -160,28 +160,40 @@ mod tests {
     fn test_extract_user_friendly_error_invalid_access_key() {
         let err = MockS3Error("InvalidAccessKeyId: The access key ID is invalid".to_string());
         let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
-        assert_eq!(msg, "Invalid AWS Access Key ID - please check your credentials");
+        assert_eq!(
+            msg,
+            "Invalid AWS Access Key ID - please check your credentials"
+        );
     }
 
     #[test]
     fn test_extract_user_friendly_error_signature_mismatch() {
         let err = MockS3Error("SignatureDoesNotMatch: The signature did not match".to_string());
         let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
-        assert_eq!(msg, "Invalid AWS Secret Access Key - please check your credentials");
+        assert_eq!(
+            msg,
+            "Invalid AWS Secret Access Key - please check your credentials"
+        );
     }
 
     #[test]
     fn test_extract_user_friendly_error_access_denied() {
         let err = MockS3Error("AccessDenied: Access Denied".to_string());
         let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
-        assert_eq!(msg, "Access denied to S3 bucket 'my-bucket' - check your permissions");
+        assert_eq!(
+            msg,
+            "Access denied to S3 bucket 'my-bucket' - check your permissions"
+        );
     }
 
     #[test]
     fn test_extract_user_friendly_error_no_such_bucket() {
         let err = MockS3Error("NoSuchBucket: The specified bucket does not exist".to_string());
         let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
-        assert_eq!(msg, "S3 bucket 'my-bucket' does not exist or you don't have access to it");
+        assert_eq!(
+            msg,
+            "S3 bucket 'my-bucket' does not exist or you don't have access to it"
+        );
     }
 
     #[test]
@@ -202,6 +214,9 @@ mod tests {
     fn test_extract_user_friendly_error_unknown() {
         let err = MockS3Error("Some other unknown error".to_string());
         let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
-        assert_eq!(msg, "S3 list objects failed - check your credentials, bucket name, and permissions");
+        assert_eq!(
+            msg,
+            "S3 list objects failed - check your credentials, bucket name, and permissions"
+        );
     }
 }

--- a/rust/batch-import-worker/src/source/s3.rs
+++ b/rust/batch-import-worker/src/source/s3.rs
@@ -139,3 +139,69 @@ impl DataSource for S3Source {
         Ok(data.to_vec())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mock error type for testing extract_user_friendly_error
+    #[derive(Debug)]
+    struct MockS3Error(String);
+
+    impl std::fmt::Display for MockS3Error {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl std::error::Error for MockS3Error {}
+
+    #[test]
+    fn test_extract_user_friendly_error_invalid_access_key() {
+        let err = MockS3Error("InvalidAccessKeyId: The access key ID is invalid".to_string());
+        let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
+        assert_eq!(msg, "Invalid AWS Access Key ID - please check your credentials");
+    }
+
+    #[test]
+    fn test_extract_user_friendly_error_signature_mismatch() {
+        let err = MockS3Error("SignatureDoesNotMatch: The signature did not match".to_string());
+        let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
+        assert_eq!(msg, "Invalid AWS Secret Access Key - please check your credentials");
+    }
+
+    #[test]
+    fn test_extract_user_friendly_error_access_denied() {
+        let err = MockS3Error("AccessDenied: Access Denied".to_string());
+        let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
+        assert_eq!(msg, "Access denied to S3 bucket 'my-bucket' - check your permissions");
+    }
+
+    #[test]
+    fn test_extract_user_friendly_error_no_such_bucket() {
+        let err = MockS3Error("NoSuchBucket: The specified bucket does not exist".to_string());
+        let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
+        assert_eq!(msg, "S3 bucket 'my-bucket' does not exist or you don't have access to it");
+    }
+
+    #[test]
+    fn test_extract_user_friendly_error_no_such_key() {
+        let err = MockS3Error("NoSuchKey: The specified key does not exist".to_string());
+        let msg = extract_user_friendly_error(&err, "my-bucket", "get object");
+        assert_eq!(msg, "The specified S3 object does not exist");
+    }
+
+    #[test]
+    fn test_extract_user_friendly_error_timeout() {
+        let err = MockS3Error("Request timeout: Connection timed out".to_string());
+        let msg = extract_user_friendly_error(&err, "my-bucket", "get object chunk");
+        assert_eq!(msg, "S3 get object chunk operation timed out - check your network connection and region settings");
+    }
+
+    #[test]
+    fn test_extract_user_friendly_error_unknown() {
+        let err = MockS3Error("Some other unknown error".to_string());
+        let msg = extract_user_friendly_error(&err, "my-bucket", "list objects");
+        assert_eq!(msg, "S3 list objects failed - check your credentials, bucket name, and permissions");
+    }
+}

--- a/rust/batch-import-worker/tests/error_handling_test.rs
+++ b/rust/batch-import-worker/tests/error_handling_test.rs
@@ -1,0 +1,316 @@
+#![allow(unused_imports)]
+//! Integration tests for error handling in batch-import-worker
+//!
+//! These tests verify that:
+//! 1. JSON parse errors produce user-friendly error messages
+//! 2. The full error chain is preserved for developer debugging
+
+use batch_import_worker::{
+    error::get_user_message,
+    source::{folder::FolderSource, DataSource},
+};
+use std::fs;
+use tempfile::TempDir;
+
+async fn setup_test_directory() -> (TempDir, FolderSource) {
+    let temp_dir = TempDir::new().unwrap();
+
+    fs::write(
+        temp_dir.path().join("valid.jsonl"),
+        r#"{"event": "$pageview", "distinct_id": "user1", "timestamp": "2024-01-01T00:00:00Z", "properties": {"$current_url": "https://example.com"}}
+{"event": "$pageview", "distinct_id": "user2", "timestamp": "2024-01-01T00:01:00Z", "properties": {"$current_url": "https://example.com/about"}}
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        temp_dir.path().join("invalid_line.jsonl"),
+        r#"{"event": "$pageview", "distinct_id": "user1", "timestamp": "2024-01-01T00:00:00Z", "properties": {}}
+this is not valid json - it will cause a parse error
+{"event": "signup", "distinct_id": "user1", "timestamp": "2024-01-01T00:02:00Z", "properties": {}}
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        temp_dir.path().join("truncated.jsonl"),
+        r#"{"event": "$pageview", "distinct_id": "user1", "timestamp": "2024-01-01T00:00:00Z", "properties": {}}
+{"event": "$pageview", "distinct_id": "user2", "timestamp": "2024-01-01T00:01:00Z", "properties": {"$current_url"
+"#,
+    )
+    .unwrap();
+
+    fs::write(temp_dir.path().join("empty_objects.jsonl"), "{}\n{}\n").unwrap();
+
+    let source = FolderSource::new(temp_dir.path().to_str().unwrap().to_string())
+        .await
+        .unwrap();
+
+    (temp_dir, source)
+}
+
+#[tokio::test]
+async fn test_folder_source_lists_files() {
+    let (_temp_dir, source) = setup_test_directory().await;
+    let keys = source.keys().await.unwrap();
+
+    assert_eq!(keys.len(), 4);
+    assert!(keys.iter().any(|k| k == "valid.jsonl"));
+    assert!(keys.iter().any(|k| k == "invalid_line.jsonl"));
+}
+
+#[tokio::test]
+async fn test_valid_file_parses_successfully() {
+    use batch_import_worker::parse::format::json_nd;
+    use common_types::RawEvent;
+
+    let (_temp_dir, source) = setup_test_directory().await;
+    let chunk = source.get_chunk("valid.jsonl", 0, 10000).await.unwrap();
+
+    let parser = json_nd::<RawEvent>(true);
+    let result = parser(chunk);
+
+    assert!(result.is_ok(), "Valid file should parse successfully");
+    let parsed = result.unwrap();
+    assert_eq!(parsed.data.len(), 2);
+}
+
+#[tokio::test]
+async fn test_invalid_json_produces_user_friendly_error() {
+    use batch_import_worker::parse::format::json_nd;
+    use common_types::RawEvent;
+
+    let (_temp_dir, source) = setup_test_directory().await;
+    let chunk = source
+        .get_chunk("invalid_line.jsonl", 0, 10000)
+        .await
+        .unwrap();
+
+    let parser = json_nd::<RawEvent>(false); // Don't skip blank lines
+    let result = parser(chunk);
+
+    assert!(result.is_err(), "Invalid JSON should produce an error");
+    let err = result.unwrap_err();
+
+    let user_message = get_user_message(&err);
+    assert!(
+        user_message.contains("JSON") && user_message.contains("column"),
+        "User message should mention JSON and include column info, got: {}",
+        user_message
+    );
+
+    let full_error = format!("{:#}", err);
+    assert!(
+        full_error.contains("json parse"),
+        "Full error should mention json parsing, got: {}",
+        full_error
+    );
+}
+
+#[tokio::test]
+async fn test_truncated_json_produces_user_friendly_error() {
+    use batch_import_worker::parse::format::json_nd;
+    use common_types::RawEvent;
+
+    let (_temp_dir, source) = setup_test_directory().await;
+    let chunk = source.get_chunk("truncated.jsonl", 0, 10000).await.unwrap();
+
+    let parser = json_nd::<RawEvent>(true);
+    let result = parser(chunk);
+
+    assert!(result.is_err(), "Truncated JSON should produce an error");
+    let err = result.unwrap_err();
+
+    let user_message = get_user_message(&err);
+    assert!(
+        user_message.contains("truncated") || user_message.contains("incomplete"),
+        "User message should mention truncated/incomplete JSON, got: {}",
+        user_message
+    );
+}
+
+#[tokio::test]
+async fn test_error_message_extraction_from_nested_errors() {
+    use anyhow::Context;
+    use batch_import_worker::error::UserError;
+
+    // Simulate the error chain as it's created in actual code:
+    // Inner error has specific message, outer error concatenates it with filename
+    let root_error = std::io::Error::new(std::io::ErrorKind::InvalidData, "unexpected token");
+    let inner_error = anyhow::Error::from(root_error)
+        .context(UserError::new("Your import file contains invalid JSON"))
+        .context("Failed to json parse line");
+
+    // Outer error concatenates inner message with filename (like job/mod.rs does)
+    let inner_msg = get_user_message(&inner_error);
+    let error = inner_error
+        .context(UserError::new(format!(
+            "Parsing data in file 'test_file.jsonl' failed: {}",
+            inner_msg
+        )))
+        .context("Processing part chunk");
+
+    let user_message = get_user_message(&error);
+    assert!(
+        user_message.contains("test_file.jsonl") && user_message.contains("invalid JSON"),
+        "Should have file context with specific error, got: {}",
+        user_message
+    );
+}
+
+#[tokio::test]
+async fn test_error_chain_preserves_all_context() {
+    use anyhow::Context;
+    use batch_import_worker::error::UserError;
+
+    let root_error =
+        serde_json::from_str::<serde_json::Value>("not valid json").unwrap_err();
+    let error = anyhow::Error::from(root_error)
+        .context(UserError::new("User-friendly message"))
+        .context("Developer context 1")
+        .context("Developer context 2");
+
+    let full_error = format!("{:#}", error);
+
+    assert!(full_error.contains("Developer context 1"));
+    assert!(full_error.contains("Developer context 2"));
+    assert!(full_error.contains("expected value") || full_error.contains("expected ident"));
+}
+
+#[test]
+fn test_schema_mismatch_produces_helpful_messages() {
+    use batch_import_worker::parse::format::json_nd;
+    use common_types::RawEvent;
+
+    let missing_event = b"{\"distinct_id\": \"user1\"}\n".to_vec();
+    let err = json_nd::<RawEvent>(false)(missing_event).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.contains("event") && msg.contains("required"),
+        "Missing event field should produce helpful message, got: {}",
+        msg
+    );
+
+    let wrong_type = b"{\"event\": 123, \"distinct_id\": \"user1\"}\n".to_vec();
+    let err = json_nd::<RawEvent>(false)(wrong_type).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.contains("event") && msg.contains("string"),
+        "Wrong type for event should mention it needs to be a string, got: {}",
+        msg
+    );
+
+    let wrong_properties = b"{\"event\": \"test\", \"properties\": \"not an object\"}\n".to_vec();
+    let err = json_nd::<RawEvent>(false)(wrong_properties).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.contains("object") || msg.contains("map"),
+        "Wrong properties type should mention it needs to be an object, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn test_mixpanel_schema_errors_produce_helpful_messages() {
+    use batch_import_worker::parse::content::mixpanel::MixpanelEvent;
+    use batch_import_worker::parse::format::json_nd;
+
+    // Missing required 'event' field
+    let missing_event = b"{\"properties\": {\"time\": 1697379000}}\n".to_vec();
+    let err = json_nd::<MixpanelEvent>(false)(missing_event).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.to_lowercase().contains("event") && msg.to_lowercase().contains("missing"),
+        "Missing event field should produce helpful message, got: {}",
+        msg
+    );
+
+    let missing_properties = b"{\"event\": \"test_event\"}\n".to_vec();
+    let err = json_nd::<MixpanelEvent>(false)(missing_properties).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.to_lowercase().contains("properties") && msg.to_lowercase().contains("missing"),
+        "Missing properties field should produce helpful message, got: {}",
+        msg
+    );
+
+    let missing_time = b"{\"event\": \"test_event\", \"properties\": {\"distinct_id\": \"user1\"}}\n".to_vec();
+    let err = json_nd::<MixpanelEvent>(false)(missing_time).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.to_lowercase().contains("time") && msg.to_lowercase().contains("missing"),
+        "Missing time field should produce helpful message, got: {}",
+        msg
+    );
+
+    let wrong_event_type = b"{\"event\": 123, \"properties\": {\"time\": 1697379000}}\n".to_vec();
+    let err = json_nd::<MixpanelEvent>(false)(wrong_event_type).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.to_lowercase().contains("event") && msg.to_lowercase().contains("string"),
+        "Wrong event type should mention it needs to be a string, got: {}",
+        msg
+    );
+
+    let wrong_time_type = b"{\"event\": \"test\", \"properties\": {\"time\": \"not a number\"}}\n".to_vec();
+    let err = json_nd::<MixpanelEvent>(false)(wrong_time_type).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.to_lowercase().contains("time") || msg.to_lowercase().contains("timestamp") || msg.to_lowercase().contains("integer"),
+        "Wrong time type should mention timestamp/integer issue, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn test_amplitude_schema_errors_produce_helpful_messages() {
+    use batch_import_worker::parse::content::amplitude::AmplitudeEvent;
+    use batch_import_worker::parse::format::json_nd;
+
+    let wrong_event_type = b"{\"event_type\": 123}\n".to_vec();
+    let err = json_nd::<AmplitudeEvent>(false)(wrong_event_type).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.to_lowercase().contains("event_type") && msg.to_lowercase().contains("string"),
+        "Wrong event_type should mention it needs to be a string, got: {}",
+        msg
+    );
+
+    let wrong_user_id = b"{\"event_type\": \"test\", \"user_id\": 12345}\n".to_vec();
+    let err = json_nd::<AmplitudeEvent>(false)(wrong_user_id).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.to_lowercase().contains("user_id") && msg.to_lowercase().contains("string"),
+        "Wrong user_id type should mention it needs to be a string, got: {}",
+        msg
+    );
+
+    // event_properties field has wrong type (string instead of object)
+    // Note: serde doesn't always include field name in type errors, so we just check for helpful type guidance
+    let wrong_properties = b"{\"event_type\": \"test\", \"event_properties\": \"not an object\"}\n".to_vec();
+    let err = json_nd::<AmplitudeEvent>(false)(wrong_properties).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.to_lowercase().contains("object"),
+        "Wrong event_properties type should mention it needs to be an object, got: {}",
+        msg
+    );
+
+    let wrong_user_properties = b"{\"event_type\": \"test\", \"user_properties\": [\"not\", \"object\"]}\n".to_vec();
+    let err = json_nd::<AmplitudeEvent>(false)(wrong_user_properties).unwrap_err();
+    let msg = get_user_message(&err);
+    assert!(
+        msg.to_lowercase().contains("object"),
+        "Wrong user_properties type should mention it needs to be an object, got: {}",
+        msg
+    );
+
+    let valid_event = b"{\"event_type\": \"button_click\", \"user_id\": \"user123\", \"event_time\": \"2023-10-15 14:30:00\"}\n".to_vec();
+    let result = json_nd::<AmplitudeEvent>(false)(valid_event);
+    assert!(
+        result.is_ok(),
+        "Valid Amplitude event should parse successfully, got: {:?}",
+        result.err()
+    );
+}
+

--- a/rust/batch-import-worker/tests/error_handling_test.rs
+++ b/rust/batch-import-worker/tests/error_handling_test.rs
@@ -95,15 +95,13 @@ async fn test_invalid_json_produces_user_friendly_error() {
     let user_message = get_user_message(&err);
     assert!(
         user_message.contains("JSON") && user_message.contains("column"),
-        "User message should mention JSON and include column info, got: {}",
-        user_message
+        "User message should mention JSON and include column info, got: {user_message}"
     );
 
-    let full_error = format!("{:#}", err);
+    let full_error = format!("{err:#}");
     assert!(
         full_error.contains("json parse"),
-        "Full error should mention json parsing, got: {}",
-        full_error
+        "Full error should mention json parsing, got: {full_error}"
     );
 }
 
@@ -124,8 +122,7 @@ async fn test_truncated_json_produces_user_friendly_error() {
     let user_message = get_user_message(&err);
     assert!(
         user_message.contains("truncated") || user_message.contains("incomplete"),
-        "User message should mention truncated/incomplete JSON, got: {}",
-        user_message
+        "User message should mention truncated/incomplete JSON, got: {user_message}"
     );
 }
 
@@ -145,16 +142,14 @@ async fn test_error_message_extraction_from_nested_errors() {
     let inner_msg = get_user_message(&inner_error);
     let error = inner_error
         .context(UserError::new(format!(
-            "Parsing data in file 'test_file.jsonl' failed: {}",
-            inner_msg
+            "Parsing data in file 'test_file.jsonl' failed: {inner_msg}"
         )))
         .context("Processing part chunk");
 
     let user_message = get_user_message(&error);
     assert!(
         user_message.contains("test_file.jsonl") && user_message.contains("invalid JSON"),
-        "Should have file context with specific error, got: {}",
-        user_message
+        "Should have file context with specific error, got: {user_message}"
     );
 }
 
@@ -169,7 +164,7 @@ async fn test_error_chain_preserves_all_context() {
         .context("Developer context 1")
         .context("Developer context 2");
 
-    let full_error = format!("{:#}", error);
+    let full_error = format!("{error:#}");
 
     assert!(full_error.contains("Developer context 1"));
     assert!(full_error.contains("Developer context 2"));
@@ -186,8 +181,7 @@ fn test_schema_mismatch_produces_helpful_messages() {
     let msg = get_user_message(&err);
     assert!(
         msg.contains("event") && msg.contains("required"),
-        "Missing event field should produce helpful message, got: {}",
-        msg
+        "Missing event field should produce helpful message, got: {msg}"
     );
 
     let wrong_type = b"{\"event\": 123, \"distinct_id\": \"user1\"}\n".to_vec();
@@ -195,8 +189,7 @@ fn test_schema_mismatch_produces_helpful_messages() {
     let msg = get_user_message(&err);
     assert!(
         msg.contains("event") && msg.contains("string"),
-        "Wrong type for event should mention it needs to be a string, got: {}",
-        msg
+        "Wrong type for event should mention it needs to be a string, got: {msg}"
     );
 
     let wrong_properties = b"{\"event\": \"test\", \"properties\": \"not an object\"}\n".to_vec();
@@ -204,8 +197,7 @@ fn test_schema_mismatch_produces_helpful_messages() {
     let msg = get_user_message(&err);
     assert!(
         msg.contains("object") || msg.contains("map"),
-        "Wrong properties type should mention it needs to be an object, got: {}",
-        msg
+        "Wrong properties type should mention it needs to be an object, got: {msg}"
     );
 }
 
@@ -220,8 +212,7 @@ fn test_mixpanel_schema_errors_produce_helpful_messages() {
     let msg = get_user_message(&err);
     assert!(
         msg.to_lowercase().contains("event") && msg.to_lowercase().contains("missing"),
-        "Missing event field should produce helpful message, got: {}",
-        msg
+        "Missing event field should produce helpful message, got: {msg}"
     );
 
     let missing_properties = b"{\"event\": \"test_event\"}\n".to_vec();
@@ -229,8 +220,7 @@ fn test_mixpanel_schema_errors_produce_helpful_messages() {
     let msg = get_user_message(&err);
     assert!(
         msg.to_lowercase().contains("properties") && msg.to_lowercase().contains("missing"),
-        "Missing properties field should produce helpful message, got: {}",
-        msg
+        "Missing properties field should produce helpful message, got: {msg}"
     );
 
     let missing_time =
@@ -239,8 +229,7 @@ fn test_mixpanel_schema_errors_produce_helpful_messages() {
     let msg = get_user_message(&err);
     assert!(
         msg.to_lowercase().contains("time") && msg.to_lowercase().contains("missing"),
-        "Missing time field should produce helpful message, got: {}",
-        msg
+        "Missing time field should produce helpful message, got: {msg}"
     );
 
     let wrong_event_type = b"{\"event\": 123, \"properties\": {\"time\": 1697379000}}\n".to_vec();
@@ -248,8 +237,7 @@ fn test_mixpanel_schema_errors_produce_helpful_messages() {
     let msg = get_user_message(&err);
     assert!(
         msg.to_lowercase().contains("event") && msg.to_lowercase().contains("string"),
-        "Wrong event type should mention it needs to be a string, got: {}",
-        msg
+        "Wrong event type should mention it needs to be a string, got: {msg}"
     );
 
     let wrong_time_type =
@@ -260,8 +248,7 @@ fn test_mixpanel_schema_errors_produce_helpful_messages() {
         msg.to_lowercase().contains("time")
             || msg.to_lowercase().contains("timestamp")
             || msg.to_lowercase().contains("integer"),
-        "Wrong time type should mention timestamp/integer issue, got: {}",
-        msg
+        "Wrong time type should mention timestamp/integer issue, got: {msg}"
     );
 }
 
@@ -275,8 +262,7 @@ fn test_amplitude_schema_errors_produce_helpful_messages() {
     let msg = get_user_message(&err);
     assert!(
         msg.to_lowercase().contains("event_type") && msg.to_lowercase().contains("string"),
-        "Wrong event_type should mention it needs to be a string, got: {}",
-        msg
+        "Wrong event_type should mention it needs to be a string, got: {msg}"
     );
 
     let wrong_user_id = b"{\"event_type\": \"test\", \"user_id\": 12345}\n".to_vec();
@@ -284,8 +270,7 @@ fn test_amplitude_schema_errors_produce_helpful_messages() {
     let msg = get_user_message(&err);
     assert!(
         msg.to_lowercase().contains("user_id") && msg.to_lowercase().contains("string"),
-        "Wrong user_id type should mention it needs to be a string, got: {}",
-        msg
+        "Wrong user_id type should mention it needs to be a string, got: {msg}"
     );
 
     // event_properties field has wrong type (string instead of object)
@@ -296,8 +281,7 @@ fn test_amplitude_schema_errors_produce_helpful_messages() {
     let msg = get_user_message(&err);
     assert!(
         msg.to_lowercase().contains("object"),
-        "Wrong event_properties type should mention it needs to be an object, got: {}",
-        msg
+        "Wrong event_properties type should mention it needs to be an object, got: {msg}"
     );
 
     let wrong_user_properties =
@@ -306,8 +290,7 @@ fn test_amplitude_schema_errors_produce_helpful_messages() {
     let msg = get_user_message(&err);
     assert!(
         msg.to_lowercase().contains("object"),
-        "Wrong user_properties type should mention it needs to be an object, got: {}",
-        msg
+        "Wrong user_properties type should mention it needs to be an object, got: {msg}"
     );
 
     let valid_event = b"{\"event_type\": \"button_click\", \"user_id\": \"user123\", \"event_time\": \"2023-10-15 14:30:00\"}\n".to_vec();

--- a/rust/batch-import-worker/tests/error_handling_test.rs
+++ b/rust/batch-import-worker/tests/error_handling_test.rs
@@ -163,8 +163,7 @@ async fn test_error_chain_preserves_all_context() {
     use anyhow::Context;
     use batch_import_worker::error::UserError;
 
-    let root_error =
-        serde_json::from_str::<serde_json::Value>("not valid json").unwrap_err();
+    let root_error = serde_json::from_str::<serde_json::Value>("not valid json").unwrap_err();
     let error = anyhow::Error::from(root_error)
         .context(UserError::new("User-friendly message"))
         .context("Developer context 1")
@@ -234,7 +233,8 @@ fn test_mixpanel_schema_errors_produce_helpful_messages() {
         msg
     );
 
-    let missing_time = b"{\"event\": \"test_event\", \"properties\": {\"distinct_id\": \"user1\"}}\n".to_vec();
+    let missing_time =
+        b"{\"event\": \"test_event\", \"properties\": {\"distinct_id\": \"user1\"}}\n".to_vec();
     let err = json_nd::<MixpanelEvent>(false)(missing_time).unwrap_err();
     let msg = get_user_message(&err);
     assert!(
@@ -252,11 +252,14 @@ fn test_mixpanel_schema_errors_produce_helpful_messages() {
         msg
     );
 
-    let wrong_time_type = b"{\"event\": \"test\", \"properties\": {\"time\": \"not a number\"}}\n".to_vec();
+    let wrong_time_type =
+        b"{\"event\": \"test\", \"properties\": {\"time\": \"not a number\"}}\n".to_vec();
     let err = json_nd::<MixpanelEvent>(false)(wrong_time_type).unwrap_err();
     let msg = get_user_message(&err);
     assert!(
-        msg.to_lowercase().contains("time") || msg.to_lowercase().contains("timestamp") || msg.to_lowercase().contains("integer"),
+        msg.to_lowercase().contains("time")
+            || msg.to_lowercase().contains("timestamp")
+            || msg.to_lowercase().contains("integer"),
         "Wrong time type should mention timestamp/integer issue, got: {}",
         msg
     );
@@ -287,7 +290,8 @@ fn test_amplitude_schema_errors_produce_helpful_messages() {
 
     // event_properties field has wrong type (string instead of object)
     // Note: serde doesn't always include field name in type errors, so we just check for helpful type guidance
-    let wrong_properties = b"{\"event_type\": \"test\", \"event_properties\": \"not an object\"}\n".to_vec();
+    let wrong_properties =
+        b"{\"event_type\": \"test\", \"event_properties\": \"not an object\"}\n".to_vec();
     let err = json_nd::<AmplitudeEvent>(false)(wrong_properties).unwrap_err();
     let msg = get_user_message(&err);
     assert!(
@@ -296,7 +300,8 @@ fn test_amplitude_schema_errors_produce_helpful_messages() {
         msg
     );
 
-    let wrong_user_properties = b"{\"event_type\": \"test\", \"user_properties\": [\"not\", \"object\"]}\n".to_vec();
+    let wrong_user_properties =
+        b"{\"event_type\": \"test\", \"user_properties\": [\"not\", \"object\"]}\n".to_vec();
     let err = json_nd::<AmplitudeEvent>(false)(wrong_user_properties).unwrap_err();
     let msg = get_user_message(&err);
     assert!(
@@ -313,4 +318,3 @@ fn test_amplitude_schema_errors_produce_helpful_messages() {
         result.err()
     );
 }
-


### PR DESCRIPTION

## Problem

When a managed migration attempts to import invalid data from the source, the user is shown an unhelpful error message. This does not allow them to self-serve and figure out why their migration is failing.

## Changes

Adds much more comprehensive error reporting for users that are attempting to import data that is invalid:
- json parsing errors get transformed into a message telling the user what they need to fix
- event schema parsing errors get transformed into a message telling the user why the event they are importing is invalid
- the internal "error message" state that gets set on the job now includes the full error context 

## How did you test this code?

Tested this code through unit tests.

Tested this code through by uploading different invalid .jsonl files to S3 and importing those events from my local build


<img width="1001" height="423" alt="Screenshot 2025-12-12 at 4 13 23 PM" src="https://github.com/user-attachments/assets/65b43856-5d08-4e4f-a455-b6dce44b34f2" />
