### PR TITLE
fix: update script error matching rule

### DIFF
--- a/frontend/src/lib/components/Errors/Exception/known-exceptions/javascript/script-error.tsx
+++ b/frontend/src/lib/components/Errors/Exception/known-exceptions/javascript/script-error.tsx
@@ -5,7 +5,7 @@ import { KnownExceptionBanner } from './base'
 
 defineKnownException({
     match(exception) {
-        return exception.value === 'Script error' && exception.type === 'Error'
+        return exception.value.startsWith('Script error') && exception.type === 'Error'
     },
     render() {
         return (


### PR DESCRIPTION
## Changes

- fix script error matching rule ("Script error." instead of "Script error")

Related to https://posthoghelp.zendesk.com/agent/tickets/45205 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46806)