### PR TITLE
fix(granian): add way to configure keepalive

### DIFF
--- a/bin/docker-server-unit
+++ b/bin/docker-server-unit
@@ -16,13 +16,11 @@ if [ "${USE_GRANIAN:-false}" = "true" ]; then
     echo "🚀 Starting with Granian ASGI server (opt-in via USE_GRANIAN=true)..."
 
     # Granian configuration
-    # K8s best practice: 1 worker per pod, scale via replicas
-    export GRANIAN_WORKERS=${GRANIAN_WORKERS:-1}
+    # Match Unit's 4 workers for equivalent sync view concurrency.
+    # With Django ASGI + sync views (thread_sensitive=True), each worker
+    # handles 1 sync request at a time - only workers give concurrency.
+    export GRANIAN_WORKERS=${GRANIAN_WORKERS:-4}
     export GRANIAN_THREADS=${GRANIAN_THREADS:-2}
-    # st mode: single-threaded runtimes, better tail latency for sync Django views
-    export GRANIAN_RUNTIME_MODE=${GRANIAN_RUNTIME_MODE:-st}
-    # Lower backpressure helps with sync workloads (default was higher)
-    export GRANIAN_BACKPRESSURE=${GRANIAN_BACKPRESSURE:-16}
 
     # Start metrics HTTP server in background on port 8001
     python ./bin/granian_metrics.py &
@@ -36,8 +34,6 @@ if [ "${USE_GRANIAN:-false}" = "true" ]; then
         posthog.asgi:application \
         --workers $GRANIAN_WORKERS \
         --runtime-threads $GRANIAN_THREADS \
-        --runtime-mode $GRANIAN_RUNTIME_MODE \
-        --backpressure $GRANIAN_BACKPRESSURE \
         --loop uvloop \
         --host 0.0.0.0 \
         --port 8000 \

--- a/bin/docker-server-unit
+++ b/bin/docker-server-unit
@@ -16,9 +16,13 @@ if [ "${USE_GRANIAN:-false}" = "true" ]; then
     echo "🚀 Starting with Granian ASGI server (opt-in via USE_GRANIAN=true)..."
 
     # Granian configuration
-    # Default to 2 workers for small pods (1 CPU), scale up via GRANIAN_WORKERS for larger pods
-    export GRANIAN_WORKERS=${GRANIAN_WORKERS:-2}
+    # K8s best practice: 1 worker per pod, scale via replicas
+    export GRANIAN_WORKERS=${GRANIAN_WORKERS:-1}
     export GRANIAN_THREADS=${GRANIAN_THREADS:-2}
+    # st mode: single-threaded runtimes, better tail latency for sync Django views
+    export GRANIAN_RUNTIME_MODE=${GRANIAN_RUNTIME_MODE:-st}
+    # Lower backpressure helps with sync workloads (default was higher)
+    export GRANIAN_BACKPRESSURE=${GRANIAN_BACKPRESSURE:-16}
 
     # Start metrics HTTP server in background on port 8001
     python ./bin/granian_metrics.py &
@@ -32,7 +36,8 @@ if [ "${USE_GRANIAN:-false}" = "true" ]; then
         posthog.asgi:application \
         --workers $GRANIAN_WORKERS \
         --runtime-threads $GRANIAN_THREADS \
-        --runtime-mode mt \
+        --runtime-mode $GRANIAN_RUNTIME_MODE \
+        --backpressure $GRANIAN_BACKPRESSURE \
         --loop uvloop \
         --host 0.0.0.0 \
         --port 8000 \

--- a/bin/docker-server-unit
+++ b/bin/docker-server-unit
@@ -20,7 +20,13 @@ if [ "${USE_GRANIAN:-false}" = "true" ]; then
     # With Django ASGI + sync views (thread_sensitive=True), each worker
     # handles 1 sync request at a time - only workers give concurrency.
     export GRANIAN_WORKERS=${GRANIAN_WORKERS:-4}
-    export GRANIAN_THREADS=${GRANIAN_THREADS:-2}
+    export GRANIAN_THREADS=${GRANIAN_THREADS:-1}
+
+    # HTTP/1 keep-alive: disable to improve SO_REUSEPORT load distribution
+    KEEPALIVE_FLAG=""
+    if [ "${GRANIAN_HTTP1_KEEP_ALIVE:-true}" = "false" ]; then
+        KEEPALIVE_FLAG="--no-http1-keep-alive"
+    fi
 
     # Start metrics HTTP server in background on port 8001
     python ./bin/granian_metrics.py &
@@ -34,6 +40,7 @@ if [ "${USE_GRANIAN:-false}" = "true" ]; then
         posthog.asgi:application \
         --workers $GRANIAN_WORKERS \
         --runtime-threads $GRANIAN_THREADS \
+        $KEEPALIVE_FLAG \
         --loop uvloop \
         --host 0.0.0.0 \
         --port 8000 \


### PR DESCRIPTION
**Problem**

Granian had worse tail latency (p99) compared to Unit despite both running ASGI.

**Investigation findings**

Django ASGI with sync views uses `sync_to_async(thread_sensitive=True)`, meaning each worker handles **only 1 sync request at a time**. The concurrency model:
- **Workers** (processes) = sync view concurrency ✓
- **Runtime threads** = Rust I/O threads only, doesn't help sync views
- **Runtime mode** (st/mt) = Rust-level isolation, doesn't help sync views
- **Backpressure** = queue depth, doesn't help sync views

**Changes**

- `GRANIAN_WORKERS` default: 4 (matching Unit)
- `GRANIAN_THREADS` default: 1 (Rust I/O threads, minimal since sync views don't benefit)
- Add `GRANIAN_HTTP1_KEEP_ALIVE` support (default true, set false to disable)

**Why HTTP1_KEEP_ALIVE option?**

Granian uses SO_REUSEPORT for kernel-level connection distribution. With keep-alive enabled, Envoy reuses connections, bypassing kernel distribution on subsequent requests. Disabling forces fresh connections per request, giving the kernel more opportunities to route to less-loaded workers.

From [Granian discussion #406](https://github.com/emmett-framework/granian/discussions/406):
> "Disabling HTTP keep-alives can help distribute load evenly and reduce latency, particularly beneficial for CPU-intensive workloads like Django applications."

**Charts PRs**
- PostHog/charts#7604 - workers=4, threads=1
- PostHog/charts#7605 - disable keep-alive (follow-up experiment)