### PR TITLE
fix: Fix fetchGroupsByKeys query performance

### DIFF
--- a/plugin-server/src/worker/ingestion/groups/repositories/postgres-dualwrite-group-repository-2pc.test.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/postgres-dualwrite-group-repository-2pc.test.ts
@@ -1446,7 +1446,12 @@ describe('PostgresDualWriteGroupRepository 2PC Dual-Write Tests', () => {
 
         it('should return empty array for empty inputs', async () => {
             expect(await repository.fetchGroupsByKeys([], [], [])).toEqual([])
-            expect(await repository.fetchGroupsByKeys([teamId], [], [])).toEqual([])
+        })
+
+        it('should throw error for mismatched array lengths', async () => {
+            await expect(repository.fetchGroupsByKeys([teamId], [], [])).rejects.toThrow(
+                'fetchGroupsByKeys: array lengths must match'
+            )
         })
 
         it('should fetch from primary repository only', async () => {

--- a/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository.integration.test.ts
+++ b/plugin-server/src/worker/ingestion/groups/repositories/postgres-group-repository.integration.test.ts
@@ -1796,9 +1796,21 @@ describe('PostgresGroupRepository Integration', () => {
 
         it('should return empty array for empty inputs', async () => {
             expect(await repository.fetchGroupsByKeys([], [], [])).toEqual([])
-            expect(await repository.fetchGroupsByKeys([teamId], [], [])).toEqual([])
-            expect(await repository.fetchGroupsByKeys([], [0 as GroupTypeIndex], [])).toEqual([])
-            expect(await repository.fetchGroupsByKeys([], [], ['key1'])).toEqual([])
+        })
+
+        it('should throw error for mismatched array lengths', async () => {
+            await expect(repository.fetchGroupsByKeys([teamId], [], [])).rejects.toThrow(
+                'fetchGroupsByKeys: array lengths must match'
+            )
+            await expect(repository.fetchGroupsByKeys([], [0 as GroupTypeIndex], [])).rejects.toThrow(
+                'fetchGroupsByKeys: array lengths must match'
+            )
+            await expect(repository.fetchGroupsByKeys([], [], ['key1'])).rejects.toThrow(
+                'fetchGroupsByKeys: array lengths must match'
+            )
+            await expect(
+                repository.fetchGroupsByKeys([teamId, teamId], [0 as GroupTypeIndex], ['key1'])
+            ).rejects.toThrow('fetchGroupsByKeys: array lengths must match')
         })
 
         it('should fetch single group by keys', async () => {


### PR DESCRIPTION
## Problem

The `fetchGroupsByKeys` query uses three separate `ANY()` clauses which matches all combinations of values instead of specific tuples. When fetching N groups, the query searches N³ combinations instead of N rows, causing CPU spikes at high cardinality.

## Changes

- Changed query to use JOIN unnest() for proper tuple matching
- Added validation that input arrays must have equal lengths
- Updated tests to reflect new behavior

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
