### PR TITLE
feat(phai): lazy reading of the data warehouse schema

### DIFF
--- a/ee/hogai/core/agent_modes/presets/sql.py
+++ b/ee/hogai/core/agent_modes/presets/sql.py
@@ -15,11 +15,12 @@ POSITIVE_EXAMPLE_INSIGHT_WITH_SEGMENTATION = """
 User: what is our ARR from the US?
 Assistant: I'll help you find your current ARR from the US users. Let me create a todo list to track this implementation.
 *Creates todo list with the following items:*
-1. Find the relevant data warehouse tables having financial data to create an SQL query
-2. Find in the tables a column that can be used to associate a user with the PostHog's default table "persons."
-3. Retrieve person properties to narrow down data to users from specific country
-4. Execute the SQL query
-5. Analyze retrieved data
+1. Read the core data warehouse schema to see what tables are available (events, persons, groups, sessions, and list of warehouse tables)
+2. Read specific warehouse table schemas that might contain financial/revenue data
+3. Find a column in the financial tables that can be used to join with the persons table
+4. Write SQL query joining financial data with persons to filter by country property
+5. Execute the SQL query and analyze retrieved data
+6. Analyze the retrieved data
 *Begins working on the first task*
 """.strip()
 
@@ -31,23 +32,27 @@ The assistant used the todo list because:
 4. Property values might require retrieving sample property values to understand the data better.
 5. Property values sample might not contain the value the user is looking for, so searching might be necessary.
 6. Taxonomy and data warehouse schema might have multiple combinations of data that will equally answer the question.
+7. Multiple warehouse tables might contain financial data, so progressive reading helps identify the right one.
 """.strip()
 
 POSITIVE_EXAMPLE_COMPANY_CHURN_ANALYSIS = """
 User: Has eleventy churned?
 Assistant: Let me first check the insights or events and properties to understand how we can track churn.
 *Uses the search tool to find insights and the read_taxonomy tool to find events and properties that can be used to track churn*
-Assistant: I haven't found any combinations of events and properties that can be used to track churn. Let me check how we can identify the company by a name in the project.
-*Uses the read_taxonomy tool to find properties that can be used to identify the company by a name in the project*
-Assistant: I've found properties that can be used to identify the company by a name in the project. I'm going to create an SQL query to find a specific company by a name.
-*Creates a todo list with specific steps to create a new SQL query*
+Assistant: I haven't found existing churn insights. Let me read the data warehouse schema to see what tables are available.
+*Uses read_data with data_warehouse_schema to see core tables and available warehouse tables*
+Assistant: I see there's a subscriptions table. Let me get its full schema.
+*Uses read_data with data_warehouse_table to get the subscriptions table schema*
+Assistant: Now I can write an SQL query to check if eleventy has churned based on their subscription status.
+*Creates a todo list with the remaining steps to execute and analyze the query*
 """.strip()
 
 POSITIVE_EXAMPLE_COMPANY_CHURN_ANALYSIS_REASONING = """
 The assistant used the todo list because:
-1. First, the assistant searched to understand the scope of the task
-2. After the assistant verified that there isn't an insight or combination of events and properties tracking the customer churn rate, it determined this was a complex task with multiple steps
-3. The todo list helps ensure every instance is tracked and updated systematically
+1. First, the assistant searched existing insights and taxonomy to understand what's already available
+2. Then progressively read the data warehouse: first the overview to see available tables, then specific table schemas
+3. This progressive approach avoided loading unnecessary schema information while identifying the right data source
+4. The todo list helps ensure every instance is tracked and updated systematically
 """.strip()
 
 POSITIVE_EXAMPLE_MULTIPLE_METRICS_ANALYSIS = """

--- a/ee/hogai/tools/read_data.py
+++ b/ee/hogai/tools/read_data.py
@@ -46,16 +46,16 @@ Use this tool to read user data created in PostHog. This tool returns data that 
 Read the SQL ClickHouse schema (tables, views, and columns) for the user's data.
 
 ## Available operations:
-- `list_tables`: Returns core PostHog tables (events, groups, persons, sessions) with their full schemas, plus a list of available data warehouse tables and views (names only). Use this first to see what data is available.
-- `table_schema`: Returns the full schema for a specific data warehouse table or view. Use this after `list_tables` to get details on specific tables you need.
+- `data_warehouse_schema`: Returns core PostHog tables (events, groups, persons, sessions) with their full schemas, plus a list of available data warehouse tables and views (names only). Use this first to see what data is available.
+- `data_warehouse_table`: Returns the full schema for a specific data warehouse table or view. Use this after `data_warehouse_schema` to get details on specific tables you need.
 
 You MUST use this tool when:
 - Working with SQL.
 - The request is about data warehouse, connected data sources, etc.
 
 Workflow:
-1. Start with `list_tables` to see available tables
-2. Use `table_schema` with a specific `table_name` to get schema details for warehouse tables you need
+1. Start with `data_warehouse_schema` to see available tables
+2. Use `data_warehouse_table` with a specific `table_name` to get schema details for warehouse tables you need
 
 # Insight
 
@@ -106,13 +106,13 @@ Query definition:
 class ReadDataWarehouseSchema(BaseModel):
     """Returns core PostHog tables (events, groups, persons, sessions) with their full schemas, plus a list of available data warehouse tables and views (names only)."""
 
-    kind: Literal["list_tables"] = "list_tables"
+    kind: Literal["data_warehouse_schema"] = "data_warehouse_schema"
 
 
 class ReadDataWarehouseTableSchema(BaseModel):
     """Returns the full schema with columns for a specific data warehouse table or view."""
 
-    kind: Literal["table_schema"] = "table_schema"
+    kind: Literal["data_warehouse_table"] = "data_warehouse_table"
     table_name: str = Field(description="The name of the table to read the schema for.")
 
 
@@ -228,8 +228,8 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
                 return result, None
             case ReadDataWarehouseSchema():
                 return await self._read_data_warehouse_schema(), None
-            case ReadDataWarehouseTableSchema() as table_schema:
-                return await self._read_data_warehouse_table_schema(table_schema.table_name), None
+            case ReadDataWarehouseTableSchema() as data_warehouse_table:
+                return await self._read_data_warehouse_table_schema(data_warehouse_table.table_name), None
             case ReadArtifacts():
                 return await self._read_artifacts()
             case ReadInsight() as schema:
@@ -331,14 +331,14 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
 
         if warehouse_tables:
             lines.append("# Data warehouse tables")
-            lines.append("Use `table_schema` with the table name to get the full schema.\n")
+            lines.append("Use `data_warehouse_table` with the table name to get the full schema.\n")
             for name in sorted(warehouse_tables):
                 lines.append(f"- {name}")
             lines.append("")
 
         if views:
             lines.append("# Views")
-            lines.append("Use `table_schema` with the view name to get the full schema.\n")
+            lines.append("Use `data_warehouse_table` with the view name to get the full schema.\n")
             for name in sorted(views):
                 lines.append(f"- {name}")
             lines.append("")

--- a/ee/hogai/tools/test/test_read_data.py
+++ b/ee/hogai/tools/test/test_read_data.py
@@ -453,7 +453,7 @@ class TestReadDataTool(BaseTest):
 
         result, _ = await tool._arun_impl({"kind": "data_warehouse_schema"})
 
-        assert "# Views" in result
+        assert "# Data warehouse views" in result
         assert "- my_custom_view" in result
         assert "- revenue_summary" in result
 

--- a/ee/hogai/tools/test/test_read_data.py
+++ b/ee/hogai/tools/test/test_read_data.py
@@ -21,7 +21,6 @@ from ee.hogai.utils.types.base import ArtifactRefMessage, NodePath
 
 class TestReadDataTool(BaseTest):
     async def test_create_tool_class_with_billing_access(self):
-        """Test that billing prompt is included when user has billing access."""
         team = MagicMock()
         user = MagicMock()
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
@@ -40,7 +39,6 @@ class TestReadDataTool(BaseTest):
         assert "Billing information" in tool.description
 
     async def test_create_tool_class_without_billing_access(self):
-        """Test that billing prompt is excluded when user lacks billing access."""
         team = MagicMock()
         user = MagicMock()
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
@@ -57,12 +55,10 @@ class TestReadDataTool(BaseTest):
         # Description should NOT include billing prompt
         assert "billing_info" not in tool.description
         assert "Billing information" not in tool.description
