### PR TITLE
fix(llma): Use Anthropic token counting for Claude models via any provider

### DIFF
--- a/plugin-server/src/ingestion/ai-costs/input-costs.test.ts
+++ b/plugin-server/src/ingestion/ai-costs/input-costs.test.ts
@@ -530,5 +530,64 @@ describe('calculateInputCost()', () => {
             // Total: 0.00375
             expectCostToBeCloseTo(result, 0.00375)
         })
+
+        it('matches Anthropic path for Claude models via Vertex provider', () => {
+            // This tests the fix for negative costs when Claude models are accessed via Vertex
+            // Vertex reports inputTokens excluding cache tokens (like Anthropic), not including them
+            const event = createTestEvent({
+                properties: {
+                    $ai_provider: 'vertex',
+                    $ai_model: 'claude-haiku-4-5',
+                    $ai_input_tokens: 457,
+                    $ai_cache_read_input_tokens: 36216,
+                },
+            })
+
+            const result = calculateInputCost(event, ANTHROPIC_MODEL)
+
+            // Should use Anthropic path because model starts with "claude"
+            // Read: 36216 * 3e-7 = 0.0108648
+            // Regular: 457 * 0.000003 = 0.001371
+            // Total: 0.0122358
+            expectCostToBeCloseTo(result, 0.0122358, 5)
+        })
+
+        it('matches Anthropic path for Claude models via Google provider', () => {
+            const event = createTestEvent({
+                properties: {
+                    $ai_provider: 'google',
+                    $ai_model: 'claude-3-5-sonnet',
+                    $ai_input_tokens: 1000,
+                    $ai_cache_read_input_tokens: 500,
+                },
+            })
+
+            const result = calculateInputCost(event, ANTHROPIC_MODEL)
+
+            // Should use Anthropic path because model starts with "claude"
+            // Read: 500 * 3e-7 = 0.00015
+            // Regular: 1000 * 0.000003 = 0.003
+            // Total: 0.00315
+            expectCostToBeCloseTo(result, 0.00315)
+        })
+
+        it('matches Anthropic path for Claude models with uppercase via non-Anthropic provider', () => {
+            const event = createTestEvent({
+                properties: {
+                    $ai_provider: 'bedrock',
+                    $ai_model: 'Claude-3-Opus',
+                    $ai_input_tokens: 1000,
+                    $ai_cache_read_input_tokens: 400,
+                },
+            })
+
+            const result = calculateInputCost(event, ANTHROPIC_MODEL)
+
+            // Should use Anthropic path (case-insensitive model check)
+            // Read: 400 * 3e-7 = 0.00012
+            // Regular: 1000 * 0.000003 = 0.003
+            // Total: 0.00312
+            expectCostToBeCloseTo(result, 0.00312)
+        })
     })
 })

--- a/plugin-server/src/ingestion/ai-costs/input-costs.ts
+++ b/plugin-server/src/ingestion/ai-costs/input-costs.ts
@@ -12,8 +12,18 @@ const matchProvider = (event: PluginEvent, provider: string): boolean => {
 
     const { $ai_provider: eventProvider, $ai_model: eventModel } = event.properties
     const normalizedProvider = provider.toLowerCase()
+    const normalizedModel = eventModel?.toLowerCase()
 
-    return eventProvider?.toLowerCase() === normalizedProvider || eventModel?.toLowerCase().includes(normalizedProvider)
+    if (eventProvider?.toLowerCase() === normalizedProvider || normalizedModel?.includes(normalizedProvider)) {
+        return true
+    }
+
+    // Claude models use Anthropic-style token counting regardless of provider (e.g., via Vertex)
+    if (normalizedProvider === 'anthropic' && normalizedModel?.startsWith('claude')) {
+        return true
+    }
+
+    return false
 }
 
 export const calculateInputCost = (event: PluginEvent, cost: ResolvedModelCost): string => {


### PR DESCRIPTION
## Problem

Claude models accessed via non-Anthropic providers (Vertex, Bedrock, Google) were producing negative cost calculations. This happened because:

1. Anthropic-style token counting excludes cache tokens from `$ai_input_tokens`
2. The cost calculation logic only used the Anthropic path when `$ai_provider` was "anthropic" or the model string contained "anthropic"
3. For Claude via Vertex, provider is "vertex" and model is "claude-haiku-4-5", so it fell into the default path
4. The default path subtracts cache tokens from input tokens: `457 - 36216 = -35759` (negative)

## Changes

Added a check in `matchProvider()` to recognize Claude models by name prefix (`claude`) and route them through the Anthropic token counting logic regardless of the reported provider.

## How did you test this code?

Added 3 test cases covering:
- Claude models via Vertex provider
- Claude models via Google provider  
- Claude models with uppercase naming via non-Anthropic providers

All 32 tests pass.