### PR TITLE
fix(ph-ai): fix conversation autoscroll

### DIFF
--- a/frontend/src/scenes/max/components/ThreadAutoScroller.tsx
+++ b/frontend/src/scenes/max/components/ThreadAutoScroller.tsx
@@ -102,7 +102,19 @@ export function ThreadAutoScroller({ children }: { children: React.ReactNode }):
         }
     }, [streamingActive, scrollToBottom])
 
+    const prevStreamingActive = useRef(streamingActive)
     useEffect(() => {
+        // Scroll to bottom when streaming ends (final scroll after all content is rendered)
+        if (prevStreamingActive.current && !streamingActive && !scrollOrigin.current.user) {
+            // Wait for browser paint cycle to ensure DOM is fully updated
+            const rafId = requestAnimationFrame(() => {
+                scrollToBottom()
+            })
+            prevStreamingActive.current = streamingActive
+            return () => cancelAnimationFrame(rafId)
+        }
+        prevStreamingActive.current = streamingActive
+
         if (!streamingActive || scrollOrigin.current.user) {
             return
         }

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -498,12 +498,17 @@ export function getScrollableContainer(element?: Element | null): HTMLElement | 
     if (!element) {
         return null
     }
-    const scrollableEl = element.parentElement // .Navigation3000__scene or .SidePanel3000__content
-    if (scrollableEl && !scrollableEl.classList.contains('SidePanel3000__content')) {
-        // In this case we need to go up to <main>, since .Navigation3000__scene is not scrollable
-        return scrollableEl.parentElement
+    let current = element.parentElement
+    while (current) {
+        if (current.classList.contains('SidePanel3000__content')) {
+            return current
+        }
+        if (current.tagName === 'MAIN') {
+            return current
+        }
+        current = current.parentElement
     }
-    return scrollableEl
+    return null
 }
 
 export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [


### PR DESCRIPTION
## Problem
PostHog AI's conversation thread doesn't autoscroll when in full screen mode. In sidebar mode, sometimes it scrolls but not to reach the bottom of the div.

## Changes
- Fixed `getScrollableContainer` in `maxLogic.tsx` to correctly identify the parent container.
- Updated `ThreadAutoScroller` to always scroll to bottom when the streaming ends

## How did you test this code?
Locally
