### PR TITLE
chore(replay): Disable full video export limit for staff

### DIFF
--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -118,7 +118,10 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 created_at__gte=start_of_month,
             ).count()
 
-            if existing_full_video_exports_count >= FULL_VIDEO_EXPORTS_LIMIT_PER_TEAM:
+            if (
+                not self.context["request"].user.is_staff
+                and existing_full_video_exports_count >= FULL_VIDEO_EXPORTS_LIMIT_PER_TEAM
+            ):
                 raise ValidationError(
                     {
                         "export_limit_exceeded": [


### PR DESCRIPTION
## Problem

I'm exporting videos of sessions for experiments with LLM-based segmentation, but there's a limit of 10 per MONTH.

## Changes

That's a low limit for our users too, but currently just disabling it for staff (i.e. _theoretically_ responsible users).

Would also love enjoy exporting WEBMs rather than MP4s, but that's a minor thing, that I'm skipping here.
