### PR TITLE
feat(experiments): Sample ratio mismatch

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -344,6 +344,7 @@ export const FEATURE_FLAGS = {
     SURVEYS_ERROR_TRACKING_CROSS_SELL: 'surveys-in-error-tracking', // owner: @adboio #team-surveys
     LIVE_EVENTS_ACTIVE_RECORDINGS: 'live-events-active-recordings', // owner: @pauldambra #team-replay
     PRODUCT_TOURS: 'product-tours-2025', // owner: @pauldambra #team-replay
+    EXPERIMENTS_SAMPLE_RATIO_MISMATCH: 'experiments-sample-ratio-mismatch', // owner: @jurajmajerik #team-experiments
     // PLEASE KEEP THIS ALPHABETICALLY ORDERED
 } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3561,6 +3561,9 @@
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
                 },
+                "sample_ratio_mismatch": {
+                    "$ref": "#/definitions/SampleRatioMismatch"
+                },
                 "timeseries": {
                     "items": {
                         "$ref": "#/definitions/ExperimentExposureTimeSeries"
@@ -13160,6 +13163,9 @@
                     "const": "ExperimentExposureQuery",
                     "type": "string"
                 },
+                "sample_ratio_mismatch": {
+                    "$ref": "#/definitions/SampleRatioMismatch"
+                },
                 "timeseries": {
                     "items": {
                         "$ref": "#/definitions/ExperimentExposureTimeSeries"
@@ -22497,6 +22503,9 @@
                             "const": "ExperimentExposureQuery",
                             "type": "string"
                         },
+                        "sample_ratio_mismatch": {
+                            "$ref": "#/definitions/SampleRatioMismatch"
+                        },
                         "timeseries": {
                             "items": {
                                 "$ref": "#/definitions/ExperimentExposureTimeSeries"
@@ -27348,6 +27357,22 @@
                     "$ref": "#/definitions/AssistantToolCallMessage"
                 }
             ]
+        },
+        "SampleRatioMismatch": {
+            "additionalProperties": false,
+            "properties": {
+                "expected": {
+                    "additionalProperties": {
+                        "type": "number"
+                    },
+                    "type": "object"
+                },
+                "p_value": {
+                    "type": "number"
+                }
+            },
+            "required": ["expected", "p_value"],
+            "type": "object"
         },
         "SamplingRate": {
             "additionalProperties": false,

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3183,11 +3183,17 @@ export interface ExperimentExposureTimeSeries {
     exposure_counts: number[]
 }
 
+export interface SampleRatioMismatch {
+    expected: Record<string, number>
+    p_value: number
+}
+
 export interface ExperimentExposureQueryResponse {
     kind: NodeKind.ExperimentExposureQuery
     timeseries: ExperimentExposureTimeSeries[]
     total_exposures: Record<string, number>
     date_range: DateRange
+    sample_ratio_mismatch?: SampleRatioMismatch
 }
 
 export type CachedExperimentQueryResponse = CachedQueryResponse<ExperimentQueryResponse>

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -1,10 +1,11 @@
 import { useActions, useValues } from 'kea'
 import { useCallback, useState } from 'react'
 
-import { IconCorrelationAnalysis, IconPencil } from '@posthog/icons'
-import { LemonButton, LemonCollapse, LemonTable, Spinner } from '@posthog/lemon-ui'
+import { IconCheckCircle, IconCorrelationAnalysis, IconPencil, IconWarning } from '@posthog/icons'
+import { LemonButton, LemonCollapse, LemonTable, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { getSeriesBackgroundColor, getSeriesColor } from 'lib/colors'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { useChart } from 'lib/hooks/useChart'
 import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils'
@@ -138,7 +139,8 @@ function getExposureCriteriaLabel(exposureCriteria: ExperimentExposureCriteria |
 }
 
 export function Exposures(): JSX.Element {
-    const { exposures, exposuresLoading, exposureCriteria, isExperimentDraft } = useValues(experimentLogic)
+    const { exposures, exposuresLoading, exposureCriteria, isExperimentDraft, featureFlags } =
+        useValues(experimentLogic)
     const { openExposureCriteriaModal } = useActions(modalsLogic)
     const colors = useChartColors()
 
@@ -162,6 +164,9 @@ export function Exposures(): JSX.Element {
             })
         }
     }
+
+    // Detect sample ratio mismatch (p < 0.001 is significant)
+    const hasSRM = exposures?.sample_ratio_mismatch != null && exposures.sample_ratio_mismatch.p_value < 0.001
 
     const { canvasRef } = useChart({
         getConfig: () => {
@@ -287,6 +292,11 @@ export function Exposures(): JSX.Element {
                                         ))}
                                     </div>
                                 )}
