### PR TITLE
fix(experiments): Fix color for "decrease" goals

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -32,7 +32,6 @@ import {
     formatMetricValue,
     formatPValue,
     getDelta,
-    getMetricColors,
     getMetricSubtitleValues,
     getNiceTickValues,
     hasValidationFailures,
@@ -116,7 +115,6 @@ export function MetricRowGroup({
     })
     const tooltipRef = useRef<HTMLDivElement>(null)
     const colors = useChartColors()
-    const goalColors = getMetricColors(colors, metric.goal)
     const scale = useAxisScale(axisRange, VIEW_BOX_WIDTH, SVG_EDGE_MARGIN)
 
     const { reportExperimentTimeseriesViewed } = useActions(experimentLogic)
@@ -512,8 +510,8 @@ export function MetricRowGroup({
                                 maxHeight: `${CELL_HEIGHT}px`,
                                 backgroundColor: significant
                                     ? winning
-                                        ? `${goalColors.positive}30`
-                                        : `${goalColors.negative}30`
+                                        ? `${colors.BAR_POSITIVE}30`
+                                        : `${colors.BAR_NEGATIVE}30`
                                     : undefined,
                             }}
                         >
@@ -803,8 +801,8 @@ export function MetricRowGroup({
                                             maxHeight: `${CELL_HEIGHT}px`,
                                             backgroundColor: significant
                                                 ? winning
-                                                    ? `${goalColors.positive}30`
-                                                    : `${goalColors.negative}30`
+                                                    ? `${colors.BAR_POSITIVE}30`
+                                                    : `${colors.BAR_NEGATIVE}30`
                                                 : undefined,
                                         }}
                                     >


### PR DESCRIPTION
## Changes
Fix a bug where the Win % cell background showed the wrong color for "decrease" goal metrics because the color was being adjusted for the goal twice.

## How did you test this code?
|Before|After|
|----|----|
|<img width="957" height="109" alt="image" src="https://github.com/user-attachments/assets/caa125b7-9976-4e91-9042-938345a97e97" />|<img width="957" height="107" alt="image" src="https://github.com/user-attachments/assets/2dbe7c3f-e5f0-462a-a3b8-eb91f25b8478" />|