### PR TITLE
feat: increment issue buckets in cymbal

### DIFF
--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -76,6 +76,7 @@ case "$RS_SVC" in
     export BIND_PORT=3302 # HACK! avoid local-dev clash with property-defs-rs port
     export ALLOW_INTERNAL_IPS="true"
     export PERSONS_URL=postgres://posthog:posthog@localhost:5432/posthog_persons
+    export ISSUE_BUCKETS_REDIS_URL=redis://localhost:6479
     ;;
 
   embedding-worker)

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -333,6 +333,8 @@ services:
             PERSONS_URL: 'postgres://posthog:posthog@db:5432/posthog'
             MAXMIND_DB_PATH: '/share/GeoLite2-City.mmdb'
             REDIS_URL: 'redis://redis:6379/'
+            ISSUE_BUCKETS_REDIS_URL: 'redis://redis7:6379/'
+            ALLOW_INTERNAL_IPS: 'true'
             RUST_LOG: 'info'
         depends_on:
             kafka:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -334,7 +334,6 @@ services:
             MAXMIND_DB_PATH: '/share/GeoLite2-City.mmdb'
             REDIS_URL: 'redis://redis:6379/'
             ISSUE_BUCKETS_REDIS_URL: 'redis://redis7:6379/'
-            ALLOW_INTERNAL_IPS: 'true'
             RUST_LOG: 'info'
         depends_on:
             kafka:

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -232,6 +232,12 @@ pub trait Client {
         seconds: u64,
         format: RedisValueFormat,
     ) -> Result<bool, CustomRedisError>;
+    async fn batch_incr_by_expire_nx(
+        &self,
+        items: Vec<(String, i64)>,
+        ttl_seconds: usize,
+    ) -> Result<(), CustomRedisError>;
+
     async fn del(&self, k: String) -> Result<(), CustomRedisError>;
     async fn hget(&self, k: String, field: String) -> Result<String, CustomRedisError>;
     async fn scard(&self, k: String) -> Result<u64, CustomRedisError>;

--- a/rust/common/redis/src/read_write.rs
+++ b/rust/common/redis/src/read_write.rs
@@ -383,6 +383,16 @@ impl Client for ReadWriteClient {
             .await
     }
 
