### PR TITLE
feat(data-modeling): qol sync now from views tab

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -252,9 +252,9 @@ export const QueryDatabase = (): JSX.Element => {
                                             <ButtonPrimitive
                                                 menuItem
                                                 disabledReasons={{
-                                                    'Materialization is already running': item.record?.view?.status === 'Running',
+                                                    'Materialization is already running':
+                                                        item.record?.view?.status === 'Running',
                                                 }}
-                                            >
                                             >
                                                 Sync now
                                             </ButtonPrimitive>

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -45,7 +45,7 @@ export const QueryDatabase = (): JSX.Element => {
         openUnsavedQuery,
         deleteUnsavedQuery,
     } = useActions(queryDatabaseLogic)
-    const { deleteDataWarehouseSavedQuery } = useActions(dataWarehouseViewsLogic)
+    const { deleteDataWarehouseSavedQuery, runDataWarehouseSavedQuery } = useActions(dataWarehouseViewsLogic)
     const { deleteJoin } = useActions(dataWarehouseSettingsLogic)
 
     const { deleteDraft } = useActions(draftsLogic)
@@ -241,6 +241,22 @@ export const QueryDatabase = (): JSX.Element => {
                                     >
                                         <ButtonPrimitive menuItem>Add join</ButtonPrimitive>
                                     </DropdownMenuItem>
+                                    {item.record?.view?.is_materialized && (
+                                        <DropdownMenuItem
+                                            asChild
+                                            onClick={(e) => {
+                                                e.stopPropagation()
+                                                runDataWarehouseSavedQuery(viewId)
+                                            }}
+                                        >
+                                            <ButtonPrimitive
+                                                menuItem
+                                                disabled={item.record?.view?.status === 'Running'}
+                                            >
+                                                Sync now
+                                            </ButtonPrimitive>
+                                        </DropdownMenuItem>
+                                    )}
                                     <DropdownMenuSeparator />
                                     <DropdownMenuItem
                                         asChild

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -251,7 +251,10 @@ export const QueryDatabase = (): JSX.Element => {
                                         >
                                             <ButtonPrimitive
                                                 menuItem
-                                                disabled={item.record?.view?.status === 'Running'}
+                                                disabledReasons={{
+                                                    'Materialization is already running': item.record?.view?.status === 'Running',
+                                                }}
+                                            >
                                             >
                                                 Sync now
                                             </ButtonPrimitive>

--- a/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
@@ -229,8 +229,15 @@ export function ViewsTab(): JSX.Element {
                                     <More
                                         overlay={
                                             <>
-                                                <LemonButton onClick={() => runMaterialization(view.id)}>
-                                                    Run now
+                                                <LemonButton
+                                                    onClick={() => runMaterialization(view.id)}
+                                                    disabledReason={
+                                                        view.status === 'Running'
+                                                            ? 'Materialization is already running'
+                                                            : undefined
+                                                    }
+                                                >
+                                                    Sync now
                                                 </LemonButton>
                                                 <LemonButton
                                                     status="danger"


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C019RAX2XBN/p1765998181836519

## Changes

Add a sync now button in the view drop down menu. Disable the sync now button when a materialization is running.

https://github.com/user-attachments/assets/4d3f9e8a-2915-4ae3-ba3d-6f1c17f2844a

## How did you test this code?

Manually. 

## Changelog: (features only) Is this feature complete?

No