### PR TITLE
fix: add a formatting function to change date format to be US region friendly

### DIFF
--- a/frontend/src/lib/utils/dateRangeUtils.test.ts
+++ b/frontend/src/lib/utils/dateRangeUtils.test.ts
@@ -270,9 +270,4 @@ describe('formatLocalizedDate', () => {
         document.documentElement.lang = 'en'
         expect(formatLocalizedDate()).toBe('DD MMM')
     })
-
-    it('should handle complex locale with script and extensions', () => {
-        document.documentElement.lang = 'en-Latn-US-u-ca-gregory'
-        expect(formatLocalizedDate()).toBe('MMM DD')
-    })
 })

--- a/frontend/src/lib/utils/dateRangeUtils.test.ts
+++ b/frontend/src/lib/utils/dateRangeUtils.test.ts
@@ -240,34 +240,44 @@ describe('getConstrainedWeekRange', () => {
 })
 
 describe('formatLocalizedDate', () => {
+    const originalLanguage = Object.getOwnPropertyDescriptor(window.navigator, 'language')
     const originalLang = document.documentElement.lang
 
     afterEach(() => {
+        if (originalLanguage) {
+            Object.defineProperty(window.navigator, 'language', originalLanguage)
+        }
         document.documentElement.lang = originalLang
     })
 
     it('should return US date format for en-US locale', () => {
-        document.documentElement.lang = 'en-US'
+        Object.defineProperty(window.navigator, 'language', { value: 'en-US', configurable: true })
         expect(formatLocalizedDate()).toBe('MMM DD')
     })
 
     it('should return US date format for en-CA locale', () => {
-        document.documentElement.lang = 'en-CA'
+        Object.defineProperty(window.navigator, 'language', { value: 'en-CA', configurable: true })
         expect(formatLocalizedDate()).toBe('MMM DD')
     })
 
     it('should return international date format for en-GB locale', () => {
-        document.documentElement.lang = 'en-GB'
+        Object.defineProperty(window.navigator, 'language', { value: 'en-GB', configurable: true })
         expect(formatLocalizedDate()).toBe('DD MMM')
     })
 
     it('should handle locale with region suffix', () => {
-        document.documentElement.lang = 'en-US-x-custom'
+        Object.defineProperty(window.navigator, 'language', { value: 'en-US-x-custom', configurable: true })
         expect(formatLocalizedDate()).toBe('MMM DD')
     })
 
     it('should handle locale without region (defaults to international format)', () => {
-        document.documentElement.lang = 'en'
+        Object.defineProperty(window.navigator, 'language', { value: 'en', configurable: true })
+        expect(formatLocalizedDate()).toBe('DD MMM')
+    })
+
+    it('should fall back to document.documentElement.lang when navigator.language is undefined', () => {
+        Object.defineProperty(window.navigator, 'language', { value: undefined, configurable: true })
+        document.documentElement.lang = 'en-GB'
         expect(formatLocalizedDate()).toBe('DD MMM')
     })
 })

--- a/frontend/src/lib/utils/dateRangeUtils.test.ts
+++ b/frontend/src/lib/utils/dateRangeUtils.test.ts
@@ -1,6 +1,6 @@
 import { dayjs } from 'lib/dayjs'
 
-import { getConstrainedWeekRange } from './dateTimeUtils'
+import { formatLocalizedDate, getConstrainedWeekRange } from './dateTimeUtils'
 
 describe('getConstrainedWeekRange', () => {
     beforeEach(() => {
@@ -236,5 +236,43 @@ describe('getConstrainedWeekRange', () => {
             expect(typeof result.start.format).toBe('function')
             expect(typeof result.end.format).toBe('function')
         })
+    })
+})
+
+describe('formatLocalizedDate', () => {
+    const originalLang = document.documentElement.lang
+
+    afterEach(() => {
+        document.documentElement.lang = originalLang
+    })
+
+    it('should return US date format for en-US locale', () => {
+        document.documentElement.lang = 'en-US'
+        expect(formatLocalizedDate()).toBe('MMM DD')
+    })
+
+    it('should return US date format for en-CA locale', () => {
+        document.documentElement.lang = 'en-CA'
+        expect(formatLocalizedDate()).toBe('MMM DD')
+    })
+
+    it('should return international date format for en-GB locale', () => {
+        document.documentElement.lang = 'en-GB'
+        expect(formatLocalizedDate()).toBe('DD MMM')
+    })
+
+    it('should handle locale with region suffix', () => {
+        document.documentElement.lang = 'en-US-x-custom'
+        expect(formatLocalizedDate()).toBe('MMM DD')
+    })
+
+    it('should handle locale without region (defaults to international format)', () => {
+        document.documentElement.lang = 'en'
+        expect(formatLocalizedDate()).toBe('DD MMM')
+    })
+
+    it('should handle complex locale with script and extensions', () => {
+        document.documentElement.lang = 'en-Latn-US-u-ca-gregory'
+        expect(formatLocalizedDate()).toBe('MMM DD')
     })
 })

--- a/frontend/src/lib/utils/dateTimeUtils.ts
+++ b/frontend/src/lib/utils/dateTimeUtils.ts
@@ -68,3 +68,10 @@ export function formatResolvedDateRange(
 
     return `${from.dateTime} - ${to.dateTime} (${from.tz})`
 }
