### PR TITLE
feat: custom event handlers in plugin server

### DIFF
--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -41,6 +41,7 @@ import { NodeInstrumentation } from './utils/node-instrumentation'
 import { captureException, shutdown as posthogShutdown } from './utils/posthog'
 import { PubSub } from './utils/pubsub'
 import { delay } from './utils/utils'
+import { internalEventHandlerRegistry } from './worker/ingestion/internal-handlers'
 import { teardownPlugins } from './worker/plugins/teardown'
 import { initPlugins as _initPlugins } from './worker/tasks'
 
@@ -103,6 +104,8 @@ export class PluginServer {
 
         const capabilities = getPluginServerCapabilities(this.config)
         const hub = (this.hub = await createHub(this.config, capabilities))
+
+        internalEventHandlerRegistry.setCelery(hub.celery)
 
         let _initPluginsPromise: Promise<void> | undefined
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/internalHandlersStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/internalHandlersStep.ts
@@ -1,0 +1,8 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { internalEventHandlerRegistry } from '../internal-handlers'
+
+export async function internalHandlersStep(event: PluginEvent): Promise<PluginEvent> {
+    await internalEventHandlerRegistry.handleEvent(event)
+    return event
+}

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -19,6 +19,7 @@ import { MergeMode, determineMergeMode } from '../persons/person-merge-types'
 import { PersonsStore } from '../persons/persons-store'
 import { EventsProcessor } from '../process-event'
 import { dropOldEventsStep } from './dropOldEventsStep'
+import { internalHandlersStep } from './internalHandlersStep'
 import {
     pipelineLastStepCounter,
     pipelineStepErrorCounter,
@@ -253,6 +254,8 @@ export class EventPipelineRunner {
             return normalizeResult
         }
         const [normalizedEvent, timestamp] = normalizeResult.value
+
+        await internalHandlersStep(normalizedEvent)
 
         const personProcessingResult = await this.processPersonForEvent(
             normalizedEvent,

--- a/plugin-server/src/worker/ingestion/internal-handlers/README.md
+++ b/plugin-server/src/worker/ingestion/internal-handlers/README.md
@@ -1,0 +1,68 @@
+# internal-handlers
+
+this is a set of event handlers that allow you to "do X when we get Y event" during event ingestion.
+
+`internalHandlerStep` triggers all handlers attached to a given event, and runs after `normalizeEventStep` in `runner.ts`
+
+## how-to
+
+1. create a handler in `handlers/<your-product>/<some-event-handler>.ts`, give it a name and specify relevant events:
+
+```typescript
+import { PluginEvent } from '@posthog/plugin-scaffold'
+import { InternalEventHandler, InternalEventHandlerContext } from '../../registry'
+
+export const myEventHandler: InternalEventHandler = {
+    name: 'unique event handler name',
+    events: ['list of', 'relevant events'],
+
+    async handle(event: PluginEvent, context: InternalEventHandlerContext): Promise<void> {
+        // do something
+    },
+}
+```
+
+2. register your handler in `index.ts`
+
+```typescript
+import { myEventHandler } from './handlers/my-product/myEventHandler'
+
+internalEventHandlerRegistry.register(myEventHandler)
+```
+
+## examples
+
+### update person property
+
+when we get a `survey shown` event, we want to update a person property `$last_seen_survey_date`.
+
+```typescript
+async handle(event: PluginEvent, _context: InternalEventHandlerContext): Promise<void> {
+    event.properties = {
+        ...(event.properties || {}),
+        $set: {
+            ...(event.properties?.['$set'] || {}),
+            $last_seen_survey_date: event.timestamp || new Date().toISOString(),
+        },
+    }
+},
+```
+
+see `handlers/surveys/surveyShown.ts`
+
+### trigger celery job
+
+when we get a `survey sent` event, we want to check if the survey needs to be disabled, e.g. it has been set to "stop survey after collecting N responses"
+
+```typescript
+async handle(event: PluginEvent, context: InternalEventHandlerContext): Promise<void> {
+    const surveyId = event.properties?.['$survey_id']
+    if (surveyId && context.celery) {
+        await context.celery.applyAsync('posthog.tasks.tasks.stop_surveys_reached_target', [], {
+            survey_id: surveyId,
+        })
+    }
+},
+```
+
+see `handlers/surveys/surveySent.ts`

--- a/plugin-server/src/worker/ingestion/internal-handlers/handlers/surveys/surveySent.ts
+++ b/plugin-server/src/worker/ingestion/internal-handlers/handlers/surveys/surveySent.ts
@@ -1,0 +1,18 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { InternalEventHandler, InternalEventHandlerContext } from '../../registry'
+
+// check if the survey needs to be stopped when a response is submitted
+export const surveySentHandler: InternalEventHandler = {
+    name: 'surveys sent',
+    events: ['survey sent'],
+
+    async handle(event: PluginEvent, context: InternalEventHandlerContext): Promise<void> {
+        const surveyId = event.properties?.['$survey_id']
+        if (surveyId && context.celery) {
+            await context.celery.applyAsync('posthog.tasks.tasks.stop_surveys_reached_target', [], {
+                survey_id: surveyId,
+            })
+        }
+    },
+}

--- a/plugin-server/src/worker/ingestion/internal-handlers/handlers/surveys/surveyShown.ts
+++ b/plugin-server/src/worker/ingestion/internal-handlers/handlers/surveys/surveyShown.ts
@@ -1,0 +1,20 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { InternalEventHandler, InternalEventHandlerContext } from '../../registry'
+
+// update $last_seen_survey_date when a user sees a survey
+export const surveyShownHandler: InternalEventHandler = {
+    name: 'surveys shown',
+    events: ['survey shown'],
+
+    handle(event: PluginEvent, _context: InternalEventHandlerContext): Promise<void> {
+        event.properties = {
+            ...(event.properties || {}),
+            $set: {
+                ...(event.properties?.['$set'] || {}),
+                $last_seen_survey_date: event.timestamp || new Date().toISOString(),
+            },
+        }
+        return Promise.resolve()
+    },
+}

--- a/plugin-server/src/worker/ingestion/internal-handlers/handlers/surveys/surveys.test.ts
+++ b/plugin-server/src/worker/ingestion/internal-handlers/handlers/surveys/surveys.test.ts
@@ -1,0 +1,70 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { InternalEventHandlerContext } from '../../registry'
+import { surveyShownHandler } from './surveyShown'
+
+const buildSurveyEvent = (overrides?: Partial<PluginEvent>): PluginEvent => {
+    return {
+        event: 'survey shown',
+        distinct_id: 'user-123',
+        team_id: 1,
+        timestamp: '2024-01-15T10:00:00Z',
+        properties: {},
+        ip: null,
+        site_url: '',
+        now: '',
+        uuid: '',
+        ...overrides,
+    }
+}
+
+const emptyContext: InternalEventHandlerContext = {}
+
+describe('surveysHandler', () => {
+    it('should set $last_seen_survey_date on survey shown events', async () => {
+        const event = buildSurveyEvent()
+
+        await surveyShownHandler.handle(event, emptyContext)
+
+        expect(event.properties!['$set']).toEqual({
+            $last_seen_survey_date: '2024-01-15T10:00:00Z',
+        })
+    })
+
+    it('should use current date if no timestamp on event', async () => {
+        const event = buildSurveyEvent({ timestamp: undefined })
+
+        const before = new Date().toISOString()
+        await surveyShownHandler.handle(event, emptyContext)
+        const after = new Date().toISOString()
+
+        const setDate = event.properties!['$set']['$last_seen_survey_date'] as string
+        expect(setDate >= before).toBe(true)
+        expect(setDate <= after).toBe(true)
+    })
+
+    it('should preserve existing $set properties', async () => {
+        const event = buildSurveyEvent({ properties: { $set: { existing_prop: 'value' } } })
+
+        await surveyShownHandler.handle(event, emptyContext)
+
+        expect(event.properties!['$set']).toEqual({
+            existing_prop: 'value',
+            $last_seen_survey_date: '2024-01-15T10:00:00Z',
+        })
+    })
+
+    it('should create properties object if missing', async () => {
+        const event = buildSurveyEvent({ properties: undefined })
+
+        await surveyShownHandler.handle(event, emptyContext)
+
+        expect(event.properties!['$set']).toEqual({
+            $last_seen_survey_date: '2024-01-15T10:00:00Z',
+        })
+    })
+
+    it('should be registered for survey shown event', () => {
+        expect(surveyShownHandler.events).toEqual(['survey shown'])
+    })
+})

--- a/plugin-server/src/worker/ingestion/internal-handlers/index.ts
+++ b/plugin-server/src/worker/ingestion/internal-handlers/index.ts
@@ -1,0 +1,9 @@
+import { surveySentHandler } from './handlers/surveys/surveySent'
+import { surveyShownHandler } from './handlers/surveys/surveyShown'
+import { internalEventHandlerRegistry } from './registry'
+
+export { internalEventHandlerRegistry } from './registry'
+
+// register internal event handlers
+internalEventHandlerRegistry.register(surveyShownHandler)
+internalEventHandlerRegistry.register(surveySentHandler)

--- a/plugin-server/src/worker/ingestion/internal-handlers/registry.test.ts
+++ b/plugin-server/src/worker/ingestion/internal-handlers/registry.test.ts
@@ -1,0 +1,127 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { InternalEventHandler, InternalEventHandlerContext, internalEventHandlerRegistry } from './registry'
+
+const buildTestEvent = (eventName: string, overrides?: Partial<PluginEvent>): PluginEvent => ({
+    event: eventName,
+    distinct_id: 'user-123',
+    team_id: 1,
+    properties: {},
+    ip: null,
+    site_url: '',
+    now: '',
+    uuid: '',
+    ...overrides,
+})
+
+describe('InternalEventHandlerRegistry', () => {
+    beforeEach(() => {
+        // Clear handlers between tests by accessing private field
+        ;(internalEventHandlerRegistry as any).handlers = []
+        ;(internalEventHandlerRegistry as any).eventToHandlers = new Map()
+        ;(internalEventHandlerRegistry as any).celery = undefined
+    })
+
+    it('should register handlers and route events correctly', async () => {
+        const handleMock = jest.fn()
+        const handler: InternalEventHandler = {
+            name: 'test-handler',
+            events: ['test event'],
+            handle: handleMock,
+        }
+
+        internalEventHandlerRegistry.register(handler)
+
+        const event = buildTestEvent('test event')
+        await internalEventHandlerRegistry.handleEvent(event)
+
+        expect(handleMock).toHaveBeenCalledWith(event, expect.objectContaining<InternalEventHandlerContext>({}))
+    })
+
+    it('should not call handlers for non-matching events', async () => {
+        const handleMock = jest.fn()
+        const handler: InternalEventHandler = {
+            name: 'test-handler',
+            events: ['test event'],
+            handle: handleMock,
+        }
+
+        internalEventHandlerRegistry.register(handler)
+
+        const event = buildTestEvent('other event')
+        await internalEventHandlerRegistry.handleEvent(event)
+
+        expect(handleMock).not.toHaveBeenCalled()
+    })
+
+    it('should handle multiple handlers for same event', async () => {
+        const handleMock1 = jest.fn()
+        const handleMock2 = jest.fn()
+
+        internalEventHandlerRegistry.register({
+            name: 'handler-1',
+            events: ['test event'],
+            handle: handleMock1,
+        })
+
+        internalEventHandlerRegistry.register({
+            name: 'handler-2',
+            events: ['test event'],
+            handle: handleMock2,
+        })
+
+        const event = buildTestEvent('test event')
+        await internalEventHandlerRegistry.handleEvent(event)
+
+        expect(handleMock1).toHaveBeenCalledWith(event, expect.any(Object))
+        expect(handleMock2).toHaveBeenCalledWith(event, expect.any(Object))
+    })
+
+    it('should catch and log errors from handlers without failing', async () => {
+        const errorHandler: InternalEventHandler = {
+            name: 'error-handler',
+            events: ['test event'],
+            handle: jest.fn().mockRejectedValue(new Error('Handler error')),
+        }
+
+        internalEventHandlerRegistry.register(errorHandler)
+
+        const event = buildTestEvent('test event')
+
+        // Should not throw
+        await expect(internalEventHandlerRegistry.handleEvent(event)).resolves.not.toThrow()
+    })
+
+    it('should support handlers for multiple events', async () => {
+        const handleMock = jest.fn()
+        const handler: InternalEventHandler = {
+            name: 'multi-event-handler',
+            events: ['event-a', 'event-b'],
+            handle: handleMock,
+        }
+
+        internalEventHandlerRegistry.register(handler)
+
+        await internalEventHandlerRegistry.handleEvent(buildTestEvent('event-a'))
+        await internalEventHandlerRegistry.handleEvent(buildTestEvent('event-b'))
+
+        expect(handleMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('should pass celery in context when set', async () => {
+        const handleMock = jest.fn()
+        const mockCelery = { applyAsync: jest.fn() }
+
+        internalEventHandlerRegistry.register({
+            name: 'test-handler',
+            events: ['test event'],
+            handle: handleMock,
+        })
+        internalEventHandlerRegistry.setCelery(mockCelery as any)
+
+        const event = buildTestEvent('test event')
+        await internalEventHandlerRegistry.handleEvent(event)
+
+        expect(handleMock).toHaveBeenCalledWith(event, { celery: mockCelery })
+    })
+})

--- a/plugin-server/src/worker/ingestion/internal-handlers/registry.ts
+++ b/plugin-server/src/worker/ingestion/internal-handlers/registry.ts
@@ -1,0 +1,57 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { Celery } from '../../../utils/db/celery'
+import { logger } from '../../../utils/logger'
+
+export interface InternalEventHandlerContext {
+    celery?: Celery
+}
+
+export interface InternalEventHandler {
+    name: string
+    events: string[]
+    handle(event: PluginEvent, context: InternalEventHandlerContext): Promise<void>
+}
+
+class InternalEventHandlerRegistry {
+    private handlers: InternalEventHandler[] = []
+    private eventToHandlers: Map<string, InternalEventHandler[]> = new Map()
+    private celery?: Celery
+
+    register(handler: InternalEventHandler): void {
+        this.handlers.push(handler)
+
+        for (const eventName of handler.events) {
+            const existing = this.eventToHandlers.get(eventName) || []
+            existing.push(handler)
+            this.eventToHandlers.set(eventName, existing)
+        }
+
+        logger.info('📋', `Registered internal event handler: ${handler.name} for events: ${handler.events.join(', ')}`)
+    }
+
+    setCelery(celery: Celery): void {
+        this.celery = celery
+    }
+
+    getHandlersForEvent(eventName: string): InternalEventHandler[] {
+        return this.eventToHandlers.get(eventName) || []
+    }
+
+    async handleEvent(event: PluginEvent): Promise<void> {
+        const handlers = this.getHandlersForEvent(event.event)
+        const context: InternalEventHandlerContext = {
+            celery: this.celery,
+        }
+
+        for (const handler of handlers) {
+            try {
+                await handler.handle(event, context)
+            } catch (error) {
+                logger.error('🔔', `Internal event handler ${handler.name} failed`, { error, event: event.event })
+            }
+        }
+    }
+}
+
+export const internalEventHandlerRegistry = new InternalEventHandlerRegistry()

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -779,28 +779,66 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
         if instance.iteration_count is not None and instance.iteration_count > 0:
             survey_key = f"{instance.id}/{instance.current_iteration or 1}"
 
-        user_submitted_dismissed_filter = {
-            "groups": [
-                {
-                    "variant": "",
-                    "rollout_percentage": 100,
-                    "properties": [
-                        {
-                            "key": f"{SurveyEventProperties.SURVEY_DISMISSED}/{survey_key}",
-                            "value": "is_not_set",
-                            "operator": "is_not_set",
-                            "type": "person",
-                        },
-                        {
-                            "key": f"{SurveyEventProperties.SURVEY_RESPONDED}/{survey_key}",
-                            "value": "is_not_set",
-                            "operator": "is_not_set",
-                            "type": "person",
-                        },
-                    ],
-                }
-            ]
-        }
+        base_properties = [
+            {
+                "key": f"{SurveyEventProperties.SURVEY_DISMISSED}/{survey_key}",
+                "value": "is_not_set",
+                "operator": "is_not_set",
+                "type": "person",
+            },
+            {
+                "key": f"{SurveyEventProperties.SURVEY_RESPONDED}/{survey_key}",
+                "value": "is_not_set",
+                "operator": "is_not_set",
+                "type": "person",
+            },
+        ]
+
+        wait_period_days = None
+        if instance.conditions and isinstance(instance.conditions, dict):
+            wait_period_days = instance.conditions.get("seenSurveyWaitPeriodInDays")
+
+        if wait_period_days is not None and wait_period_days > 0:
+            user_submitted_dismissed_filter = {
+                "groups": [
+                    {
+                        "variant": "",
+                        "rollout_percentage": 100,
+                        "properties": [
+                            *base_properties,
+                            {
+                                "key": SurveyEventProperties.SURVEY_LAST_SEEN_DATE,
+                                "value": "is_not_set",
+                                "operator": "is_not_set",
+                                "type": "person",
+                            },
+                        ],
+                    },
+                    {
+                        "variant": "",
+                        "rollout_percentage": 100,
+                        "properties": [
+                            *base_properties,
+                            {
+                                "key": SurveyEventProperties.SURVEY_LAST_SEEN_DATE,
+                                "value": f"-{int(wait_period_days)}d",
+                                "operator": "is_date_before",
+                                "type": "person",
+                            },
+                        ],
+                    },
+                ]
+            }
+        else:
+            user_submitted_dismissed_filter = {
+                "groups": [
+                    {
+                        "variant": "",
+                        "rollout_percentage": 100,
+                        "properties": base_properties,
+                    }
+                ]
+            }
 
         if instance.internal_targeting_flag:
             existing_targeting_flag = instance.internal_targeting_flag

--- a/posthog/models/surveys/util.py
+++ b/posthog/models/surveys/util.py
@@ -19,6 +19,7 @@ class SurveyEventProperties(StrEnum):
     SURVEY_RESPONDED = "$survey_responded"
     SURVEY_DISMISSED = "$survey_dismissed"
     SURVEY_COMPLETED = "$survey_completed"
+    SURVEY_LAST_SEEN_DATE = "$last_seen_survey_date"
 
 
 def get_survey_response_clickhouse_query(

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -730,10 +730,10 @@ def verify_persons_data_in_sync() -> None:
 
 
 @shared_task(ignore_result=True)
-def stop_surveys_reached_target() -> None:
+def stop_surveys_reached_target(survey_id: str | None = None) -> None:
     from posthog.tasks.stop_surveys_reached_target import stop_surveys_reached_target
 
-    stop_surveys_reached_target()
+    stop_surveys_reached_target(survey_id=survey_id)
 
 
 @shared_task(ignore_result=True)


### PR DESCRIPTION
## Problem

for surveys, we want to react to some events by triggering celery jobs, updating person properties, etc -- right now there's no good way to do that

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds a new "internal event handler" concept to the plugin server which allows for generic "do X when we get Y event" handlers

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

i haven't yet! pls don't merge this!

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->