### PR TITLE
fix: don't show re-auth dialog when updating has_seen_product_intro

### DIFF
--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -433,6 +433,7 @@ class UserViewSet(
         "set_current_organization",
         "allow_sidebar_suggestions",
         "shortcut_position",
+        "has_seen_product_intro_for",
     ]
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["is_staff", "email"]


### PR DESCRIPTION
## Problem

We show the re-auth dialog when hiding the product intros. This is bad ux.

## Changes

- exclude `has_seen_product_intro` from re-auth fields

## How did you test this code?

Manually

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