+                                {hasSRM && (
+                                    <Tooltip title="The observed distribution differs significantly from expected (p < 0.001). This may indicate issues with randomization or data collection.">
+                                        <IconWarning className="text-warning text-lg" />
+                                    </Tooltip>
+                                )}
                             </>
                         )}
                     </div>
@@ -336,127 +346,149 @@ export function Exposures(): JSX.Element {
                                 </div>
                             )}
 
-                            {/* Exposure Criteria & Total Exposures Section */}
-                            <div>
-                                <div className="flex justify-between mb-4">
-                                    <div>
-                                        <h3 className="card-secondary">Exposure criteria</h3>
-                                        <div className="flex items-center gap-2">
-                                            <div className="text-sm font-semibold">
-                                                {getExposureCriteriaLabel(exposureCriteria)}
-                                            </div>
-                                            <LemonButton
-                                                icon={<IconPencil fontSize="12" />}
-                                                size="xsmall"
-                                                className="flex items-center gap-2"
-                                                type="secondary"
-                                                onClick={() => openExposureCriteriaModal()}
-                                            />
-                                        </div>
+                            {/* Exposure Criteria Section */}
+                            <div className="mb-4">
+                                <h3 className="card-secondary">Exposure criteria</h3>
+                                <div className="flex items-center gap-2">
+                                    <div className="text-sm font-semibold">
+                                        {getExposureCriteriaLabel(exposureCriteria)}
                                     </div>
+                                    <LemonButton
+                                        icon={<IconPencil fontSize="12" />}
+                                        size="xsmall"
+                                        className="flex items-center gap-2"
+                                        type="secondary"
+                                        onClick={() => openExposureCriteriaModal()}
+                                    />
                                 </div>
