### PR TITLE
feat(kafka-deduplicator): Add partition worker architecture for parallel processing

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
+            - 'jose-sequeira/paralelize-partitions-kafka-dedup'
 
 jobs:
     build:

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,7 +8,6 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
-            - 'jose-sequeira/paralelize-partitions-kafka-dedup'
 
 jobs:
     build:

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -121,6 +121,10 @@ pub struct Config {
     #[envconfig(default = "102400")] // 100MB max bytes to prefetch (value is in KB)
     pub kafka_consumer_queued_max_messages_kbytes: u32,
 
+    // Partition worker channel buffer size for pipeline parallelism
+    #[envconfig(default = "10")]
+    pub partition_worker_channel_buffer_size: usize,
+
     #[envconfig(default = "120")] // 120 seconds (2 minutes)
     pub flush_interval_secs: u64,
 

--- a/rust/kafka-deduplicator/src/deduplication_batch_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_batch_processor.rs
@@ -106,7 +106,10 @@ impl DuplicateEventProducerWrapper {
                     .with_label("status", "failure")
                     .increment(1);
 
-                error!("Failed to publish duplicate event to topic {}: {}", topic, e);
+                error!(
+                    "Failed to publish duplicate event to topic {}: {}",
+                    topic, e
+                );
                 Ok(())
             }
         }
@@ -260,15 +263,17 @@ impl BatchDeduplicationProcessor {
                     if let Some(original_event) = result.get_original_event() {
                         let duplicate_event = DuplicateEvent::from_result(original_event, result);
                         if let Some(event) = duplicate_event {
-                            duplicate_event_futures.push(DuplicateEventProducerWrapper::send_static(
-                                duplicate_producer.producer.clone(),
-                                duplicate_producer.topic.clone(),
-                                event,
-                                key.clone(),
-                                self.config.producer_send_timeout,
-                                partition.topic().to_string(),
-                                partition.partition_number(),
-                            ));
+                            duplicate_event_futures.push(
+                                DuplicateEventProducerWrapper::send_static(
+                                    duplicate_producer.producer.clone(),
+                                    duplicate_producer.topic.clone(),
+                                    event,
+                                    key.clone(),
+                                    self.config.producer_send_timeout,
+                                    partition.topic().to_string(),
+                                    partition.partition_number(),
+                                ),
+                            );
                         }
                     }
                 }
