### PR TITLE
feat: add a management command for batch soft delete of session recordings

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -576,7 +576,7 @@
   (
      (SELECT persons.id AS id
       FROM
-        (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', ''), person.version) AS properties___name,
+        (SELECT tupleElement(argMax(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '')), person.version), 1) AS properties___name,
                 person.id AS id
          FROM person
          WHERE and(equals(person.team_id, 99999), in(id,
@@ -584,7 +584,7 @@
                                                         FROM person AS where_optimization
                                                         WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'name'), ''), 'null'), '^"|"$', ''), 'test'), 0)))))
          GROUP BY person.id
-         HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+         HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
       WHERE ifNull(equals(persons.properties___name, 'test'), 0)
       ORDER BY persons.id ASC
       LIMIT 1000000000 SETTINGS optimize_aggregation_in_order=1,
@@ -604,12 +604,12 @@
                                   e.distinct_id AS distinct_id
                            FROM events AS e
                            LEFT OUTER JOIN
-                             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
                                      person_distinct_id_overrides.distinct_id AS distinct_id
                               FROM person_distinct_id_overrides
                               WHERE equals(person_distinct_id_overrides.team_id, 99999)
                               GROUP BY person_distinct_id_overrides.distinct_id
-                              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
                            WHERE and(equals(e.team_id, 99999), greaterOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')), equals(e.event, '$pageview')))
                         GROUP BY actor_id) AS source
                      ORDER BY source.id ASC
@@ -623,7 +623,8 @@
                                                                                 max_bytes_before_external_group_by=0,
                                                                                 transform_null_in=1,
                                                                                 optimize_min_equality_disjunction_chain_length=4294967295,
