### PR TITLE
feat: custom rate limiter for materialized endpoints execution

### DIFF
--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -183,6 +183,7 @@ __API_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
 __APP_CONCURRENT_QUERY_PER_ORG: Optional[RateLimit] = None
 __APP_CONCURRENT_DASHBOARD_QUERIES_PER_ORG: Optional[RateLimit] = None
 __WEB_ANALYTICS_API_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
+__MATERIALIZED_ENDPOINTS_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
 
 
 def get_api_team_rate_limiter():
@@ -312,6 +313,39 @@ def get_web_analytics_api_rate_limiter():
             retry_timeout=30.0,
         )
     return __WEB_ANALYTICS_API_CONCURRENT_QUERY_PER_TEAM
+
+
+def get_materialized_endpoints_rate_limiter():
+    """
+    Limits the number of concurrent materialized endpoint queries per team.
+
+    Materialized endpoint queries read from pre-computed S3 tables,
+    so they can handle higher concurrency than inline queries.
+    """
+    global __MATERIALIZED_ENDPOINTS_CONCURRENT_QUERY_PER_TEAM
+
+    def __applicable(
+        *args,
+        team_id: Optional[int] = None,
+        is_materialized_endpoint: Optional[bool] = None,
+        **kwargs,
+    ) -> bool:
+        return bool(not TEST and team_id and is_materialized_endpoint)
+
+    if __MATERIALIZED_ENDPOINTS_CONCURRENT_QUERY_PER_TEAM is None:
+        __MATERIALIZED_ENDPOINTS_CONCURRENT_QUERY_PER_TEAM = RateLimit(
+            max_concurrency=10,
+            applicable=__applicable,
+            limit_name="materialized_endpoints_per_team",
+            get_task_name=lambda *args, **kwargs: f"materialized_endpoints:query:per-team:{kwargs.get('team_id')}",
+            get_task_id=lambda *args, **kwargs: (
+                current_task.request.id if current_task else (kwargs.get("task_id") or generate_short_id())
+            ),
+            ttl=600,
+            retry=0.134,
+            retry_timeout=30.0,
+        )
+    return __MATERIALIZED_ENDPOINTS_CONCURRENT_QUERY_PER_TEAM
 
 
 class ConcurrencyLimitExceeded(Exception):

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -80,6 +80,7 @@ from posthog.clickhouse.client.limit import (
     get_api_team_rate_limiter,
     get_app_dashboard_queries_rate_limiter,
     get_app_org_rate_limiter,
+    get_materialized_endpoints_rate_limiter,
     get_org_app_concurrency_limit,
 )
 from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
@@ -1026,6 +1027,51 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         # Nothing useful out of cache, nor async query status
         return None
 
+    def _call_with_rate_limits(self, *, dashboard_id: Optional[int]) -> tuple[R, float]:
+        """Execute calculate() with all rate limiters applied.
+
+        Returns:
+            Tuple of (query_result, query_duration_ms)
+        """
+        concurrency_limit = self.get_api_queries_concurrency_limit()
+        is_materialized_endpoint = get_query_tag_value("workload") == Workload.ENDPOINTS
+        is_api_key_access = get_query_tag_value("access_method") == "personal_api_key"
+
+        if self.is_query_service:
+            tag_queries(chargeable=1)
+
+        with (
+            get_materialized_endpoints_rate_limiter().run(
+                team_id=self.team.pk,
+                task_id=self.query_id,
+                is_materialized_endpoint=is_materialized_endpoint,
+            ),
+            get_api_team_rate_limiter().run(
+                is_api=self.is_query_service and not is_materialized_endpoint,
+                team_id=self.team.pk,
+                task_id=self.query_id,
+                limit=concurrency_limit,
+            ),
+            get_app_org_rate_limiter().run(
+                org_id=self.team.organization_id,
+                task_id=self.query_id,
+                team_id=self.team.id,
+                is_api=is_api_key_access,
+                limit=get_org_app_concurrency_limit(self.team.organization_id),
+            ),
+            get_app_dashboard_queries_rate_limiter().run(
+                org_id=self.team.organization_id,
+                dashboard_id=dashboard_id,
+                task_id=self.query_id,
+                team_id=self.team.id,
+                is_api=is_api_key_access,
+            ),
+        ):
+            query_start_time = perf_counter()
+            query_result = self.calculate()
+            query_duration_ms = round((perf_counter() - query_start_time) * 1000, 2)
+            return query_result, query_duration_ms
+
     def run(
         self,
         execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
@@ -1151,43 +1197,17 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 self.modifiers = create_default_modifiers_for_user(user, self.team, self.modifiers)
                 self.modifiers.useMaterializedViews = True
 
-            concurrency_limit = self.get_api_queries_concurrency_limit()
-            with get_api_team_rate_limiter().run(
-                is_api=self.is_query_service,
-                team_id=self.team.pk,
-                task_id=self.query_id,
-                limit=concurrency_limit,
-            ):
-                if self.is_query_service:
-                    tag_queries(chargeable=1)
+            query_result, query_duration_ms = self._call_with_rate_limits(dashboard_id=dashboard_id)
 
-                with get_app_org_rate_limiter().run(
-                    org_id=self.team.organization_id,
-                    task_id=self.query_id,
-                    team_id=self.team.id,
-                    is_api=get_query_tag_value("access_method") == "personal_api_key",
-                    limit=get_org_app_concurrency_limit(self.team.organization_id),
-                ):
-                    with get_app_dashboard_queries_rate_limiter().run(
-                        org_id=self.team.organization_id,
-                        dashboard_id=dashboard_id,
-                        task_id=self.query_id,
-                        team_id=self.team.id,
-                        is_api=get_query_tag_value("access_method") == "personal_api_key",
-                    ):
-                        query_start_time = perf_counter()
-                        query_result = self.calculate()
-                        query_duration_ms = round((perf_counter() - query_start_time) * 1000, 2)
-
-                        fresh_response_dict = {
-                            **query_result.model_dump(),
-                            "is_cached": False,
-                            "last_refresh": last_refresh,
-                            "next_allowed_client_refresh": last_refresh + self._refresh_frequency(),
-                            "cache_key": cache_key,
-                            "timezone": self.team.timezone,
-                            "cache_target_age": target_age,
-                        }
+            fresh_response_dict = {
+                **query_result.model_dump(),
+                "is_cached": False,
+                "last_refresh": last_refresh,
+                "next_allowed_client_refresh": last_refresh + self._refresh_frequency(),
+                "cache_key": cache_key,
+                "timezone": self.team.timezone,
+                "cache_target_age": target_age,
+            }
 
             try:
                 query_metadata = extract_query_metadata(query=self.query, team=self.team).model_dump()


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

endpoints are meant to provide better api rate limits - not like the rest

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- add a new rate limiter to 10 concurrent materialized endpoint execution

## How did you test this code?
- tests, but also not sure tbf

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
yeah why not - materialized endpoints provide better limits