### PR TITLE
feat(capture): apply configurable timeout for Capture produce acks

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
+            - 'eli.r/capture-ack-timeout'
 
 jobs:
     build:

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -131,6 +131,8 @@ pub struct KafkaConfig {
     pub kafka_producer_queue_mib: u32, // Size of the in-memory producer queue in mebibytes
     #[envconfig(default = "20000")]
     pub kafka_message_timeout_ms: u32, // Time before we stop retrying producing a message: 20 seconds
+    #[envconfig(default = "30000")]
+    pub kafka_ack_timeout_ms: u64, // App-level timeout for Kafka delivery ACK (default 30s)
     #[envconfig(default = "1000000")]
     pub kafka_producer_message_max_bytes: u32, // message.max.bytes - max kafka message size we will produce
     #[envconfig(default = "none")]

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -53,6 +53,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
         kafka_producer_linger_ms: 0, // Send messages as soon as possible
         kafka_producer_queue_mib: 10,
         kafka_message_timeout_ms: 10000, // 10s, ACKs can be slow on low volumes, should be tuned
+        kafka_ack_timeout_ms: 30000,     // 30s app-level timeout for delivery ACK
         kafka_producer_message_max_bytes: 1000000, // 1MB, rdkafka default
         kafka_topic_metadata_refresh_interval_ms: 10000,
         kafka_compression_codec: "none".to_string(),


### PR DESCRIPTION
## Problem
@langesven noticed some hanging requests in contour, timing out at 5 mins on Envoy side, in `contour` logs today.

We don't see these requests in our capture-side latency metrics, but we wouldn't if they aren't completing by pod shutdown. These appear to be happening app side, so I want to address and instrument potential causes to be tested in mirror deploy.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add timeout to `produce_ack`s in the Kafka sink
* Add instrumentation (logs, metrics) for the same
* Better faceting for kafka produce error metrics to correlate these on deploy

**Notes:**
* Planning to smoke test this in mirror before rolling it out to avoid surprises
* This is one of two potential sources of hung requests in capture I could find. Adding handling/instrumentation for the other in a separate PR
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, CI, mirror smoke testing
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
