### PR TITLE
test(hobby): smoke test without preview label

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Hobby deployment script for self-hosted PostHog instances
 
 set -e
 


### PR DESCRIPTION
Stacked on #40783

Triggers hobby smoke test workflow (no `hobby-preview` label = ephemeral droplet).

**Purpose:** Verify smoke test mode works correctly:
- Creates ephemeral droplet
- Runs tests
- Destroys droplet after completion