### PR TITLE
fix(replay): EASY pass hasRecording from event row overflow menu

### DIFF
--- a/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
+++ b/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
@@ -36,6 +36,7 @@ export default function ViewRecordingButton({
     inModal = false,
     checkIfViewed = false,
     matchingEvents,
+    hasRecording,
     ...props
 }: Pick<LemonButtonProps, 'size' | 'type' | 'data-attr' | 'fullWidth' | 'className' | 'loading'> &
     ViewRecordingProps & {
@@ -50,6 +51,7 @@ export default function ViewRecordingButton({
         timestamp,
         matchingEvents,
         inModal,
+        hasRecording,
     })
 
     const { recordingViewed, recordingViewedLoading } = useValues(

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -611,6 +611,7 @@ export function DataTable({
                                       sessionId={event?.properties?.$session_id}
                                       recordingStatus={event?.properties?.$recording_status}
                                       timestamp={event?.timestamp}
+                                      hasRecording={event?.properties?.has_recording as boolean | undefined}
                                       inModal
                                       size="xsmall"
                                       type="secondary"

--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -47,6 +47,7 @@ export function eventRowActionsContent(event: EventType): JSX.Element {
                 sessionId={event.properties.$session_id}
                 recordingStatus={event.properties.$recording_status}
                 timestamp={event.timestamp}
+                hasRecording={event.properties.has_recording as boolean | undefined}
                 data-attr="events-table-view-recordings"
             />
             {event.event === '$exception' && '$exception_issue_id' in event.properties ? (

--- a/frontend/src/scenes/activity/explore/EventDetails.tsx
+++ b/frontend/src/scenes/activity/explore/EventDetails.tsx
@@ -48,6 +48,7 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                             sessionId={properties.$session_id}
                                             recordingStatus={properties.$recording_status}
                                             timestamp={event.timestamp}
+                                            hasRecording={properties.has_recording as boolean | undefined}
                                             inModal={false}
                                             size="small"
                                             type="secondary"


### PR DESCRIPTION
## Problem

whoops, i changed this for ERROR entrypoint today, but forgot about passing along from event/activity entrypoints
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

pass hasRecording
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

now it shows up as we expect, enabled!

![Screenshot 2025-12-16 at 12.27.54 PM.png](https://app.graphite.com/user-attachments/assets/ea230970-dcf4-4f1b-9418-87912360411a.png)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
