### PR TITLE
fix(logs): show resource attributes in log row

### DIFF
--- a/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
@@ -172,7 +172,7 @@ export function LogRow({
 
                 {/* Attribute columns */}
                 {attributeColumns.map((attributeKey) => {
-                    const attrValue = log.attributes[attributeKey]
+                    const attrValue = log.attributes[attributeKey] ?? log.resource_attributes[attributeKey]
                     return (
                         <AttributeCell
                             key={attributeKey}


### PR DESCRIPTION
## Problem

User-defined columns for log resource attributes (e.g., service.name) don't display values, showing - instead.

## Changes

Look in both log.attributes and log.resource_attributes when rendering attribute columns.

## How did you test this code?

Added a resource attribute as a column, verified it now displays the value.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._