### PR TITLE
fix(experiments): parametrized functions as `math_hogql`

### DIFF
--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_base.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_base.ambr
@@ -1,4 +1,61 @@
 # serializer version: 1
+# name: TestExperimentQueryRunner.test_mean_metric_with_parametric_aggregation
+  '''
+  SELECT entity_metrics.variant AS variant,
+         count(entity_metrics.entity_id) AS num_users,
+         sum(entity_metrics.value) AS total_sum,
+         sum(power(entity_metrics.value, 2)) AS total_sum_of_squares
+  FROM
+    (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
+            quantile(0.9)(coalesce(accurateCastOrNull(metric_events.value, 'Float64'), 0)) AS value
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id) AS exposures
+     LEFT JOIN
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'margin'), ''), 'null'), '^"|"$', '') AS value
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), plus(assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'checkout-conversion'))) AS metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), greaterOrEquals(metric_events.timestamp, exposures.first_exposure_time))
+     GROUP BY exposures.entity_id,
+              exposures.variant) AS entity_metrics
+  GROUP BY entity_metrics.variant
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=600,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=39728447488,
+                     allow_experimental_analyzer=1,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
 # name: TestExperimentQueryRunner.test_query_runner_excludes_multiple_variants
   '''
   SELECT entity_metrics.variant AS variant,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_ratio_metric.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_ratio_metric.ambr
