### PR TITLE
fix: persons db urls like non-persons in base yml

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -294,6 +294,8 @@ services:
         environment:
             WRITE_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             READ_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
+            PERSONS_WRITE_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
+            PERSONS_READ_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             MAXMIND_DB_PATH: '/share/GeoLite2-City.mmdb'
             # Shared Redis for non-critical path (analytics, billing, cookieless)
             REDIS_URL: 'redis://redis:6379/'


### PR DESCRIPTION
i saw this comment that suggested someone had to add environment variables to get self-hosted running

so i added them

i'm not sure why the defaults are to localhost in the code
but then we set them in the base yml

maybe the defaults should change instead but...

## Changelog: (features only) Is this feature complete?

no