### PR TITLE
fix: live activity pause button works (fixes #43457)

### DIFF
--- a/frontend/src/scenes/activity/live/LiveEventsTable.tsx
+++ b/frontend/src/scenes/activity/live/LiveEventsTable.tsx
@@ -85,7 +85,7 @@ export function LiveEventsTable(): JSX.Element {
     const { pauseStream, resumeStream, setFilters, clearEvents } = useActions(liveEventsLogic)
     const tabs = useActivityTabs()
 
-    const isVisible = usePageVisibility()
+    const { isVisible } = usePageVisibility()
     useEffect(() => {
         if (isVisible) {
             resumeStream()


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/43457

## Changes

Minor issue from https://github.com/PostHog/posthog/pull/43084.

Fixes the play/pause behavior by using the boolean from `usePageVisibility` instead of the whole object, so the visibility effect only fires when the page actually changes visibility and no longer auto-resumes on every render.

## How did you test this code?

Locally, with :eyes: