### PR TITLE
fix(cdp): use Klaviyo profile-import endpoint to fix 409 errors

### DIFF
--- a/posthog/cdp/templates/klaviyo/test_template_klaviyo.py
+++ b/posthog/cdp/templates/klaviyo/test_template_klaviyo.py
@@ -42,7 +42,7 @@ class TestTemplateKlaviyoUser(BaseHogFunctionTemplateTest):
 
         assert self.get_mock_fetch_calls()[0] == snapshot(
             (
-                "https://a.klaviyo.com/api/profiles",
+                "https://a.klaviyo.com/api/profile-import",
                 {
                     "method": "POST",
                     "headers": {
@@ -65,61 +65,6 @@ class TestTemplateKlaviyoUser(BaseHogFunctionTemplateTest):
                                 "email": "max@posthog.com",
                                 "external_id": "EXTERNAL_ID",
                             },
-                        }
-                    },
-                },
-            )
-        )
-
-    def test_patch_existing_profile(self):
-        self.mock_fetch_response = lambda *args: {  # type: ignore
-            "status": 409,
-            "body": {
-                "errors": [
-                    {
-                        "id": "207e2b13-ac84-4afe-a064-616a33006e6e",
-                        "status": 409,
-                        "code": "duplicate_profile",
-                        "title": "Conflict.",
-                        "detail": "A profile already exists with one of these identifiers.",
-                        "source": {"pointer": "/data/attributes"},
-                        "links": {},
-                        "meta": {"duplicate_profile_id": "01JAFS0VVWGJFE7QE4EJQBA5AS"},
-                    }
-                ]
-            },
-        }
-
-        # both requests will fail with error code 409
-        with pytest.raises(UncaughtHogVMException):
-            self.run_function(inputs=self.create_inputs())
-
-        assert self.get_mock_fetch_calls()[1] == snapshot(
-            (
-                "https://a.klaviyo.com/api/profiles/01JAFS0VVWGJFE7QE4EJQBA5AS",
-                {
-                    "method": "PATCH",
-                    "headers": {
-                        "Authorization": "Klaviyo-API-Key API_KEY",
-                        "revision": "2024-10-15",
-                        "Content-Type": "application/json",
-                    },
-                    "body": {
-                        "data": {
-                            "type": "profile",
-                            "attributes": {
-                                "location": {},
-                                "properties": {
-                                    "first_name": "Max",
-                                    "last_name": "AI",
-                                    "title": "Hedgehog in Residence",
-                                    "organization": "PostHog",
-                                    "phone_number": "+0123456789",
-                                },
-                                "email": "max@posthog.com",
-                                "external_id": "EXTERNAL_ID",
-                            },
-                            "id": "01JAFS0VVWGJFE7QE4EJQBA5AS",
                         }
                     },
                 },
@@ -167,7 +112,7 @@ class TestTemplateKlaviyoUser(BaseHogFunctionTemplateTest):
         self.mock_fetch_response = lambda *args: {"status": 400, "body": {"error": "error"}}  # type: ignore
         with pytest.raises(UncaughtHogVMException) as e:
             self.run_function(inputs=self.create_inputs())
-        assert e.value.message == "Error from a.klaviyo.com api: 400: {'error': 'error'}"
+        assert e.value.message == "Error from a.klaviyo.com api: 400"
 
 
 class TestTemplateKlaviyoEvent(BaseHogFunctionTemplateTest):


### PR DESCRIPTION
## Summary

The Klaviyo "Update contact" destination was experiencing intermittent 409 errors due to race conditions in the previous two-step approach:

1. POST to `/api/profiles` to create a profile
2. If 409 conflict, extract `duplicate_profile_id` and PATCH to `/api/profiles/{id}`

This fix switches to Klaviyo's `/api/profile-import` endpoint which handles upserts (create-or-update) natively in a single request, eliminating the 409 errors.

### Changes

- Use `/api/profile-import` instead of `/api/profiles` + PATCH fallback
- Add debug logging for easier troubleshooting
- Remove obsolete 409 conflict handling code

### Why profile-import?

Per [Klaviyo's documentation](https://developers.klaviyo.com/en/reference/create_or_update_profile): "To create or update profiles from server-side applications, use POST /api/profile-import."

## Test plan

- [x] Tested with a real customer's destination for 3 days before this PR - no more 409 errors
- [x] Unit tests updated and passing

## Changelog: (features only) Is this feature complete?

yes

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
