### PR TITLE
chore: add tooltips to destination template buttons

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/components/HogFunctionTemplateOptions.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/components/HogFunctionTemplateOptions.tsx
@@ -26,12 +26,20 @@ export function HogFunctionTemplateOptions(): JSX.Element {
                     <LemonButton>Close</LemonButton>
                 </div>
 
-                <LemonButton type="secondary" onClick={() => duplicateFromTemplate()}>
+                <LemonButton
+                    type="secondary"
+                    onClick={() => duplicateFromTemplate()}
+                    tooltip="Create a new destination using the latest template version"
+                >
                     New function from template
                 </LemonButton>
 
                 {templateHasChanged ? (
-                    <LemonButton type="primary" onClick={() => resetToTemplate()}>
+                    <LemonButton
+                        type="primary"
+                        onClick={() => resetToTemplate()}
+                        tooltip="Replace your current code with the latest template version"
+                    >
                         Reset to template
                     </LemonButton>
                 ) : null}


### PR DESCRIPTION
## Problem

Feedback: https://posthoghelp.zendesk.com/agent/tickets/45262 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46443)

## Changes

<img width="1012" height="300" alt="image" src="https://github.com/user-attachments/assets/eaeb8cfa-cea3-4229-a55c-9ab83f505385" />

<img width="1260" height="304" alt="image" src="https://github.com/user-attachments/assets/aef265b5-2bac-4c34-917a-676d76a8db4c" />


## How did you test this code?

locally

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