-                                {exposures?.timeseries.length > 0 && (
-                                    <div>
-                                        <h3 className="card-secondary">Total exposures</h3>
-                                        <div>
-                                            <LemonTable
-                                                dataSource={[
-                                                    ...(exposures?.timeseries || []),
-                                                    // Add total row
-                                                    { variant: '__total__', isTotal: true },
-                                                ]}
-                                                columns={[
-                                                    {
-                                                        title: 'Variant',
-                                                        key: 'variant',
-                                                        render: function Variant(_, series) {
-                                                            if (series.isTotal) {
-                                                                return <span className="font-semibold">Total</span>
+                            </div>
+                            {exposures?.timeseries.length > 0 && (
+                                <div>
+                                    <h3 className="card-secondary">Total exposures</h3>
+                                    <LemonTable
+                                        dataSource={[
+                                            ...(exposures?.timeseries || []),
+                                            { variant: '__total__', isTotal: true },
+                                        ]}
+                                        columns={[
+                                            {
+                                                title: 'Variant',
+                                                key: 'variant',
+                                                render: function Variant(_, series) {
+                                                    if (series.isTotal) {
+                                                        return <span className="font-semibold">Total</span>
+                                                    }
+                                                    return <VariantTag variantKey={series.variant} />
+                                                },
+                                            },
+                                            {
+                                                title: 'Exposures',
+                                                key: 'exposures',
+                                                render: function Exposures(_, series) {
+                                                    if (series.isTotal) {
+                                                        return (
+                                                            <span className="font-semibold">
+                                                                {humanFriendlyNumber(totalExposures)}
+                                                            </span>
+                                                        )
+                                                    }
+                                                    return humanFriendlyNumber(
+                                                        exposures?.total_exposures[series.variant]
+                                                    )
+                                                },
+                                            },
+                                            {
+                                                title: '%',
+                                                key: 'percentage',
+                                                render: function Percentage(_, series) {
+                                                    if (series.isTotal) {
+                                                        let totalPercentage = 0
+                                                        let total = 0
+                                                        if (exposures?.total_exposures) {
+                                                            for (const [_, value] of Object.entries(
+                                                                exposures.total_exposures
+                                                            )) {
+                                                                total += Number(value)
                                                             }
-                                                            return <VariantTag variantKey={series.variant} />
-                                                        },
-                                                    },
-                                                    {
-                                                        title: 'Exposures',
-                                                        key: 'exposures',
-                                                        render: function Exposures(_, series) {
-                                                            if (series.isTotal) {
-                                                                return (
-                                                                    <span className="font-semibold">
-                                                                        {humanFriendlyNumber(totalExposures)}
-                                                                    </span>
-                                                                )
-                                                            }
-                                                            return humanFriendlyNumber(
-                                                                exposures?.total_exposures[series.variant]
-                                                            )
-                                                        },
-                                                    },
-                                                    {
-                                                        title: '%',
-                                                        key: 'percentage',
-                                                        render: function Percentage(_, series) {
-                                                            if (series.isTotal) {
-                                                                // Calculate sum of all individual percentages
-                                                                let totalPercentage = 0
-                                                                let total = 0
-                                                                if (exposures?.total_exposures) {
-                                                                    for (const [_, value] of Object.entries(
-                                                                        exposures.total_exposures
-                                                                    )) {
-                                                                        total += Number(value)
-                                                                    }
-                                                                    if (total > 0) {
-                                                                        for (const [_, count] of Object.entries(
-                                                                            exposures.total_exposures
-                                                                        )) {
-                                                                            totalPercentage +=
-                                                                                (Number(count) / total) * 100
-                                                                        }
-                                                                    }
-                                                                }
-                                                                return (
-                                                                    <span className="font-semibold">
-                                                                        {totalPercentage
-                                                                            ? `${totalPercentage.toFixed(1)}%`
-                                                                            : '-%'}
-                                                                    </span>
-                                                                )
-                                                            }
-                                                            let total = 0
-                                                            if (exposures?.total_exposures) {
-                                                                for (const [_, value] of Object.entries(
+                                                            if (total > 0) {
+                                                                for (const [_, count] of Object.entries(
                                                                     exposures.total_exposures
                                                                 )) {
-                                                                    total += Number(value)
+                                                                    totalPercentage += (Number(count) / total) * 100
                                                                 }
                                                             }
-                                                            return (
+                                                        }
+                                                        return (
+                                                            <span className="font-semibold">
+                                                                {totalPercentage
+                                                                    ? `${totalPercentage.toFixed(1)}%`
+                                                                    : '-%'}
+                                                            </span>
+                                                        )
+                                                    }
+                                                    let total = 0
+                                                    if (exposures?.total_exposures) {
+                                                        for (const [_, value] of Object.entries(
+                                                            exposures.total_exposures
+                                                        )) {
+                                                            total += Number(value)
+                                                        }
+                                                    }
+                                                    return (
+                                                        <span className="font-semibold">
+                                                            {total ? (
+                                                                <>
+                                                                    {(
+                                                                        (exposures?.total_exposures[series.variant] /
+                                                                            total) *
+                                                                        100
+                                                                    ).toFixed(1)}
+                                                                    %
+                                                                </>
+                                                            ) : (
+                                                                <>-%</>
+                                                            )}
+                                                        </span>
+                                                    )
+                                                },
+                                            },
+                                        ]}
+                                    />
+                                    {featureFlags[FEATURE_FLAGS.EXPERIMENTS_SAMPLE_RATIO_MISMATCH] &&
+                                        exposures?.sample_ratio_mismatch != null && (
+                                            <div className="flex items-center gap-1 text-xs mt-2">
+                                                {hasSRM ? (
+                                                    <>
+                                                        <Tooltip title="The observed distribution differs significantly from expected (p < 0.001). This may indicate issues with randomization or data collection.">
+                                                            <span className="flex items-center gap-1 text-warning cursor-pointer">
+                                                                <IconWarning className="text-sm" />
                                                                 <span className="font-semibold">
-                                                                    {total ? (
-                                                                        <>
-                                                                            {(
-                                                                                (exposures?.total_exposures[
-                                                                                    series.variant
-                                                                                ] /
-                                                                                    total) *
-                                                                                100
-                                                                            ).toFixed(1)}
-                                                                            %
-                                                                        </>
-                                                                    ) : (
-                                                                        <>-%</>
-                                                                    )}
+                                                                    Sample ratio mismatch detected
                                                                 </span>
-                                                            )
-                                                        },
-                                                    },
-                                                ]}
-                                            />
-                                        </div>
-                                    </div>
-                                )}
-                            </div>
+                                                            </span>
+                                                        </Tooltip>
+                                                        <span className="text-muted">
+                                                            (p ={' '}
+                                                            {exposures.sample_ratio_mismatch.p_value.toExponential(2)})
+                                                        </span>
+                                                    </>
+                                                ) : (
+                                                    <>
+                                                        <Tooltip title="No sample ratio mismatch detected. The distribution of users across variants matches the expected rollout percentages.">
+                                                            <span className="flex items-center gap-1 text-success cursor-pointer">
+                                                                <IconCheckCircle className="text-sm" />
+                                                                <span>Exposure distribution is balanced</span>
+                                                            </span>
+                                                        </Tooltip>
+                                                        <span className="text-muted">
+                                                            (p = {exposures.sample_ratio_mismatch.p_value.toFixed(3)})
+                                                        </span>
+                                                    </>
+                                                )}
+                                            </div>
+                                        )}
+                                </div>
+                            )}
                         </div>
                     ),
                 },

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -22,6 +22,9 @@ import { modalsLogic } from '../modalsLogic'
 import { getExposureConfigDisplayName } from '../utils'
 import { VariantTag } from './components'
 
+const srmFailureTooltipText =
+    "The distribution of users across variants doesn't match your configured rollout percentages (p < 0.001). This may indicate issues with randomization or data collection."
+
 interface MicroChartProps {
     exposures: ExperimentExposureQueryResponse
 }
@@ -292,8 +295,8 @@ export function Exposures(): JSX.Element {
                                         ))}
                                     </div>
                                 )}
