### PR TITLE
fix(replay): replay entrypoint from cohort more menu

### DIFF
--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -7,6 +7,7 @@ import { LemonDialog, LemonInput, LemonSelect } from '@posthog/lemon-ui'
 
 import { MemberSelect } from 'lib/components/MemberSelect'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
+import { ViewReplayButton } from 'lib/components/ViewReplayButton/ViewReplayButton'
 import { ListHog } from 'lib/components/hedgehogs'
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -25,7 +26,7 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
-import { CohortType } from '~/types'
+import { CohortType, FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
 
 export const scene: SceneExport = {
     component: Cohorts,
@@ -87,6 +88,7 @@ export function Cohorts(): JSX.Element {
         {
             width: 0,
             render: function RenderActions(_, cohort) {
+                const cohortId = typeof cohort.id === 'number' ? cohort.id : null
                 return (
                     <More
                         overlay={
@@ -94,26 +96,26 @@ export function Cohorts(): JSX.Element {
                                 <LemonButton to={urls.cohort(cohort.id)} fullWidth>
                                     Edit
                                 </LemonButton>
-                                <LemonButton
-                                    to={
-                                        combineUrl(urls.replay(), {
-                                            filters: {
-                                                properties: [
+                                {cohortId && (
+                                    <ViewReplayButton
+                                        filters={{
+                                            filter_group: {
+                                                type: FilterLogicalOperator.And,
+                                                values: [
                                                     {
+                                                        type: PropertyFilterType.Cohort,
                                                         key: 'id',
-                                                        label: cohort.name,
-                                                        type: 'cohort',
-                                                        value: cohort.id,
+                                                        operator: PropertyOperator.In,
+                                                        value: cohortId,
                                                     },
                                                 ],
                                             },
-                                        }).url
-                                    }
-                                    fullWidth
-                                    targetBlank
-                                >
-                                    View session recordings
-                                </LemonButton>
+                                        }}
+                                        fullWidth
+                                        label="View session recordings"
+                                        data-attr="cohort-view-recordings"
+                                    />
+                                )}
                                 <LemonButton
                                     onClick={() =>
                                         exportCohortPersons(cohort.id, [


### PR DESCRIPTION
## Problem

fix the meatball menu entrypoint -- previously not applying filters

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
 convert to new unified button
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
