### PR TITLE
fix(exports): add partial unique index on insightviewed

### DIFF
--- a/posthog/migrations/0946_fix_insightviewed_null_duplicates.py
+++ b/posthog/migrations/0946_fix_insightviewed_null_duplicates.py
@@ -1,0 +1,62 @@
+from django.db import migrations
+from django.db.models import Count, Max
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+def clean_duplicates(apps, schema_editor):
+    """Delete duplicate InsightViewed records where team and user are NULL."""
+    InsightViewed = apps.get_model("posthog", "InsightViewed")
+
+    # Find insights with duplicate NULL team/user records
+    duplicates = (
+        InsightViewed.objects.filter(team__isnull=True, user__isnull=True)
+        .values("insight_id")
+        .annotate(count=Count("id"), keep_id=Max("id"))
+        .filter(count__gt=1)
+    )
+
+    deleted_count = 0
+    for dup in duplicates:
+        # Delete all but the most recent (highest id) for each insight
+        result = (
+            InsightViewed.objects.filter(
+                team__isnull=True,
+                user__isnull=True,
+                insight_id=dup["insight_id"],
+            )
+            .exclude(id=dup["keep_id"])
+            .delete()
+        )
+        deleted_count += result[0]
+
+    logger.info("clean_duplicates_complete", deleted_count=deleted_count)
+
+
+class Migration(migrations.Migration):
+    atomic = False  # Required for CREATE INDEX CONCURRENTLY
+
+    dependencies = [
+        ("posthog", "0945_scheduledchange_recurring_fields"),
+    ]
+
+    operations = [
+        # Step 1: Clean up existing duplicates
+        migrations.RunPython(clean_duplicates, migrations.RunPython.noop),
+        # Step 2: Add partial unique index to prevent future duplicates
+        # The existing unique constraint on (team_id, user_id, insight_id) doesn't
+        # prevent duplicates when team_id and user_id are NULL because PostgreSQL
+        # treats NULL != NULL. This partial index enforces uniqueness for that case.
+        migrations.RunSQL(
+            """
+            CREATE UNIQUE INDEX CONCURRENTLY "posthog_insightviewed_null_team_user_unique"
+            ON "posthog_insightviewed" ("insight_id")
+            WHERE "team_id" IS NULL AND "user_id" IS NULL; -- not-null-ignore
+            """,
+            reverse_sql="""
+                DROP INDEX IF EXISTS "posthog_insightviewed_null_team_user_unique";
+            """,
+        ),
+    ]

