### PR TITLE
fix(ci): add collate job to ci-python for path filtering

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -185,7 +185,7 @@ jobs:
                   fi
 
                   # Check actual job result
-                  if [[ "${{ needs.code-quality.result }}" != "success" ]]; then
+                  if [[ "${{ needs.code-quality.result }}" != "success" && "${{ needs.code-quality.result }}" != "skipped" ]]; then
                     echo "Python code quality checks failed."
                     exit 1
                   fi

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -7,6 +7,9 @@ on:
     pull_request:
     merge_group:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -58,7 +61,7 @@ jobs:
         if: needs.changes.outputs.python == 'true'
         timeout-minutes: 30
 
-        name: Python code quality checks
+        name: Python code quality
         runs-on: depot-ubuntu-latest
 
         steps:
@@ -157,3 +160,34 @@ jobs:
             #   shell: bash
             #   run: |
             #       npm run taxonomy:build:json && git diff --exit-code
+
+    # Collate job - single required status check for branch protection.
+    # The code-quality job skips when no Python changes, but this job always
+    # runs and reports success, allowing PRs to merge.
+    python_tests:
+        needs: [changes, code-quality]
+        name: Python code quality checks
+        runs-on: ubuntu-latest
+        if: always()
+        steps:
+            - name: Check Python CI status
+              run: |
+                  # Fail if change detection itself failed
+                  if [[ "${{ needs.changes.result }}" == "failure" ]]; then
+                    echo "Change detection job failed."
+                    exit 1
+                  fi
+
+                  # Pass if no Python changes detected (jobs were skipped)
+                  if [[ "${{ needs.changes.outputs.python }}" != "true" ]]; then
+                    echo "Python checks were skipped (no relevant changes)"
+                    exit 0
+                  fi
+
+                  # Check actual job result
+                  if [[ "${{ needs.code-quality.result }}" != "success" ]]; then
+                    echo "Python code quality checks failed."
+                    exit 1
+                  fi
+
+                  echo "All Python checks passed."


### PR DESCRIPTION
**Problem:** `Python code quality checks` required check was failing when PRs had no Python changes. The job would skip entirely due to path filtering, and GitHub treats skipped required checks as failures.

**Why ci-python was broken:** Unlike ci-rust, ci-backend, ci-frontend etc., ci-python had no "collate" job. The required check pointed directly to the test job (`code-quality`) which has `if: needs.changes.outputs.python == 'true'`.

**Fix:** Add a collate job following the established pattern from other workflows:
- Rename actual test job display name to `Python code quality`
- Add `python_tests` collate job with display name `Python code quality checks` (matches existing required check)
- Collate runs with `if: always()` so it never skips
- Returns success when no Python changes, otherwise checks actual job result