### PR TITLE
chore: Rename customer feeds to profile

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -75,7 +75,7 @@ export function Group({ tabId }: { tabId?: string }): JSX.Element {
     }
 
     const settingLevel = featureFlags[FEATURE_FLAGS.ENVIRONMENTS] ? 'environment' : 'project'
-    const activeTab = groupTab ?? (featureFlags[FEATURE_FLAGS.CUSTOMER_ANALYTICS] ? 'feed' : 'overview')
+    const activeTab = groupTab ?? (featureFlags[FEATURE_FLAGS.CUSTOMER_ANALYTICS] ? 'profile' : 'overview')
 
     return (
         <SceneContent>
@@ -112,8 +112,8 @@ export function Group({ tabId }: { tabId?: string }): JSX.Element {
                     ...(featureFlags[FEATURE_FLAGS.CUSTOMER_ANALYTICS]
                         ? [
                               {
-                                  key: GroupsTabType.FEED,
-                                  label: <span data-attr="groups-feed-tab">Feed</span>,
+                                  key: GroupsTabType.PROFILE,
+                                  label: <span data-attr="groups-profile-tab">Profile</span>,
                                   content: <GroupFeedCanvas group={groupData} tabId={tabId} />,
                               },
                           ]

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -256,8 +256,8 @@ export function PersonScene(): JSX.Element | null {
                 tabs={[
                     feedEnabled
                         ? {
-                              key: PersonsTabType.FEED,
-                              label: <span data-attr="persons-feed-tab">Feed</span>,
+                              key: PersonsTabType.PROFILE,
+                              label: <span data-attr="persons-profile-tab">Profile</span>,
                               content: <PersonFeedCanvas person={person} />,
                           }
                         : false,

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -329,7 +329,7 @@ export const personsLogic = kea<personsLogicType>([
         currentTab: [(s) => [s.activeTab, s.defaultTab], (activeTab, defaultTab) => activeTab || defaultTab],
         defaultTab: [
             (s) => [s.feedEnabled],
-            (feedEnabled) => (feedEnabled ? PersonsTabType.FEED : PersonsTabType.PROPERTIES),
+            (feedEnabled) => (feedEnabled ? PersonsTabType.PROFILE : PersonsTabType.PROPERTIES),
         ],
         breadcrumbs: [
             (s) => [s.person, router.selectors.location],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1498,7 +1498,7 @@ export enum StepOrderValue {
 }
 
 export enum PersonsTabType {
-    FEED = 'feed',
+    PROFILE = 'profile',
     EVENTS = 'events',
     EXCEPTIONS = 'exceptions',
     SURVEY_RESPONSES = 'surveyResponses',
@@ -1511,7 +1511,7 @@ export enum PersonsTabType {
 }
 
 export enum GroupsTabType {
-    FEED = 'feed',
+    PROFILE = 'profile',
     NOTES = 'notes',
     OVERVIEW = 'overview',
 }


### PR DESCRIPTION
## Problem

The current UI refers to the customer analytics tab as "Feed" which may not accurately represent its purpose. Renaming it to "Profile" would better reflect the content and functionality of this tab.

## Changes

Renamed the "Feed" tab to "Profile" in both the Persons and Groups scenes:

- Updated tab labels from "Feed" to "Profile" in the UI
- Changed the corresponding enum values in `PersonsTabType` and `GroupsTabType` from `FEED` to `PROFILE`
- Updated data attributes from `data-attr="persons-feed-tab"` to `data-attr="persons-profile-tab"` and `data-attr="groups-feed-tab"` to `data-attr="groups-profile-tab"`
- Modified the default tab selection logic to use "profile" instead of "feed"

## How did you test this code?

Tested by:
- Verifying the tab name changes appear correctly in the UI for both Persons and Groups pages
- Confirming that navigation between tabs continues to work as expected
- Ensuring the default tab selection logic correctly defaults to "profile" when customer analytics is enabled