### PR TITLE
chore: add a delete from session replay metadata management command

### DIFF
--- a/posthog/management/commands/delete_session_replay_events.py
+++ b/posthog/management/commands/delete_session_replay_events.py
@@ -1,0 +1,160 @@
+import csv
+from collections.abc import Iterator
+
+from django.core.management.base import BaseCommand, CommandError
+
+from clickhouse_driver.errors import SocketTimeoutError
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models.team.team import Team
+from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
+
+BATCH_SIZE = 1000
+
+
+class Command(BaseCommand):
+    help = "Delete session replay events from ClickHouse by session_id"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", required=True, type=int, help="Team ID for the session recordings")
+        parser.add_argument("--session-ids", type=str, help="Comma-separated list of session IDs")
+        parser.add_argument("--csv-file", type=str, help="Path to CSV file with session IDs (single column)")
+        parser.add_argument("--skip-header", action="store_true", help="Skip the first row of the CSV file")
+        parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+        parser.add_argument("--batch-size", type=int, default=BATCH_SIZE, help=f"Batch size (default: {BATCH_SIZE})")
+
+    def handle(self, *args, **options):
+        team_id = options["team_id"]
+        session_ids_arg = options["session_ids"]
+        csv_file = options["csv_file"]
+        skip_header = options["skip_header"]
+        dry_run = options["dry_run"]
+        batch_size = options["batch_size"]
+
+        if not session_ids_arg and not csv_file:
+            raise CommandError("Must provide either --session-ids or --csv-file")
+
+        if session_ids_arg and csv_file:
+            raise CommandError("Provide only one of --session-ids or --csv-file, not both")
+
+        team = Team.objects.filter(id=team_id).first()
+        if not team:
+            raise CommandError(f"Team with ID {team_id} does not exist")
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Dry run - no changes will be made"))
+            self._process_dry_run(team, session_ids_arg, csv_file, skip_header, batch_size)
+        else:
+            self._process_deletions(team, session_ids_arg, csv_file, skip_header, batch_size)
+
+    def _iter_session_ids(self, session_ids_arg: str | None, csv_file: str | None, skip_header: bool) -> Iterator[str]:
+        if session_ids_arg:
+            for sid in session_ids_arg.split(","):
+                if sid.strip():
+                    yield sid.strip()
+            return
+
+        if csv_file:
+            try:
+                with open(csv_file, newline="") as f:
+                    reader = csv.reader(f)
+                    if skip_header:
+                        next(reader, None)
+                    for row in reader:
+                        if len(row) > 0 and row[0].strip():
+                            yield row[0].strip()
+            except FileNotFoundError:
+                raise CommandError(f"CSV file not found: {csv_file}")
+            except PermissionError:
+                raise CommandError(f"Permission denied reading CSV file: {csv_file}")
+            except OSError as e:
+                raise CommandError(f"Error reading CSV file {csv_file}: {e}")
+
+    def _iter_batches(
+        self, session_ids_arg: str | None, csv_file: str | None, skip_header: bool, batch_size: int
+    ) -> Iterator[list[str]]:
+        batch: list[str] = []
+
+        for sid in self._iter_session_ids(session_ids_arg, csv_file, skip_header):
+            batch.append(sid)
+
+            if len(batch) >= batch_size:
+                yield list(set(batch))
+                batch = []
+
+        if batch:
+            yield list(set(batch))
+
+    def _count_existing(self, team: Team, session_ids: list[str]) -> int:
+        result = sync_execute(
+            """
+            SELECT count(DISTINCT session_id)
+            FROM session_replay_events
+            WHERE team_id = %(team_id)s AND session_id IN %(session_ids)s
+            """,
+            {"team_id": team.pk, "session_ids": session_ids},
+        )
+        return result[0][0] if result else 0
+
+    def _process_dry_run(
+        self, team: Team, session_ids_arg: str | None, csv_file: str | None, skip_header: bool, batch_size: int
+    ) -> None:
+        total_would_delete = 0
+        total_not_found = 0
+        total_processed = 0
+
+        for batch in self._iter_batches(session_ids_arg, csv_file, skip_header, batch_size):
+            total_processed += len(batch)
+
+            existing_count = self._count_existing(team, batch)
+            total_would_delete += existing_count
+            total_not_found += len(batch) - existing_count
+
+            self.stdout.write(f"  Processed {total_processed} session IDs...")
+
+        if total_processed == 0:
+            self.stdout.write(self.style.WARNING("No session IDs to process"))
+            return
+
+        self.stdout.write("")
+        self.stdout.write(self.style.NOTICE(f"Would delete {total_would_delete} sessions from ClickHouse"))
+        self.stdout.write(self.style.SUCCESS(f"Not found in ClickHouse: {total_not_found} (no action needed)"))
+
+    def _process_deletions(
+        self, team: Team, session_ids_arg: str | None, csv_file: str | None, skip_header: bool, batch_size: int
+    ) -> None:
+        total_processed = 0
+        total_batches_deleted = 0
+
+        for batch in self._iter_batches(session_ids_arg, csv_file, skip_header, batch_size):
+            total_processed += len(batch)
+
+            query = f"""
+                DELETE FROM sharded_session_replay_events
+                ON CLUSTER '{CLICKHOUSE_CLUSTER}'
+                WHERE team_id = %(team_id)s AND session_id IN %(session_ids)s
+            """
+
+            try:
+                sync_execute(query, {"team_id": team.pk, "session_ids": batch})
+                total_batches_deleted += 1
+            except SocketTimeoutError:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Batch {total_batches_deleted + 1} timed out (mutation continues in background)"
+                    )
+                )
+                total_batches_deleted += 1
+
+            self.stdout.write(f"  Processed {total_processed} session IDs...")
+
+        if total_processed == 0:
+            self.stdout.write(self.style.WARNING("No session IDs to process"))
+            return
+
+        self.stdout.write("")
+        self.stdout.write(
+            self.style.SUCCESS(f"Issued {total_batches_deleted} delete mutations for {total_processed} session IDs")
+        )
+        self.stdout.write(self.style.NOTICE("Note: ClickHouse mutations run asynchronously in the background"))
+        self.stdout.write(self.style.SUCCESS("Done"))

