### PR TITLE
chore(plugin-server): log url when connecting to redis, there is more than one in use

### DIFF
--- a/plugin-server/src/utils/db/redis.ts
+++ b/plugin-server/src/utils/db/redis.ts
@@ -106,15 +106,15 @@ export async function createRedisClient(url: string, options?: RedisOptions): Pr
             errorCounter++
             captureException(error)
             if (errorCounter > REDIS_ERROR_COUNTER_LIMIT) {
-                logger.error('😡', 'Redis error encountered! Enough of this, I quit!\n', error)
+                logger.error('😡', 'Redis error encountered! url:', url, ' Enough of this, I quit!', error)
                 killGracefully()
             } else {
-                logger.error('🔴', 'Redis error encountered! Trying to reconnect...\n', error)
+                logger.error('🔴', 'Redis error encountered! url:', url, ' Trying to reconnect...', error)
             }
         })
         .on('ready', () => {
             if (process.env.NODE_ENV !== 'test') {
-                logger.info('✅', 'Connected to Redis!')
+                logger.info('✅', 'Connected to Redis!', url)
             }
         })
     await redis.info()


### PR DESCRIPTION
my self-hosted install is error-ing connecting to redis
but there are two
and i don't know which is failing
since we also print that we connected to redis multiple times

let's log the url

## Changelog: (features only) Is this feature complete?


no
