### PR TITLE
fix: add new prefix to shortcuts

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -455,7 +455,7 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                               }
                             : {
                                   path: shortcutPath,
-                                  type: item.type,
+                                  type: (item as FileSystemImport).iconType || item.type,
                                   ref: item.ref,
                                   href: item.href,
                               }

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -96,7 +96,10 @@ export function convertFileSystemEntryToTreeDataItem({
 }: ConvertProps): TreeDataItem[] {
     function itemToTreeDataItem(item: FileSystemImport | FileSystemEntry): TreeDataItem {
         const pathSplit = splitPath(item.path)
-        const itemName = unescapePath(pathSplit.pop() ?? 'Unnamed')
+        const lastPart = pathSplit.pop()
+        const itemName = unescapePath(
+            lastPart ? (item.href?.includes('new') ? `New ${lastPart.toLowerCase()}` : lastPart) : 'Unnamed'
+        )
         const nodeId = getItemId(item, root)
         const displayName = <SearchHighlightMultiple string={itemName} substring={searchTerm ?? ''} />
         const user: UserBasicType | undefined = item.meta?.created_by ? users?.[item.meta.created_by] : undefined

--- a/frontend/src/lib/components/FileSystem/ItemSelectModal/ItemSelectModal.tsx
+++ b/frontend/src/lib/components/FileSystem/ItemSelectModal/ItemSelectModal.tsx
@@ -135,7 +135,7 @@ export function ItemSelectModal({ className, includeProtocol, includeRoot }: Ite
                                       : undefined
                             }
                         >
-                            Add {selectedItem?.name || selectedItem?.displayName}
+                            Add {selectedItem?.name.toLowerCase() || selectedItem?.displayName} shortcut
                         </LemonButton>
                     </>
                 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
New $something shortcuts are not clear. They're missing `new`
<img width="706" height="642" alt="image" src="https://github.com/user-attachments/assets/f1463618-29f4-4a53-a0a6-6f0b5ca4965b" />
And some icons are not shown properly in shortcuts (ie web analytics)
<img width="198" height="205" alt="image" src="https://github.com/user-attachments/assets/c8a75947-e03c-4be9-8622-0a8f48ad6b9d" />

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="175" height="261" alt="image" src="https://github.com/user-attachments/assets/4479b145-6a79-4f37-ae52-16b875e84078" />

## How did you test this code?
- locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
nah