### PR TITLE
feat(sessions): Change backfill to insert to local table

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -207,6 +207,10 @@ class ClickhouseCluster:
     def shards(self) -> list[int]:
         return list(self.__shards.keys())
 
+    @property
+    def num_shards(self) -> int:
+        return len(self.__shards)
+
     def any_host(self, fn: Callable[[Client], T]) -> Future[T]:
         with ThreadPoolExecutor() as executor:
             host = next(iter(self.__hosts))

--- a/posthog/clickhouse/test/test_raw_sessions_v3_model.py
+++ b/posthog/clickhouse/test/test_raw_sessions_v3_model.py
@@ -327,12 +327,18 @@ class TestRawSessionsModel(ClickhouseTestMixin, BaseTest):
 
         # just test that the backfill SQL can be run without error
         sync_execute(
-            RAW_SESSION_TABLE_BACKFILL_SQL_V3("team_id = %(team_id)s AND timestamp >= '2024-03-01'"),
+            RAW_SESSION_TABLE_BACKFILL_SQL_V3(
+                where="team_id = %(team_id)s AND timestamp >= '2024-03-01'",
+                shard_index=0,
+                num_shards=1,
+            ),
             {"team_id": self.team.id},
         )
         sync_execute(
             RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(
-                "team_id = %(team_id)s AND min_first_timestamp >= '2024-03-01'"
+                where="team_id = %(team_id)s AND min_first_timestamp >= '2024-03-01'",
+                shard_index=0,
+                num_shards=1,
             ),
             {"team_id": self.team.id},
         )

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -559,7 +559,6 @@ def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(where: str, shard_index: int, n
     Each shard should call this with its own shard_index to only SELECT recordings
     that will end up on that shard, then INSERT directly to the local sharded table.
     """
-    # Use %% to escape the modulo operator since clickhouse-driver uses % for param substitution
     shard_filter = f"cityHash64(toUInt128(accurateCast(session_id, 'UUID'))) %% {num_shards} = {shard_index}"
     combined_where = f"({where}) AND {shard_filter}"
 

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -529,34 +529,49 @@ AS
     )
 
 
-def RAW_SESSION_TABLE_BACKFILL_SQL_V3(where="TRUE", use_sharded_source=True):
+def RAW_SESSION_TABLE_BACKFILL_SQL_V3(where: str, shard_index: int, num_shards: int):
+    """
+    Generates SQL to backfill sessions from events.
+
+    Each shard should call this with its own shard_index to only SELECT events
+    that will end up on that shard, then INSERT directly to the local sharded table.
+    """
+    shard_filter = f"cityHash64(`$session_id_uuid`) %% {num_shards} = {shard_index}"
+    combined_where = f"({where}) AND {shard_filter}"
+
     return """
-INSERT INTO {database}.{writable_table}
+INSERT INTO {database}.{target_table}
 {select_sql}
 """.format(
         database=settings.CLICKHOUSE_DATABASE,
-        writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
+        target_table=SHARDED_RAW_SESSIONS_TABLE_V3(),
         select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL_V3(
-            where=where,
-            source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_events"
-            if use_sharded_source
-            else f"{settings.CLICKHOUSE_DATABASE}.events",
+            where=combined_where,
+            source_table=f"{settings.CLICKHOUSE_DATABASE}.events",
         ),
     )
 
 
-def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(where="TRUE", use_sharded_source=True):
+def RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3(where: str, shard_index: int, num_shards: int):
+    """
+    Generates SQL to backfill sessions from session replay events.
+
+    Each shard should call this with its own shard_index to only SELECT recordings
+    that will end up on that shard, then INSERT directly to the local sharded table.
+    """
+    # Use %% to escape the modulo operator since clickhouse-driver uses % for param substitution
+    shard_filter = f"cityHash64(toUInt128(accurateCast(session_id, 'UUID'))) %% {num_shards} = {shard_index}"
+    combined_where = f"({where}) AND {shard_filter}"
+
     return """
-INSERT INTO {database}.{writable_table}
+INSERT INTO {database}.{target_table}
 {select_sql}
 """.format(
         database=settings.CLICKHOUSE_DATABASE,
-        writable_table=WRITABLE_RAW_SESSIONS_TABLE_V3(),
+        target_table=SHARDED_RAW_SESSIONS_TABLE_V3(),
         select_sql=RAW_SESSION_TABLE_MV_RECORDINGS_SELECT_SQL_V3(
-            where=where,
-            source_table=f"{settings.CLICKHOUSE_DATABASE}.sharded_session_replay_events"
-            if use_sharded_source
-            else f"{settings.CLICKHOUSE_DATABASE}.session_replay_events",
+            where=combined_where,
+            source_table=f"{settings.CLICKHOUSE_DATABASE}.session_replay_events",
         ),
     )
 


### PR DESCRIPTION
## Problem
The previous backfill wrote from sharded -> distributed tables. This overloaded the distribution queue, see https://posthog.slack.com/archives/C076R4753Q8/p1765649291151049

## Changes

Changes this to write from distributed -> sharded. (We can't do sharded -> sharded as the sharding keys between the tables are different

## How did you test this code?

Ran this manually in local dev dagster

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
