### PR TITLE
fix(surveys): no more xss

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -16,7 +16,6 @@ from django.utils.text import slugify
 from django.views.decorators.csrf import csrf_exempt
 
 import nh3
-import orjson
 import structlog
 import posthoganalytics
 from axes.decorators import axes_dispatch
@@ -2014,8 +2013,8 @@ def public_survey_page(request, survey_id: str):
     survey_data = serializer.data
     context = {
         "name": survey.name,
-        "survey_data": orjson.dumps(survey_data).decode("utf-8"),
-        "project_config_json": orjson.dumps(project_config).decode("utf-8"),
+        "survey_data": survey_data,
+        "project_config": project_config,
         "debug": settings.DEBUG,
     }
 

--- a/posthog/api/test/test_external_surveys.py
+++ b/posthog/api/test/test_external_surveys.py
@@ -49,6 +49,18 @@ class TestExternalSurveys(APIBaseTest):
 
     # SECURITY TESTS
 
+    def test_xss_prevention_in_survey_data(self):
+        xss_payload = "</script><script>alert(1)</script>"
+        survey = self.create_external_survey(name=xss_payload)
+
+        response = self.client.get(f"/external_surveys/{survey.id}/")
+        assert response.status_code == 200
+
+        content = response.content.decode()
+
+        assert xss_payload not in content
+        assert "\\u003C/script\\u003E" in content or "\\u003c/script\\u003e" in content
+
     def test_valid_survey_id_required(self):
         """Test that invalid survey IDs are rejected"""
         # Invalid UUID format
@@ -167,10 +179,10 @@ class TestExternalSurveys(APIBaseTest):
         assert "projectConfig" in content
         assert survey.team.api_token in content
 
-        # Extract and validate project config JSON
+        # Extract and validate project config JSON from json_script tag
         import re
 
-        config_match = re.search(r"projectConfig = ({.*?});", content)
+        config_match = re.search(r'<script[^>]*id="project-config"[^>]*>(.*?)</script>', content, re.DOTALL)
         assert config_match is not None
 
         project_config = json.loads(config_match.group(1))

--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -626,10 +626,12 @@
     </div>
 
     <!-- PostHog JavaScript -->
+    {{ survey_data|json_script:"survey-data" }}
+    {{ project_config|json_script:"project-config" }}
     <script nonce="{{ request.csp_nonce }}">
         // Project config from Django and helper functions
-        const survey = {{ survey_data | safe }};
-        const projectConfig = {{ project_config_json | safe }};
+        const survey = JSON.parse(document.getElementById("survey-data").textContent);
+        const projectConfig = JSON.parse(document.getElementById("project-config").textContent);
 
         const BLACK_TEXT_COLOR = '#020617'
 


### PR DESCRIPTION
## Problem

xss vulnerability: https://posthoghelp.zendesk.com/agent/tickets/45250 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46349)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- remove `orjson.dumps` from survey creation, store content directly
- use django `json_script` filter instead of `safe` on the public survey page template

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing, was able to repro the issue locally, issue not happening after fix

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->