### PR TITLE
chore: Swap login button order

### DIFF
--- a/posthog/templates/admin/posthog/user/change_form.html
+++ b/posthog/templates/admin/posthog/user/change_form.html
@@ -46,11 +46,11 @@
 {% block object-tools-items %}
     {{ block.super }}
     {% if original.allow_impersonation == False %}
-        <li><a id="loginas-readonly-link" href="#" class="loginas-disabled" title="Disallowed by user">Log in as user</a></li>
         <li><a id="loginas-link" href="#" class="loginas-disabled" title="Disallowed by user">Log in as user (read/write)</a></li>
+        <li><a id="loginas-readonly-link" href="#" class="loginas-disabled" title="Disallowed by user">Log in as user</a></li>
     {% else %}
-        <li><a id="loginas-readonly-link" href="#">Log in as user</a></li>
         <li><a id="loginas-link" href="#">Log in as user (read/write)</a></li>
+        <li><a id="loginas-readonly-link" href="#">Log in as user</a></li>
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Problem

[It's hard to break old habits](https://posthog.slack.com/archives/C0351B1DMUY/p1765931024733509?thread_ts=1765579829.406009&cid=C0351B1DMUY), plus primary action (i.e. read-only login) top right probably makes more sense!

## Changes

Swap login as button order in Django admin.