### PR TITLE
fix(MA): Asking for admin consent in the flow

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -332,6 +332,7 @@ class OauthIntegration:
                 scope="https://ads.microsoft.com/msads.manage offline_access openid profile",
                 id_path="id",
                 name_path="userPrincipalName",
+                additional_authorize_params={"prompt": "consent"},
             )
         elif kind == "intercom":
             if not settings.INTERCOM_APP_CLIENT_ID or not settings.INTERCOM_APP_CLIENT_SECRET:


### PR DESCRIPTION
## Problem


A user is having this error:
```
error=invalid_client&error_description=AADSTS650052: The app is trying to access a service 'd42ffc93-c136-491d-b4fd-6f18168c68fd'(Microsoft Advertising API Service) that your organization 'a47d863d-6fb5-4541-b7fa-6e4c03772563' lacks a service principal for. Contact your IT Admin to review the configuration of your service subscriptions or consent to the application in order to create the required service principal. Trace ID: 5fe59d66-1500-496d-9c6f-731079623300 Correlation ID: ac06383f-3aab-4ea9-aa49-f303f046838f Timestamp: 2025-12-10 17:14:23Z&
```

## Changes

I'm not 100% sure this will fix, I did many tests, create different types of accounts and I wasn't able to repro but with this prompt I ensure that the admin has to consent the permission, so the user won't have the error in case he doesn't have the permissions.

## How did you test this code?
Manually with different accounts

<img width="569" height="507" alt="Screenshot 2025-12-16 at 1 36 54 PM" src="https://github.com/user-attachments/assets/631fa9ae-e64a-40a0-9233-d7b54cf96d79" />

<img width="530" height="634" alt="Screenshot 2025-12-16 at 1 36 41 PM" src="https://github.com/user-attachments/assets/b8f23511-be5b-4bf6-ba15-161d94d4f566" />

