### PR TITLE
Question input styling fix

### DIFF
--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -116,7 +116,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                             'input-like flex flex-col',
                             'border border-[var(--color-border-primary)]',
                             'bg-[var(--color-bg-fill-input)]',
-                            isThreadVisible ? 'border-primary m-0.5 rounded-[7px]' : 'rounded-lg'
+                            isThreadVisible ? 'border-primary m-0.5 rounded-[10px]' : 'rounded-lg'
                         )}
                     >
                         {!isSharedThread && (


### PR DESCRIPTION
## Problem

The `QuestionInput` component displayed an incorrect, more blocky border radius when a thread was visible due to a recent styling change. This regressed the intended rounded appearance.

## Changes

Reverted the border radius for the `QuestionInput` component from `rounded-[7px]` to `rounded-[10px]` when `isThreadVisible`, restoring the correct rounded styling.

## How did you test this code?

Visually confirmed the fix by comparing the updated styling against the provided "good" screenshot (15.29.17).

## Changelog: (features only) Is this feature complete?

No

---
[Slack Thread](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1765891136114599?thread_ts=1765891136.114599&cid=C06NZEZ7V3Q)

<a href="https://cursor.com/background-agent?bcId=bc-07fd20e4-a763-4373-80da-3e5851b3f6f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07fd20e4-a763-4373-80da-3e5851b3f6f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

