### PR TITLE
feat(llma): remove backend feature flag checks for summarization and translation

### DIFF
--- a/products/llm_analytics/backend/api/summarization.py
+++ b/products/llm_analytics/backend/api/summarization.py
@@ -316,9 +316,6 @@ representation, and uses an LLM to create a concise summary with line references
 - "Interesting Notes" section for failures, successes, or unusual patterns
 - Line references in [L45] or [L45-52] format pointing to relevant sections
 
-**Feature Flag:**
-- Requires `llm-analytics-summarization` feature flag enabled at team level
-
 **Use Cases:**
 - Quick understanding of complex traces
 - Identifying key events and patterns

--- a/products/llm_analytics/backend/api/summarization.py
+++ b/products/llm_analytics/backend/api/summarization.py
@@ -12,11 +12,9 @@ Endpoints:
 import time
 from typing import cast
 
-from django.conf import settings
 from django.core.cache import cache
 
 import structlog
-import posthoganalytics
 from asgiref.sync import async_to_sync
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, extend_schema
@@ -35,10 +33,6 @@ from posthog.rate_limit import (
     LLMAnalyticsSummarizationSustainedThrottle,
 )
 
-from products.llm_analytics.backend.summarization.constants import (
-    EARLY_ADOPTERS_FEATURE_FLAG,
-    SUMMARIZATION_FEATURE_FLAG,
-)
 from products.llm_analytics.backend.summarization.llm import summarize
 from products.llm_analytics.backend.text_repr.formatters import (
     FormatterOptions,
@@ -143,44 +137,14 @@ class LLMAnalyticsSummarizationViewSet(TeamAndOrgViewSetMixin, viewsets.GenericV
         ]
 
     def _validate_feature_access(self, request: Request) -> None:
-        """Validate that the user has access to the summarization feature."""
+        """Validate that the user is authenticated and AI data processing is approved."""
         if not request.user.is_authenticated:
             raise exceptions.NotAuthenticated()
 
-        if settings.DEBUG:
-            return
-
-        user = cast(User, request.user)
-        distinct_id = str(user.distinct_id)
-        organization_id = str(self.team.organization_id)
-
-        # Include person properties for cohort-based targeting and
-        # groups/group_properties for organization-level targeting (including Early Access Features)
-        person_properties = {"email": user.email}
-        groups = {"organization": organization_id}
-        group_properties = {"organization": {"id": organization_id}}
-
-        if not (
-            posthoganalytics.feature_enabled(
-                SUMMARIZATION_FEATURE_FLAG,
-                distinct_id,
-                person_properties=person_properties,
-                groups=groups,
-                group_properties=group_properties,
-                only_evaluate_locally=False,
-                send_feature_flag_events=False,
+        if not self.organization.is_ai_data_processing_approved:
+            raise exceptions.PermissionDenied(
+                "AI data processing must be approved by your organization before using summarization"
             )
-            or posthoganalytics.feature_enabled(
-                EARLY_ADOPTERS_FEATURE_FLAG,
-                distinct_id,
-                person_properties=person_properties,
-                groups=groups,
-                group_properties=group_properties,
-                only_evaluate_locally=False,
-                send_feature_flag_events=False,
-            )
-        ):
-            raise exceptions.PermissionDenied("LLM trace summarization is not enabled for this user")
 
     def _get_cache_key(self, summarize_type: str, entity_id: str, mode: str) -> str:
         """Generate cache key for summary results.

--- a/products/llm_analytics/backend/api/test/test_summarization.py
+++ b/products/llm_analytics/backend/api/test/test_summarization.py
@@ -27,10 +27,12 @@ class TestSummarizationAPI(APIBaseTest):
         response = self.client.post(f"/api/environments/{self.team.id}/llm_analytics/summarization/")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    @patch("products.llm_analytics.backend.api.summarization.posthoganalytics.feature_enabled", return_value=True)
     @patch("products.llm_analytics.backend.api.summarization.async_to_sync")
-    def test_event_summarization_includes_title(self, mock_async_to_sync, mock_feature_enabled):
+    def test_event_summarization_includes_title(self, mock_async_to_sync):
         """Should include title field in summarization response."""
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
         # Mock the summarize function to return a SummarizationResponse with title
         mock_summary = SummarizationResponse(
             title="Test Event Summary",
@@ -86,10 +88,12 @@ class TestSummarizationAPI(APIBaseTest):
         self.assertIn("summary_bullets", data["summary"])
         self.assertIn("interesting_notes", data["summary"])
 
-    @patch("products.llm_analytics.backend.api.summarization.posthoganalytics.feature_enabled", return_value=True)
     @patch("products.llm_analytics.backend.api.summarization.async_to_sync")
-    def test_trace_summarization_includes_title(self, mock_async_to_sync, mock_feature_enabled):
+    def test_trace_summarization_includes_title(self, mock_async_to_sync):
         """Should include title field in trace summarization response."""
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
         # Mock the summarize function
         mock_summary = SummarizationResponse(
             title="Multi-step Trace Execution",
@@ -137,9 +141,11 @@ class TestSummarizationAPI(APIBaseTest):
         self.assertIn("title", data["summary"])
         self.assertEqual(data["summary"]["title"], "Multi-step Trace Execution")
 
-    @patch("products.llm_analytics.backend.api.summarization.posthoganalytics.feature_enabled", return_value=True)
-    def test_missing_summarize_type(self, mock_feature_enabled):
+    def test_missing_summarize_type(self):
         """Should return 400 for missing summarize_type."""
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
         request_data: dict[str, Any] = {"data": {"event": {}}}
 
         response = self.client.post(
@@ -151,9 +157,11 @@ class TestSummarizationAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("summarize_type", str(response.data).lower())
 
-    @patch("products.llm_analytics.backend.api.summarization.posthoganalytics.feature_enabled", return_value=True)
-    def test_missing_data(self, mock_feature_enabled):
+    def test_missing_data(self):
         """Should return 400 for missing data."""
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
         request_data = {"summarize_type": "event"}
 
         response = self.client.post(
@@ -165,9 +173,11 @@ class TestSummarizationAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("data", str(response.data).lower())
 
-    @patch("products.llm_analytics.backend.api.summarization.posthoganalytics.feature_enabled", return_value=True)
-    def test_invalid_summarize_type(self, mock_feature_enabled):
+    def test_invalid_summarize_type(self):
         """Should return 400 for invalid summarize_type."""
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
         request_data = {
             "summarize_type": "invalid",
             "data": {"event": {}},
@@ -181,10 +191,11 @@ class TestSummarizationAPI(APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    @patch("products.llm_analytics.backend.api.summarization.posthoganalytics.feature_enabled", return_value=True)
     @patch("products.llm_analytics.backend.api.summarization.async_to_sync")
-    def test_events_in_same_trace_have_separate_cache(self, mock_async_to_sync, mock_feature_enabled):
+    def test_events_in_same_trace_have_separate_cache(self, mock_async_to_sync):
         """Should cache event summaries by event ID, not trace ID, to avoid collisions."""
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
 
         # Mock the summarize function to return different summaries
         def mock_summarize(*args, **kwargs):
@@ -266,9 +277,11 @@ class TestSummarizationAPI(APIBaseTest):
         response = self.client.post(f"/api/environments/{self.team.id}/llm_analytics/summarization/batch_check/")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    @patch("products.llm_analytics.backend.api.summarization.posthoganalytics.feature_enabled", return_value=True)
-    def test_batch_check_empty_traces(self, mock_feature_enabled):
+    def test_batch_check_empty_traces(self):
         """Should return empty list when no traces have cached summaries."""
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
         response = self.client.post(
             f"/api/environments/{self.team.id}/llm_analytics/summarization/batch_check/",
             {"trace_ids": ["trace1", "trace2"], "mode": "minimal"},
@@ -277,10 +290,12 @@ class TestSummarizationAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["summaries"], [])
 
-    @patch("products.llm_analytics.backend.api.summarization.posthoganalytics.feature_enabled", return_value=True)
     @patch("products.llm_analytics.backend.api.summarization.async_to_sync")
-    def test_batch_check_returns_cached_summaries(self, mock_async_to_sync, mock_feature_enabled):
+    def test_batch_check_returns_cached_summaries(self, mock_async_to_sync):
         """Should return cached summaries for traces that have been summarized."""
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
         mock_summary = SummarizationResponse(
             title="Cached Summary",
             flow_diagram="Flow",
@@ -315,9 +330,11 @@ class TestSummarizationAPI(APIBaseTest):
         self.assertEqual(response.data["summaries"][0]["trace_id"], "cached_trace")
         self.assertEqual(response.data["summaries"][0]["title"], "Cached Summary")
 
-    @patch("products.llm_analytics.backend.api.summarization.posthoganalytics.feature_enabled", return_value=True)
-    def test_batch_check_requires_trace_ids(self, mock_feature_enabled):
+    def test_batch_check_requires_trace_ids(self):
         """Should return 400 when trace_ids is missing."""
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
         response = self.client.post(
             f"/api/environments/{self.team.id}/llm_analytics/summarization/batch_check/",
             {"mode": "minimal"},
@@ -326,39 +343,16 @@ class TestSummarizationAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("trace_ids", str(response.data).lower())
 
-    def test_feature_disabled_returns_permission_denied(self):
-        """Should return 403 when feature flags are disabled for user."""
-        with patch(
-            "products.llm_analytics.backend.api.summarization.posthoganalytics.feature_enabled", return_value=False
-        ):
-            response = self.client.post(
-                f"/api/environments/{self.team.id}/llm_analytics/summarization/",
-                {"summarize_type": "event", "mode": "minimal", "data": {"event": {"id": "test"}}},
-                format="json",
-            )
-            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-            self.assertIn("not enabled", str(response.data).lower())
+    def test_summarization_denied_when_ai_consent_not_approved(self):
+        """Should return 403 when AI data processing is not approved."""
+        self.organization.is_ai_data_processing_approved = False
+        self.organization.save()
 
-    @patch("products.llm_analytics.backend.api.summarization.posthoganalytics.feature_enabled")
-    def test_feature_flag_called_with_organization_context(self, mock_feature_enabled):
-        """Should call feature_enabled with groups and group_properties for organization targeting."""
-        mock_feature_enabled.return_value = False
-
-        self.client.post(
+        response = self.client.post(
             f"/api/environments/{self.team.id}/llm_analytics/summarization/",
             {"summarize_type": "event", "mode": "minimal", "data": {"event": {"id": "test"}}},
             format="json",
         )
 
-        # Verify feature_enabled was called with correct parameters
-        self.assertTrue(mock_feature_enabled.called)
-        call_kwargs = mock_feature_enabled.call_args_list[0][1]
-        self.assertIn("groups", call_kwargs)
-        self.assertIn("group_properties", call_kwargs)
-        self.assertEqual(call_kwargs["groups"], {"organization": str(self.team.organization_id)})
-        self.assertEqual(call_kwargs["group_properties"], {"organization": {"id": str(self.team.organization_id)}})
-        self.assertIn("person_properties", call_kwargs)
-        self.assertEqual(call_kwargs["person_properties"], {"email": self.user.email})
-        # Server-side evaluation to access Early Access Feature enrollment properties
-        self.assertEqual(call_kwargs["only_evaluate_locally"], False)
-        self.assertEqual(call_kwargs["send_feature_flag_events"], False)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("AI data processing must be approved", response.data["detail"])

--- a/products/llm_analytics/backend/summarization/constants.py
+++ b/products/llm_analytics/backend/summarization/constants.py
@@ -3,7 +3,3 @@
 # LLM model configuration
 SUMMARIZATION_MODEL = "gpt-4.1-mini"
 SUMMARIZATION_TIMEOUT = 120  # 2 minutes
-
-# Feature flags
-SUMMARIZATION_FEATURE_FLAG = "llm-analytics-summarization"
-EARLY_ADOPTERS_FEATURE_FLAG = "llm-analytics-early-adopters"

--- a/products/llm_analytics/backend/translation/constants.py
+++ b/products/llm_analytics/backend/translation/constants.py
@@ -3,10 +3,6 @@
 import json
 from pathlib import Path
 
-# Feature flags
-LLM_ANALYTICS_TRANSLATION = "llm-analytics-translation"
-EARLY_ADOPTERS_FEATURE_FLAG = "llm-analytics-early-adopters"
-
 # Load supported languages from shared JSON file
 _LANGUAGES_JSON_PATH = Path(__file__).parent.parent.parent / "shared" / "supported_languages.json"
 with open(_LANGUAGES_JSON_PATH) as f:


### PR DESCRIPTION
## Problem

The backend feature flag checks for LLM analytics summarization and translation endpoints were not working correctly and added unnecessary complexity. Users with valid access were being blocked, creating friction.

## Changes

- Remove `posthoganalytics.feature_enabled()` checks from summarization and translation endpoints
- Simplify `_validate_feature_access` to only check authentication and AI data processing consent
- Remove unused feature flag constants from constants.py files
- Update tests to reflect the simplified validation logic

Protection remains in place via:
- Frontend feature flags (LLM_ANALYTICS_SUMMARIZATION, LLM_ANALYTICS_TRANSLATION, LLM_ANALYTICS_EARLY_ADOPTERS)
- Rate limiting: summarization (50/min burst, 200/hour, 500/day) and translation (30/min burst, 200/hour, 500/day)
- AI data processing consent check at organization level
- Authentication requirement

This is cleanup and simplification - the backend checks were redundant given the existing frontend gating and rate limiting.

## How did you test this code?

Ran all 24 tests for summarization and translation endpoints:
```
pytest products/llm_analytics/backend/api/test/test_summarization.py products/llm_analytics/backend/api/test/test_translate.py -v
```

All tests pass, including:
- Authentication checks (401 for unauthenticated)
- AI consent checks (403 when not approved)
- Request validation (400 for invalid requests)
- Successful summarization and translation flows

## Changelog: (features only) Is this feature complete?

No - this is an internal cleanup, not a user-facing feature.