### PR TITLE
chore(subscriptions): Add retries for asset creation

### DIFF
--- a/ee/clickhouse/test/test_error.py
+++ b/ee/clickhouse/test/test_error.py
@@ -67,6 +67,16 @@ from posthog.errors import ch_error_type, wrap_query_error
             None,
             "CHQueryErrorTimeoutExceeded",
         ),
+        (
+            ServerException(
+                "Code: 499. DB::Exception: Failed to get object info: No response body.. HTTP response code: 404: while reading file.parquet",
+                code=499,
+            ),
+            "CHQueryErrorS3Error",
+            "Code: 499.\nS3 error occurred. Try again later.",
+            499,
+            "CHQueryErrorS3Error",
+        ),
     ],
 )
 def test_wrap_query_error(error, expected_type, expected_message, expected_code, expected_ch_error):

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -193,7 +193,7 @@ async def generate_assets_async(
 
             @retry(
                 retry=retry_if_exception_type(EXCEPTIONS_TO_RETRY),
-                stop=stop_after_attempt(3),
+                stop=stop_after_attempt(4),
                 wait=wait_exponential_jitter(initial=2, max=10),
                 reraise=True,
             )
@@ -227,6 +227,7 @@ async def generate_assets_async(
                     insight_id=asset.insight_id,
                     subscription_id=subscription_id,
                     error=str(e),
+                    exc_info=True,
                     retryable_error=retyable_error,
                     team_id=resource.team_id,
                 )

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -228,7 +228,7 @@ async def generate_assets_async(
                     subscription_id=subscription_id,
                     error=str(e),
                     exc_info=True,
-                    retryable_error=retyable_error,
+                    retryable_error=retryable_error,
                     team_id=resource.team_id,
                 )
                 asset.exception = str(e)

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -195,7 +195,7 @@ async def generate_assets_async(
 
             @retry(
                 retry=retry_if_exception_type(RETRIABLE_EXPORT_ERRORS),
-                stop=stop_after_attempt(4),
+                stop=stop_after_attempt(3),
                 wait=wait_exponential_jitter(initial=2, max=10),
                 reraise=True,
             )

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -220,7 +220,7 @@ async def generate_assets_async(
                     team_id=resource.team_id,
                 )
             except Exception as e:
-                retyable_error = isinstance(e, EXCEPTIONS_TO_RETRY)
+                retryable_error = isinstance(e, EXCEPTIONS_TO_RETRY)
                 logger.error(  # noqa: TRY400
                     "generate_assets_async.export_failed",
                     asset_id=asset.id,

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -215,7 +215,6 @@ async def generate_assets_async(
 
             try:
                 await export_with_retry()
-                asset.exception = None
                 logger.info(
                     "generate_assets_async.asset_exported",
                     asset_id=asset.id,

--- a/ee/tasks/test/subscriptions/test_generate_assets_async.py
+++ b/ee/tasks/test/subscriptions/test_generate_assets_async.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest_asyncio
 from asgiref.sync import sync_to_async
 
+from posthog.errors import CHQueryErrorS3Error
 from posthog.models.dashboard import Dashboard
 from posthog.models.dashboard_tile import DashboardTile
 from posthog.models.exported_asset import ExportedAsset
@@ -314,3 +315,59 @@ async def test_async_generate_assets_partial_success(mock_export: MagicMock, tea
     assets_without_content = [a for a in assets if not a.content and not a.content_location]
     assert len(assets_with_content) == 2
     assert len(assets_without_content) == 1
+
+
+@patch("posthog.tasks.exporter.export_asset_direct")
+async def test_async_generate_assets_retries_on_s3_error(mock_export: MagicMock, team, user) -> None:
+    call_count = 0
+
+    def export_with_transient_failure(asset: ExportedAsset, **kwargs) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise CHQueryErrorS3Error("S3 error occurred", code=499)
+        asset.content = b"fake image data"
+        asset.save()
+
+    mock_export.side_effect = export_with_transient_failure
+
+    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="retrytest", name="Retry Test")
+    subscription = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+
+    subscription = await sync_to_async(
+        lambda: type(subscription)
+        .objects.select_related("team", "dashboard", "insight", "created_by")
+        .get(id=subscription.id)
+    )()
+
+    # Patch tenacity sleep to speed up test
+    with patch("tenacity.nap.sleep"):
+        insights, assets = await generate_assets_async(subscription)
+
+    assert len(assets) == 1
+    assert assets[0].content == b"fake image data"
+    assert assets[0].exception is None
+    assert mock_export.call_count == 3
+
+
+@patch("posthog.tasks.exporter.export_asset_direct")
+async def test_async_generate_assets_fails_after_max_retries(mock_export: MagicMock, team, user) -> None:
+    mock_export.side_effect = CHQueryErrorS3Error("S3 error occurred", code=499)
+
+    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="maxretry", name="Max Retry Test")
+    subscription = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+
+    subscription = await sync_to_async(
+        lambda: type(subscription)
+        .objects.select_related("team", "dashboard", "insight", "created_by")
+        .get(id=subscription.id)
+    )()
+
+    # Patch tenacity sleep to speed up test
+    with patch("tenacity.nap.sleep"):
+        insights, assets = await generate_assets_async(subscription)
+
+    assert len(assets) == 1
+    assert assets[0].content is None
+    assert "S3 error" in str(assets[0].exception)
+    assert mock_export.call_count == 4

--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -107,11 +107,16 @@ class CHQueryErrorCannotScheduleTask(InternalCHQueryError):
     pass
 
 
+class CHQueryErrorS3Error(InternalCHQueryError):
+    pass
+
+
 CLICKHOUSE_SPECIFIC_ERROR_LOOKUP = {
     "TOO_MANY_SIMULTANEOUS_QUERIES": CHQueryErrorTooManySimultaneousQueries(
         "Too many simultaneous queries. Try again later.", code=202
     ),
     "CANNOT_SCHEDULE_TASK": CHQueryErrorCannotScheduleTask("Cannot schedule task. Try again later.", code=439),
+    "S3_ERROR": CHQueryErrorS3Error("S3 error occurred. Try again later.", code=499),
 }
 
 #

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -8,7 +8,7 @@ import posthoganalytics
 from celery import current_task, shared_task
 from prometheus_client import Counter, Histogram
 
-from posthog.errors import CHQueryErrorTooManySimultaneousQueries
+from posthog.errors import CHQueryErrorS3Error, CHQueryErrorTooManySimultaneousQueries
 from posthog.event_usage import groups
 from posthog.models import ExportedAsset
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
@@ -43,7 +43,10 @@ EXPORT_TIMER = Histogram(
     buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, float("inf")),
 )
 
-EXCEPTIONS_TO_RETRY = (CHQueryErrorTooManySimultaneousQueries,)
+EXCEPTIONS_TO_RETRY = (
+    CHQueryErrorS3Error,
+    CHQueryErrorTooManySimultaneousQueries,
+)
 
 
 # export_asset is used in chords/groups and so must not ignore its results

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -1,7 +1,7 @@
 from time import perf_counter
 from typing import Optional
 
-from django.db import transaction
+from django.db import OperationalError, transaction
 
 import structlog
 import posthoganalytics
@@ -46,6 +46,7 @@ EXPORT_TIMER = Histogram(
 EXCEPTIONS_TO_RETRY = (
     CHQueryErrorS3Error,
     CHQueryErrorTooManySimultaneousQueries,
+    OperationalError,
 )
 
 

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -136,6 +136,7 @@ def export_asset_direct(
             },
             groups=groups(team.organization, team),
         )
+        exported_asset.exception = None
     except Exception as e:
         is_retriable = isinstance(e, EXCEPTIONS_TO_RETRY)
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Currently some of our subscription jobs fail with transient errors ([example](https://posthoghelp.zendesk.com/agent/tickets/43469), but [this example](https://posthoghelp.zendesk.com/agent/tickets/43967)). I'm proposing to add retries to better deal with these errors and avoid having such errors cause a negative impact on our customers experience.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

In order to reduce our error rate and improve the resiliency of our jobs, I would propose to add retries for specific, known transient errors to our asset generation code. 

This PR introduces that. From what I've gathered, this should be safe, as the process is idempotent to my knowledge (I might have missed something here, as there is quite a lot of code!). The only drawback is that it would re-do certain steps depending on where it failed, e.g. if it fails in the image generation, it will refetch the full data again in the next run. However given that this is a rare case, and we can control the retryable exceptions, I figured this was acceptable. 

The erorrs included are suggested by Claude:

**OperationalError**
>  I'm reasonably confident but not 100% certain. The error pattern suggests:  
>     - Port 6543 = likely PgBouncer
>     - "FATAL client_login_timeout" = PostgreSQL protocol error
>
> In psycopg2/psycopg, connection failures raise OperationalError, which Django wraps as django.db.OperationalError. 

**CHQueryErrorS3Error:**
> I'm confident. Here's the verified chain:
> ClickHouse error code 499
>   ↓
> posthog/errors.py line 536: 499: ErrorCodeMeta("S3_ERROR")
>   ↓
> wrap_query_error() calls look_up_error_code_meta(err) → returns meta.name = "S3_ERROR"
>   ↓
> posthog/errors.py line 119: "S3_ERROR": CHQueryErrorS3Error(...)
>   ↓
> Returns CHQueryErrorS3Error instance
> And the test confirms this works: ServerException("Code: 499. DB::Exception: Failed to get object info...", code=499)
> → wraps to CHQueryErrorS3Error
> The mapping exists at line 536 (499: ErrorCodeMeta("S3_ERROR")) and the lookup at line 119 returns CHQueryErrorS3Error. So code 499 from ClickHouse will definitely be caught by our retry logic.


**CHQueryErrorTooManySimultaneousQueries:**
Was already marked as retryable error in the Celery flow, I've included this one for good measure. 

This additionally aligns the retry logic for subscriptions (using temporal) with that of the "browser based exports", which has the retry logic defined over here: https://github.com/PostHog/posthog/blob/861504c12da63f2e4636902febab27fed293a9b3/posthog/tasks/exporter.py#L53-L80.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

✅  - Tests are passing

For the code changes, I had to temporarily disable emails in order to avoid the `temporal-worker` to fill up with errors about not being able to send e-mails:
<img width="699" height="431" alt="CleanShot 2025-12-16 at 16 24 52" src="https://github.com/user-attachments/assets/b98eb3a4-f1a4-480f-929a-d74dfc9dfcff" />

_Note: Ignore the `directory not empty` errors, those are happening due to how our Chrome setup works and are ignored by the code_

✅  - Running a subscription locally (happy path)

<img width="1238" height="878" alt="CleanShot 2025-12-16 at 16 39 02" src="https://github.com/user-attachments/assets/a849229f-247e-4a8a-bbf1-b423a2ce36f3" />
<img width="1909" height="1331" alt="CleanShot 2025-12-16 at 16 39 12" src="https://github.com/user-attachments/assets/3a7a1ac1-c05c-4e70-a4d4-091d93046e06" />



✅ - Running a subscription locally with retries (failing 3 runs, succeeding on 4th)

Using the following "test hack" in order to simulate the errors, for this and the next run.
<img width="810" height="781" alt="CleanShot 2025-12-16 at 16 30 52" src="https://github.com/user-attachments/assets/b338d04c-b48c-42a4-bf52-5972998e99fa" />

Result:

<img width="1229" height="1633" alt="CleanShot 2025-12-16 at 16 37 52" src="https://github.com/user-attachments/assets/ab86442a-78b0-435f-9f29-044bf7ac7803" />
<img width="1906" height="1316" alt="CleanShot 2025-12-16 at 16 37 43" src="https://github.com/user-attachments/assets/0b176e42-d064-42e5-83da-f80efa0eadaa" />


✅ - Running a subscription locally with an exception that is not "retryable" will fail on the first request

Changed code to: 
<img width="676" height="290" alt="CleanShot 2025-12-16 at 16 40 03" src="https://github.com/user-attachments/assets/14d2d8f7-f270-4931-b96b-2b2e97b6d625" />

Result:
<img width="1279" height="775" alt="CleanShot 2025-12-16 at 16 46 53" src="https://github.com/user-attachments/assets/5eb7e37f-23ab-4c46-9671-9eea19a6da33" />

Note: I also disabled `exc_info` in the logs, as it would avoid the code printing a full stack trace like so:

<img width="635" height="1539" alt="CleanShot 2025-12-16 at 16 47 59" src="https://github.com/user-attachments/assets/01ca5720-59dc-4f4a-aec7-f234d48617c0" />

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._


## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->

N/A
