### PR TITLE
chore(ci): skip Rust jobs entirely when no relevant changes

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -43,11 +43,9 @@ jobs:
                         - 'docker-compose.dev.yml'
 
     build:
-        # TODO: Once "Rust Tests Pass" is the only required check, add:
-        #   if: needs.changes.outputs.rust == 'true'
-        # and remove the per-step `if` conditions to skip the entire job when no Rust changes.
         name: Build Rust services
         needs: changes
+        if: needs.changes.outputs.rust == 'true'
         runs-on: depot-ubuntu-22.04-4
 
         defaults:
@@ -59,36 +57,28 @@ jobs:
             # Use sparse checkout to only select files in rust directory
             # Turning off cone mode ensures that files in the project root are not included during checkout
             - uses: actions/checkout@v4
-              if: needs.changes.outputs.rust == 'true'
               with:
                   sparse-checkout: 'rust/'
                   sparse-checkout-cone-mode: false
                   clean: false
 
             - name: Install rust
-              if: needs.changes.outputs.rust == 'true'
               uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e
               with:
                   toolchain: 1.88.0
 
             - name: Install sccache
-              if: needs.changes.outputs.rust == 'true'
               uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
             - name: Configure sccache
-              if: needs.changes.outputs.rust == 'true'
               run: |
                   echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
                   sccache --start-server
 
             - name: Run cargo build
-              if: needs.changes.outputs.rust == 'true'
               run: cargo build --all --locked --release && find target/release/ -maxdepth 1 -executable -type f | xargs strip
 
     test:
-        # TODO: Once "Rust Tests Pass" is the only required check, add:
-        #   if: needs.changes.outputs.rust == 'true'
-        # and remove the per-step `if` conditions to skip the entire job when no Rust changes.
         name: Test Rust services
         strategy:
             matrix:
@@ -125,6 +115,7 @@ jobs:
                     - property-defs-rs
                     - serve-metrics
         needs: changes
+        if: needs.changes.outputs.rust == 'true'
         runs-on: depot-ubuntu-24.04-4
         timeout-minutes: 20
 
@@ -134,11 +125,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
-              if: needs.changes.outputs.rust == 'true'
               with:
                   clean: false
             - name: Clean up data directories with container permissions
-              if: needs.changes.outputs.rust == 'true'
               working-directory: .
               run: |
                   # Use docker to clean up files created by containers (from repo root, not rust/)
@@ -146,7 +135,6 @@ jobs:
               continue-on-error: true
 
             - name: Setup main repo and dependencies
-              if: needs.changes.outputs.rust == 'true'
               run: |
                   docker compose -f ../docker-compose.dev.yml down
                   docker compose -f ../docker-compose.dev.yml up -d
@@ -161,53 +149,45 @@ jobs:
 
             # please keep the tag version here in sync with rust-version in rust/*/Cargo.toml
             - name: Install rust
-              if: needs.changes.outputs.rust == 'true'
               uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e
               with:
                   toolchain: 1.88.0
 
             - name: Install sccache
-              if: needs.changes.outputs.rust == 'true'
               uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
             - name: Configure sccache
-              if: needs.changes.outputs.rust == 'true'
               run: |
                   echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
                   sccache --start-server
 
             - name: Set up Python
-              if: needs.changes.outputs.rust == 'true'
               uses: actions/setup-python@v5
               with:
                   python-version-file: 'pyproject.toml'
 
             - name: Install uv
               id: setup-uv
-              if: needs.changes.outputs.rust == 'true'
               uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
               with:
                   enable-cache: true
                   version: 0.9.9
 
             - name: Install SAML (python3-saml) dependencies
-              if: needs.changes.outputs.rust == 'true' && steps.setup-uv.outputs.cache-hit != 'true'
+              if: steps.setup-uv.outputs.cache-hit != 'true'
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl postgresql-client
 
             - name: Install python dependencies
-              if: needs.changes.outputs.rust == 'true'
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev --directory ..
 
             - name: Install sqlx-cli
-              if: needs.changes.outputs.rust == 'true'
               run: |
                   cargo install sqlx-cli --version 0.8.0 --features postgres --no-default-features --locked
 
             - name: Set up databases
-              if: needs.changes.outputs.rust == 'true'
               env:
                   DEBUG: 'true'
                   TEST: 'true'
@@ -216,19 +196,16 @@ jobs:
               run: cd ../ && python manage.py setup_test_environment
 
             - name: Run sqlx migrations
