### PR TITLE
chore: Remove `API_QUERIES_ON_ONLINE_CLUSTER` setting and related logic

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -31,9 +31,8 @@ from posthog.clickhouse.query_tagging import (
     get_query_tag_value,
     get_query_tags,
 )
-from posthog.cloud_utils import is_cloud
 from posthog.errors import ch_error_type, wrap_query_error
-from posthog.settings import API_QUERIES_ON_ONLINE_CLUSTER, CLICKHOUSE_PER_TEAM_QUERY_SETTINGS, TEST
+from posthog.settings import CLICKHOUSE_PER_TEAM_QUERY_SETTINGS, TEST
 from posthog.temporal.common.clickhouse import update_query_tags_with_temporal_info
 from posthog.utils import generate_short_id, patchable
 
@@ -152,16 +151,6 @@ def sync_execute(
     if tags_id == "posthog.tasks.tasks.process_query_task":
         workload = Workload.ONLINE
         ch_user = ClickHouseUser.API if is_personal_api_key else ClickHouseUser.APP
-
-    # Customer is paying for API
-    if (
-        team_id
-        and workload == Workload.OFFLINE
-        and tags.chargeable
-        and is_cloud()
-        and team_id in API_QUERIES_ON_ONLINE_CLUSTER
-    ):
-        workload = Workload.ONLINE
 
     if tags.workload == Workload.ENDPOINTS:
         workload = Workload.ENDPOINTS

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -278,11 +278,6 @@ with suppress(Exception):
     as_json = json.loads(os.getenv("API_QUERIES_PER_TEAM", "{}"))
     API_QUERIES_PER_TEAM = {int(k): int(v) for k, v in as_json.items()}
 
-API_QUERIES_ON_ONLINE_CLUSTER = set[int]([])
-with suppress(Exception):
-    as_json = json.loads(os.getenv("API_QUERIES_ON_ONLINE_CLUSTER", "[]"))
-    API_QUERIES_ON_ONLINE_CLUSTER = {int(v) for v in as_json}
-
 _clickhouse_http_protocol = "http://"
 _clickhouse_http_port = "8123"
 if CLICKHOUSE_SECURE:


### PR DESCRIPTION
Running user queries on online cluster does not work.