### PR TITLE
fix(ci): skip stale PR checks during Christmas/New Year holidays

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -17,9 +17,9 @@ jobs:
               id: holiday
               run: |
                   # Skip during Christmas/New Year holidays (Dec 20 - Jan 3)
-                  MONTH=$(date +%m)
-                  DAY=$(date +%d)
-                  if [[ "$MONTH" == "12" && "$DAY" -ge 20 ]] || [[ "$MONTH" == "01" && "$DAY" -le 3 ]]; then
+                  MONTH=$(TZ=UTC date +%m)
+                  DAY=$(TZ=UTC date +%-d)
+                  if [[ "$MONTH" == "12" && $DAY -ge 20 ]] || [[ "$MONTH" == "01" && $DAY -le 3 ]]; then
                     echo "skip=true" >> $GITHUB_OUTPUT
                     echo "Skipping stale check during holiday period"
                   else

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,7 +13,21 @@ jobs:
     stale:
         runs-on: ubuntu-24.04
         steps:
+            - name: Check if holiday period
+              id: holiday
+              run: |
+                  # Skip during Christmas/New Year holidays (Dec 20 - Jan 3)
+                  MONTH=$(date +%m)
+                  DAY=$(date +%d)
+                  if [[ "$MONTH" == "12" && "$DAY" -ge 20 ]] || [[ "$MONTH" == "01" && "$DAY" -le 3 ]]; then
+                    echo "skip=true" >> $GITHUB_OUTPUT
+                    echo "Skipping stale check during holiday period"
+                  else
+                    echo "skip=false" >> $GITHUB_OUTPUT
+                  fi
+
             - uses: actions/stale@v9
+              if: steps.holiday.outputs.skip != 'true'
               with:
                   days-before-issue-stale: 730
                   days-before-issue-close: 14


### PR DESCRIPTION
Adds a date check to the stale workflow so it skips running between Dec 20 - Jan 3. Prevents PRs from being marked stale or auto-closed while folks are on vacation.