### PR TITLE
chore: Make hog-transformer-service profiler friendly

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -136,26 +136,188 @@ export class HogTransformerService {
         }
     }
 
+    private async transformEventAndProduceMessagesImpl(event: PluginEvent): Promise<TransformationResult> {
+        hogTransformationAttempts.inc({ type: 'with_messages' })
+
+        const teamHogFunctions = await this.hogFunctionManager.getHogFunctionsForTeam(event.team_id, ['transformation'])
+
+        const transformationResult = await this.transformEvent(event, teamHogFunctions)
+
+        for (const result of transformationResult.invocationResults) {
+            this.invocationResults.push(result)
+        }
+        hogTransformationPendingInvocationResults.set(this.invocationResults.length)
+
+        hogTransformationCompleted.inc({ type: 'with_messages' })
+        return {
+            ...transformationResult,
+        }
+    }
+
     public transformEventAndProduceMessages(event: PluginEvent): Promise<TransformationResult> {
-        return instrumentFn(`hogTransformer.transformEventAndProduceMessages`, async () => {
-            hogTransformationAttempts.inc({ type: 'with_messages' })
+        return instrumentFn(`hogTransformer.transformEventAndProduceMessages`, () =>
+            this.transformEventAndProduceMessagesImpl(event)
+        )
+    }
 
-            const teamHogFunctions = await this.hogFunctionManager.getHogFunctionsForTeam(event.team_id, [
-                'transformation',
-            ])
+    private async transformEventImpl(
+        event: PluginEvent,
+        teamHogFunctions: HogFunctionType[]
+    ): Promise<TransformationResult> {
+        hogTransformationInvocations.inc()
+        const results: CyclotronJobInvocationResult[] = []
+        const transformationsSucceeded: string[] = []
+        const transformationsFailed: string[] = []
+        const transformationsSkipped: string[] = []
 
-            const transformationResult = await this.transformEvent(event, teamHogFunctions)
+        const shouldRunHogWatcher = Math.random() < this.hub.CDP_HOG_WATCHER_SAMPLE_RATE
 
-            for (const result of transformationResult.invocationResults) {
-                this.invocationResults.push(result)
+        for (const hogFunction of teamHogFunctions) {
+            const transformationIdentifier = `${hogFunction.name} (${hogFunction.id})`
+
+            // Check if function is in a degraded state, but only if hogwatcher is enabled
+            if (shouldRunHogWatcher) {
+                const functionState = this.cachedStates[hogFunction.id]
+
+                // If the function is in a degraded state, skip it
+                if (functionState && functionState === HogWatcherState.disabled) {
+                    this.hogFunctionMonitoringService.queueAppMetric(
+                        {
+                            team_id: event.team_id,
+                            app_source_id: hogFunction.id,
+                            metric_kind: 'failure',
+                            metric_name: 'disabled_permanently',
+                            count: 1,
+                        },
+                        'hog_function'
+                    )
+                    continue
+                }
             }
-            hogTransformationPendingInvocationResults.set(this.invocationResults.length)
 
-            hogTransformationCompleted.inc({ type: 'with_messages' })
-            return {
-                ...transformationResult,
+            const globals = this.createInvocationGlobals(event)
+            const filterGlobals = convertToHogFunctionFilterGlobal(globals)
+
+            // Check if function has filters - if not, always apply
+            if (hogFunction.filters?.bytecode) {
+                const filterResults = await filterFunctionInstrumented({
+                    fn: hogFunction,
+                    filters: hogFunction.filters,
+                    filterGlobals,
+                })
+
+                // If filter didn't pass skip the actual transformation and add logs and errors from the filterResult
+                this.hogFunctionMonitoringService.queueAppMetrics(filterResults.metrics, 'hog_function')
+                this.hogFunctionMonitoringService.queueLogs(filterResults.logs, 'hog_function')
+
+                if (!filterResults.match) {
+                    transformationsSkipped.push(transformationIdentifier)
+                    continue
+                }
             }
-        })
+
+            const result = await this.executeHogFunction(hogFunction, globals)
+
+            results.push(result)
+
+            if (result.error) {
+                transformationsFailed.push(transformationIdentifier)
+                continue
+            }
+
+            if (!result.execResult) {
+                hogTransformationDroppedEvents.inc()
+                this.hogFunctionMonitoringService.queueAppMetric(
+                    {
+                        team_id: event.team_id,
+                        app_source_id: hogFunction.id,
+                        metric_kind: 'other',
+                        metric_name: 'dropped',
+                        count: 1,
+                    },
+                    'hog_function'
+                )
+                transformationsFailed.push(transformationIdentifier)
+                return {
+                    event: null,
+                    invocationResults: results,
+                }
+            }
+
+            const transformedEvent: unknown = result.execResult
+
+            if (
+                !transformedEvent ||
+                typeof transformedEvent !== 'object' ||
+                !('properties' in transformedEvent) ||
+                !transformedEvent.properties ||
+                typeof transformedEvent.properties !== 'object'
+            ) {
+                logger.error('⚠️', 'Invalid transformation result - missing or invalid properties', {
+                    function_id: hogFunction.id,
+                })
+                transformationsFailed.push(transformationIdentifier)
+                continue
+            }
+
+            event.properties = {
+                ...transformedEvent.properties,
+            }
+
+            event.ip = event.properties.$ip ?? null
+
+            if ('event' in transformedEvent) {
+                if (typeof transformedEvent.event !== 'string') {
+                    logger.error('⚠️', 'Invalid transformation result - event name must be a string', {
+                        function_id: hogFunction.id,
+                        event: transformedEvent.event,
+                    })
+                    transformationsFailed.push(transformationIdentifier)
+                    continue
+                }
+                event.event = transformedEvent.event
+            }
+
+            if ('distinct_id' in transformedEvent) {
+                if (typeof transformedEvent.distinct_id !== 'string') {
+                    logger.error('⚠️', 'Invalid transformation result - distinct_id must be a string', {
+                        function_id: hogFunction.id,
+                        distinct_id: transformedEvent.distinct_id,
+                    })
+                    transformationsFailed.push(transformationIdentifier)
+                    continue
+                }
+                event.distinct_id = transformedEvent.distinct_id
+            }
+
+            transformationsSucceeded.push(transformationIdentifier)
+        }
+
+        if (transformationsFailed.length > 0) {
+            event.properties = {
+                ...event.properties,
+                $transformations_failed: transformationsFailed,
+            }
+        }
+
+        if (transformationsSkipped.length > 0) {
+            event.properties = {
+                ...event.properties,
+                $transformations_skipped: transformationsSkipped,
+            }
+        }
+
+        if (transformationsSucceeded.length > 0) {
+            event.properties = {
+                ...event.properties,
+                $transformations_succeeded: transformationsSucceeded,
+            }
+        }
+
+        return {
+            event,
+            invocationResults: results,
+        }
     }
 
     public transformEvent(event: PluginEvent, teamHogFunctions: HogFunctionType[]): Promise<TransformationResult> {
@@ -168,162 +330,7 @@ export class HogTransformerService {
             }
         }
 
-        return instrumentFn(`hogTransformer.transformEvent`, async () => {
-            hogTransformationInvocations.inc()
-            const results: CyclotronJobInvocationResult[] = []
-            const transformationsSucceeded: string[] = []
-            const transformationsFailed: string[] = []
-            const transformationsSkipped: string[] = []
-
-            const shouldRunHogWatcher = Math.random() < this.hub.CDP_HOG_WATCHER_SAMPLE_RATE
-
-            for (const hogFunction of teamHogFunctions) {
-                const transformationIdentifier = `${hogFunction.name} (${hogFunction.id})`
-
-                // Check if function is in a degraded state, but only if hogwatcher is enabled
-                if (shouldRunHogWatcher) {
-                    const functionState = this.cachedStates[hogFunction.id]
-
-                    // If the function is in a degraded state, skip it
-                    if (functionState && functionState === HogWatcherState.disabled) {
-                        this.hogFunctionMonitoringService.queueAppMetric(
-                            {
-                                team_id: event.team_id,
-                                app_source_id: hogFunction.id,
-                                metric_kind: 'failure',
-                                metric_name: 'disabled_permanently',
-                                count: 1,
-                            },
-                            'hog_function'
-                        )
-                        continue
-                    }
-                }
-
-                const globals = this.createInvocationGlobals(event)
-                const filterGlobals = convertToHogFunctionFilterGlobal(globals)
-
-                // Check if function has filters - if not, always apply
-                if (hogFunction.filters?.bytecode) {
-                    const filterResults = await filterFunctionInstrumented({
-                        fn: hogFunction,
-                        filters: hogFunction.filters,
-                        filterGlobals,
-                    })
-
-                    // If filter didn't pass skip the actual transformation and add logs and errors from the filterResult
-                    this.hogFunctionMonitoringService.queueAppMetrics(filterResults.metrics, 'hog_function')
-                    this.hogFunctionMonitoringService.queueLogs(filterResults.logs, 'hog_function')
-
-                    if (!filterResults.match) {
-                        transformationsSkipped.push(transformationIdentifier)
-                        continue
-                    }
-                }
-
-                const result = await this.executeHogFunction(hogFunction, globals)
-
-                results.push(result)
-
-                if (result.error) {
-                    transformationsFailed.push(transformationIdentifier)
-                    continue
-                }
-
-                if (!result.execResult) {
-                    hogTransformationDroppedEvents.inc()
-                    this.hogFunctionMonitoringService.queueAppMetric(
-                        {
-                            team_id: event.team_id,
-                            app_source_id: hogFunction.id,
-                            metric_kind: 'other',
-                            metric_name: 'dropped',
-                            count: 1,
-                        },
-                        'hog_function'
-                    )
-                    transformationsFailed.push(transformationIdentifier)
-                    return {
-                        event: null,
-                        invocationResults: results,
-                    }
-                }
-
-                const transformedEvent: unknown = result.execResult
-
-                if (
-                    !transformedEvent ||
-                    typeof transformedEvent !== 'object' ||
-                    !('properties' in transformedEvent) ||
-                    !transformedEvent.properties ||
-                    typeof transformedEvent.properties !== 'object'
-                ) {
-                    logger.error('⚠️', 'Invalid transformation result - missing or invalid properties', {
-                        function_id: hogFunction.id,
-                    })
-                    transformationsFailed.push(transformationIdentifier)
-                    continue
-                }
-
-                event.properties = {
-                    ...transformedEvent.properties,
-                }
-
-                event.ip = event.properties.$ip ?? null
-
-                if ('event' in transformedEvent) {
-                    if (typeof transformedEvent.event !== 'string') {
-                        logger.error('⚠️', 'Invalid transformation result - event name must be a string', {
-                            function_id: hogFunction.id,
-                            event: transformedEvent.event,
-                        })
-                        transformationsFailed.push(transformationIdentifier)
-                        continue
-                    }
-                    event.event = transformedEvent.event
-                }
-
-                if ('distinct_id' in transformedEvent) {
-                    if (typeof transformedEvent.distinct_id !== 'string') {
-                        logger.error('⚠️', 'Invalid transformation result - distinct_id must be a string', {
-                            function_id: hogFunction.id,
-                            distinct_id: transformedEvent.distinct_id,
-                        })
-                        transformationsFailed.push(transformationIdentifier)
-                        continue
-                    }
-                    event.distinct_id = transformedEvent.distinct_id
-                }
-
-                transformationsSucceeded.push(transformationIdentifier)
-            }
-
-            if (transformationsFailed.length > 0) {
-                event.properties = {
-                    ...event.properties,
-                    $transformations_failed: transformationsFailed,
-                }
-            }
-
-            if (transformationsSkipped.length > 0) {
-                event.properties = {
-                    ...event.properties,
-                    $transformations_skipped: transformationsSkipped,
-                }
-            }
-
-            if (transformationsSucceeded.length > 0) {
-                event.properties = {
-                    ...event.properties,
-                    $transformations_succeeded: transformationsSucceeded,
-                }
-            }
-
-            return {
-                event,
-                invocationResults: results,
-            }
-        })
+        return instrumentFn(`hogTransformer.transformEvent`, () => this.transformEventImpl(event, teamHogFunctions))
     }
 
     private async executeHogFunction(


### PR DESCRIPTION
## Problem

Currently we can't see the profiler stack for methods in `hog-transformer.service.ts` because of the way it is instrumented, since it uses anonymous functions with a large body, this PR fixes that while maintaining functionality

## Changes

- Name InstrumentedFn methods in hog transformer service

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
