### PR TITLE
feat: allow duplicating survey from the surveys table

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -44,6 +44,7 @@ import {
     ActivityScope,
     PropertyFilterType,
     PropertyOperator,
+    Survey,
     SurveyEventName,
     SurveyEventProperties,
     SurveyQuestionType,
@@ -56,9 +57,8 @@ const RESOURCE_TYPE = 'survey'
 
 export function SurveyView({ id }: { id: string }): JSX.Element {
     const { survey, surveyLoading } = useValues(surveyLogic)
-    const { editingSurvey, updateSurvey, stopSurvey, resumeSurvey, duplicateSurvey, setIsDuplicateToProjectModalOpen } =
-        useActions(surveyLogic)
-    const { deleteSurvey } = useActions(surveysLogic)
+    const { editingSurvey, updateSurvey, stopSurvey, resumeSurvey } = useActions(surveyLogic)
+    const { deleteSurvey, duplicateSurvey, setSurveyToDuplicate } = useActions(surveysLogic)
     const { currentOrganization } = useValues(organizationLogic)
 
     const hasMultipleProjects = currentOrganization?.teams && currentOrganization.teams.length > 1
@@ -97,10 +97,12 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                             <SceneDuplicate
                                 dataAttrKey={RESOURCE_TYPE}
                                 onClick={() => {
+                                    // SurveyView is only rendered for existing surveys, so we can safely cast
+                                    const existingSurvey = survey as Survey
                                     if (hasMultipleProjects) {
-                                        setIsDuplicateToProjectModalOpen(true)
+                                        setSurveyToDuplicate(existingSurvey)
                                     } else {
-                                        duplicateSurvey()
+                                        duplicateSurvey(existingSurvey)
                                     }
                                 }}
                             />
@@ -322,7 +324,7 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                             },
                         ]}
                     />
-                    {hasMultipleProjects && <DuplicateToProjectModal />}
+                    <DuplicateToProjectModal />
                 </SceneContent>
             )}
         </div>

--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -24,6 +24,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType, ActivityScope } from '~/types'
 
+import { DuplicateToProjectModal } from './DuplicateToProjectModal'
 import { SurveySettings, SurveysDisabledBanner } from './SurveySettings'
 import { SURVEY_CREATED_SOURCE } from './constants'
 import { SurveysTabs, surveysLogic } from './surveysLogic'
@@ -138,6 +139,7 @@ function Surveys(): JSX.Element {
                     <SurveysTable />
                 </>
             )}
+            <DuplicateToProjectModal />
         </SceneContent>
     )
 }

