### PR TITLE
chore(flags): Increment experience continuity metric and remove other unused metrics

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -18,9 +18,9 @@ use crate::flags::flag_operations::flags_require_db_preparation;
 use crate::metrics::consts::{
     DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER, FLAG_DB_PROPERTIES_FETCH_TIME,
     FLAG_EVALUATE_ALL_CONDITIONS_TIME, FLAG_EVALUATION_ERROR_COUNTER, FLAG_EVALUATION_TIME,
-    FLAG_GET_MATCH_TIME, FLAG_GROUP_CACHE_FETCH_TIME, FLAG_GROUP_DB_FETCH_TIME,
-    FLAG_HASH_KEY_PROCESSING_TIME, FLAG_HASH_KEY_WRITES_COUNTER, PROPERTY_CACHE_HITS_COUNTER,
-    PROPERTY_CACHE_MISSES_COUNTER,
+    FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER, FLAG_GET_MATCH_TIME, FLAG_GROUP_CACHE_FETCH_TIME,
+    FLAG_GROUP_DB_FETCH_TIME, FLAG_HASH_KEY_PROCESSING_TIME, FLAG_HASH_KEY_WRITES_COUNTER,
+    PROPERTY_CACHE_HITS_COUNTER, PROPERTY_CACHE_MISSES_COUNTER,
 };
 use crate::metrics::utils::parse_exception_for_prometheus_label;
 use crate::properties::property_models::PropertyFilter;
@@ -1486,6 +1486,7 @@ impl FeatureFlagMatcher {
         let hash_key_timer = common_metrics::timing_guard(FLAG_HASH_KEY_PROCESSING_TIME, &[]);
         let (hash_key_overrides, flag_hash_key_override_error) =
             if flags_have_experience_continuity_enabled {
+                common_metrics::inc(FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER, &[], 1);
                 match hash_key_override {
                     Some(hash_key) => {
                         let target_distinct_ids = vec![self.distinct_id.clone(), hash_key.clone()];

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -28,8 +28,6 @@ pub const DB_CONNECTION_POOL_MAX_COUNTER: &str = "flags_db_connection_pool_max_t
 // Flag evaluation timing
 pub const FLAG_EVALUATION_TIME: &str = "flags_evaluation_time";
 pub const FLAG_HASH_KEY_PROCESSING_TIME: &str = "flags_hash_key_processing_time";
-pub const FLAG_LOCAL_PROPERTY_OVERRIDE_MATCH_TIME: &str =
-    "flags_local_property_override_match_time";
 pub const FLAG_DB_PROPERTIES_FETCH_TIME: &str = "flags_properties_db_fetch_time";
 pub const FLAG_GROUP_DB_FETCH_TIME: &str = "flags_groups_db_fetch_time"; // this is how long it takes to fetch the group type mappings from the DB
 pub const FLAG_GROUP_CACHE_FETCH_TIME: &str = "flags_groups_cache_fetch_time"; // this is how long it takes to fetch the group type mappings from the cache
@@ -50,7 +48,6 @@ pub const FLAG_REQUEST_KLUDGE_COUNTER: &str = "flags_request_kludge_total";
 // New diagnostic metrics for pool exhaustion investigation
 pub const FLAG_POOL_UTILIZATION_GAUGE: &str = "flags_pool_utilization_ratio";
 pub const FLAG_CONNECTION_HOLD_TIME: &str = "flags_connection_hold_time_ms";
-pub const FLAG_CONNECTION_QUEUE_DEPTH_GAUGE: &str = "flags_connection_queue_depth";
 pub const FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER: &str =
     "flags_experience_continuity_requests_total";
 


### PR DESCRIPTION
## Problem

The [Grafana dashboard panel for "Experience Continuity Requests"](https://grafana.prod-us.posthog.dev/d/feature-flag-last-called-sync/feature-flags-product) shows no data because the metric `flags_experience_continuity_requests_total` is defined but never incremented.

The constant `FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER` exists in `rust/feature-flags/src/metrics/consts.rs:54-55`, but no code ever calls `common_metrics::inc()` with it. This means we have no visibility into how often experience continuity is being triggered in production.

I also noticed a couple other metrics were defined but not used:

* `FLAG_LOCAL_PROPERTY_OVERRIDE_MATCH_TIME`
* `FLAG_CONNECTION_QUEUE_DEPTH_GAUGE`

I removed these because we don't have any dashboards showing them and I wasn't sure what they were for. If this is wrong, let me know.

## Changes

Add the metric increment in `flag_matching.rs` to track when experience continuity processing is triggered. The metric should be incremented when `flags_have_experience_continuity_enabled` is true, likely inside `process_hash_key_override_if_needed()` or after the check at line 235-239:

```rust
let flags_need_hash_key_override = feature_flags.flags.iter().any(|flag| {
    flag.ensure_experience_continuity.unwrap_or(false)
        && flag.get_group_type_index().is_none()
        && flag.get_bucketing_identifier() == BucketingIdentifier::DistinctId
});
```

## How did you test this code?

- [x] Unit tests pass

## Changelog: (features only) Is this feature complete?

No - this is an internal observability fix, not a user-facing feature.
