### PR TITLE
refactor: break out hog function prefetching step

### DIFF
--- a/plugin-server/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
+++ b/plugin-server/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
@@ -1,4 +1,4 @@
-import { EventHeaders, IncomingEventWithTeam } from '../../types'
+import { EventHeaders, IncomingEventWithTeam, Team } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restriction-manager'
 import {
     createApplyPersonProcessingRestrictionsStep,
@@ -11,6 +11,7 @@ import { PipelineBuilder, StartPipelineBuilder } from '../pipelines/builders/pip
 export interface PostTeamPreprocessingSubpipelineInput {
     headers: EventHeaders
     eventWithTeam: IncomingEventWithTeam
+    team: Team
 }
 
 export interface PostTeamPreprocessingSubpipelineConfig {

--- a/plugin-server/src/ingestion/analytics/pre-team-preprocessing-subpipeline.ts
+++ b/plugin-server/src/ingestion/analytics/pre-team-preprocessing-subpipeline.ts
@@ -2,7 +2,7 @@ import { Message } from 'node-rdkafka'
 
 import { TeamManager } from '~/utils/team-manager'
 
-import { EventHeaders, IncomingEvent, IncomingEventWithTeam } from '../../types'
+import { EventHeaders, IncomingEvent, IncomingEventWithTeam, Team } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restriction-manager'
 import {
     createApplyEventRestrictionsStep,
@@ -23,6 +23,7 @@ export interface PreTeamPreprocessingSubpipelineOutput {
     headers: EventHeaders
     event: IncomingEvent
     eventWithTeam: IncomingEventWithTeam
+    team: Team
 }
 
 export interface PreTeamPreprocessingSubpipelineConfig {

--- a/plugin-server/src/ingestion/event-preprocessing/resolve-team.test.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/resolve-team.test.ts
@@ -106,6 +106,7 @@ describe('createResolveTeamStep()', () => {
         expect(response).toEqual(
             ok({
                 ...input,
+                team: teamTwo,
                 eventWithTeam: {
                     event: { ...pipelineEvent, token: teamTwoToken },
                     team: teamTwo,
@@ -152,6 +153,7 @@ describe('createResolveTeamStep()', () => {
         expect(response).toEqual(
             ok({
                 ...input,
+                team: teamTwo,
                 eventWithTeam: {
                     event: { ...pipelineEvent, team_id: 3, token: teamTwoToken },
                     team: teamTwo,

--- a/plugin-server/src/ingestion/event-processing/prefetch-hog-functions-step.test.ts
+++ b/plugin-server/src/ingestion/event-processing/prefetch-hog-functions-step.test.ts
@@ -172,19 +172,6 @@ describe('prefetchHogFunctionsStep', () => {
         expect(mockHogTransformer.fetchAndCacheHogFunctionStates).not.toHaveBeenCalled()
     })
 
-    it('skips prefetching when sample rate is 0', async () => {
-        const step = createPrefetchHogFunctionsStep(mockHogTransformer, 0)
-        const inputs = [createTestInput(createTestTeam({ id: 1 }))]
-
-        const results = await step(inputs)
-
-        expect(results).toHaveLength(1)
-        expect(results[0].type).toBe(PipelineResultType.OK)
-        expect(mockHogTransformer.clearHogFunctionStates).toHaveBeenCalledTimes(1)
-        expect(mockGetHogFunctionIdsForTeams).not.toHaveBeenCalled()
-        expect(mockHogTransformer.fetchAndCacheHogFunctionStates).not.toHaveBeenCalled()
-    })
-
     describe('sampling rate', () => {
         let mockRandom: jest.SpyInstance
 
@@ -206,6 +193,7 @@ describe('prefetchHogFunctionsStep', () => {
 
             await step(inputs)
 
+            expect(mockHogTransformer.clearHogFunctionStates).toHaveBeenCalled()
             expect(mockGetHogFunctionIdsForTeams).toHaveBeenCalled()
             expect(mockHogTransformer.fetchAndCacheHogFunctionStates).toHaveBeenCalledWith(['func-1'])
         })
@@ -218,6 +206,7 @@ describe('prefetchHogFunctionsStep', () => {
 
             await step(inputs)
 
+            expect(mockHogTransformer.clearHogFunctionStates).not.toHaveBeenCalled()
             expect(mockGetHogFunctionIdsForTeams).not.toHaveBeenCalled()
             expect(mockHogTransformer.fetchAndCacheHogFunctionStates).not.toHaveBeenCalled()
         })
@@ -231,6 +220,7 @@ describe('prefetchHogFunctionsStep', () => {
             await step(inputs)
 
             // 0.3 < 0.3 is false, so should skip
+            expect(mockHogTransformer.clearHogFunctionStates).not.toHaveBeenCalled()
             expect(mockGetHogFunctionIdsForTeams).not.toHaveBeenCalled()
         })
 
@@ -244,18 +234,19 @@ describe('prefetchHogFunctionsStep', () => {
 
             await step(inputs)
 
+            expect(mockHogTransformer.clearHogFunctionStates).toHaveBeenCalled()
             expect(mockGetHogFunctionIdsForTeams).toHaveBeenCalled()
         })
 
-        it('never prefetches when sample rate is 0', async () => {
-            mockRandom.mockReturnValue(0)
+        it('skips prefetching when sample rate is 0', async () => {
+            mockRandom.mockReturnValue(0.5)
 
             const step = createPrefetchHogFunctionsStep(mockHogTransformer, 0)
             const inputs = [createTestInput(createTestTeam({ id: 1 }))]
 
             await step(inputs)
 
-            // 0 < 0 is false, so should skip
+            expect(mockHogTransformer.clearHogFunctionStates).not.toHaveBeenCalled()
             expect(mockGetHogFunctionIdsForTeams).not.toHaveBeenCalled()
         })
     })

--- a/plugin-server/src/ingestion/event-processing/prefetch-hog-functions-step.test.ts
+++ b/plugin-server/src/ingestion/event-processing/prefetch-hog-functions-step.test.ts
@@ -1,0 +1,262 @@
+import { v4 } from 'uuid'
+
+import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
+import { ProjectId, Team } from '../../types'
+import { PipelineResultType } from '../pipelines/results'
+import { PrefetchHogFunctionsStepInput, createPrefetchHogFunctionsStep } from './prefetch-hog-functions-step'
+
+const createTestTeam = (overrides: Partial<Team> = {}): Team => ({
+    id: 1,
+    project_id: 1 as ProjectId,
+    organization_id: 'test-org-id',
+    uuid: v4(),
+    name: 'Test Team',
+    anonymize_ips: false,
+    api_token: 'test-api-token',
+    slack_incoming_webhook: null,
+    session_recording_opt_in: true,
+    person_processing_opt_out: null,
+    heatmaps_opt_in: null,
+    ingested_event: true,
+    person_display_name_properties: null,
+    test_account_filters: null,
+    cookieless_server_hash_mode: null,
+    timezone: 'UTC',
+    available_features: [],
+    drop_events_older_than_seconds: null,
+    ...overrides,
+})
+
+const createTestInput = (team: Team): PrefetchHogFunctionsStepInput => ({
+    team,
+})
+
+describe('prefetchHogFunctionsStep', () => {
+    let mockHogTransformer: jest.Mocked<HogTransformerService>
+    let mockGetHogFunctionIdsForTeams: jest.Mock
+
+    beforeEach(() => {
+        mockGetHogFunctionIdsForTeams = jest.fn()
+        mockHogTransformer = {
+            clearHogFunctionStates: jest.fn(),
+            fetchAndCacheHogFunctionStates: jest.fn(),
+            hogFunctionManager: {
+                getHogFunctionIdsForTeams: mockGetHogFunctionIdsForTeams,
+            },
+        } as unknown as jest.Mocked<HogTransformerService>
+    })
+
+    it('clears cached hog function states before processing', async () => {
+        mockGetHogFunctionIdsForTeams.mockResolvedValue({})
+
+        const step = createPrefetchHogFunctionsStep(mockHogTransformer, 1)
+        const input = createTestInput(createTestTeam())
+
+        await step([input])
+
+        expect(mockHogTransformer.clearHogFunctionStates).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns events unchanged when no events provided', async () => {
+        const step = createPrefetchHogFunctionsStep(mockHogTransformer, 1)
+
+        const results = await step([])
+
+        expect(results).toEqual([])
+        expect(mockHogTransformer.clearHogFunctionStates).toHaveBeenCalledTimes(1)
+        expect(mockGetHogFunctionIdsForTeams).not.toHaveBeenCalled()
+    })
+
+    it('extracts unique team IDs and fetches hog function IDs', async () => {
+        mockGetHogFunctionIdsForTeams.mockResolvedValue({ 1: ['func-1', 'func-2'] })
+        mockHogTransformer.fetchAndCacheHogFunctionStates.mockResolvedValue(undefined)
+
+        const step = createPrefetchHogFunctionsStep(mockHogTransformer, 1)
+        const team = createTestTeam({ id: 1 })
+        const inputs = [createTestInput(team), createTestInput(team), createTestInput(team)]
+
+        await step(inputs)
+
+        expect(mockGetHogFunctionIdsForTeams).toHaveBeenCalledWith([1], ['transformation'])
+    })
+
+    it('handles multiple teams and deduplicates team IDs', async () => {
+        mockGetHogFunctionIdsForTeams.mockResolvedValue({
+            1: ['func-1'],
+            2: ['func-2'],
+            3: ['func-3'],
+        })
+        mockHogTransformer.fetchAndCacheHogFunctionStates.mockResolvedValue(undefined)
+
+        const step = createPrefetchHogFunctionsStep(mockHogTransformer, 1)
+        const team1 = createTestTeam({ id: 1 })
+        const team2 = createTestTeam({ id: 2 })
+        const team3 = createTestTeam({ id: 3 })
+        const inputs = [
+            createTestInput(team1),
+            createTestInput(team1),
+            createTestInput(team2),
+            createTestInput(team3),
+            createTestInput(team2),
+        ]
+
+        await step(inputs)
+
+        expect(mockGetHogFunctionIdsForTeams).toHaveBeenCalledTimes(1)
+        const calledTeamIds = mockGetHogFunctionIdsForTeams.mock.calls[0][0]
+        expect(calledTeamIds).toHaveLength(3)
+        expect(calledTeamIds).toContain(1)
+        expect(calledTeamIds).toContain(2)
+        expect(calledTeamIds).toContain(3)
+    })
+
+    it('fetches and caches hog function states when functions exist', async () => {
+        mockGetHogFunctionIdsForTeams.mockResolvedValue({
+            1: ['func-1', 'func-2'],
+            2: ['func-3'],
+        })
+        mockHogTransformer.fetchAndCacheHogFunctionStates.mockResolvedValue(undefined)
+
+        const step = createPrefetchHogFunctionsStep(mockHogTransformer, 1)
+        const inputs = [createTestInput(createTestTeam({ id: 1 })), createTestInput(createTestTeam({ id: 2 }))]
+
+        await step(inputs)
+
+        expect(mockHogTransformer.fetchAndCacheHogFunctionStates).toHaveBeenCalledWith(['func-1', 'func-2', 'func-3'])
+    })
+
+    it('does not fetch hog function states when no functions exist', async () => {
+        mockGetHogFunctionIdsForTeams.mockResolvedValue({})
+
+        const step = createPrefetchHogFunctionsStep(mockHogTransformer, 1)
+        const inputs = [createTestInput(createTestTeam({ id: 1 }))]
+
+        await step(inputs)
+
+        expect(mockHogTransformer.fetchAndCacheHogFunctionStates).not.toHaveBeenCalled()
+    })
+
+    it('returns all events as OK results unchanged', async () => {
+        mockGetHogFunctionIdsForTeams.mockResolvedValue({ 1: ['func-1'] })
+        mockHogTransformer.fetchAndCacheHogFunctionStates.mockResolvedValue(undefined)
+
+        const step = createPrefetchHogFunctionsStep(mockHogTransformer, 1)
+        const team = createTestTeam({ id: 1 })
+        const inputs = [
+            { team, extraField: 'value1' },
+            { team, extraField: 'value2' },
+        ]
+
+        const results = await step(inputs)
+
+        expect(results).toHaveLength(2)
+        expect(results[0].type).toBe(PipelineResultType.OK)
+        expect(results[1].type).toBe(PipelineResultType.OK)
+        if (results[0].type === PipelineResultType.OK && results[1].type === PipelineResultType.OK) {
+            expect(results[0].value).toEqual(inputs[0])
+            expect(results[1].value).toEqual(inputs[1])
+        }
+    })
+
+    it('handles teams with empty hog function arrays', async () => {
+        mockGetHogFunctionIdsForTeams.mockResolvedValue({
+            1: [],
+            2: [],
+        })
+
+        const step = createPrefetchHogFunctionsStep(mockHogTransformer, 1)
+        const inputs = [createTestInput(createTestTeam({ id: 1 })), createTestInput(createTestTeam({ id: 2 }))]
+
+        await step(inputs)
+
+        expect(mockHogTransformer.fetchAndCacheHogFunctionStates).not.toHaveBeenCalled()
+    })
+
+    it('skips prefetching when sample rate is 0', async () => {
+        const step = createPrefetchHogFunctionsStep(mockHogTransformer, 0)
+        const inputs = [createTestInput(createTestTeam({ id: 1 }))]
+
+        const results = await step(inputs)
+
+        expect(results).toHaveLength(1)
+        expect(results[0].type).toBe(PipelineResultType.OK)
+        expect(mockHogTransformer.clearHogFunctionStates).toHaveBeenCalledTimes(1)
+        expect(mockGetHogFunctionIdsForTeams).not.toHaveBeenCalled()
+        expect(mockHogTransformer.fetchAndCacheHogFunctionStates).not.toHaveBeenCalled()
+    })
+
+    describe('sampling rate', () => {
+        let mockRandom: jest.SpyInstance
+
+        beforeEach(() => {
+            mockRandom = jest.spyOn(Math, 'random')
+        })
+
+        afterEach(() => {
+            mockRandom.mockRestore()
+        })
+
+        it('prefetches when random value is below sample rate', async () => {
+            mockRandom.mockReturnValue(0.2)
+            mockGetHogFunctionIdsForTeams.mockResolvedValue({ 1: ['func-1'] })
+            mockHogTransformer.fetchAndCacheHogFunctionStates.mockResolvedValue(undefined)
+
+            const step = createPrefetchHogFunctionsStep(mockHogTransformer, 0.3)
+            const inputs = [createTestInput(createTestTeam({ id: 1 }))]
+
+            await step(inputs)
+
+            expect(mockGetHogFunctionIdsForTeams).toHaveBeenCalled()
+            expect(mockHogTransformer.fetchAndCacheHogFunctionStates).toHaveBeenCalledWith(['func-1'])
+        })
+
+        it('skips prefetching when random value is above sample rate', async () => {
+            mockRandom.mockReturnValue(0.4)
+
+            const step = createPrefetchHogFunctionsStep(mockHogTransformer, 0.3)
+            const inputs = [createTestInput(createTestTeam({ id: 1 }))]
+
+            await step(inputs)
+
+            expect(mockGetHogFunctionIdsForTeams).not.toHaveBeenCalled()
+            expect(mockHogTransformer.fetchAndCacheHogFunctionStates).not.toHaveBeenCalled()
+        })
+
+        it('skips prefetching when random value equals sample rate', async () => {
+            mockRandom.mockReturnValue(0.3)
+
+            const step = createPrefetchHogFunctionsStep(mockHogTransformer, 0.3)
+            const inputs = [createTestInput(createTestTeam({ id: 1 }))]
+
+            await step(inputs)
+
+            // 0.3 < 0.3 is false, so should skip
+            expect(mockGetHogFunctionIdsForTeams).not.toHaveBeenCalled()
+        })
+
+        it('always prefetches when sample rate is 1', async () => {
+            mockRandom.mockReturnValue(0.999)
+            mockGetHogFunctionIdsForTeams.mockResolvedValue({ 1: ['func-1'] })
+            mockHogTransformer.fetchAndCacheHogFunctionStates.mockResolvedValue(undefined)
+
+            const step = createPrefetchHogFunctionsStep(mockHogTransformer, 1)
+            const inputs = [createTestInput(createTestTeam({ id: 1 }))]
+
+            await step(inputs)
+
+            expect(mockGetHogFunctionIdsForTeams).toHaveBeenCalled()
+        })
+
+        it('never prefetches when sample rate is 0', async () => {
+            mockRandom.mockReturnValue(0)
+
+            const step = createPrefetchHogFunctionsStep(mockHogTransformer, 0)
+            const inputs = [createTestInput(createTestTeam({ id: 1 }))]
+
+            await step(inputs)
+
+            // 0 < 0 is false, so should skip
+            expect(mockGetHogFunctionIdsForTeams).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/plugin-server/src/ingestion/event-processing/prefetch-hog-functions-step.ts
+++ b/plugin-server/src/ingestion/event-processing/prefetch-hog-functions-step.ts
@@ -12,14 +12,14 @@ export function createPrefetchHogFunctionsStep<TInput extends PrefetchHogFunctio
     sampleRate: number
 ): BatchProcessingStep<TInput, TInput> {
     return async function prefetchHogFunctionsStep(events: TInput[]): Promise<PipelineResult<TInput>[]> {
-        // Clear cached hog function states before fetching new ones
-        hogTransformer.clearHogFunctionStates()
-
         // Skip prefetching if sampling determines we shouldn't run hog watcher
         const shouldRunHogWatcher = Math.random() < sampleRate
         if (!shouldRunHogWatcher) {
             return events.map((event) => ok(event))
         }
+
+        // Clear cached hog function states before fetching new ones
+        hogTransformer.clearHogFunctionStates()
 
         // Extract unique team IDs from the batch
         const teamIds = new Set<number>()

--- a/plugin-server/src/ingestion/event-processing/prefetch-hog-functions-step.ts
+++ b/plugin-server/src/ingestion/event-processing/prefetch-hog-functions-step.ts
@@ -1,0 +1,51 @@
+import { HogTransformerService } from '../../cdp/hog-transformations/hog-transformer.service'
+import { Team } from '../../types'
+import { BatchProcessingStep } from '../pipelines/base-batch-pipeline'
+import { PipelineResult, ok } from '../pipelines/results'
+
+export interface PrefetchHogFunctionsStepInput {
+    team: Team
+}
+
+export function createPrefetchHogFunctionsStep<TInput extends PrefetchHogFunctionsStepInput>(
+    hogTransformer: HogTransformerService,
+    sampleRate: number
+): BatchProcessingStep<TInput, TInput> {
+    return async function prefetchHogFunctionsStep(events: TInput[]): Promise<PipelineResult<TInput>[]> {
+        // Clear cached hog function states before fetching new ones
+        hogTransformer.clearHogFunctionStates()
+
+        // Skip prefetching if sampling determines we shouldn't run hog watcher
+        const shouldRunHogWatcher = Math.random() < sampleRate
+        if (!shouldRunHogWatcher) {
+            return events.map((event) => ok(event))
+        }
+
+        // Extract unique team IDs from the batch
+        const teamIds = new Set<number>()
+        for (const event of events) {
+            teamIds.add(event.team.id)
+        }
+
+        if (teamIds.size === 0) {
+            return events.map((event) => ok(event))
+        }
+
+        // Get hog function IDs for transformations
+        const teamHogFunctionIds = await hogTransformer['hogFunctionManager'].getHogFunctionIdsForTeams(
+            Array.from(teamIds),
+            ['transformation']
+        )
+
+        // Flatten all hog function IDs into a single array
+        const allHogFunctionIds = Object.values(teamHogFunctionIds).flat()
+
+        if (allHogFunctionIds.length > 0) {
+            // Cache the hog function states
+            await hogTransformer.fetchAndCacheHogFunctionStates(allHogFunctionIds)
+        }
+
+        // Return events unchanged
+        return events.map((event) => ok(event))
+    }
+}


### PR DESCRIPTION
## Problem

We still have some code between the preprocessing and processing pipelines in ingestion.

## Changes

- Breaks out hog function prefething into a preprocessing step
- Adds team to post-team pipelines

## How did you test this code?

- Added new tests for the step
