### PR TITLE
perf: Fix SQL editor typing lag by memoizing DatabaseTree

### DIFF
--- a/frontend/src/layout/panel-layout/DatabaseTree/DatabaseTree.tsx
+++ b/frontend/src/layout/panel-layout/DatabaseTree/DatabaseTree.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { memo } from 'react'
 
 import { IconSidebarClose } from '@posthog/icons'
 
@@ -13,7 +14,11 @@ import { QueryDatabase } from 'scenes/data-warehouse/editor/sidebar/QueryDatabas
 
 import { SyncMoreNotice } from './SyncMoreNotice'
 
-export function DatabaseTree({ databaseTreeRef }: { databaseTreeRef: React.RefObject<HTMLDivElement> }): JSX.Element {
+export const DatabaseTree = memo(function DatabaseTree({
+    databaseTreeRef,
+}: {
+    databaseTreeRef: React.RefObject<HTMLDivElement>
+}): JSX.Element {
     const { databaseTreeWidth, databaseTreeResizerProps, isDatabaseTreeCollapsed, databaseTreeWillCollapse } =
         useValues(editorSizingLogic)
     const { toggleDatabaseTreeCollapsed, setDatabaseTreeCollapsed } = useActions(editorSizingLogic)
@@ -69,4 +74,4 @@ export function DatabaseTree({ databaseTreeRef }: { databaseTreeRef: React.RefOb
             />
         </div>
     )
-}
+})


### PR DESCRIPTION
## Summary

- Wraps `DatabaseTree` component with `React.memo()` to prevent unnecessary re-renders

## Problem

The SQL editor was experiencing significant lag when typing, especially in projects with many database tables/views (~500ms per keystroke in some cases).

**Root cause:** `EditorScene` subscribes to `queryInput` via `useValues(multitabEditorLogic)`, causing the entire component tree to re-render on every keystroke. This cascaded to `DatabaseTree` which re-rendered `LemonTree` with potentially thousands of nodes.

## Solution

Wrap `DatabaseTree` with `React.memo()`. Since the only prop (`databaseTreeRef`) is a stable ref, the component will skip re-rendering when the parent re-renders due to `queryInput` changes.

## Test plan

- [x] Tested locally with 500 fake view nodes - typing is now snappy
- [ ] Test in production on projects with many tables/views

🤖 Generated with [Claude Code](https://claude.com/claude-code)