### PR TITLE
feat: add rate limit to overflow step

### DIFF
--- a/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
+++ b/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
@@ -107,6 +107,8 @@ exports[`IngestionConsumer general overflow should emit to overflow if token and
       "distinct_id": "overflow-distinct-id",
       "event": "$pageview",
       "now": "2025-01-01T00:00:00.000Z",
+      "redirect-step": "rateLimitToOverflowStep",
+      "redirect-timestamp": "2025-01-01T00:00:00.000Z",
       "token": "THIS IS NOT A TOKEN FOR TEAM 2",
       "uuid": "<REPLACED-UUID-0>",
     },

--- a/plugin-server/src/ingestion/event-preprocessing/index.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/index.ts
@@ -4,6 +4,7 @@ export { createApplyPersonProcessingRestrictionsStep } from './apply-person-proc
 export { createDropExceptionEventsStep } from './drop-exception-events'
 export { createParseHeadersStep } from './parse-headers'
 export { createParseKafkaMessageStep } from './parse-kafka-message'
+export { createRateLimitToOverflowStep } from './rate-limit-to-overflow-step'
 export { createResolveTeamStep } from './resolve-team'
 export { createValidateEventMetadataStep } from './validate-event-metadata'
 export { createValidateEventPropertiesStep } from './validate-event-properties'

--- a/plugin-server/src/ingestion/event-preprocessing/rate-limit-to-overflow-step.test.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/rate-limit-to-overflow-step.test.ts
@@ -1,0 +1,330 @@
+import { EventHeaders } from '../../types'
+import { PipelineResultType } from '../pipelines/results'
+import { MemoryRateLimiter } from '../utils/overflow-detector'
+import { RateLimitToOverflowStepInput, createRateLimitToOverflowStep } from './rate-limit-to-overflow-step'
+
+const createMockHeaders = (token: string, distinctId: string, now?: Date): EventHeaders => ({
+    token,
+    distinct_id: distinctId,
+    now: now ?? new Date(),
+    force_disable_person_processing: false,
+    historical_migration: false,
+})
+
+const createMockEvent = (token: string, distinctId: string, now?: Date): RateLimitToOverflowStepInput => ({
+    headers: createMockHeaders(token, distinctId, now),
+})
+
+describe('createRateLimitToOverflowStep', () => {
+    describe('when overflow is disabled', () => {
+        it('returns all events as ok', async () => {
+            const rateLimiter = new MemoryRateLimiter(100, 10)
+            const step = createRateLimitToOverflowStep(rateLimiter, false, 'overflow_topic', true)
+
+            const events = [
+                createMockEvent('token1', 'user1'),
+                createMockEvent('token1', 'user2'),
+                createMockEvent('token2', 'user1'),
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(3)
+            results.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.OK)
+            })
+        })
+    })
+
+    describe('when overflow is enabled', () => {
+        it('returns ok for events below rate limit', async () => {
+            const rateLimiter = new MemoryRateLimiter(100, 10)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            const events = [createMockEvent('token1', 'user1'), createMockEvent('token1', 'user2')]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(2)
+            results.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.OK)
+            })
+        })
+
+        it('redirects events that exceed rate limit', async () => {
+            const rateLimiter = new MemoryRateLimiter(5, 1)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            // Create 10 events for the same key (will exceed limit of 5)
+            const events = Array.from({ length: 10 }, () => createMockEvent('token1', 'user1'))
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(10)
+            results.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.REDIRECT)
+                if (result.type === PipelineResultType.REDIRECT) {
+                    expect(result.reason).toBe('rate_limit_exceeded')
+                    expect(result.topic).toBe('overflow_topic')
+                }
+            })
+        })
+
+        it('groups events by token:distinct_id key', async () => {
+            const rateLimiter = new MemoryRateLimiter(3, 1)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            const events = [
+                // 3 events for token1:user1 (at limit)
+                createMockEvent('token1', 'user1'),
+                createMockEvent('token1', 'user1'),
+                createMockEvent('token1', 'user1'),
+                // 3 events for token1:user2 (at limit)
+                createMockEvent('token1', 'user2'),
+                createMockEvent('token1', 'user2'),
+                createMockEvent('token1', 'user2'),
+                // 3 events for token2:user1 (at limit)
+                createMockEvent('token2', 'user1'),
+                createMockEvent('token2', 'user1'),
+                createMockEvent('token2', 'user1'),
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(9)
+            // All should be ok since each key has exactly 3 events (at the limit)
+            results.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.OK)
+            })
+        })
+
+        it('redirects only keys that exceed limit, not others', async () => {
+            const rateLimiter = new MemoryRateLimiter(4, 1)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            const events = [
+                // 5 events for token1:user1 (exceeds limit of 4)
+                createMockEvent('token1', 'user1'),
+                createMockEvent('token1', 'user1'),
+                createMockEvent('token1', 'user1'),
+                createMockEvent('token1', 'user1'),
+                createMockEvent('token1', 'user1'),
+                // 2 events for token1:user2 (below limit)
+                createMockEvent('token1', 'user2'),
+                createMockEvent('token1', 'user2'),
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(7)
+
+            // First 5 should be redirected (token1:user1 exceeded)
+            for (let i = 0; i < 5; i++) {
+                expect(results[i].type).toBe(PipelineResultType.REDIRECT)
+            }
+
+            // Last 2 should be ok (token1:user2 below limit)
+            expect(results[5].type).toBe(PipelineResultType.OK)
+            expect(results[6].type).toBe(PipelineResultType.OK)
+        })
+
+        it('handles empty token or distinct_id', async () => {
+            const rateLimiter = new MemoryRateLimiter(5, 1)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            const events = [createMockEvent('', 'user1'), createMockEvent('token1', ''), createMockEvent('', '')]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(3)
+            results.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.OK)
+            })
+        })
+
+        it('uses headers timestamp for rate limiting', async () => {
+            const rateLimiter = new MemoryRateLimiter(2, 1)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            const baseTime = new Date()
+
+            const events = [
+                // 2 events at time T (at limit)
+                createMockEvent('token1', 'user1', baseTime),
+                createMockEvent('token1', 'user1', baseTime),
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(2)
+            results.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.OK)
+            })
+        })
+
+        it('preserves input structure in results', async () => {
+            const rateLimiter = new MemoryRateLimiter(100, 10)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            const events = [
+                {
+                    ...createMockEvent('token1', 'user1'),
+                    additionalField: 'test',
+                },
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(1)
+            expect(results[0].type).toBe(PipelineResultType.OK)
+            if (results[0].type === PipelineResultType.OK) {
+                expect(results[0].value).toHaveProperty('additionalField', 'test')
+            }
+        })
+
+        it('maintains ordering of events in results', async () => {
+            const rateLimiter = new MemoryRateLimiter(100, 10)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            const events = [
+                createMockEvent('token1', 'user1'),
+                createMockEvent('token2', 'user2'),
+                createMockEvent('token3', 'user3'),
+                createMockEvent('token1', 'user1'),
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(4)
+
+            for (let i = 0; i < results.length; i++) {
+                const result = results[i]
+                if (result.type === PipelineResultType.OK) {
+                    expect(result.value.headers.token).toBe(events[i].headers.token)
+                    expect(result.value.headers.distinct_id).toBe(events[i].headers.distinct_id)
+                }
+            }
+        })
+
+        it('preserves partition key when preservePartitionLocality is true', async () => {
+            const rateLimiter = new MemoryRateLimiter(1, 1)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            const events = [
+                createMockEvent('token1', 'user1'),
+                createMockEvent('token1', 'user1'), // Will exceed limit
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(2)
+            results.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.REDIRECT)
+                if (result.type === PipelineResultType.REDIRECT) {
+                    expect(result.preserveKey).toBe(true)
+                }
+            })
+        })
+
+        it('does not preserve partition key when preservePartitionLocality is false', async () => {
+            const rateLimiter = new MemoryRateLimiter(1, 1)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', false)
+
+            const events = [
+                createMockEvent('token1', 'user1'),
+                createMockEvent('token1', 'user1'), // Will exceed limit
+            ]
+
+            const results = await step(events)
+
+            expect(results).toHaveLength(2)
+            results.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.REDIRECT)
+                if (result.type === PipelineResultType.REDIRECT) {
+                    expect(result.preserveKey).toBe(false)
+                }
+            })
+        })
+
+        it('rate limiter state persists across step calls', async () => {
+            const rateLimiter = new MemoryRateLimiter(5, 1)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            const baseTime = new Date()
+
+            // First batch: consume 3 of 5 tokens
+            const firstBatch = Array.from({ length: 3 }, () => createMockEvent('token1', 'user1', baseTime))
+            const firstResults = await step(firstBatch)
+
+            expect(firstResults).toHaveLength(3)
+            firstResults.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.OK)
+            })
+
+            // Second batch: consume 3 more tokens (total 6, exceeds limit of 5)
+            const secondBatch = Array.from({ length: 3 }, () => createMockEvent('token1', 'user1', baseTime))
+            const secondResults = await step(secondBatch)
+
+            expect(secondResults).toHaveLength(3)
+            secondResults.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.REDIRECT)
+            })
+        })
+
+        it('tokens replenish over time allowing more events', async () => {
+            // Capacity 4, replenish 2 tokens per second
+            const rateLimiter = new MemoryRateLimiter(4, 2)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            const baseTime = new Date()
+
+            // First batch at T=0: consume all 4 tokens
+            const firstBatch = Array.from({ length: 4 }, () => createMockEvent('token1', 'user1', baseTime))
+            const firstResults = await step(firstBatch)
+
+            expect(firstResults).toHaveLength(4)
+            firstResults.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.OK)
+            })
+
+            // Second batch at T=0: no tokens left, should redirect
+            const secondBatch = [createMockEvent('token1', 'user1', baseTime)]
+            const secondResults = await step(secondBatch)
+
+            expect(secondResults).toHaveLength(1)
+            expect(secondResults[0].type).toBe(PipelineResultType.REDIRECT)
+
+            // Third batch at T=2s: replenished 4 tokens (2/sec * 2s = 4, capped at capacity)
+            const laterTime = new Date(baseTime.getTime() + 2000)
+            const thirdBatch = Array.from({ length: 3 }, () => createMockEvent('token1', 'user1', laterTime))
+            const thirdResults = await step(thirdBatch)
+
+            expect(thirdResults).toHaveLength(3)
+            thirdResults.forEach((result) => {
+                expect(result.type).toBe(PipelineResultType.OK)
+            })
+        })
+
+        it('different keys have independent rate limit state across calls', async () => {
+            const rateLimiter = new MemoryRateLimiter(3, 1)
+            const step = createRateLimitToOverflowStep(rateLimiter, true, 'overflow_topic', true)
+
+            const baseTime = new Date()
+
+            // First batch: exhaust tokens for user1
+            const firstBatch = Array.from({ length: 3 }, () => createMockEvent('token1', 'user1', baseTime))
+            await step(firstBatch)
+
+            // Second batch: user1 should be redirected, user2 should be ok
+            const secondBatch = [
+                createMockEvent('token1', 'user1', baseTime),
+                createMockEvent('token1', 'user2', baseTime),
+            ]
+            const secondResults = await step(secondBatch)
+
+            expect(secondResults).toHaveLength(2)
+            expect(secondResults[0].type).toBe(PipelineResultType.REDIRECT)
+            expect(secondResults[1].type).toBe(PipelineResultType.OK)
+        })
+    })
+})

--- a/plugin-server/src/ingestion/event-preprocessing/rate-limit-to-overflow-step.test.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/rate-limit-to-overflow-step.test.ts
@@ -1,18 +1,23 @@
-import { EventHeaders } from '../../types'
+import { createTestMessage } from '../../../tests/helpers/kafka-message'
+import { EventHeaders, PipelineEvent, Team } from '../../types'
 import { PipelineResultType } from '../pipelines/results'
 import { MemoryRateLimiter } from '../utils/overflow-detector'
 import { RateLimitToOverflowStepInput, createRateLimitToOverflowStep } from './rate-limit-to-overflow-step'
 
-const createMockHeaders = (token: string, distinctId: string, now?: Date): EventHeaders => ({
-    token,
-    distinct_id: distinctId,
-    now: now ?? new Date(),
-    force_disable_person_processing: false,
-    historical_migration: false,
-})
-
 const createMockEvent = (token: string, distinctId: string, now?: Date): RateLimitToOverflowStepInput => ({
-    headers: createMockHeaders(token, distinctId, now),
+    headers: {
+        token,
+        distinct_id: distinctId,
+        now: now ?? new Date(),
+        force_disable_person_processing: false,
+        historical_migration: false,
+    },
+    eventWithTeam: {
+        message: createTestMessage(),
+        event: { distinct_id: distinctId, token } as PipelineEvent,
+        team: { id: 1 } as Team,
+        headers: {} as EventHeaders,
+    },
 })
 
 describe('createRateLimitToOverflowStep', () => {

--- a/plugin-server/src/ingestion/event-preprocessing/rate-limit-to-overflow-step.ts
+++ b/plugin-server/src/ingestion/event-preprocessing/rate-limit-to-overflow-step.ts
@@ -1,0 +1,59 @@
+import { EventHeaders } from '../../types'
+import { PipelineResult, ok, redirect } from '../pipelines/results'
+import { MemoryRateLimiter } from '../utils/overflow-detector'
+
+export interface RateLimitToOverflowStepInput {
+    headers: EventHeaders
+}
+
+export function createRateLimitToOverflowStep<T extends RateLimitToOverflowStepInput>(
+    overflowRateLimiter: MemoryRateLimiter,
+    overflowEnabled: boolean,
+    overflowTopic: string,
+    preservePartitionLocality: boolean
+) {
+    return async function rateLimitToOverflowStep(inputs: T[]): Promise<PipelineResult<T>[]> {
+        if (!overflowEnabled) {
+            return Promise.resolve(inputs.map((input) => ok(input)))
+        }
+
+        // Count events by token:distinct_id and track first timestamp
+        const keyStats = new Map<string, { count: number; firstTimestamp: number }>()
+
+        for (const { headers } of inputs) {
+            const token = headers.token ?? ''
+            const distinctId = headers.distinct_id ?? ''
+            const eventKey = `${token}:${distinctId}`
+            const timestamp = headers.now?.getTime() ?? Date.now()
+
+            const existing = keyStats.get(eventKey)
+            if (existing) {
+                existing.count++
+            } else {
+                keyStats.set(eventKey, { count: 1, firstTimestamp: timestamp })
+            }
+        }
+
+        // Check rate limiter for each key
+        const shouldRedirectKey = new Map<string, boolean>()
+
+        for (const [eventKey, stats] of keyStats) {
+            const isBelowRateLimit = overflowRateLimiter.consume(eventKey, stats.count, stats.firstTimestamp)
+            shouldRedirectKey.set(eventKey, !isBelowRateLimit)
+        }
+
+        // Build results in original order
+        return inputs.map((input) => {
+            const { headers } = input
+            const token = headers.token ?? ''
+            const distinctId = headers.distinct_id ?? ''
+            const eventKey = `${token}:${distinctId}`
+
+            if (shouldRedirectKey.get(eventKey)) {
+                return redirect('rate_limit_exceeded', overflowTopic, preservePartitionLocality)
+            } else {
+                return ok(input)
+            }
+        })
+    }
+}

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -1,5 +1,4 @@
 import { Message } from 'node-rdkafka'
-import { Counter } from 'prom-client'
 
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 import { MessageSizeTooLarge } from '~/utils/db/error'
@@ -8,7 +7,6 @@ import { captureIngestionWarning } from '~/worker/ingestion/utils'
 import { HogTransformerService } from '../cdp/hog-transformations/hog-transformer.service'
 import { KafkaConsumer, parseKafkaHeaders } from '../kafka/consumer'
 import { KafkaProducerWrapper } from '../kafka/producer'
-import { ingestionOverflowingMessagesTotal } from '../main/ingestion-queues/batch-processing/metrics'
 import { latestOffsetTimestampGauge, setUsageInNonPersonEventsCounter } from '../main/ingestion-queues/metrics'
 import {
     EventHeaders,
@@ -22,7 +20,7 @@ import {
     PluginsServerConfig,
     Team,
 } from '../types'
-import { EventIngestionRestrictionManager, Restriction } from '../utils/event-ingestion-restriction-manager'
+import { EventIngestionRestrictionManager } from '../utils/event-ingestion-restriction-manager'
 import { logger } from '../utils/logger'
 import { PromiseScheduler } from '../utils/promise-scheduler'
 import { BatchWritingGroupStore } from '../worker/ingestion/groups/batch-writing-group-store'
@@ -36,16 +34,6 @@ import { newBatchPipelineBuilder } from './pipelines/builders'
 import { createBatch, createContext, createUnwrapper } from './pipelines/helpers'
 import { ok } from './pipelines/results'
 import { MemoryRateLimiter } from './utils/overflow-detector'
-
-const ingestionEventOverflowed = new Counter({
-    name: 'ingestion_event_overflowed',
-    help: 'Indicates that a given event has overflowed capacity and been redirected to a different topic.',
-})
-
-const forcedOverflowEventsCounter = new Counter({
-    name: 'ingestion_forced_overflow_events_total',
-    help: 'Number of events that were routed to overflow because they matched the force overflow tokens list',
-})
 
 type EventWithHeaders = IncomingEventWithTeam & { headers: EventHeaders }
 
@@ -100,7 +88,6 @@ export class IngestionConsumer {
     protected kafkaOverflowProducer?: KafkaProducerWrapper
     public hogTransformer: HogTransformerService
     private overflowRateLimiter: MemoryRateLimiter
-    private ingestionWarningLimiter: MemoryRateLimiter
     private tokenDistinctIdsToDrop: string[] = []
     private tokenDistinctIdsToSkipPersons: string[] = []
     private tokenDistinctIdsToForceOverflow: string[] = []
@@ -154,8 +141,6 @@ export class IngestionConsumer {
             this.hub.EVENT_OVERFLOW_BUCKET_CAPACITY,
             this.hub.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE
         )
-
-        this.ingestionWarningLimiter = new MemoryRateLimiter(1, 1.0 / 3600)
         this.hogTransformer = new HogTransformerService(hub)
 
         this.personsStore = new BatchWritingPersonsStore(this.hub.personRepository, this.hub.db.kafkaProducer, {
@@ -394,8 +379,8 @@ export class IngestionConsumer {
     }
 
     /**
-     * Redirect events to overflow or testing topic based on their configuration
-     * returning events that have not been redirected
+     * Redirect events to testing topic if configured.
+     * Note: Overflow redirection is now handled in the preprocessing pipeline.
      */
     private redirectEvents(eventsForDistinctId: EventsForDistinctId): EventsForDistinctId {
         if (!eventsForDistinctId.events.length) {
@@ -406,51 +391,6 @@ export class IngestionConsumer {
             void this.promiseScheduler.schedule(
                 this.emitToTestingTopic(eventsForDistinctId.events.map((x) => x.message))
             )
-            return {
-                ...eventsForDistinctId,
-                events: [],
-            }
-        }
-
-        // NOTE: We know at this point that all these events are the same token distinct_id
-        const token = eventsForDistinctId.token
-        const distinctId = eventsForDistinctId.distinctId
-        const kafkaTimestamp = eventsForDistinctId.events[0].message.timestamp
-        const eventKey = `${token}:${distinctId}`
-
-        // Check if this token is in the force overflow static/dynamic config list
-        const restrictions = this.getAppliedRestrictions(token, distinctId)
-        const shouldForceOverflow = restrictions.has(Restriction.FORCE_OVERFLOW)
-
-        // Check the rate limiter and emit to overflow if necessary
-        const isBelowRateLimit = this.overflowRateLimiter.consume(
-            eventKey,
-            eventsForDistinctId.events.length,
-            kafkaTimestamp
-        )
-
-        if (this.overflowEnabled() && (shouldForceOverflow || !isBelowRateLimit)) {
-            ingestionEventOverflowed.inc(eventsForDistinctId.events.length)
-
-            if (shouldForceOverflow) {
-                forcedOverflowEventsCounter.inc()
-            } else if (this.ingestionWarningLimiter.consume(eventKey, eventsForDistinctId.events.length)) {
-                logger.warn('🪣', `Local overflow detection triggered on key ${eventKey}`)
-            }
-
-            // NOTE: If we are forcing to overflow we typically want to keep the partition key
-            // If the event is marked for skipping persons however locality doesn't matter so we would rather have the higher throughput
-            // of random partitioning.
-            const preserveLocality =
-                shouldForceOverflow && !restrictions.has(Restriction.SKIP_PERSON_PROCESSING) ? true : undefined
-
-            void this.promiseScheduler.schedule(
-                this.emitToOverflow(
-                    eventsForDistinctId.events.map((x) => x.message),
-                    preserveLocality
-                )
-            )
-
             return {
                 ...eventsForDistinctId,
                 events: [],
@@ -527,43 +467,11 @@ export class IngestionConsumer {
         return groupedEvents
     }
 
-    private getAppliedRestrictions(token?: string, distinctId?: string): ReadonlySet<Restriction> {
-        return this.eventIngestionRestrictionManager.getAppliedRestrictions(token, { distinct_id: distinctId })
-    }
-
     private overflowEnabled(): boolean {
         return (
             !!this.hub.INGESTION_CONSUMER_OVERFLOW_TOPIC &&
             this.hub.INGESTION_CONSUMER_OVERFLOW_TOPIC !== this.topic &&
             !this.testingTopic
-        )
-    }
-
-    private async emitToOverflow(kafkaMessages: Message[], preservePartitionLocalityOverride?: boolean): Promise<void> {
-        const overflowTopic = this.hub.INGESTION_CONSUMER_OVERFLOW_TOPIC
-        if (!overflowTopic) {
-            throw new Error('No overflow topic configured')
-        }
-
-        ingestionOverflowingMessagesTotal.inc(kafkaMessages.length)
-
-        const preservePartitionLocality =
-            preservePartitionLocalityOverride !== undefined
-                ? preservePartitionLocalityOverride
-                : this.hub.INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY
-
-        await Promise.all(
-            kafkaMessages.map((message) => {
-                return this.kafkaOverflowProducer!.produce({
-                    topic: this.overflowTopic!,
-                    value: message.value,
-                    // ``message.key`` should not be undefined here, but in the
-                    // (extremely) unlikely event that it is, set it to ``null``
-                    // instead as that behavior is safer.
-                    key: preservePartitionLocality ? (message.key ?? null) : null,
-                    headers: parseKafkaHeaders(message.headers),
-                })
-            })
         )
     }
 

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -206,6 +206,7 @@ export class IngestionConsumer {
                 personsStore: this.personsStore,
                 hogTransformer: this.hogTransformer,
                 eventIngestionRestrictionManager: this.eventIngestionRestrictionManager,
+                overflowRateLimiter: this.overflowRateLimiter,
                 overflowEnabled: this.overflowEnabled(),
                 overflowTopic: this.overflowTopic || '',
                 dlqTopic: this.dlqTopic,


### PR DESCRIPTION
## Problem

Last major bit of logic between the analytics ingestion pipelines is rate limiting to overflow.

## Changes

- Creates a new `rateLimitToOverflowStep` batch processing step, applied right after assigning cookieless distinct IDs
- Removes the overflow metris, as they can be replaced with generic pipelines metrics now

## How did you test this code?

- Added tests for the step
- Existing integration tests for ingestion consumer