--- a/posthog/management/commands/test/test_delete_session_replay_events.py
+++ b/posthog/management/commands/test/test_delete_session_replay_events.py
@@ -1,0 +1,188 @@
+import os
+import tempfile
+from io import StringIO
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.utils.timezone import now
+
+from dateutil.relativedelta import relativedelta
+from parameterized import parameterized
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models import Organization, Team
+from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
+
+
+class TestDeleteSessionReplayEventsCommand(ClickhouseTestMixin, APIBaseTest):
+    def _count_replay_events(self, team_id: int, session_ids: list[str]) -> int:
+        result = sync_execute(
+            """
+            SELECT count(DISTINCT session_id)
+            FROM session_replay_events
+            WHERE team_id = %(team_id)s AND session_id IN %(session_ids)s
+            """,
+            {"team_id": team_id, "session_ids": session_ids},
+        )
+        return result[0][0] if result else 0
+
+    def _create_replay(self, session_id: str, team_id: int | None = None) -> None:
+        produce_replay_summary(
+            session_id=session_id,
+            team_id=team_id or self.team.pk,
+            first_timestamp=now() - relativedelta(days=1),
+            last_timestamp=now() - relativedelta(days=1),
+            distinct_id="test_user",
+            retention_period_days=30,
+        )
+
+    @parameterized.expand(
+        [
+            ("single_id", "session1", ["session1"]),
+            ("multiple_ids", "session1,session2,session3", ["session1", "session2", "session3"]),
+            ("with_spaces", "session1, session2 , session3", ["session1", "session2", "session3"]),
+        ]
+    )
+    def test_deletes_session_replay_events(self, _name: str, session_ids_arg: str, expected_ids: list[str]):
+        for sid in expected_ids:
+            self._create_replay(sid)
+
+        assert self._count_replay_events(self.team.pk, expected_ids) == len(expected_ids)
+
+        call_command(
+            "delete_session_replay_events",
+            f"--team-id={self.team.id}",
+            f"--session-ids={session_ids_arg}",
+        )
+
+        assert self._count_replay_events(self.team.pk, expected_ids) == 0
+
+    @parameterized.expand(
+        [
+            ("without_header", "session1\nsession2\nsession3\n", False),
+            ("with_header", "session_id\nsession1\nsession2\nsession3\n", True),
+        ]
+    )
+    def test_parses_session_ids_from_csv_file(self, _name: str, csv_content: str, skip_header: bool):
+        expected_ids = ["session1", "session2", "session3"]
+        for sid in expected_ids:
+            self._create_replay(sid)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write(csv_content)
+            csv_path = f.name
+
+        try:
+            args = [
+                "delete_session_replay_events",
+                f"--team-id={self.team.id}",
+                f"--csv-file={csv_path}",
+            ]
+            if skip_header:
+                args.append("--skip-header")
+
+            call_command(*args)
+
+            assert self._count_replay_events(self.team.pk, expected_ids) == 0
+        finally:
+            os.unlink(csv_path)
+
+    def test_dry_run_does_not_delete_data(self):
+        self._create_replay("existing_session")
+
+        out = StringIO()
+        call_command(
+            "delete_session_replay_events",
+            f"--team-id={self.team.id}",
+            "--session-ids=existing_session",
+            "--dry-run",
+            stdout=out,
+        )
+
+        assert self._count_replay_events(self.team.pk, ["existing_session"]) == 1
+        assert "Would delete 1 sessions" in out.getvalue()
+
+    def test_dry_run_reports_not_found(self):
+        out = StringIO()
+        call_command(
+            "delete_session_replay_events",
+            f"--team-id={self.team.id}",
+            "--session-ids=nonexistent_session",
+            "--dry-run",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        assert "Would delete 0 sessions" in output
+        assert "Not found in ClickHouse: 1" in output
+
+    def test_only_affects_specified_team(self):
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+
+        self._create_replay("my_session", team_id=self.team.pk)
+        self._create_replay("other_session", team_id=other_team.pk)
+
+        call_command(
+            "delete_session_replay_events",
+            f"--team-id={self.team.id}",
+            "--session-ids=my_session,other_session",
+        )
+
+        assert self._count_replay_events(self.team.pk, ["my_session"]) == 0
+        assert self._count_replay_events(other_team.pk, ["other_session"]) == 1
+
+    def test_idempotent_running_twice_is_safe(self):
+        self._create_replay("session1")
+
+        call_command(
+            "delete_session_replay_events",
+            f"--team-id={self.team.id}",
+            "--session-ids=session1",
+        )
+
+        call_command(
+            "delete_session_replay_events",
+            f"--team-id={self.team.id}",
+            "--session-ids=session1",
+        )
+
+        assert self._count_replay_events(self.team.pk, ["session1"]) == 0
+
+    def test_raises_error_when_no_input_provided(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command(
+                "delete_session_replay_events",
+                f"--team-id={self.team.id}",
+            )
+        assert "Must provide either --session-ids or --csv-file" in str(cm.exception)
+
+    def test_raises_error_when_both_inputs_provided(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command(
+                "delete_session_replay_events",
+                f"--team-id={self.team.id}",
+                "--session-ids=session1",
+                "--csv-file=/tmp/test.csv",
+            )
+        assert "Provide only one of --session-ids or --csv-file" in str(cm.exception)
+
+    def test_raises_error_for_nonexistent_team(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command(
+                "delete_session_replay_events",
+                "--team-id=999999",
+                "--session-ids=session1",
+            )
+        assert "Team with ID 999999 does not exist" in str(cm.exception)
+
+    def test_raises_error_for_nonexistent_csv_file(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command(
+                "delete_session_replay_events",
+                f"--team-id={self.team.id}",
+                "--csv-file=/nonexistent/path/to/file.csv",
+            )
+        assert "CSV file not found" in str(cm.exception)

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -2997,6 +2997,55 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.10
   '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."queryable_folder",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.11
+  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -3015,7 +3064,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.11
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.12
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -3045,7 +3094,7 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.12
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.13
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
@@ -3055,7 +3104,7 @@
                                                                'at_base_time'))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.13
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.14
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id",
          "posthog_user"."email"
@@ -3065,16 +3114,6 @@
                                                            'at_base_time')
          AND "posthog_sessionrecordingviewed"."team_id" = 99999
          AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.14
-  '''
-  SELECT "posthog_sessionrecordingviewed"."session_id"
-  FROM "posthog_sessionrecordingviewed"
-  WHERE ("posthog_sessionrecordingviewed"."team_id" = 99999
-         AND "posthog_sessionrecordingviewed"."user_id" = 99999
-         AND "posthog_sessionrecordingviewed"."session_id" IN ('at_base_time_plus_20',
-                                                               'at_base_time'))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.15
@@ -3451,6 +3490,19 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.8
   '''
+  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
+         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
+         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
+         "posthog_teamrevenueanalyticsconfig"."events",
+         "posthog_teamrevenueanalyticsconfig"."goals",
+         "posthog_teamrevenueanalyticsconfig"."base_currency"
+  FROM "posthog_teamrevenueanalyticsconfig"
+  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.9
+  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -3477,55 +3529,6 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.9
-  '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."queryable_folder",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending


### PR DESCRIPTION
duplicated the postgres delete management command
with a clickhouse delete 

need to look at how the more robust temporal kob handles it

## Changelog: (features only) Is this feature complete?

no
