### PR TITLE
chore(insights): move pinned breakdown columns to Kea logic

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -2,9 +2,8 @@ import './InsightsTable.scss'
 
 import { useActions, useValues } from 'kea'
 import { compare as compareFn } from 'natural-orderby'
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 
-import { useLocalStorage } from 'lib/hooks/useLocalStorage'
 import { LemonTable, LemonTableColumn } from 'lib/lemon-ui/LemonTable'
 import { COUNTRY_CODE_TO_LONG_NAME } from 'lib/utils/geography/country'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -89,39 +88,11 @@ export function InsightsTable({
         insightData,
     } = useValues(trendsDataLogic(insightProps))
     const { toggleResultHidden, toggleAllResultsHidden } = useActions(trendsDataLogic(insightProps))
-    const { aggregation, allowAggregation } = useValues(insightsTableDataLogic(insightProps))
-    const { setDetailedResultsAggregationType } = useActions(insightsTableDataLogic(insightProps))
+    const { aggregation, allowAggregation, pinnedColumns, isColumnPinned } = useValues(
+        insightsTableDataLogic(insightProps)
+    )
+    const { setDetailedResultsAggregationType, toggleColumnPin } = useActions(insightsTableDataLogic(insightProps))
     const { weekStartDay, timezone } = useValues(teamLogic)
-
-    // Pinned breakdown columns state (persisted in localStorage per insight)
-    const storageKey = insight?.short_id
-        ? `insight-pinned-columns-${insight.short_id}`
-        : 'insight-pinned-columns-default'
-    const [pinnedBreakdownColumns, setPinnedBreakdownColumns] = useLocalStorage<string[]>(storageKey, [])
-
-    const pinnedColumns = useMemo(() => {
-        const pinned: string[] = ['label'] // Series column is always pinned
-        return [...pinned, ...pinnedBreakdownColumns]
-    }, [pinnedBreakdownColumns])
-
-    const toggleColumnPin = useCallback(
-        (columnKey: string): void => {
-            setPinnedBreakdownColumns((current) => {
-                if (current.includes(columnKey)) {
-                    return current.filter((k) => k !== columnKey)
-                }
-                return [...current, columnKey]
-            })
-        },
-        [setPinnedBreakdownColumns]
-    )
-
-    const isColumnPinned = useCallback(
-        (columnKey: string): boolean => {
-            return pinnedBreakdownColumns.includes(columnKey)
-        },
-        [pinnedBreakdownColumns]
-    )
 
     const handleSeriesEditClick = (item: IndexedTrendResult): void => {
         const entityFilter = entityFilterLogic.findMounted({

--- a/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.ts
+++ b/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.ts
@@ -1,4 +1,4 @@
-import { connect, kea, key, path, props, selectors } from 'kea'
+import { actions, connect, kea, key, path, props, reducers, selectors } from 'kea'
 
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
@@ -26,7 +26,39 @@ export const insightsTableDataLogic = kea<insightsTableDataLogicType>([
         actions: [insightVizDataLogic(props), ['setDetailedResultsAggregationType']],
     })),
 
+    actions({
+        toggleColumnPin: (columnKey: string) => ({ columnKey }),
+    }),
+
+    reducers({
+        pinnedBreakdownColumns: [
+            [] as string[],
+            { persist: true },
+            {
+                toggleColumnPin: (state, { columnKey }) => {
+                    if (state.includes(columnKey)) {
+                        return state.filter((k) => k !== columnKey)
+                    }
+                    return [...state, columnKey]
+                },
+            },
+        ],
+    }),
+
     selectors({
+        pinnedColumns: [
+            (s) => [s.pinnedBreakdownColumns],
+            (pinnedBreakdownColumns): string[] => {
+                return ['label', ...pinnedBreakdownColumns]
+            },
+        ],
+        isColumnPinned: [
+            (s) => [s.pinnedBreakdownColumns],
+            (pinnedBreakdownColumns) =>
+                (columnKey: string): boolean => {
+                    return pinnedBreakdownColumns.includes(columnKey)
+                },
+        ],
         /** Only allow table aggregation options when the math is total volume
          * otherwise double counting will happen when the math is set to unique.
          * Except when view type is Table or WorldMap */


### PR DESCRIPTION
Re: https://github.com/PostHog/posthog/pull/43494

- Replaced useLocalStorage hook with persisted Kea reducer
- Added toggleColumnPin action, pinnedBreakdownColumns reducer
- Added pinnedColumns and isColumnPinned selectors
- Persistence handled via Kea's persist: true option

## How did you test this code?

locally
