### PR TITLE
test: verify visual_review isolated testing

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -3,6 +3,8 @@ Business logic for visual_review.
 
 ORM queries, validation, calculations, business rules.
 Called by api/api.py facade. Do not call from outside this module.
+
+Test change to verify isolated product testing.
 """
 
 from uuid import UUID

--- a/products/visual_review/backend/tests/test_diff.py
+++ b/products/visual_review/backend/tests/test_diff.py
@@ -103,3 +103,7 @@ class TestComputeDiff:
         diff_img = Image.open(io.BytesIO(result.diff_image))
         assert diff_img.size == (10, 10)
         assert diff_img.mode == "RGBA"
+
+    def test_intentional_failure_to_verify_ci_runs_tests(self):
+        """This test intentionally fails to verify CI is running visual_review tests."""
+        raise AssertionError("SUCCESS: CI is running visual_review tests! Remove this test.")


### PR DESCRIPTION
**Test PR stacked on #43397**

Tiny change to `products/visual_review/backend/logic.py` (just a comment).

**Expected behavior:**
- `bazel-coordinator` should detect only `visual_review` targets
- `run_legacy` should be `false` (no `//ci:legacy_pytest` in affected targets)
- Only `bazel-tests` job runs visual_review tests
- Legacy pytest (40+ jobs) should NOT run

This validates the isolated product architecture works correctly.