### PR TITLE
chore: make sql editor output tabs consistent & improve descriptions

### DIFF
--- a/frontend/src/layout/panel-layout/DatabaseTree/DatabaseTree.tsx
+++ b/frontend/src/layout/panel-layout/DatabaseTree/DatabaseTree.tsx
@@ -26,7 +26,7 @@ export const DatabaseTree = memo(function DatabaseTree({
     return (
         <div
             className={cn(
-                'relative bg-primary border-r border-primary transition-opacity duration-100 flex flex-col',
+                'relative bg-primary border-r border-primary transition-opacity duration-100 flex flex-col min-w-min',
                 isDatabaseTreeCollapsed ? 'w-11' : `w-[var(--database-tree-width)]`,
                 databaseTreeWillCollapse && 'opacity-50'
             )}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -11,6 +11,7 @@ import {
     LemonSegmentedButton,
     LemonSelect,
     LemonSwitch,
+    Link,
     Popover,
 } from '@posthog/lemon-ui'
 
@@ -295,6 +296,7 @@ interface VariableComponentProps {
     variableOverridesAreSet: boolean
     onRemove?: (variableId: string) => void
     variableSettingsOnClick?: () => void
+    onInsertAtCursor?: (text: string) => void
     insightsUsingVariable?: string[]
     emptyState?: JSX.Element | string
     size?: 'small' | 'medium'
@@ -307,19 +309,35 @@ export const VariableComponent = ({
     variableOverridesAreSet,
     onRemove,
     variableSettingsOnClick,
+    onInsertAtCursor,
     insightsUsingVariable,
     emptyState = '',
     size = 'medium',
 }: VariableComponentProps): JSX.Element => {
     const [isPopoverOpen, setPopoverOpen] = useState(false)
 
-    let tooltip = `Use this variable in your HogQL by referencing {variables.${variable.code_name}}`
+    const variableAsHogQL = `{variables.${variable.code_name}}`
 
-    if (insightsUsingVariable && insightsUsingVariable.length) {
-        tooltip += `. Insights using this variable: ${insightsUsingVariable.join(', ')}`
-    }
+    const tooltip = (
+        <div className="flex flex-col gap-1">
+            <span>
+                Use this variable in your HogQL by referencing <code>{variableAsHogQL}</code> or
+                {onInsertAtCursor && (
+                    <>
+                        {' '}
+                        <Link subtle onClick={() => onInsertAtCursor(variableAsHogQL)}>
+                            insert at cursor.
+                        </Link>
+                    </>
+                )}
+            </span>
+            {insightsUsingVariable && insightsUsingVariable.length > 0 && (
+                <span>Insights using this variable: {insightsUsingVariable.join(', ')}</span>
+            )}
+        </div>
+    )
 
-    // Dont show the popover overlay for list variables not in edit mode
+    // Don't show the popover overlay for list variables not in edit mode
     if (!showEditingUI && variable.type === 'List') {
         return (
             <LemonField.Pure label={variable.name} className="gap-0" info={tooltip}>

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -321,10 +321,11 @@ export const VariableComponent = ({
     const tooltip = (
         <div className="flex flex-col gap-1">
             <span>
-                Use this variable in your HogQL by referencing <code>{variableAsHogQL}</code> or
+                Use this variable in your HogQL by referencing <code>{variableAsHogQL}</code>
                 {onInsertAtCursor && (
                     <>
                         {' '}
+                        or{' '}
                         <Link subtle onClick={() => onInsertAtCursor(variableAsHogQL)}>
                             insert at cursor.
                         </Link>

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -866,7 +866,7 @@ const Content = ({
         }
         return (
             <TabScroller>
-                <div className="px-6 py-4 border-t max-w-1/2">
+                <div className="px-6 py-4 border-t">
                     <QueryVariables />
                 </div>
             </TabScroller>

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -235,6 +235,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             viewId,
         }),
         syncUrlWithQuery: true,
+        insertTextAtCursor: (text: string) => ({ text }),
     })),
     propsChanged(({ actions, props }, oldProps) => {
         if (!oldProps.monaco && !oldProps.editor && props.monaco && props.editor) {
@@ -392,6 +393,37 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
         },
         fixErrorsFailure: () => {
             posthog.capture('ai-error-fixer-failure')
+        },
+        insertTextAtCursor: ({ text }) => {
+            const editor = props.editor
+            if (!editor) {
+                return
+            }
+
+            const position = editor.getPosition()
+            if (!position) {
+                return
+            }
+
+            editor.executeEdits('insert-variable', [
+                {
+                    range: {
+                        startLineNumber: position.lineNumber,
+                        startColumn: position.column,
+                        endLineNumber: position.lineNumber,
+                        endColumn: position.column,
+                    },
+                    text,
+                },
+            ])
+
+            // Move cursor to end of inserted text
+            editor.setPosition({
+                lineNumber: position.lineNumber,
+                column: position.column + text.length,
+            })
+
+            editor.focus()
         },
         shareTab: () => {
             const currentTab = values.activeTab

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/Endpoint.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/Endpoint.tsx
@@ -8,6 +8,7 @@ import {
     LemonSwitch,
     LemonTag,
     LemonTextArea,
+    Link,
     lemonToast,
 } from '@posthog/lemon-ui'
 
@@ -99,17 +100,19 @@ export function Endpoint({ tabId }: EndpointProps): JSX.Element {
     }
 
     return (
-        <div className="space-y-4">
+        <div className="overflow-auto" data-attr="sql-editor-endpoint-pane">
             <div className="flex flex-row items-center gap-2">
                 <h3 className="mb-0">Endpoint</h3>
-                <LemonTag type="completion">ALPHA</LemonTag>
+                <LemonTag type="warning">BETA</LemonTag>
             </div>
             <div className="space-y-2">
                 <p className="text-xs">
-                    Endpoints are a way of pre-defining queries that you can query via the API, with additional
-                    performance improvements and the benefits of monitoring cost and usage.
+                    Endpoints allows you to pre-define a query that you'd like to expose as an API endpoint to use in
+                    your customer-facing dashboard, on your landing page or in your internal tool.
                     <br />
-                    Once created, you will get a URL that you can make an API request to from your own code.
+                    <Link data-attr="endpoints-help" to="https://posthog.com/docs/endpoints" target="_blank">
+                        Learn more about endpoints.
+                    </Link>
                 </p>
 
                 <div className="flex items-center gap-2">

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
@@ -259,7 +259,7 @@ export function QueryInfo({ tabId }: QueryInfoProps): JSX.Element {
                                         to="https://posthog.com/docs/data-warehouse/views#materializing-and-scheduling-a-view"
                                         target="_blank"
                                     >
-                                        Learn more about materialization.
+                                        Learn more about materialization
                                     </Link>
                                     .
                                 </p>

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
@@ -252,13 +252,14 @@ export function QueryInfo({ tabId }: QueryInfoProps): JSX.Element {
                             <div>
                                 <p className="text-xs">
                                     Materialized views are a way to pre-compute data in your data warehouse. This allows
-                                    you to run queries faster and more efficiently. Learn more about materialization{' '}
+                                    you to run queries faster and more efficiently.
+                                    <br />
                                     <Link
                                         data-attr="materializing-help"
                                         to="https://posthog.com/docs/data-warehouse/views#materializing-and-scheduling-a-view"
                                         target="_blank"
                                     >
-                                        here
+                                        Learn more about materialization.
                                     </Link>
                                     .
                                 </p>

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryVariables.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryVariables.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx'
-import { useActions } from 'kea'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 
 import { Link } from '@posthog/lemon-ui'
 
@@ -12,6 +11,8 @@ import { variableModalLogic } from '~/queries/nodes/DataVisualization/Components
 import { variablesLogic } from '~/queries/nodes/DataVisualization/Components/Variables/variablesLogic'
 import { dataVisualizationLogic } from '~/queries/nodes/DataVisualization/dataVisualizationLogic'
 
+import { multitabEditorLogic } from '../multitabEditorLogic'
+
 const documentationUrl = 'https://posthog.com/docs/sql/variables'
 
 export function QueryVariables(): JSX.Element {
@@ -20,17 +21,22 @@ export function QueryVariables(): JSX.Element {
     const { showEditingUI } = useValues(dataVisualizationLogic)
     const { variableOverridesAreSet } = useValues(dataNodeLogic)
     const { openExistingVariableModal } = useActions(variableModalLogic)
+    const { insertTextAtCursor } = useActions(multitabEditorLogic)
 
     return (
-        <div className="flex flex-col gap-1.5" data-attr="sql-editor-sidebar-query-variables-pane">
-            <div className="flex flex-col items-start">
+        <div className="overflow-auto" data-attr="sql-editor-sidebar-query-variables-pane">
+            <div className="flex flex-row items-center gap-2">
                 <h3 className="mb-0">Query variables</h3>
-                <span className="text-xs">
-                    Query variables let you dynamically set values in your SQL query.{' '}
+            </div>
+            <div className="space-y-2">
+                <p className="text-xs">
+                    Query variables let you dynamically set values in your SQL query. Add a variable and then use it in
+                    your HogQL query. The value you set here can be changed when viewing the insight or dashboard.
+                    <br />
                     <Link to={documentationUrl} target="_blank">
-                        Learn more
+                        Learn more about variables
                     </Link>
-                </span>
+                </p>
             </div>
             <div
                 className={clsx(
@@ -44,6 +50,7 @@ export function QueryVariables(): JSX.Element {
                         variable={n}
                         showEditingUI={showEditingUI}
                         onChange={updateVariableValue}
+                        onInsertAtCursor={insertTextAtCursor}
                         onRemove={removeVariable}
                         variableOverridesAreSet={variableOverridesAreSet}
                         variableSettingsOnClick={() => openExistingVariableModal(n)}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
watched a user stumble not realizing how to use a variable.
the inconsistency in text position between sql editor output tabs was hurting my eyes

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- added a 'insert at cursor' button on the variable
- standardised the position of text between output tabs
- made the descriptions slightly more complete

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
- locally

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

[output-panes.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/285fbfc5-589b-4098-a7d9-55a85cdca06f.mov" />](https://app.graphite.com/user-attachments/video/285fbfc5-589b-4098-a7d9-55a85cdca06f.mov)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
nah
