### PR TITLE
fix: properly parse git meta from vercel in cli

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1521,7 +1521,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.17"
+version = "0.5.18"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/tests/git.rs
+++ b/cli/tests/git.rs
@@ -1,4 +1,4 @@
-use posthog_cli::utils::git::{get_remote_url, get_repo_name};
+use posthog_cli::utils::git::{get_git_info, get_remote_url, get_repo_name};
 use std::fs;
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -82,4 +82,31 @@ fn test_get_repo_infos_ssh_without_dot_git() {
     );
     assert_eq!(get_repo_name(&git_dir).as_deref(), Some("posthog"));
     let _ = fs::remove_dir_all(git_dir.parent().unwrap());
+}
+
+#[test]
+fn test_get_git_info_from_vercel_env() {
+    std::env::set_var("VERCEL", "1");
+    std::env::set_var("VERCEL_GIT_PROVIDER", "github");
+    std::env::set_var("VERCEL_GIT_REPO_OWNER", "PostHog");
+    std::env::set_var("VERCEL_GIT_REPO_SLUG", "posthog");
+    std::env::set_var("VERCEL_GIT_COMMIT_REF", "main");
+    std::env::set_var("VERCEL_GIT_COMMIT_SHA", "abc123def456");
+
+    let info = get_git_info(None).expect("should not error").expect("should return info");
+
+    assert_eq!(info.branch, "main");
+    assert_eq!(info.commit_id, "abc123def456");
+    assert_eq!(info.repo_name.as_deref(), Some("posthog"));
+    assert_eq!(
+        info.remote_url.as_deref(),
+        Some("https://github.com/PostHog/posthog.git")
+    );
+
+    std::env::remove_var("VERCEL");
+    std::env::remove_var("VERCEL_GIT_PROVIDER");
+    std::env::remove_var("VERCEL_GIT_REPO_OWNER");
+    std::env::remove_var("VERCEL_GIT_REPO_SLUG");
+    std::env::remove_var("VERCEL_GIT_COMMIT_REF");
+    std::env::remove_var("VERCEL_GIT_COMMIT_SHA");
 }

--- a/cli/tests/git.rs
+++ b/cli/tests/git.rs
@@ -93,7 +93,9 @@ fn test_get_git_info_from_vercel_env() {
     std::env::set_var("VERCEL_GIT_COMMIT_REF", "main");
     std::env::set_var("VERCEL_GIT_COMMIT_SHA", "abc123def456");
 
-    let info = get_git_info(None).expect("should not error").expect("should return info");
+    let info = get_git_info(None)
+        .expect("should not error")
+        .expect("should return info");
 
     assert_eq!(info.branch, "main");
     assert_eq!(info.commit_id, "abc123def456");


### PR DESCRIPTION
## Problem

When our CLI is inside vercel's CI, we set branch so `master` always and repository to `path0`. This is obviously wrong.

## Changes

Added proper checks and reads from env variables when in vercel's CI based on this https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL