### PR TITLE
fix: Dont overwrite API input anonymize_ips with org default

### DIFF
--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -2149,6 +2149,25 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
         new_team = Team.objects.get(name="Test No IP Anonymization")
         self.assertFalse(new_team.anonymize_ips)
 
+    def test_new_team_explicit_anonymize_ips_overrides_org_default(self):
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ENVIRONMENTS, "name": "Environments", "limit": None}
+        ]
+        self.organization.default_anonymize_ips = False
+        self.organization.save()
+
+        response = self.client.post(
+            "/api/projects/@current/environments/",
+            {"name": "Explicit Anonymize IPs", "anonymize_ips": True},
+        )
+        assert response.status_code == 201
+        assert response.json()["anonymize_ips"] is True
+
+        new_team = Team.objects.get(name="Explicit Anonymize IPs")
+        self.assertTrue(new_team.anonymize_ips)
+
     def test_new_team_defaults_to_false_when_org_default_is_none(self):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -122,8 +122,7 @@ class TeamManager(models.Manager):
         # Get organization to apply defaults
         organization = kwargs.get("organization") or Organization.objects.get(id=kwargs.get("organization_id"))
 
-        # Apply organization-level IP anonymization default
-        team.anonymize_ips = organization.default_anonymize_ips
+        team.anonymize_ips = kwargs.get("anonymize_ips", organization.default_anonymize_ips)
 
         team.test_account_filters = self.set_test_account_filters(organization.id)
 


### PR DESCRIPTION
## Problem

When creating a project via the API with `anonymize_ips: true`, the returned response shows false. The `Team.objects.create_with_data()` method unconditionally overwrites any explicitly provided `anonymize_ips` value with the organization's `default_anonymize_ips` setting.

## Changes

  - Modified `posthog/models/team/team.py` to only apply the organization default when anonymize_ips is
  not explicitly provided in the request
  - Added a test

## How did you test this code?

- Unit tests