### PR TITLE
fix: update hobby ci environment variable

### DIFF
--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -33,7 +33,7 @@ class HobbyTester:
         record=None,
     ):
         if not token:
-            token = os.getenv("DIGITALOCEAN_TOKEN")
+            token = os.getenv("DIGITAL_OCEAN_HOBBY_TOKEN")
         self.token = token
         self.branch = branch
         self.release_tag = release_tag


### PR DESCRIPTION
## Problem

We rotated secrets and the DO hobby CI key changed its name.

## Changes

Updates the env variable name from `DIGITALOCEAN_TOKEN` to `DIGITAL_OCEAN_HOBBY_TOKEN`.

## How did you test this code?

Will test on a PR after merging.