--- a/posthog/migrations/0947_insightviewed_null_unique_index.py
+++ b/posthog/migrations/0947_insightviewed_null_unique_index.py
@@ -14,13 +14,11 @@ class Migration(migrations.Migration):
         # prevent duplicates when team_id and user_id are NULL because PostgreSQL
         # treats NULL != NULL. This partial index enforces uniqueness for that case.
         migrations.RunSQL(
-            """
-            CREATE UNIQUE INDEX CONCURRENTLY "posthog_insightviewed_null_team_user_unique"
-            ON "posthog_insightviewed" ("insight_id")
-            WHERE "team_id" IS NULL AND "user_id" IS NULL; -- not-null-ignore
+            sql="""
+                CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "posthog_insightviewed_null_team_user_unique"
+                ON "posthog_insightviewed" ("insight_id")
+                WHERE "team_id" IS NULL AND "user_id" IS NULL
             """,
-            reverse_sql="""
-                DROP INDEX IF EXISTS "posthog_insightviewed_null_team_user_unique";
-            """,
+            reverse_sql='DROP INDEX CONCURRENTLY IF EXISTS "posthog_insightviewed_null_team_user_unique"',
         ),
     ]

--- a/posthog/migrations/0947_insightviewed_null_unique_index.py
+++ b/posthog/migrations/0947_insightviewed_null_unique_index.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False  # Required for CREATE INDEX CONCURRENTLY
+
+    dependencies = [
+        ("posthog", "0946_fix_insightviewed_null_duplicates"),
+    ]
+
+    operations = [
+        # Add partial unique index to prevent future duplicates.
+        # The existing unique constraint on (team_id, user_id, insight_id) doesn't
+        # prevent duplicates when team_id and user_id are NULL because PostgreSQL
+        # treats NULL != NULL. This partial index enforces uniqueness for that case.
+        migrations.RunSQL(
+            """
+            CREATE UNIQUE INDEX CONCURRENTLY "posthog_insightviewed_null_team_user_unique"
+            ON "posthog_insightviewed" ("insight_id")
+            WHERE "team_id" IS NULL AND "user_id" IS NULL; -- not-null-ignore
+            """,
+            reverse_sql="""
+                DROP INDEX IF EXISTS "posthog_insightviewed_null_team_user_unique";
+            """,
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0946_fix_insightviewed_null_duplicates
+0947_insightviewed_null_unique_index

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0945_scheduledchange_recurring_fields
+0946_fix_insightviewed_null_duplicates


### PR DESCRIPTION
## Problem

Exports fail with "Timeout while waiting for the page to load" for certain insights ([example log](https://grafana.prod-us.posthog.dev/goto/YpO3tyGDR?orgId=1)). 


This is due to a duplicate record in the posthog_insightviewed table for the insight, resulting in the following ORM error
```
get() returned more than one InsightViewed -- it returned 2!
```
from: https://grafana.prod-us.posthog.dev/goto/QNZkhsMvg?orgId=1

For insight 3444795 there are two records with team_id and user_id = null that were created within 8ms of each other. 
<img width="620" height="241" alt="Screenshot 2025-12-16 at 5 52 16 PM" src="https://github.com/user-attachments/assets/c0cce641-deed-4fc3-9fee-f567adecce09" />
from: https://metabase.prod-us.posthog.dev/question/1763-duplicate-insight-viewed

The table has this index 
```
CREATE UNIQUE INDEX posthog_unique_insightviewed ON public.posthog_insightviewed USING btree (team_id, user_id, insight_id)
```
but PostgreSQL treats NULL != NULL, so the constraint doesn't prevent duplicate rows when team_id and user_id are both NULL.


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add migration to delete duplicates. 

Add a partial unique index that enforces uniqueness when team and user are NULL:
```SQL
CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "posthog_insightviewed_null_team_user_unique"
ON "posthog_insightviewed" ("insight_id")
WHERE "team_id" IS NULL AND "user_id" IS NULL
```

In prod, there are only three sets of duplicates in both US and EU as I write this.
```
SELECT insight_id, COUNT(*) as count
FROM posthog_insightviewed
WHERE team_id IS NULL AND user_id IS NULL
GROUP BY insight_id
HAVING COUNT(*) > 1
ORDER BY count DESC;
```
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Verified locally, I could create a duplicate before the migration and could not create a duplicate insightviewed record after migration. 

```
-- First, find an insight_id to test with
SELECT id FROM posthog_insight LIMIT 1;

-- Try inserting two rows with NULL team and user for the same insight
INSERT INTO posthog_insightviewed (team_id, user_id, insight_id, last_viewed_at)
VALUES (NULL, NULL, <insight_id>, NOW());

INSERT INTO posthog_insightviewed (team_id, user_id, insight_id, last_viewed_at)
VALUES (NULL, NULL, <insight_id>, NOW());

-- Both should succeed (This is the bug)

-- Check they both exist
SELECT * FROM posthog_insightviewed
WHERE team_id IS NULL AND user_id IS NULL AND insight_id = <insight_id>;
```
<img width="1734" height="414" alt="Screenshot 2025-12-16 at 5 41 11 PM" src="https://github.com/user-attachments/assets/3adaa94e-c693-4512-b503-f66b3e3f7f99" />

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
