### PR TITLE
chore: Add tooltip explaining what power users are

### DIFF
--- a/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { urls } from 'scenes/urls'
@@ -99,7 +99,12 @@ function PowerUsersTable(): JSX.Element {
     return (
         <>
             <div className="flex items-center gap-2">
-                <h2 className="mb-0 ml-1">Power {customerLabel.plural}</h2>
+                <Tooltip
+                    title={`Power ${customerLabel.plural} are the ${customerLabel.plural} that performed your activity event most frequently in the past 30 days.`}
+                    // TODO: Add docs link when released
+                >
+                    <h2 className="mb-0 ml-1">Power {customerLabel.plural}</h2>
+                </Tooltip>
                 <LemonButton size="small" noPadding targetBlank to={buttonTo} tooltip={tooltip} />
             </div>
             <Query


### PR DESCRIPTION
## Problem

Power users are an important concept in customer analytics, but the current UI lacks a clear explanation of what they are, making it difficult for users to understand this metric.

## Changes

Added a tooltip to the "Power Users" heading that explains these are users who performed the activity event most frequently in the past 30 days.

## How did you test this code?

Tested the tooltip functionality by:
- Verifying the tooltip appears on hover
- Confirming the tooltip text is clear and helpful
- Checking that the tooltip positioning is correct and doesn't interfere with other UI elements

## Changelog:
No