### PR TITLE
feat(cdp): enable quota limiting

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
@@ -314,7 +314,7 @@ describe('CdpDatawarehouseEventsConsumer', () => {
         })
     })
 
-    describe('quota limiting for teams without legacy addon', () => {
+    describe('quota limiting', () => {
         let fnFetchNoFilters: HogFunctionType
         let fnDataWarehouseFunction: HogFunctionType
         let globals: HogFunctionInvocationGlobals
@@ -417,84 +417,6 @@ describe('CdpDatawarehouseEventsConsumer', () => {
                             metric_kind: 'other',
                             metric_name: 'triggered',
                             team_id: team2.id,
-                        }),
-                    }),
-                ])
-            )
-        })
-    })
-
-    describe('quota limiting for teams with legacy data_pipelines addon', () => {
-        let fnTeamLegacy1: HogFunctionType
-        let fnTeamLegacy2: HogFunctionType
-        let globals: HogFunctionInvocationGlobals
-
-        beforeEach(async () => {
-            // Create functions for team (which has data_pipelines by default)
-            fnTeamLegacy1 = await insertHogFunction({
-                team_id: team.id,
-                ...HOG_EXAMPLES.simple_fetch,
-                ...HOG_INPUTS_EXAMPLES.simple_fetch_data_warehouse_table,
-                ...HOG_FILTERS_EXAMPLES.no_filters_data_warehouse_table,
-            })
-
-            fnTeamLegacy2 = await insertHogFunction({
-                team_id: team.id,
-                ...HOG_EXAMPLES.input_printer,
-                ...HOG_INPUTS_EXAMPLES.simple_fetch_data_warehouse_table,
-                ...HOG_FILTERS_EXAMPLES.no_filters_data_warehouse_table,
-            })
-
-            // Globals for team (with data_pipelines - legacy addon)
-            const event = createDataWarehouseEvent(team.id, { test_prop: 'test_value' })
-            const messages = [createKafkaMessage(event)]
-            globals = (await processor._parseKafkaBatch(messages))[0]
-        })
-
-        it('should not filter out functions when team has legacy data_pipelines addon', async () => {
-            // Mock quota limiting to return true BUT team has legacy addon
-            jest.mocked(hub.quotaLimiting.isTeamQuotaLimited).mockClear()
-            jest.mocked(hub.quotaLimiting.isTeamQuotaLimited).mockResolvedValue(true)
-
-            const { invocations } = await processor.processBatch([globals])
-
-            // Team has data_pipelines so should NOT be filtered despite quota limit
-            expect(invocations).toHaveLength(2)
-            expect(hub.quotaLimiting.isTeamQuotaLimited).toHaveBeenCalledWith(team.id, 'cdp_trigger_events')
-
-            // Check that triggered metrics were produced (not quota_limited)
-            const metrics = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
-            expect(metrics).toEqual(
-                expect.arrayContaining([
-                    expect.objectContaining({
-                        topic: 'clickhouse_app_metrics2_test',
-                        value: expect.objectContaining({
-                            app_source: 'hog_function',
-                            app_source_id: fnTeamLegacy1.id,
-                            metric_kind: 'other',
-                            metric_name: 'triggered',
-                            team_id: team.id,
-                        }),
-                    }),
-                    expect.objectContaining({
-                        topic: 'clickhouse_app_metrics2_test',
-                        value: expect.objectContaining({
-                            app_source: 'hog_function',
-                            app_source_id: fnTeamLegacy2.id,
-                            metric_kind: 'other',
-                            metric_name: 'triggered',
-                            team_id: team.id,
-                        }),
-                    }),
-                ])
-            )
-
-            // Ensure no quota_limited metrics
-            expect(metrics).not.toEqual(
-                expect.arrayContaining([
-                    expect.objectContaining({
-                        value: expect.objectContaining({
-                            metric_name: 'quota_limited',
                         }),
                     }),
                 ])

--- a/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
@@ -150,19 +150,17 @@ export class CdpDatawarehouseEventsConsumer extends CdpConsumerBase {
                 if (isQuotaLimited && !isTeamOnLegacyAddon) {
                     counterQuotaLimited.labels({ team_id: item.teamId }).inc()
 
-                    // TODO: Once happy - we add the below code to track a quota limited metric and skip the invocation
-
-                    // this.hogFunctionMonitoringService.queueAppMetric(
-                    //     {
-                    //         team_id: item.teamId,
-                    //         app_source_id: item.functionId,
-                    //         metric_kind: 'failure',
-                    //         metric_name: 'quota_limited',
-                    //         count: 1,
-                    //     },
-                    //     'hog_function'
-                    // )
-                    // return
+                    this.hogFunctionMonitoringService.queueAppMetric(
+                        {
+                            team_id: item.teamId,
+                            app_source_id: item.functionId,
+                            metric_kind: 'failure',
+                            metric_name: 'quota_limited',
+                            count: 1,
+                        },
+                        'hog_function'
+                    )
+                    return
                 }
 
                 const state = states[item.hogFunction.id].state

--- a/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
@@ -82,10 +82,11 @@ export class CdpDatawarehouseEventsConsumer extends CdpConsumerBase {
         invocationGlobals: HogFunctionInvocationGlobals[]
     ): Promise<CyclotronJobInvocation[]> {
         const teamsToLoad = [...new Set(invocationGlobals.map((x) => x.project.id))]
-        const [hogFunctionsByTeam, teamsById] = await Promise.all([
-            this.hogFunctionManager.getHogFunctionsForTeams(teamsToLoad, this.hogTypes, this.filterHogFunction),
-            this.hub.teamManager.getTeams(teamsToLoad),
-        ])
+        const hogFunctionsByTeam = await this.hogFunctionManager.getHogFunctionsForTeams(
+            teamsToLoad,
+            this.hogTypes,
+            this.filterHogFunction
+        )
 
         const possibleInvocations = (
             await Promise.all(
@@ -143,7 +144,6 @@ export class CdpDatawarehouseEventsConsumer extends CdpConsumerBase {
                 const shouldBlock = await shouldBlockInvocationDueToQuota(item, {
                     hub: this.hub,
                     hogFunctionMonitoringService: this.hogFunctionMonitoringService,
-                    teamsById,
                 })
 
                 if (shouldBlock) {

--- a/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
@@ -141,12 +141,12 @@ export class CdpDatawarehouseEventsConsumer extends CdpConsumerBase {
                     logger.error('🔴', 'Error checking rate limit for hog function', { err: e })
                 }
 
-                const shouldBlock = await shouldBlockInvocationDueToQuota(item, {
+                const isQuotaLimited = await shouldBlockInvocationDueToQuota(item, {
                     hub: this.hub,
                     hogFunctionMonitoringService: this.hogFunctionMonitoringService,
                 })
 
-                if (shouldBlock) {
+                if (isQuotaLimited) {
                     return
                 }
 

--- a/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.ts
@@ -21,7 +21,8 @@ import {
     MinimalAppMetric,
 } from '../types'
 import { CdpConsumerBase } from './cdp-base.consumer'
-import { counterHogFunctionStateOnEvent, counterParseError, counterQuotaLimited, counterRateLimited } from './metrics'
+import { counterHogFunctionStateOnEvent, counterParseError, counterRateLimited } from './metrics'
+import { shouldBlockInvocationDueToQuota } from './quota-limiting-helper'
 
 export class CdpDatawarehouseEventsConsumer extends CdpConsumerBase {
     protected name = 'CdpDatawarehouseEventsConsumer'
@@ -139,27 +140,13 @@ export class CdpDatawarehouseEventsConsumer extends CdpConsumerBase {
                     logger.error('🔴', 'Error checking rate limit for hog function', { err: e })
                 }
 
-                const isQuotaLimited = await this.hub.quotaLimiting.isTeamQuotaLimited(
-                    item.teamId,
-                    'cdp_trigger_events'
-                )
+                const shouldBlock = await shouldBlockInvocationDueToQuota(item, {
+                    hub: this.hub,
+                    hogFunctionMonitoringService: this.hogFunctionMonitoringService,
+                    teamsById,
+                })
 
-                // The legacy addon was not usage based so we skip dropping if they are on it
-                const isTeamOnLegacyAddon = !!teamsById[`${item.teamId}`]?.available_features.includes('data_pipelines')
-
-                if (isQuotaLimited && !isTeamOnLegacyAddon) {
-                    counterQuotaLimited.labels({ team_id: item.teamId }).inc()
-
-                    this.hogFunctionMonitoringService.queueAppMetric(
-                        {
-                            team_id: item.teamId,
-                            app_source_id: item.functionId,
-                            metric_kind: 'failure',
-                            metric_name: 'quota_limited',
-                            count: 1,
-                        },
-                        'hog_function'
-                    )
+                if (shouldBlock) {
                     return
                 }
 

--- a/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -50,10 +50,15 @@ describe.each([
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub()
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub) // This team has data_pipelines feature by default (legacy addon)
+
+        // Create second organization without data_pipelines for testing quota limiting
         const otherOrganizationId = await createOrganization(hub.postgres)
         const team2Id = await createTeam(hub.postgres, otherOrganizationId)
-        team2 = (await getTeam(hub, team2Id))!
+        team2 = (await getTeam(hub, team2Id))! // This team does NOT have data_pipelines
+
+        // Set up default quota limiting mock - not limited by default
+        jest.spyOn(hub.quotaLimiting, 'isTeamQuotaLimited').mockResolvedValue(false)
 
         processor = new Consumer(hub)
 
@@ -345,6 +350,214 @@ describe.each([
                         },
                     },
                 ])
+            })
+        })
+
+        describe('quota limiting for teams without legacy addon', () => {
+            let fnFetchNoFilters: HogFunctionType
+            let fnPrinterPageviewFilters: HogFunctionType
+            let globals: HogFunctionInvocationGlobals
+
+            beforeEach(async () => {
+                // Create functions for team2 (no data_pipelines feature)
+                fnFetchNoFilters = await insertHogFunction({
+                    team_id: team2.id,
+                    ...HOG_EXAMPLES.simple_fetch,
+                    ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                    ...HOG_FILTERS_EXAMPLES.no_filters,
+                })
+
+                fnPrinterPageviewFilters = await insertHogFunction({
+                    team_id: team2.id,
+                    ...HOG_EXAMPLES.input_printer,
+                    ...HOG_INPUTS_EXAMPLES.secret_inputs,
+                    ...HOG_FILTERS_EXAMPLES.pageview_or_autocapture_filter,
+                })
+
+                // Globals for team2 (without data_pipelines)
+                globals = createHogExecutionGlobals({
+                    project: {
+                        id: team2.id,
+                    } as any,
+                    event: {
+                        uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
+                        event: '$pageview',
+                        properties: {
+                            $current_url: 'https://posthog.com',
+                            $lib_version: '1.0.0',
+                        },
+                    } as any,
+                })
+            })
+
+            it('should filter out functions when team is quota limited', async () => {
+                // Mock quota limiting to return true for team2 (which doesn't have data_pipelines)
+                jest.mocked(hub.quotaLimiting.isTeamQuotaLimited).mockClear()
+                jest.mocked(hub.quotaLimiting.isTeamQuotaLimited).mockResolvedValue(true)
+
+                const { invocations } = await processor.processBatch([globals])
+
+                expect(hub.quotaLimiting.isTeamQuotaLimited).toHaveBeenCalledWith(team2.id, 'cdp_trigger_events')
+
+                // Now check invocations length - should be 0 because team2 is quota limited and has no legacy addon
+                expect(invocations).toHaveLength(0)
+
+                // Check that quota_limited metrics were produced
+                const metrics = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
+                expect(metrics).toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({
+                            topic: 'clickhouse_app_metrics2_test',
+                            value: expect.objectContaining({
+                                app_source: 'hog_function',
+                                app_source_id: fnFetchNoFilters.id,
+                                count: 1,
+                                metric_kind: 'failure',
+                                metric_name: 'quota_limited',
+                                team_id: team2.id,
+                            }),
+                        }),
+                        expect.objectContaining({
+                            topic: 'clickhouse_app_metrics2_test',
+                            value: expect.objectContaining({
+                                app_source: 'hog_function',
+                                app_source_id: fnPrinterPageviewFilters.id,
+                                count: 1,
+                                metric_kind: 'failure',
+                                metric_name: 'quota_limited',
+                                team_id: team2.id,
+                            }),
+                        }),
+                    ])
+                )
+            })
+
+            it('should not filter out functions when team is not quota limited', async () => {
+                // Mock quota limiting to return false for team2
+                jest.mocked(hub.quotaLimiting.isTeamQuotaLimited).mockClear()
+                jest.mocked(hub.quotaLimiting.isTeamQuotaLimited).mockResolvedValue(false)
+
+                const { invocations } = await processor.processBatch([globals])
+
+                expect(invocations).toHaveLength(2)
+                expect(hub.quotaLimiting.isTeamQuotaLimited).toHaveBeenCalledWith(team2.id, 'cdp_trigger_events')
+
+                // Check that triggered metrics were produced instead
+                const metrics = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
+                expect(metrics).toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({
+                            topic: 'clickhouse_app_metrics2_test',
+                            value: expect.objectContaining({
+                                app_source: 'hog_function',
+                                app_source_id: fnFetchNoFilters.id,
+                                count: 1,
+                                metric_kind: 'other',
+                                metric_name: 'triggered',
+                                team_id: team2.id,
+                            }),
+                        }),
+                        expect.objectContaining({
+                            topic: 'clickhouse_app_metrics2_test',
+                            value: expect.objectContaining({
+                                app_source: 'hog_function',
+                                app_source_id: fnPrinterPageviewFilters.id,
+                                count: 1,
+                                metric_kind: 'other',
+                                metric_name: 'triggered',
+                                team_id: team2.id,
+                            }),
+                        }),
+                    ])
+                )
+            })
+        })
+
+        describe('quota limiting for teams with legacy data_pipelines addon', () => {
+            let fnTeamLegacy1: HogFunctionType
+            let fnTeamLegacy2: HogFunctionType
+            let globals: HogFunctionInvocationGlobals
+
+            beforeEach(async () => {
+                // Create functions for team (which has data_pipelines by default)
+                fnTeamLegacy1 = await insertHogFunction({
+                    team_id: team.id,
+                    ...HOG_EXAMPLES.simple_fetch,
+                    ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                    ...HOG_FILTERS_EXAMPLES.no_filters,
+                })
+
+                fnTeamLegacy2 = await insertHogFunction({
+                    team_id: team.id,
+                    ...HOG_EXAMPLES.input_printer,
+                    ...HOG_INPUTS_EXAMPLES.secret_inputs,
+                    ...HOG_FILTERS_EXAMPLES.pageview_or_autocapture_filter,
+                })
+
+                // Globals for team (with data_pipelines - legacy addon)
+                globals = createHogExecutionGlobals({
+                    project: {
+                        id: team.id,
+                    } as any,
+                    event: {
+                        uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
+                        event: '$pageview',
+                        properties: {
+                            $current_url: 'https://posthog.com',
+                            $lib_version: '1.0.0',
+                        },
+                    } as any,
+                })
+            })
+
+            it('should not filter out functions when team has legacy data_pipelines addon', async () => {
+                // Mock quota limiting to return true BUT team has legacy addon
+                jest.mocked(hub.quotaLimiting.isTeamQuotaLimited).mockClear()
+                jest.mocked(hub.quotaLimiting.isTeamQuotaLimited).mockResolvedValue(true)
+
+                const { invocations } = await processor.processBatch([globals])
+
+                // Team has data_pipelines so should NOT be filtered despite quota limit
+                expect(invocations).toHaveLength(2)
+                expect(hub.quotaLimiting.isTeamQuotaLimited).toHaveBeenCalledWith(team.id, 'cdp_trigger_events')
+
+                // Check that triggered metrics were produced (not quota_limited)
+                const metrics = mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
+                expect(metrics).toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({
+                            topic: 'clickhouse_app_metrics2_test',
+                            value: expect.objectContaining({
+                                app_source: 'hog_function',
+                                app_source_id: fnTeamLegacy1.id,
+                                metric_kind: 'other',
+                                metric_name: 'triggered',
+                                team_id: team.id,
+                            }),
+                        }),
+                        expect.objectContaining({
+                            topic: 'clickhouse_app_metrics2_test',
+                            value: expect.objectContaining({
+                                app_source: 'hog_function',
+                                app_source_id: fnTeamLegacy2.id,
+                                metric_kind: 'other',
+                                metric_name: 'triggered',
+                                team_id: team.id,
+                            }),
+                        }),
+                    ])
+                )
+
+                // Ensure no quota_limited metrics
+                expect(metrics).not.toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({
+                            value: expect.objectContaining({
+                                metric_name: 'quota_limited',
+                            }),
+                        }),
+                    ])
+                )
             })
         })
 

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -140,12 +140,12 @@ export class CdpEventsConsumer extends CdpConsumerBase {
                     logger.error('🔴', 'Error checking rate limit for hog function', { err: e })
                 }
 
