### PR TITLE
fix: validate request support serializer class and instances

### DIFF
--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -185,8 +185,18 @@ def validated_request(
             if strict_response_validation or settings.DEBUG:
                 if response_config is None:
                     return result
-                serializer_class = response_config.response
+                response_serializer = response_config.response
+                if response_serializer is None:
+                    return result
+
                 context: dict[str, Any] = getattr(self, "get_serializer_context", lambda: {})()
+
+                # Handle both class and instance to match DRF Spectacular's behavior
+                serializer_class = (
+                    type(response_serializer)
+                    if isinstance(response_serializer, serializers.Serializer)
+                    else response_serializer
+                )
                 serialized = serializer_class(data=data, context=context)
 
                 if not serialized.is_valid(raise_exception=strict_response_validation):


### PR DESCRIPTION
## Problem

`@extend_schema` in DRF spectacular supports both serializer instances and classes. `@validated_request` doesn't support both. Some of the endpoints migrated over (local eval) would crash (oopsies)

This does break local dev 😭 oopsies.

Tests did not catch this, only breaks `settings.DEBUG=True` or if we're using strict validation (we're not)

## Changes

Fixes this to handle both classes and instances so we can keep migrating `@extend_schema` over more-or-less literally.

## How did you test this code?

Test local_eval and other endpoints on local dev.

Ran tests

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
