### PR TITLE
chore(flags): Add client_type label to missing_data_prefix and base64_fallback_success metrics

### DIFF
--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -6,12 +6,85 @@ use crate::{
     flags::flag_request::FlagRequest,
     metrics::consts::FLAG_REQUEST_KLUDGE_COUNTER,
 };
-use axum::http::{header::CONTENT_TYPE, HeaderMap};
+use axum::http::{header::CONTENT_TYPE, header::USER_AGENT, HeaderMap};
 use base64::{engine::general_purpose, Engine as _};
 use bytes::Bytes;
 use common_compression;
 use common_metrics::inc;
 use percent_encoding::percent_decode;
+
+/// Classifies the client type from a User-Agent header for metric labels.
+/// Returns a low-cardinality string suitable for use as a Prometheus label.
+fn classify_client_type(user_agent: Option<&str>) -> &'static str {
+    let Some(ua) = user_agent else {
+        return "unknown";
+    };
+
+    // PostHog JS SDK (browser)
+    if ua.starts_with("posthog-js/") {
+        return "posthog-js";
+    }
+
+    // PostHog mobile SDKs
+    if ua.starts_with("posthog-android/") {
+        return "posthog-android";
+    }
+    if ua.starts_with("posthog-ios/") {
+        return "posthog-ios";
+    }
+    if ua.starts_with("posthog-react-native/") {
+        return "posthog-react-native";
+    }
+    if ua.starts_with("posthog-flutter/") {
+        return "posthog-flutter";
+    }
+
+    // PostHog server SDKs
+    if ua.starts_with("posthog-python/") {
+        return "posthog-python";
+    }
+    if ua.starts_with("posthog-ruby/") {
+        return "posthog-ruby";
+    }
+    if ua.starts_with("posthog-php/") {
+        return "posthog-php";
+    }
+    if ua.starts_with("posthog-java/") {
+        return "posthog-java";
+    }
+    if ua.starts_with("posthog-go/") {
+        return "posthog-go";
+    }
+    if ua.starts_with("posthog-node/") {
+        return "posthog-node";
+    }
+    if ua.starts_with("posthog-dotnet/") {
+        return "posthog-dotnet";
+    }
+    if ua.starts_with("posthog-elixir/") {
+        return "posthog-elixir";
+    }
+
+    // Generic browser detection (for non-SDK browser requests)
+    if ua.contains("Mozilla/")
+        || ua.contains("Chrome/")
+        || ua.contains("Safari/")
+        || ua.contains("Firefox/")
+        || ua.contains("Edge/")
+    {
+        return "browser";
+    }
+
+    // Common HTTP clients
+    if ua.contains("curl/") {
+        return "curl";
+    }
+    if ua.contains("python-requests/") {
+        return "python-requests";
+    }
+
+    "other"
+}
 
 /// Lightweight token extraction for rate limiting.
 /// Tries to extract the token without full request deserialization.
