### PR TITLE
fix: show cancel trial action for Enterprises

### DIFF
--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -96,7 +96,7 @@ export const BillingProductAddonActions = ({
                     You're on a trial for this add-on
                 </LemonTag>
             </Tooltip>
-            {addon.type !== 'enterprise' && (
+            {(addon.type !== 'enterprise' || billing?.trial?.type === 'autosubscribe') && (
                 <LemonButton
                     type="primary"
                     size="small"

--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -96,7 +96,7 @@ export const BillingProductAddonActions = ({
                     You're on a trial for this add-on
                 </LemonTag>
             </Tooltip>
-            {/* Hide Cancel button for Enterprise 'standard' trials without auto-subscription (typically sales-managed) */}
+            {/* Hide Cancel button only for Enterprise 'standard' trials (typically sales-managed) */}
             {(addon.type !== 'enterprise' || billing?.trial?.type === 'autosubscribe') && (
                 <LemonButton
                     type="primary"

--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -96,7 +96,7 @@ export const BillingProductAddonActions = ({
                     You're on a trial for this add-on
                 </LemonTag>
             </Tooltip>
-            {addon.type !== 'enterprise' && (
+            {(addon.type !== 'enterprise' || billing?.trial?.silence_notifications === false) && (
                 <LemonButton
                     type="primary"
                     size="small"

--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -96,7 +96,7 @@ export const BillingProductAddonActions = ({
                     You're on a trial for this add-on
                 </LemonTag>
             </Tooltip>
-            {(addon.type !== 'enterprise' || billing?.trial?.silence_notifications === false) && (
+            {addon.type !== 'enterprise' && (
                 <LemonButton
                     type="primary"
                     size="small"

--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -96,6 +96,7 @@ export const BillingProductAddonActions = ({
                     You're on a trial for this add-on
                 </LemonTag>
             </Tooltip>
+            {/* Hide Cancel button for Enterprise 'standard' trials without auto-subscription (typically sales-managed) */}
             {(addon.type !== 'enterprise' || billing?.trial?.type === 'autosubscribe') && (
                 <LemonButton
                     type="primary"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1980,7 +1980,6 @@ export interface BillingType {
         status: 'active' | 'expired' | 'cancelled' | 'converted'
         target: 'paid' | 'teams' | 'enterprise'
         expires_at: string
-        silence_notifications?: boolean
     }
     billing_plan: BillingPlan | null
     startup_program_label?: StartupProgramLabel | null

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1980,6 +1980,7 @@ export interface BillingType {
         status: 'active' | 'expired' | 'cancelled' | 'converted'
         target: 'paid' | 'teams' | 'enterprise'
         expires_at: string
+        silence_notifications?: boolean
     }
     billing_plan: BillingPlan | null
     startup_program_label?: StartupProgramLabel | null


### PR DESCRIPTION
## Problem

Enterprise add-on customers get a “trial ending / you can cancel” email, but they can’t cancel in-app because the Cancel trial button isn’t shown for Enterprise add-on trials.

More context: https://posthog.slack.com/archives/C08ERRQT41E/p1765882307102609

<img width="573" height="247" alt="Screenshot 2025-12-16 at 1 30 40 PM" src="https://github.com/user-attachments/assets/d778db5e-e869-4a18-b253-4880e248eff2" />

## Changes
- Hide Cancel trial button for Enterprise addon trials when trial type is Standard (without Auto Subscribe)

![2025-12-16 13 09 14](https://github.com/user-attachments/assets/2edd6707-e4db-4ba8-95ea-f8982b0116be)

## How did you test this code?
Manually