### PR TITLE
fix: Apply correct aggregation when rolling up breakdowns

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -76,6 +76,15 @@ import {
 import { LocalFilter } from '../entityFilterLogic'
 import { entityFilterLogicType } from '../entityFilterLogicType'
 
+// Property math types that can be meaningfully aggregated when rolling up histogram buckets
+// e.g. taking p99 of p99 values doesn't make sense
+const SUPPORTED_PROPERTY_MATH_FOR_HISTOGRAM_BREAKDOWN = new Set([
+    PropertyMathType.Sum,
+    PropertyMathType.Average,
+    PropertyMathType.Minimum,
+    PropertyMathType.Maximum,
+])
+
 const DragHandle = (props: DraggableSyntheticListeners | undefined): JSX.Element => (
     <span className="ActionFilterRowDragHandle" key="drag-handle" {...props}>
         <SortableDragIcon />
@@ -782,6 +791,12 @@ function useMathSelectorOptions({
         isInsightVizNode(query) &&
         isTrendsQuery(query.source) &&
         query.source.trendsFilter?.display === ChartDisplayType.CalendarHeatmap
+    const isHistogramBreakdown =
+        query &&
+        isInsightVizNode(query) &&
+        isTrendsQuery(query.source) &&
+        (query.source.breakdownFilter?.breakdown_histogram_bin_count != null ||
+            query.source.breakdownFilter?.breakdowns?.some((b) => b.histogram_bin_count != null))
 
     const {
         needsUpgradeForGroups,
@@ -951,6 +966,13 @@ function useMathSelectorOptions({
                                     label: definition.shortName,
                                     tooltip: definition.description,
                                     'data-attr': `math-${key}-${index}`,
+                                    disabledReason:
+                                        isHistogramBreakdown &&
+                                        // the backend raises an exception for queries that try to use unsupported math types
+                                        // for histogram breakdowns, but it's a nicer UX if we just disallow it in the first place.
+                                        !SUPPORTED_PROPERTY_MATH_FOR_HISTOGRAM_BREAKDOWN.has(key as PropertyMathType)
+                                            ? 'Not supported when breaking down by a numeric property'
+                                            : undefined,
                                 }))}
                             onClick={(e) => e.stopPropagation()}
                             size="small"

--- a/posthog/hogql_queries/insights/trends/aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/aggregation_operations.py
@@ -147,6 +147,19 @@ class AggregationOperations(DataWarehouseInsightQueryMixin):
     def is_first_matching_event(self):
         return self.series.math == "first_matching_event_for_user"
 
+    def get_outer_aggregation_name(self) -> str:
+        """
+        Returns the aggregation function to use when rolling up already-aggregated values.
+
+        For example, if we computed max(price) per day per breakdown, rolling up across
+        breakdowns should use max() not sum() - the max of maxes is the overall max.
+        """
+        if self.series.math == "max":
+            return "max"
+        elif self.series.math == "min":
+            return "min"
+        return "sum"
+
     def _get_math_chain(self) -> list[str | int]:
         if not self.series.math_property:
             raise ValueError("No math property set")

--- a/posthog/hogql_queries/insights/trends/aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/aggregation_operations.py
@@ -147,18 +147,20 @@ class AggregationOperations(DataWarehouseInsightQueryMixin):
     def is_first_matching_event(self):
         return self.series.math == "first_matching_event_for_user"
 
-    def get_outer_aggregation_name(self) -> str:
+    def get_outer_aggregation(self, field: ast.Expr) -> ast.Expr:
         """
-        Returns the aggregation function to use when rolling up already-aggregated values.
+        Returns the aggregation expression to use when rolling up already-aggregated values.
 
         For example, if we computed max(price) per day per breakdown, rolling up across
         breakdowns should use max() not sum() - the max of maxes is the overall max.
         """
         if self.series.math == "max":
-            return "max"
+            return ast.Call(name="max", args=[field])
         elif self.series.math == "min":
-            return "min"
-        return "sum"
+            return ast.Call(name="min", args=[field])
+        elif self.series.math == "avg":
+            return ast.Call(name="avg", args=[field])
+        return ast.Call(name="sum", args=[field])
 
     def _get_math_chain(self) -> list[str | int]:
         if not self.series.math_property:

--- a/posthog/hogql_queries/insights/trends/aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/aggregation_operations.py
@@ -1,6 +1,6 @@
 from typing import Optional, Union, cast
 
-from posthog.schema import ActionsNode, BaseMathType, ChartDisplayType, DataWarehouseNode, EventsNode
+from posthog.schema import ActionsNode, BaseMathType, ChartDisplayType, DataWarehouseNode, EventsNode, PropertyMathType
 
 from posthog.hogql import ast
 from posthog.hogql.base import Expr
@@ -17,6 +17,15 @@ from posthog.models.team.team import Team
 
 DEFAULT_CURRENCY_VALUE = "USD"
 DEFAULT_REVENUE_PROPERTY = "$revenue"
+
+# Property math types that can be meaningfully aggregated when rolling up histogram buckets
+# e.g. taking p99 of p99 values doesn't make sense
+SUPPORTED_PROPERTY_MATH_FOR_HISTOGRAM_BREAKDOWN = (
+    PropertyMathType.SUM,
+    PropertyMathType.AVG,
+    PropertyMathType.MIN,
+    PropertyMathType.MAX,
+)
 
 
 def create_placeholder(name: str) -> ast.Placeholder:
@@ -147,13 +156,23 @@ class AggregationOperations(DataWarehouseInsightQueryMixin):
     def is_first_matching_event(self):
         return self.series.math == "first_matching_event_for_user"
 
-    def get_outer_aggregation(self, field: ast.Expr) -> ast.Expr:
+    def get_outer_aggregation(self, field: ast.Expr, is_histogram_breakdown: bool = False) -> ast.Expr:
         """
         Returns the aggregation expression to use when rolling up already-aggregated values.
 
         For example, if we computed max(price) per day per breakdown, rolling up across
         breakdowns should use max() not sum() - the max of maxes is the overall max.
         """
+        if (
+            is_histogram_breakdown
+            and self.series.math in set(PropertyMathType)
+            and self.series.math not in SUPPORTED_PROPERTY_MATH_FOR_HISTOGRAM_BREAKDOWN
+        ):
+            raise ValueError(
+                f"Math type '{self.series.math}' is not supported with histogram breakdowns. "
+                f"Supported property math types are: {', '.join(t.value for t in SUPPORTED_PROPERTY_MATH_FOR_HISTOGRAM_BREAKDOWN)}."
+            )
+
         if self.series.math == "max":
             return ast.Call(name="max", args=[field])
         elif self.series.math == "min":

--- a/posthog/hogql_queries/insights/trends/aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/aggregation_operations.py
@@ -22,7 +22,7 @@ DEFAULT_REVENUE_PROPERTY = "$revenue"
 # e.g. taking p99 of p99 values doesn't make sense
 SUPPORTED_PROPERTY_MATH_FOR_HISTOGRAM_BREAKDOWN = (
     PropertyMathType.SUM,
-    PropertyMathType.AVG,
+    PropertyMathType.AVG,  # buckets have same size
     PropertyMathType.MIN,
     PropertyMathType.MAX,
 )

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_formula.ambr
@@ -93,7 +93,7 @@
             breakdown_value AS breakdown_value,
             rowNumberInAllBlocks() AS row_number
      FROM
-       (SELECT sum(total) AS count,
+       (SELECT avg(total) AS count,
                day_start AS day_start,
                breakdown_value AS breakdown_value
         FROM
@@ -165,7 +165,7 @@
 # ---
 # name: TestFormula.test_breakdown_aggregated.1
   '''
-  SELECT sum(total) AS total,
+  SELECT avg(total) AS total,
          if(ifNull(ifNull(greaterOrEquals(row_number, 26), 0), 0), '$$_posthog_breakdown_other_$$', breakdown_value) AS breakdown_value
   FROM
     (SELECT count AS total,
@@ -173,7 +173,7 @@
                      row_number() OVER (
                                         ORDER BY total DESC) AS row_number
      FROM
-       (SELECT sum(total) AS count,
+       (SELECT avg(total) AS count,
                breakdown_value AS breakdown_value
         FROM
           (SELECT ifNull(avg(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'xyz'), ''), 'null'), '^"|"$', ''), 'Float64')), 0) AS total,
@@ -267,7 +267,7 @@
             breakdown_value AS breakdown_value,
             rowNumberInAllBlocks() AS row_number
      FROM
-       (SELECT sum(total) AS count,
+       (SELECT avg(total) AS count,
                day_start AS day_start,
                breakdown_value AS breakdown_value
         FROM
@@ -365,7 +365,7 @@
             breakdown_value AS breakdown_value,
             rowNumberInAllBlocks() AS row_number
      FROM
-       (SELECT sum(total) AS count,
+       (SELECT avg(total) AS count,
                day_start AS day_start,
                breakdown_value AS breakdown_value
         FROM
@@ -586,7 +586,7 @@
             breakdown_value AS breakdown_value,
             rowNumberInAllBlocks() AS row_number
      FROM
-       (SELECT sum(total) AS count,
+       (SELECT avg(total) AS count,
                day_start AS day_start,
                breakdown_value AS breakdown_value
         FROM
@@ -826,7 +826,7 @@
          arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
                                                                                                                                                                                                    and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total
   FROM
-    (SELECT sum(total) AS count,
+    (SELECT avg(total) AS count,
             day_start AS day_start
      FROM
        (SELECT ifNull(avg(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'xyz'), ''), 'null'), '^"|"$', ''), 'Float64')), 0) AS total,
@@ -886,7 +886,7 @@
          arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
                                                                                                                                                                                                    and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total
   FROM
-    (SELECT sum(total) AS count,
+    (SELECT avg(total) AS count,
             day_start AS day_start
      FROM
        (SELECT ifNull(avg(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'xyz'), ''), 'null'), '^"|"$', ''), 'Float64')), 0) AS total,
@@ -916,7 +916,7 @@
          arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
                                                                                                                                                                                                    and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total
   FROM
-    (SELECT sum(total) AS count,
+    (SELECT avg(total) AS count,
             day_start AS day_start
      FROM
        (SELECT ifNull(avg(accurateCastOrNull(session_duration, 'Float64')), 0) AS total,

--- a/posthog/hogql_queries/insights/trends/test/test_aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/test/test_aggregation_operations.py
@@ -239,6 +239,42 @@ def test_actor_id_returns_correct_field(
 
 
 @pytest.mark.parametrize(
+    "math,is_histogram_breakdown,should_raise",
+    [
+        [PropertyMathType.MEDIAN, True, True],
+        [PropertyMathType.P75, True, True],
+        [PropertyMathType.P90, True, True],
+        [PropertyMathType.P95, True, True],
+        [PropertyMathType.P99, True, True],
+        [PropertyMathType.SUM, True, False],
+        [PropertyMathType.AVG, True, False],
+        [PropertyMathType.MIN, True, False],
+        [PropertyMathType.MAX, True, False],
+        [BaseMathType.TOTAL, True, False],
+    ],
+)
+def test_get_outer_aggregation_histogram_validation(
+    math: Union[BaseMathType, PropertyMathType],
+    is_histogram_breakdown: bool,
+    should_raise: bool,
+):
+    team = Team()
+    series = EventsNode(event="$pageview", math=math)
+    query_date_range = QueryDateRange(date_range=None, interval=None, now=datetime.now(), team=team)
+
+    agg_ops = AggregationOperations(team, series, ChartDisplayType.ACTIONS_LINE_GRAPH, query_date_range, False)
+    field = ast.Field(chain=["total"])
+
+    if should_raise:
+        with pytest.raises(ValueError) as exc_info:
+            agg_ops.get_outer_aggregation(field, is_histogram_breakdown=is_histogram_breakdown)
+        assert "is not supported with histogram breakdowns" in str(exc_info.value)
+    else:
+        result = agg_ops.get_outer_aggregation(field, is_histogram_breakdown=is_histogram_breakdown)
+        assert isinstance(result, ast.Call)
+
+
+@pytest.mark.parametrize(
     "math,expected_agg_name",
     [
         [PropertyMathType.MAX, "max"],

--- a/posthog/hogql_queries/insights/trends/test/test_aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/test/test_aggregation_operations.py
@@ -239,6 +239,27 @@ def test_actor_id_returns_correct_field(
 
 
 @pytest.mark.parametrize(
+    "math,expected_outer_agg",
+    [
+        [PropertyMathType.MAX, "max"],
+        [PropertyMathType.MIN, "min"],
+        [PropertyMathType.SUM, "sum"],
+        [BaseMathType.TOTAL, "sum"],
+    ],
+)
+def test_get_outer_aggregation_name(
+    math: Union[BaseMathType, PropertyMathType],
+    expected_outer_agg: str,
+):
+    team = Team()
+    series = EventsNode(event="$pageview", math=math)
+    query_date_range = QueryDateRange(date_range=None, interval=None, now=datetime.now(), team=team)
+
+    agg_ops = AggregationOperations(team, series, ChartDisplayType.ACTIONS_LINE_GRAPH, query_date_range, False)
+    assert agg_ops.get_outer_aggregation_name() == expected_outer_agg
+
+
+@pytest.mark.parametrize(
     "math,math_group_type_index,expected_group_field",
     [
         [BaseMathType.WEEKLY_ACTIVE, MathGroupTypeIndex.NUMBER_0, "sql(e.$group_0)"],

--- a/posthog/hogql_queries/insights/trends/test/test_aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/test/test_aggregation_operations.py
@@ -239,24 +239,30 @@ def test_actor_id_returns_correct_field(
 
 
 @pytest.mark.parametrize(
-    "math,expected_outer_agg",
+    "math,expected_agg_name",
     [
         [PropertyMathType.MAX, "max"],
         [PropertyMathType.MIN, "min"],
+        [PropertyMathType.AVG, "avg"],
         [PropertyMathType.SUM, "sum"],
         [BaseMathType.TOTAL, "sum"],
     ],
 )
-def test_get_outer_aggregation_name(
+def test_get_outer_aggregation(
     math: Union[BaseMathType, PropertyMathType],
-    expected_outer_agg: str,
+    expected_agg_name: str,
 ):
     team = Team()
     series = EventsNode(event="$pageview", math=math)
     query_date_range = QueryDateRange(date_range=None, interval=None, now=datetime.now(), team=team)
 
     agg_ops = AggregationOperations(team, series, ChartDisplayType.ACTIONS_LINE_GRAPH, query_date_range, False)
-    assert agg_ops.get_outer_aggregation_name() == expected_outer_agg
+    field = ast.Field(chain=["total"])
+    result = agg_ops.get_outer_aggregation(field)
+
+    assert isinstance(result, ast.Call)
+    assert result.name == expected_agg_name
+    assert result.args == [field]
 
 
 @pytest.mark.parametrize(

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -1695,6 +1695,61 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             0,
         ]
 
+    def test_trends_breakdown_histogram_with_max_aggregation(self):
+        """
+        Test that when using max() math with histogram breakdowns, the histogram buckets
+        correctly use max (not sum) when rolling up values from different raw breakdown values
+        that fall into the same bucket.
+
+        Setup:
+        - breakdown_prop=1, agg_prop=100  -> bucket [1, 2.5]
+        - breakdown_prop=2, agg_prop=200  -> bucket [1, 2.5] (same bucket)
+        - breakdown_prop=3, agg_prop=150  -> bucket [2.5, 4.01]
+
+        Before fix: bucket [1, 2.5] would show 300 (sum of 100+200)
+        After fix: bucket [1, 2.5] should show 200 (max of 100, 200)
+        """
+        self._create_events(
+            [
+                SeriesTestData(
+                    distinct_id="p1",
+                    events=[Series(event="$pageview", timestamps=["2020-01-12T12:00:00Z"])],
+                    properties={"breakdown_prop": 1, "agg_prop": 100},
+                ),
+                SeriesTestData(
+                    distinct_id="p2",
+                    events=[Series(event="$pageview", timestamps=["2020-01-12T12:00:00Z"])],
+                    properties={"breakdown_prop": 2, "agg_prop": 200},
+                ),
+                SeriesTestData(
+                    distinct_id="p3",
+                    events=[Series(event="$pageview", timestamps=["2020-01-12T12:00:00Z"])],
+                    properties={"breakdown_prop": 3, "agg_prop": 150},
+                ),
+            ]
+        )
+
+        response = self._run_trends_query(
+            "2020-01-11",
+            "2020-01-13",
+            IntervalType.DAY,
+            [EventsNode(event="$pageview", math=PropertyMathType.MAX, math_property="agg_prop")],
+            None,
+            BreakdownFilter(
+                breakdown_type=BreakdownType.EVENT,
+                breakdown="breakdown_prop",
+                breakdown_histogram_bin_count=2,
+            ),
+        )
+
+        assert len(response.results) == 2
+
+        results_by_breakdown = {r["breakdown_value"]: r for r in response.results}
+
+        assert results_by_breakdown["[1,2]"]["data"] == [0, 100.0, 0]
+
+        assert results_by_breakdown["[2,3.01]"]["data"] == [0, 200.0, 0]
+
     def test_trends_aggregation_hogql(self):
         self._create_test_events()
 

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -4098,7 +4098,7 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             "2020-01-09",
             "2020-01-20",
             IntervalType.DAY,
-            [EventsNode(event="$pageview", math=PropertyMathType.MEDIAN, math_property="$session_duration")],
+            [EventsNode(event="$pageview", math=PropertyMathType.AVG, math_property="$session_duration")],
             None,
             BreakdownFilter(
                 breakdown="$session_duration", breakdown_type=BreakdownType.SESSION, breakdown_histogram_bin_count=4
@@ -4108,7 +4108,7 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             "2020-01-09",
             "2020-01-20",
             IntervalType.DAY,
-            [EventsNode(event="$pageview", math=PropertyMathType.MEDIAN, math_property="$session_duration")],
+            [EventsNode(event="$pageview", math=PropertyMathType.AVG, math_property="$session_duration")],
             None,
             BreakdownFilter(
                 breakdowns=[

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -1750,6 +1750,22 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         assert results_by_breakdown["[2,3.01]"]["data"] == [0, 200.0, 0]
 
+    def test_trends_breakdown_histogram_with_unsupported_math_type_raises_error(self):
+        with pytest.raises(ValueError) as exc_info:
+            self._run_trends_query(
+                "2020-01-11",
+                "2020-01-13",
+                IntervalType.DAY,
+                [EventsNode(event="$pageview", math=PropertyMathType.MEDIAN, math_property="agg_prop")],
+                None,
+                BreakdownFilter(
+                    breakdown_type=BreakdownType.EVENT,
+                    breakdown="breakdown_prop",
+                    breakdown_histogram_bin_count=2,
+                ),
+            )
+        assert "is not supported with histogram breakdowns" in str(exc_info.value)
+
     def test_trends_aggregation_hogql(self):
         self._create_test_events()
 

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -93,16 +93,16 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
         )
 
         return parse_select(
-            """
+            f"""
             SELECT
-                SUM(total) AS total,
-                {breakdown_select}
+                {self._aggregation_operation.get_outer_aggregation_name()}(total) AS total,
+                {{breakdown_select}}
             FROM
-                {rank_query}
-            WHERE {breakdown_filter}
+                {{rank_query}}
+            WHERE {{breakdown_filter}}
             GROUP BY breakdown_value
             ORDER BY
-                {breakdown_order_by},
+                {{breakdown_order_by}},
                 total DESC,
                 breakdown_value ASC
             """,
@@ -178,7 +178,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
                     -- "Other" breakdown value
                     SELECT
                         day_start,
-                        sum(count) as value,
+                        {self._aggregation_operation.get_outer_aggregation_name()}(count) as value,
                         {{breakdown_other}} as breakdown_value
                     FROM ranked_breakdown_values
                     WHERE breakdown_rank > {{breakdown_limit}}
@@ -361,10 +361,10 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
         query = cast(
             ast.SelectQuery,
             parse_select(
-                """
+                f"""
                 SELECT
-                    sum(total) AS count
-                FROM {inner_query}
+                    {self._aggregation_operation.get_outer_aggregation_name()}(total) AS count
+                FROM {{inner_query}}
             """,
                 placeholders={"inner_query": inner_query},
             ),

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -107,7 +107,9 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
                 breakdown_value ASC
             """,
             placeholders={
-                "outer_agg": self._aggregation_operation.get_outer_aggregation(ast.Field(chain=["total"])),
+                "outer_agg": self._aggregation_operation.get_outer_aggregation(
+                    ast.Field(chain=["total"]), is_histogram_breakdown=self.breakdown.is_histogram_breakdown
+                ),
                 "breakdown_select": self._breakdown_outer_query_select(
                     self.breakdown, breakdown_limit=self._get_breakdown_limit() + 1
                 ),
@@ -223,7 +225,9 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
                     "breakdown_limit": breakdown_limit_expr,
                     "breakdown_order": self._breakdown_query_order_by(self.breakdown),
                     "all_dates": self._get_date_subqueries(),
-                    "outer_agg": self._aggregation_operation.get_outer_aggregation(ast.Field(chain=["count"])),
+                    "outer_agg": self._aggregation_operation.get_outer_aggregation(
+                        ast.Field(chain=["count"]), is_histogram_breakdown=self.breakdown.is_histogram_breakdown
+                    ),
                     **self.query_date_range.to_placeholders(),
                 },
             )
@@ -369,7 +373,9 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
                 FROM {inner_query}
             """,
                 placeholders={
-                    "outer_agg": self._aggregation_operation.get_outer_aggregation(ast.Field(chain=["total"])),
+                    "outer_agg": self._aggregation_operation.get_outer_aggregation(
+                        ast.Field(chain=["total"]), is_histogram_breakdown=self.breakdown.is_histogram_breakdown
+                    ),
                     "inner_query": inner_query,
                 },
             ),


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0368RPHLQH/p1765648129066039

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
