### PR TITLE
feat(replay): update Web Analytics entrypoints, extend unified Replay button

### DIFF
--- a/frontend/src/lib/components/ViewReplayButton/ViewReplayButton.tsx
+++ b/frontend/src/lib/components/ViewReplayButton/ViewReplayButton.tsx
@@ -8,43 +8,71 @@ import { RecordingUniversalFilters, ReplayTabs } from '~/types'
 
 /**
  * Unified button component for navigating to Session Replay.
+ *
+ * Supports two modes:
+ * 1. Filtered list mode: Opens replay with filters applied (for exploring recordings)
+ * 2. Single recording mode: Opens a specific recording by ID
+ *
+ * @example
+ * // Open replay with filters
+ * <ViewReplayButton
+ *   filters={{ filter_group: {...} }}
+ *   label="View recordings"
+ * />
+ *
+ * @example
+ * // Open a specific recording
+ * <ViewReplayButton
+ *   recordingId="abc123"
+ * />
  */
 
-type ViewReplayButtonProps = {
-    filters: Partial<RecordingUniversalFilters>
+type ViewReplayButtonBaseProps = {
     label?: string
     tooltip?: string
-} & Pick<
-    LemonButtonProps,
-    | 'size'
-    | 'type'
-    | 'data-attr'
-    | 'fullWidth'
-    | 'className'
-    | 'icon'
-    | 'sideIcon'
-    | 'loading'
-    | 'disabled'
-    | 'disabledReason'
->
+} & Pick<LemonButtonProps, 'size' | 'type' | 'data-attr' | 'fullWidth' | 'loading' | 'disabled' | 'disabledReason'>
+
+type ViewReplayButtonFilteredProps = ViewReplayButtonBaseProps & {
+    /** Filters to apply when opening replay (opens filtered list) */
+    filters: Partial<RecordingUniversalFilters>
+    recordingId?: never
+}
+
+type ViewReplayButtonSingleProps = ViewReplayButtonBaseProps & {
+    /** ID of a specific recording to open (opens single recording) */
+    recordingId: string
+    filters?: never
+}
+
+type ViewReplayButtonProps = ViewReplayButtonFilteredProps | ViewReplayButtonSingleProps
 
 export function ViewReplayButton({
     filters,
-    label = 'View recordings',
+    recordingId,
+    label,
     tooltip,
-    icon,
-    sideIcon,
     ...buttonProps
 }: ViewReplayButtonProps): JSX.Element {
     const onClick = (): void => {
-        // Open replay with filters in a new PostHog internal tab
-        const replayUrl = urls.replay(ReplayTabs.Home, filters)
+        let replayUrl: string
+
+        if (recordingId) {
+            // Single recording mode: open specific recording
+            replayUrl = urls.replaySingle(recordingId)
+        } else {
+            // Filtered list mode: open replay with filters
+            replayUrl = urls.replay(ReplayTabs.Home, filters)
+        }
+
         newInternalTab(replayUrl)
     }
 
+    // Default label based on mode
+    const defaultLabel = recordingId ? 'View recording' : 'View recordings'
+
     const button = (
-        <LemonButton onClick={onClick} icon={icon} sideIcon={sideIcon ?? <IconRewindPlay />} {...buttonProps}>
-            {label}
+        <LemonButton onClick={onClick} sideIcon={<IconRewindPlay />} {...buttonProps}>
+            {label ?? defaultLabel}
         </LemonButton>
     )
 

--- a/frontend/src/scenes/web-analytics/CrossSellButtons/ReplayButton.tsx
+++ b/frontend/src/scenes/web-analytics/CrossSellButtons/ReplayButton.tsx
@@ -1,11 +1,8 @@
-import { IconRewindPlay } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
-
+import { ViewReplayButton } from 'lib/components/ViewReplayButton/ViewReplayButton'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
-import { urls } from 'scenes/urls'
 
 import { ProductIntentContext, ProductKey, WebStatsBreakdown } from '~/queries/schema/schema-general'
-import { FilterLogicalOperator, PropertyFilterType, PropertyOperator, ReplayTabs } from '~/types'
+import { FilterLogicalOperator, PropertyFilterType, PropertyOperator, RecordingUniversalFilters } from '~/types'
 
 /**
  * Map breakdown types to their corresponding property filter type
@@ -59,103 +56,102 @@ interface ReplayButtonProps {
 }
 
 export const ReplayButton = ({ date_from, date_to, breakdownBy, value }: ReplayButtonProps): JSX.Element => {
-    const sharedButtonProps = {
-        icon: <IconRewindPlay />,
-        type: 'tertiary' as const,
-        size: 'xsmall' as const,
-        tooltip: 'View recordings',
-        className: 'no-underline',
-        targetBlank: true,
-        hideExternalLinkIcon: true,
-        onClick: (e: React.MouseEvent) => {
-            e.stopPropagation()
-            void addProductIntentForCrossSell({
-                from: ProductKey.WEB_ANALYTICS,
-                to: ProductKey.SESSION_REPLAY,
-                intent_context: ProductIntentContext.WEB_ANALYTICS_INSIGHT,
-            })
-        },
+    const handleClick = (e: React.MouseEvent): void => {
+        e.stopPropagation()
+        void addProductIntentForCrossSell({
+            from: ProductKey.WEB_ANALYTICS,
+            to: ProductKey.SESSION_REPLAY,
+            intent_context: ProductIntentContext.WEB_ANALYTICS_INSIGHT,
+        })
     }
 
     /** If value is empty - just open session replay home page */
     if (value === '') {
-        return <LemonButton {...sharedButtonProps} to={urls.replay(ReplayTabs.Home, { date_from, date_to })} />
+        const filters: Partial<RecordingUniversalFilters> = {
+            date_from,
+            date_to,
+        }
+        return (
+            <div onClick={handleClick}>
+                <ViewReplayButton filters={filters} type="tertiary" size="xsmall" />
+            </div>
+        )
     }
 
     /** View port is a unique case, so we need to handle it differently */
     if (breakdownBy === WebStatsBreakdown.Viewport) {
-        return (
-            <LemonButton
-                {...sharedButtonProps}
-                to={urls.replay(ReplayTabs.Home, {
-                    date_from: date_from,
-                    date_to: date_to,
-                    filter_group: {
+        const filters: Partial<RecordingUniversalFilters> = {
+            date_from,
+            date_to,
+            filter_group: {
+                type: FilterLogicalOperator.And,
+                values: [
+                    {
                         type: FilterLogicalOperator.And,
                         values: [
                             {
-                                type: FilterLogicalOperator.And,
-                                values: [
-                                    {
-                                        key: '$viewport_width',
-                                        type: PropertyFilterType.Event,
-                                        value: [value[0]],
-                                        operator: PropertyOperator.Exact,
-                                    },
-                                    {
-                                        key: '$viewport_height',
-                                        type: PropertyFilterType.Event,
-                                        value: [value[1]],
-                                        operator: PropertyOperator.Exact,
-                                    },
-                                ],
+                                key: '$viewport_width',
+                                type: PropertyFilterType.Event,
+                                value: [value[0]],
+                                operator: PropertyOperator.Exact,
+                            },
+                            {
+                                key: '$viewport_height',
+                                type: PropertyFilterType.Event,
+                                value: [value[1]],
+                                operator: PropertyOperator.Exact,
                             },
                         ],
                     },
-                })}
-            />
+                ],
+            },
+        }
+        return (
+            <div onClick={handleClick}>
+                <ViewReplayButton filters={filters} type="tertiary" size="xsmall" />
+            </div>
         )
     }
 
     /** UTM source, medium, campaign is a unique case, so we need to handle it differently, as combining them with AND */
     if (breakdownBy === WebStatsBreakdown.InitialUTMSourceMediumCampaign) {
         const values = value.split(' / ')
-        return (
-            <LemonButton
-                {...sharedButtonProps}
-                to={urls.replay(ReplayTabs.Home, {
-                    date_from: date_from,
-                    date_to: date_to,
-                    filter_group: {
+        const filters: Partial<RecordingUniversalFilters> = {
+            date_from,
+            date_to,
+            filter_group: {
+                type: FilterLogicalOperator.And,
+                values: [
+                    {
                         type: FilterLogicalOperator.And,
                         values: [
                             {
-                                type: FilterLogicalOperator.And,
-                                values: [
-                                    {
-                                        key: '$entry_utm_source',
-                                        type: PropertyFilterType.Session,
-                                        value: [values[0] || ''],
-                                        operator: PropertyOperator.Exact,
-                                    },
-                                    {
-                                        key: '$entry_utm_medium',
-                                        type: PropertyFilterType.Session,
-                                        value: [values[1] || ''],
-                                        operator: PropertyOperator.Exact,
-                                    },
-                                    {
-                                        key: '$entry_utm_campaign',
-                                        type: PropertyFilterType.Session,
-                                        value: [values[2] || ''],
-                                        operator: PropertyOperator.Exact,
-                                    },
-                                ],
+                                key: '$entry_utm_source',
+                                type: PropertyFilterType.Session,
+                                value: [values[0] || ''],
+                                operator: PropertyOperator.Exact,
+                            },
+                            {
+                                key: '$entry_utm_medium',
+                                type: PropertyFilterType.Session,
+                                value: [values[1] || ''],
+                                operator: PropertyOperator.Exact,
+                            },
+                            {
+                                key: '$entry_utm_campaign',
+                                type: PropertyFilterType.Session,
+                                value: [values[2] || ''],
+                                operator: PropertyOperator.Exact,
                             },
                         ],
                     },
-                })}
-            />
+                ],
+            },
+        }
+        return (
+            <div onClick={handleClick}>
+                <ViewReplayButton filters={filters} type="tertiary" size="xsmall" />
+            </div>
         )
     }
 
@@ -167,29 +163,29 @@ export const ReplayButton = ({ date_from, date_to, breakdownBy, value }: ReplayB
     }
 
     /** Render the button */
-    return (
-        <LemonButton
-            {...sharedButtonProps}
-            to={urls.replay(ReplayTabs.Home, {
-                date_from: date_from,
-                date_to: date_to,
-                filter_group: {
+    const filters: Partial<RecordingUniversalFilters> = {
+        date_from,
+        date_to,
+        filter_group: {
+            type: FilterLogicalOperator.And,
+            values: [
+                {
                     type: FilterLogicalOperator.And,
                     values: [
                         {
-                            type: FilterLogicalOperator.And,
-                            values: [
-                                {
-                                    key: key,
-                                    type: type,
-                                    value: [value],
-                                    operator: PropertyOperator.Exact,
-                                },
-                            ],
+                            key: key,
+                            type: type,
+                            value: [value],
+                            operator: PropertyOperator.Exact,
                         },
                     ],
                 },
-            })}
-        />
+            ],
+        },
+    }
+    return (
+        <div onClick={handleClick}>
+            <ViewReplayButton filters={filters} type="tertiary" size="xsmall" />
+        </div>
     )
 }

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsRecordings.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsRecordings.tsx
@@ -1,14 +1,11 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 
-import { IconRewindPlay } from '@posthog/icons'
-
 import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { ViewReplayButton } from 'lib/components/ViewReplayButton/ViewReplayButton'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
-import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { humanFriendlyDuration } from 'lib/utils'
 import { asDisplay } from 'scenes/persons/person-utils'
 import { ActivityScoreLabel } from 'scenes/session-recordings/components/RecordingRow'
@@ -19,7 +16,7 @@ import { ReplayTile } from 'scenes/web-analytics/common'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
-import { ReplayTabs, SessionRecordingType } from '~/types'
+import { SessionRecordingType } from '~/types'
 
 export function WebAnalyticsRecordingsTile({ tile }: { tile: ReplayTile }): JSX.Element {
     const { layout } = tile
@@ -55,7 +52,6 @@ export function WebAnalyticsRecordingsTile({ tile }: { tile: ReplayTile }): JSX.
                 buttonText: 'Learn more',
                 buttonTo: 'https://posthog.com/docs/user-guides/recordings',
             }
-    const to = items.length > 0 ? urls.replay(ReplayTabs.Home, replayFilters) : urls.replay()
     return (
         <>
             <div
@@ -109,14 +105,19 @@ export function WebAnalyticsRecordingsTile({ tile }: { tile: ReplayTile }): JSX.
                                     ),
                                 },
                                 {
-                                    title: '',
+                                    title: 'Recording',
                                     render: (_, recording: SessionRecordingType) => (
-                                        <LemonButton
-                                            size="xsmall"
-                                            targetBlank
-                                            to={urls.replaySingle(recording.id ?? '')}
-                                            icon={<IconRewindPlay />}
-                                        />
+                                        <div
+                                            onClick={() => {
+                                                addProductIntentForCrossSell({
+                                                    from: ProductKey.WEB_ANALYTICS,
+                                                    to: ProductKey.SESSION_REPLAY,
+                                                    intent_context: ProductIntentContext.WEB_ANALYTICS_INSIGHT,
+                                                })
+                                            }}
+                                        >
+                                            <ViewReplayButton recordingId={recording.id ?? ''} size="xsmall" />
+                                        </div>
                                     ),
                                 },
                             ]}
@@ -125,9 +126,7 @@ export function WebAnalyticsRecordingsTile({ tile }: { tile: ReplayTile }): JSX.
                     )}
                 </div>
                 <div className="flex flex-row-reverse my-2">
-                    <LemonButton
-                        to={to}
-                        icon={<IconOpenInNew />}
+                    <div
                         onClick={() => {
                             addProductIntentForCrossSell({
                                 from: ProductKey.WEB_ANALYTICS,
@@ -135,11 +134,9 @@ export function WebAnalyticsRecordingsTile({ tile }: { tile: ReplayTile }): JSX.
                                 intent_context: ProductIntentContext.WEB_ANALYTICS_INSIGHT,
                             })
                         }}
-                        size="small"
-                        type="secondary"
                     >
-                        View all
-                    </LemonButton>
+                        <ViewReplayButton filters={replayFilters} size="small" type="secondary" label="View all" />
+                    </div>
                 </div>
             </div>
         </>


### PR DESCRIPTION
## Problem

**Entrypoints done: 3/20** (I'm sure i'll find more as i go)


<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- extend Unified button to account for single-video (vs playlist/filters)
- make it opinionated (we want to AVOID people over-customizing
- update some entrypoints in Web Analytics


## How did you test this code?

[web_analytics_entrypoints.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/ab8a2e1a-303b-4a55-99a8-3ffcc6d9bc2c.mov" />](https://app.graphite.com/user-attachments/video/ab8a2e1a-303b-4a55-99a8-3ffcc6d9bc2c.mov)

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
