### PR TITLE
fix(ph-ai): ff and experiment suggestions should be page specific

### DIFF
--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -587,6 +587,7 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
     {
         label: 'Feature flags',
         icon: iconForType('feature_flag'),
+        url: urls.featureFlags(),
         suggestions: [
             {
                 content: 'Create a flag to gradually roll out…',
@@ -605,6 +606,7 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
     {
         label: 'Experiments',
         icon: iconForType('experiment'),
+        url: urls.experiments(),
         suggestions: [
             {
                 content: 'Create an experiment to test…',


### PR DESCRIPTION
## Problem
Feature flags and experiments suggestions should redirect to the product pages, since `MaxTool`s currently only work there.

## Changes
Add urls to the suggestions definitions so that the user is sent to those pages before submitting an answer, so that the contextual tools are loaded.

## How did you test this code?
Locally