@@ -629,9 +634,7 @@ impl BatchDeduplicationProcessor {
         output_topic: String,
         timeout: Duration,
     ) -> Result<()> {
-        let mut record = FutureRecord::to(&output_topic)
-            .key(&key)
-            .payload(&payload);
+        let mut record = FutureRecord::to(&output_topic).key(&key).payload(&payload);
 
         if let Some(ref h) = headers {
             record = record.headers(h.clone());

--- a/rust/kafka-deduplicator/src/deduplication_batch_processor.rs
+++ b/rust/kafka-deduplicator/src/deduplication_batch_processor.rs
@@ -318,8 +318,8 @@ impl BatchDeduplicationProcessor {
         metrics::histogram!(PARTITION_BATCH_PROCESSING_DURATION_MS)
             .record(batch_duration.as_millis() as f64);
 
-        // Warn on slow partition batches (> 2 seconds indicates potential issues)
-        if batch_duration.as_secs() > 2 {
+        // Warn on slow partition batches (>= 2 seconds indicates potential issues)
+        if batch_duration >= Duration::from_secs(2) {
             warn!(
                 topic = partition.topic(),
                 partition = partition.partition_number(),

--- a/rust/kafka-deduplicator/src/kafka/batch_message.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_message.rs
@@ -229,6 +229,20 @@ impl<T> KafkaMessage<T> {
     pub fn take_message(&mut self) -> Option<T> {
         self.message.take()
     }
+
+    /// Create a simple KafkaMessage for testing purposes
+    #[cfg(test)]
+    pub fn new_for_test(partition: Partition, offset: i64, message: T) -> Self {
+        Self {
+            topic_partition: partition,
+            offset,
+            key: None,
+            message: Some(message),
+            timestamp: SystemTime::now(),
+            original_headers: None,
+            original_payload: None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
+++ b/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
@@ -55,3 +55,12 @@ pub const BATCH_CONSUMER_BATCH_SIZE: &str = "kafka_batch_consumer_batch_size";
 pub const BATCH_CONSUMER_KAFKA_ERROR: &str = "kafka_batch_consumer_kafka_error";
 
 pub const BATCH_CONSUMER_MESSAGE_ERROR: &str = "kafka_batch_consumer_message_error";
+
+/// Histogram for batch fill ratio (actual batch size / max batch size)
+/// Values range from 0.0 to 1.0, where 1.0 means batch was full
+pub const BATCH_CONSUMER_BATCH_FILL_RATIO: &str = "kafka_batch_consumer_batch_fill_ratio";
+
+/// Histogram for time spent collecting a batch (in milliseconds)
+/// Measures latency from start of batch collection to batch ready for processing
+pub const BATCH_CONSUMER_BATCH_COLLECTION_DURATION_MS: &str =
+    "kafka_batch_consumer_batch_collection_duration_ms";

--- a/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
+++ b/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
@@ -64,3 +64,12 @@ pub const BATCH_CONSUMER_BATCH_FILL_RATIO: &str = "kafka_batch_consumer_batch_fi
 /// Measures latency from start of batch collection to batch ready for processing
 pub const BATCH_CONSUMER_BATCH_COLLECTION_DURATION_MS: &str =
     "kafka_batch_consumer_batch_collection_duration_ms";
+
+// ==== Partition Worker metrics ====
+/// Counter for partition worker channel backpressure events
+/// Incremented when route_batch has to wait because the worker channel is full
+pub const PARTITION_WORKER_BACKPRESSURE_TOTAL: &str = "kafka_partition_worker_backpressure_total";
+
+/// Histogram for time spent waiting due to partition worker backpressure (in milliseconds)
+pub const PARTITION_WORKER_BACKPRESSURE_WAIT_MS: &str =
+    "kafka_partition_worker_backpressure_wait_ms";

--- a/rust/kafka-deduplicator/src/kafka/mod.rs
+++ b/rust/kafka-deduplicator/src/kafka/mod.rs
@@ -4,7 +4,10 @@ pub mod batch_context;
 pub mod batch_message;
 pub mod config;
 pub mod metrics_consts;
+pub mod partition_router;
+pub mod partition_worker;
 pub mod rebalance_handler;
+pub mod routing_processor;
 pub mod types;
 
 // Used in "mod tests" and tests/ directory (integration tests)
@@ -12,4 +15,7 @@ pub mod test_utils;
 
 // Public API
 pub use config::ConsumerConfigBuilder;
+pub use partition_router::{PartitionRouter, PartitionRouterConfig};
+pub use partition_worker::{PartitionBatch, PartitionWorker, PartitionWorkerConfig};
 pub use rebalance_handler::RebalanceHandler;
+pub use routing_processor::RoutingProcessor;

--- a/rust/kafka-deduplicator/src/kafka/partition_router.rs
+++ b/rust/kafka-deduplicator/src/kafka/partition_router.rs
@@ -1,0 +1,329 @@
+//! Partition Router - Routes messages to partition-specific workers
+//!
+//! The router manages a collection of partition workers. Workers are created
+//! synchronously during partition assignment (rebalance) and removed during
+//! partition revocation. Message routing only sends to existing workers.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use dashmap::DashMap;
+use tracing::{info, warn};
+
+use crate::kafka::batch_consumer::BatchConsumerProcessor;
+use crate::kafka::batch_message::KafkaMessage;
+use crate::kafka::partition_worker::{PartitionBatch, PartitionWorker, PartitionWorkerConfig};
+use crate::kafka::types::Partition;
+
+/// Configuration for the partition router
+#[derive(Debug, Clone, Default)]
+pub struct PartitionRouterConfig {
+    /// Configuration for individual partition workers
+    pub worker_config: PartitionWorkerConfig,
+}
+
+/// Routes messages to partition-specific workers
+///
+/// Workers must be created via `add_partition` before messages can be routed.
+/// This ensures workers are created synchronously during rebalance.
+pub struct PartitionRouter<T, P>
+where
+    T: Send + 'static,
+    P: BatchConsumerProcessor<T> + 'static,
+{
+    workers: DashMap<Partition, PartitionWorker<T>>,
+    processor: Arc<P>,
+    config: PartitionRouterConfig,
+}
+
+impl<T, P> PartitionRouter<T, P>
+where
+    T: Send + 'static,
+    P: BatchConsumerProcessor<T> + 'static,
+{
+    /// Create a new partition router
+    pub fn new(processor: Arc<P>, config: PartitionRouterConfig) -> Self {
+        Self {
+            workers: DashMap::new(),
+            processor,
+            config,
+        }
+    }
+
+    /// Add a worker for a partition (called during partition assignment)
+    ///
+    /// This should be called synchronously during `on_partitions_assigned`.
+    /// If a worker already exists for this partition, it will be replaced.
+    pub fn add_partition(&self, partition: Partition) {
+        if self.workers.contains_key(&partition) {
+            warn!(
+                "Worker already exists for {}:{}, replacing",
+                partition.topic(),
+                partition.partition_number()
+            );
+        }
+
+        info!(
+            "Creating partition worker for {}:{}",
+            partition.topic(),
+            partition.partition_number()
+        );
+
+        let worker = PartitionWorker::new(
+            partition.clone(),
+            self.processor.clone(),
+            &self.config.worker_config,
+        );
+        self.workers.insert(partition, worker);
+    }
+
+    /// Add workers for multiple partitions
+    pub fn add_partitions(&self, partitions: &[Partition]) {
+        for partition in partitions {
+            self.add_partition(partition.clone());
+        }
+    }
+
+    /// Remove a worker for a partition (called during partition revocation)
+    ///
+    /// This should be called during `on_partitions_revoked`.
+    /// Returns the worker for async shutdown if it existed.
+    pub fn remove_partition(&self, partition: &Partition) -> Option<PartitionWorker<T>> {
+        let worker = self.workers.remove(partition).map(|(_, w)| w);
+
+        if worker.is_some() {
+            info!(
+                "Removed partition worker for {}:{}",
+                partition.topic(),
+                partition.partition_number()
+            );
+        }
+
+        worker
+    }
+
+    /// Remove workers for multiple partitions
+    /// Returns the workers for async shutdown
+    pub fn remove_partitions(&self, partitions: &[Partition]) -> Vec<PartitionWorker<T>> {
+        partitions
+            .iter()
+            .filter_map(|p| {
+                let worker = self.workers.remove(p).map(|(_, w)| w);
+                if worker.is_some() {
+                    info!(
+                        "Removed partition worker for {}:{}",
+                        p.topic(),
+                        p.partition_number()
+                    );
+                }
+                worker
+            })
+            .collect()
+    }
+
+    /// Route a batch of messages to the appropriate partition worker
+    ///
+    /// Returns an error if no worker exists for the partition.
+    pub async fn route_batch(
+        &self,
+        partition: Partition,
+        messages: Vec<KafkaMessage<T>>,
+    ) -> Result<()> {
+        let batch = PartitionBatch::new(partition.clone(), messages);
+
+        let worker_ref = self.workers.get(&partition).ok_or_else(|| {
+            anyhow!(
+                "No worker for partition {}:{} - was it assigned?",
+                partition.topic(),
+                partition.partition_number()
+            )
+        })?;
+
+        worker_ref.send(batch).await.map_err(|_| {
+            anyhow!(
+                "Failed to send batch to worker for {}:{}: channel closed",
+                partition.topic(),
+                partition.partition_number()
+            )
+        })
+    }
+
+    /// Route multiple batches organized by partition
+    /// This is more efficient when routing messages from a single Kafka poll
+    pub async fn route_batches(
+        &self,
+        batches: HashMap<Partition, Vec<KafkaMessage<T>>>,
+    ) -> Result<()> {
+        for (partition, messages) in batches {
+            self.route_batch(partition, messages).await?;
+        }
+        Ok(())
+    }
+
+    /// Get the number of active workers
+    pub fn worker_count(&self) -> usize {
+        self.workers.len()
+    }
+
+    /// Get a list of active partitions
+    pub fn active_partitions(&self) -> Vec<Partition> {
+        self.workers.iter().map(|r| r.key().clone()).collect()
+    }
+
+    /// Check if a partition has an active worker
+    pub fn has_partition(&self, partition: &Partition) -> bool {
+        self.workers.contains_key(partition)
+    }
+
+    /// Shutdown all workers and return them for async cleanup
+    pub fn shutdown_all(&self) -> Vec<PartitionWorker<T>> {
+        let count = self.workers.len();
+        info!("Shutting down partition router with {} workers", count);
+
+        // Collect keys first, then remove each worker
+        let keys: Vec<Partition> = self.workers.iter().map(|r| r.key().clone()).collect();
+        let mut workers = Vec::with_capacity(keys.len());
+        for key in keys {
+            if let Some((_, worker)) = self.workers.remove(&key) {
+                workers.push(worker);
+            }
+        }
+        workers
+    }
+}
+
+/// Helper function to shutdown workers asynchronously
+pub async fn shutdown_workers<T: Send + 'static>(workers: Vec<PartitionWorker<T>>) {
+    for worker in workers {
+        worker.shutdown().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct TestProcessor {
+        processed_count: AtomicUsize,
+    }
+
+    impl TestProcessor {
+        fn new() -> Self {
+            Self {
+                processed_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl BatchConsumerProcessor<String> for TestProcessor {
+        async fn process_batch(&self, messages: Vec<KafkaMessage<String>>) -> Result<()> {
+            self.processed_count
+                .fetch_add(messages.len(), Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_router_add_partition() {
+        let processor = Arc::new(TestProcessor::new());
+        let config = PartitionRouterConfig::default();
+        let router = PartitionRouter::new(processor, config);
+
+        assert_eq!(router.worker_count(), 0);
+
+        let partition = Partition::new("test-topic".to_string(), 0);
+        router.add_partition(partition.clone());
+
+        assert_eq!(router.worker_count(), 1);
+        assert!(router.has_partition(&partition));
+
+        let workers = router.shutdown_all();
+        shutdown_workers(workers).await;
+    }
+
+    #[tokio::test]
+    async fn test_router_route_requires_worker() {
+        let processor = Arc::new(TestProcessor::new());
+        let config = PartitionRouterConfig::default();
+        let router = PartitionRouter::new(processor, config);
+
+        let partition = Partition::new("test-topic".to_string(), 0);
+
+        // Should fail - no worker exists
+        let result = router.route_batch(partition.clone(), vec![]).await;
+        assert!(result.is_err());
+
+        // Add worker
+        router.add_partition(partition.clone());
+
+        // Should succeed now
+        let result = router.route_batch(partition, vec![]).await;
+        assert!(result.is_ok());
+
+        let workers = router.shutdown_all();
+        shutdown_workers(workers).await;
+    }
+
+    #[tokio::test]
+    async fn test_router_multiple_partitions() {
+        let processor = Arc::new(TestProcessor::new());
+        let config = PartitionRouterConfig::default();
+        let router = PartitionRouter::new(processor, config);
+
+        let partitions: Vec<Partition> = (0..5)
+            .map(|i| Partition::new("test-topic".to_string(), i))
+            .collect();
+
+        router.add_partitions(&partitions);
+        assert_eq!(router.worker_count(), 5);
+
+        let workers = router.shutdown_all();
+        shutdown_workers(workers).await;
+    }
+
+    #[tokio::test]
+    async fn test_router_remove_partition() {
+        let processor = Arc::new(TestProcessor::new());
+        let config = PartitionRouterConfig::default();
+        let router = PartitionRouter::new(processor, config);
+
+        let partition = Partition::new("test-topic".to_string(), 0);
+        router.add_partition(partition.clone());
+
+        assert_eq!(router.worker_count(), 1);
+
+        let worker = router.remove_partition(&partition);
+        assert!(worker.is_some());
+        assert_eq!(router.worker_count(), 0);
+
+        if let Some(w) = worker {
+            w.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_router_reuses_after_readd() {
+        let processor = Arc::new(TestProcessor::new());
+        let config = PartitionRouterConfig::default();
+        let router = PartitionRouter::new(processor, config);
+
+        let partition = Partition::new("test-topic".to_string(), 0);
+
+        // Add, remove, add again (simulating rebalance)
+        router.add_partition(partition.clone());
+        let worker = router.remove_partition(&partition);
+        if let Some(w) = worker {
+            w.shutdown().await;
+        }
+
+        router.add_partition(partition.clone());
+        assert_eq!(router.worker_count(), 1);
+
+        let workers = router.shutdown_all();
+        shutdown_workers(workers).await;
+    }
+}

--- a/rust/kafka-deduplicator/src/kafka/partition_worker.rs
+++ b/rust/kafka-deduplicator/src/kafka/partition_worker.rs
@@ -74,7 +74,7 @@ impl<T: Send + 'static> PartitionWorker<T> {
     }
 
     /// Send a batch to this worker for processing
-    /// Returns error if the channel is full (backpressure) or closed
+    /// Awaits until channel has capacity. Returns error only if channel is closed (receiver dropped)
     pub async fn send(
         &self,
         batch: PartitionBatch<T>,

--- a/rust/kafka-deduplicator/src/kafka/partition_worker.rs
+++ b/rust/kafka-deduplicator/src/kafka/partition_worker.rs
@@ -96,6 +96,14 @@ impl<T: Send + 'static> PartitionWorker<T> {
         self.sender.capacity() > 0
     }
 
+    /// Get a clone of the sender for use outside of DashMap guards
+    ///
+    /// This allows callers to release DashMap guards before awaiting on send operations,
+    /// preventing blocking of other DashMap operations during backpressure.
+    pub fn sender(&self) -> mpsc::Sender<PartitionBatch<T>> {
+        self.sender.clone()
+    }
+
     /// Get the current capacity of the channel
     pub fn capacity(&self) -> usize {
         self.sender.capacity()

--- a/rust/kafka-deduplicator/src/kafka/rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/kafka/rebalance_handler.rs
@@ -4,27 +4,65 @@ use rdkafka::TopicPartitionList;
 
 /// Trait for handling Kafka consumer rebalance events
 /// Users implement this to define their partition-specific logic
+///
+/// ## Method Pairs: Setup vs Cleanup
+///
+/// Each rebalance event has two phases:
+///
+/// **Setup methods** (`setup_*`) - Called synchronously within librdkafka callbacks.
+/// These MUST be fast and non-blocking. They run BEFORE messages can arrive/stop.
+/// - `setup_assigned_partitions`: Create workers before messages arrive
+/// - `setup_revoked_partitions`: Remove stores from map before revocation completes
+///
+/// **Cleanup methods** (`cleanup_*`) - Called asynchronously after callbacks return.
+/// These can be slow and do I/O. They run in the background.
+/// - `cleanup_assigned_partitions`: Post-assignment initialization (e.g., download checkpoints)
+/// - `cleanup_revoked_partitions`: Drain queues, delete files
 #[async_trait]
 pub trait RebalanceHandler: Send + Sync {
-    /// Called when partitions are assigned to this consumer
-    /// This happens after Kafka coordinator assigns partitions during rebalance
-    async fn on_partitions_assigned(&self, partitions: &TopicPartitionList) -> Result<()>;
+    // ============================================
+    // SETUP METHODS - Called within librdkafka callbacks
+    // MUST be fast and non-blocking
+    // ============================================
 
-    /// Called when partitions are revoked from this consumer  
-    /// This happens before Kafka coordinator revokes partitions during rebalance
-    async fn on_partitions_revoked(&self, partitions: &TopicPartitionList) -> Result<()>;
+    /// Called synchronously when partitions are assigned.
+    /// Runs WITHIN post_rebalance callback, BEFORE consumer stream resumes.
+    ///
+    /// Use for fast operations: creating workers, initializing maps.
+    /// Default implementation does nothing.
+    fn setup_assigned_partitions(&self, _partitions: &TopicPartitionList) {
+        // Default implementation does nothing
+    }
+
+    /// Called synchronously when partitions are revoked.
+    /// Runs WITHIN pre_rebalance callback, BEFORE revocation completes.
+    ///
+    /// Use for fast operations: removing stores from map, stopping new writes.
+    /// Default implementation does nothing.
+    fn setup_revoked_partitions(&self, _partitions: &TopicPartitionList) {
+        // Default implementation does nothing
+    }
+
+    // ============================================
+    // CLEANUP METHODS - Called after callbacks return
+    // For slow operations like I/O, draining queues, etc.
+    // ============================================
+
+    /// Called asynchronously after partition assignment.
+    /// Use for slow initialization: downloading checkpoints, warming caches.
+    async fn cleanup_assigned_partitions(&self, partitions: &TopicPartitionList) -> Result<()>;
+
+    /// Called asynchronously after partition revocation.
+    /// Use for slow cleanup: draining worker queues, uploading checkpoints, deleting files.
+    async fn cleanup_revoked_partitions(&self, partitions: &TopicPartitionList) -> Result<()>;
 
     /// Called before any rebalance operation begins
-    /// Use this for preparation work before partition changes
     async fn on_pre_rebalance(&self) -> Result<()> {
-        // Default implementation does nothing
         Ok(())
     }
 
     /// Called after rebalance operation completes
-    /// Use this for cleanup or post-rebalance initialization
     async fn on_post_rebalance(&self) -> Result<()> {
-        // Default implementation does nothing
         Ok(())
     }
 }
@@ -50,25 +88,32 @@ mod tests {
 
     #[async_trait]
     impl RebalanceHandler for TestRebalanceHandler {
-        async fn on_partitions_assigned(&self, partitions: &TopicPartitionList) -> Result<()> {
+        fn setup_assigned_partitions(&self, partitions: &TopicPartitionList) {
             self.assigned_count.fetch_add(1, Ordering::SeqCst);
 
             let mut assigned = self.assigned_partitions.lock().unwrap();
             for elem in partitions.elements() {
                 assigned.push(Partition::from(elem));
             }
-
-            Ok(())
         }
 
-        async fn on_partitions_revoked(&self, partitions: &TopicPartitionList) -> Result<()> {
+        fn setup_revoked_partitions(&self, partitions: &TopicPartitionList) {
             self.revoked_count.fetch_add(1, Ordering::SeqCst);
 
             let mut revoked = self.revoked_partitions.lock().unwrap();
             for elem in partitions.elements() {
                 revoked.push(Partition::from(elem));
             }
+        }
 
+        async fn cleanup_assigned_partitions(
+            &self,
+            _partitions: &TopicPartitionList,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn cleanup_revoked_partitions(&self, _partitions: &TopicPartitionList) -> Result<()> {
             Ok(())
         }
 
@@ -99,8 +144,8 @@ mod tests {
         let handler = TestRebalanceHandler::default();
         let partitions = create_test_partition_list();
 
-        // Test partition assignment
-        handler.on_partitions_assigned(&partitions).await.unwrap();
+        // Test partition assignment (sync setup)
+        handler.setup_assigned_partitions(&partitions);
 
         assert_eq!(handler.assigned_count.load(Ordering::SeqCst), 1);
         assert_eq!(handler.revoked_count.load(Ordering::SeqCst), 0);
@@ -117,8 +162,8 @@ mod tests {
         let handler = TestRebalanceHandler::default();
         let partitions = create_test_partition_list();
 
-        // Test partition revocation
-        handler.on_partitions_revoked(&partitions).await.unwrap();
+        // Test partition revocation (sync setup)
+        handler.setup_revoked_partitions(&partitions);
 
         assert_eq!(handler.assigned_count.load(Ordering::SeqCst), 0);
         assert_eq!(handler.revoked_count.load(Ordering::SeqCst), 1);
@@ -147,11 +192,25 @@ mod tests {
         let handler = Arc::new(TestRebalanceHandler::default());
         let partitions = create_test_partition_list();
 
-        // Simulate full rebalance flow
+        // Simulate full rebalance flow:
+        // 1. Pre-rebalance (async, but runs first)
         handler.on_pre_rebalance().await.unwrap();
-        handler.on_partitions_revoked(&partitions).await.unwrap();
-        handler.on_partitions_assigned(&partitions).await.unwrap();
+        // 2. Revoke setup (sync, within callback)
+        handler.setup_revoked_partitions(&partitions);
+        // 3. Assign setup (sync, within callback)
+        handler.setup_assigned_partitions(&partitions);
+        // 4. Post-rebalance (async)
         handler.on_post_rebalance().await.unwrap();
+        // 5. Revoke cleanup (async, in background)
+        handler
+            .cleanup_revoked_partitions(&partitions)
+            .await
+            .unwrap();
+        // 6. Assign cleanup (async, in background)
+        handler
+            .cleanup_assigned_partitions(&partitions)
+            .await
+            .unwrap();
 
         assert_eq!(handler.pre_rebalance_count.load(Ordering::SeqCst), 1);
         assert_eq!(handler.revoked_count.load(Ordering::SeqCst), 1);

--- a/rust/kafka-deduplicator/src/kafka/routing_processor.rs
+++ b/rust/kafka-deduplicator/src/kafka/routing_processor.rs
@@ -1,0 +1,189 @@
+//! Routing Processor - Routes messages to partition workers via channels
+//!
+//! This processor groups incoming messages by partition and routes them
+//! to dedicated partition workers, enabling true parallel processing with
+//! pipelining between consumption and processing.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::async_trait;
+use tracing::warn;
+
+use crate::kafka::batch_consumer::BatchConsumerProcessor;
+use crate::kafka::batch_message::KafkaMessage;
+use crate::kafka::partition_router::PartitionRouter;
+use crate::kafka::types::Partition;
+
+/// A processor that routes messages to partition-specific workers
+///
+/// This implements `BatchConsumerProcessor` so it can be used with the existing
+/// `BatchConsumer`. Instead of processing messages directly, it groups them by
+/// partition and sends them to dedicated workers via channels.
+pub struct RoutingProcessor<T, P>
+where
+    T: Send + 'static,
+    P: BatchConsumerProcessor<T> + 'static,
+{
+    router: Arc<PartitionRouter<T, P>>,
+}
+
+impl<T, P> RoutingProcessor<T, P>
+where
+    T: Send + 'static,
+    P: BatchConsumerProcessor<T> + 'static,
+{
+    pub fn new(router: Arc<PartitionRouter<T, P>>) -> Self {
+        Self { router }
+    }
+
+    /// Get a reference to the underlying router
+    pub fn router(&self) -> &Arc<PartitionRouter<T, P>> {
+        &self.router
+    }
+}
+
+#[async_trait]
+impl<T, P> BatchConsumerProcessor<T> for RoutingProcessor<T, P>
+where
+    T: Send + Sync + 'static,
+    P: BatchConsumerProcessor<T> + 'static,
+{
+    async fn process_batch(&self, messages: Vec<KafkaMessage<T>>) -> Result<()> {
+        if messages.is_empty() {
+            return Ok(());
+        }
+
+        // Group messages by partition
+        let mut messages_by_partition: HashMap<Partition, Vec<KafkaMessage<T>>> = HashMap::new();
+        for message in messages {
+            let partition = message.get_topic_partition();
+            messages_by_partition
+                .entry(partition)
+                .or_default()
+                .push(message);
+        }
+
+        // Route each partition's messages to its worker
+        for (partition, partition_messages) in messages_by_partition {
+            if let Err(e) = self
+                .router
+                .route_batch(partition.clone(), partition_messages)
+                .await
+            {
+                // Log but don't fail the batch - the worker may have been removed during rebalance
+                warn!(
+                    "Failed to route batch to partition {}:{}: {}",
+                    partition.topic(),
+                    partition.partition_number(),
+                    e
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kafka::partition_router::shutdown_workers;
+    use crate::kafka::partition_router::PartitionRouterConfig;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::time::{sleep, Duration};
+
+    struct CountingProcessor {
+        count: AtomicUsize,
+    }
+
+    impl CountingProcessor {
+        fn new() -> Self {
+            Self {
+                count: AtomicUsize::new(0),
+            }
+        }
+
+        fn get_count(&self) -> usize {
+            self.count.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl BatchConsumerProcessor<String> for CountingProcessor {
+        async fn process_batch(&self, messages: Vec<KafkaMessage<String>>) -> Result<()> {
+            self.count.fetch_add(messages.len(), Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_routing_processor_groups_by_partition() {
+        let processor = Arc::new(CountingProcessor::new());
+        let config = PartitionRouterConfig::default();
+        let router = Arc::new(PartitionRouter::new(processor.clone(), config));
+
+        // Add workers for two partitions
+        let p0 = Partition::new("test-topic".to_string(), 0);
+        let p1 = Partition::new("test-topic".to_string(), 1);
+        router.add_partition(p0.clone());
+        router.add_partition(p1.clone());
+
+        let routing_processor = RoutingProcessor::new(router.clone());
+
+        // Create messages for different partitions
+        let messages = vec![
+            KafkaMessage::new_for_test(p0.clone(), 0, "msg1".to_string()),
+            KafkaMessage::new_for_test(p0.clone(), 1, "msg2".to_string()),
+            KafkaMessage::new_for_test(p1.clone(), 0, "msg3".to_string()),
+        ];
+
+        // Route the batch
+        routing_processor.process_batch(messages).await.unwrap();
+
+        // Give workers time to process
+        sleep(Duration::from_millis(50)).await;
+
+        // All 3 messages should have been processed
+        assert_eq!(processor.get_count(), 3);
+
+        // Cleanup
+        let workers = router.shutdown_all();
+        shutdown_workers(workers).await;
+    }
+
+    #[tokio::test]
+    async fn test_routing_processor_handles_missing_worker() {
+        let processor = Arc::new(CountingProcessor::new());
+        let config = PartitionRouterConfig::default();
+        let router = Arc::new(PartitionRouter::new(processor.clone(), config));
+
+        // Only add worker for partition 0
+        let p0 = Partition::new("test-topic".to_string(), 0);
+        router.add_partition(p0.clone());
+
+        let routing_processor = RoutingProcessor::new(router.clone());
+
+        // Create messages including one for a partition without a worker
+        let p1 = Partition::new("test-topic".to_string(), 1);
+        let messages = vec![
+            KafkaMessage::new_for_test(p0.clone(), 0, "msg1".to_string()),
+            KafkaMessage::new_for_test(p1, 0, "msg2".to_string()), // No worker for this
+        ];
+
+        // Should not fail, just warn
+        let result = routing_processor.process_batch(messages).await;
+        assert!(result.is_ok());
+
+        // Give worker time to process
+        sleep(Duration::from_millis(50)).await;
+
+        // Only the message for partition 0 should be processed
+        assert_eq!(processor.get_count(), 1);
+
+        // Cleanup
+        let workers = router.shutdown_all();
+        shutdown_workers(workers).await;
+    }
+}

--- a/rust/kafka-deduplicator/src/kafka/test_utils.rs
+++ b/rust/kafka-deduplicator/src/kafka/test_utils.rs
@@ -22,25 +22,29 @@ pub struct TestRebalanceHandler {
 
 #[async_trait]
 impl RebalanceHandler for TestRebalanceHandler {
-    async fn on_partitions_assigned(&self, partitions: &TopicPartitionList) -> Result<()> {
+    fn setup_assigned_partitions(&self, partitions: &TopicPartitionList) {
         self.assigned_count.fetch_add(1, Ordering::SeqCst);
 
         let mut assigned = self.assigned_partitions.lock().unwrap();
         for elem in partitions.elements() {
             assigned.push(Partition::from(elem));
         }
-
-        Ok(())
     }
 
-    async fn on_partitions_revoked(&self, partitions: &TopicPartitionList) -> Result<()> {
+    fn setup_revoked_partitions(&self, partitions: &TopicPartitionList) {
         self.revoked_count.fetch_add(1, Ordering::SeqCst);
 
         let mut revoked = self.revoked_partitions.lock().unwrap();
         for elem in partitions.elements() {
             revoked.push(Partition::from(elem));
         }
+    }
 
+    async fn cleanup_assigned_partitions(&self, _partitions: &TopicPartitionList) -> Result<()> {
+        Ok(())
+    }
+
+    async fn cleanup_revoked_partitions(&self, _partitions: &TopicPartitionList) -> Result<()> {
         Ok(())
     }
 

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -126,3 +126,29 @@ pub const CHECKPOINT_FILE_FETCH_STORE_HISTOGRAM: &str = "checkpoint_file_fetch_a
 
 /// Histogram for checkpoint metadata file list duration; only measured on success
 pub const CHECKPOINT_LIST_METADATA_HISTOGRAM: &str = "checkpoint_list_metadata_seconds";
+
+// ==== Store Manager Diagnostics ====
+/// Histogram for store creation duration (in milliseconds)
+pub const STORE_CREATION_DURATION_MS: &str = "store_creation_duration_ms";
+
+/// Counter for store creation events by outcome (success/failure)
+pub const STORE_CREATION_EVENTS: &str = "store_creation_events_total";
+
+/// Gauge for active store count
+pub const ACTIVE_STORE_COUNT: &str = "active_store_count";
+
+// ==== Partition Batch Processing Diagnostics ====
+/// Histogram for partition batch processing duration (in milliseconds)
+pub const PARTITION_BATCH_PROCESSING_DURATION_MS: &str = "partition_batch_processing_duration_ms";
+
+/// Histogram for RocksDB multi_get duration (in milliseconds)
+pub const ROCKSDB_MULTI_GET_DURATION_MS: &str = "rocksdb_multi_get_duration_ms";
+
+/// Histogram for RocksDB put_batch duration (in milliseconds)
+pub const ROCKSDB_PUT_BATCH_DURATION_MS: &str = "rocksdb_put_batch_duration_ms";
+
+/// Histogram for Kafka producer send duration (in milliseconds)
+pub const KAFKA_PRODUCER_SEND_DURATION_MS: &str = "kafka_producer_send_duration_ms";
+
+/// Histogram for event parsing duration using rayon (in milliseconds)
+pub const EVENT_PARSING_DURATION_MS: &str = "event_parsing_duration_ms";

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use dashmap::DashSet;
 use rdkafka::TopicPartitionList;
 use std::sync::Arc;
 use tracing::{error, info};
@@ -18,6 +19,9 @@ where
 {
     store_manager: Arc<StoreManager>,
     router: Option<Arc<PartitionRouter<T, P>>>,
+    /// Partitions pending cleanup - added on revoke, removed on assign
+    /// This tracks which partitions should be cleaned up vs which were re-assigned
+    pending_cleanup: DashSet<Partition>,
 }
 
 impl<T, P> ProcessorRebalanceHandler<T, P>
@@ -29,6 +33,7 @@ where
         Self {
             store_manager,
             router: None,
+            pending_cleanup: DashSet::new(),
         }
     }
 
@@ -39,6 +44,7 @@ where
         Self {
             store_manager,
             router: Some(router),
+            pending_cleanup: DashSet::new(),
         }
     }
 }
@@ -49,16 +55,38 @@ where
     T: Send + Sync + 'static,
     P: BatchConsumerProcessor<T> + 'static,
 {
-    async fn on_partitions_assigned(&self, partitions: &TopicPartitionList) -> Result<()> {
+    // ============================================
+    // SETUP METHODS - Called synchronously within librdkafka callbacks
+    // These run BEFORE messages can arrive/stop
+    // ============================================
+
+    fn setup_assigned_partitions(&self, partitions: &TopicPartitionList) {
         let partition_infos: Vec<Partition> = partitions
             .elements()
             .into_iter()
             .map(Partition::from)
             .collect();
 
-        info!("Partitions assigned: {} partitions", partition_infos.len());
+        info!(
+            "Setting up {} assigned partitions (sync)",
+            partition_infos.len()
+        );
 
-        // Create partition workers if router is configured
+        // Remove from pending cleanup - if partition was revoked then re-assigned,
+        // the async cleanup should skip it
+        for partition in &partition_infos {
+            if self.pending_cleanup.remove(partition).is_some() {
+                info!(
+                    "Partition {}:{} re-assigned, removing from pending cleanup",
+                    partition.topic(),
+                    partition.partition_number()
+                );
+            }
+        }
+
+        // Create partition workers BEFORE messages can arrive
+        // This is fast - just spawning tokio tasks and creating channels
+        // If worker already exists (rapid re-assignment), it will be reused
         if let Some(ref router) = self.router {
             router.add_partitions(&partition_infos);
             info!(
@@ -66,41 +94,132 @@ where
                 router.worker_count()
             );
         }
-
-        // TODO: We should download the checkpoint from S3 here
-        // We should not allow the processor to start until the checkpoint is downloaded
-        Ok(())
     }
 
-    async fn on_partitions_revoked(&self, partitions: &TopicPartitionList) -> Result<()> {
+    fn setup_revoked_partitions(&self, partitions: &TopicPartitionList) {
         let partition_infos: Vec<Partition> = partitions
             .elements()
             .into_iter()
             .map(Partition::from)
             .collect();
 
-        info!("Partitions revoked: {} partitions", partition_infos.len());
+        info!(
+            "Setting up {} revoked partitions (sync)",
+            partition_infos.len()
+        );
 
-        // IMPORTANT: Remove stores BEFORE shutting down workers.
-        // This prevents a race condition where:
-        // 1. Worker is processing messages during shutdown
-        // 2. Worker calls store_manager.get_or_create() which creates a new store
-        // 3. store_manager.remove() deletes the directory
-        // 4. Worker's write fails with "No such file or directory"
-        //
-        // By removing stores first, any in-flight worker operations will fail
-        // gracefully with "store not found" rather than filesystem errors.
+        // Mark partitions as pending cleanup
+        // If they get re-assigned before cleanup runs, they'll be removed from this set
         for partition in &partition_infos {
-            // Only remove from DashMap, don't delete files yet
-            // Files will be deleted after workers are shut down
+            self.pending_cleanup.insert(partition.clone());
+        }
+
+        // Remove stores from DashMap BEFORE revocation completes
+        // This prevents new store creation during shutdown
+        // This is fast - just DashMap removes
+        for partition in &partition_infos {
             self.store_manager
                 .remove_from_map(partition.topic(), partition.partition_number());
         }
 
-        // Shutdown partition workers - they may still have queued messages
-        // but won't be able to create new stores since we removed them above
+        info!(
+            "Removed {} stores from map. Active stores: {}. Pending cleanup: {}",
+            partition_infos.len(),
+            self.store_manager.get_active_store_count(),
+            self.pending_cleanup.len()
+        );
+    }
+
+    // ============================================
+    // CLEANUP METHODS - Called asynchronously after callbacks return
+    // For slow operations like I/O, draining queues, etc.
+    // ============================================
+
+    async fn cleanup_assigned_partitions(&self, partitions: &TopicPartitionList) -> Result<()> {
+        let partition_infos: Vec<Partition> = partitions
+            .elements()
+            .into_iter()
+            .map(Partition::from)
+            .collect();
+
+        info!(
+            "Cleaning up {} assigned partitions (async)",
+            partition_infos.len()
+        );
+
+        // TODO: We should download the checkpoint from S3 here
+        // We should not allow the processor to start until the checkpoint is downloaded
+
+        // Pre-create stores for assigned partitions
+        // This reduces latency on the first message batch by having the store ready
+        // If messages arrive before this completes, get_or_create in the processor
+        // will handle it and emit a warning (indicating pre-creation didn't complete in time)
+        for partition in &partition_infos {
+            match self
+                .store_manager
+                .get_or_create_for_rebalance(partition.topic(), partition.partition_number())
+                .await
+            {
+                Ok(_) => {
+                    info!(
+                        "Pre-created store for partition {}:{}",
+                        partition.topic(),
+                        partition.partition_number()
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to pre-create store for partition {}:{}: {}",
+                        partition.topic(),
+                        partition.partition_number(),
+                        e
+                    );
+                    // Don't fail the whole cleanup - the processor will retry on first message
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn cleanup_revoked_partitions(&self, partitions: &TopicPartitionList) -> Result<()> {
+        let partition_infos: Vec<Partition> = partitions
+            .elements()
+            .into_iter()
+            .map(Partition::from)
+            .collect();
+
+        info!(
+            "Cleaning up {} revoked partitions (async)",
+            partition_infos.len()
+        );
+
+        // Only clean up partitions that are still pending cleanup
+        // If a partition was re-assigned, it was removed from pending_cleanup
+        let partitions_to_cleanup: Vec<Partition> = partition_infos
+            .into_iter()
+            .filter(|p| {
+                let should_cleanup = self.pending_cleanup.remove(p).is_some();
+                if !should_cleanup {
+                    info!(
+                        "Skipping cleanup for {}:{} - partition was re-assigned",
+                        p.topic(),
+                        p.partition_number()
+                    );
+                }
+                should_cleanup
+            })
+            .collect();
+
+        if partitions_to_cleanup.is_empty() {
+            info!("No partitions to clean up (all were re-assigned)");
+            return Ok(());
+        }
+
+        // Shutdown partition workers - drain their queues
+        // Stores are already removed from map (done in setup_revoked_partitions)
         if let Some(ref router) = self.router {
-            let workers = router.remove_partitions(&partition_infos);
+            let workers = router.remove_partitions(&partitions_to_cleanup);
             shutdown_workers(workers).await;
             info!(
                 "Shut down partition workers. Active workers: {}",
@@ -108,8 +227,8 @@ where
             );
         }
 
-        // Now safe to delete files - workers are shut down and can't write anymore
-        for partition in &partition_infos {
+        // Now safe to delete files - workers are shut down
+        for partition in &partitions_to_cleanup {
             if let Err(e) = self
                 .store_manager
                 .delete_partition_files(partition.topic(), partition.partition_number())
@@ -214,7 +333,7 @@ mod tests {
         // Initially no workers
         assert_eq!(router.worker_count(), 0);
 
-        // Assign partitions
+        // Assign partitions (sync setup creates workers)
         let mut partitions = rdkafka::TopicPartitionList::new();
         partitions
             .add_partition_offset("test-topic", 0, Offset::Beginning)
@@ -223,16 +342,17 @@ mod tests {
             .add_partition_offset("test-topic", 1, Offset::Beginning)
             .unwrap();
 
-        handler.on_partitions_assigned(&partitions).await.unwrap();
+        handler.setup_assigned_partitions(&partitions);
         assert_eq!(router.worker_count(), 2);
 
-        // Revoke one partition
+        // Revoke one partition (sync setup + async cleanup)
         let mut revoked = rdkafka::TopicPartitionList::new();
         revoked
             .add_partition_offset("test-topic", 0, Offset::Beginning)
             .unwrap();
 
-        handler.on_partitions_revoked(&revoked).await.unwrap();
+        handler.setup_revoked_partitions(&revoked);
+        handler.cleanup_revoked_partitions(&revoked).await.unwrap();
         assert_eq!(router.worker_count(), 1);
 
         // Cleanup
@@ -248,8 +368,8 @@ mod tests {
         // 3. store_manager.remove() deletes the directory
         // 4. Worker's write fails with "No such file or directory"
         //
-        // The fix ensures stores are removed from the map BEFORE workers are shut down,
-        // so workers cannot create new stores during shutdown.
+        // The fix ensures stores are removed from the map (in setup_revoked_partitions)
+        // BEFORE workers are shut down (in cleanup_revoked_partitions).
 
         let temp_dir = TempDir::new().unwrap();
         let store_config = DeduplicationStoreConfig {
@@ -271,22 +391,29 @@ mod tests {
             .add_partition_offset("test-topic", 0, Offset::Beginning)
             .unwrap();
 
-        handler.on_partitions_assigned(&partitions).await.unwrap();
+        handler.setup_assigned_partitions(&partitions);
         assert_eq!(router.worker_count(), 1);
 
         // Create a store for the partition (simulating what happens during processing)
         store_manager.get_or_create("test-topic", 0).await.unwrap();
         assert_eq!(store_manager.get_active_store_count(), 1);
 
-        // Revoke the partition
-        handler.on_partitions_revoked(&partitions).await.unwrap();
+        // Revoke the partition (sync setup removes store from map)
+        handler.setup_revoked_partitions(&partitions);
+        assert_eq!(store_manager.get_active_store_count(), 0);
+        // Worker still exists at this point
+        assert_eq!(router.worker_count(), 1);
 
-        // After revocation:
+        // Async cleanup shuts down workers and deletes files
+        handler
+            .cleanup_revoked_partitions(&partitions)
+            .await
+            .unwrap();
+
+        // After cleanup:
         // - Worker should be shut down
-        // - Store should be removed from map
         // - Files should be deleted
         assert_eq!(router.worker_count(), 0);
-        assert_eq!(store_manager.get_active_store_count(), 0);
 
         // Verify files are deleted
         let partition_dir = temp_dir.path().join("test-topic_0");
@@ -324,6 +451,66 @@ mod tests {
 
         // Cleanup
         store_manager.remove("test-topic", 0).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_rapid_revoke_assign_does_not_remove_new_worker() {
+        // This test verifies that when a partition is rapidly revoked and re-assigned,
+        // the cleanup for the revocation does NOT remove the newly created worker.
+        //
+        // Scenario:
+        // 1. Partition 0 is assigned (worker created)
+        // 2. Partition 0 is revoked (store removed from map)
+        // 3. Partition 0 is immediately re-assigned (NEW worker created)
+        // 4. Async cleanup for step 2 runs - should NOT remove the new worker
+
+        let temp_dir = TempDir::new().unwrap();
+        let store_config = DeduplicationStoreConfig {
+            path: temp_dir.path().to_path_buf(),
+            max_capacity: 1000,
+        };
+        let store_manager = Arc::new(StoreManager::new(store_config));
+        let processor = Arc::new(TestProcessor);
+        let router = Arc::new(PartitionRouter::new(
+            processor,
+            PartitionRouterConfig::default(),
+        ));
+
+        let handler = ProcessorRebalanceHandler::with_router(store_manager.clone(), router.clone());
+
+        // Step 1: Initial assignment
+        let mut partitions = rdkafka::TopicPartitionList::new();
+        partitions
+            .add_partition_offset("test-topic", 0, Offset::Beginning)
+            .unwrap();
+
+        handler.setup_assigned_partitions(&partitions);
+        assert_eq!(router.worker_count(), 1);
+
+        // Step 2: Revoke (sync - removes store from map)
+        handler.setup_revoked_partitions(&partitions);
+
+        // Step 3: Immediate re-assign (sync - creates NEW worker)
+        handler.setup_assigned_partitions(&partitions);
+        assert_eq!(router.worker_count(), 1); // Still have 1 worker (the new one)
+
+        // Step 4: Async cleanup for the revoke runs
+        // This should detect that partition 0 is now assigned and skip cleanup
+        handler
+            .cleanup_revoked_partitions(&partitions)
+            .await
+            .unwrap();
+
+        // The new worker should still exist!
+        assert_eq!(
+            router.worker_count(),
+            1,
+            "New worker should NOT be removed by stale revocation cleanup"
+        );
+
+        // Cleanup
+        let workers = router.shutdown_all();
+        shutdown_workers(workers).await;
     }
 
     #[tokio::test]

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -4,25 +4,68 @@ use rdkafka::TopicPartitionList;
 use std::sync::Arc;
 use tracing::{error, info};
 
+use crate::kafka::batch_consumer::BatchConsumerProcessor;
+use crate::kafka::partition_router::{shutdown_workers, PartitionRouter};
 use crate::kafka::rebalance_handler::RebalanceHandler;
 use crate::kafka::types::Partition;
 use crate::store_manager::StoreManager;
 
-/// Rebalance handler that coordinates store cleanup on partition revocation
-pub struct ProcessorRebalanceHandler {
+/// Rebalance handler that coordinates store cleanup and partition workers
+pub struct ProcessorRebalanceHandler<T, P>
+where
+    T: Send + 'static,
+    P: BatchConsumerProcessor<T> + 'static,
+{
     store_manager: Arc<StoreManager>,
+    router: Option<Arc<PartitionRouter<T, P>>>,
 }
 
-impl ProcessorRebalanceHandler {
+impl<T, P> ProcessorRebalanceHandler<T, P>
+where
+    T: Send + 'static,
+    P: BatchConsumerProcessor<T> + 'static,
+{
     pub fn new(store_manager: Arc<StoreManager>) -> Self {
-        Self { store_manager }
+        Self {
+            store_manager,
+            router: None,
+        }
+    }
+
+    pub fn with_router(
+        store_manager: Arc<StoreManager>,
+        router: Arc<PartitionRouter<T, P>>,
+    ) -> Self {
+        Self {
+            store_manager,
+            router: Some(router),
+        }
     }
 }
 
 #[async_trait]
-impl RebalanceHandler for ProcessorRebalanceHandler {
+impl<T, P> RebalanceHandler for ProcessorRebalanceHandler<T, P>
+where
+    T: Send + Sync + 'static,
+    P: BatchConsumerProcessor<T> + 'static,
+{
     async fn on_partitions_assigned(&self, partitions: &TopicPartitionList) -> Result<()> {
-        info!("Partitions assigned: {} partitions", partitions.count());
+        let partition_infos: Vec<Partition> = partitions
+            .elements()
+            .into_iter()
+            .map(Partition::from)
+            .collect();
+
+        info!("Partitions assigned: {} partitions", partition_infos.len());
+
+        // Create partition workers if router is configured
+        if let Some(ref router) = self.router {
+            router.add_partitions(&partition_infos);
+            info!(
+                "Created partition workers. Active workers: {}",
+                router.worker_count()
+            );
+        }
 
         // TODO: We should download the checkpoint from S3 here
         // We should not allow the processor to start until the checkpoint is downloaded
@@ -30,14 +73,23 @@ impl RebalanceHandler for ProcessorRebalanceHandler {
     }
 
     async fn on_partitions_revoked(&self, partitions: &TopicPartitionList) -> Result<()> {
-        info!("Partitions revoked: {} partitions", partitions.count());
-
-        // Extract partition info for cleanup
         let partition_infos: Vec<Partition> = partitions
             .elements()
             .into_iter()
             .map(Partition::from)
             .collect();
+
+        info!("Partitions revoked: {} partitions", partition_infos.len());
+
+        // Shutdown partition workers if router is configured
+        if let Some(ref router) = self.router {
+            let workers = router.remove_partitions(&partition_infos);
+            shutdown_workers(workers).await;
+            info!(
+                "Shut down partition workers. Active workers: {}",
+                router.worker_count()
+            );
+        }
 
         // Clean up stores for revoked partitions
         for partition in &partition_infos {
@@ -75,6 +127,10 @@ impl RebalanceHandler for ProcessorRebalanceHandler {
         let store_count = self.store_manager.stores().len();
         info!("Active deduplication stores: {}", store_count);
 
+        if let Some(ref router) = self.router {
+            info!("Active partition workers: {}", router.worker_count());
+        }
+
         Ok(())
     }
 }
@@ -82,41 +138,88 @@ impl RebalanceHandler for ProcessorRebalanceHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::deduplication_batch_processor::DeduplicationConfig;
-    use rdkafka::config::ClientConfig;
-    use std::time::Duration;
+    use crate::kafka::batch_message::KafkaMessage;
+    use crate::kafka::partition_router::PartitionRouterConfig;
+    use crate::store::DeduplicationStoreConfig;
+    use rdkafka::Offset;
     use tempfile::TempDir;
 
-    fn create_test_config() -> (DeduplicationConfig, TempDir) {
-        let temp_dir = TempDir::new().unwrap();
-        let store_config = crate::store::DeduplicationStoreConfig {
-            path: temp_dir.path().to_path_buf(),
-            max_capacity: 1000,
-        };
+    struct TestProcessor;
 
-        let mut producer_config = ClientConfig::new();
-        producer_config.set("bootstrap.servers", "localhost:9092");
-
-        let config = DeduplicationConfig {
-            output_topic: Some("test-output".to_string()),
-            duplicate_events_topic: None,
-            producer_config,
-            store_config,
-            producer_send_timeout: Duration::from_secs(5),
-            flush_interval: Duration::from_secs(120),
-        };
-
-        (config, temp_dir)
+    #[async_trait]
+    impl BatchConsumerProcessor<String> for TestProcessor {
+        async fn process_batch(&self, _messages: Vec<KafkaMessage<String>>) -> Result<()> {
+            Ok(())
+        }
     }
 
     #[tokio::test]
     async fn test_rebalance_handler_creation() {
-        let (_config, _temp_dir) = create_test_config();
+        let temp_dir = TempDir::new().unwrap();
+        let store_config = DeduplicationStoreConfig {
+            path: temp_dir.path().to_path_buf(),
+            max_capacity: 1000,
+        };
+        let store_manager = Arc::new(StoreManager::new(store_config));
 
-        // This would fail without Kafka, but we can test the handler creation logic
-        // In practice, we'd need to mock the processor or run integration tests
+        // Test handler without router
+        let handler: ProcessorRebalanceHandler<String, TestProcessor> =
+            ProcessorRebalanceHandler::new(store_manager.clone());
+        assert!(handler.router.is_none());
 
-        // For now, just test that the structs can be created
-        assert!(std::mem::size_of::<ProcessorRebalanceHandler>() > 0);
+        // Test handler with router
+        let processor = Arc::new(TestProcessor);
+        let router = Arc::new(PartitionRouter::new(
+            processor,
+            PartitionRouterConfig::default(),
+        ));
+        let handler_with_router =
+            ProcessorRebalanceHandler::with_router(store_manager, router.clone());
+        assert!(handler_with_router.router.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_rebalance_handler_manages_workers() {
+        let temp_dir = TempDir::new().unwrap();
+        let store_config = DeduplicationStoreConfig {
+            path: temp_dir.path().to_path_buf(),
+            max_capacity: 1000,
+        };
+        let store_manager = Arc::new(StoreManager::new(store_config));
+        let processor = Arc::new(TestProcessor);
+        let router = Arc::new(PartitionRouter::new(
+            processor,
+            PartitionRouterConfig::default(),
+        ));
+
+        let handler = ProcessorRebalanceHandler::with_router(store_manager, router.clone());
+
+        // Initially no workers
+        assert_eq!(router.worker_count(), 0);
+
+        // Assign partitions
+        let mut partitions = rdkafka::TopicPartitionList::new();
+        partitions
+            .add_partition_offset("test-topic", 0, Offset::Beginning)
+            .unwrap();
+        partitions
+            .add_partition_offset("test-topic", 1, Offset::Beginning)
+            .unwrap();
+
+        handler.on_partitions_assigned(&partitions).await.unwrap();
+        assert_eq!(router.worker_count(), 2);
+
+        // Revoke one partition
+        let mut revoked = rdkafka::TopicPartitionList::new();
+        revoked
+            .add_partition_offset("test-topic", 0, Offset::Beginning)
+            .unwrap();
+
+        handler.on_partitions_revoked(&revoked).await.unwrap();
+        assert_eq!(router.worker_count(), 1);
+
+        // Cleanup
+        let workers = router.shutdown_all();
+        shutdown_workers(workers).await;
     }
 }

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -81,7 +81,24 @@ where
 
         info!("Partitions revoked: {} partitions", partition_infos.len());
 
-        // Shutdown partition workers if router is configured
+        // IMPORTANT: Remove stores BEFORE shutting down workers.
+        // This prevents a race condition where:
+        // 1. Worker is processing messages during shutdown
+        // 2. Worker calls store_manager.get_or_create() which creates a new store
+        // 3. store_manager.remove() deletes the directory
+        // 4. Worker's write fails with "No such file or directory"
+        //
+        // By removing stores first, any in-flight worker operations will fail
+        // gracefully with "store not found" rather than filesystem errors.
+        for partition in &partition_infos {
+            // Only remove from DashMap, don't delete files yet
+            // Files will be deleted after workers are shut down
+            self.store_manager
+                .remove_from_map(partition.topic(), partition.partition_number());
+        }
+
+        // Shutdown partition workers - they may still have queued messages
+        // but won't be able to create new stores since we removed them above
         if let Some(ref router) = self.router {
             let workers = router.remove_partitions(&partition_infos);
             shutdown_workers(workers).await;
@@ -91,21 +108,21 @@ where
             );
         }
 
-        // Clean up stores for revoked partitions
+        // Now safe to delete files - workers are shut down and can't write anymore
         for partition in &partition_infos {
             if let Err(e) = self
                 .store_manager
-                .remove(partition.topic(), partition.partition_number())
+                .delete_partition_files(partition.topic(), partition.partition_number())
             {
                 error!(
-                    "Failed to remove store for revoked partition {}:{}: {}",
+                    "Failed to delete files for revoked partition {}:{}: {}",
                     partition.topic(),
                     partition.partition_number(),
                     e
                 );
             } else {
                 info!(
-                    "Cleaned up deduplication store and files for revoked partition {}:{}",
+                    "Cleaned up deduplication store files for revoked partition {}:{}",
                     partition.topic(),
                     partition.partition_number()
                 );
@@ -221,5 +238,130 @@ mod tests {
         // Cleanup
         let workers = router.shutdown_all();
         shutdown_workers(workers).await;
+    }
+
+    #[tokio::test]
+    async fn test_rebalance_removes_stores_before_workers_shutdown() {
+        // This test verifies the fix for the race condition where:
+        // 1. Worker is processing messages during shutdown
+        // 2. Worker calls store_manager.get_or_create() which would create a new store
+        // 3. store_manager.remove() deletes the directory
+        // 4. Worker's write fails with "No such file or directory"
+        //
+        // The fix ensures stores are removed from the map BEFORE workers are shut down,
+        // so workers cannot create new stores during shutdown.
+
+        let temp_dir = TempDir::new().unwrap();
+        let store_config = DeduplicationStoreConfig {
+            path: temp_dir.path().to_path_buf(),
+            max_capacity: 1000,
+        };
+        let store_manager = Arc::new(StoreManager::new(store_config));
+        let processor = Arc::new(TestProcessor);
+        let router = Arc::new(PartitionRouter::new(
+            processor,
+            PartitionRouterConfig::default(),
+        ));
+
+        let handler = ProcessorRebalanceHandler::with_router(store_manager.clone(), router.clone());
+
+        // Assign partition and create a store
+        let mut partitions = rdkafka::TopicPartitionList::new();
+        partitions
+            .add_partition_offset("test-topic", 0, Offset::Beginning)
+            .unwrap();
+
+        handler.on_partitions_assigned(&partitions).await.unwrap();
+        assert_eq!(router.worker_count(), 1);
+
+        // Create a store for the partition (simulating what happens during processing)
+        store_manager.get_or_create("test-topic", 0).await.unwrap();
+        assert_eq!(store_manager.get_active_store_count(), 1);
+
+        // Revoke the partition
+        handler.on_partitions_revoked(&partitions).await.unwrap();
+
+        // After revocation:
+        // - Worker should be shut down
+        // - Store should be removed from map
+        // - Files should be deleted
+        assert_eq!(router.worker_count(), 0);
+        assert_eq!(store_manager.get_active_store_count(), 0);
+
+        // Verify files are deleted
+        let partition_dir = temp_dir.path().join("test-topic_0");
+        assert!(
+            !partition_dir.exists(),
+            "Partition directory should be deleted after revocation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rebalance_store_not_found_during_shutdown() {
+        // This test verifies that after stores are removed from the map,
+        // any attempt to get_or_create will return an error rather than
+        // creating a new store that would be immediately deleted.
+
+        let temp_dir = TempDir::new().unwrap();
+        let store_config = DeduplicationStoreConfig {
+            path: temp_dir.path().to_path_buf(),
+            max_capacity: 1000,
+        };
+        let store_manager = Arc::new(StoreManager::new(store_config));
+
+        // Create a store
+        store_manager.get_or_create("test-topic", 0).await.unwrap();
+        assert_eq!(store_manager.get_active_store_count(), 1);
+
+        // Remove from map only (simulating first step of revocation)
+        store_manager.remove_from_map("test-topic", 0);
+        assert_eq!(store_manager.get_active_store_count(), 0);
+
+        // Verify we can still create a new store if needed
+        // (this would happen if partition is re-assigned)
+        store_manager.get_or_create("test-topic", 0).await.unwrap();
+        assert_eq!(store_manager.get_active_store_count(), 1);
+
+        // Cleanup
+        store_manager.remove("test-topic", 0).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_delete_partition_files_after_remove_from_map() {
+        // Test that delete_partition_files works correctly after remove_from_map
+
+        let temp_dir = TempDir::new().unwrap();
+        let store_config = DeduplicationStoreConfig {
+            path: temp_dir.path().to_path_buf(),
+            max_capacity: 1000,
+        };
+        let store_manager = Arc::new(StoreManager::new(store_config));
+
+        // Create a store (this creates the directory)
+        store_manager.get_or_create("test-topic", 0).await.unwrap();
+
+        let partition_dir = temp_dir.path().join("test-topic_0");
+        assert!(partition_dir.exists(), "Partition directory should exist");
+
+        // Remove from map (store is dropped, RocksDB is closed)
+        store_manager.remove_from_map("test-topic", 0);
+        assert_eq!(store_manager.get_active_store_count(), 0);
+
+        // Directory should still exist (files not deleted yet)
+        assert!(
+            partition_dir.exists(),
+            "Partition directory should still exist after remove_from_map"
+        );
+
+        // Now delete the files
+        store_manager
+            .delete_partition_files("test-topic", 0)
+            .unwrap();
+
+        // Directory should be deleted
+        assert!(
+            !partition_dir.exists(),
+            "Partition directory should be deleted after delete_partition_files"
+        );
     }
 }

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -21,7 +21,10 @@ use crate::{
     checkpoint::s3_uploader::S3Uploader,
     checkpoint_manager::CheckpointManager,
     config::Config,
-    kafka::{batch_consumer::BatchConsumer, ConsumerConfigBuilder},
+    kafka::{
+        batch_consumer::BatchConsumer, ConsumerConfigBuilder, PartitionRouter,
+        PartitionRouterConfig, PartitionWorkerConfig, RoutingProcessor,
+    },
     processor_rebalance_handler::ProcessorRebalanceHandler,
     store::DeduplicationStoreConfig,
     store_manager::{CleanupTaskHandle, StoreManager},
@@ -228,17 +231,32 @@ impl KafkaDeduplicatorService {
         };
 
         // Create a processor with the store manager and both producers
-        let processor = BatchDeduplicationProcessor::new(
-            dedup_config,
-            self.store_manager.clone(),
-            main_producer,
-            duplicate_producer,
-        )
-        .with_context(|| "Failed to create deduplication processor")?;
+        let processor = Arc::new(
+            BatchDeduplicationProcessor::new(
+                dedup_config,
+                self.store_manager.clone(),
+                main_producer,
+                duplicate_producer,
+            )
+            .with_context(|| "Failed to create deduplication processor")?,
+        );
 
-        // Create rebalance handler with the store manager
-        let rebalance_handler =
-            Arc::new(ProcessorRebalanceHandler::new(self.store_manager.clone()));
+        // Create partition router for parallel processing across partitions
+        let router_config = PartitionRouterConfig {
+            worker_config: PartitionWorkerConfig {
+                channel_buffer_size: self.config.partition_worker_channel_buffer_size,
+            },
+        };
+        let router = Arc::new(PartitionRouter::new(processor, router_config));
+
+        // Create routing processor that distributes messages to partition workers
+        let routing_processor = Arc::new(RoutingProcessor::new(router.clone()));
+
+        // Create rebalance handler with the router for partition worker management
+        let rebalance_handler = Arc::new(ProcessorRebalanceHandler::with_router(
+            self.store_manager.clone(),
+            router,
+        ));
 
         // Create consumer config using the kafka module's builder
         let consumer_config =
@@ -307,11 +325,11 @@ impl KafkaDeduplicatorService {
             self.config.checkpoint_interval(),
         );
 
-        // Create stateful Kafka consumer that sends to the processor pool
+        // Create stateful Kafka consumer that routes to partition workers
         let kafka_consumer = BatchConsumer::new(
             &consumer_config,
             rebalance_handler,
-            Arc::new(processor),
+            routing_processor,
             shutdown_rx,
             &self.config.kafka_consumer_topic,
             self.config.kafka_consumer_batch_size,


### PR DESCRIPTION
## Problem

The kafka-deduplicator processes batches from multiple partitions, but the current design processes all partitions sequentially within each batch. This creates a bottleneck where slow partitions (e.g., due to RocksDB operations or Kafka producer backpressure) delay processing of all other partitions in the same batch.


## Changes

Introduces a **partition worker architecture** that enables parallel processing across partitions:

- **Partition Router & Workers**: Each assigned partition gets a dedicated worker with its own async task and message channel. Messages are routed to workers by partition, enabling concurrent processing.
- **Pipeline parallelism**: While one batch is being consumed from Kafka, previous batches are being processed in parallel across partition workers.
- **Rebalance handling**: Workers are created during partition assignment and gracefully shut down during revocation, with proper offset commits before cleanup.
- **Backpressure handling**: Workers use bounded channels with configurable buffer sizes. When a worker's channel is full, the router waits with backpressure metrics.
- **Concurrent Kafka produces**: Refactored `publish_event` to batch all Kafka sends per partition and execute them concurrently via `join_all`.
- **Store pre-creation**: RocksDB stores are now pre-created during rebalance assignment (via `get_or_create_for_rebalance`) to avoid creation latency during message processing.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
