### PR TITLE
feat(mcp): Add self-hosted PostHog support with Docker

### DIFF
--- a/products/mcp/Dockerfile.selfhosted
+++ b/products/mcp/Dockerfile.selfhosted
@@ -1,0 +1,53 @@
+# Dockerfile for running PostHog MCP Server for self-hosted PostHog instances
+# This runs the MCP server locally (via wrangler dev) and connects to your
+# self-hosted PostHog instance.
+#
+# Build from the PostHog monorepo root:
+#   docker build -f products/mcp/Dockerfile.selfhosted -t posthog-mcp-selfhosted .
+#
+# Run:
+#   docker run -d -p 8787:8787 -e POSTHOG_BASE_URL=https://your-posthog-instance.com posthog-mcp-selfhosted
+#
+# Then configure your MCP client to connect to http://localhost:8787/mcp
+
+FROM node:22-slim
+
+WORKDIR /app
+
+# Install pnpm (same version as monorepo)
+RUN npm install -g pnpm@9.15.0
+
+# Copy monorepo package files and lockfile first for better caching
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches/ ./patches/
+
+# Copy the MCP product package files
+COPY products/mcp/package.json ./products/mcp/
+COPY products/mcp/typescript/package.json ./products/mcp/typescript/
+
+# Install dependencies
+RUN pnpm install --filter @posthog/agent-toolkit...
+
+# Install CA certificates (needed for workerd to trust various CAs)
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Update wrangler to latest version for updated CA bundle
+WORKDIR /app/products/mcp/typescript
+RUN pnpm add -D wrangler@latest
+
+# Copy MCP source code
+WORKDIR /app
+COPY products/mcp/ ./products/mcp/
+
+# Set working directory to the MCP typescript folder
+WORKDIR /app/products/mcp/typescript
+
+# Expose port 8787 (wrangler dev default port)
+EXPOSE 8787
+
+# POSTHOG_BASE_URL must be set when running the container
+# Example: -e POSTHOG_BASE_URL=https://your-posthog-instance.com
+
+# Create a .dev.vars file at runtime to pass env vars to wrangler
+# Then run wrangler dev bound to all interfaces
+CMD ["sh", "-c", "echo \"POSTHOG_BASE_URL=${POSTHOG_BASE_URL}\" > .dev.vars && pnpm exec wrangler dev --ip 0.0.0.0 --port 8787"]

--- a/products/mcp/typescript/src/resources/index.ts
+++ b/products/mcp/typescript/src/resources/index.ts
@@ -218,7 +218,8 @@ export async function registerResources(server: McpServer, context: Context): Pr
         const manifest = loadManifest(archive)
         registerManifestResources(server, manifest, archive)
     } catch (error) {
-        console.error('Failed to fetch and register manifest resources:', error)
-        throw error
+        // Don't throw - make resources loading optional for self-hosted environments
+        // where fetching from GitHub might fail
+        console.error('Failed to fetch and register manifest resources (continuing without them):', error)
     }
 }


### PR DESCRIPTION
## Problem

  Self-hosted PostHog users cannot use the MCP (Model Context Protocol) server because the cloud-hosted MCP at mcp.posthog.com only connects to PostHog Cloud (US/EU). There was no documentation or easy way for self-hosted users to run the MCP server themselves.

## Changes

  - Add Dockerfile.selfhosted for running MCP server locally against self-hosted PostHog instances
  - Expand README with detailed self-hosted setup instructions including architecture diagram, Docker commands, and MCP client configuration
  - Make resource loading fail gracefully for environments where fetching from GitHub might fail (e.g., network-restricted setups)

## Architecture:
  ```
  MCP Client (Claude/Cursor/VS Code)
       │
       │ (connects via mcp-remote)
       ▼
  MCP Server (running locally via Docker)
       │
       │ (makes API calls)
       ▼
  Self-hosted PostHog Instance
  ```

## How did you test this code?

  - Built Docker image: docker build -f products/mcp/Dockerfile.selfhosted -t posthog-mcp-selfhosted .
  - Ran container against self-hosted instance: docker run -d -p 8787:8787 -e POSTHOG_BASE_URL=https://example.com posthog-mcp-selfhosted
  - Verified MCP initialize request returns 200 OK with correct capabilities
  - Confirmed server connects to self-hosted PostHog API successfully

## Changelog: (features only) Is this feature complete?

  Yes - this enables self-hosted PostHog users to use the MCP server with their instances.