### PR TITLE
fix: allow users with personal api keys to be deactivated

### DIFF
--- a/posthog/admin/inlines/organization_member_inline.py
+++ b/posthog/admin/inlines/organization_member_inline.py
@@ -10,5 +10,5 @@ class OrganizationMemberInline(TabularInlinePaginated):
     pagination_key = "page-member"
     show_change_link = True
     readonly_fields = ("user", "joined_at", "updated_at")
-    autocomplete_fields = ("user", "organization")
+    autocomplete_fields = ("organization",)
     ordering = ("-level",)  # Order by level descending (Owner -> Admin -> Member)

--- a/posthog/admin/inlines/personal_api_key_inline.py
+++ b/posthog/admin/inlines/personal_api_key_inline.py
@@ -8,10 +8,18 @@ class PersonalAPIKeyInline(admin.TabularInline):
     extra = 0
     fields = ("label", "mask_value", "created_at", "last_used_at", "scopes")
     readonly_fields = ("label", "mask_value", "created_at", "last_used_at", "scopes")
-    can_delete = True
+    can_delete = False
     show_change_link = True
     ordering = ("-created_at",)
 
     def has_add_permission(self, request, obj=None):
         # Prevent adding API keys through the admin (they should be created via API)
         return False
+
+    def has_change_permission(self, request, obj=None):
+        # Make the inline completely read-only to prevent formset validation issues
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        # Ensure the inline is still visible even though change permission is False
+        return True


### PR DESCRIPTION
## Problem

Users with a personal api key cannot be deactivated using the admin view.

## Changes

- Remove unnecessary autocomplete for org membership inline
- Make personal api key read-only for inline view

## How did you test this code?

Manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
