### PR TITLE
feat(surveys): add unsupported sdks to the sdk warning

### DIFF
--- a/frontend/src/scenes/surveys/QuickSurveyModal.tsx
+++ b/frontend/src/scenes/surveys/QuickSurveyModal.tsx
@@ -16,7 +16,7 @@ import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { SurveyAppearancePreview } from 'scenes/surveys/SurveyAppearancePreview'
 import { SurveyPopupToggle } from 'scenes/surveys/SurveySettings'
 import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings'
-import { getSurveyVersionWarnings } from 'scenes/surveys/surveyVersionRequirements'
+import { getSurveyWarnings } from 'scenes/surveys/surveyVersionRequirements'
 import { surveysSdkLogic } from 'scenes/surveys/surveysSdkLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -54,8 +54,8 @@ export function QuickSurveyForm({ context, info, onCancel, showFollowupToggle }:
     const { teamSdkVersions } = useValues(surveysSdkLogic)
     const shouldShowSurveyToggle = useRef(!currentTeam?.surveys_opt_in).current
 
-    const versionWarnings = useMemo(
-        () => getSurveyVersionWarnings(previewSurvey as Survey, teamSdkVersions),
+    const warnings = useMemo(
+        () => getSurveyWarnings(previewSurvey as Survey, teamSdkVersions),
         [previewSurvey, teamSdkVersions]
     )
 
@@ -217,7 +217,7 @@ export function QuickSurveyForm({ context, info, onCancel, showFollowupToggle }:
                     </div>
                 )}
 
-                <SdkVersionWarnings warnings={versionWarnings} />
+                <SdkVersionWarnings warnings={warnings} />
 
                 {submitDisabledReason && (
                     <LemonBanner type="error" className="mb-4">

--- a/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
+++ b/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
@@ -12,7 +12,7 @@ import { doesSurveyHaveDisplayConditions } from 'scenes/surveys/utils'
 import { AccessControlLevel, AccessControlResourceType, SurveyType } from '~/types'
 
 export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNode }): JSX.Element {
-    const { survey, surveyVersionWarnings } = useValues(surveyLogic)
+    const { survey, surveyWarnings } = useValues(surveyLogic)
     const { showSurveysDisabledBanner } = useValues(surveysLogic)
     const { launchSurvey } = useActions(surveyLogic)
 
@@ -43,7 +43,7 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                                         : 'all your users'}
                                     .
                                 </div>