-                                {hasSRM && (
-                                    <Tooltip title="The observed distribution differs significantly from expected (p < 0.001). This may indicate issues with randomization or data collection.">
+                                {featureFlags[FEATURE_FLAGS.EXPERIMENTS_SAMPLE_RATIO_MISMATCH] && hasSRM && (
+                                    <Tooltip title={srmFailureTooltipText}>
                                         <IconWarning className="text-warning text-lg" />
                                     </Tooltip>
                                 )}
@@ -459,7 +462,7 @@ export function Exposures(): JSX.Element {
                                             <div className="flex items-center gap-1 text-xs mt-2">
                                                 {hasSRM ? (
                                                     <>
-                                                        <Tooltip title="The observed distribution differs significantly from expected (p < 0.001). This may indicate issues with randomization or data collection.">
+                                                        <Tooltip title={srmFailureTooltipText}>
                                                             <span className="flex items-center gap-1 text-warning cursor-pointer">
                                                                 <IconWarning className="text-sm" />
                                                                 <span className="font-semibold">
@@ -474,10 +477,12 @@ export function Exposures(): JSX.Element {
                                                     </>
                                                 ) : (
                                                     <>
-                                                        <Tooltip title="No sample ratio mismatch detected. The distribution of users across variants matches the expected rollout percentages.">
+                                                        <Tooltip title="No sample ratio mismatch detected. The difference between actual and expected exposures is within normal random variation.">
                                                             <span className="flex items-center gap-1 text-success cursor-pointer">
                                                                 <IconCheckCircle className="text-sm" />
-                                                                <span>Exposure distribution is balanced</span>
+                                                                <span>
+                                                                    Exposure distribution matches rollout percentages
+                                                                </span>
                                                             </span>
                                                         </Tooltip>
                                                         <span className="text-muted">

--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -132,8 +132,12 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         # Holdout takes its percentage from the total, other variants share the remainder
         if self.query.holdout:
             holdout_key = f"holdout-{self.query.holdout.id}"
-            holdout_filters = self.query.holdout.get("filters", [])
-            holdout_pct = holdout_filters[0].get("rollout_percentage", 0) if holdout_filters else 0
+            holdout_filters = self.query.holdout.filters
+            holdout_pct = (
+                holdout_filters[0].rollout_percentage
+                if holdout_filters and holdout_filters[0].rollout_percentage is not None
+                else 0
+            )
 
             if holdout_pct > 0:
                 rollout_percentages[holdout_key] = holdout_pct

--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -3,6 +3,7 @@ from typing import Optional
 from zoneinfo import ZoneInfo
 
 from rest_framework.exceptions import ValidationError
+from scipy.stats import chisquare
 
 from posthog.schema import (
     CachedExperimentExposureQueryResponse,
@@ -11,6 +12,7 @@ from posthog.schema import (
     ExperimentExposureQueryResponse,
     ExperimentExposureTimeSeries,
     IntervalType,
+    SampleRatioMismatch,
 )
 
 from posthog.hogql import ast
@@ -30,6 +32,7 @@ from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
 QUERY_ROW_LIMIT = 5000  # Should be sufficient for all experiments (days * variants)
+SRM_MINIMUM_SAMPLE_SIZE = 100  # Minimum total exposures required for SRM calculation
 
 
 class ExperimentExposuresQueryRunner(QueryRunner):
@@ -107,6 +110,69 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         )
         return builder.get_exposure_timeseries_query()
 
+    def _calculate_srm(self, total_exposures: dict[str, int]) -> SampleRatioMismatch | None:
+        """
+        Calculate Sample Ratio Mismatch using chi-squared goodness-of-fit test.
+        Compares observed variant distribution against expected (from rollout percentages).
+        Returns None if insufficient data.
+        """
+        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
+        variants_config = multivariate_data.get("variants", [])
+
+        if not variants_config or not total_exposures:
+            return None
+
+        rollout_percentages: dict[str, float] = {}
+        for variant_config in variants_config:
+            key = variant_config.get("key")
+            pct = variant_config.get("rollout_percentage", 0)
+            if key:
+                rollout_percentages[key] = pct
+
+        # Holdout takes its percentage from the total, other variants share the remainder
+        if self.query.holdout:
+            holdout_key = f"holdout-{self.query.holdout.id}"
+            holdout_filters = self.query.holdout.get("filters", [])
+            holdout_pct = holdout_filters[0].get("rollout_percentage", 0) if holdout_filters else 0
+
+            if holdout_pct > 0:
+                rollout_percentages[holdout_key] = holdout_pct
+                remaining = 100 - holdout_pct
+                for key in list(rollout_percentages.keys()):
+                    if key != holdout_key:
+                        rollout_percentages[key] = rollout_percentages[key] * (remaining / 100)
+
+        # Exclude MULTIPLE_VARIANT_KEY
+        total_observed = sum(count for key, count in total_exposures.items() if key != MULTIPLE_VARIANT_KEY)
+        if total_observed < SRM_MINIMUM_SAMPLE_SIZE:
+            return None
+
+        observed: list[float] = []
+        expected: list[float] = []
+        expected_counts: dict[str, float] = {}
+
+        for variant_key, obs_count in total_exposures.items():
+            if variant_key == MULTIPLE_VARIANT_KEY:
+                continue
+
+            rollout_pct = rollout_percentages.get(variant_key, 0)
+            exp_count = (rollout_pct / 100) * total_observed
+
+            if exp_count > 0:
+                observed.append(float(obs_count))
+                expected.append(exp_count)
+                expected_counts[variant_key] = exp_count
+
+        if len(observed) < 2:
+            return None
+
+        _, p_value = chisquare(observed, expected)
+
+        return SampleRatioMismatch(
+            expected=expected_counts,
+            p_value=float(p_value),
+        )
+
     def _calculate(self) -> ExperimentExposureQueryResponse:
         try:
             # Adding experiment specific tags to the tag collection
@@ -172,10 +238,13 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             for variant, series in variant_series.items():
                 total_exposures[variant] = int(series.exposure_counts[-1]) if series.exposure_counts else 0
 
+            sample_ratio_mismatch = self._calculate_srm(total_exposures)
+
             return ExperimentExposureQueryResponse(
                 timeseries=ordered_timeseries,
                 total_exposures=total_exposures,
                 date_range=self.date_range,
+                sample_ratio_mismatch=sample_ratio_mismatch,
             )
         except Exception as e:
             capture_exception(

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -1353,6 +1353,7 @@ class TestExperimentExposuresQueryRunner(ClickhouseTestMixin, APIBaseTest):
         runner = ExperimentExposuresQueryRunner(team=self.team, query=query)
 
         # Note: holdout.id is a float in schema, so key becomes "holdout-123.0"
+        assert query.holdout is not None
         holdout_key = f"holdout-{query.holdout.id}"
 
         # Directly test _calculate_srm with holdout-adjusted data
@@ -1361,7 +1362,7 @@ class TestExperimentExposuresQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         result = runner._calculate_srm(total_exposures)
 
-        self.assertIsNotNone(result)
+        assert result is not None
         # With 20% holdout, expected is: holdout=20, control=40, test=40 of 100
         self.assertEqual(result.expected[holdout_key], 20.0)
         self.assertEqual(result.expected["control"], 40.0)
@@ -1405,7 +1406,7 @@ class TestExperimentExposuresQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         result = runner._calculate_srm(total_exposures)
 
-        self.assertIsNotNone(result)
+        assert result is not None
         # Only control and test should be in expected
         self.assertEqual(len(result.expected), 2)
         self.assertIn("control", result.expected)
@@ -1431,6 +1432,6 @@ class TestExperimentExposuresQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         result = runner._calculate_srm(total_exposures)
 
-        self.assertIsNotNone(result)
+        assert result is not None
         # Should detect severe mismatch (100/0 vs expected 50/50)
         self.assertLess(result.p_value, 0.001)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2787,16 +2787,6 @@ class QueryResponseAlternative7(BaseModel):
     stdout: str | None = None
 
 
-class QueryResponseAlternative21(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    date_range: DateRange
-    kind: Literal["ExperimentExposureQuery"] = "ExperimentExposureQuery"
-    timeseries: list[ExperimentExposureTimeSeries]
-    total_exposures: dict[str, float]
-
-
 class QueryResponseAlternative73(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -3026,6 +3016,14 @@ class RevenueCurrencyPropertyConfig(BaseModel):
     )
     property: str | None = None
     static: CurrencyCode | None = None
+
+
+class SampleRatioMismatch(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    expected: dict[str, float]
+    p_value: float
 
 
 class SamplingRate(BaseModel):
@@ -4562,6 +4560,7 @@ class ExperimentExposureQueryResponse(BaseModel):
     )
     date_range: DateRange
     kind: Literal["ExperimentExposureQuery"] = "ExperimentExposureQuery"
+    sample_ratio_mismatch: SampleRatioMismatch | None = None
     timeseries: list[ExperimentExposureTimeSeries]
     total_exposures: dict[str, float]
 
@@ -5158,6 +5157,17 @@ class QueryResponseAlternative10(BaseModel):
     timings: list[QueryTiming] | None = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
+
+
+class QueryResponseAlternative21(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    date_range: DateRange
+    kind: Literal["ExperimentExposureQuery"] = "ExperimentExposureQuery"
+    sample_ratio_mismatch: SampleRatioMismatch | None = None
+    timeseries: list[ExperimentExposureTimeSeries]
+    total_exposures: dict[str, float]
 
 
 class QueryResponseAlternative29(BaseModel):
@@ -7125,6 +7135,7 @@ class CachedExperimentExposureQueryResponse(BaseModel):
     query_status: QueryStatus | None = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
+    sample_ratio_mismatch: SampleRatioMismatch | None = None
     timeseries: list[ExperimentExposureTimeSeries]
     timezone: str
     total_exposures: dict[str, float]


### PR DESCRIPTION
_Feature flag:_ `experiments-sample-ratio-mismatch`

## Problem
Users don't know if differences in exposures are actually statistically significant.

## Changes
Calculate the sample ratio mismatch and show this information in Exposures panel:

<img width="677" height="72" alt="image" src="https://github.com/user-attachments/assets/63f7c342-e15c-4272-b350-d48700efcdd4" />

<img width="664" height="560" alt="image" src="https://github.com/user-attachments/assets/016407b6-950d-4f46-b352-9568b8286b8e" />

<img width="663" height="558" alt="image" src="https://github.com/user-attachments/assets/c8e1aab2-b548-48f6-9d07-ff58ded1d70b" />

## How did you test this code?
- Added tests
- 👀 