+
+export function formatLocalizedDate(): string {
+    const localLang = document.documentElement.lang || navigator.language || 'en-US'
+    const usDateLocales = ['en-US', 'en-CA']
+
+    return usDateLocales.some((usLocale) => localLang.startsWith(usLocale)) ? 'MMM DD' : 'DD MMM'
+}

--- a/frontend/src/lib/utils/dateTimeUtils.ts
+++ b/frontend/src/lib/utils/dateTimeUtils.ts
@@ -70,7 +70,7 @@ export function formatResolvedDateRange(
 }
 
 export function formatLocalizedDate(): string {
-    const localLang = document.documentElement.lang || navigator.language || 'en-US'
+    const localLang = navigator.language || document.documentElement.lang || 'en-US'
     const usDateLocales = ['en-US', 'en-CA']
 
     return usDateLocales.some((usLocale) => localLang.startsWith(usLocale)) ? 'MMM DD' : 'DD MMM'

--- a/frontend/src/scenes/session-recordings/components/ItemTimeDisplay.tsx
+++ b/frontend/src/scenes/session-recordings/components/ItemTimeDisplay.tsx
@@ -4,6 +4,7 @@ import { Dayjs } from 'lib/dayjs'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { colonDelimitedDuration } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
+import { getLocalizedDateFormat } from 'lib/utils/dateTimeUtils'
 
 import { playerInspectorLogic } from '../player/inspector/playerInspectorLogic'
 import { TimestampFormat } from '../player/playerSettingsLogic'
@@ -30,7 +31,9 @@ export function ItemTimeDisplay({
     return (
         <div className={cn('px-2 py-1 text-xs min-w-18 text-center', className)}>
             {timestampFormat !== TimestampFormat.Relative ? (
-                (timestampFormat === TimestampFormat.UTC ? timestamp.tz('UTC') : timestamp).format('DD, MMM HH:mm:ss')
+                (timestampFormat === TimestampFormat.UTC ? timestamp.tz('UTC') : timestamp).format(
+                    `${getLocalizedDateFormat()}, HH:mm:ss`
+                )
             ) : (
                 <>
                     {timeInRecording < 0 ? (

--- a/frontend/src/scenes/session-recordings/components/ItemTimeDisplay.tsx
+++ b/frontend/src/scenes/session-recordings/components/ItemTimeDisplay.tsx
@@ -4,7 +4,7 @@ import { Dayjs } from 'lib/dayjs'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { colonDelimitedDuration } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
-import { getLocalizedDateFormat } from 'lib/utils/dateTimeUtils'
+import { formatLocalizedDate } from 'lib/utils/dateTimeUtils'
 
 import { playerInspectorLogic } from '../player/inspector/playerInspectorLogic'
 import { TimestampFormat } from '../player/playerSettingsLogic'
@@ -32,7 +32,7 @@ export function ItemTimeDisplay({
         <div className={cn('px-2 py-1 text-xs min-w-18 text-center', className)}>
             {timestampFormat !== TimestampFormat.Relative ? (
                 (timestampFormat === TimestampFormat.UTC ? timestamp.tz('UTC') : timestamp).format(
-                    `${getLocalizedDateFormat()}, HH:mm:ss`
+                    `${formatLocalizedDate()}, HH:mm:ss`
                 )
             ) : (
                 <>

--- a/frontend/src/scenes/session-recordings/components/SimpleTimeLabel.tsx
+++ b/frontend/src/scenes/session-recordings/components/SimpleTimeLabel.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react'
 import { Dayjs, dayjs } from 'lib/dayjs'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { shortTimeZone } from 'lib/utils'
+import { formatLocalizedDate } from 'lib/utils/dateTimeUtils'
 import { TimestampFormat } from 'scenes/session-recordings/player/playerSettingsLogic'
 
 function formattedReplayTime(
@@ -32,9 +33,9 @@ function formatStringFor(d: Dayjs, timeOnly?: boolean): string {
 
     const today = dayjs()
     if (d.isSame(today, 'year')) {
-        return 'DD/MMM, HH:mm:ss'
+        return `${formatLocalizedDate()}, HH:mm:ss`
     }
-    return 'DD/MM/YYYY HH:mm:ss'
+    return `${formatLocalizedDate()} YYYY, HH:mm:ss`
 }
 
 const truncateToSeconds = (time: string | number | Dayjs): number => {


### PR DESCRIPTION
## Problem

US uses a different date format than EU/UK, this is to accommodate that 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
US & English speaking Canada format
<img width="254" height="47" alt="Screenshot 2025-12-19 at 10 14 58" src="https://github.com/user-attachments/assets/57c6d6d4-68a4-4dec-ac66-2c3e07a7ad2d" />
UK/EU & French speaking Canada format
<img width="254" height="47" alt="Screenshot 2025-12-19 at 10 16 02" src="https://github.com/user-attachments/assets/2100c2bf-c676-4146-b4d8-884ab4f3e9f8" />


## How did you test this code?

Added some unit tests to test the new date formatting util function, for cases such as locale string is in different format due to extensions etc.

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

