### PR TITLE
perf(cdp): adjust group manager cache size

### DIFF
--- a/plugin-server/src/cdp/services/managers/groups-manager.service.ts
+++ b/plugin-server/src/cdp/services/managers/groups-manager.service.ts
@@ -28,7 +28,7 @@ export class GroupsManagerService {
 
     constructor(private hub: Hub) {
         // There is only 5 per team so we can have a very high cache and a very long cooldown
-        this.groupTypesMappingCache = new LRUCache({ max: 1_000_000, ttl: GROUP_TYPES_CACHE_TTL_MS })
+        this.groupTypesMappingCache = new LRUCache({ max: 100_000, ttl: GROUP_TYPES_CACHE_TTL_MS })
     }
 
     private async filterTeamsWithGroups(teams: Team['id'][]): Promise<Team['id'][]> {


### PR DESCRIPTION
## Problem

<img width="1456" height="386" alt="Screenshot 2025-12-17 at 09 43 14" src="https://github.com/user-attachments/assets/7d101917-9e01-4e17-980f-9ac122c6fa03" />

LRU Cache:
  - Pre-allocates massive arrays upfront for its max capacity
 - With max: 1_000_000, it immediately creates:
    - 1M-slot array for cache entries
    - 1M-slot array for TTL tracking (setItemTTL)
    - 1M-slot ZeroArray for internal bookkeeping
  - Memory profile showed 41% of total memory consumed by LRU Cache

## Changes

 - Reduced LRU cache from 1,000,000 to 100,000 entries
  - we would like to see 90% memory reduction