### PR TITLE
fix: Remove blocking code from bigquery batch export

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -409,7 +409,7 @@ class BigQueryClient:
             """
 
         try:
-            query_job = self.sync_client.query(query, job_config=job_config)
+            query_job = await asyncio.to_thread(self.sync_client.query, query, job_config=job_config)
             await asyncio.to_thread(query_job.result)
         except Forbidden:
             return False
@@ -524,7 +524,7 @@ class BigQueryClient:
 
         self.logger.info("Inserting into final table", format=format, table_id=final.name, stage_table_id=stage.name)
 
-        query_job = self.sync_client.query(query, job_config=job_config)
+        query_job = await asyncio.to_thread(self.sync_client.query, query, job_config=job_config)
         result = await asyncio.to_thread(query_job.result)
         return result
 
@@ -625,7 +625,7 @@ class BigQueryClient:
             VALUES ({values});
         """
 
-        query_job = self.sync_client.query(merge_query, job_config=job_config)
+        query_job = await asyncio.to_thread(self.sync_client.query, merge_query, job_config=job_config)
         return await asyncio.to_thread(query_job.result)
 
     async def load_file(self, file, format: FileFormat, table: BigQueryTable):


### PR DESCRIPTION
## Problem

Calls to `bigquery.Client.query` are blocking (at the very least, they make an HTTP request).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Wrap them in `asyncio.to_thread`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
