### PR TITLE
fix(dashboard-templates): fix error message for duplicate names

### DIFF
--- a/posthog/api/dashboards/dashboard_templates.py
+++ b/posthog/api/dashboards/dashboard_templates.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from django.db import IntegrityError
 from django.db.models import Q
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
@@ -52,6 +53,14 @@ class DashboardTemplateSerializer(serializers.ModelSerializer):
             "availability_contexts",
         ]
 
+    def _handle_integrity_error(self, exc: IntegrityError) -> None:
+        error_str = str(exc)
+        if "unique_template_name_per_team" in error_str:
+            raise ValidationError(
+                {"template_name": ["A dashboard template with this name already exists for this project."]}
+            ) from exc
+        raise exc
+
     def create(self, validated_data: dict, *args, **kwargs) -> DashboardTemplate:
         if not validated_data["tiles"]:
             raise ValidationError(detail="You need to provide tiles for the template.")
@@ -61,14 +70,20 @@ class DashboardTemplateSerializer(serializers.ModelSerializer):
             validated_data["scope"] = DashboardTemplate.Scope.ONLY_TEAM
 
         validated_data["team_id"] = self.context["team_id"]
-        return super().create(validated_data, *args, **kwargs)
+        try:
+            return super().create(validated_data, *args, **kwargs)
+        except IntegrityError as exc:
+            self._handle_integrity_error(exc)
 
     def update(self, instance: DashboardTemplate, validated_data: dict, *args, **kwargs) -> DashboardTemplate:
         # if the original request was to make the template scope to team only, and the template is none then deny the request
         if validated_data.get("scope") == "team" and instance.scope == "global" and not instance.team_id:
             raise ValidationError(detail="The original templates cannot be made private as they would be lost.")
 
-        return super().update(instance, validated_data, *args, **kwargs)
+        try:
+            return super().update(instance, validated_data, *args, **kwargs)
+        except IntegrityError as exc:
+            self._handle_integrity_error(exc)
 
 
 class DashboardTemplateViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):

--- a/posthog/api/dashboards/dashboard_templates.py
+++ b/posthog/api/dashboards/dashboard_templates.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import NoReturn
 
 from django.db import IntegrityError
 from django.db.models import Q
@@ -53,7 +54,7 @@ class DashboardTemplateSerializer(serializers.ModelSerializer):
             "availability_contexts",
         ]
 
-    def _handle_integrity_error(self, exc: IntegrityError) -> None:
+    def _handle_integrity_error(self, exc: IntegrityError) -> NoReturn:
         error_str = str(exc)
         if "unique_template_name_per_team" in error_str:
             raise ValidationError(

--- a/posthog/api/dashboards/test/test_dashboard_templates.py
+++ b/posthog/api/dashboards/test/test_dashboard_templates.py
@@ -109,6 +109,25 @@ class TestDashboardTemplates(APIBaseTest):
 
         assert get_template_from_response(response, dashboard_template.id)["team_id"] == self.team.pk
 
+    def test_create_dashboard_template_duplicate_name_returns_bad_request(self) -> None:
+        # create first template
+        self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            variable_template,
+        )
+
+        # create second template
+        duplicate_response = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            variable_template,
+        )
+
+        assert duplicate_response.status_code == status.HTTP_400_BAD_REQUEST, duplicate_response
+        assert (
+            duplicate_response.json()["detail"]
+            == "A dashboard template with this name already exists for this project."
+        )
+
     def test_staff_can_make_dashboard_template_public(self) -> None:
         assert self.team.pk is not None
         response = self.client.post(


### PR DESCRIPTION
## Problem

500 error when creating a dashboard template with an existing name

## Changes

400 error with message

## How did you test this code?

Added a test