### PR TITLE
chore: bump cli version

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.5.19
+
+- chore: upgrade cargo-dist to 0.30.3
+
 # 0.5.17
 
 - feat: add --file option to target built files directly

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - chore: upgrade cargo-dist to 0.30.3
 
+# 0.5.18
+
+- fix: fix git info parsing in vercel environment
+
 # 0.5.17
 
 - feat: add --file option to target built files directly

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1521,7 +1521,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.18"
+version = "0.5.19"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",


### PR DESCRIPTION
## Problem

Fix vulnerability reported here: https://github.com/PostHog/posthog/pull/43373#issuecomment-3656625101

## Changes

- use newly upgrade cargo-dist