@@ -599,6 +599,107 @@
                      use_hive_partitioning=0
   '''
 # ---
+# name: TestExperimentRatioMetric.test_ratio_metric_with_parametric_aggregation
+  '''
+  SELECT entity_metrics.variant AS variant,
+         count(entity_metrics.entity_id) AS num_users,
+         sum(entity_metrics.numerator_value) AS total_sum,
+         sum(power(entity_metrics.numerator_value, 2)) AS total_sum_of_squares,
+         sum(entity_metrics.denominator_value) AS denominator_sum,
+         sum(power(entity_metrics.denominator_value, 2)) AS denominator_sum_squares,
+         sum(multiply(entity_metrics.numerator_value, entity_metrics.denominator_value)) AS numerator_denominator_sum_product
+  FROM
+    (SELECT numerator_aggregated.variant AS variant,
+            numerator_aggregated.entity_id AS entity_id,
+            numerator_aggregated.numerator_value AS numerator_value,
+            coalesce(denominator_aggregated.denominator_value, 0) AS denominator_value
+     FROM
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               quantile(0.95)(coalesce(accurateCastOrNull(numerator_events.value, 'Float64'), 0)) AS numerator_value
+        FROM
+          (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+                  if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+                  min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+                  max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+                  argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+                  argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+           GROUP BY entity_id) AS exposures
+        LEFT JOIN
+          (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', '') AS value
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), plus(assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'purchase'))) AS numerator_events ON and(equals(exposures.entity_id, numerator_events.entity_id), greaterOrEquals(numerator_events.timestamp, exposures.first_exposure_time))
+        GROUP BY exposures.entity_id,
+                 exposures.variant) AS numerator_aggregated
+     LEFT JOIN
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               uniqExact(coalesce(accurateCastOrNull(denominator_events.value, 'Float64'), 0)) AS denominator_value
+        FROM
+          (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+                  if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+                  min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+                  max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+                  argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+                  argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+           GROUP BY entity_id) AS exposures
+        LEFT JOIN
+          (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  events.distinct_id AS value
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), plus(assumeNotNull(toDateTime('2020-01-10 00:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'purchase'))) AS denominator_events ON and(equals(exposures.entity_id, denominator_events.entity_id), greaterOrEquals(denominator_events.timestamp, exposures.first_exposure_time))
+        GROUP BY exposures.entity_id,
+                 exposures.variant) AS denominator_aggregated ON and(equals(numerator_aggregated.entity_id, denominator_aggregated.entity_id), equals(numerator_aggregated.variant, denominator_aggregated.variant))) AS entity_metrics
+  GROUP BY entity_metrics.variant
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=600,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=39728447488,
+                     allow_experimental_analyzer=1,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
 # name: TestExperimentRatioMetric.test_ratio_metric_zero_denominator
   '''
   SELECT entity_metrics.variant AS variant,

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
@@ -2200,3 +2200,92 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
         self.assertEqual(control_variant.number_of_samples, 2)  # 2 unique groups exposed to control
         self.assertEqual(test_variant.sum, 3)  # 3 unique groups with purchase events
         self.assertEqual(test_variant.number_of_samples, 3)  # 3 unique groups exposed to test
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    @snapshot_clickhouse_queries
+    def test_mean_metric_with_parametric_aggregation(self):
+        """Test that parametric aggregations like quantile work in mean metrics.
+
+        This test demonstrates the bug where quantile(0.90)(properties.margin) fails
+        because the query builder loses the 0.90 parameter when reconstructing the SQL.
+        """
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(
+            feature_flag=feature_flag,
+            start_date=datetime(2020, 1, 1),
+            end_date=datetime(2020, 1, 10),
+        )
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Create a metric using parametric aggregation (quantile)
+        metric = ExperimentMeanMetric(
+            source=EventsNode(
+                event="checkout-conversion",
+                math=ExperimentMetricMathType.HOGQL,
+                math_hogql="quantile(0.90)(properties.margin)",
+            )
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        # Create test data for both variants with varying margin values
+        for variant, user_count in [("control", 5), ("test", 5)]:
+            for i in range(user_count):
+                distinct_id = f"user_{variant}_{i}"
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+
+                # Create exposure event
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+
+                # Create conversion event with margin property
+                # Vary the margin: values from 10 to 90 (step of 20)
+                margin_value = 10 + (i * 20)
+                _create_event(
+                    team=self.team,
+                    event="checkout-conversion",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-03T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "margin": margin_value,  # Margins: 10, 30, 50, 70, 90
+                    },
+                )
+
+        flush_persons_and_events()
+
+        # This should not raise an error
+        # Without the fix, this will fail with "Function 'quantile' requires at least 1 parameter"
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = query_runner.calculate()
+
+        # Verify the query was executed successfully
+        assert result.variant_results is not None
+        self.assertEqual(len(result.variant_results), 1)
+
+        # Verify that the generated SQL contains the parameter
+        # This is the key assertion - the query should preserve quantile(0.90)
+        from posthog.hogql_queries.experiments.experiment_query_builder import ExperimentQueryBuilder
+
+        builder = ExperimentQueryBuilder(metric, experiment, self.team)
+        query_str = builder.to_query()
+        self.assertIn("quantile(0.90)", query_str, "Query should contain 'quantile(0.90)' with the parameter preserved")

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
@@ -2282,10 +2282,12 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
         assert result.variant_results is not None
         self.assertEqual(len(result.variant_results), 1)
 
-        # Verify that the generated SQL contains the parameter
-        # This is the key assertion - the query should preserve quantile(0.90)
-        from posthog.hogql_queries.experiments.experiment_query_builder import ExperimentQueryBuilder
+        # Verify the query was executed successfully and produced results
+        # If the query didn't preserve the parameter, it would have failed in ClickHouse
+        # The fact that we got results proves the parametric aggregation worked
+        control_variant = result.baseline
+        test_variant = result.variant_results[0]
 
-        builder = ExperimentQueryBuilder(metric, experiment, self.team)
-        query_str = builder.to_query()
-        self.assertIn("quantile(0.90)", query_str, "Query should contain 'quantile(0.90)' with the parameter preserved")
+        # Both variants should have computed values (proves quantile worked)
+        assert control_variant is not None
+        assert test_variant is not None

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_ratio_metric.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_ratio_metric.py
@@ -1037,13 +1037,12 @@ class TestExperimentRatioMetric(ExperimentQueryRunnerBaseTest):
         assert result.variant_results is not None
         self.assertEqual(len(result.variant_results), 1)
 
-        # Verify that the generated SQL contains the parameter
-        from posthog.hogql_queries.experiments.experiment_query_builder import ExperimentQueryBuilder
+        # Verify the query was executed successfully and produced results
+        # If the query didn't preserve the parameter, it would have failed in ClickHouse
+        # The fact that we got results proves the parametric aggregation worked
+        control_variant = result.baseline
+        test_variant = result.variant_results[0]
 
-        builder = ExperimentQueryBuilder(metric, experiment, self.team)
-        query_str = builder.to_query()
-        self.assertIn(
-            "quantile(0.95)",
-            query_str,
-            "Query should contain 'quantile(0.95)' with the parameter preserved in numerator",
-        )
+        # Both variants should have computed values (proves quantile worked)
+        assert control_variant is not None
+        assert test_variant is not None

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_ratio_metric.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_ratio_metric.py
@@ -948,3 +948,102 @@ class TestExperimentRatioMetric(ExperimentQueryRunnerBaseTest):
         # Check main-denominator sum product
         self.assertIsNotNone(control_variant.numerator_denominator_sum_product)
         self.assertIsNotNone(test_variant.numerator_denominator_sum_product)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    @snapshot_clickhouse_queries
+    def test_ratio_metric_with_parametric_aggregation(self):
+        """Test parametric aggregations in ratio metrics.
+
+        This test demonstrates the bug where parametric aggregations like
+        quantile(0.95)(properties.amount) fail in ratio metric numerators
+        because the query builder loses the parameter.
+        """
+        from datetime import datetime
+
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(
+            feature_flag=feature_flag,
+            start_date=datetime(2020, 1, 1),
+            end_date=datetime(2020, 1, 10),
+        )
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Create a ratio metric where numerator uses parametric aggregation
+        metric = ExperimentRatioMetric(
+            numerator=EventsNode(
+                event="purchase",
+                math=ExperimentMetricMathType.HOGQL,
+                math_hogql="quantile(0.95)(properties.amount)",
+            ),
+            denominator=EventsNode(
+                event="purchase",
+                math=ExperimentMetricMathType.HOGQL,
+                math_hogql="uniqExact(distinct_id)",  # Count unique users
+            ),
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        # Create test data
+        for variant, user_count in [("control", 5), ("test", 5)]:
+            for i in range(user_count):
+                distinct_id = f"user_{variant}_{i}"
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+
+                # Create exposure event
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+
+                # Create purchase event with varying amounts
+                amount_value = 50 + (i * 25)  # Amounts: 50, 75, 100, 125, 150
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-03T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "amount": amount_value,
+                    },
+                )
+
+        flush_persons_and_events()
+
+        # This should not raise an error
+        # Without the fix, this will fail with "Function 'quantile' requires at least 1 parameter"
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        # Verify the query was executed successfully
+        assert result.variant_results is not None
+        self.assertEqual(len(result.variant_results), 1)
+
+        # Verify that the generated SQL contains the parameter
+        from posthog.hogql_queries.experiments.experiment_query_builder import ExperimentQueryBuilder
+
+        builder = ExperimentQueryBuilder(metric, experiment, self.team)
+        query_str = builder.to_query()
+        self.assertIn(
+            "quantile(0.95)",
+            query_str,
+            "Query should contain 'quantile(0.95)' with the parameter preserved in numerator",
+        )

--- a/posthog/hogql_queries/experiments/test/test_hogql_aggregation_integration.py
+++ b/posthog/hogql_queries/experiments/test/test_hogql_aggregation_integration.py
@@ -56,7 +56,7 @@ class TestHogQLAggregationIntegration(BaseTest):
 
         for expr_str, expected_agg, description in test_cases:
             with self.subTest(expression=expr_str, description=description):
-                aggregation, inner_expr = extract_aggregation_and_inner_expr(expr_str)
+                aggregation, inner_expr, _ = extract_aggregation_and_inner_expr(expr_str)
 
                 if expected_agg is None:
                     self.assertIsNone(aggregation, f"Expected no aggregation for: {expr_str}")

--- a/posthog/hogql_queries/experiments/test/test_hogql_aggregation_utils.py
+++ b/posthog/hogql_queries/experiments/test/test_hogql_aggregation_utils.py
@@ -128,14 +128,18 @@ class TestHogQLAggregationUtils(BaseTest):
         self.assertEqual(agg, "quantile")
         self.assertIsInstance(inner, ast.Field)
         self.assertIsNotNone(params)
+        assert params is not None  # for mypy
         self.assertEqual(len(params), 1)
         self.assertIsInstance(params[0], ast.Constant)
+        assert isinstance(params[0], ast.Constant)  # for mypy
         self.assertEqual(params[0].value, 0.90)
 
         # Test quantile with different level
         agg, inner, params = extract_aggregation_and_inner_expr("quantile(0.50)(properties.value)")
         self.assertEqual(agg, "quantile")
         self.assertIsNotNone(params)
+        assert params is not None  # for mypy
+        assert isinstance(params[0], ast.Constant)  # for mypy
         self.assertEqual(params[0].value, 0.50)
 
         # Test non-parametric aggregation returns None for params
@@ -147,7 +151,7 @@ class TestHogQLAggregationUtils(BaseTest):
         """Test that build_aggregation_call handles parametric functions."""
 
         inner_expr = parse_expr("properties.value")
-        params = [ast.Constant(value=0.90)]
+        params: list[ast.Expr] = [ast.Constant(value=0.90)]
 
         # Build quantile with parameter
         result = build_aggregation_call("quantile", inner_expr, params=params)
@@ -156,7 +160,9 @@ class TestHogQLAggregationUtils(BaseTest):
         self.assertIsInstance(result, ast.Call)
         self.assertEqual(result.name, "quantile")
         self.assertIsNotNone(result.params)
+        assert result.params is not None  # for mypy
         self.assertEqual(len(result.params), 1)
+        assert isinstance(result.params[0], ast.Constant)  # for mypy
         self.assertEqual(result.params[0].value, 0.90)
         self.assertEqual(result.args[0], inner_expr)
 

--- a/posthog/hogql_queries/experiments/test/test_hogql_aggregation_utils.py
+++ b/posthog/hogql_queries/experiments/test/test_hogql_aggregation_utils.py
@@ -37,48 +37,58 @@ class TestHogQLAggregationUtils(BaseTest):
         """Test extracting aggregation function and inner expression."""
 
         # Test sum with arithmetic operation
-        aggregation, inner_expr = extract_aggregation_and_inner_expr("sum(properties.revenue - properties.expense)")
+        aggregation, inner_expr, params = extract_aggregation_and_inner_expr(
+            "sum(properties.revenue - properties.expense)"
+        )
         self.assertEqual(aggregation, "sum")
         self.assertIsInstance(inner_expr, ast.ArithmeticOperation)
+        self.assertIsNone(params)  # Non-parametric aggregation
 
         # Test avg with field
-        aggregation, inner_expr = extract_aggregation_and_inner_expr("avg(properties.price)")
+        aggregation, inner_expr, params = extract_aggregation_and_inner_expr("avg(properties.price)")
         self.assertEqual(aggregation, "avg")
         self.assertIsInstance(inner_expr, ast.Field)
+        self.assertIsNone(params)
 
         # Test count with no arguments
-        aggregation, inner_expr = extract_aggregation_and_inner_expr("count()")
+        aggregation, inner_expr, params = extract_aggregation_and_inner_expr("count()")
         self.assertEqual(aggregation, "count")
         self.assertIsInstance(inner_expr, ast.Constant)
         self.assertEqual(inner_expr.value, 1)  # type: ignore[attr-defined]
+        self.assertIsNone(params)
 
         # Test min with field
-        aggregation, inner_expr = extract_aggregation_and_inner_expr("min(properties.score)")
+        aggregation, inner_expr, params = extract_aggregation_and_inner_expr("min(properties.score)")
         self.assertEqual(aggregation, "min")
         self.assertIsInstance(inner_expr, ast.Field)
+        self.assertIsNone(params)
 
         # Test max with field
-        aggregation, inner_expr = extract_aggregation_and_inner_expr("max(properties.value)")
+        aggregation, inner_expr, params = extract_aggregation_and_inner_expr("max(properties.value)")
         self.assertEqual(aggregation, "max")
         self.assertIsInstance(inner_expr, ast.Field)
+        self.assertIsNone(params)
 
     def test_extract_aggregation_and_inner_expr_without_aggregation(self):
         """Test extracting from non-aggregation expressions."""
 
         # Test simple field
-        aggregation, inner_expr = extract_aggregation_and_inner_expr("properties.revenue")
+        aggregation, inner_expr, params = extract_aggregation_and_inner_expr("properties.revenue")
         self.assertIsNone(aggregation)
         self.assertIsInstance(inner_expr, ast.Field)
+        self.assertIsNone(params)
 
         # Test arithmetic operation
-        aggregation, inner_expr = extract_aggregation_and_inner_expr("1 + 2")
+        aggregation, inner_expr, params = extract_aggregation_and_inner_expr("1 + 2")
         self.assertIsNone(aggregation)
         self.assertIsInstance(inner_expr, ast.ArithmeticOperation)
+        self.assertIsNone(params)
 
         # Test function call that's not an aggregation
-        aggregation, inner_expr = extract_aggregation_and_inner_expr("toFloat(properties.value)")
+        aggregation, inner_expr, params = extract_aggregation_and_inner_expr("toFloat(properties.value)")
         self.assertIsNone(aggregation)
         self.assertIsInstance(inner_expr, ast.Call)
+        self.assertIsNone(params)
 
     def test_extract_aggregation_and_inner_expr_with_ast_input(self):
         """Test that the function works with AST nodes as input."""
@@ -87,9 +97,10 @@ class TestHogQLAggregationUtils(BaseTest):
         expr = parse_expr("sum(properties.revenue)")
 
         # Extract from AST
-        aggregation, inner_expr = extract_aggregation_and_inner_expr(expr)
+        aggregation, inner_expr, params = extract_aggregation_and_inner_expr(expr)
         self.assertEqual(aggregation, "sum")
         self.assertIsInstance(inner_expr, ast.Field)
+        self.assertIsNone(params)
 
     def test_build_aggregation_call(self):
         """Test building aggregation calls."""
@@ -108,3 +119,49 @@ class TestHogQLAggregationUtils(BaseTest):
         # Test building with distinct
         agg_call_distinct = build_aggregation_call("count", inner_expr, distinct=True)
         self.assertTrue(agg_call_distinct.distinct)
+
+    def test_extract_aggregation_with_params(self):
+        """Test that parametric aggregations preserve their parameters."""
+
+        # Test quantile with single parameter
+        agg, inner, params = extract_aggregation_and_inner_expr("quantile(0.90)(properties.margin)")
+        self.assertEqual(agg, "quantile")
+        self.assertIsInstance(inner, ast.Field)
+        self.assertIsNotNone(params)
+        self.assertEqual(len(params), 1)
+        self.assertIsInstance(params[0], ast.Constant)
+        self.assertEqual(params[0].value, 0.90)
+
+        # Test quantile with different level
+        agg, inner, params = extract_aggregation_and_inner_expr("quantile(0.50)(properties.value)")
+        self.assertEqual(agg, "quantile")
+        self.assertIsNotNone(params)
+        self.assertEqual(params[0].value, 0.50)
+
+        # Test non-parametric aggregation returns None for params
+        agg, inner, params = extract_aggregation_and_inner_expr("sum(properties.revenue)")
+        self.assertEqual(agg, "sum")
+        self.assertIsNone(params)
+
+    def test_build_aggregation_call_with_params(self):
+        """Test that build_aggregation_call handles parametric functions."""
+
+        inner_expr = parse_expr("properties.value")
+        params = [ast.Constant(value=0.90)]
+
+        # Build quantile with parameter
+        result = build_aggregation_call("quantile", inner_expr, params=params)
+
+        # Should produce: quantile(0.90)(properties.value)
+        self.assertIsInstance(result, ast.Call)
+        self.assertEqual(result.name, "quantile")
+        self.assertIsNotNone(result.params)
+        self.assertEqual(len(result.params), 1)
+        self.assertEqual(result.params[0].value, 0.90)
+        self.assertEqual(result.args[0], inner_expr)
+
+        # Test building without params (non-parametric aggregation)
+        result_no_params = build_aggregation_call("sum", inner_expr, params=None)
+        self.assertIsInstance(result_no_params, ast.Call)
+        self.assertEqual(result_no_params.name, "sum")
+        self.assertIsNone(result_no_params.params)


### PR DESCRIPTION
## Problem

Mean metrics support `ExperimentMetricMathType.HOGQL` as a math type, but only for simple aggregation functions like `sum`. When using a parametrized function like `quatile`, the aggregation parameters were lost during the expression extraction.

| Parametrized HogQL function |
| - |
| <img width="867" height="592" alt="image" src="https://github.com/user-attachments/assets/26ca4698-15cd-4114-ad49-0b479ce09434" /> |

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We fix parametric aggregation by modifying `build_aggregation_call` and `extract_aggregation_and_inner_expr` to handle optional parameters.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
hogli test:python posthog/hogql_queries/experiments/test/experiment_query_runner/test_base.py
hogli test:python posthog/hogql_queries/experiments/test/experiment_query_runner/test_ratio_metric.py
hogli test:python posthog/hogql_queries/experiments/test/test_hogql_aggregation_integration.py
hogli test:python posthog/hogql_queries/experiments/test/test_hogql_aggregation_utils.py
```

or just

```bash
hogli test:python posthog/hogql_queries/experiments/test/
```

and also some

![cat-type-small](https://github.com/user-attachments/assets/4fa058b0-1352-444c-b4f9-64573b9b797b)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