-                                                                                allow_experimental_join_condition=1
+                                                                                allow_experimental_join_condition=1,
+                                                                                use_hive_partitioning=0
   '''
 # ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.13

--- a/posthog/management/commands/delete_session_recordings.py
+++ b/posthog/management/commands/delete_session_recordings.py
@@ -1,0 +1,117 @@
+import csv
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.db.models import Q
+
+import structlog
+
+from posthog.models.team.team import Team
+from posthog.session_recordings.models.session_recording import SessionRecording
+
+logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = "Mark session recordings as deleted by session_id"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", required=True, type=int, help="Team ID for the session recordings")
+        parser.add_argument("--session-ids", type=str, help="Comma-separated list of session IDs")
+        parser.add_argument("--csv-file", type=str, help="Path to CSV file with session IDs (single column)")
+        parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+
+    def handle(self, *args, **options):
+        team_id = options["team_id"]
+        session_ids_arg = options["session_ids"]
+        csv_file = options["csv_file"]
+        dry_run = options["dry_run"]
+
+        if not session_ids_arg and not csv_file:
+            raise CommandError("Must provide either --session-ids or --csv-file")
+
+        if session_ids_arg and csv_file:
+            raise CommandError("Provide only one of --session-ids or --csv-file, not both")
+
+        team = Team.objects.filter(id=team_id).first()
+        if not team:
+            raise CommandError(f"Team with ID {team_id} does not exist")
+
+        session_ids = self._collect_session_ids(session_ids_arg, csv_file)
+        if not session_ids:
+            logger.info("No session IDs to process")
+            return
+
+        unique_session_ids = list(set(session_ids))
+        logger.info(f"Processing {len(unique_session_ids)} unique session IDs for team {team_id}")
+
+        if dry_run:
+            logger.info("Dry run - no changes will be made")
+            self._report_plan(team, unique_session_ids)
+            return
+
+        self._mark_recordings_deleted(team, unique_session_ids)
+
+    def _collect_session_ids(self, session_ids_arg: str | None, csv_file: str | None) -> list[str]:
+        if session_ids_arg:
+            return [sid.strip() for sid in session_ids_arg.split(",") if sid.strip()]
+
+        if csv_file:
+            session_ids = []
+            try:
+                with open(csv_file, newline="") as f:
+                    reader = csv.reader(f)
+                    for row in reader:
+                        if row and row[0].strip():
+                            session_ids.append(row[0].strip())
+            except FileNotFoundError:
+                raise CommandError(f"CSV file not found: {csv_file}")
+            except PermissionError:
+                raise CommandError(f"Permission denied reading CSV file: {csv_file}")
+            except OSError as e:
+                raise CommandError(f"Error reading CSV file {csv_file}: {e}")
+            return session_ids
+
+        return []
+
+    def _report_plan(self, team: Team, session_ids: list[str]) -> None:
+        existing = set(
+            SessionRecording.objects.filter(team=team, session_id__in=session_ids).values_list("session_id", flat=True)
+        )
+        already_deleted = set(
+            SessionRecording.objects.filter(team=team, session_id__in=session_ids, deleted=True).values_list(
+                "session_id", flat=True
+            )
+        )
+
+        to_update = existing - already_deleted
+        to_create = set(session_ids) - existing
+
+        logger.info(f"Would update {len(to_update)} existing recordings to deleted=True")
+        logger.info(f"Would create {len(to_create)} new recordings with deleted=True")
+        logger.info(f"Already deleted: {len(already_deleted)} (no action needed)")
+
+    def _mark_recordings_deleted(self, team: Team, session_ids: list[str]) -> None:
+        existing_ids = set(
+            SessionRecording.objects.filter(team=team, session_id__in=session_ids).values_list("session_id", flat=True)
+        )
+        new_ids = set(session_ids) - existing_ids
+
+        with transaction.atomic():
+            not_yet_deleted = Q(deleted__isnull=True) | Q(deleted=False)
+            updated_count = (
+                SessionRecording.objects.filter(team=team, session_id__in=existing_ids)
+                .filter(not_yet_deleted)
+                .update(deleted=True)
+            )
+
+            if new_ids:
+                new_recordings = [SessionRecording(team=team, session_id=sid, deleted=True) for sid in new_ids]
+                SessionRecording.objects.bulk_create(new_recordings, ignore_conflicts=True)
+
+        if new_ids:
+            logger.info(f"Created up to {len(new_ids)} new recordings with deleted=True")
+        logger.info(f"Updated {updated_count} existing recordings to deleted=True")
+        logger.info("Done")

--- a/posthog/management/commands/test/test_delete_session_recordings.py
+++ b/posthog/management/commands/test/test_delete_session_recordings.py
@@ -1,0 +1,189 @@
+import os
+import tempfile
+from io import StringIO
+
+from posthog.test.base import BaseTest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from parameterized import parameterized
+
+from posthog.session_recordings.models.session_recording import SessionRecording
+
+
+class TestDeleteSessionRecordingsCommand(BaseTest):
+    @parameterized.expand(
+        [
+            ("single_id", "session1", ["session1"]),
+            ("multiple_ids", "session1,session2,session3", ["session1", "session2", "session3"]),
+            ("with_spaces", "session1, session2 , session3", ["session1", "session2", "session3"]),
+            ("with_duplicates", "session1,session1,session2", ["session1", "session2"]),
+            ("with_empty_entries", "session1,,session2,", ["session1", "session2"]),
+        ]
+    )
+    def test_parses_session_ids_from_arg(self, _name: str, session_ids_arg: str, expected_ids: list[str]):
+        call_command(
+            "delete_session_recordings",
+            f"--team-id={self.team.id}",
+            f"--session-ids={session_ids_arg}",
+        )
+
+        created_ids = set(
+            SessionRecording.objects.filter(team=self.team, deleted=True).values_list("session_id", flat=True)
+        )
+        assert created_ids == set(expected_ids)
+
+    def test_parses_session_ids_from_csv_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write("session1\n")
+            f.write("session2\n")
+            f.write("\n")
+            f.write("session3\n")
+            f.write("\n")
+            csv_path = f.name
+
+        try:
+            call_command(
+                "delete_session_recordings",
+                f"--team-id={self.team.id}",
+                f"--csv-file={csv_path}",
+            )
+
+            created_ids = set(
+                SessionRecording.objects.filter(team=self.team, deleted=True).values_list("session_id", flat=True)
+            )
+            assert created_ids == {"session1", "session2", "session3"}
+        finally:
+            os.unlink(csv_path)
+
+    def test_updates_existing_recordings_to_deleted(self):
+        SessionRecording.objects.create(team=self.team, session_id="existing1", deleted=False)
+        SessionRecording.objects.create(team=self.team, session_id="existing2", deleted=None)
+
+        call_command(
+            "delete_session_recordings",
+            f"--team-id={self.team.id}",
+            "--session-ids=existing1,existing2",
+        )
+
+        assert SessionRecording.objects.get(session_id="existing1").deleted is True
+        assert SessionRecording.objects.get(session_id="existing2").deleted is True
+
+    def test_creates_new_recordings_with_deleted_true(self):
+        call_command(
+            "delete_session_recordings",
+            f"--team-id={self.team.id}",
+            "--session-ids=new1,new2",
+        )
+
+        new1 = SessionRecording.objects.get(session_id="new1")
+        new2 = SessionRecording.objects.get(session_id="new2")
+
+        assert new1.team == self.team
+        assert new1.deleted is True
+        assert new2.team == self.team
+        assert new2.deleted is True
+
+    def test_idempotent_running_twice_is_safe(self):
+        call_command(
+            "delete_session_recordings",
+            f"--team-id={self.team.id}",
+            "--session-ids=session1,session2",
+        )
+
+        first_run_count = SessionRecording.objects.filter(team=self.team, deleted=True).count()
+
+        call_command(
+            "delete_session_recordings",
+            f"--team-id={self.team.id}",
+            "--session-ids=session1,session2",
+        )
+
+        second_run_count = SessionRecording.objects.filter(team=self.team, deleted=True).count()
+
+        assert first_run_count == second_run_count == 2
+
+    def test_dry_run_does_not_modify_data(self):
+        SessionRecording.objects.create(team=self.team, session_id="existing", deleted=False)
+
+        out = StringIO()
+        call_command(
+            "delete_session_recordings",
+            f"--team-id={self.team.id}",
+            "--session-ids=existing,new_session",
+            "--dry-run",
+            stdout=out,
+        )
+
+        existing = SessionRecording.objects.get(session_id="existing")
+        assert existing.deleted is False
+
+        assert not SessionRecording.objects.filter(session_id="new_session").exists()
+
+    def test_only_affects_specified_team(self):
+        from posthog.models import Organization, Team
+
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+
+        SessionRecording.objects.create(team=self.team, session_id="my_team_session", deleted=False)
+        SessionRecording.objects.create(team=other_team, session_id="other_team_session", deleted=False)
+
+        call_command(
+            "delete_session_recordings",
+            f"--team-id={self.team.id}",
+            "--session-ids=my_team_session,other_team_session",
+        )
+
+        assert SessionRecording.objects.get(session_id="my_team_session").deleted is True
+        assert SessionRecording.objects.get(session_id="other_team_session").deleted is False
+
+    def test_handles_mixed_existing_and_new_recordings(self):
+        SessionRecording.objects.create(team=self.team, session_id="existing", deleted=False)
+
+        call_command(
+            "delete_session_recordings",
+            f"--team-id={self.team.id}",
+            "--session-ids=existing,new",
+        )
+
+        assert SessionRecording.objects.get(session_id="existing").deleted is True
+        assert SessionRecording.objects.get(session_id="new").deleted is True
+        assert SessionRecording.objects.filter(team=self.team, deleted=True).count() == 2
+
+    def test_raises_error_when_no_input_provided(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command(
+                "delete_session_recordings",
+                f"--team-id={self.team.id}",
+            )
+        assert "Must provide either --session-ids or --csv-file" in str(cm.exception)
+
+    def test_raises_error_when_both_inputs_provided(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command(
+                "delete_session_recordings",
+                f"--team-id={self.team.id}",
+                "--session-ids=session1",
+                "--csv-file=/tmp/test.csv",
+            )
+        assert "Provide only one of --session-ids or --csv-file" in str(cm.exception)
+
+    def test_raises_error_for_nonexistent_team(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command(
+                "delete_session_recordings",
+                "--team-id=999999",
+                "--session-ids=session1",
+            )
+        assert "Team with ID 999999 does not exist" in str(cm.exception)
+
+    def test_raises_error_for_nonexistent_csv_file(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command(
+                "delete_session_recordings",
+                f"--team-id={self.team.id}",
+                "--csv-file=/nonexistent/path/to/file.csv",
+            )
+        assert "CSV file not found" in str(cm.exception)


### PR DESCRIPTION
## Problem

We need to bulk soft-delete a bunch of recordings

It feels wrong as a migration, running forever more every time we run migrations, away into the distant future 👎 

And it feels wrong in the django admin, since we don't want this to become a common activity

So, management command it is

I don't know that I can get a CSV onto a toolbox instance, but if I can, then this supports that

## Changelog: (features only) Is this feature complete?

no, well, yes, but shouldn't go in the changelog
