### PR TITLE
feat(customers): Add search and hide null properties to notebook node properties

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroupProperties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroupProperties.tsx
@@ -7,6 +7,8 @@ import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 import { groupLogic } from 'scenes/groups/groupLogic'
 import { createPostHogWidgetNode } from 'scenes/notebooks/Nodes/NodeWrapper'
 
+import { PropertyDefinitionType } from '~/types'
+
 import { NotebookNodeType } from '../types'
 import { Properties } from './components/Properties'
 import { notebookNodeLogic } from './notebookNodeLogic'
@@ -28,19 +30,13 @@ const Component = (): JSX.Element | null => {
         return null
     }
 
-    const pinnedProperties = Object.fromEntries(
-        Object.entries(groupData.group_properties).filter(([key, _]) => pinnedGroupProperties.includes(key))
-    )
-    const unpinnedProperties = Object.fromEntries(
-        Object.entries(groupData.group_properties).filter(([key, _]) => !pinnedGroupProperties.includes(key))
-    )
-
     return (
         <Properties
-            pinnedProperties={pinnedProperties}
-            unpinnedProperties={unpinnedProperties}
+            properties={groupData.group_properties || {}}
+            pinnedProperties={pinnedGroupProperties}
             onPin={pinGroupProperty}
             onUnpin={unpinGroupProperty}
+            type={PropertyDefinitionType.Group}
         />
     )
 }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonProperties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonProperties.tsx
@@ -7,6 +7,8 @@ import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 import { createPostHogWidgetNode } from 'scenes/notebooks/Nodes/NodeWrapper'
 import { personLogic } from 'scenes/persons/personLogic'
 
+import { PropertyDefinitionType } from '~/types'
+
 import { NotebookNodeProps, NotebookNodeType } from '../types'
 import { Properties } from './components/Properties'
 import { notebookNodeLogic } from './notebookNodeLogic'
@@ -31,19 +33,13 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonPropertie
         return null
     }
 
-    const pinnedProperties = Object.fromEntries(
-        Object.entries(person.properties).filter(([key, _]) => pinnedPersonProperties.includes(key))
-    )
-    const unpinnedProperties = Object.fromEntries(
-        Object.entries(person.properties).filter(([key, _]) => !pinnedPersonProperties.includes(key))
-    )
-
     return (
         <Properties
-            pinnedProperties={pinnedProperties}
-            unpinnedProperties={unpinnedProperties}
+            properties={person.properties || {}}
+            pinnedProperties={pinnedPersonProperties}
             onPin={pinPersonProperty}
             onUnpin={unpinPersonProperty}
+            type={PropertyDefinitionType.Person}
         />
     )
 }

--- a/frontend/src/scenes/notebooks/Nodes/components/Properties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/Properties.tsx
@@ -10,6 +10,8 @@ import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 
 import { PropertyDefinitionType } from '~/types'
 
+import { sortProperties } from '../utils'
+
 interface PropertiesProps {
     properties: Record<string, any>
     pinnedProperties: string[]
@@ -46,25 +48,7 @@ export function Properties({
             entries = entries.filter(([, value]) => value !== null)
         }
 
-        entries.sort(([aKey], [bKey]) => {
-            const aIsPinned = pinnedProperties.includes(aKey)
-            const bIsPinned = pinnedProperties.includes(bKey)
-
-            if (aIsPinned && !bIsPinned) {
-                return -1
-            }
-            if (!aIsPinned && bIsPinned) {
-                return 1
-            }
-
-            // If both are pinned or both aren't, maintain their relative order
-            // based on the pinnedProperties array order for pinned items
-            if (aIsPinned && bIsPinned) {
-                return pinnedProperties.indexOf(aKey) - pinnedProperties.indexOf(bKey)
-            }
-
-            return aKey.localeCompare(bKey)
-        })
+        entries = sortProperties(entries, pinnedProperties)
 
         return Object.fromEntries(entries)
     }, [properties, searchTerm, hideNullValues, pinnedProperties])

