### PR TITLE
feat(replay): add survey for filter feedback

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -316,6 +316,7 @@ export const FEATURE_FLAGS = {
     SESSIONS_EXPLORER: 'sessions-explorer', // owner: @jabahamondes #team-web-analytics
     SHOPIFY_DWH: 'shopify-dwh', // owner: @andrew #team-data-stack
     SHOW_REFERRER_FAVICON: 'show-referrer-favicon', // owner: @jordanm-posthog #team-web-analytics
+    SHOW_REPLAY_FILTERS_FEEDBACK_BUTTON: 'show-replay-filters-feedback-button', // owner: @ksvat #team-replay
     SSE_DASHBOARDS: 'sse-dashboards', // owner: @aspicer #team-analytics-platform
     SURVEY_ANALYSIS_MAX_TOOL: 'survey-analysis-max-tool', // owner: #team-surveys
     SURVEYS_EXPERIMENTS_CROSS_SELL: 'surveys-experiments-cross-sell', // owner: @adboio #team-surveys

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -718,20 +718,35 @@ const ReplayFiltersTab = ({
 
             <LemonDivider className="mt-4" />
 
-            <div className="flex items-center py-2 justify-end px-1 gap-2">
-                <LemonButton
-                    type="tertiary"
-                    size="small"
-                    onClick={handleResetFilters}
-                    icon={<IconRevert />}
-                    tooltip="Remove all filters and reset to defaults"
-                    disabledReason={!(resetFilters && (totalFiltersCount ?? 0) > 0) ? 'No filters applied' : undefined}
-                >
-                    Reset filters
-                </LemonButton>
-                <LemonButton type="primary" size="small" onClick={() => setIsSaveFiltersModalOpen(true)}>
-                    Save as new filter
-                </LemonButton>
+            <div className="flex items-center py-2 justify-between px-1 gap-2">
+                {useFeatureFlag('SHOW_REPLAY_FILTERS_FEEDBACK_BUTTON') && (
+                    <LemonButton
+                        id="replay-filters-feedback-button"
+                        type="tertiary"
+                        status="danger"
+                        size="small"
+                        data-attr="replay-filters-feedback-button"
+                    >
+                        Unexpected filter results?
+                    </LemonButton>
+                )}
+                <div className="flex gap-2 ml-auto">
+                    <LemonButton
+                        type="tertiary"
+                        size="small"
+                        onClick={handleResetFilters}
+                        icon={<IconRevert />}
+                        tooltip="Remove all filters and reset to defaults"
+                        disabledReason={
+                            !(resetFilters && (totalFiltersCount ?? 0) > 0) ? 'No filters applied' : undefined
+                        }
+                    >
+                        Reset filters
+                    </LemonButton>
+                    <LemonButton type="primary" size="small" onClick={() => setIsSaveFiltersModalOpen(true)}>
+                        Save as new filter
+                    </LemonButton>
+                </div>
             </div>
 
             <SaveFiltersModal isOpen={isSaveFiltersModalOpen} setIsOpen={setIsSaveFiltersModalOpen} filters={filters} />


### PR DESCRIPTION
## Problem

we're getting a lot of one-off tickets and anecdotes that filters are broken, lets expedite the feedback/iteration

## Changes

add survey, behind flag

## How did you test this code?

![Screenshot 2025-12-15 at 7.19.34 PM.png](https://app.graphite.com/user-attachments/assets/a63a1bce-7672-44b4-a18b-6117d0c71ab7.png)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
