### PR TITLE
fix: handle case when stack trace has no .frames

### DIFF
--- a/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
+++ b/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
@@ -41,7 +41,7 @@ export function ExceptionRenderer({
             <div>
                 {match(exception.stacktrace)
                     .when(
-                        (stack) => stack === null || stack === undefined || stack.frames.length === 0,
+                        (stack) => stack === null || stack === undefined || !stack.frames || stack.frames.length === 0,
                         () => renderUndefinedTrace(exception, knownException)
                     )
                     .when(

--- a/frontend/src/lib/components/Errors/Exception/known-exceptions/registry.ts
+++ b/frontend/src/lib/components/Errors/Exception/known-exceptions/registry.ts
@@ -8,7 +8,11 @@ export class KnownExceptionRegistry {
     }
 
     static match(exception: ErrorTrackingException): KnownException | undefined {
-        return this.knownExceptionList.find((knownException) => knownException.match(exception))
+        try {
+            return this.knownExceptionList.find((knownException) => knownException.match(exception))
+        } catch {
+            return undefined
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Having no `stacktrace.frames` currently throws mega error and entire page becomes unusable.

## Changes

Accounted for that case.

<img width="1629" height="379" alt="image" src="https://github.com/user-attachments/assets/c414d8da-cbd3-45cf-ba5e-4ba2ce8c003c" />
