### PR TITLE
feat(product tours): cleanup + advance-type selection

### DIFF
--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -2,6 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { useEffect, useMemo } from 'react'
 
+import { IconInfo } from '@posthog/icons'
 import {
     LemonButton,
     LemonDivider,
@@ -10,6 +11,7 @@ import {
     LemonSelect,
     LemonSwitch,
     LemonTag,
+    Tooltip,
 } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -25,6 +27,10 @@ import { PropertyDefinitionType, SurveyMatchType } from '~/types'
 
 import { EditInToolbarButton } from './components/EditInToolbarButton'
 import { productTourLogic } from './productTourLogic'
+
+function InlineCode({ text }: { text: string }): JSX.Element {
+    return <code className="border border-1 border-primary rounded-xs px-1 py-0.5 text-xs">{text}</code>
+}
 
 export function ProductTourEdit({ id }: { id: string }): JSX.Element {
     const { productTour, productTourLoading, productTourForm, targetingFlagFilters, isProductTourFormSubmitting } =
@@ -108,10 +114,12 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                     <LemonDivider />
 
                     <div>
-                        <h3 className="font-semibold mb-2">Tour URLs</h3>
-                        <p className="text-secondary text-sm mb-4">
-                            Tour will only display on URLs matching these conditions
-                        </p>
+                        <h3 className="font-semibold mb-4">
+                            Tour URLs&nbsp;
+                            <Tooltip title="Tour will only display on URLs matching these conditions.">
+                                <IconInfo />
+                            </Tooltip>
+                        </h3>
                         <div className="flex gap-2">
                             <LemonSelect
                                 value={conditions.urlMatchType || SurveyMatchType.Contains}
@@ -160,6 +168,18 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                                 data-attr="product-tour-url-input"
                             />
                         </div>
+                        {conditions.urlMatchType === SurveyMatchType.Exact && (
+                            <div className="flex flex-col gap-2 mt-2 text-secondary text-sm">
+                                <p className="m-0">
+                                    When using <InlineCode text="= equals" />, trailing slashes will be removed before
+                                    URL comparison.
+                                </p>
+                                <p className="m-0">
+                                    Example: <InlineCode text="https://posthog.com/" /> will also match{' '}
+                                    <InlineCode text="https://posthog.com" />, and vice versa.
+                                </p>
+                            </div>
+                        )}
                     </div>
 
                     <LemonDivider />

--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -13,7 +13,7 @@ import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
 import { ElementHighlight } from '~/toolbar/product-tours/ElementHighlight'
 import { StepEditor } from '~/toolbar/product-tours/StepEditor'
-import { productToursLogic } from '~/toolbar/product-tours/productToursLogic'
+import { getStepElement, productToursLogic } from '~/toolbar/product-tours/productToursLogic'
 import { getBoxColors, getHeatMapHue } from '~/toolbar/utils'
 
 import { toolbarLogic } from '../bar/toolbarLogic'
@@ -35,18 +35,21 @@ export function Elements(): JSX.Element {
     const { highestClickCount } = useValues(heatmapToolbarMenuLogic)
     const { refreshClickmap } = useActions(heatmapToolbarMenuLogic)
     const {
-        isInspecting: productToursInspecting,
+        isSelecting: productToursSelecting,
+        isEditing: productToursEditing,
         hoverElementRect: productToursHoverRect,
         selectedElementRect: productToursSelectedRect,
-        isEditingStep,
         tourForm,
-        inspectingElement,
-        editingModalStep,
-        editingSurveyStep,
+        editingStepIndex,
+        editingStepType,
+        rectUpdateCounter,
     } = useValues(productToursLogic)
 
     const shiftPressed = useShiftKeyPressed(refreshClickmap)
     const heatmapPointerEvents = shiftPressed ? 'none' : 'all'
+
+    // Force re-render when rectUpdateCounter changes (triggered by MutationObserver for modal open/close)
+    void rectUpdateCounter
 
     const { theme } = useValues(toolbarLogic)
 
@@ -77,50 +80,47 @@ export function Elements(): JSX.Element {
                 <ScrollDepth />
                 {activeToolbarMode === 'heatmap' && <HeatmapCanvas context="toolbar" />}
                 {highlightElementMeta?.rect ? <FocusRect rect={highlightElementMeta.rect} /> : null}
-                {/* Product tours: show highlights with step numbers for all selected steps */}
-                {tourForm?.steps?.map(
-                    (step: { id: string; selector: string; element?: HTMLElement }, index: number) => {
-                        const element = step.element || (step.selector ? document.querySelector(step.selector) : null)
-                        if (!element) {
-                            return null
-                        }
-                        const domRect = element.getBoundingClientRect()
-                        const rect = {
-                            x: domRect.x,
-                            y: domRect.y,
-                            width: domRect.width,
-                            height: domRect.height,
-                            top: domRect.top,
-                            left: domRect.left,
-                            right: domRect.right,
-                            bottom: domRect.bottom,
-                        }
-                        const isActive = inspectingElement === index
-
-                        return (
-                            <ElementHighlight key={step.id} rect={rect} isSelected={isActive} stepNumber={index + 1} />
-                        )
+                {/* Product tours: show highlights with step numbers for all element steps */}
+                {tourForm?.steps?.map((step, index: number) => {
+                    if (step.type !== 'element') {
+                        return null
                     }
-                )}
+                    const element = getStepElement(step)
+                    if (!element) {
+                        return null
+                    }
+                    const domRect = element.getBoundingClientRect()
+                    const rect = {
+                        x: domRect.x,
+                        y: domRect.y,
+                        width: domRect.width,
+                        height: domRect.height,
+                        top: domRect.top,
+                        left: domRect.left,
+                        right: domRect.right,
+                        bottom: domRect.bottom,
+                    }
+                    const isActive = editingStepIndex === index
 
-                {/* Product tours: hover highlight when inspecting */}
-                {productToursInspecting && !isEditingStep && productToursHoverRect && (
-                    <ElementHighlight rect={productToursHoverRect} />
-                )}
+                    return <ElementHighlight key={step.id} rect={rect} isSelected={isActive} stepNumber={index + 1} />
+                })}
 
-                {/* Product tours: selected element highlight + editor */}
-                {productToursInspecting && isEditingStep && productToursSelectedRect && (
+                {/* Product tours: hover highlight when selecting */}
+                {productToursSelecting && productToursHoverRect && <ElementHighlight rect={productToursHoverRect} />}
+
+                {/* Product tours: element step editor */}
+                {productToursEditing && editingStepType === 'element' && (
                     <>
-                        <ElementHighlight rect={productToursSelectedRect} isSelected />
-                        <StepEditor rect={productToursSelectedRect} />
+                        {productToursSelectedRect && <ElementHighlight rect={productToursSelectedRect} isSelected />}
+                        <StepEditor
+                            rect={productToursSelectedRect ?? undefined}
+                            elementNotFound={!productToursSelectedRect}
+                        />
                     </>
                 )}
 
-                {/* Product tours: modal step editor (no element) */}
-                {productToursInspecting && editingModalStep && <StepEditor />}
-
-                {/* Product tours: survey step editor (always modal-style) */}
-                {productToursInspecting && editingSurveyStep && <StepEditor />}
+                {/* Product tours: modal/survey step editor */}
+                {productToursEditing && (editingStepType === 'modal' || editingStepType === 'survey') && <StepEditor />}
 
                 {elementsToDisplay.map(({ rect, element, apparentZIndex }, index) => {
                     return (

--- a/frontend/src/toolbar/product-tours/ProductToursEditingBar.tsx
+++ b/frontend/src/toolbar/product-tours/ProductToursEditingBar.tsx
@@ -1,7 +1,16 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
-import { IconCheck, IconMagicWand, IconMessage, IconPlus, IconQuestion, IconTrash, IconX } from '@posthog/icons'
+import {
+    IconCheck,
+    IconCursorClick,
+    IconMagicWand,
+    IconMessage,
+    IconPlus,
+    IconQuestion,
+    IconTrash,
+    IconX,
+} from '@posthog/icons'
 import { LemonButton, LemonInput, LemonMenu, Tooltip } from '@posthog/lemon-ui'
 
 import { Spinner } from 'lib/lemon-ui/Spinner'
@@ -36,18 +45,26 @@ const BAR_HEIGHT = 56
 
 export function ProductToursEditingBar(): JSX.Element | null {
     const { theme } = useValues(toolbarLogic)
-    const { selectedTourId, tourForm, tourFormErrors, inspectingElement, aiGenerating, aiGenerationStep, stepCount } =
-        useValues(productToursLogic)
+    const {
+        selectedTourId,
+        tourForm,
+        tourFormErrors,
+        editorState,
+        editingStepIndex,
+        aiGenerating,
+        aiGenerationStep,
+        stepCount,
+    } = useValues(productToursLogic)
     const {
         selectTour,
         editStep,
         removeStep,
-        inspectForElementWithIndex,
         saveTour,
         generateWithAI,
         setTourFormValue,
-        addModalStep,
-        addSurveyStep,
+        addStep,
+        setEditorState,
+        cancelEditing,
     } = useActions(productToursLogic)
 
     const themeProps = { theme } as { theme?: string }
@@ -94,62 +111,62 @@ export function ProductToursEditingBar(): JSX.Element | null {
     }
 
     return (
-        <div
-            className="fixed top-0 left-0 right-0 flex items-center gap-3 px-4 bg-bg-light border-b shadow-lg pointer-events-auto"
-            // eslint-disable-next-line react/forbid-dom-props
-            style={{ zIndex: 2147483019, height: BAR_HEIGHT }}
-            onClick={(e) => e.stopPropagation()}
-            {...themeProps}
-        >
-            {/* Left: Tour name */}
-            <div className="flex items-center gap-2">
-                <LemonInput
-                    size="small"
-                    placeholder="Tour name"
-                    value={tourForm?.name || ''}
-                    onChange={(value) => setTourFormValue('name', value)}
-                    status={tourFormErrors?.name ? 'danger' : undefined}
-                    className="w-48"
-                />
-            </div>
+        <>
+            <div
+                className="fixed top-0 left-0 right-0 flex items-center gap-3 px-4 bg-bg-light border-b shadow-lg pointer-events-auto"
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{ zIndex: 2147483019, height: BAR_HEIGHT }}
+                onClick={(e) => e.stopPropagation()}
+                {...themeProps}
+            >
+                {/* Left: Tour name */}
+                <div className="flex items-center gap-2">
+                    <LemonInput
+                        size="small"
+                        placeholder="Tour name"
+                        value={tourForm?.name || ''}
+                        onChange={(value) => setTourFormValue('name', value)}
+                        status={tourFormErrors?.name ? 'danger' : undefined}
+                        className="w-48"
+                    />
+                </div>
 
-            {/* Center: Step buttons with titles */}
-            <div className="flex-1 flex items-center justify-center gap-1.5">
-                {stepCount === 0 && (
-                    <span className="text-muted text-sm">Click an element on the page to add a step</span>
-                )}
-                {steps.map((step: TourStep, index: number) => {
-                    const isActive = inspectingElement === index
-                    const isDragging = dragIndex === index
-                    const isDropTarget = dropIndex === index && dragIndex !== index
-                    const hasContent = stepHasContent(step)
-                    const title = getStepTitle(step, index)
-                    // Truncate to ~15 chars for compact display
-                    const displayTitle = title.length > 15 ? title.slice(0, 14) + '…' : title
+                {/* Center: Step buttons with titles */}
+                <div className="flex-1 flex items-center justify-center gap-1.5">
+                    {stepCount === 0 && editorState.mode === 'idle' && (
+                        <span className="text-muted text-sm">Click + to start adding steps</span>
+                    )}
+                    {steps.map((step: TourStep, index: number) => {
+                        const isActive = editingStepIndex === index
+                        const isDragging = dragIndex === index
+                        const isDropTarget = dropIndex === index && dragIndex !== index
+                        const hasContent = stepHasContent(step)
+                        const title = getStepTitle(step, index)
+                        const displayTitle = title.length > 15 ? title.slice(0, 14) + '…' : title
 
-                    return (
-                        <div
-                            key={step.id}
-                            className={`flex items-center toolbar-animate-blur-right transition-all ${
-                                isDragging ? 'opacity-50 scale-95' : ''
-                            } ${isDropTarget ? 'translate-x-1' : ''}`}
-                            draggable
-                            onDragStart={() => handleDragStart(index)}
-                            onDragOver={(e) => handleDragOver(e, index)}
-                            onDragEnd={handleDragEnd}
-                        >
-                            {index > 0 && <span className="text-muted text-xs mx-0.5">→</span>}
-                            <Tooltip title={title !== displayTitle ? title : undefined}>
-                                <button
-                                    type="button"
-                                    onClick={() => {
-                                        if (isActive) {
-                                            inspectForElementWithIndex(null)
-                                        } else {
-                                            editStep(index)
-                                        }
-                                    }}
-                                    className={`
+                        return (
+                            <div
+                                key={step.id}
+                                className={`flex items-center toolbar-animate-blur-right transition-all ${
+                                    isDragging ? 'opacity-50 scale-95' : ''
+                                } ${isDropTarget ? 'translate-x-1' : ''}`}
+                                draggable
+                                onDragStart={() => handleDragStart(index)}
+                                onDragOver={(e) => handleDragOver(e, index)}
+                                onDragEnd={handleDragEnd}
+                            >
+                                {index > 0 && <span className="text-muted text-xs mx-0.5">→</span>}
+                                <Tooltip title={title !== displayTitle ? title : undefined}>
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            if (isActive) {
+                                                cancelEditing()
+                                            } else {
+                                                editStep(index)
+                                            }
+                                        }}
+                                        className={`
                                         flex items-center gap-1.5 px-2 py-1 rounded-md text-xs
                                         cursor-grab active:cursor-grabbing transition-all
                                         ${
@@ -158,98 +175,130 @@ export function ProductToursEditingBar(): JSX.Element | null {
                                                 : 'bg-bg-3000 hover:bg-border text-default'
                                         }
                                     `}
-                                >
-                                    <span
-                                        className="w-4 h-4 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
-                                        // eslint-disable-next-line react/forbid-dom-props
-                                        style={{ backgroundColor: POSTHOG_BLUE }}
                                     >
-                                        {index + 1}
-                                    </span>
-                                    <span className="font-medium">{displayTitle}</span>
-                                    {!hasContent && <span className="w-1.5 h-1.5 rounded-full bg-warning shrink-0" />}
+                                        <span
+                                            className="w-4 h-4 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
+                                            // eslint-disable-next-line react/forbid-dom-props
+                                            style={{ backgroundColor: POSTHOG_BLUE }}
+                                        >
+                                            {index + 1}
+                                        </span>
+                                        <span className="font-medium">{displayTitle}</span>
+                                        {!hasContent && (
+                                            <span className="w-1.5 h-1.5 rounded-full bg-warning shrink-0" />
+                                        )}
+                                    </button>
+                                </Tooltip>
+                                <button
+                                    type="button"
+                                    onClick={() => removeStep(index)}
+                                    className="ml-0.5 w-5 h-5 rounded flex items-center justify-center text-muted hover:text-danger transition-colors opacity-60 hover:opacity-100"
+                                    title="Remove step"
+                                >
+                                    <IconTrash className="w-3 h-3" />
                                 </button>
-                            </Tooltip>
-                            <button
-                                type="button"
-                                onClick={() => removeStep(index)}
-                                className="ml-0.5 w-5 h-5 rounded flex items-center justify-center text-muted hover:text-danger transition-colors opacity-60 hover:opacity-100"
-                                title="Remove step"
-                            >
-                                <IconTrash className="w-3 h-3" />
-                            </button>
-                        </div>
-                    )
-                })}
-                <LemonMenu
-                    items={[
-                        {
-                            icon: <IconMessage />,
-                            label: 'Add modal step',
-                            onClick: () => addModalStep(),
-                        },
-                        {
-                            icon: <IconQuestion />,
-                            label: 'Add survey step',
-                            onClick: () => addSurveyStep(),
-                        },
-                    ]}
-                    placement="bottom"
-                    className="min-w-48"
-                >
-                    <button
-                        type="button"
-                        disabled={aiGenerating}
-                        className="w-6 h-6 rounded-md border border-dashed border-border flex items-center justify-center text-muted hover:border-primary hover:text-primary transition-colors disabled:opacity-50 ml-1"
+                            </div>
+                        )
+                    })}
+                    <LemonMenu
+                        items={[
+                            {
+                                icon: <IconCursorClick />,
+                                label: 'Element step',
+                                onClick: () => addStep('element'),
+                            },
+                            {
+                                icon: <IconMessage />,
+                                label: 'Modal step',
+                                onClick: () => addStep('modal'),
+                            },
+                            {
+                                icon: <IconQuestion />,
+                                label: 'Survey step',
+                                onClick: () => addStep('survey'),
+                            },
+                        ]}
+                        placement="bottom"
+                        className="min-w-48"
                     >
-                        <IconPlus className="w-3 h-3" />
-                    </button>
-                </LemonMenu>
-            </div>
+                        <button
+                            type="button"
+                            disabled={aiGenerating || editorState.mode !== 'idle'}
+                            className="w-6 h-6 rounded-md border border-dashed border-border flex items-center justify-center text-muted hover:border-primary hover:text-primary transition-colors disabled:opacity-50 ml-1"
+                        >
+                            <IconPlus className="w-3 h-3" />
+                        </button>
+                    </LemonMenu>
+                </div>
 
-            {/* Right: Actions */}
-            <div className="flex items-center gap-2">
-                {aiGenerating ? (
-                    <span className="flex items-center gap-2 text-primary text-sm px-3">
-                        <Spinner className="w-4 h-4" />
-                        {generationStatus}
-                    </span>
-                ) : (
+                {/* Right: Actions */}
+                <div className="flex items-center gap-2">
+                    {aiGenerating ? (
+                        <span className="flex items-center gap-2 text-primary text-sm px-3">
+                            <Spinner className="w-4 h-4" />
+                            {generationStatus}
+                        </span>
+                    ) : (
+                        <LemonButton
+                            size="small"
+                            type="secondary"
+                            icon={<IconMagicWand />}
+                            onClick={generateWithAI}
+                            disabledReason={stepCount === 0 ? 'Add at least one step first' : undefined}
+                        >
+                            Generate
+                        </LemonButton>
+                    )}
+
+                    <LemonButton size="small" type="secondary" icon={<IconX />} onClick={() => selectTour(null)}>
+                        Discard
+                    </LemonButton>
+
                     <LemonButton
                         size="small"
-                        type="secondary"
-                        icon={<IconMagicWand />}
-                        onClick={generateWithAI}
-                        disabledReason={stepCount === 0 ? 'Add at least one step first' : undefined}
+                        type="primary"
+                        icon={<IconCheck />}
+                        onClick={saveTour}
+                        disabledReason={
+                            aiGenerating
+                                ? 'Wait for generation'
+                                : stepCount === 0
+                                  ? 'Add at least one step'
+                                  : tourFormErrors?.name
+                                    ? String(tourFormErrors.name)
+                                    : !tourForm?.name
+                                      ? 'Enter a tour name'
+                                      : undefined
+                        }
                     >
-                        Generate
+                        Save
                     </LemonButton>
-                )}
-
-                <LemonButton size="small" type="secondary" icon={<IconX />} onClick={() => selectTour(null)}>
-                    Discard
-                </LemonButton>
-
-                <LemonButton
-                    size="small"
-                    type="primary"
-                    icon={<IconCheck />}
-                    onClick={saveTour}
-                    disabledReason={
-                        aiGenerating
-                            ? 'Wait for generation'
-                            : stepCount === 0
-                              ? 'Add at least one step'
-                              : tourFormErrors?.name
-                                ? String(tourFormErrors.name)
-                                : !tourForm?.name
-                                  ? 'Enter a tour name'
-                                  : undefined
-                    }
-                >
-                    Save
-                </LemonButton>
+                </div>
             </div>
-        </div>
+
+            {/* Mode indicator - fixed below the bar */}
+            {editorState.mode === 'selecting' && (
+                <div
+                    className="fixed left-1/2 -translate-x-1/2 flex items-center gap-2 px-3 py-2 rounded-full bg-[#1d4aff] text-white text-sm font-medium shadow-lg pointer-events-auto"
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{ zIndex: 2147483019, top: BAR_HEIGHT + 12 }}
+                    {...themeProps}
+                >
+                    <IconCursorClick className="w-4 h-4" />
+                    <span>
+                        Click to {editorState.stepIndex < stepCount ? 'change' : 'select'} step{' '}
+                        {editorState.stepIndex + 1}
+                        {editorState.stepIndex < stepCount ? ' element' : ''}
+                    </span>
+                    <button
+                        type="button"
+                        onClick={() => setEditorState({ mode: 'idle' })}
+                        className="ml-1 p-0.5 rounded-full hover:bg-white/20 transition-colors"
+                    >
+                        <IconX className="w-4 h-4" />
+                    </button>
+                </div>
+            )}
+        </>
     )
 }

--- a/frontend/src/toolbar/product-tours/TourGoalModal.tsx
+++ b/frontend/src/toolbar/product-tours/TourGoalModal.tsx
@@ -17,7 +17,7 @@ const GOAL_SUGGESTIONS = [
 export function TourGoalModal(): JSX.Element | null {
     const { theme } = useValues(toolbarLogic)
     const { goalModalOpen, aiGoal } = useValues(productToursLogic)
-    const { closeGoalModal, setAIGoal, startSelectionMode } = useActions(productToursLogic)
+    const { closeGoalModal, setAIGoal, startFromGoalModal } = useActions(productToursLogic)
 
     const canProceed = aiGoal.trim().length > 0
 
@@ -34,7 +34,7 @@ export function TourGoalModal(): JSX.Element | null {
                     </LemonButton>
                     <LemonButton
                         type="primary"
-                        onClick={startSelectionMode}
+                        onClick={startFromGoalModal}
                         disabledReason={!canProceed ? 'Enter a goal first' : undefined}
                     >
                         Start building

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -13,7 +13,14 @@ import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { ElementRect } from '~/toolbar/types'
 import { TOOLBAR_ID, elementToActionStep, getRectForElement } from '~/toolbar/utils'
-import { ProductTour, ProductTourStep, ProductTourSurveyQuestion, StepOrderVersion } from '~/types'
+import {
+    ProductTour,
+    ProductTourProgressionTriggerType,
+    ProductTourStep,
+    ProductTourStepType,
+    ProductTourSurveyQuestion,
+    StepOrderVersion,
+} from '~/types'
 
 import type { productToursLogicType } from './productToursLogicType'
 import { captureScreenshot, getElementMetadata, getSmartUrlDefaults } from './utils'
@@ -21,6 +28,18 @@ import { captureScreenshot, getElementMetadata, getSmartUrlDefaults } from './ut
 const RECENT_GOALS_KEY = 'posthog-product-tours-recent-goals'
 
 export type AIGenerationStep = 'idle' | 'capturing' | 'analyzing' | 'generating' | 'done' | 'error'
+
+/**
+ * Editor state machine - explicit states instead of multiple boolean flags.
+ *
+ * - idle: Default state, no hover effects, step badges visible. Cmd/ctrl+click passes through.
+ * - selecting: User is picking an element from the page. Hover highlighting active.
+ * - editing: User is editing a step's content. Editor panel is open.
+ */
+export type EditorState =
+    | { mode: 'idle' }
+    | { mode: 'selecting'; stepIndex: number }
+    | { mode: 'editing'; stepIndex: number; stepType: ProductTourStepType }
 
 function saveRecentGoal(goal: string): void {
     try {
@@ -34,16 +53,9 @@ function saveRecentGoal(goal: string): void {
     }
 }
 
-export interface TourStep {
-    id: string
-    selector: string
-    content: JSONContent | null
+export interface TourStep extends ProductTourStep {
     /** Local-only: reference to DOM element, not persisted */
     element?: HTMLElement
-    /** Inline survey question config - if present, this is a survey step */
-    survey?: ProductTourSurveyQuestion
-    /** ID of the auto-created survey for this step (set by backend, must be preserved on updates) */
-    linkedSurveyId?: string
 }
 
 export interface TourForm {
@@ -64,11 +76,8 @@ function tourToForm(tour: ProductTour): TourForm {
         id: tour.id,
         name: tour.name,
         steps: (tour.content?.steps ?? []).map((step) => ({
-            id: step.id || uuid(), // Preserve existing ID, generate new one only if missing
-            selector: step.selector,
-            content: step.content,
-            survey: step.survey,
-            linkedSurveyId: step.linkedSurveyId,
+            ...step,
+            id: step.id || uuid(),
         })),
     }
 }
@@ -76,6 +85,14 @@ function tourToForm(tour: ProductTour): TourForm {
 function isToolbarElement(element: HTMLElement): boolean {
     const toolbar = document.getElementById(TOOLBAR_ID)
     return toolbar?.contains(element) ?? false
+}
+
+/** Get the DOM element for a step, checking cached ref is still valid */
+export function getStepElement(step: TourStep): HTMLElement | null {
+    if (step.element && document.body.contains(step.element)) {
+        return step.element
+    }
+    return step.selector ? (document.querySelector(step.selector) as HTMLElement | null) : null
 }
 
 /** Check if steps have changed compared to the latest version in history */
@@ -114,42 +131,49 @@ export const productToursLogic = kea<productToursLogicType>([
     actions({
         showButtonProductTours: true,
         hideButtonProductTours: true,
-        inspectForElementWithIndex: (index: number | null) => ({ index }),
-        setInspectingElementIndex: (index: number | null) => ({ index }),
+
+        setEditorState: (state: EditorState) => ({ state }),
+
+        // Step actions
+        addStep: (stepType: ProductTourStepType) => ({ stepType }),
         editStep: (index: number) => ({ index }),
+        changeStepElement: true,
         selectElement: (element: HTMLElement) => ({ element }),
-        confirmStep: (content: JSONContent | null, selector?: string, survey?: ProductTourSurveyQuestion) => ({
-            content,
-            selector,
-            survey,
-        }),
-        cancelStep: true,
+        setHoverElement: (element: HTMLElement | null) => ({ element }),
+        clearSelectedElement: true,
+        confirmStep: (
+            content: JSONContent | null,
+            selector?: string,
+            survey?: ProductTourSurveyQuestion,
+            progressionTrigger?: ProductTourProgressionTriggerType
+        ) => ({ content, selector, survey, progressionTrigger }),
+        cancelEditing: true,
+        removeStep: (index: number) => ({ index }),
+
+        // Tour CRUD
         selectTour: (id: string | null) => ({ id }),
         newTour: true,
-        addStep: true,
-        addModalStep: true,
-        addSurveyStep: true,
-        setEditingModalStep: (isModal: boolean) => ({ isModal }),
-        setEditingSurveyStep: (isSurvey: boolean) => ({ isSurvey }),
-        removeStep: (index: number) => ({ index }),
-        setHoverElement: (element: HTMLElement | null) => ({ element }),
-        updateRects: true,
         saveTour: true,
         deleteTour: (id: string) => ({ id }),
-        // Goal modal actions
+
+        updateRects: true,
+
+        // Goal modal
         openGoalModal: true,
         closeGoalModal: true,
-        startSelectionMode: true,
-        // AI generation actions
+        startFromGoalModal: true,
+
+        // AI generation
         setAIGoal: (goal: string) => ({ goal }),
         generateWithAI: true,
-        generateWithAISuccess: (steps: Array<{ selector: string; content: JSONContent }>, name?: string) => ({
+        generateWithAISuccess: (steps: Array<{ selector?: string; content: JSONContent }>, name?: string) => ({
             steps,
             name,
         }),
         generateWithAIFailure: (error: string) => ({ error }),
         setAIGenerationStep: (step: AIGenerationStep) => ({ step }),
-        // Creation mode actions
+
+        // Creation
         startCreation: true,
         setCachedScreenshot: (screenshot: string | null) => ({ screenshot }),
     }),
@@ -186,68 +210,34 @@ export const productToursLogic = kea<productToursLogicType>([
                 saveTourSuccess: (_, { tours }) => tours[0]?.id ?? null,
             },
         ],
-        inspectingElement: [
-            null as number | null,
+        editorState: [
+            { mode: 'idle' } as EditorState,
             {
-                inspectForElementWithIndex: (_, { index }) => index,
-                setInspectingElementIndex: (_, { index }) => index,
-                editStep: (_, { index }) => index,
-                selectTour: () => null,
-                newTour: () => null,
-                hideButtonProductTours: () => null,
+                setEditorState: (_, { state }) => state,
+                selectTour: () => ({ mode: 'idle' }),
+                newTour: () => ({ mode: 'idle' }),
+                hideButtonProductTours: () => ({ mode: 'idle' }),
+                cancelEditing: () => ({ mode: 'idle' }),
             },
         ],
+        // Element currently being hovered during selection mode
         hoverElement: [
             null as HTMLElement | null,
             {
                 setHoverElement: (_, { element }) => element,
-                selectElement: () => null,
-                confirmStep: () => null,
-                cancelStep: () => null,
-                inspectForElementWithIndex: () => null,
+                setEditorState: () => null,
                 hideButtonProductTours: () => null,
             },
         ],
+        // Element selected for the current step being edited
         selectedElement: [
             null as HTMLElement | null,
             {
                 selectElement: (_, { element }) => element,
-                cancelStep: () => null,
-                inspectForElementWithIndex: () => null,
-                addModalStep: () => null,
-                addSurveyStep: () => null,
-                setEditingModalStep: (state, { isModal }) => (isModal ? null : state),
-                setEditingSurveyStep: (state, { isSurvey }) => (isSurvey ? null : state),
+                clearSelectedElement: () => null,
+                setEditorState: (state, { state: newState }) => (newState.mode === 'editing' ? state : null),
+                cancelEditing: () => null,
                 hideButtonProductTours: () => null,
-                // Note: confirmStep clears this AFTER the listener runs via actions.cancelStep()
-            },
-        ],
-        editingModalStep: [
-            false,
-            {
-                addModalStep: () => true,
-                setEditingModalStep: (_, { isModal }) => isModal,
-                selectElement: () => false,
-                cancelStep: () => false,
-                confirmStep: () => false,
-                inspectForElementWithIndex: () => false,
-                selectTour: () => false,
-                hideButtonProductTours: () => false,
-                addSurveyStep: () => false, // Survey steps use their own flag
-            },
-        ],
-        editingSurveyStep: [
-            false,
-            {
-                addSurveyStep: () => true,
-                setEditingSurveyStep: (_, { isSurvey }) => isSurvey,
-                selectElement: () => false,
-                cancelStep: () => false,
-                confirmStep: () => false,
-                inspectForElementWithIndex: () => false,
-                selectTour: () => false,
-                hideButtonProductTours: () => false,
-                addModalStep: () => false, // Modal steps use their own flag
             },
         ],
         rectUpdateCounter: [
@@ -256,16 +246,14 @@ export const productToursLogic = kea<productToursLogicType>([
                 updateRects: (state) => state + 1,
             },
         ],
-        // Goal modal state
         goalModalOpen: [
             false,
             {
                 openGoalModal: () => true,
                 closeGoalModal: () => false,
-                startSelectionMode: () => false,
+                startFromGoalModal: () => false,
             },
         ],
-        // AI generation state
         aiGoal: [
             '',
             {
@@ -409,9 +397,16 @@ export const productToursLogic = kea<productToursLogicType>([
                 return null
             },
         ],
-        isInspecting: [
-            (s) => [s.inspectingElement, s.selectedTourId],
-            (inspectingElement, selectedTourId) => selectedTourId !== null && inspectingElement !== null,
+        isSelecting: [(s) => [s.editorState], (editorState) => editorState.mode === 'selecting'],
+        isEditing: [(s) => [s.editorState], (editorState) => editorState.mode === 'editing'],
+        editingStepIndex: [
+            (s) => [s.editorState],
+            (editorState): number | null =>
+                editorState.mode === 'editing' || editorState.mode === 'selecting' ? editorState.stepIndex : null,
+        ],
+        editingStepType: [
+            (s) => [s.editorState],
+            (editorState): ProductTourStepType | null => (editorState.mode === 'editing' ? editorState.stepType : null),
         ],
         hoverElementRect: [
             (s) => [s.hoverElement, s.rectUpdateCounter],
@@ -431,18 +426,13 @@ export const productToursLogic = kea<productToursLogicType>([
                 return getRectForElement(selectedElement)
             },
         ],
-        isEditingStep: [
-            (s) => [s.selectedElement, s.editingModalStep, s.editingSurveyStep],
-            (selectedElement, editingModalStep, editingSurveyStep) =>
-                selectedElement !== null || editingModalStep || editingSurveyStep,
-        ],
         editingStep: [
-            (s) => [s.inspectingElement, s.tourForm],
-            (inspectingElement, tourForm): TourStep | null => {
-                if (inspectingElement === null) {
+            (s) => [s.editingStepIndex, s.tourForm],
+            (editingStepIndex, tourForm): TourStep | null => {
+                if (editingStepIndex === null) {
                     return null
                 }
-                return tourForm?.steps?.[inspectingElement] ?? null
+                return tourForm?.steps?.[editingStepIndex] ?? null
             },
         ],
         stepCount: [(s) => [s.tourForm], (tourForm) => tourForm?.steps?.length ?? 0],
@@ -462,41 +452,14 @@ export const productToursLogic = kea<productToursLogicType>([
     })),
 
     listeners(({ actions, values }) => ({
-        confirmStep: ({ content, selector: selectorOverride, survey }) => {
-            // Check inspectingElement since editingModalStep reducer runs before listener
-            if (values.tourForm && values.inspectingElement !== null) {
-                // For modal/survey steps (no element), selector is empty by default
-                const selector = values.selectedElement
-                    ? (selectorOverride ??
-                      elementToActionStep(values.selectedElement, values.dataAttributes).selector ??
-                      '')
-                    : (selectorOverride ?? '')
-
-                const steps = [...(values.tourForm.steps || [])]
-                const index = values.inspectingElement
-
-                // When editing an existing step, preserve its ID; otherwise generate a new one
-                const existingStep = index !== null && index < steps.length ? steps[index] : null
-                const stepId = existingStep?.id ?? uuid()
-
-                const newStep: TourStep = {
-                    id: stepId,
-                    selector,
-                    content,
-                    element: values.selectedElement ?? undefined,
-                    ...(survey ? { survey } : {}),
-                }
-
-                if (index !== null && index < steps.length) {
-                    steps[index] = newStep
-                } else {
-                    steps.push(newStep)
-                }
-
-                actions.setTourFormValue('steps', steps)
-                // Clear editing state and go to selecting next element
-                actions.cancelStep()
-                actions.inspectForElementWithIndex(steps.length)
+        addStep: ({ stepType }) => {
+            const nextIndex = values.tourForm?.steps?.length ?? 0
+            if (stepType === 'element') {
+                // Element steps need element selection first
+                actions.setEditorState({ mode: 'selecting', stepIndex: nextIndex })
+            } else {
+                // Modal/survey steps go directly to editing
+                actions.setEditorState({ mode: 'editing', stepIndex: nextIndex, stepType })
             }
         },
         editStep: ({ index }) => {
@@ -505,58 +468,95 @@ export const productToursLogic = kea<productToursLogicType>([
                 return
             }
 
-            // Survey steps are always modal-style
-            if (step.survey) {
-                actions.setEditingSurveyStep(true)
-                return
+            // For element steps, try to find and highlight the element
+            if (step.type === 'element') {
+                const element = getStepElement(step)
+                if (element) {
+                    element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                    actions.selectElement(element)
+                } else {
+                    // Element not found - clear so editor shows centered with warning
+                    actions.clearSelectedElement()
+                }
             }
 
-            // Try to find the element - first check cached reference, then query by selector
-            let element = step.element
-            if (!element || !document.body.contains(element)) {
-                element = step.selector
-                    ? ((document.querySelector(step.selector) as HTMLElement | null) ?? undefined)
-                    : undefined
-            }
-
-            if (element) {
-                // Scroll element into view so the card is visible
-                element.scrollIntoView({ behavior: 'smooth', block: 'center' })
-                actions.selectElement(element)
-            } else {
-                // Modal step (no selector/element) - edit in centered modal mode
-                actions.setEditingModalStep(true)
+            actions.setEditorState({ mode: 'editing', stepIndex: index, stepType: step.type })
+        },
+        changeStepElement: () => {
+            // Re-enter selecting mode for the current step
+            const { editorState } = values
+            if (editorState.mode === 'editing') {
+                actions.setEditorState({ mode: 'selecting', stepIndex: editorState.stepIndex })
             }
         },
         selectElement: ({ element }) => {
-            // Auto-detect if this element belongs to an existing step
-            const steps = values.tourForm?.steps ?? []
-            const matchingIndex = steps.findIndex(
-                (step) => step.element === element || (step.selector && element.matches(step.selector))
-            )
-            if (matchingIndex >= 0) {
-                // Use setInspectingElementIndex to avoid clearing selectedElement
-                actions.setInspectingElementIndex(matchingIndex)
+            const { editorState, tourForm, dataAttributes } = values
+            if (editorState.mode !== 'selecting') {
+                return
+            }
+
+            const { stepIndex } = editorState
+            const isChangingExistingStep = tourForm && stepIndex < (tourForm.steps?.length ?? 0)
+
+            if (isChangingExistingStep) {
+                // Changing element for existing step - update immediately
+                const selector = elementToActionStep(element, dataAttributes).selector ?? ''
+                const steps = [...(tourForm.steps || [])]
+                steps[stepIndex] = {
+                    ...steps[stepIndex],
+                    selector,
+                    element,
+                }
+                actions.setTourFormValue('steps', steps)
+                actions.setEditorState({ mode: 'idle' })
+            } else {
+                // New step - go to editing mode
+                actions.setEditorState({
+                    mode: 'editing',
+                    stepIndex,
+                    stepType: 'element',
+                })
             }
         },
-        addStep: () => {
-            const nextIndex = values.tourForm?.steps?.length ?? 0
-            actions.inspectForElementWithIndex(nextIndex)
-        },
-        addModalStep: () => {
-            const nextIndex = values.tourForm?.steps?.length ?? 0
-            actions.setInspectingElementIndex(nextIndex)
-        },
-        addSurveyStep: () => {
-            const nextIndex = values.tourForm?.steps?.length ?? 0
-            actions.setInspectingElementIndex(nextIndex)
-            // editingSurveyStep reducer handles setting the flag
+        confirmStep: ({ content, selector: selectorOverride, survey, progressionTrigger }) => {
+            const { editorState, tourForm, selectedElement } = values
+            if (editorState.mode !== 'editing' || !tourForm) {
+                return
+            }
+
+            const { stepIndex, stepType } = editorState
+            const steps = [...(tourForm.steps || [])]
+            const existingStep = stepIndex < steps.length ? steps[stepIndex] : null
+
+            // For element steps, use selector from UI (which handles all derivation logic)
+            // Preserve existing selector if none provided (e.g., editing content only)
+            const selector = stepType === 'element' ? (selectorOverride ?? existingStep?.selector) : undefined
+
+            const newStep: TourStep = {
+                id: existingStep?.id ?? uuid(),
+                type: stepType,
+                selector,
+                content,
+                element: selectedElement ?? existingStep?.element,
+                ...(survey ? { survey } : {}),
+                ...(progressionTrigger ? { progressionTrigger } : {}),
+            }
+
+            if (stepIndex < steps.length) {
+                steps[stepIndex] = newStep
+            } else {
+                steps.push(newStep)
+            }
+
+            actions.setTourFormValue('steps', steps)
+            actions.setEditorState({ mode: 'idle' })
         },
         removeStep: ({ index }) => {
             if (values.tourForm) {
                 const steps = [...(values.tourForm.steps || [])]
                 steps.splice(index, 1)
                 actions.setTourFormValue('steps', steps)
+                actions.setEditorState({ mode: 'idle' })
             }
         },
         newTour: () => {
@@ -569,6 +569,27 @@ export const productToursLogic = kea<productToursLogicType>([
         },
         saveTour: () => {
             actions.submitTourForm()
+        },
+        updateRects: () => {
+            // When editing an element step, check if selected element is still valid
+            const { editorState, selectedElement, tourForm } = values
+            if (editorState.mode === 'editing' && editorState.stepType === 'element') {
+                const selectedElementValid = selectedElement && document.body.contains(selectedElement)
+
+                if (!selectedElementValid) {
+                    // Element missing or detached - try to find it via selector
+                    const step = tourForm?.steps?.[editorState.stepIndex]
+                    if (step?.selector) {
+                        const element = document.querySelector(step.selector) as HTMLElement | null
+                        if (element) {
+                            actions.selectElement(element)
+                        } else if (selectedElement) {
+                            // Had an element but it's gone - clear it
+                            actions.clearSelectedElement()
+                        }
+                    }
+                }
+            }
         },
         deleteTour: async ({ id }) => {
             const response = await toolbarFetch(`/api/projects/@current/product_tours/${id}/`, 'DELETE')
@@ -589,8 +610,7 @@ export const productToursLogic = kea<productToursLogicType>([
         },
         generateWithAI: async () => {
             const steps = values.tourForm?.steps ?? []
-            // Filter out survey steps - AI should only generate content for element/modal steps
-            const nonSurveySteps = steps.filter((step) => !step.survey)
+            const nonSurveySteps = steps.filter((step) => step.type !== 'survey')
 
             if (nonSurveySteps.length === 0) {
                 lemonToast.error('Add at least one element before generating')
@@ -599,7 +619,6 @@ export const productToursLogic = kea<productToursLogicType>([
             }
 
             try {
-                // Step 1: Use cached screenshot or capture new one
                 actions.setAIGenerationStep('capturing')
                 let screenshot = values.cachedScreenshot
                 if (!screenshot) {
@@ -610,7 +629,6 @@ export const productToursLogic = kea<productToursLogicType>([
                     }
                 }
 
-                // Step 2: Build element metadata (only for non-survey steps)
                 actions.setAIGenerationStep('analyzing')
                 const elements = nonSurveySteps.map((step) => {
                     let metadata = { selector: step.selector, tag: 'unknown', text: '', attributes: {} }
@@ -631,7 +649,6 @@ export const productToursLogic = kea<productToursLogicType>([
                     return metadata
                 })
 
-                // Step 3: Call AI
                 actions.setAIGenerationStep('generating')
                 const response = await toolbarFetch('/api/projects/@current/product_tours/generate/', 'POST', {
                     screenshot,
@@ -641,45 +658,36 @@ export const productToursLogic = kea<productToursLogicType>([
 
                 if (!response.ok) {
                     const error = await response.json()
-                    console.error('[AI Generate] API error:', error)
                     throw new Error(error.error || 'Failed to generate tour content')
                 }
 
                 const data = await response.json()
 
-                // Save goal to recent goals
                 if (values.aiGoal.trim()) {
                     saveRecentGoal(values.aiGoal.trim())
                 }
 
                 actions.generateWithAISuccess(data.steps, data.name)
             } catch (e) {
-                console.error('[AI Generate] Error:', e)
                 const message = e instanceof Error ? e.message : 'Failed to generate tour content'
                 lemonToast.error(message)
                 actions.generateWithAIFailure(message)
             }
         },
         generateWithAISuccess: ({ steps: generatedSteps, name }) => {
-            // Set name if provided
             if (name) {
                 actions.setTourFormValue('name', name)
             }
 
-            // Merge AI-generated content into existing steps, skipping survey steps
             const currentSteps = [...(values.tourForm?.steps ?? [])]
             let aiStepIndex = 0
             currentSteps.forEach((step, i) => {
-                // Skip survey steps - AI doesn't generate content for them
-                if (step.survey) {
+                if (step.type === 'survey') {
                     return
                 }
                 if (aiStepIndex < generatedSteps.length) {
-                    const aiStep = generatedSteps[aiStepIndex] as { selector: string; content: JSONContent }
-                    currentSteps[i] = {
-                        ...currentSteps[i],
-                        content: aiStep.content,
-                    }
+                    const aiStep = generatedSteps[aiStepIndex]
+                    currentSteps[i] = { ...currentSteps[i], content: aiStep.content }
                     aiStepIndex++
                 }
             })
@@ -687,21 +695,16 @@ export const productToursLogic = kea<productToursLogicType>([
             actions.setTourFormValue('steps', currentSteps)
             lemonToast.success('Tour content generated!')
         },
-        // Opens the goal modal
         startCreation: () => {
             toolbarLogic.actions.setVisibleMenu('none')
             actions.openGoalModal()
         },
-        // After setting goal, start creating a new tour
-        startSelectionMode: async () => {
+        startFromGoalModal: async () => {
             actions.newTour()
-            // Default tour name to the goal
             if (values.aiGoal.trim()) {
                 actions.setTourFormValue('name', values.aiGoal.trim())
             }
-            actions.inspectForElementWithIndex(0)
 
-            // Capture screenshot in background for later AI generation
             try {
                 const screenshot = await captureScreenshot().catch(() => null)
                 actions.setCachedScreenshot(screenshot)
@@ -713,8 +716,27 @@ export const productToursLogic = kea<productToursLogicType>([
 
     events(({ actions, values, cache }) => ({
         afterMount: () => {
+            // Watch for DOM changes to update highlights when elements appear/disappear
+            cache.mutationTimeout = null as ReturnType<typeof setTimeout> | null
+            cache.mutationObserver = new MutationObserver(() => {
+                // Debounce updates to avoid performance issues
+                if (cache.mutationTimeout) {
+                    clearTimeout(cache.mutationTimeout)
+                }
+                cache.mutationTimeout = setTimeout(() => {
+                    actions.updateRects()
+                }, 50)
+            })
+            cache.mutationObserver.observe(document.body, {
+                childList: true,
+                subtree: true,
+                attributes: true,
+                attributeFilter: ['style', 'class', 'hidden'],
+            })
+
             cache.onMouseOver = (e: MouseEvent): void => {
-                if (!values.isInspecting) {
+                // Only show hover highlight when in selecting mode
+                if (values.editorState.mode !== 'selecting') {
                     return
                 }
                 const target = e.target as HTMLElement
@@ -724,14 +746,40 @@ export const productToursLogic = kea<productToursLogicType>([
             }
 
             cache.onClick = (e: MouseEvent): void => {
-                if (!values.isInspecting || values.isEditingStep) {
+                // Cmd/ctrl+click always passes through (for click-through navigation)
+                if (e.metaKey || e.ctrlKey) {
                     return
                 }
+
                 const target = e.target as HTMLElement
-                if (target && !isToolbarElement(target)) {
+                if (!target || isToolbarElement(target)) {
+                    return
+                }
+
+                // In selecting mode: capture the element
+                if (values.editorState.mode === 'selecting') {
                     e.preventDefault()
                     e.stopPropagation()
                     actions.selectElement(target)
+                    return
+                }
+
+                // In idle mode: check if clicked element belongs to a step
+                if (values.editorState.mode === 'idle' && values.tourForm?.steps) {
+                    const steps = values.tourForm.steps
+                    for (let i = 0; i < steps.length; i++) {
+                        const step = steps[i]
+                        if (step.type !== 'element') {
+                            continue
+                        }
+                        const stepElement = getStepElement(step)
+                        if (stepElement && (stepElement === target || stepElement.contains(target))) {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            actions.editStep(i)
+                            return
+                        }
+                    }
                 }
             }
 
@@ -748,9 +796,8 @@ export const productToursLogic = kea<productToursLogicType>([
             }
 
             cache.onKeyDown = (e: KeyboardEvent): void => {
-                if (e.key === 'Escape' && values.isInspecting) {
-                    actions.inspectForElementWithIndex(null)
-                    actions.setHoverElement(null)
+                if (e.key === 'Escape' && values.editorState.mode !== 'idle') {
+                    actions.setEditorState({ mode: 'idle' })
                 }
             }
 
@@ -761,6 +808,12 @@ export const productToursLogic = kea<productToursLogicType>([
             window.addEventListener('keydown', cache.onKeyDown)
         },
         beforeUnmount: () => {
+            if (cache.mutationTimeout) {
+                clearTimeout(cache.mutationTimeout)
+            }
+            if (cache.mutationObserver) {
+                cache.mutationObserver.disconnect()
+            }
             if (cache.onMouseOver) {
                 document.removeEventListener('mouseover', cache.onMouseOver, true)
             }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3252,16 +3252,24 @@ export interface ProductTourSurveyQuestion {
     upperBoundLabel?: string
 }
 
+export type ProductTourProgressionTriggerType = 'button' | 'click'
+
+export type ProductTourStepType = 'element' | 'modal' | 'survey'
+
 export interface ProductTourStep {
     id: string
-    selector: string
+    type: ProductTourStepType
+    /** CSS selector for element steps, empty/undefined for modal/survey steps */
+    selector?: string
     /** Rich text content in tiptap JSONContent format */
     content: Record<string, any> | null
     position?: 'top' | 'bottom' | 'left' | 'right'
-    /** Inline survey question config - if present, this is a survey step */
+    /** Inline survey question config - only for survey steps */
     survey?: ProductTourSurveyQuestion
     /** ID of the auto-created survey for this step (set by backend) */
     linkedSurveyId?: string
+    /** how this step progresses, e.g. next button or click trigger */
+    progressionTrigger?: ProductTourProgressionTriggerType
 }
 
 /** Tracks a snapshot of steps at a point in time for funnel analysis */


### PR DESCRIPTION
## Problem

1. product tour logic is messy
2. during tour building, it's impossible to interact with elements that have steps attached (we hijack the clicks)
3. need to be able to toggle next button vs. 'click' progression triggers

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

[product-tour-refactor-demo.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/99b11288-a5e9-49a0-907f-6bfaf2ed2af2.mp4" />](https://app.graphite.com/user-attachments/video/99b11288-a5e9-49a0-907f-6bfaf2ed2af2.mp4)

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->