-                                <SdkVersionWarnings warnings={surveyVersionWarnings} />
+                                <SdkVersionWarnings warnings={surveyWarnings} />
                             </div>
                         ),
                         primaryButton: {

--- a/frontend/src/scenes/surveys/components/SdkVersionWarnings.tsx
+++ b/frontend/src/scenes/surveys/components/SdkVersionWarnings.tsx
@@ -1,49 +1,69 @@
+import { useValues } from 'kea'
+
 import { LemonBanner, Link } from '@posthog/lemon-ui'
 
-import { SurveyVersionWarning } from 'scenes/surveys/surveyVersionRequirements'
+import { SurveyFeatureWarning } from 'scenes/surveys/surveyVersionRequirements'
+import { surveysSdkLogic } from 'scenes/surveys/surveysSdkLogic'
 
-export function SdkVersionWarnings({ warnings }: { warnings: SurveyVersionWarning[] }): JSX.Element | null {
+export function SdkVersionWarnings({ warnings }: { warnings: SurveyFeatureWarning[] }): JSX.Element | null {
+    const { teamSdkVersions } = useValues(surveysSdkLogic)
+
     if (warnings.length === 0) {
         return null
     }
 
-    const warningsByFeature = warnings.reduce(
-        (acc, warning) => {
-            if (!acc[warning.feature]) {
-                acc[warning.feature] = []
-            }
-            acc[warning.feature].push(warning)
-            return acc
-        },
-        {} as Record<string, SurveyVersionWarning[]>
-    )
+    const hasVersionIssues = warnings.some((w) => w.versionIssues.length > 0)
+
+    const relevantSdks = new Set<string>()
+    for (const warning of warnings) {
+        for (const issue of warning.versionIssues) {
+            relevantSdks.add(issue.sdkType)
+        }
+        for (const sdk of warning.unsupportedSdks) {
+            relevantSdks.add(sdk)
+        }
+    }
+
+    const sdkVersionsDisplay = Array.from(relevantSdks)
+        .filter((sdk) => teamSdkVersions[sdk as keyof typeof teamSdkVersions])
+        .map((sdk) => `${sdk} v${teamSdkVersions[sdk as keyof typeof teamSdkVersions]}`)
+        .join(', ')
 
     return (
-        <LemonBanner type="warning" hideIcon>
+        <LemonBanner type="warning" hideIcon className="mt-2">
             <div className="flex items-start gap-2">
                 <div>
-                    <p className="font-semibold mb-1">SDK version warning</p>
+                    <p className="font-semibold mb-1">SDK warnings</p>
+                    {sdkVersionsDisplay && (
+                        <p className="text-sm text-secondary mb-2">Your SDKs: {sdkVersionsDisplay}</p>
+                    )}
                     <ul className="text-sm list-disc pl-4 mb-2 space-y-2">
-                        {Object.entries(warningsByFeature).map(([feature, featureWarnings]) => (
-                            <li key={feature}>
-                                <strong>{feature}</strong>
-                                <ul className="list-none pl-2 mt-0.5">
-                                    {featureWarnings.map((warning, idx) => (
-                                        <li key={idx} className="text-secondary">
-                                            Requires {warning.sdkType} v{warning.minVersion}+ (you have v
-                                            {warning.currentVersion})
+                        {warnings.map((warning) => (
+                            <li key={warning.feature}>
+                                <strong>{warning.feature}</strong>
+                                <ul className="list-none pl-2 mt-0.5 space-y-0.5">
+                                    {warning.versionIssues.map((issue, idx) => (
+                                        <li key={`version-${idx}`} className="text-secondary">
+                                            Requires {issue.sdkType} v{issue.minVersion}+
                                         </li>
                                     ))}
+                                    {warning.unsupportedSdks.length > 0 && (
+                                        <li className="text-secondary">
+                                            Not supported on {warning.unsupportedSdks.join(', ')}
+                                        </li>
+                                    )}
                                 </ul>
                             </li>
                         ))}
                     </ul>
-                    <p className="text-sm text-secondary">
-                        <Link to="https://posthog.com/docs/libraries" target="_blank">
-                            Update your SDK
-                        </Link>{' '}
-                        to ensure these features work correctly.
-                    </p>
+                    {hasVersionIssues && (
+                        <p className="text-sm text-secondary">
+                            <Link to="https://posthog.com/docs/libraries" target="_blank">
+                                Update your SDK
+                            </Link>{' '}
+                            to ensure these features work correctly.
+                        </p>
+                    )}
                 </div>
             </div>
         </LemonBanner>

--- a/frontend/src/scenes/surveys/components/SurveysTable.tsx
+++ b/frontend/src/scenes/surveys/components/SurveysTable.tsx
@@ -16,7 +16,7 @@ import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings
 import { SurveyStatusTag } from 'scenes/surveys/components/SurveyStatusTag'
 import { SurveysEmptyState } from 'scenes/surveys/components/empty-state/SurveysEmptyState'
 import { SURVEY_TYPE_LABEL_MAP, SurveyQuestionLabel } from 'scenes/surveys/constants'
-import { getSurveyVersionWarnings } from 'scenes/surveys/surveyVersionRequirements'
+import { getSurveyWarnings } from 'scenes/surveys/surveyVersionRequirements'
 import { SurveysTabs, surveysLogic } from 'scenes/surveys/surveysLogic'
 import { isSurveyRunning } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
@@ -192,10 +192,7 @@ export function SurveysTable(): JSX.Element {
                                                     <LemonButton
                                                         fullWidth
                                                         onClick={() => {
-                                                            const versionWarnings = getSurveyVersionWarnings(
-                                                                survey,
-                                                                teamSdkVersions
-                                                            )
+                                                            const warnings = getSurveyWarnings(survey, teamSdkVersions)
                                                             LemonDialog.open({
                                                                 title: 'Launch this survey?',
                                                                 content: (
@@ -204,9 +201,7 @@ export function SurveysTable(): JSX.Element {
                                                                             The survey will immediately start displaying
                                                                             to users matching the display conditions.
                                                                         </div>
-                                                                        <SdkVersionWarnings
-                                                                            warnings={versionWarnings}
-                                                                        />
+                                                                        <SdkVersionWarnings warnings={warnings} />
                                                                     </div>
                                                                 ),
                                                                 primaryButton: {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -85,7 +85,7 @@ import {
     defaultSurveyFieldValues,
 } from './constants'
 import type { surveyLogicType } from './surveyLogicType'
-import { SurveyVersionWarning, getSurveyVersionWarnings } from './surveyVersionRequirements'
+import { SurveyFeatureWarning, getSurveyWarnings } from './surveyVersionRequirements'
 import { surveysLogic } from './surveysLogic'
 import {
     DATE_FORMAT,
@@ -2039,10 +2039,10 @@ export const surveyLogic = kea<surveyLogicType>([
                 return responsesByQuestion
             },
         ],
-        surveyVersionWarnings: [
+        surveyWarnings: [
             (s) => [s.survey, s.teamSdkVersions],
-            (survey, teamSdkVersions): SurveyVersionWarning[] => {
-                return getSurveyVersionWarnings(survey as Survey, teamSdkVersions)
+            (survey, teamSdkVersions): SurveyFeatureWarning[] => {
+                return getSurveyWarnings(survey as Survey, teamSdkVersions)
             },
         ],
     }),

--- a/frontend/src/scenes/surveys/surveyVersionRequirements.ts
+++ b/frontend/src/scenes/surveys/surveyVersionRequirements.ts
@@ -21,6 +21,7 @@ export type SurveyFeatureRequirement = {
     sdkVersions: SdkVersionRequirements
     feature: string
     docsUrl?: string
+    unsupportedSdks?: SurveySdkType[]
 }
 
 // list of survey things that require specific sdk version(s)
@@ -35,6 +36,11 @@ export const SURVEY_SDK_REQUIREMENTS: SurveyFeatureRequirement[] = [
         feature: 'URL targeting with exact match',
         sdkVersions: { 'posthog-js': '1.82.0' },
         check: (s) => s.conditions?.urlMatchType === SurveyMatchType.Exact,
+    },
+    {
+        feature: 'Device types targeting',
+        sdkVersions: { 'posthog-js': '1.214.0' },
+        check: (s) => (s.conditions?.deviceTypes?.length ?? 0) > 0,
     },
     {
         feature: 'Custom font selection',
@@ -54,11 +60,13 @@ export const SURVEY_SDK_REQUIREMENTS: SurveyFeatureRequirement[] = [
     {
         feature: 'Partial response collection',
         sdkVersions: { 'posthog-js': '1.240.0' },
+        unsupportedSdks: ['posthog-ios', 'posthog-android', 'posthog-react-native'],
         check: (s) => s.enable_partial_responses === true,
     },
     {
         feature: 'Auto-submit on selection',
         sdkVersions: { 'posthog-js': '1.244.0' },
+        unsupportedSdks: ['posthog-ios', 'posthog-android', 'posthog-react-native'],
         check: (s) =>
             s.questions.some(
                 (q) =>
@@ -84,6 +92,7 @@ export const SURVEY_SDK_REQUIREMENTS: SurveyFeatureRequirement[] = [
     {
         feature: 'Event trigger property filters',
         sdkVersions: { 'posthog-js': '1.268.0' },
+        unsupportedSdks: ['posthog-ios', 'posthog-android', 'posthog-react-native'],
         check: (s) =>
             (s.conditions?.events?.values?.length ?? 0) > 0 &&
             !!s.conditions?.events?.values?.some((e) => Object.keys(e.propertyFilters ?? {}).length > 0),
@@ -96,11 +105,13 @@ export const SURVEY_SDK_REQUIREMENTS: SurveyFeatureRequirement[] = [
     {
         feature: 'Cancellation events',
         sdkVersions: { 'posthog-js': '1.299.0' },
+        unsupportedSdks: ['posthog-ios', 'posthog-android', 'posthog-react-native'],
         check: (s) => (s.conditions?.cancelEvents?.values?.length ?? 0) > 0,
     },
     {
         feature: 'Targeting with actions',
         sdkVersions: { 'posthog-js': '1.299.0' },
+        unsupportedSdks: ['posthog-ios', 'posthog-android', 'posthog-react-native'],
         check: (s) => (s.conditions?.actions?.values?.length ?? 0) > 0,
     },
     {
@@ -123,35 +134,41 @@ export function meetsVersionRequirement(version: string | null | undefined, minV
 
 export type TeamSdkVersions = Partial<Record<SurveySdkType, string | null>>
 
-export type SurveyVersionWarning = {
+export type SurveyFeatureWarning = {
     feature: string
-    sdkType: SurveySdkType
-    currentVersion: string
-    minVersion: string
-    docsUrl?: string
+    versionIssues: { sdkType: SurveySdkType; currentVersion: string; minVersion: string }[]
+    unsupportedSdks: SurveySdkType[]
 }
 
-export function getSurveyVersionWarnings(survey: Survey, teamSdkVersions: TeamSdkVersions): SurveyVersionWarning[] {
-    const warnings: SurveyVersionWarning[] = []
+export function getSurveyWarnings(survey: Survey, teamSdkVersions: TeamSdkVersions): SurveyFeatureWarning[] {
+    const warnings: SurveyFeatureWarning[] = []
+    const activeTeamSdkTypes = Object.keys(teamSdkVersions) as SurveySdkType[]
 
     for (const req of SURVEY_SDK_REQUIREMENTS) {
         if (!req.check(survey)) {
             continue
         }
 
+        const versionIssues: SurveyFeatureWarning['versionIssues'] = []
+        const unsupportedSdks: SurveySdkType[] = []
+
         for (const [sdkType, minVersion] of Object.entries(req.sdkVersions) as [SurveySdkType, string][]) {
             const teamVersion = teamSdkVersions[sdkType]
-
-            // only warn if we've seen the team use this sdk AND it's outdated
             if (teamVersion && !meetsVersionRequirement(teamVersion, minVersion)) {
-                warnings.push({
-                    feature: req.feature,
-                    sdkType,
-                    currentVersion: teamVersion,
-                    minVersion,
-                    docsUrl: req.docsUrl,
-                })
+                versionIssues.push({ sdkType, currentVersion: teamVersion, minVersion })
             }
+        }
+
+        if (req.unsupportedSdks) {
+            for (const sdk of req.unsupportedSdks) {
+                if (activeTeamSdkTypes.includes(sdk)) {
+                    unsupportedSdks.push(sdk)
+                }
+            }
+        }
+
+        if (versionIssues.length > 0 || unsupportedSdks.length > 0) {
+            warnings.push({ feature: req.feature, versionIssues, unsupportedSdks })
         }
     }
 


### PR DESCRIPTION
## Problem

the surveys SDK version warning banner (on survey launch) only shows warnings about specific SDK versions, **not** whether you are using features that are entirely unsupported by your SDK(s)

relevant ticket: https://posthoghelp.zendesk.com/agent/tickets/44854 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/47096)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds unsupported SDK data to the warning when you launch

![Screenshot 2025-12-15 at 11.08.46 AM.png](https://app.graphite.com/user-attachments/assets/39016d67-cc5e-4812-9773-bbacccc8fb63.png)



<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->