### PR TITLE
feat(capture): expose _readiness status change trigger check for preStop in capture

### DIFF
--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -78,19 +78,14 @@ async fn index() -> &'static str {
     "capture"
 }
 
-async fn readiness(
-    axum::extract::State(state): axum::extract::State<State>,
-) -> axum::http::StatusCode {
+async fn readiness() -> axum::http::StatusCode {
     use crate::metrics_middleware::ShutdownStatus;
 
     let shutdown_status = crate::metrics_middleware::get_shutdown_status();
     let is_running_or_unknown =
         shutdown_status == ShutdownStatus::Running || shutdown_status == ShutdownStatus::Unknown;
 
-    if is_running_or_unknown
-        && state.is_mirror_deploy
-        && std::path::Path::new("/tmp/shutdown").exists()
-    {
+    if is_running_or_unknown && std::path::Path::new("/tmp/shutdown").exists() {
         crate::metrics_middleware::set_shutdown_status(ShutdownStatus::Prestop);
         tracing::info!("Shutdown status change: PRESTOP");
     }


### PR DESCRIPTION
## Problem
Now that we've smoke tested the new `preStop` phase `_readiness` state handling in mirror deploy, we should enable it everywhere
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* remove mirror deploy gating on readiness state change checks
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, CI, mirror deploy 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
