### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Problem

We need a simple Express server to provide activity feed data for the Graphite demo application. This will allow frontend development to proceed with realistic data without requiring a full backend implementation.

## Changes

Created a new Express server that:
- Sets up a basic Express application listening on port 3000
- Includes sample activity feed data with different types of activities
- Implements a `/feed` endpoint that returns the activity feed as JSON

## How did you test this code?

Tested the server by:
- Starting the server locally
- Making GET requests to the `/feed` endpoint using a browser and Postman
- Verifying that the correct JSON data was returned with proper formatting

## Changelog: (features only) Is this feature complete?

Yes - this provides a functional API endpoint for the activity feed that can be used by the frontend.