-              if: needs.changes.outputs.rust == 'true'
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog_persons'
               run: |
                   sqlx migrate run --source persons_migrations/
 
             - name: Download MaxMind Database
-              if: needs.changes.outputs.rust == 'true'
               run: |
                   cd ../ && ./bin/download-mmdb
 
             - name: Run cargo test
-              if: needs.changes.outputs.rust == 'true'
               env:
                   RUST_BACKTRACE: 1
                   # Set up dual database environment for feature-flags service
@@ -240,11 +217,9 @@ jobs:
                   echo "Cargo test completed"
 
     linting:
-        # TODO: Once "Rust Tests Pass" is the only required check, add:
-        #   if: needs.changes.outputs.rust == 'true'
-        # and remove the per-step `if` conditions to skip the entire job when no Rust changes.
         name: Lint Rust services
         needs: changes
+        if: needs.changes.outputs.rust == 'true'
         runs-on: depot-ubuntu-22.04-4
 
         defaults:
@@ -256,47 +231,38 @@ jobs:
             # Use sparse checkout to only select files in rust directory
             # Turning off cone mode ensures that files in the project root are not included during checkout
             - uses: actions/checkout@v4
-              if: needs.changes.outputs.rust == 'true'
               with:
                   sparse-checkout: 'rust/'
                   sparse-checkout-cone-mode: false
                   clean: false
 
             - name: Install rust
-              if: needs.changes.outputs.rust == 'true'
               uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e
               with:
                   toolchain: 1.88.0
                   components: clippy,rustfmt
 
             - name: Install sccache
-              if: needs.changes.outputs.rust == 'true'
               uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
             - name: Configure sccache
-              if: needs.changes.outputs.rust == 'true'
               run: |
                   echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
                   sccache --start-server
 
             - name: Check format
-              if: needs.changes.outputs.rust == 'true'
               run: cargo fmt -- --check
 
             - name: Run clippy
-              if: needs.changes.outputs.rust == 'true'
               run: cargo clippy --all-targets --all-features -- -D warnings
 
             - name: Run cargo check
-              if: needs.changes.outputs.rust == 'true'
               run: cargo check --all-features
 
     shear:
-        # TODO: Once "Rust Tests Pass" is the only required check, add:
-        #   if: needs.changes.outputs.rust == 'true'
-        # and remove the per-step `if` conditions to skip the entire job when no Rust changes.
         name: Shear Rust services
         needs: changes
+        if: needs.changes.outputs.rust == 'true'
         runs-on: depot-ubuntu-22.04-4
 
         defaults:
@@ -308,32 +274,21 @@ jobs:
             # Use sparse checkout to only select files in rust directory
             # Turning off cone mode ensures that files in the project root are not included during checkout
             - uses: actions/checkout@v4
-              if: needs.changes.outputs.rust == 'true'
               with:
                   sparse-checkout: 'rust/'
                   sparse-checkout-cone-mode: false
                   clean: false
 
             - name: Install cargo-binstall
-              if: needs.changes.outputs.rust == 'true'
               uses: cargo-bins/cargo-binstall@5cbf019d8cb9b9d5b086218c41458ea35d817691 # main
 
             - name: Install cargo-shear
-              if: needs.changes.outputs.rust == 'true'
               run: cargo binstall --no-confirm cargo-shear@1.1.12
 
             - run: cargo shear
-              if: needs.changes.outputs.rust == 'true'
 
-    # Collate job to require a single passing status for branch protection.
-    # After merging, update the repository ruleset (Settings > Rules > Rulesets):
-    #   1. Add "Rust Tests Pass" to required status checks
-    #   2. Remove these 34 individual checks:
-    #      - "Build Rust services"
-    #      - "Lint Rust services"
-    #      - "Shear Rust services"
-    #      - "Test Rust services (*)" (all 31 matrix jobs)
-    #   3. Then apply the TODO comments above to skip jobs entirely when no Rust changes
+    # Collate job - single required status check for branch protection.
+    # Individual jobs skip entirely when no Rust changes, saving runner time.
     rust_tests:
         needs: [changes, build, test, linting, shear]
         name: Rust Tests Pass


### PR DESCRIPTION
Follow-up to #42554. Now that "Rust Tests Pass" is the only required check, skip jobs at the job level instead of per-step to avoid spinning up runners for non-Rust PRs.

Removes ~53 lines of per-step `if` conditions.