-                const shouldBlock = await shouldBlockInvocationDueToQuota(item, {
+                const isQuotaLimited = await shouldBlockInvocationDueToQuota(item, {
                     hub: this.hub,
                     hogFunctionMonitoringService: this.hogFunctionMonitoringService,
                 })
 
-                if (shouldBlock) {
+                if (isQuotaLimited) {
                     return
                 }
 

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -81,10 +81,11 @@ export class CdpEventsConsumer extends CdpConsumerBase {
         await this.groupsManager.enrichGroups(invocationGlobals)
 
         const teamsToLoad = [...new Set(invocationGlobals.map((x) => x.project.id))]
-        const [hogFunctionsByTeam, teamsById] = await Promise.all([
-            this.hogFunctionManager.getHogFunctionsForTeams(teamsToLoad, this.hogTypes, this.filterHogFunction),
-            this.hub.teamManager.getTeams(teamsToLoad),
-        ])
+        const hogFunctionsByTeam = await this.hogFunctionManager.getHogFunctionsForTeams(
+            teamsToLoad,
+            this.hogTypes,
+            this.filterHogFunction
+        )
 
         const possibleInvocations = (
             await Promise.all(
@@ -142,7 +143,6 @@ export class CdpEventsConsumer extends CdpConsumerBase {
                 const shouldBlock = await shouldBlockInvocationDueToQuota(item, {
                     hub: this.hub,
                     hogFunctionMonitoringService: this.hogFunctionMonitoringService,
-                    teamsById,
                 })
 
                 if (shouldBlock) {

--- a/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events.consumer.ts
@@ -149,19 +149,17 @@ export class CdpEventsConsumer extends CdpConsumerBase {
                 if (isQuotaLimited && !isTeamOnLegacyAddon) {
                     counterQuotaLimited.labels({ team_id: item.teamId }).inc()
 
-                    // TODO: Once happy - we add the below code to track a quota limited metric and skip the invocation
-
-                    // this.hogFunctionMonitoringService.queueAppMetric(
-                    //     {
-                    //         team_id: item.teamId,
-                    //         app_source_id: item.functionId,
-                    //         metric_kind: 'failure',
-                    //         metric_name: 'quota_limited',
-                    //         count: 1,
-                    //     },
-                    //     'hog_function'
-                    // )
-                    // return
+                    this.hogFunctionMonitoringService.queueAppMetric(
+                        {
+                            team_id: item.teamId,
+                            app_source_id: item.functionId,
+                            metric_kind: 'failure',
+                            metric_name: 'quota_limited',
+                            count: 1,
+                        },
+                        'hog_function'
+                    )
+                    return
                 }
 
                 const state = states[item.hogFunction.id].state

--- a/plugin-server/src/cdp/consumers/quota-limiting-helper.ts
+++ b/plugin-server/src/cdp/consumers/quota-limiting-helper.ts
@@ -1,0 +1,47 @@
+import { QuotaResource } from '../../common/services/quota-limiting.service'
+import { Team } from '../../types'
+import { HogFunctionMonitoringService } from '../services/monitoring/hog-function-monitoring.service'
+import { CyclotronJobInvocationHogFunction } from '../types'
+import { counterQuotaLimited } from './metrics'
+
+export interface QuotaLimitingContext {
+    hub: {
+        quotaLimiting: {
+            isTeamQuotaLimited: (teamId: number, resource: QuotaResource) => Promise<boolean>
+        }
+    }
+    hogFunctionMonitoringService: HogFunctionMonitoringService
+    teamsById: Record<string, Team | null>
+}
+
+/**
+ * Checks if an invocation should be quota limited and handles the appropriate metrics.
+ * Returns true if the invocation should be blocked, false otherwise.
+ */
+export async function shouldBlockInvocationDueToQuota(
+    item: CyclotronJobInvocationHogFunction,
+    context: QuotaLimitingContext
+): Promise<boolean> {
+    const isQuotaLimited = await context.hub.quotaLimiting.isTeamQuotaLimited(item.teamId, 'cdp_trigger_events')
+
+    // The legacy addon was not usage based so we skip dropping if they are on it
+    const isTeamOnLegacyAddon = !!context.teamsById[`${item.teamId}`]?.available_features.includes('data_pipelines')
+
+    if (isQuotaLimited && !isTeamOnLegacyAddon) {
+        counterQuotaLimited.labels({ team_id: item.teamId }).inc()
+
+        context.hogFunctionMonitoringService.queueAppMetric(
+            {
+                team_id: item.teamId,
+                app_source_id: item.functionId,
+                metric_kind: 'failure',
+                metric_name: 'quota_limited',
+                count: 1,
+            },
+            'hog_function'
+        )
+        return true
+    }
+
+    return false
+}

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -232,6 +232,7 @@ export type MinimalAppMetric = {
         | 'email_blocked'
         | 'email_spam'
         | 'email_unsubscribed'
+        | 'quota_limited'
     count: number
 }
 


### PR DESCRIPTION
## Changes

  1. Quota Limiting Enforcement
    - Added quota limiting check for CDP trigger events before processing hog functions
    - Teams that exceed their quota have their CDP invocations blocked
    - dispatch metrics tracking for quota-limited events

## How did you test this code
- added tests