### PR TITLE
feat(llma): grant early adopters access to discussions and translation

### DIFF
--- a/products/llm_analytics/frontend/ConversationDisplay/MessageActionsMenu.tsx
+++ b/products/llm_analytics/frontend/ConversationDisplay/MessageActionsMenu.tsx
@@ -70,8 +70,9 @@ export const MessageActionsMenu = ({ content }: MessageActionsMenuProps): JSX.El
         setTimeout(() => insertQuoteIntoEditor(quotedContent), EDITOR_RETRY_DELAY_MS)
     }
 
-    const showDiscussions = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_DISCUSSIONS]
-    const showTranslation = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TRANSLATION]
+    const isEarlyAdopter = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
+    const showDiscussions = isEarlyAdopter || !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_DISCUSSIONS]
+    const showTranslation = isEarlyAdopter || !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TRANSLATION]
 
     const menuItems: LemonMenuItems = [
         ...(showDiscussions


### PR DESCRIPTION
## Problem

Early adopters enrolled in the `llm-analytics-early-adopters` feature flag should have access to discussions and translation features in LLM analytics. The backend already checks this flag for the translation API, but the frontend was only checking the individual feature flags.

## Changes

Updated `MessageActionsMenu.tsx` to check for `LLM_ANALYTICS_EARLY_ADOPTERS` flag in addition to the specific feature flags. Users with the early adopters flag now see both discussions and translation menu items, matching the backend access pattern.

## How did you test this code?

Verified TypeScript compilation passes for the changed file. The pre-existing TS errors in the codebase are unrelated to this change.

## Changelog: No

Feature is still behind feature flags.