### PR TITLE
fix: hobby seaweed bucket creation on first startup

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -494,13 +494,22 @@ services:
             - /bin/sh
             - -c
             - |
-                (
-                    until echo "s3.bucket.create -name posthog" | /usr/bin/weed shell -master=localhost:9333 2>/dev/null; do
-                        sleep 5
-                    done
-                    echo "Created bucket: posthog"
-                ) &
-                exec /usr/bin/weed "$$@"
+                /usr/bin/weed "$$@" &
+                WEED_PID=$$!
+                echo "Waiting for SeaweedFS to initialize..."
+                while true; do
+                    sleep 5
+                    echo "Checking if posthog bucket exists..."
+                    if echo "s3.bucket.list" | /usr/bin/weed shell -master=localhost:9333 2>&1 | grep -q "posthog"; then
+                        echo "Bucket posthog exists!"
+                        break
+                    fi
+                    echo "Bucket not found, attempting to create..."
+                    echo "s3.bucket.create -name posthog" | /usr/bin/weed shell -master=localhost:9333 2>&1 || true
+                    echo "Retrying in 5s..."
+                done
+                echo "SeaweedFS ready with posthog bucket"
+                wait $$WEED_PID
             - --
         command: ['server', '-s3', '-s3.port=8333', '-dir=/data']
 


### PR DESCRIPTION
## Problem

This PR added cymbal to hobby deploy and made it use `seaweed` - https://github.com/PostHog/posthog/pull/43296

Everything was working on my test instance but turns out that it was working only because I restarted seaweed somewhere along the debugging/testing.

I discovered that the `posthog` bucket does not get created on the initial startup but strangely restarting seaweed solves the problem.

In short - error tracking won't work in a fresh hobby deploy until you restart seaweed.

## Changes

Changed creation command to a more strict one. So now we not only check whether create response was successful but we then actually check against the seaweed if that bucket exists and we retry indefinitely until that's true.

| 1 | 2 |
|--------|--------|
| <img width="663" height="872" alt="image" src="https://github.com/user-attachments/assets/dd0e8906-712c-49fc-900f-c3845a3b494c" /> | <img width="926" height="800" alt="image" src="https://github.com/user-attachments/assets/2ef40d4c-4c52-483a-9a5b-aeb9280eb851" /> | 





Tested that again and now it works as expected on the fresh, first run.

I did a posthog fork and applied the same changes here so if you want to test it yourself, you can run this command (on an Ubuntu machine)
```
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/ablaszkiewicz/posthog-hobby-test/refs/heads/master/bin/deploy-hobby)"
```

Both events and exceptions (this means that cymbal works) are properly ingested.

<img width="1634" height="785" alt="image" src="https://github.com/user-attachments/assets/401eef6e-da71-4f8a-8daf-e93cc40052e2" />
