### PR TITLE
chore(dev): Recreate docker services on startup

### DIFF
--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -284,7 +284,7 @@ build:
         description: Build products manifest from TypeScript/JSX files
 docker:
     docker:services:up:
-        cmd: docker compose -f docker-compose.dev.yml up -d
+        cmd: docker compose -f docker-compose.dev.yml up -d --force-recreate
         description: Start Docker infrastructure services (Postgres, ClickHouse, Redis,
             Kafka)
         services:


### PR DESCRIPTION
This recreates our dev containers on every start, which maintains good hygiene and ensures we're not relying on ephemeral state.
