### PR TITLE
feat(gateway): build and deploy workflow

### DIFF
--- a/.github/workflows/llm-gateway-cd.yml
+++ b/.github/workflows/llm-gateway-cd.yml
@@ -1,6 +1,7 @@
 name: LLM Gateway CD
 
 on:
+    workflow_dispatch:
     push:
         branches:
             - master
@@ -79,11 +80,12 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ github.sha }}@${{ needs.build.outputs.sha }}"
+                            "sha": "${{ needs.build.outputs.sha }}"
                           }
                         },
                         "release": "llm-gateway",
                         "commit": ${{ toJson(github.event.head_commit) }},
                         "repository": ${{ toJson(github.repository) }},
+                        "labels": [],
                         "timestamp": "${{ github.event.head_commit.timestamp }}"
                       }

--- a/.github/workflows/llm-gateway-cd.yml
+++ b/.github/workflows/llm-gateway-cd.yml
@@ -60,6 +60,7 @@ jobs:
     deploy:
         runs-on: ubuntu-24.04
         needs: build
+        permissions: {}
         steps:
             - name: get deployer token
               id: deployer
@@ -78,7 +79,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ needs.build.outputs.sha }}"
+                            "sha": "${{ github.sha }}@${{ needs.build.outputs.sha }}"
                           }
                         },
                         "release": "llm-gateway",

--- a/.github/workflows/llm-gateway-cd.yml
+++ b/.github/workflows/llm-gateway-cd.yml
@@ -1,0 +1,88 @@
+name: LLM Gateway CD
+
+on:
+    push:
+        branches:
+            - master
+        paths:
+            - 'services/llm-gateway/**'
+            - '.github/workflows/llm-gateway-cd.yml'
+
+jobs:
+    build:
+        runs-on: depot-ubuntu-latest
+
+        permissions:
+            contents: read
+            packages: write
+            id-token: write
+
+        outputs:
+            sha: ${{ steps.push.outputs.digest }}
+
+        steps:
+            - name: Check out llm-gateway code
+              uses: actions/checkout@v4
+              with:
+                  sparse-checkout: 'services/llm-gateway/'
+                  sparse-checkout-cone-mode: false
+
+            - name: Log in to the Container registry
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+                  logout: false
+
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
+              with:
+                  images: ghcr.io/posthog/posthog/llm-gateway
+
+            - name: Set up Depot CLI
+              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
+
+            - name: Build and push Docker image
+              id: push
+              if: github.ref == 'refs/heads/master'
+              uses: depot/build-push-action@2583627a84956d07561420dcc1d0eb1f2af3fac0 # v1
+              with:
+                  context: ./services/llm-gateway/
+                  file: services/llm-gateway/Dockerfile
+                  push: true
+                  platforms: linux/amd64,linux/arm64
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  project: 90mkjhdrjz # llm-gateway depot project
+
+    deploy:
+        runs-on: ubuntu-24.04
+        needs: build
+        steps:
+            - name: get deployer token
+              id: deployer
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
+              with:
+                  app_id: ${{ secrets.GH_APP_CHARTS_DEPLOYER_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_CHARTS_DEPLOYER_PRIVATE_KEY }}
+
+            - name: Trigger llm-gateway deployment
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repository: PostHog/charts
+                  event-type: commit_state_update
+                  client-payload: |
+                      {
+                        "values": {
+                          "image": {
+                            "sha": "${{ needs.build.outputs.sha }}"
+                          }
+                        },
+                        "release": "llm-gateway",
+                        "commit": ${{ toJson(github.event.head_commit) }},
+                        "repository": ${{ toJson(github.repository) }},
+                        "timestamp": "${{ github.event.head_commit.timestamp }}"
+                      }


### PR DESCRIPTION
## Problem

We want to deploy the llm gateway service on changes.

## Changes

Adds a workflow for building the docker image for the gateway service and then pushing an update to `state.yml` in the charts repo. We don't have anything defined for the gateway in charts yet, so this shouldn't do anything other than updating the state file.