@@ -43,13 +116,17 @@ pub fn decode_request(
 
     let base_content_type = content_type.split(';').next().unwrap_or("").trim();
 
+    let user_agent = headers.get(USER_AGENT).and_then(|v| v.to_str().ok());
+
     match base_content_type {
         "application/json" | "text/plain" => {
             let decoded_body = decode_body(body, query.compression, headers)?;
 
             try_parse_with_fallbacks(decoded_body)
         }
-        "application/x-www-form-urlencoded" => decode_form_data(body, query.compression),
+        "application/x-www-form-urlencoded" => {
+            decode_form_data(body, query.compression, user_agent)
+        }
         _ => {
             tracing::warn!("unsupported content type: {}", content_type);
             Err(FlagError::RequestDecodingError(format!(
@@ -175,6 +252,7 @@ pub fn try_parse_with_fallbacks(body: Bytes) -> Result<FlagRequest, FlagError> {
 pub fn decode_form_data(
     body: Bytes,
     compression: Option<Compression>,
+    user_agent: Option<&str>,
 ) -> Result<FlagRequest, FlagError> {
     // Convert bytes to string first so we can manipulate it
     let form_data = String::from_utf8(body.to_vec()).map_err(|e| {
@@ -196,9 +274,14 @@ pub fn decode_form_data(
         decoded_form.split('=').nth(1).unwrap_or("")
     } else {
         // Count how often we receive base64 data without the 'data=' prefix
+        // Include client_type to help identify which SDKs are sending malformed data
+        let client_type = classify_client_type(user_agent);
         inc(
             FLAG_REQUEST_KLUDGE_COUNTER,
-            &[("type".to_string(), "missing_data_prefix".to_string())],
+            &[
+                ("type".to_string(), "missing_data_prefix".to_string()),
+                ("client_type".to_string(), client_type.to_string()),
+            ],
             1,
         );
         &decoded_form
@@ -431,5 +514,42 @@ mod tests {
 
         let token = extract_token(&body);
         assert_eq!(token, None);
+    }
+
+    mod classify_client_type_tests {
+        use super::*;
+        use rstest::rstest;
+
+        #[rstest]
+        #[case(Some("posthog-js/1.88.0"), "posthog-js")]
+        #[case(Some("posthog-android/3.1.0"), "posthog-android")]
+        #[case(Some("posthog-ios/3.0.0"), "posthog-ios")]
+        #[case(Some("posthog-react-native/2.5.0"), "posthog-react-native")]
+        #[case(Some("posthog-flutter/4.0.0"), "posthog-flutter")]
+        #[case(Some("posthog-python/1.4.0"), "posthog-python")]
+        #[case(Some("posthog-ruby/2.0.0"), "posthog-ruby")]
+        #[case(Some("posthog-php/3.0.0"), "posthog-php")]
+        #[case(Some("posthog-java/1.0.0"), "posthog-java")]
+        #[case(Some("posthog-go/0.1.0"), "posthog-go")]
+        #[case(Some("posthog-node/2.2.0"), "posthog-node")]
+        #[case(Some("posthog-dotnet/1.0.0"), "posthog-dotnet")]
+        #[case(Some("posthog-elixir/0.2.0"), "posthog-elixir")]
+        #[case(
+            Some("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"),
+            "browser"
+        )]
+        #[case(
+            Some("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/91.0.4472.124"),
+            "browser"
+        )]
+        #[case(Some("Mozilla/5.0 (X11; Linux x86_64) Firefox/89.0"), "browser")]
+        #[case(Some("curl/7.68.0"), "curl")]
+        #[case(Some("python-requests/2.28.0"), "python-requests")]
+        #[case(Some("custom-client/1.0"), "other")]
+        #[case(Some(""), "other")]
+        #[case(None, "unknown")]
+        fn test_classify_client_type(#[case] user_agent: Option<&str>, #[case] expected: &str) {
+            assert_eq!(classify_client_type(user_agent), expected);
+        }
     }
 }

--- a/rust/feature-flags/src/handler/decoding.rs
+++ b/rust/feature-flags/src/handler/decoding.rs
@@ -20,6 +20,11 @@ fn classify_client_type(user_agent: Option<&str>) -> &'static str {
         return "unknown";
     };
 
+    // Empty string means header was present but empty - semantically same as missing
+    if ua.is_empty() {
+        return "unknown";
+    }
+
     // PostHog JS SDK (browser)
     if ua.starts_with("posthog-js/") {
         return "posthog-js";
@@ -247,7 +252,7 @@ pub fn try_parse_with_fallbacks(
                 );
                 tracing::info!(
                     client_type = client_type,
-                    "Successfully parsed request using base64 fallback"
+                    "Successfully parsed request after base64 fallback decoding"
                 );
                 return Ok(request);
             }
@@ -560,7 +565,7 @@ mod tests {
         #[case(Some("curl/7.68.0"), "curl")]
         #[case(Some("python-requests/2.28.0"), "python-requests")]
         #[case(Some("custom-client/1.0"), "other")]
-        #[case(Some(""), "other")]
+        #[case(Some(""), "unknown")]
         #[case(None, "unknown")]
         fn test_classify_client_type(#[case] user_agent: Option<&str>, #[case] expected: &str) {
             assert_eq!(classify_client_type(user_agent), expected);

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -446,7 +446,7 @@ fn test_decode_form_data_kludges() {
 
     for (input, should_succeed) in test_cases {
         let body = Bytes::from(input);
-        let result = decoding::decode_form_data(body, None);
+        let result = decoding::decode_form_data(body, None, None);
 
         if should_succeed {
             assert!(result.is_ok(), "Failed to decode: {input}");
@@ -480,7 +480,7 @@ fn test_handle_unencoded_form_data_with_emojis() {
     let base64 = general_purpose::STANDARD.encode(json.to_string());
     let body = Bytes::from(format!("data={base64}"));
 
-    let result = decoding::decode_form_data(body, None);
+    let result = decoding::decode_form_data(body, None, None);
     assert!(result.is_ok(), "Failed to decode emoji content");
 
     let request = result.unwrap();
@@ -507,7 +507,7 @@ fn test_decode_base64_encoded_form_data_with_emojis() {
     let base64 = general_purpose::STANDARD.encode(json.to_string());
     let body = Bytes::from(format!("data={base64}"));
 
-    let result = decoding::decode_form_data(body, Some(Compression::Base64));
+    let result = decoding::decode_form_data(body, Some(Compression::Base64), None);
     assert!(result.is_ok(), "Failed to decode emoji content");
 
     let request = result.unwrap();
@@ -527,22 +527,22 @@ fn test_decode_form_data_compression_types() {
     let body = Bytes::from(input);
 
     // Base64 compression should work
-    let result = decoding::decode_form_data(body.clone(), Some(Compression::Base64));
+    let result = decoding::decode_form_data(body.clone(), Some(Compression::Base64), None);
     assert!(result.is_ok());
 
     // No compression should work
-    let result = decoding::decode_form_data(body.clone(), None);
+    let result = decoding::decode_form_data(body.clone(), None, None);
     assert!(result.is_ok());
 
     // Gzip compression should fail
-    let result = decoding::decode_form_data(body.clone(), Some(Compression::Gzip));
+    let result = decoding::decode_form_data(body.clone(), Some(Compression::Gzip), None);
     assert!(matches!(
         result,
         Err(FlagError::RequestDecodingError(msg)) if msg.contains("not supported")
     ));
 
     // Unsupported compression should fail
-    let result = decoding::decode_form_data(body, Some(Compression::Unsupported));
+    let result = decoding::decode_form_data(body, Some(Compression::Unsupported), None);
     assert!(matches!(
         result,
         Err(FlagError::RequestDecodingError(msg)) if msg.contains("Unsupported")
@@ -562,7 +562,7 @@ fn test_decode_form_data_malformed_input() {
 
     for input in test_cases {
         let body = Bytes::from(input);
-        let result = decoding::decode_form_data(body, None);
+        let result = decoding::decode_form_data(body, None, None);
         assert!(
             result.is_err(),
             "Expected error for malformed input: {input}",
@@ -574,7 +574,7 @@ fn test_decode_form_data_malformed_input() {
 fn test_decode_form_data_real_world_payload() {
     let input = "data=eyJ0b2tlbiI6InNUTUZQc0ZoZFAxU3NnIiwiZGlzdGluY3RfaWQiOiIkcG9zdGhvZ19jb29raWVsZXNzIiwiZ3JvdXBzIjp7fSwicGVyc29uX3Byb3BlcnRpZXMiOnsiJGluaXRpYWxfcmVmZXJyZXIiOiIkZGlyZWN0IiwiJGluaXRpYWxfcmVmZXJyaW5nX2RvbWFpbiI6IiRkaXJlY3QiLCIkaW5pdGlhbF9jdXJyZW50X3VybCI6Imh0dHBzOi8vcG9zdGhvZy5jb20vIiwiJGluaXRpYWxfaG9zdCI6InBvc3Rob2cuY29tIiwiJGluaXRpYWxfcGF0aG5hbWUiOiIvIiwiJGluaXRpYWxfdXRtX3NvdXJjZSI6bnVsbCwiJGluaXRpYWxfdXRtX21lZGl1bSI6bnVsbCwiJGluaXRpYWxfdXRtX2NhbXBhaWduIjpudWxsLCIkaW5pdGlhbF91dG1fY29udGVudCI6bnVsbCwiJGluaXRpYWxfdXRtX3Rlcm0iOm51bGwsIiRpbml0aWFsX2dhZF9zb3VyY2UiOm51bGwsIiRpbml0aWFsX21jX2NpZCI6bnVsbCwiJGluaXRpYWxfZ2NsaWQiOm51bGwsIiRpbml0aWFsX2djbHNyYyI6bnVsbCwiJGluaXRpYWxfZGNsaWQiOm51bGwsIiRpbml0aWFsX2dicmFpZCI6bnVsbCwiJGluaXRpYWxfd2JyYWlkIjpudWxsLCIkaW5pdGlhbF9mYmNsaWQiOm51bGwsIiRpbml0aWFsX21zY2xraWQiOm51bGwsIiRpbml0aWFsX3R3Y2xpZCI6bnVsbCwiJGluaXRpYWxfbGlfZmF0X2lkIjpudWxsLCIkaW5pdGlhbF9pZ3NoaWQiOm51bGwsIiRpbml0aWFsX3R0Y2xpZCI6bnVsbCwiJGluaXRpYWxfcmR0X2NpZCI6bnVsbCwiJGluaXRpYWxfZXBpayI6bnVsbCwiJGluaXRpYWxfcWNsaWQiOm51bGwsIiRpbml0aWFsX3NjY2lkIjpudWxsLCIkaW5pdGlhbF9pcmNsaWQiOm51bGwsIiRpbml0aWFsX19reCI6bnVsbCwic3F1ZWFrRW1haWwiOiJsdWNhc0Bwb3N0aG9nLmNvbSIsInNxdWVha1VzZXJuYW1lIjoibHVjYXNAcG9zdGhvZy5jb20iLCJzcXVlYWtDcmVhdGVkQXQiOiIyMDI0LTEyLTE2VDE1OjU5OjAzLjQ1MVoiLCJzcXVlYWtQcm9maWxlSWQiOjMyMzg3LCJzcXVlYWtGaXJzdE5hbWUiOiJMdWNhcyIsInNxdWVha0xhc3ROYW1lIjoiRmFyaWEiLCJzcXVlYWtCaW9ncmFwaHkiOiJIb3cgZG8gcGVvcGxlIGRlc2NyaWJlIG1lOlxuXG4tIFNvbWV0aW1lcyBvYnNlc3NpdmVcbi0gT3Zlcmx5IG9wdGltaXN0aWNcbi0gTG9va3MgYXQgc2NyZWVucyBmb3Igd2F5IHRvbyBtYW55IGhvdXJzXG5cblllYWgsIEkgZ290IGFkZGljdGVkIHRvIGNvbXB1dGVycyBwcmV0dHkgeW91bmcgZHVlIHRvIFRpYmlhIGFuZCBSYWduYXJvayBPbmxpbmUg7aC97biFXG5cblRoYXQncyBhY3R1YWxseSBob3cgSSBsZWFybmVkIHRvIHNwZWFrIGVuZ2xpc2ghXG5cbkFueXdheSwgSSdtIEx1Y2FzLCBhIEJyYXppbGlhbiBlbmdpbmVlciB3aG8gbG92ZXMgY29kaW5nLCBhbmltYWxzLCBib29rcyBhbmQgbmF0dXJlLiBbTXkgZnVsbCBhYm91dCBwYWdlIGlzIGhlcmVdKGh0dHBzOi8vbHVjYXNmYXJpYS5kZXYvYWJvdXQpLlxuXG5JIGFsc28gW3B1Ymxpc2ggYSBuZXdzbGV0dGVyXShodHRwOi8vbmV3c2xldHRlci5uYWdyaW5nYS5kZXYvKSBmb3IgQnJhemlsaWFuIGVuZ2luZWVycywgaWYgeW91J3JlIGxvb2tpbmcgdG8gZ2V0IHNvbWUgY2FyZWVyIGluc2lnaHRzLlxuXG5JIGRvbid0IGtub3cgaG93IGRpZCBJIGdldCBoZXJlLCBidXQgSSdsbCB0cnkgbXkgYmVzdCB0byB0ZWFjaCB5b3UgZXZlcnl0aGluZyBJIGxlYXJuIGFsb25nIHRoZSB3YXkuIiwic3F1ZWFrQ29tcGFueSI6bnVsbCwic3F1ZWFrQ29tcGFueVJvbGUiOiJQcm9kdWN0IEVuZ2luZWVyIiwic3F1ZWFrR2l0aHViIjoiaHR0cHM6Ly9naXRodWIuY29tL2x1Y2FzaGVyaXF1ZXMiLCJzcXVlYWtMaW5rZWRJbiI6Imh0dHBzOi8vd3d3LmxpbmtlZGluLmNvbS9pbi9sdWNhcy1mYXJpYS8iLCJzcXVlYWtMb2NhdGlvbiI6IkJyYXppbCIsInNxdWVha1R3aXR0ZXIiOiJodHRwczovL3guY29tL29uZWx1Y2FzZmFyaWEiLCJzcXVlYWtXZWJzaXRlIjoiaHR0cHM6Ly9sdWNhc2ZhcmlhLmRldi8ifSwidGltZXpvbmUiOiJBbWVyaWNhL1Nhb19QYXVsbyJ9";
     let body = Bytes::from(input);
-    let result = decoding::decode_form_data(body, Some(Compression::Base64));
+    let result = decoding::decode_form_data(body, Some(Compression::Base64), None);
 
     assert!(result.is_ok(), "Failed to decode real world payload");
     let request = result.unwrap();


### PR DESCRIPTION
## Problem

Our [Feature Flags - Product](https://grafana.prod-us.posthog.dev/d/feature-flag-last-called-sync/feature-flags-product) Grafana dashboard has a panel showing when SDK clients do not send base64 data correctly.

Unfortunately, we have no visibility into which clients are sending malformed requests. The `flags_request_kludge_total` metric increments for `missing_data_prefix` and `base64_fallback_success` cases, but we can't tell which SDKs are responsible.

## Changes

- Add `classify_client_type()` function to categorize User-Agent headers into low-cardinality client types (posthog-js, posthog-android, browser, etc.)
- Add `client_type` label to `flags_request_kludge_total` metric for both:
  - `type="missing_data_prefix"` - form-encoded base64 data without the `data=` prefix
  - `type="base64_fallback_success"` - JSON content that required base64 decoding fallback
- Add structured logging with client_type for debugging
- Add parameterized tests for client type classification

## How did you test this code?

- Added parameterized unit tests covering all SDK User-Agent patterns, browser detection, curl, python-requests, and edge cases (empty string, None)
- Existing tests updated to pass the new user_agent parameter

