### PR TITLE
fix(array): proxy logs via django

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -4,6 +4,7 @@ import logging
 import traceback
 from typing import cast
 
+from django.http import HttpResponse
 from django.utils import timezone
 
 from drf_spectacular.utils import OpenApiResponse, extend_schema
@@ -443,3 +444,14 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         expires_in = 3600
         serializer = TaskRunArtifactPresignResponseSerializer({"url": url, "expires_in": expires_in})
         return Response(serializer.data)
+
+    @action(detail=True, methods=["get"], url_path="logs", required_scopes=["task:read"])
+    def logs(self, request, pk=None, **kwargs):
+        """Proxy endpoint to fetch logs from S3, avoiding CORS issues."""
+        task_run = cast(TaskRun, self.get_object())
+        log_content = object_storage.read(task_run.log_url, missing_ok=True)
+        if log_content is None:
+            return HttpResponse(status=404)
+        response = HttpResponse(log_content, content_type="application/jsonl")
+        response["Cache-Control"] = "no-cache"
+        return response

--- a/products/tasks/frontend/logics/taskDetailSceneLogic.ts
+++ b/products/tasks/frontend/logics/taskDetailSceneLogic.ts
@@ -95,9 +95,10 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
                         return null
                     }
                     const run = await api.tasks.runs.get(props.taskId, values.selectedRunId)
-                    if (run.log_url) {
-                        actions.loadLogs({ url: run.log_url })
-                    }
+                    // Use proxy endpoint to avoid CORS issues with direct S3 access
+                    actions.loadLogs({
+                        url: `/api/projects/@current/tasks/${props.taskId}/runs/${values.selectedRunId}/logs/`,
+                    })
                     return run
                 },
             },


### PR DESCRIPTION
In production, we limit direct access to the S3 bucket - this proxies logs via django to avoid that.

Adds a small latency, but fine for cloud runs.