--- a/frontend/src/scenes/surveys/components/SurveysTable.tsx
+++ b/frontend/src/scenes/surveys/components/SurveysTable.tsx
@@ -12,6 +12,7 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { createdAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { cn } from 'lib/utils/css-classes'
 import stringWithWBR from 'lib/utils/stringWithWBR'
+import { organizationLogic } from 'scenes/organizationLogic'
 import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings'
 import { SurveyStatusTag } from 'scenes/surveys/components/SurveyStatusTag'
 import { SurveysEmptyState } from 'scenes/surveys/components/empty-state/SurveysEmptyState'
@@ -38,9 +39,20 @@ export function SurveysTable(): JSX.Element {
         hasNextSearchPage,
         teamSdkVersions,
     } = useValues(surveysLogic)
+    const { currentOrganization } = useValues(organizationLogic)
 
-    const { deleteSurvey, updateSurvey, setSearchTerm, setSurveysFilters, loadNextPage, loadNextSearchPage } =
-        useActions(surveysLogic)
+    const {
+        deleteSurvey,
+        updateSurvey,
+        setSearchTerm,
+        setSurveysFilters,
+        loadNextPage,
+        loadNextSearchPage,
+        duplicateSurvey,
+        setSurveyToDuplicate,
+    } = useActions(surveysLogic)
+
+    const hasMultipleProjects = currentOrganization?.teams && currentOrganization.teams.length > 1
 
     const shouldShowEmptyState = !dataLoading && surveys.length === 0
 
@@ -183,6 +195,24 @@ export function SurveysTable(): JSX.Element {
                                             >
                                                 View
                                             </LemonButton>
+                                            <AccessControlAction
+                                                resourceType={AccessControlResourceType.Survey}
+                                                minAccessLevel={AccessControlLevel.Editor}
+                                                userAccessLevel={survey.user_access_level}
+                                            >
+                                                <LemonButton
+                                                    fullWidth
+                                                    onClick={() => {
+                                                        if (hasMultipleProjects) {
+                                                            setSurveyToDuplicate(survey)
+                                                        } else {
+                                                            duplicateSurvey(survey)
+                                                        }
+                                                    }}
+                                                >
+                                                    Duplicate
+                                                </LemonButton>
+                                            </AccessControlAction>
                                             {!survey.start_date && (
                                                 <AccessControlAction
                                                     resourceType={AccessControlResourceType.Survey}

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -10,7 +10,7 @@ import api from 'lib/api'
 import { FEATURE_FLAGS, PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { FeatureFlagsSet, featureFlagLogic as enabledFlagLogic } from 'lib/logic/featureFlagLogic'
-import { allOperatorsMapping, debounce, hasFormErrors, isObject, objectClean, pluralize } from 'lib/utils'
+import { allOperatorsMapping, debounce, hasFormErrors, isObject, objectClean } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { Scene } from 'scenes/sceneTypes'
@@ -197,23 +197,6 @@ export type DataCollectionType = 'until_stopped' | 'until_limit' | 'until_adapti
 export interface SurveyDateRange {
     date_from: string | null
     date_to: string | null
-}
-
-function duplicateExistingSurvey(survey: Survey | NewSurvey): Partial<Survey> {
-    return {
-        ...survey,
-        questions: survey.questions.map((question) => ({
-            ...question,
-            id: undefined,
-        })),
-        id: NEW_SURVEY.id,
-        name: `${survey.name} (duplicated at ${dayjs().format('YYYY-MM-DD HH:mm:ss')})`,
-        archived: false,
-        start_date: null,
-        end_date: null,
-        targeting_flag_filters: survey.targeting_flag?.filters ?? NEW_SURVEY.targeting_flag_filters,
-        linked_flag_id: survey.linked_flag?.id ?? NEW_SURVEY.linked_flag_id,
-    }
 }
 
 function isEmptyOrUndefined(value: any): boolean {
@@ -555,7 +538,6 @@ export const surveyLogic = kea<surveyLogicType>([
         setFilterSurveyStatsByDistinctId: (filterByDistinctId: boolean) => ({ filterByDistinctId }),
         setBaseStatsResults: (results: SurveyBaseStatsResult) => ({ results }),
         setDismissedAndSentCount: (count: DismissedAndSentCountResult) => ({ count }),
-        setIsDuplicateToProjectModalOpen: (isOpen: boolean) => ({ isOpen }),
         setShowArchivedResponses: (show: boolean) => ({ show }),
         archiveResponse: (responseUuid: string) => ({ responseUuid }),
         unarchiveResponse: (responseUuid: string) => ({ responseUuid }),
@@ -710,65 +692,6 @@ export const surveyLogic = kea<surveyLogicType>([
                     },
                 })
                 return response
-            },
-        },
-        duplicatedSurvey: {
-            duplicateSurvey: async () => {
-                const { survey } = values
-                const payload = duplicateExistingSurvey(survey)
-                try {
-                    const createdSurvey = await api.surveys.create(sanitizeSurvey(payload))
-
-                    lemonToast.success('Survey duplicated.', {
-                        toastId: `survey-duplicated-${createdSurvey.id}`,
-                        button: {
-                            label: 'View Survey',
-                            action: () => {
-                                router.actions.push(urls.survey(createdSurvey.id))
-                            },
-                        },
-                    })
-
-                    actions.setIsDuplicateToProjectModalOpen(false)
-                    actions.reportSurveyCreated(createdSurvey, true)
-                    actions.addProductIntent({
-                        product_type: ProductKey.SURVEYS,
-                        intent_context: ProductIntentContext.SURVEY_DUPLICATED,
-                        metadata: {
-                            survey_id: createdSurvey.id,
-                        },
-                    })
-                    return survey
-                } catch (error) {
-                    posthog.captureException(error, {
-                        action: 'duplicate-survey',
-                        survey: payload,
-                    })
-                    lemonToast.error('Error while duplicating survey. Please try again.')
-                    return null
-                }
-            },
-        },
-        duplicatedToProjectSurvey: {
-            duplicateToProject: async ({ sourceSurvey, targetTeamIds }) => {
-                const response = await api.surveys.duplicateToProjects(sourceSurvey.id, targetTeamIds)
-
-                lemonToast.success(`Survey duplicated to ${pluralize(response.count, 'project')}.`, {
-                    toastId: `survey-bulk-duplicated-${sourceSurvey.id}`,
-                })
-
-                actions.addProductIntent({
-                    product_type: ProductKey.SURVEYS,
-                    intent_context: ProductIntentContext.SURVEY_BULK_DUPLICATED,
-                    metadata: {
-                        survey_id: sourceSurvey.id,
-                        target_team_ids: targetTeamIds,
-                        bulk_operation: true,
-                    },
-                })
-
-                actions.setIsDuplicateToProjectModalOpen(false)
-                return sourceSurvey
             },
         },
         surveyBaseStats: {
@@ -952,12 +875,6 @@ export const surveyLogic = kea<surveyLogicType>([
                 actions.reportSurveyEdited(survey)
                 actions.loadSurveys()
             },
-            duplicateSurveySuccess: () => {
-                actions.loadSurveys()
-            },
-            duplicatedToProjectSurveySuccess: () => {
-                actions.loadSurveys()
-            },
             launchSurveySuccess: ({ survey }) => {
                 lemonToast.success(<>Survey {survey.name} launched</>)
                 actions.loadSurveys()
@@ -1128,12 +1045,6 @@ export const surveyLogic = kea<surveyLogicType>([
             false,
             {
                 editingSurvey: (_, { editing }) => editing,
-            },
-        ],
-        isDuplicateToProjectModalOpen: [
-            false,
-            {
-                setIsDuplicateToProjectModalOpen: (_, { isOpen }) => isOpen,
             },
         ],
         surveyMissing: [

--- a/frontend/src/scenes/surveys/surveysLogic.tsx
+++ b/frontend/src/scenes/surveys/surveysLogic.tsx
@@ -7,10 +7,11 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api, { CountedPaginatedResponse } from 'lib/api'
 import { featureFlagLogic as enabledFlagLogic } from 'lib/logic/featureFlagLogic'
+import { pluralize } from 'lib/utils'
 import { Scene } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
 import { SURVEY_CREATED_SOURCE, SURVEY_PAGE_SIZE, SurveyTemplate } from 'scenes/surveys/constants'
-import { sanitizeSurvey } from 'scenes/surveys/utils'
+import { duplicateExistingSurvey, sanitizeSurvey } from 'scenes/surveys/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -126,6 +127,7 @@ export const surveysLogic = kea<surveysLogicType>([
         setTab: (tab: SurveysTabs) => ({ tab }),
         loadNextPage: true,
         loadNextSearchPage: true,
+        setSurveyToDuplicate: (survey: Survey | null) => ({ survey }),
     }),
     loaders(({ values, actions }) => ({
         data: {
@@ -245,6 +247,54 @@ export const surveysLogic = kea<surveysLogicType>([
                 return surveysResponsesCount
             },
         },
+        duplicatedSurvey: {
+            __default: null as Survey | null,
+            duplicateSurvey: async (survey: Survey) => {
+                const payload = duplicateExistingSurvey(survey)
+                const createdSurvey = await api.surveys.create(sanitizeSurvey(payload))
+
+                lemonToast.success('Survey duplicated', {
+                    toastId: `survey-duplicated-${createdSurvey.id}`,
+                    button: {
+                        label: 'View survey',
+                        action: () => {
+                            router.actions.push(urls.survey(createdSurvey.id))
+                        },
+                    },
+                })
+
+                actions.setSurveyToDuplicate(null)
+                actions.addProductIntent({
+                    product_type: ProductKey.SURVEYS,
+                    intent_context: ProductIntentContext.SURVEY_DUPLICATED,
+                    metadata: {
+                        survey_id: createdSurvey.id,
+                    },
+                })
+
+                return createdSurvey
+            },
+            duplicateToProjects: async ({ survey, targetTeamIds }: { survey: Survey; targetTeamIds: number[] }) => {
+                const response = await api.surveys.duplicateToProjects(survey.id, targetTeamIds)
+
+                lemonToast.success(`Survey duplicated to ${pluralize(response.count, 'project')}`, {
+                    toastId: `survey-bulk-duplicated-${survey.id}`,
+                })
+
+                actions.addProductIntent({
+                    product_type: ProductKey.SURVEYS,
+                    intent_context: ProductIntentContext.SURVEY_BULK_DUPLICATED,
+                    metadata: {
+                        survey_id: survey.id,
+                        target_team_ids: targetTeamIds,
+                        bulk_operation: true,
+                    },
+                })
+
+                actions.setSurveyToDuplicate(null)
+                return survey
+            },
+        },
     })),
     reducers({
         isAppearanceModalOpen: [
@@ -288,6 +338,12 @@ export const surveysLogic = kea<surveysLogicType>([
                 loadNextSearchPageSuccess: (_, { data }) => hasMorePages(data.searchSurveys, data.searchSurveysCount),
             },
         ],
+        surveyToDuplicate: [
+            null as Survey | null,
+            {
+                setSurveyToDuplicate: (_, { survey }) => survey,
+            },
+        ],
     }),
     listeners(({ actions, values }) => ({
         deleteSurveySuccess: (_, __, action) => {
@@ -304,6 +360,12 @@ export const surveysLogic = kea<surveysLogicType>([
         updateSurveySuccess: () => {
             lemonToast.success('Survey updated')
             actions.loadCurrentTeam()
+        },
+        duplicateSurveySuccess: () => {
+            actions.loadSurveys()
+        },
+        duplicateToProjectsSuccess: () => {
+            actions.loadSurveys()
         },
         setSurveysFilters: () => {
             actions.loadSurveys()

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -4,7 +4,7 @@ import posthog from 'posthog-js'
 
 import { dayjs } from 'lib/dayjs'
 import { dateStringToDayJs } from 'lib/utils'
-import { NewSurvey, SURVEY_CREATED_SOURCE } from 'scenes/surveys/constants'
+import { NEW_SURVEY, NewSurvey, SURVEY_CREATED_SOURCE } from 'scenes/surveys/constants'
 import { SurveyRatingResults } from 'scenes/surveys/surveyLogic'
 
 import {
@@ -641,4 +641,21 @@ export function getExpressionCommentForQuestion(
 
 export function getSurveyForFeatureFlagVariant(variantKey: string, surveys?: Survey[]): Survey | undefined {
     return surveys?.find((survey) => survey.conditions?.linkedFlagVariant === variantKey)
+}
+
+export function duplicateExistingSurvey(survey: Survey | NewSurvey): Partial<Survey> {
+    return {
+        ...survey,
+        questions: survey.questions.map((question) => ({
+            ...question,
+            id: undefined,
+        })),
+        id: NEW_SURVEY.id,
+        name: `${survey.name} (duplicated at ${dayjs().format('YYYY-MM-DD HH:mm:ss')})`,
+        archived: false,
+        start_date: null,
+        end_date: null,
+        targeting_flag_filters: survey.targeting_flag?.filters ?? NEW_SURVEY.targeting_flag_filters,
+        linked_flag_id: survey.linked_flag?.id ?? NEW_SURVEY.linked_flag_id,
+    }
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

duplicating surveys is only available through the action menu, and only on the specific surveys page. makes discoverability hard

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

![CleanShot 2025-12-17 at 16.10.34@2x.jpg](https://app.graphite.com/user-attachments/assets/2e502728-3806-4f92-bc23-85d273968bbb.jpg)

adds the option to duplicate the survey from the Surveys table. plus moves the duplication logic to the surveysLogic instead so it doesn't need the other, and share the code between the two logics

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

tested locally

## Changelog: (features only) Is this feature complete?

Yes, it's complete.

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->