### PR TITLE
fix(llma): Langchain tool use display for Anthropic

### DIFF
--- a/frontend/src/lib/components/Errors/ExceptionList/CollapsibleExceptionList.tsx
+++ b/frontend/src/lib/components/Errors/ExceptionList/CollapsibleExceptionList.tsx
@@ -38,6 +38,7 @@ export function CollapsibleExceptionList({
         if (!hasInAppFrames) {
             setShowAllFrames(true)
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [hasInAppFrames])
 
     return (

--- a/frontend/src/lib/components/Errors/ExceptionList/RawExceptionList.tsx
+++ b/frontend/src/lib/components/Errors/ExceptionList/RawExceptionList.tsx
@@ -28,6 +28,7 @@ export function RawExceptionList({
         if (!hasInAppFrames) {
             setShowAllFrames(true)
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [hasInAppFrames])
 
     return (

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -336,6 +336,7 @@ export function LineGraph_({
             window.removeEventListener('keydown', handleKeyDown)
             window.removeEventListener('keyup', handleKeyUp)
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isBar, isStacked])
 
     // Add scrollend event on main element to hide tooltips when scrolling

--- a/products/error_tracking/frontend/components/ExceptionCard/ExceptionCard.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/ExceptionCard.tsx
@@ -44,6 +44,7 @@ export function ExceptionCard({ issueId, event, loading, ...contentProps }: Exce
                 properties: event?.properties,
                 id: event?.uuid ?? issueId ?? 'error',
             }) as ErrorPropertiesLogicProps,
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [event?.uuid ?? issueId]
     )
 

--- a/products/error_tracking/frontend/hooks/use-callback-once.tsx
+++ b/products/error_tracking/frontend/hooks/use-callback-once.tsx
@@ -4,14 +4,19 @@ import { useCallback, useEffect, useRef } from 'react'
 export function useCallbackOnce<F extends (...args: any[]) => any>(cb: F, deps: any[]): (...args: any[]) => void {
     const called = useRef(false)
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => {
         called.current = false
     }, deps)
 
-    return useCallback((...args: any[]) => {
-        if (!called.current) {
-            cb(...args)
-            called.current = true
-        }
-    }, [])
+    return useCallback(
+        (...args: any[]) => {
+            if (!called.current) {
+                cb(...args)
+                called.current = true
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        []
+    )
 }

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -635,9 +635,29 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
 
     // Input message
     if (isAnthropicRoleBasedMessage(rawMessage)) {
-        // Content is a nested array (tool responses, etc.)
+        // Check for top-level tool_calls (already normalized by SDK)
+        const topLevelToolCalls =
+            'tool_calls' in rawMessage && isOpenAICompatToolCallsArray(rawMessage.tool_calls)
+                ? parseOpenAIToolCalls(rawMessage.tool_calls)
+                : undefined
+
         if (Array.isArray(rawMessage.content)) {
-            return rawMessage.content.map((content) => normalizeMessage(content, roleToUse)).flat()
+            // If we have top-level tool_calls, skip tool_use blocks in content (they're duplicates with incomplete data)
+            const contentToProcess = topLevelToolCalls
+                ? rawMessage.content.filter((item) => !isAnthropicToolCallMessage(item))
+                : rawMessage.content
+
+            const contentMessages = contentToProcess.map((content) => normalizeMessage(content, roleToUse)).flat()
+
+            if (topLevelToolCalls && topLevelToolCalls.length > 0) {
+                contentMessages.push({
+                    role: roleToUse,
+                    content: '',
+                    tool_calls: topLevelToolCalls,
+                })
+            }
+
+            return contentMessages
         }
 
         return [


### PR DESCRIPTION
Fixes an issue where Langchain calls for Anthropic wouldn't properly show tool call arguments since the information is partially duplicated in the output field.