### PR TITLE
feat(dwh): add hover tooltip to show full table names

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -434,6 +434,14 @@ export const QueryDatabase = (): JSX.Element => {
                     )
                 }
             }}
+            renderItemTooltip={(item) => {
+                // Show tooltip with full name for items that could be truncated
+                const tooltipTypes = ['table', 'view', 'managed-view', 'endpoint', 'draft', 'column', 'unsaved-query']
+                if (tooltipTypes.includes(item.record?.type)) {
+                    return item.name
+                }
+                return undefined
+            }}
             renderItemIcon={(item) => {
                 if (item.record?.type === 'column') {
                     return <></>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
When table names are too long, they are truncated in the data warehouse sidebar making it very hard to know which tables you're working with. users can now hover over them to see the full name in a tooltip. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- add tooltip on LemonTree

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
locally
<img width="382" height="131" alt="image" src="https://github.com/user-attachments/assets/dacc63da-18d2-424c-8987-91866d3de666" />
<img width="323" height="270" alt="image" src="https://github.com/user-attachments/assets/fc86572f-3a94-41c9-90c1-e2a4c4176163" />

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
sure, small QoL thing
