### PR TITLE
chore: allow search on creating a new api key & control the scroll

### DIFF
--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -113,6 +113,7 @@ export const API_KEY_SCOPE_PRESETS: {
         scopes: ['action:read', 'query:read', 'project:read', 'organization:read', 'user:read', 'webhook:write'],
     },
     { value: 'analytics', label: 'Performing analytics queries', scopes: ['query:read'] },
+    { value: 'endpoints', label: 'Endpoint execution', scopes: ['endpoint:read'] },
     {
         value: 'project_management',
         label: 'Project & user management',

--- a/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
@@ -24,7 +24,7 @@ import {
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { IconErrorOutline } from 'lib/lemon-ui/icons'
-import { API_KEY_SCOPE_PRESETS, API_SCOPES, MAX_API_KEYS_PER_USER } from 'lib/scopes'
+import { API_KEY_SCOPE_PRESETS, MAX_API_KEYS_PER_USER } from 'lib/scopes'
 import { capitalizeFirstLetter, detailedTime, humanFriendlyDetailedTime } from 'lib/utils'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
@@ -45,8 +45,11 @@ export function EditKeyModal({ zIndex }: EditKeyModalProps): JSX.Element {
         editingKey,
         allTeams,
         allOrganizations,
+        filteredScopes,
+        searchTerm,
     } = useValues(personalAPIKeysLogic)
-    const { setEditingKeyId, setScopeRadioValue, submitEditingKey, resetScopes } = useActions(personalAPIKeysLogic)
+    const { setEditingKeyId, setScopeRadioValue, submitEditingKey, resetScopes, setSearchTerm } =
+        useActions(personalAPIKeysLogic)
     const { isCloudOrDev } = useValues(preflightLogic)
 
     const isNew = editingKeyId === 'new'
@@ -131,68 +134,97 @@ export function EditKeyModal({ zIndex }: EditKeyModalProps): JSX.Element {
                                     </LemonBanner>
                                 ) : (
                                     <div>
-                                        {API_SCOPES.map(
-                                            ({ key, disabledActions, warnings, disabledWhenProjectScoped, info }) => {
-                                                const disabledDueToProjectScope =
-                                                    disabledWhenProjectScoped && editingKey.access_type === 'teams'
-                                                return (
-                                                    <Fragment key={key}>
-                                                        <div className="flex items-center justify-between gap-2 min-h-8">
-                                                            <div
-                                                                className={clsx(
-                                                                    'flex items-center gap-1',
-                                                                    disabledDueToProjectScope && 'text-muted'
-                                                                )}
-                                                            >
-                                                                <b>{capitalizeFirstLetter(key.replace(/_/g, ' '))}</b>
+                                        <LemonInput
+                                            type="search"
+                                            placeholder="Search scopes..."
+                                            value={searchTerm}
+                                            onChange={setSearchTerm}
+                                            className="mb-2"
+                                            size="small"
+                                        />
+                                        <div className="max-h-[50vh] overflow-y-auto">
+                                            {filteredScopes.length === 0 ? (
+                                                <div className="text-muted text-sm py-2">
+                                                    No scopes match "{searchTerm}"
+                                                </div>
+                                            ) : (
+                                                filteredScopes.map(
+                                                    ({
+                                                        key,
+                                                        disabledActions,
+                                                        warnings,
+                                                        disabledWhenProjectScoped,
+                                                        info,
+                                                    }) => {
+                                                        const disabledDueToProjectScope =
+                                                            disabledWhenProjectScoped &&
+                                                            editingKey.access_type === 'teams'
+                                                        return (
+                                                            <Fragment key={key}>
+                                                                <div className="flex items-center justify-between gap-2 min-h-8">
+                                                                    <div
+                                                                        className={clsx(
+                                                                            'flex items-center gap-1',
+                                                                            disabledDueToProjectScope && 'text-muted'
+                                                                        )}
+                                                                    >
+                                                                        <b>
+                                                                            {capitalizeFirstLetter(
+                                                                                key.replace(/_/g, ' ')
+                                                                            )}
+                                                                        </b>
 
-                                                                {info ? (
-                                                                    <Tooltip title={info}>
-                                                                        <IconInfo className="text-secondary text-base" />
-                                                                    </Tooltip>
-                                                                ) : null}
-                                                            </div>
-                                                            <LemonSegmentedButton
-                                                                onChange={(value) => setScopeRadioValue(key, value)}
-                                                                value={formScopeRadioValues[key] ?? 'none'}
-                                                                options={[
-                                                                    { label: 'No access', value: 'none' },
-                                                                    {
-                                                                        label: 'Read',
-                                                                        value: 'read',
-                                                                        disabledReason: disabledActions?.includes(
-                                                                            'read'
-                                                                        )
-                                                                            ? 'Does not apply to this resource'
-                                                                            : disabledDueToProjectScope
-                                                                              ? 'Not available for project scoped keys'
-                                                                              : undefined,
-                                                                    },
-                                                                    {
-                                                                        label: 'Write',
-                                                                        value: 'write',
-                                                                        disabledReason: disabledActions?.includes(
-                                                                            'write'
-                                                                        )
-                                                                            ? 'Does not apply to this resource'
-                                                                            : disabledDueToProjectScope
-                                                                              ? 'Not available for project scoped keys'
-                                                                              : undefined,
-                                                                    },
-                                                                ]}
-                                                                size="xsmall"
-                                                            />
-                                                        </div>
-                                                        {warnings?.[formScopeRadioValues[key]] && (
-                                                            <div className="flex items-start gap-2 text-xs italic pb-2">
-                                                                <IconWarning className="text-base text-secondary mt-0.5" />
-                                                                <span>{warnings[formScopeRadioValues[key]]}</span>
-                                                            </div>
-                                                        )}
-                                                    </Fragment>
+                                                                        {info ? (
+                                                                            <Tooltip title={info}>
+                                                                                <IconInfo className="text-secondary text-base" />
+                                                                            </Tooltip>
+                                                                        ) : null}
+                                                                    </div>
+                                                                    <LemonSegmentedButton
+                                                                        onChange={(value) =>
+                                                                            setScopeRadioValue(key, value)
+                                                                        }
+                                                                        value={formScopeRadioValues[key] ?? 'none'}
+                                                                        options={[
+                                                                            { label: 'No access', value: 'none' },
+                                                                            {
+                                                                                label: 'Read',
+                                                                                value: 'read',
+                                                                                disabledReason:
+                                                                                    disabledActions?.includes('read')
+                                                                                        ? 'Does not apply to this resource'
+                                                                                        : disabledDueToProjectScope
+                                                                                          ? 'Not available for project scoped keys'
+                                                                                          : undefined,
+                                                                            },
+                                                                            {
+                                                                                label: 'Write',
+                                                                                value: 'write',
+                                                                                disabledReason:
+                                                                                    disabledActions?.includes('write')
+                                                                                        ? 'Does not apply to this resource'
+                                                                                        : disabledDueToProjectScope
+                                                                                          ? 'Not available for project scoped keys'
+                                                                                          : undefined,
+                                                                            },
+                                                                        ]}
+                                                                        size="xsmall"
+                                                                    />
+                                                                </div>
+                                                                {warnings?.[formScopeRadioValues[key]] && (
+                                                                    <div className="flex items-start gap-2 text-xs italic pb-2">
+                                                                        <IconWarning className="text-base text-secondary mt-0.5" />
+                                                                        <span>
+                                                                            {warnings[formScopeRadioValues[key]]}
+                                                                        </span>
+                                                                    </div>
+                                                                )}
+                                                            </Fragment>
+                                                        )
+                                                    }
                                                 )
-                                            }
-                                        )}
+                                            )}
+                                        </div>
                                     </div>
                                 )}
                             </>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
i watched some recordings:
1. user spent like 10 seconds trying to find the scope they needed
2. once he found it, clicking the create button at the bottom and failing to create - confusing not to see what the validation error is (missing api key label)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- only scroll the scopes - not the inputs on the top
- add a search on scopes

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
- locally fiddled with it
<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->


[api-keys-search-and-scroll.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/dad89924-c1b1-4ed2-93a5-3d3606b092b6.mov" />](https://app.graphite.com/user-attachments/video/dad89924-c1b1-4ed2-93a5-3d3606b092b6.mov)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
nah
