### PR TITLE
fix: early return usekeyheld

### DIFF
--- a/frontend/src/lib/hooks/useKeyHeld.tsx
+++ b/frontend/src/lib/hooks/useKeyHeld.tsx
@@ -17,11 +17,17 @@ export function useKeyHeld(key: string, deps?: DependencyList): boolean {
     useEventListener(
         'keydown',
         (event) => {
-            const key = event.key
-            const keysHeldCopy = new Set(keysHeldRef.current)
-            keysHeldCopy.add(key)
-            keysHeldRef.current = keysHeldCopy
-            checkKeysHeld()
+            const eventKey = event.key
+            // Only update state if this is the key we're watching
+            if (eventKey !== key) {
+                return
+            }
+            if (!keysHeldRef.current.has(eventKey)) {
+                const keysHeldCopy = new Set(keysHeldRef.current)
+                keysHeldCopy.add(eventKey)
+                keysHeldRef.current = keysHeldCopy
+                checkKeysHeld()
+            }
         },
         undefined,
         [...(deps || [])]
@@ -30,11 +36,17 @@ export function useKeyHeld(key: string, deps?: DependencyList): boolean {
     useEventListener(
         'keyup',
         (event) => {
-            const key = event.key
-            const keysHeldCopy = new Set(keysHeldRef.current)
-            keysHeldCopy.delete(key)
-            keysHeldRef.current = keysHeldCopy
-            checkKeysHeld()
+            const eventKey = event.key
+            // Only update state if this is the key we're watching
+            if (eventKey !== key) {
+                return
+            }
+            if (keysHeldRef.current.has(eventKey)) {
+                const keysHeldCopy = new Set(keysHeldRef.current)
+                keysHeldCopy.delete(eventKey)
+                keysHeldRef.current = keysHeldCopy
+                checkKeysHeld()
+            }
         },
         undefined,
         [...(deps || [])]


### PR DESCRIPTION
## Problem

- these eventlistener's are firing everywhere according to chrome profiler

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- early return if key isn't of interest

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