--- a/frontend/src/scenes/notebooks/Nodes/components/Properties.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/Properties.tsx
@@ -1,60 +1,136 @@
+import { useActions, useValues } from 'kea'
+import { useMemo, useState } from 'react'
+
 import { IconPin, IconPinFilled } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonInput } from '@posthog/lemon-ui'
 
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
+import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 
 import { PropertyDefinitionType } from '~/types'
 
 interface PropertiesProps {
-    pinnedProperties: Record<string, string | number | boolean>
-    unpinnedProperties: Record<string, string | number | boolean>
+    properties: Record<string, any>
+    pinnedProperties: string[]
     onPin: (propertyName: string) => void
     onUnpin: (propertyName: string) => void
+    type: PropertyDefinitionType
 }
 
-export function Properties({ pinnedProperties, unpinnedProperties, ...props }: PropertiesProps): JSX.Element | null {
-    const numUnpinnedProperties = Object.keys(unpinnedProperties).length
-    const numPinnedProperties = Object.keys(pinnedProperties).length
+export function Properties({
+    properties,
+    pinnedProperties,
+    onPin,
+    onUnpin,
+    type,
+}: PropertiesProps): JSX.Element | null {
+    const [searchTerm, setSearchTerm] = useState('')
+    const { hideNullValues } = useValues(userPreferencesLogic)
+    const { setHideNullValues } = useActions(userPreferencesLogic)
+
+    const filteredProperties = useMemo(() => {
+        let entries = Object.entries(properties)
+
+        if (searchTerm) {
+            const normalizedSearchTerm = searchTerm.toLowerCase()
+            entries = entries.filter(([key, value]) => {
+                return (
+                    key.toLowerCase().includes(normalizedSearchTerm) ||
+                    JSON.stringify(value).toLowerCase().includes(normalizedSearchTerm)
+                )
+            })
+        }
+
+        if (hideNullValues) {
+            entries = entries.filter(([, value]) => value !== null)
+        }
+
+        entries.sort(([aKey], [bKey]) => {
+            const aIsPinned = pinnedProperties.includes(aKey)
+            const bIsPinned = pinnedProperties.includes(bKey)
+
+            if (aIsPinned && !bIsPinned) {
+                return -1
+            }
+            if (!aIsPinned && bIsPinned) {
+                return 1
+            }
+
+            // If both are pinned or both aren't, maintain their relative order
+            // based on the pinnedProperties array order for pinned items
+            if (aIsPinned && bIsPinned) {
+                return pinnedProperties.indexOf(aKey) - pinnedProperties.indexOf(bKey)
+            }
+
+            return aKey.localeCompare(bKey)
+        })
+
+        return Object.fromEntries(entries)
+    }, [properties, searchTerm, hideNullValues, pinnedProperties])
+
+    const numProperties = Object.keys(filteredProperties).length
+    const totalProperties = Object.keys(properties).length
 
     return (
         <div className="py-2 px-4 text-xs">
-            {Object.entries(pinnedProperties).map(([key, value], index) => {
-                const isLast = index === numPinnedProperties + numUnpinnedProperties - 1
-
-                return <PropertyItem key={key} name={key} value={value} isLast={isLast} isPinned {...props} />
-            })}
-            {Object.entries(unpinnedProperties).map(([key, value], index) => {
-                const isLast = index === numUnpinnedProperties - 1
-
-                return <PropertyItem key={key} name={key} value={value} isLast={isLast} {...props} />
-            })}
-        </div>
-    )
-}
-
-interface PropertyItemProps {
-    name: string
-    value: any
-    isLast: boolean
-    isPinned?: boolean
-    onPin: (propertyName: string) => void
-    onUnpin: (propertyName: string) => void
-}
-
-function PropertyItem({ name, value, isLast, isPinned = false, onPin, onUnpin }: PropertyItemProps): JSX.Element {
-    const Icon = isPinned ? IconPinFilled : IconPin
-    const onClick = isPinned ? () => onUnpin(name) : () => onPin(name)
-
-    return (
-        <div key={name} className="mb-1">
-            <div className="flex justify-between leading-4">
-                <PropertyKeyInfo value={name} />
-                <LemonButton noPadding size="small" icon={<Icon />} onClick={onClick} />
+            <div className="flex items-center gap-2 mb-2">
+                <LemonInput
+                    type="search"
+                    placeholder="Search properties..."
+                    value={searchTerm}
+                    onChange={setSearchTerm}
+                    size="small"
+                    className="flex-1"
+                />
+                <LemonCheckbox
+                    checked={!hideNullValues}
+                    onChange={(checked) => setHideNullValues(!checked)}
+                    label="Show null"
+                    size="small"
+                />
             </div>
-            <div className={`${!isLast && 'border-b border-primary pb-1'}`}>
-                <PropertiesTable properties={value} rootKey={name} type={PropertyDefinitionType.Person} />
-            </div>
+
+            {numProperties === 0 ? (
+                <div className="text-muted text-center py-2 text-xs">
+                    {searchTerm || hideNullValues
+                        ? `No properties match your filters (${totalProperties} total)`
+                        : 'No properties'}
+                </div>
+            ) : (
+                <div>
+                    {Object.entries(filteredProperties).map(([key, value], index) => {
+                        const isPinned = pinnedProperties.includes(key)
+                        const Icon = isPinned ? IconPinFilled : IconPin
+                        const onClick = isPinned ? () => onUnpin(key) : () => onPin(key)
+                        const isLast = index === numProperties - 1
+
+                        return (
+                            <div key={key} className="mb-1">
+                                <div className="flex justify-between leading-4">
+                                    <PropertyKeyInfo value={key} />
+                                    <LemonButton noPadding size="small" icon={<Icon />} onClick={onClick} />
+                                </div>
+                                <div className={`${!isLast && 'border-b border-primary pb-1'}`}>
+                                    <PropertiesTable
+                                        properties={value}
+                                        rootKey={key}
+                                        type={type}
+                                        embedded
+                                        sortProperties={false}
+                                    />
+                                </div>
+                            </div>
+                        )
+                    })}
+                </div>
+            )}
+
+            {(searchTerm || hideNullValues) && numProperties > 0 && (
+                <div className="text-muted text-xs mt-1">
+                    Showing {numProperties} of {totalProperties} properties
+                </div>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/notebooks/Nodes/utils.test.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/utils.test.tsx
@@ -10,6 +10,7 @@ import {
     SHORT_CODE_REGEX_MATCH_GROUPS,
     UUID_REGEX_MATCH_GROUPS,
     createUrlRegex,
+    sortProperties,
     useSyncedAttributes,
 } from './utils'
 
@@ -172,6 +173,213 @@ describe('notebook node utils', () => {
             regex = createUrlRegex(url)
             matches = regex.exec('http://localhost/insights/TAg12F?dashboardId=1234')
             expect(matches?.[1]).toEqual('TAg12F')
+        })
+    })
+
+    describe('sortProperties', () => {
+        describe('pinned properties take priority', () => {
+            it('should place pinned properties before non-pinned ones', () => {
+                const entries: [string, any][] = [
+                    ['name', 'John'],
+                    ['email', 'john@example.com'],
+                    ['age', 25],
+                ]
+                const pinnedProperties = ['email']
+
+                const result = sortProperties(entries, pinnedProperties)
+
+                expect(result).toEqual([
+                    ['email', 'john@example.com'],
+                    ['age', 25],
+                    ['name', 'John'],
+                ])
+            })
+
+            it('should maintain pinned properties in their specified order', () => {
+                const entries: [string, any][] = [
+                    ['name', 'John'],
+                    ['email', 'john@example.com'],
+                    ['userId', '123'],
+                    ['timestamp', '2023-01-01'],
+                ]
+                const pinnedProperties = ['userId', 'email', 'name']
+
+                const result = sortProperties(entries, pinnedProperties)
+
+                expect(result).toEqual([
+                    ['userId', '123'],
+                    ['email', 'john@example.com'],
+                    ['name', 'John'],
+                    ['timestamp', '2023-01-01'],
+                ])
+            })
+
+            it('should sort non-pinned properties alphabetically after pinned ones', () => {
+                const entries: [string, any][] = [
+                    ['zebra', 'value1'],
+                    ['apple', 'value2'],
+                    ['priority', 'value3'],
+                    ['banana', 'value4'],
+                ]
+                const pinnedProperties = ['priority']
+
+                const result = sortProperties(entries, pinnedProperties)
+
+                expect(result).toEqual([
+                    ['priority', 'value3'],
+                    ['apple', 'value2'],
+                    ['banana', 'value4'],
+                    ['zebra', 'value1'],
+                ])
+            })
+        })
+
+        describe('alphabetical sorting for non-pinned properties', () => {
+            it('should sort all properties alphabetically when none are pinned', () => {
+                const entries: [string, any][] = [
+                    ['zebra', 'last'],
+                    ['apple', 'first'],
+                    ['middle', 'second'],
+                    ['banana', 'third'],
+                ]
+
+                const result = sortProperties(entries, [])
+
+                expect(result).toEqual([
+                    ['apple', 'first'],
+                    ['banana', 'third'],
+                    ['middle', 'second'],
+                    ['zebra', 'last'],
+                ])
+            })
+
+            it('should handle case sensitivity in alphabetical sorting', () => {
+                const entries: [string, any][] = [
+                    ['Apple', 'capital'],
+                    ['apple', 'lowercase'],
+                    ['Zebra', 'capital-z'],
+                ]
+
+                const result = sortProperties(entries, [])
+
+                expect(result).toEqual([
+                    ['apple', 'lowercase'],
+                    ['Apple', 'capital'],
+                    ['Zebra', 'capital-z'],
+                ])
+            })
+
+            it('should handle special characters properly', () => {
+                const entries: [string, any][] = [
+                    ['normal', 'regular'],
+                    ['$special', 'dollar'],
+                    ['_underscore', 'underscore'],
+                    ['regular', 'alphabetic'],
+                ]
+
+                const result = sortProperties(entries, [])
+
+                expect(result).toEqual([
+                    ['_underscore', 'underscore'],
+                    ['$special', 'dollar'],
+                    ['normal', 'regular'],
+                    ['regular', 'alphabetic'],
+                ])
+            })
+        })
+
+        describe('edge cases', () => {
+            it('should handle empty entries array', () => {
+                const result = sortProperties([], ['some', 'pinned'])
+                expect(result).toEqual([])
+            })
+
+            it('should handle empty pinned properties', () => {
+                const entries: [string, any][] = [
+                    ['zebra', 'last'],
+                    ['apple', 'first'],
+                ]
+
+                const result = sortProperties(entries, [])
+
+                expect(result).toEqual([
+                    ['apple', 'first'],
+                    ['zebra', 'last'],
+                ])
+            })
+
+            it('should handle properties not in pinned array', () => {
+                const entries: [string, any][] = [
+                    ['notPinned1', 'value1'],
+                    ['notPinned2', 'value2'],
+                ]
+                const pinnedProperties = ['somethingElse']
+
+                const result = sortProperties(entries, pinnedProperties)
+
+                expect(result).toEqual([
+                    ['notPinned1', 'value1'],
+                    ['notPinned2', 'value2'],
+                ])
+            })
+
+            it('should handle duplicate property names gracefully', () => {
+                const entries: [string, any][] = [
+                    ['same', 'value1'],
+                    ['same', 'value2'],
+                ]
+
+                const result = sortProperties(entries, [])
+
+                expect(result).toEqual([
+                    ['same', 'value1'],
+                    ['same', 'value2'],
+                ])
+            })
+        })
+
+        describe('real-world scenarios', () => {
+            it('should sort PostHog event properties correctly', () => {
+                const entries: [string, any][] = [
+                    ['timestamp', '2023-01-01T10:00:00Z'],
+                    ['$current_url', 'https://example.com'],
+                    ['name', 'Button Click'],
+                    ['$browser', 'Chrome'],
+                    ['user_id', '12345'],
+                ]
+                const pinnedProperties = ['$current_url', '$browser']
+
+                const result = sortProperties(entries, pinnedProperties)
+
+                expect(result).toEqual([
+                    ['$current_url', 'https://example.com'],
+                    ['$browser', 'Chrome'],
+                    ['name', 'Button Click'],
+                    ['timestamp', '2023-01-01T10:00:00Z'],
+                    ['user_id', '12345'],
+                ])
+            })
+
+            it('should handle complex pinned order with many properties', () => {
+                const entries: [string, any][] = [
+                    ['prop5', 'value5'],
+                    ['prop1', 'value1'],
+                    ['unpinned', 'valueX'],
+                    ['prop3', 'value3'],
+                    ['another', 'valueY'],
+                ]
+                const pinnedProperties = ['prop1', 'prop2', 'prop3', 'prop4', 'prop5']
+
+                const result = sortProperties(entries, pinnedProperties)
+
+                expect(result).toEqual([
+                    ['prop1', 'value1'],
+                    ['prop3', 'value3'],
+                    ['prop5', 'value5'],
+                    ['another', 'valueY'],
+                    ['unpinned', 'valueX'],
+                ])
+            })
         })
     })
 })

--- a/frontend/src/scenes/notebooks/Nodes/utils.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/utils.tsx
@@ -169,3 +169,25 @@ export const getLogicKey = ({
     const entityKey = personId || groupKey
     return `${tabId}-${entityKey}`
 }
+
+export function sortProperties(entries: [string, any][], pinnedProperties: string[]): [string, any][] {
+    return entries.sort(([aKey], [bKey]) => {
+        const aIsPinned = pinnedProperties.includes(aKey)
+        const bIsPinned = pinnedProperties.includes(bKey)
+
+        if (aIsPinned && !bIsPinned) {
+            return -1
+        }
+        if (!aIsPinned && bIsPinned) {
+            return 1
+        }
+
+        // If both are pinned or both aren't, maintain their relative order
+        // based on the pinnedProperties array order for pinned items
+        if (aIsPinned && bIsPinned) {
+            return pinnedProperties.indexOf(aKey) - pinnedProperties.indexOf(bKey)
+        }
+
+        return aKey.localeCompare(bKey)
+    })
+}

--- a/frontend/src/scenes/notebooks/Nodes/utils.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/utils.tsx
@@ -171,9 +171,12 @@ export const getLogicKey = ({
 }
 
 export function sortProperties(entries: [string, any][], pinnedProperties: string[]): [string, any][] {
+    const pinnedSet = new Set(pinnedProperties)
+    const pinnedIndexMap = new Map(pinnedProperties.map((key, index) => [key, index]))
+
     return entries.sort(([aKey], [bKey]) => {
-        const aIsPinned = pinnedProperties.includes(aKey)
-        const bIsPinned = pinnedProperties.includes(bKey)
+        const aIsPinned = pinnedSet.has(aKey)
+        const bIsPinned = pinnedSet.has(bKey)
 
         if (aIsPinned && !bIsPinned) {
             return -1
@@ -185,7 +188,7 @@ export function sortProperties(entries: [string, any][], pinnedProperties: strin
         // If both are pinned or both aren't, maintain their relative order
         // based on the pinnedProperties array order for pinned items
         if (aIsPinned && bIsPinned) {
-            return pinnedProperties.indexOf(aKey) - pinnedProperties.indexOf(bKey)
+            return pinnedIndexMap.get(aKey)! - pinnedIndexMap.get(bKey)!
         }
 
         return aKey.localeCompare(bKey)


### PR DESCRIPTION
## Problem

The current properties display in notebooks for both person and group properties lacks filtering capabilities, making it difficult for users to find specific properties when dealing with large property sets.

## Changes

Enhanced the Properties component in notebooks with improved functionality:

- Added search functionality to filter properties by name or value
- Added option to show/hide null values
- Improved property sorting with pinned properties displayed first
- Maintained consistent sorting order within pinned and unpinned groups
- Added count indicators showing how many properties are displayed vs. total
- Simplified the component interface by passing the full properties object and pinned property list instead of pre-filtered objects

![image.png](https://app.graphite.com/user-attachments/assets/d2a91355-14f7-4c3c-9778-89829c020b58.png)![image.png](https://app.graphite.com/user-attachments/assets/f64c2b48-50ab-4457-a82d-f2a749f59bf6.png)![image.png](https://app.graphite.com/user-attachments/assets/c40bf7f4-1b3a-4333-b360-3e30d38ee9ef.png)

## How did you test this code?

Tested with various person and group property datasets, verifying:

- Search functionality correctly filters properties by both key and value
- Null value filtering works as expected
- Pinned properties consistently appear at the top of the list
- Property counts are accurate when filtering is applied
- Sorting behavior maintains expected order in all scenarios

## Changelog:

No