### PR TITLE
fix: Don't capture team not existing exception

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -1889,9 +1889,12 @@ def surveys(request: Request):
             COUNTER_SURVEYS_API_USE_REMOTE_CONFIG.labels(result="found").inc()
             response = hypercache_response
 
+        except Team.DoesNotExist:
+            COUNTER_SURVEYS_API_USE_REMOTE_CONFIG.labels(result="not_found").inc()
+            pass
         except Exception as e:
             capture_exception(e)
-            COUNTER_SURVEYS_API_USE_REMOTE_CONFIG.labels(result="not_found").inc()
+            COUNTER_SURVEYS_API_USE_REMOTE_CONFIG.labels(result="error").inc()
             pass  # For now fallback
 
     # If we didn't get a hypercache response or we are comparing then load the normal response to compare


### PR DESCRIPTION
## Problem

We're catching tonnes of [useless exceptions](https://us.posthog.com/project/2/error_tracking/019a5869-1e7a-7a50-8c53-745e546c3c22?timestamp=2025-12-17%2006%3A05%3A39.447000-08%3A00).

## Changes

* Don't track if the team doesnt exist

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
