### PR TITLE
fix(experiments): Validate metric UUIDs are present in ordering

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -341,6 +341,9 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
                 saved_metric_serializer.save()
                 # TODO: Going the above route means we can still sometimes fail when validation fails?
                 # But this shouldn't really happen, if it does its a bug in our validation logic (validate_saved_metrics_ids)
+
+        self._validate_metric_ordering(experiment, {})
+
         return experiment
 
     def update(self, instance: Experiment, validated_data: dict, *args: Any, **kwargs: Any) -> Experiment:
@@ -494,6 +497,8 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
 
                 validated_data[metric_field] = updated_metrics
 
+        self._validate_metric_ordering(instance, validated_data)
+
         if instance.is_draft and has_start_date:
             feature_flag.active = True
             feature_flag.save()
@@ -502,6 +507,78 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
             # Not a draft, doesn't have start date
             # Or draft without start date
             return super().update(instance, validated_data)
+
+    def _validate_metric_ordering(self, instance: Experiment, validated_data: dict) -> None:
+        """
+        Validate that ordering arrays contain all metric UUIDs.
+
+        This catches bugs where the frontend sends metrics but fails to include
+        their UUIDs in the ordering arrays
+        """
+        primary_ordering = validated_data.get("primary_metrics_ordered_uuids", instance.primary_metrics_ordered_uuids)
+        secondary_ordering = validated_data.get(
+            "secondary_metrics_ordered_uuids", instance.secondary_metrics_ordered_uuids
+        )
+
+        # Get inline metrics
+        primary_metrics = validated_data.get("metrics", instance.metrics) or []
+        secondary_metrics = validated_data.get("metrics_secondary", instance.metrics_secondary) or []
+
+        # Get saved metrics from the db (they were just created/recreated in update())
+        saved_metrics = list(instance.experimenttosavedmetric_set.select_related("saved_metric").all())
+
+        expected_primary_uuids: set[str] = set()
+        expected_secondary_uuids: set[str] = set()
+
+        # Add inline metric UUIDs
+        for metric in primary_metrics:
+            uuid = metric.get("uuid")
+            if uuid:
+                expected_primary_uuids.add(uuid)
+
+        for metric in secondary_metrics:
+            uuid = metric.get("uuid")
+            if uuid:
+                expected_secondary_uuids.add(uuid)
+
+        # Add saved metric UUIDs
+        for link in saved_metrics:
+            saved_metric = link.saved_metric
+            uuid = saved_metric.query.get("uuid") if saved_metric.query else None
+            if uuid:
+                metric_type = link.metadata.get("type", "primary") if link.metadata else "primary"
+                if metric_type == "primary":
+                    expected_primary_uuids.add(uuid)
+                else:
+                    expected_secondary_uuids.add(uuid)
+
+        # Validate: if there are primary metrics, ordering array must exist and contain all UUIDs
+        if expected_primary_uuids:
+            if primary_ordering is None:
+                raise ValidationError(
+                    "primary_metrics_ordered_uuids is null but primary metrics exist. "
+                    "This is likely a frontend bug - please refresh and try again."
+                )
+            missing = expected_primary_uuids - set(primary_ordering)
+            if missing:
+                raise ValidationError(
+                    f"primary_metrics_ordered_uuids is missing UUIDs: {sorted(missing)}. "
+                    "This is likely a frontend bug - please refresh and try again."
+                )
+
+        # Validate: if there are secondary metrics, ordering array must exist and contain all UUIDs
+        if expected_secondary_uuids:
+            if secondary_ordering is None:
+                raise ValidationError(
+                    "secondary_metrics_ordered_uuids is null but secondary metrics exist. "
+                    "This is likely a frontend bug - please refresh and try again."
+                )
+            missing = expected_secondary_uuids - set(secondary_ordering)
+            if missing:
+                raise ValidationError(
+                    f"secondary_metrics_ordered_uuids is missing UUIDs: {sorted(missing)}. "
+                    "This is likely a frontend bug - please refresh and try again."
+                )
 
 
 class ExperimentStatus(str, Enum):

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -2773,6 +2773,7 @@ class TestExperimentCRUD(APILicensedTest):
                 "parameters": {},
                 "filters": {},
                 "metrics": [initial_mean_metric, initial_funnel_metric, initial_ratio_metric],
+                "primary_metrics_ordered_uuids": ["metric-1", "metric-2", "metric-3"],
             },
         )
         exp_id = response.json()["id"]
@@ -2827,6 +2828,11 @@ class TestExperimentCRUD(APILicensedTest):
             f"/api/projects/{self.team.id}/experiments/{exp_id}",
             {
                 "metrics": [updated_funnel_metric, updated_mean_metric, updated_ratio_metric],
+                "primary_metrics_ordered_uuids": [
+                    "964398d7-ec8a-424d-890b-4e6bbc9a5c84",
+                    "824e38ae-f9d7-41f4-962c-74c9e744529a",
+                    "70e0c887-1f32-4c7d-8405-0faded2e9722",
+                ],
                 "start_date": "2024-01-01T10:00:00Z",
                 "stats_config": {"method": "frequentist"},
                 "exposure_criteria": {


### PR DESCRIPTION
## Problem
When metrics are added to an experiment, the frontend must also add their UUIDs to the ordering arrays (`primary_metrics_ordered_uuids` / `secondary_metrics_ordered_uuids`) which control display order.

We have a bug where some metrics were saved but their UUIDs were missing from these arrays. As a result, these metrics do not render in the UI. Even worse, saved metrics that were already added can't be re-added to the experiment when this bug occurs.

## Changes
I wasn't able to solve this bug yet. For now, I'm adding a validation to ensure that every metric has its UUID present in the ordering array before the experiment can be created or updated.

If a UUID is missing, the API throws an error. I'm hoping to debug this further via a session recording/stack trace when this happens again.

I'll fix affected records via a management command before merging this.

## How did you test this code?
- Added tests