-
-        # Should still have base prompt content
-        assert "data warehouse" in tool.description
+        assert "list_tables" in tool.description
+        assert "read_table_schema" in tool.description
 
     async def test_create_tool_class_without_context_manager(self):
-        """Test that create_tool_class creates context manager if not provided."""
         team = MagicMock()
         user = MagicMock()
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))

--- a/ee/hogai/tools/test/test_read_data.py
+++ b/ee/hogai/tools/test/test_read_data.py
@@ -425,7 +425,7 @@ class TestReadDataTool(BaseTest):
         assert "# Data warehouse tables" in result
         assert "- hubspot_contacts" in result
         assert "- stripe_customers" in result
-        assert "Use `data_warehouse_table` with the table name to get the full schema" in result
+        assert "Use the `read_data` tool with the `data_warehouse_table` kind" in result
 
     async def test_list_tables_includes_views(self):
         """Test that data_warehouse_schema includes view names."""

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -16,6 +16,7 @@ import { IconQuestionAnswer, IconRobot } from 'lib/lemon-ui/icons'
 import { Scene } from 'scenes/sceneTypes'
 
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+import { isObject } from '~/lib/utils'
 import { AgentMode, AssistantTool } from '~/queries/schema/schema-assistant-messages'
 import { RecordingUniversalFilters } from '~/types'
 
@@ -225,7 +226,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
         ) {
             if (
                 this.subtools &&
-                typeof toolCall.args.query === 'object' &&
+                isObject(toolCall.args?.query) &&
                 toolCall.args.query &&
                 'kind' in toolCall.args.query &&
                 typeof toolCall.args.query.kind === 'string' &&
@@ -255,26 +256,33 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
                     return 'Reading billing data...'
                 },
             },