+    async fn batch_incr_by_expire_nx(
+        &self,
+        items: Vec<(String, i64)>,
+        ttl_seconds: usize,
+    ) -> Result<(), CustomRedisError> {
+        self.writer
+            .batch_incr_by_expire_nx(items, ttl_seconds)
+            .await
+    }
+
     async fn del(&self, k: String) -> Result<(), CustomRedisError> {
         self.writer.del(k).await
     }

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -51,6 +51,7 @@ pub struct AppContext {
 
     pub team_manager: TeamManager,
     pub billing_limiter: RedisLimiter,
+    pub issue_buckets_redis_client: Arc<RedisClient>,
 
     pub filtered_teams: Vec<i32>,
     pub filter_mode: FilterMode,
@@ -166,6 +167,24 @@ impl AppContext {
         .await?;
         let redis_client = Arc::new(redis_client);
 
+        let issue_buckets_redis_client = RedisClient::with_config(
+            config.issue_buckets_redis_url.clone(),
+            common_redis::CompressionConfig::disabled(),
+            common_redis::RedisValueFormat::default(),
+            if config.redis_response_timeout_ms == 0 {
+                None
+            } else {
+                Some(Duration::from_millis(config.redis_response_timeout_ms))
+            },
+            if config.redis_connection_timeout_ms == 0 {
+                None
+            } else {
+                Some(Duration::from_millis(config.redis_connection_timeout_ms))
+            },
+        )
+        .await?;
+        let issue_buckets_redis_client = Arc::new(issue_buckets_redis_client);
+
         // TODO - we expect here rather returning an UnhandledError because the limiter returns an Anyhow::Result,
         // which we don't want to put into the UnhandledError enum since it basically means "any error"
         let billing_limiter = RedisLimiter::new(
@@ -204,6 +223,7 @@ impl AppContext {
             team_manager,
             geoip_client,
             billing_limiter,
+            issue_buckets_redis_client,
             filtered_teams,
             filter_mode,
         })

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -143,6 +143,9 @@ pub struct Config {
     #[envconfig(default = "redis://localhost:6379/")]
     pub redis_url: String,
 
+    #[envconfig(from = "ISSUE_BUCKETS_REDIS_URL", default = "redis://localhost:6479/")]
+    pub issue_buckets_redis_url: String,
+
     #[envconfig(default = "100")]
     pub redis_response_timeout_ms: u64,
 

--- a/rust/cymbal/src/issue_buckets.rs
+++ b/rust/cymbal/src/issue_buckets.rs
@@ -1,0 +1,84 @@
+use chrono::{DateTime, SecondsFormat, Utc};
+use common_redis::Client;
+use std::collections::HashMap;
+use tracing::warn;
+use uuid::Uuid;
+
+const ISSUE_BUCKET_TTL_SECONDS: usize = 60 * 60;
+const ISSUE_BUCKET_INTERVAL_MINUTES: i64 = 5;
+
+fn round_datetime_to_minutes(datetime: DateTime<Utc>, minutes: i64) -> DateTime<Utc> {
+    assert!(minutes > 0, "minutes must be > 0");
+    let bucket_seconds = minutes * 60;
+    let now_ts = datetime.timestamp();
+    let rounded_ts = now_ts - now_ts.rem_euclid(bucket_seconds);
+    DateTime::<Utc>::from_timestamp(rounded_ts, 0).expect("rounded timestamp is always valid")
+}
+
+pub(crate) fn get_rounded_to_minutes(datetime: DateTime<Utc>, minutes: i64) -> String {
+    round_datetime_to_minutes(datetime, minutes).to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+pub fn get_now_rounded_to_minutes(minutes: i64) -> String {
+    get_rounded_to_minutes(Utc::now(), minutes)
+}
+
+pub(crate) async fn try_increment_issue_buckets(
+    redis: &(dyn Client + Send + Sync),
+    issue_counts: HashMap<Uuid, u32>,
+) {
+    if issue_counts.is_empty() {
+        return;
+    }
+
+    let now_rounded_to_minutes = get_now_rounded_to_minutes(ISSUE_BUCKET_INTERVAL_MINUTES);
+    let items: Vec<(String, i64)> = issue_counts
+        .into_iter()
+        .map(|(issue_id, count)| {
+            (
+                format!("issue-buckets:{issue_id}-{now_rounded_to_minutes}"),
+                count as i64,
+            )
+        })
+        .collect();
+
+    if let Err(err) = redis
+        .batch_incr_by_expire_nx(items, ISSUE_BUCKET_TTL_SECONDS)
+        .await
+    {
+        warn!("Failed to increment issue buckets batch: {err}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn test_get_rounded_to_minutes_floor_rounding() {
+        let dt = Utc.with_ymd_and_hms(2025, 12, 16, 12, 34, 56).unwrap();
+        assert_eq!(
+            get_rounded_to_minutes(dt, 5),
+            "2025-12-16T12:30:00Z".to_string()
+        );
+    }
+
+    #[test]
+    fn test_get_rounded_to_minutes_exact_boundary() {
+        let dt = Utc.with_ymd_and_hms(2025, 12, 16, 12, 35, 0).unwrap();
+        assert_eq!(
+            get_rounded_to_minutes(dt, 5),
+            "2025-12-16T12:35:00Z".to_string()
+        );
+    }
+
+    #[test]
+    fn test_get_rounded_to_minutes_12() {
+        let dt = Utc.with_ymd_and_hms(2025, 12, 16, 12, 34, 56).unwrap();
+        assert_eq!(
+            get_rounded_to_minutes(dt, 12),
+            "2025-12-16T12:24:00Z".to_string()
+        );
+    }
+}

--- a/rust/cymbal/src/lib.rs
+++ b/rust/cymbal/src/lib.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub mod error;
 pub mod fingerprinting;
 pub mod frames;
+pub mod issue_buckets;
 pub mod issue_resolution;
 pub mod langs;
 pub mod metric_consts;

--- a/rust/cymbal/src/pipeline/exception/mod.rs
+++ b/rust/cymbal/src/pipeline/exception/mod.rs
@@ -6,6 +6,7 @@ use metrics::counter;
 use serde_json::Value;
 use stack_processing::do_stack_processing;
 use tracing::{error, warn};
+use uuid::Uuid;
 
 pub mod issue_processing;
 pub mod stack_processing;
@@ -13,6 +14,7 @@ pub mod stack_processing;
 use crate::{
     app_context::AppContext,
     error::{EventError, PipelineFailure, PipelineResult, UnhandledError},
+    issue_buckets,
     issue_resolution::IssueStatus,
     metric_consts::{
         ISSUE_PROCESSING_TIME, STACK_PROCESSING_TIME, SUPPRESSED_ISSUE_DROPPED_EVENTS,
@@ -58,11 +60,12 @@ pub async fn do_exception_handling(
     stack_timer.fin();
 
     let issue_timer = common_metrics::timing_guard(ISSUE_PROCESSING_TIME, &[]);
-    let issues = do_issue_processing(context, &events, &fingerprinted).await?;
+    let issues = do_issue_processing(context.clone(), &events, &fingerprinted).await?;
     issue_timer.fin();
 
     // Unfreeze, as we're about to replace the event properties.
     let mut events = events;
+    let mut issue_counts: std::collections::HashMap<Uuid, u32> = std::collections::HashMap::new();
     for (index, fingerprinted) in fingerprinted.into_iter() {
         let issue = issues
             .get(&fingerprinted.fingerprint.value)
@@ -81,7 +84,11 @@ pub async fn do_exception_handling(
 
         let output = fingerprinted.to_output(issue.id);
         event.properties = Some(serde_json::to_string(&output).map_err(|e| (index, e.into()))?);
+        *issue_counts.entry(issue.id).or_insert(0) += 1;
     }
+
+    issue_buckets::try_increment_issue_buckets(&*context.issue_buckets_redis_client, issue_counts)
+        .await;
 
     Ok(events)
 }


### PR DESCRIPTION
## Problem

Fighting exception spikes!
Valkey which we will be using here got created in this PR https://github.com/PostHog/posthog-cloud-infra/pull/6051

## Changes

Made cymbal write to the new valkey.

We construct 5 minutes buckets with 60 minutes TTL in this format:
```
key - value
issue-buckets:issueA-2025-01-01T00:00:00 -> 21
issue-buckets:issueA-2025-01-01T00:05:00 -> 3
issue-buckets:issueA-2025-01-01T00:10:00 -> 8
```

## How did you test this code?

Checked local redis db manually.

<img width="642" height="92" alt="image" src="https://github.com/user-attachments/assets/daf462a3-85c1-4719-8d0b-ba3903ba7e07" />

<img width="1466" height="197" alt="image" src="https://github.com/user-attachments/assets/53abd6f4-b900-4e8c-9264-3573e1f21d1d" />

Also tested a case where we send multiple events per issue and multiple issues at once - all is working as expected
