### PR TITLE
fix(logs): fix missing resource type on service.name filter

### DIFF
--- a/products/logs/frontend/filters/ServiceFilter.tsx
+++ b/products/logs/frontend/filters/ServiceFilter.tsx
@@ -15,6 +15,7 @@ export const ServiceFilter = (): JSX.Element => {
 
     const endpoint = combineUrl(`api/environments/${currentProjectId}/logs/values`, {
         key: 'service.name',
+        attribute_type: 'resource',
         dateRange,
     }).url
 


### PR DESCRIPTION
## Problem

#43292 broke the service name filter as it wasn't specifying attribute type, which defaults to log instead of resource (service.name is a resource level attribute)

## Changes

fix the missing attribute type

## How did you test this code?

locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