-            list_tables: {
-                name: 'List data warehouse tables',
-                description: 'List data warehouse tables available in this project',
+            data_warehouse_schema: {
+                name: 'Read data warehouse schema',
+                description: 'Read data warehouse schema available in this project',
                 icon: iconForType('data_warehouse'),
                 displayFormatter: (toolCall) => {
                     if (toolCall.status === 'completed') {
-                        return 'Listed data warehouse tables'
+                        return 'Read data warehouse schema'
                     }
-                    return 'Listing data warehouse tables...'
+                    return 'Reading data warehouse schema...'
                 },
             },
-            read_table_schema: {
-                name: 'Read table schema',
-                description: 'Read table schema for a specific table',
+            data_warehouse_table: {
+                name: 'Read data warehouse table schema',
+                description: 'Read data warehouse table schema for a specific table',
                 icon: iconForType('data_warehouse'),
                 displayFormatter: (toolCall) => {
+                    const tableName =
+                        isObject(toolCall.args?.query) && 'table_name' in toolCall.args.query
+                            ? toolCall.args.query.table_name
+                            : null
+
                     if (toolCall.status === 'completed') {
-                        return 'Read table schema'
+                        return tableName ? `Read schema for \`${tableName}\`` : 'Read data warehouse table schema'
                     }
-                    return 'Reading table schema...'
+                    return tableName
+                        ? `Reading schema for \`${tableName}\`...`
+                        : 'Reading data warehouse table schema...'
                 },
             },
             artifacts: {
@@ -295,7 +303,7 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
                 displayFormatter: (toolCall) => {
                     function isExecuting(): boolean {
                         return !!(
-                            typeof toolCall.args?.query === 'object' &&
+                            isObject(toolCall.args?.query) &&
                             toolCall.args?.query &&
                             'execute' in toolCall.args?.query &&
                             toolCall.args?.query.execute

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -255,15 +255,26 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
                     return 'Reading billing data...'
                 },
             },
-            datawarehouse_schema: {
-                name: 'Read your data warehouse schema',
-                description: 'Read your data warehouse schema',
+            list_tables: {
+                name: 'List data warehouse tables',
+                description: 'List data warehouse tables available in this project',
                 icon: iconForType('data_warehouse'),
                 displayFormatter: (toolCall) => {
                     if (toolCall.status === 'completed') {
-                        return 'Read data warehouse schema'
+                        return 'Listed data warehouse tables'
                     }
-                    return 'Reading data warehouse schema...'
+                    return 'Listing data warehouse tables...'
+                },
+            },
+            read_table_schema: {
+                name: 'Read table schema',
+                description: 'Read table schema for a specific table',
+                icon: iconForType('data_warehouse'),
+                displayFormatter: (toolCall) => {
+                    if (toolCall.status === 'completed') {
+                        return 'Read table schema'
+                    }
+                    return 'Reading table schema...'
                 },
             },
             artifacts: {

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -683,55 +683,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.10
   '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."queryable_folder",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.11
-  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -750,7 +701,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.12
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.11
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -780,7 +731,7 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.13
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.12
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
@@ -788,6 +739,18 @@
          AND "posthog_sessionrecordingviewed"."user_id" = 99999
          AND "posthog_sessionrecordingviewed"."session_id" IN ('session2',
                                                                'session1'))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.13
+  '''
+  SELECT "posthog_sessionrecordingviewed"."session_id",
+         "posthog_user"."email"
+  FROM "posthog_sessionrecordingviewed"
+  INNER JOIN "posthog_user" ON ("posthog_sessionrecordingviewed"."user_id" = "posthog_user"."id")
+  WHERE ("posthog_sessionrecordingviewed"."session_id" IN ('session2',
+                                                           'session1')
+         AND "posthog_sessionrecordingviewed"."team_id" = 99999
+         AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.14
@@ -1224,19 +1187,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.8
   '''
-  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
-         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
-         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
-         "posthog_teamrevenueanalyticsconfig"."events",
-         "posthog_teamrevenueanalyticsconfig"."goals",
-         "posthog_teamrevenueanalyticsconfig"."base_currency"
-  FROM "posthog_teamrevenueanalyticsconfig"
-  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.9
-  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -1263,6 +1213,55 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.9
+  '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."queryable_folder",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_1_multiple_snapshots
@@ -4199,6 +4198,55 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.10
   '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."queryable_folder",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.11
+  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -4217,7 +4265,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.11
+# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.12
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -4247,7 +4295,7 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.12
+# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.13
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
@@ -4255,18 +4303,6 @@
          AND "posthog_sessionrecordingviewed"."user_id" = 99999
          AND "posthog_sessionrecordingviewed"."session_id" IN ('at_base_time',
                                                                'at_base_time_plus_20'))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.13
-  '''
-  SELECT "posthog_sessionrecordingviewed"."session_id",
-         "posthog_user"."email"
-  FROM "posthog_sessionrecordingviewed"
-  INNER JOIN "posthog_user" ON ("posthog_sessionrecordingviewed"."user_id" = "posthog_user"."id")
-  WHERE ("posthog_sessionrecordingviewed"."session_id" IN ('at_base_time',
-                                                           'at_base_time_plus_20')
-         AND "posthog_sessionrecordingviewed"."team_id" = 99999
-         AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.14
@@ -4642,6 +4678,19 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.8
   '''
+  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
+         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
+         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
+         "posthog_teamrevenueanalyticsconfig"."events",
+         "posthog_teamrevenueanalyticsconfig"."goals",
+         "posthog_teamrevenueanalyticsconfig"."base_currency"
+  FROM "posthog_teamrevenueanalyticsconfig"
+  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.9
+  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -4668,55 +4717,6 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.9
-  '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."queryable_folder",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons


### PR DESCRIPTION
## Problem

Project 2 struggles to generate SQL queries because the serialized DWH schema is around 115k tokens. This PR enables the retrieval of a table schema on demand. Let's check how large the schema is with only views and tables.

**Demo**

<img width="557" height="557" alt="Screenshot 2025-12-17 at 14 54 37" src="https://github.com/user-attachments/assets/f0bce577-4cb3-4f2d-bb2e-b24150cffdd3" />


## Changes

- Refactored the read_data tool, so only system tables are now serialized in full.
- Added an argument to retrieve data for a specific table.
- Updated prompting around data warehouse schemas, so the agent retrieves tables progressively.

## How did you test this code?

Manual tests & unit tests.

## Changelog: (features only) Is this feature complete?

PostHog AI retrieves the data warehouse schema smartly by lazy reading tables and columns.
