### PR TITLE
fix: use Redis to hold data between activities in recording export

### DIFF
--- a/posthog/temporal/export_recording/activities.py
+++ b/posthog/temporal/export_recording/activities.py
@@ -1,5 +1,7 @@
 import re
+import json
 import uuid
+import base64
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -7,6 +9,7 @@ from urllib import parse
 from uuid import uuid4
 
 import pytz
+import redis.asyncio as redis
 from temporalio import activity
 
 from posthog.models.exported_recording import ExportedRecording
@@ -17,9 +20,18 @@ from posthog.storage import session_recording_v2_object_storage
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.logger import get_write_only_logger
-from posthog.temporal.export_recording.types import ExportContext, ExportRecordingInput
+from posthog.temporal.export_recording.types import ExportContext, ExportRecordingInput, RedisConfig
 
 LOGGER = get_write_only_logger()
+
+
+def _redis_url(config: RedisConfig) -> str:
+    return f"redis://{config.redis_host}:{config.redis_port}"
+
+
+def _redis_key(export_id: uuid.UUID, key_type: str, suffix: str = "") -> str:
+    base_key = f"export-recording:{export_id}:{key_type}"
+    return f"{base_key}:{suffix}" if suffix else base_key
 
 
 @activity.defn
@@ -43,6 +55,7 @@ async def build_recording_export_context(input: ExportRecordingInput) -> ExportC
         exported_recording_id=input.exported_recording_id,
         session_id=export_record.session_id,
         team_id=export_record.team.id,
+        redis_config=input.redis_config,
     )
 
 
@@ -68,13 +81,11 @@ async def export_replay_clickhouse_rows(input: ExportContext) -> None:
 
     logger.info(f"Received {len(raw_response)} bytes from ClickHouse")
 
-    output_path = Path("/tmp") / str(input.export_id) / "clickhouse" / "session-replay-events.json"
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    redis_key = _redis_key(input.export_id, "replay-events")
+    async with redis.from_url(_redis_url(input.redis_config)) as r:
+        await r.setex(redis_key, input.redis_config.redis_ttl, raw_response)
 
-    with output_path.open("wb") as f:
-        f.write(raw_response)
-
-    logger.info(f"Wrote replay ClickHouse metadata to {output_path}")
+    logger.info(f"Wrote replay ClickHouse metadata to Redis key {redis_key}")
 
 
 @activity.defn
@@ -108,13 +119,11 @@ async def export_event_clickhouse_rows(input: ExportContext) -> None:
 
     logger.info(f"Received {len(raw_response)} bytes from ClickHouse")
 
-    output_path = Path("/tmp") / str(input.export_id) / "clickhouse" / "events.json"
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    redis_key = _redis_key(input.export_id, "events")
+    async with redis.from_url(_redis_url(input.redis_config)) as r:
+        await r.setex(redis_key, input.redis_config.redis_ttl, raw_response)
 
-    with output_path.open("wb") as f:
-        f.write(raw_response)
-
-    logger.info(f"Wrote event ClickHouse data to {output_path}")
+    logger.info(f"Wrote event ClickHouse data to Redis key {redis_key}")
 
 
 @activity.defn
@@ -138,13 +147,11 @@ async def export_recording_data_prefix(input: ExportContext) -> None:
 
     logger.info(f"Found S3 prefix: {prefix}")
 
-    output_path = Path("/tmp") / str(input.export_id) / "s3_prefix.txt"
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    redis_key = _redis_key(input.export_id, "s3-prefix")
+    async with redis.from_url(_redis_url(input.redis_config)) as r:
+        await r.setex(redis_key, input.redis_config.redis_ttl, prefix)
 
-    with output_path.open("w") as f:
-        f.write(prefix)
-
-    logger.info(f"Wrote S3 prefix to {output_path}")
+    logger.info(f"Wrote S3 prefix to Redis key {redis_key}")
 
 
 @activity.defn
@@ -158,41 +165,48 @@ async def export_recording_data(input: ExportContext) -> None:
 
     logger.info(f"Found {len(recording_blocks)} blocks to export")
 
-    output_files: list[Path] = []
+    block_manifest: list[dict] = []
 
-    for block in recording_blocks:
-        _, _, s3_path, _, query, _ = parse.urlparse(block.url)
+    async with redis.from_url(_redis_url(input.redis_config)) as r:
+        for block in recording_blocks:
+            _, _, s3_path, _, query, _ = parse.urlparse(block.url)
 
-        filename = s3_path.split("/")[-1]
+            filename = s3_path.split("/")[-1]
 
-        match = re.match(r"^range=bytes=(\d+)-(\d+)$", query)
+            match = re.match(r"^range=bytes=(\d+)-(\d+)$", query)
 
-        if not match:
-            logger.warning(f"Got malformed byte range in block URL: {query}, skipping...")
-            continue
+            if not match:
+                logger.warning(f"Got malformed byte range in block URL: {query}, skipping...")
+                continue
 
-        block_offset = int(match.group(1))
+            block_offset = int(match.group(1))
 
-        try:
-            async with session_recording_v2_object_storage.async_client() as storage:
-                block_data = await storage.fetch_block_bytes(block.url)
-            logger.info(f"Successfully fetched block data ({len(block_data)} bytes)")
-        except session_recording_v2_object_storage.BlockFetchError:
-            logger.warning(f"Failed to fetch block at {block.url}, skipping...")
-            continue
+            try:
+                async with session_recording_v2_object_storage.async_client() as storage:
+                    block_data = await storage.fetch_block_bytes(block.url)
+                logger.info(f"Successfully fetched block data ({len(block_data)} bytes)")
+            except session_recording_v2_object_storage.BlockFetchError:
+                logger.warning(f"Failed to fetch block at {block.url}, skipping...")
+                continue
 
-        output_path = Path("/tmp") / str(input.export_id) / "data" / filename
-        output_path.parent.mkdir(parents=True, exist_ok=True)
+            redis_key = _redis_key(input.export_id, "block", filename)
+            encoded_data = base64.b64encode(block_data).decode("utf-8")
+            await r.setex(redis_key, input.redis_config.redis_ttl, encoded_data)
 
-        with output_path.open("wb") as f:
-            f.write(b"\x00" * block_offset)
-            f.write(block_data)
-            f.write(b"\x00" * 1024)
+            block_manifest.append(
+                {
+                    "filename": filename,
+                    "offset": block_offset,
+                    "redis_key": redis_key,
+                }
+            )
 
-        logger.info(f"Wrote block data to {output_path}")
-        output_files.append(output_path)
+            logger.info(f"Wrote block data to Redis key {redis_key}")
 
-    logger.info(f"Exported recording data to {len(output_files)} files")
+        manifest_key = _redis_key(input.export_id, "block-manifest")
+        await r.setex(manifest_key, input.redis_config.redis_ttl, json.dumps(block_manifest))
+
+    logger.info(f"Exported {len(block_manifest)} recording blocks to Redis")
 
 
 @activity.defn
@@ -201,9 +215,56 @@ async def store_export_data(input: ExportContext) -> None:
     logger.info(f"Storing export data for session {input.session_id}")
 
     export_dir = Path("/tmp") / str(input.export_id)
+    export_dir.mkdir(parents=True, exist_ok=True)
 
-    if not export_dir.exists():
-        raise RuntimeError(f"Export directory {export_dir} does not exist")
+    async with redis.from_url(_redis_url(input.redis_config)) as r:
+        replay_events_data = await r.get(_redis_key(input.export_id, "replay-events"))
+        events_data = await r.get(_redis_key(input.export_id, "events"))
+        s3_prefix = await r.get(_redis_key(input.export_id, "s3-prefix"))
+        block_manifest_raw = await r.get(_redis_key(input.export_id, "block-manifest"))
+
+        clickhouse_dir = export_dir / "clickhouse"
+        clickhouse_dir.mkdir(parents=True, exist_ok=True)
+
+        if replay_events_data:
+            replay_events_path = clickhouse_dir / "session-replay-events.json"
+            with replay_events_path.open("wb") as f:
+                f.write(replay_events_data if isinstance(replay_events_data, bytes) else replay_events_data.encode())
+            logger.info(f"Wrote replay events to {replay_events_path}")
+
+        if events_data:
+            events_path = clickhouse_dir / "events.json"
+            with events_path.open("wb") as f:
+                f.write(events_data if isinstance(events_data, bytes) else events_data.encode())
+            logger.info(f"Wrote events to {events_path}")
+
+        if s3_prefix:
+            s3_prefix_path = export_dir / "s3_prefix.txt"
+            with s3_prefix_path.open("w") as f:
+                f.write(s3_prefix if isinstance(s3_prefix, str) else s3_prefix.decode())
+            logger.info(f"Wrote S3 prefix to {s3_prefix_path}")
+
+        if block_manifest_raw:
+            data_dir = export_dir / "data"
+            data_dir.mkdir(parents=True, exist_ok=True)
+
+            block_manifest = json.loads(block_manifest_raw)
+            for block_info in block_manifest:
+                block_data_encoded = await r.get(block_info["redis_key"])
+                if not block_data_encoded:
+                    logger.warning(f"Missing block data for {block_info['filename']}, skipping...")
+                    continue
+
+                block_data = base64.b64decode(block_data_encoded)
+                block_offset = block_info["offset"]
+
+                output_path = data_dir / block_info["filename"]
+                with output_path.open("wb") as f:
+                    f.write(b"\x00" * block_offset)
+                    f.write(block_data)
+                    f.write(b"\x00" * 1024)
+
+                logger.info(f"Wrote block data to {output_path}")
 
     zip_path = Path("/tmp") / f"{input.export_id}.zip"
     shutil.make_archive(str(zip_path.with_suffix("")), "zip", export_dir)
@@ -218,6 +279,7 @@ async def store_export_data(input: ExportContext) -> None:
     logger.info(f"Uploaded zip archive to S3 at {s3_key}")
 
     zip_path.unlink()
+    shutil.rmtree(export_dir)
 
     export_record = await ExportedRecording.objects.aget(id=input.exported_recording_id)
     export_record.export_location = s3_key
@@ -232,15 +294,20 @@ async def cleanup_export_data(input: ExportContext) -> None:
     logger = LOGGER.bind()
     logger.info(f"Cleaning up export data for session {input.session_id}")
 
-    export_dir = Path("/tmp") / str(input.export_id)
-    zip_path = Path("/tmp") / f"{input.export_id}.zip"
+    keys_to_delete = [
+        _redis_key(input.export_id, "replay-events"),
+        _redis_key(input.export_id, "events"),
+        _redis_key(input.export_id, "s3-prefix"),
+        _redis_key(input.export_id, "block-manifest"),
+    ]
 
-    if export_dir.exists():
-        shutil.rmtree(export_dir)
-        logger.info(f"Deleted export directory {export_dir}")
-    else:
-        logger.warning(f"Export directory {export_dir} does not exist, skipping cleanup")
+    async with redis.from_url(_redis_url(input.redis_config)) as r:
+        block_manifest_raw = await r.get(_redis_key(input.export_id, "block-manifest"))
+        if block_manifest_raw:
+            block_manifest = json.loads(block_manifest_raw)
+            for block_info in block_manifest:
+                keys_to_delete.append(block_info["redis_key"])
 
-    if zip_path.exists():
-        zip_path.unlink()
-        logger.info(f"Deleted zip file {zip_path}")
+        if keys_to_delete:
+            deleted_count = await r.delete(*keys_to_delete)
+            logger.info(f"Deleted {deleted_count} Redis keys for export {input.export_id}")

--- a/posthog/temporal/export_recording/activities.py
+++ b/posthog/temporal/export_recording/activities.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from urllib import parse
 from uuid import uuid4
 
+from django.conf import settings
+
 import pytz
 import redis.asyncio as redis
 from temporalio import activity
@@ -26,7 +28,7 @@ LOGGER = get_write_only_logger()
 
 
 def _redis_url(config: RedisConfig) -> str:
-    return f"redis://{config.redis_host}:{config.redis_port}"
+    return config.redis_url or settings.SESSION_RECORDING_REDIS_URL
 
 
 def _redis_key(export_id: uuid.UUID, key_type: str, suffix: str = "") -> str:

--- a/posthog/temporal/export_recording/types.py
+++ b/posthog/temporal/export_recording/types.py
@@ -4,8 +4,7 @@ from pydantic import BaseModel
 
 
 class RedisConfig(BaseModel):
-    redis_host: str = "localhost"
-    redis_port: int = 6379
+    redis_url: str | None = None  # Defaults to settings.SESSION_RECORDING_REDIS_URL
     redis_ttl: int = 3600 * 6  # 6 hours
 
 

--- a/posthog/temporal/export_recording/types.py
+++ b/posthog/temporal/export_recording/types.py
@@ -3,8 +3,15 @@ from uuid import UUID
 from pydantic import BaseModel
 
 
+class RedisConfig(BaseModel):
+    redis_host: str = "localhost"
+    redis_port: int = 6379
+    redis_ttl: int = 3600 * 6  # 6 hours
+
+
 class ExportRecordingInput(BaseModel):
     exported_recording_id: UUID
+    redis_config: RedisConfig = RedisConfig()
 
 
 class ExportContext(BaseModel):
@@ -12,3 +19,4 @@ class ExportContext(BaseModel):
     exported_recording_id: UUID
     session_id: str
     team_id: int
+    redis_config: RedisConfig

--- a/posthog/temporal/export_recording/workflows.py
+++ b/posthog/temporal/export_recording/workflows.py
@@ -1,4 +1,3 @@
-import os
 import json
 import asyncio
 from datetime import timedelta
@@ -15,7 +14,7 @@ from posthog.temporal.export_recording.activities import (
     export_replay_clickhouse_rows,
     store_export_data,
 )
-from posthog.temporal.export_recording.types import ExportRecordingInput, RedisConfig
+from posthog.temporal.export_recording.types import ExportRecordingInput
 
 
 @workflow.defn(name="export-recording")
@@ -26,12 +25,6 @@ class ExportRecordingWorkflow(PostHogWorkflow):
 
     @workflow.run
     async def run(self, input: ExportRecordingInput) -> None:
-        if input.redis_config.redis_host == RedisConfig().redis_host:
-            input.redis_config.redis_host = os.getenv("EXPORT_RECORDING_REDIS_HOST", "localhost")
-
-        if input.redis_config.redis_port == RedisConfig().redis_port:
-            input.redis_config.redis_port = int(os.getenv("EXPORT_RECORDING_REDIS_PORT", "6379"))
-
         export_context = await workflow.execute_activity(
             build_recording_export_context,
             input,

--- a/posthog/temporal/import_recording/workflows.py
+++ b/posthog/temporal/import_recording/workflows.py
@@ -8,6 +8,7 @@ from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.import_recording.activities import (
     build_import_context,
     cleanup_import_data,
+    import_event_clickhouse_rows,
     import_recording_data,
     import_replay_clickhouse_rows,
 )
@@ -46,7 +47,7 @@ class ImportRecordingWorkflow(PostHogWorkflow):
                     ),
                 )
             )
-            """import_tasks.create_task(
+            import_tasks.create_task(
                 workflow.execute_activity(
                     import_event_clickhouse_rows,
                     import_context,
@@ -57,7 +58,7 @@ class ImportRecordingWorkflow(PostHogWorkflow):
                         initial_interval=timedelta(minutes=1),
                     ),
                 )
-            )"""
+            )
             import_tasks.create_task(
                 workflow.execute_activity(
                     import_recording_data,

--- a/posthog/temporal/tests/export_recording/test_activities.py
+++ b/posthog/temporal/tests/export_recording/test_activities.py
@@ -1,3 +1,5 @@
+import json
+import base64
 from uuid import UUID, uuid4
 
 import pytest
@@ -6,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from posthog.models.exported_recording import ExportedRecording
 from posthog.storage import session_recording_v2_object_storage
 from posthog.temporal.export_recording.activities import (
+    _redis_key,
+    _redis_url,
     build_recording_export_context,
     cleanup_export_data,
     export_event_clickhouse_rows,
@@ -14,9 +18,27 @@ from posthog.temporal.export_recording.activities import (
     export_replay_clickhouse_rows,
     store_export_data,
 )
-from posthog.temporal.export_recording.types import ExportContext, ExportRecordingInput
+from posthog.temporal.export_recording.types import ExportContext, ExportRecordingInput, RedisConfig
 
 TEST_RECORDING_ID = UUID("01938a67-1234-7000-8000-000000000001")
+TEST_REDIS_CONFIG = RedisConfig(redis_host="test-redis", redis_port=6379, redis_ttl=3600)
+
+
+def test_redis_url():
+    config = RedisConfig(redis_host="my-redis", redis_port=6380)
+    assert _redis_url(config) == "redis://my-redis:6380"
+
+
+def test_redis_key_without_suffix():
+    export_id = UUID("01938a67-1234-7000-8000-000000000001")
+    key = _redis_key(export_id, "replay-events")
+    assert key == f"export-recording:{export_id}:replay-events"
+
+
+def test_redis_key_with_suffix():
+    export_id = UUID("01938a67-1234-7000-8000-000000000001")
+    key = _redis_key(export_id, "block", "file.json")
+    assert key == f"export-recording:{export_id}:block:file.json"
 
 
 @pytest.mark.asyncio
@@ -41,52 +63,145 @@ async def test_build_recording_export_context_success():
         patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
     ):
         mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
-        result = await build_recording_export_context(ExportRecordingInput(exported_recording_id=TEST_RECORDING_ID))
+        result = await build_recording_export_context(
+            ExportRecordingInput(exported_recording_id=TEST_RECORDING_ID, redis_config=TEST_REDIS_CONFIG)
+        )
 
     assert result.session_id == TEST_SESSION_ID
     assert result.team_id == TEST_TEAM_ID
     assert result.exported_recording_id == TEST_RECORDING_ID
+    assert result.redis_config == TEST_REDIS_CONFIG
     mock_qs.select_related.assert_called_once_with("team")
     mock_qs.select_related.return_value.only.assert_called_once_with("status", "session_id", "team__id")
     mock_qs.select_related.return_value.only.return_value.aget.assert_called_once_with(id=TEST_RECORDING_ID)
 
 
 @pytest.mark.asyncio
-async def test_export_recording_data_prefix_success(tmp_path):
+async def test_export_replay_clickhouse_rows_success():
     export_id = uuid4()
     export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
+    )
+
+    mock_ch_response = MagicMock()
+    mock_ch_response.content.read = AsyncMock(return_value=b'{"data": []}')
+
+    mock_query_ctx = MagicMock()
+    mock_query_ctx.__aenter__ = AsyncMock(return_value=mock_ch_response)
+    mock_query_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client = MagicMock()
+    mock_client.aget_query.return_value = mock_query_ctx
+
+    mock_redis = AsyncMock()
+
+    with (
+        patch("posthog.temporal.export_recording.activities.get_client") as mock_get_client,
+        patch("posthog.temporal.export_recording.activities.SessionReplayEvents.get_metadata_query") as mock_query,
+        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+    ):
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+        mock_query.return_value = "SELECT * FROM session_replay_events"
+        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+
+        await export_replay_clickhouse_rows(export_context)
+
+        mock_client.aget_query.assert_called_once()
+        mock_redis.setex.assert_called_once()
+        call_args = mock_redis.setex.call_args
+        assert call_args[0][0] == _redis_key(export_id, "replay-events")
+        assert call_args[0][1] == TEST_REDIS_CONFIG.redis_ttl
+        assert call_args[0][2] == b'{"data": []}'
+
+
+@pytest.mark.asyncio
+async def test_export_event_clickhouse_rows_success():
+    export_id = uuid4()
+    export_context = ExportContext(
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
+    )
+
+    mock_ch_response = MagicMock()
+    mock_ch_response.content.read = AsyncMock(return_value=b'{"data": []}')
+
+    mock_query_ctx = MagicMock()
+    mock_query_ctx.__aenter__ = AsyncMock(return_value=mock_ch_response)
+    mock_query_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    mock_client = MagicMock()
+    mock_client.aget_query.return_value = mock_query_ctx
+
+    mock_redis = AsyncMock()
+
+    with (
+        patch("posthog.temporal.export_recording.activities.get_client") as mock_get_client,
+        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+    ):
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+
+        await export_event_clickhouse_rows(export_context)
+
+        mock_client.aget_query.assert_called_once()
+        mock_redis.setex.assert_called_once()
+        call_args = mock_redis.setex.call_args
+        assert call_args[0][0] == _redis_key(export_id, "events")
+        assert call_args[0][1] == TEST_REDIS_CONFIG.redis_ttl
+
+
+@pytest.mark.asyncio
+async def test_export_recording_data_prefix_success():
+    export_id = uuid4()
+    export_context = ExportContext(
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
     )
 
     mock_block = MagicMock()
     mock_block.url = "s3://bucket/team_id/123/session_id/test-session/data/file.json?range=bytes=0-100"
 
     mock_recording = MagicMock()
+    mock_redis = AsyncMock()
 
     with (
         patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
         patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
         patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
-        patch("posthog.temporal.export_recording.activities.Path") as mock_path_cls,
+        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
     ):
         mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
         mock_list_blocks.return_value = [mock_block]
-
-        mock_output_path = MagicMock()
-        mock_parent = MagicMock()
-        mock_output_path.parent = mock_parent
-        mock_path_cls.return_value.__truediv__.return_value.__truediv__.return_value = mock_output_path
+        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
 
         await export_recording_data_prefix(export_context)
 
-        mock_output_path.open.assert_called_once_with("w")
+        mock_redis.setex.assert_called_once()
+        call_args = mock_redis.setex.call_args
+        assert call_args[0][0] == _redis_key(export_id, "s3-prefix")
+        assert call_args[0][1] == TEST_REDIS_CONFIG.redis_ttl
+        assert call_args[0][2] == "team_id/123/session_id/test-session/data"
 
 
 @pytest.mark.asyncio
 async def test_export_recording_data_prefix_no_blocks():
     export_id = uuid4()
     export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
     )
 
     mock_recording = MagicMock()
@@ -95,106 +210,241 @@ async def test_export_recording_data_prefix_no_blocks():
         patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
         patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
         patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
+        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
     ):
         mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
         mock_list_blocks.return_value = []
 
         await export_recording_data_prefix(export_context)
 
-
-@pytest.mark.asyncio
-async def test_cleanup_export_data_success(tmp_path):
-    export_id = uuid4()
-    export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
-    )
-
-    export_dir = tmp_path / str(export_id)
-    export_dir.mkdir()
-    (export_dir / "test_file.json").write_text("test content")
-    (export_dir / "subdir").mkdir()
-    (export_dir / "subdir" / "nested_file.txt").write_text("nested content")
-
-    zip_path = tmp_path / f"{export_id}.zip"
-    zip_path.write_text("fake zip content")
-
-    assert export_dir.exists()
-    assert zip_path.exists()
-
-    with patch("posthog.temporal.export_recording.activities.Path") as mock_path_cls:
-
-        def path_side_effect(base):
-            if base == "/tmp":
-                return tmp_path
-            return MagicMock()
-
-        mock_path_cls.side_effect = path_side_effect
-
-        await cleanup_export_data(export_context)
-
-    assert not export_dir.exists()
-    assert not zip_path.exists()
+        mock_redis_from_url.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_cleanup_export_data_directory_not_exists():
+async def test_export_recording_data_success():
     export_id = uuid4()
     export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
     )
 
-    with patch("posthog.temporal.export_recording.activities.Path") as mock_path_cls:
-        mock_export_dir = MagicMock()
-        mock_export_dir.exists.return_value = False
+    mock_block = MagicMock()
+    mock_block.url = "s3://bucket/team/123/session/test-session/data/file.json?range=bytes=100-200"
 
-        mock_zip_path = MagicMock()
-        mock_zip_path.exists.return_value = False
+    mock_recording = MagicMock()
+    mock_storage = AsyncMock()
+    mock_storage.fetch_block_bytes = AsyncMock(return_value=b"block data content")
+    mock_redis = AsyncMock()
 
-        def truediv_side_effect(path):
-            if ".zip" in str(path):
-                return mock_zip_path
-            return mock_export_dir
+    with (
+        patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
+        patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
+        patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
+        patch(
+            "posthog.temporal.export_recording.activities.session_recording_v2_object_storage.async_client"
+        ) as mock_storage_client,
+        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+    ):
+        mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
+        mock_list_blocks.return_value = [mock_block]
+        mock_storage_client.return_value.__aenter__.return_value = mock_storage
+        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
 
-        mock_tmp_path = MagicMock()
-        mock_tmp_path.__truediv__ = MagicMock(side_effect=truediv_side_effect)
-        mock_path_cls.return_value = mock_tmp_path
+        await export_recording_data(export_context)
 
-        await cleanup_export_data(export_context)
+        mock_storage.fetch_block_bytes.assert_called_once_with(mock_block.url)
+        assert mock_redis.setex.call_count == 2
+
+        block_call = mock_redis.setex.call_args_list[0]
+        assert block_call[0][0] == _redis_key(export_id, "block", "file.json")
+        assert block_call[0][2] == base64.b64encode(b"block data content").decode("utf-8")
+
+        manifest_call = mock_redis.setex.call_args_list[1]
+        assert manifest_call[0][0] == _redis_key(export_id, "block-manifest")
+        manifest_data = json.loads(manifest_call[0][2])
+        assert len(manifest_data) == 1
+        assert manifest_data[0]["filename"] == "file.json"
+        assert manifest_data[0]["offset"] == 100
+
+
+@pytest.mark.asyncio
+async def test_export_recording_data_no_blocks():
+    export_id = uuid4()
+    export_context = ExportContext(
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
+    )
+
+    mock_recording = MagicMock()
+    mock_redis = AsyncMock()
+
+    with (
+        patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
+        patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
+        patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
+        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+    ):
+        mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
+        mock_list_blocks.return_value = []
+        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+
+        await export_recording_data(export_context)
+
+        mock_redis.setex.assert_called_once()
+        manifest_call = mock_redis.setex.call_args
+        assert manifest_call[0][0] == _redis_key(export_id, "block-manifest")
+        assert json.loads(manifest_call[0][2]) == []
+
+
+@pytest.mark.asyncio
+async def test_export_recording_data_malformed_url():
+    export_id = uuid4()
+    export_context = ExportContext(
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
+    )
+
+    mock_block = MagicMock()
+    mock_block.url = "s3://bucket/team/123/session/test-session/data/file.json?invalid_query"
+
+    mock_recording = MagicMock()
+    mock_redis = AsyncMock()
+
+    with (
+        patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
+        patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
+        patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
+        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+    ):
+        mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
+        mock_list_blocks.return_value = [mock_block]
+        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+
+        await export_recording_data(export_context)
+
+        mock_redis.setex.assert_called_once()
+        manifest_call = mock_redis.setex.call_args
+        assert json.loads(manifest_call[0][2]) == []
+
+
+@pytest.mark.asyncio
+async def test_export_recording_data_block_fetch_error():
+    export_id = uuid4()
+    export_context = ExportContext(
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
+    )
+
+    mock_block = MagicMock()
+    mock_block.url = "s3://bucket/team/123/session/test-session/data/file.json?range=bytes=100-200"
+
+    mock_recording = MagicMock()
+    mock_storage = AsyncMock()
+    mock_storage.fetch_block_bytes = AsyncMock(
+        side_effect=session_recording_v2_object_storage.BlockFetchError("Fetch failed")
+    )
+    mock_redis = AsyncMock()
+
+    with (
+        patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
+        patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
+        patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
+        patch(
+            "posthog.temporal.export_recording.activities.session_recording_v2_object_storage.async_client"
+        ) as mock_storage_client,
+        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+    ):
+        mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
+        mock_list_blocks.return_value = [mock_block]
+        mock_storage_client.return_value.__aenter__.return_value = mock_storage
+        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+
+        await export_recording_data(export_context)
+
+        mock_redis.setex.assert_called_once()
+        manifest_call = mock_redis.setex.call_args
+        assert json.loads(manifest_call[0][2]) == []
 
 
 @pytest.mark.asyncio
 async def test_store_export_data_success(tmp_path):
     export_id = uuid4()
     export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
     )
 
-    export_dir = tmp_path / str(export_id)
-    export_dir.mkdir()
-    (export_dir / "test_file.json").write_text("test content")
+    block_manifest = [
+        {"filename": "file.json", "offset": 100, "redis_key": f"export-recording:{export_id}:block:file.json"}
+    ]
+    block_data_encoded = base64.b64encode(b"block content").decode("utf-8")
+
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(
+        side_effect=lambda key: {
+            _redis_key(export_id, "replay-events"): b'{"data": []}',
+            _redis_key(export_id, "events"): b'{"events": []}',
+            _redis_key(export_id, "s3-prefix"): "team/123/session",
+            _redis_key(export_id, "block-manifest"): json.dumps(block_manifest),
+            f"export-recording:{export_id}:block:file.json": block_data_encoded,
+        }.get(key)
+    )
 
     mock_record = MagicMock()
     mock_record.save = MagicMock()
     mock_storage = AsyncMock()
 
     with (
+        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
         patch("posthog.temporal.export_recording.activities.Path") as mock_path_cls,
         patch("posthog.temporal.export_recording.activities.shutil.make_archive") as mock_make_archive,
+        patch("posthog.temporal.export_recording.activities.shutil.rmtree"),
         patch(
             "posthog.temporal.export_recording.activities.session_recording_v2_object_storage.async_client"
         ) as mock_storage_client,
         patch("posthog.temporal.export_recording.activities.ExportedRecording.objects") as mock_record_qs,
         patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
     ):
+        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+
         mock_export_dir = MagicMock()
-        mock_export_dir.exists.return_value = True
+        mock_clickhouse_dir = MagicMock()
+        mock_data_dir = MagicMock()
         mock_zip_path = MagicMock()
         mock_zip_path.with_suffix.return_value = tmp_path / f"{export_id}"
 
-        mock_path_cls.return_value.__truediv__.side_effect = [mock_export_dir, mock_zip_path]
+        def truediv_side_effect(path):
+            if str(path) == str(export_id):
+                return mock_export_dir
+            if ".zip" in str(path):
+                return mock_zip_path
+            return MagicMock()
+
+        mock_path_cls.return_value.__truediv__ = MagicMock(side_effect=truediv_side_effect)
+        mock_export_dir.__truediv__ = MagicMock(
+            side_effect=lambda p: mock_clickhouse_dir
+            if p == "clickhouse"
+            else mock_data_dir
+            if p == "data"
+            else MagicMock()
+        )
 
         mock_storage_client.return_value.__aenter__.return_value = mock_storage
-
         mock_record_qs.aget = AsyncMock(return_value=mock_record)
         mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
 
@@ -206,43 +456,45 @@ async def test_store_export_data_success(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_store_export_data_directory_not_exists():
-    export_id = uuid4()
-    export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
-    )
-
-    with patch("posthog.temporal.export_recording.activities.Path") as mock_path_cls:
-        mock_export_dir = MagicMock()
-        mock_export_dir.exists.return_value = False
-        mock_path_cls.return_value.__truediv__.return_value = mock_export_dir
-
-        with pytest.raises(RuntimeError, match="Export directory .* does not exist"):
-            await store_export_data(export_context)
-
-
-@pytest.mark.asyncio
 async def test_store_export_data_s3_upload_failure():
     export_id = uuid4()
     export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
     )
+
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=None)
 
     mock_storage = AsyncMock()
     mock_storage.upload_file.side_effect = session_recording_v2_object_storage.FileUploadError("Upload failed")
 
     with (
+        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
         patch("posthog.temporal.export_recording.activities.Path") as mock_path_cls,
         patch("posthog.temporal.export_recording.activities.shutil.make_archive"),
         patch(
             "posthog.temporal.export_recording.activities.session_recording_v2_object_storage.async_client"
         ) as mock_storage_client,
     ):
+        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+
         mock_export_dir = MagicMock()
-        mock_export_dir.exists.return_value = True
+        mock_clickhouse_dir = MagicMock()
         mock_zip_path = MagicMock()
 
-        mock_path_cls.return_value.__truediv__.side_effect = [mock_export_dir, mock_zip_path]
+        def truediv_side_effect(path):
+            if str(path) == str(export_id):
+                return mock_export_dir
+            if ".zip" in str(path):
+                return mock_zip_path
+            return MagicMock()
+
+        mock_path_cls.return_value.__truediv__ = MagicMock(side_effect=truediv_side_effect)
+        mock_export_dir.__truediv__ = MagicMock(return_value=mock_clickhouse_dir)
         mock_storage_client.return_value.__aenter__.return_value = mock_storage
 
         with pytest.raises(session_recording_v2_object_storage.FileUploadError):
@@ -250,188 +502,58 @@ async def test_store_export_data_s3_upload_failure():
 
 
 @pytest.mark.asyncio
-async def test_export_replay_clickhouse_rows_success():
+async def test_cleanup_export_data_success():
     export_id = uuid4()
     export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
     )
 
-    mock_ch_response = MagicMock()
-    mock_ch_response.content.read = AsyncMock(return_value=b'{"data": []}')
+    block_manifest = [
+        {"filename": "file.json", "offset": 100, "redis_key": f"export-recording:{export_id}:block:file.json"}
+    ]
 
-    mock_query_ctx = MagicMock()
-    mock_query_ctx.__aenter__ = AsyncMock(return_value=mock_ch_response)
-    mock_query_ctx.__aexit__ = AsyncMock(return_value=None)
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=json.dumps(block_manifest))
+    mock_redis.delete = AsyncMock(return_value=5)
 
-    mock_client = MagicMock()
-    mock_client.aget_query.return_value = mock_query_ctx
+    with patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url:
+        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
 
-    with (
-        patch("posthog.temporal.export_recording.activities.get_client") as mock_get_client,
-        patch("posthog.temporal.export_recording.activities.SessionReplayEvents.get_metadata_query") as mock_query,
-        patch("posthog.temporal.export_recording.activities.Path") as mock_path_cls,
-    ):
-        mock_get_client.return_value.__aenter__.return_value = mock_client
-        mock_query.return_value = "SELECT * FROM session_replay_events"
+        await cleanup_export_data(export_context)
 
-        mock_output_path = MagicMock()
-        mock_parent = MagicMock()
-        mock_output_path.parent = mock_parent
-        mock_path_cls.return_value.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value = (
-            mock_output_path
-        )
-
-        await export_replay_clickhouse_rows(export_context)
-
-        mock_client.aget_query.assert_called_once()
-        mock_output_path.open.assert_called_once_with("wb")
+        mock_redis.delete.assert_called_once()
+        delete_args = mock_redis.delete.call_args[0]
+        assert _redis_key(export_id, "replay-events") in delete_args
+        assert _redis_key(export_id, "events") in delete_args
+        assert _redis_key(export_id, "s3-prefix") in delete_args
+        assert _redis_key(export_id, "block-manifest") in delete_args
+        assert f"export-recording:{export_id}:block:file.json" in delete_args
 
 
 @pytest.mark.asyncio
-async def test_export_event_clickhouse_rows_success():
+async def test_cleanup_export_data_no_manifest():
     export_id = uuid4()
     export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
+        export_id=export_id,
+        exported_recording_id=TEST_RECORDING_ID,
+        session_id="test-session",
+        team_id=123,
+        redis_config=TEST_REDIS_CONFIG,
     )
 
-    mock_ch_response = MagicMock()
-    mock_ch_response.content.read = AsyncMock(return_value=b'{"data": []}')
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=None)
+    mock_redis.delete = AsyncMock(return_value=4)
 
-    mock_query_ctx = MagicMock()
-    mock_query_ctx.__aenter__ = AsyncMock(return_value=mock_ch_response)
-    mock_query_ctx.__aexit__ = AsyncMock(return_value=None)
+    with patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url:
+        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
 
-    mock_client = MagicMock()
-    mock_client.aget_query.return_value = mock_query_ctx
+        await cleanup_export_data(export_context)
 
-    with (
-        patch("posthog.temporal.export_recording.activities.get_client") as mock_get_client,
-        patch("posthog.temporal.export_recording.activities.Path") as mock_path_cls,
-    ):
-        mock_get_client.return_value.__aenter__.return_value = mock_client
-
-        mock_output_path = MagicMock()
-        mock_parent = MagicMock()
-        mock_output_path.parent = mock_parent
-        mock_path_cls.return_value.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value = (
-            mock_output_path
-        )
-
-        await export_event_clickhouse_rows(export_context)
-
-        mock_client.aget_query.assert_called_once()
-        mock_output_path.open.assert_called_once_with("wb")
-
-
-@pytest.mark.asyncio
-async def test_export_recording_data_success():
-    export_id = uuid4()
-    export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
-    )
-
-    mock_block = MagicMock()
-    mock_block.url = "s3://bucket/team/123/session/test-session/data/file.json?range=bytes=100-200"
-
-    mock_recording = MagicMock()
-    mock_storage = AsyncMock()
-    mock_storage.fetch_block_bytes = AsyncMock(return_value=b"block data content")
-
-    with (
-        patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
-        patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
-        patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
-        patch(
-            "posthog.temporal.export_recording.activities.session_recording_v2_object_storage.async_client"
-        ) as mock_storage_client,
-        patch("posthog.temporal.export_recording.activities.Path") as mock_path_cls,
-    ):
-        mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
-        mock_list_blocks.return_value = [mock_block]
-        mock_storage_client.return_value.__aenter__.return_value = mock_storage
-
-        mock_output_path = MagicMock()
-        mock_parent = MagicMock()
-        mock_output_path.parent = mock_parent
-        mock_path_cls.return_value.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value = (
-            mock_output_path
-        )
-
-        await export_recording_data(export_context)
-
-        mock_storage.fetch_block_bytes.assert_called_once_with(mock_block.url)
-        mock_output_path.open.assert_called_once_with("wb")
-
-
-@pytest.mark.asyncio
-async def test_export_recording_data_no_blocks():
-    export_id = uuid4()
-    export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
-    )
-
-    mock_recording = MagicMock()
-
-    with (
-        patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
-        patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
-        patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
-    ):
-        mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
-        mock_list_blocks.return_value = []
-
-        await export_recording_data(export_context)
-
-
-@pytest.mark.asyncio
-async def test_export_recording_data_malformed_url():
-    export_id = uuid4()
-    export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
-    )
-
-    mock_block = MagicMock()
-    mock_block.url = "s3://bucket/team/123/session/test-session/data/file.json?invalid_query"
-
-    mock_recording = MagicMock()
-
-    with (
-        patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
-        patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
-        patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
-    ):
-        mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
-        mock_list_blocks.return_value = [mock_block]
-
-        await export_recording_data(export_context)
-
-
-@pytest.mark.asyncio
-async def test_export_recording_data_block_fetch_error():
-    export_id = uuid4()
-    export_context = ExportContext(
-        export_id=export_id, exported_recording_id=TEST_RECORDING_ID, session_id="test-session", team_id=123
-    )
-
-    mock_block = MagicMock()
-    mock_block.url = "s3://bucket/team/123/session/test-session/data/file.json?range=bytes=100-200"
-
-    mock_recording = MagicMock()
-    mock_storage = AsyncMock()
-    mock_storage.fetch_block_bytes = AsyncMock(
-        side_effect=session_recording_v2_object_storage.BlockFetchError("Fetch failed")
-    )
-
-    with (
-        patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
-        patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
-        patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
-        patch(
-            "posthog.temporal.export_recording.activities.session_recording_v2_object_storage.async_client"
-        ) as mock_storage_client,
-    ):
-        mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
-        mock_list_blocks.return_value = [mock_block]
-        mock_storage_client.return_value.__aenter__.return_value = mock_storage
-
-        await export_recording_data(export_context)
+        mock_redis.delete.assert_called_once()
+        delete_args = mock_redis.delete.call_args[0]
+        assert len(delete_args) == 4

--- a/posthog/temporal/tests/export_recording/test_activities.py
+++ b/posthog/temporal/tests/export_recording/test_activities.py
@@ -109,11 +109,11 @@ async def test_export_replay_clickhouse_rows_success():
     with (
         patch("posthog.temporal.export_recording.activities.get_client") as mock_get_client,
         patch("posthog.temporal.export_recording.activities.SessionReplayEvents.get_metadata_query") as mock_query,
-        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+        patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client,
     ):
         mock_get_client.return_value.__aenter__.return_value = mock_client
         mock_query.return_value = "SELECT * FROM session_replay_events"
-        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+        mock_get_async_client.return_value = mock_redis
 
         await export_replay_clickhouse_rows(export_context)
 
@@ -150,10 +150,10 @@ async def test_export_event_clickhouse_rows_success():
 
     with (
         patch("posthog.temporal.export_recording.activities.get_client") as mock_get_client,
-        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+        patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client,
     ):
         mock_get_client.return_value.__aenter__.return_value = mock_client
-        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+        mock_get_async_client.return_value = mock_redis
 
         await export_event_clickhouse_rows(export_context)
 
@@ -185,11 +185,11 @@ async def test_export_recording_data_prefix_success():
         patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
         patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
         patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
-        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+        patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client,
     ):
         mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
         mock_list_blocks.return_value = [mock_block]
-        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+        mock_get_async_client.return_value = mock_redis
 
         await export_recording_data_prefix(export_context)
 
@@ -217,14 +217,14 @@ async def test_export_recording_data_prefix_no_blocks():
         patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
         patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
         patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
-        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+        patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client,
     ):
         mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
         mock_list_blocks.return_value = []
 
         await export_recording_data_prefix(export_context)
 
-        mock_redis_from_url.assert_not_called()
+        mock_get_async_client.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -253,12 +253,12 @@ async def test_export_recording_data_success():
         patch(
             "posthog.temporal.export_recording.activities.session_recording_v2_object_storage.async_client"
         ) as mock_storage_client,
-        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+        patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client,
     ):
         mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
         mock_list_blocks.return_value = [mock_block]
         mock_storage_client.return_value.__aenter__.return_value = mock_storage
-        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+        mock_get_async_client.return_value = mock_redis
 
         await export_recording_data(export_context)
 
@@ -295,11 +295,11 @@ async def test_export_recording_data_no_blocks():
         patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
         patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
         patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
-        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+        patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client,
     ):
         mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
         mock_list_blocks.return_value = []
-        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+        mock_get_async_client.return_value = mock_redis
 
         await export_recording_data(export_context)
 
@@ -330,11 +330,11 @@ async def test_export_recording_data_malformed_url():
         patch("posthog.temporal.export_recording.activities.SessionRecording", return_value=mock_recording),
         patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
         patch("posthog.temporal.export_recording.activities.list_blocks") as mock_list_blocks,
-        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+        patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client,
     ):
         mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
         mock_list_blocks.return_value = [mock_block]
-        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+        mock_get_async_client.return_value = mock_redis
 
         await export_recording_data(export_context)
 
@@ -371,12 +371,12 @@ async def test_export_recording_data_block_fetch_error():
         patch(
             "posthog.temporal.export_recording.activities.session_recording_v2_object_storage.async_client"
         ) as mock_storage_client,
-        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+        patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client,
     ):
         mock_db_sync.side_effect = lambda fn: AsyncMock(return_value=fn())
         mock_list_blocks.return_value = [mock_block]
         mock_storage_client.return_value.__aenter__.return_value = mock_storage
-        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+        mock_get_async_client.return_value = mock_redis
 
         await export_recording_data(export_context)
 
@@ -417,7 +417,7 @@ async def test_store_export_data_success(tmp_path):
     mock_storage = AsyncMock()
 
     with (
-        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+        patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client,
         patch("posthog.temporal.export_recording.activities.Path") as mock_path_cls,
         patch("posthog.temporal.export_recording.activities.shutil.make_archive") as mock_make_archive,
         patch("posthog.temporal.export_recording.activities.shutil.rmtree"),
@@ -427,7 +427,7 @@ async def test_store_export_data_success(tmp_path):
         patch("posthog.temporal.export_recording.activities.ExportedRecording.objects") as mock_record_qs,
         patch("posthog.temporal.export_recording.activities.database_sync_to_async") as mock_db_sync,
     ):
-        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+        mock_get_async_client.return_value = mock_redis
 
         mock_export_dir = MagicMock()
         mock_clickhouse_dir = MagicMock()
@@ -480,14 +480,14 @@ async def test_store_export_data_s3_upload_failure():
     mock_storage.upload_file.side_effect = session_recording_v2_object_storage.FileUploadError("Upload failed")
 
     with (
-        patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url,
+        patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client,
         patch("posthog.temporal.export_recording.activities.Path") as mock_path_cls,
         patch("posthog.temporal.export_recording.activities.shutil.make_archive"),
         patch(
             "posthog.temporal.export_recording.activities.session_recording_v2_object_storage.async_client"
         ) as mock_storage_client,
     ):
-        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+        mock_get_async_client.return_value = mock_redis
 
         mock_export_dir = MagicMock()
         mock_clickhouse_dir = MagicMock()
@@ -527,8 +527,8 @@ async def test_cleanup_export_data_success():
     mock_redis.get = AsyncMock(return_value=json.dumps(block_manifest))
     mock_redis.delete = AsyncMock(return_value=5)
 
-    with patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url:
-        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+    with patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client:
+        mock_get_async_client.return_value = mock_redis
 
         await cleanup_export_data(export_context)
 
@@ -556,8 +556,8 @@ async def test_cleanup_export_data_no_manifest():
     mock_redis.get = AsyncMock(return_value=None)
     mock_redis.delete = AsyncMock(return_value=4)
 
-    with patch("posthog.temporal.export_recording.activities.redis.from_url") as mock_redis_from_url:
-        mock_redis_from_url.return_value.__aenter__.return_value = mock_redis
+    with patch("posthog.temporal.export_recording.activities.get_async_client") as mock_get_async_client:
+        mock_get_async_client.return_value = mock_redis
 
         await cleanup_export_data(export_context)
 

--- a/posthog/temporal/tests/export_recording/test_activities.py
+++ b/posthog/temporal/tests/export_recording/test_activities.py
@@ -21,12 +21,19 @@ from posthog.temporal.export_recording.activities import (
 from posthog.temporal.export_recording.types import ExportContext, ExportRecordingInput, RedisConfig
 
 TEST_RECORDING_ID = UUID("01938a67-1234-7000-8000-000000000001")
-TEST_REDIS_CONFIG = RedisConfig(redis_host="test-redis", redis_port=6379, redis_ttl=3600)
+TEST_REDIS_CONFIG = RedisConfig(redis_url="redis://test-redis:6379", redis_ttl=3600)
 
 
-def test_redis_url():
-    config = RedisConfig(redis_host="my-redis", redis_port=6380)
+def test_redis_url_with_custom_url():
+    config = RedisConfig(redis_url="redis://my-redis:6380")
     assert _redis_url(config) == "redis://my-redis:6380"
+
+
+def test_redis_url_with_default_uses_settings():
+    config = RedisConfig()
+    with patch("posthog.temporal.export_recording.activities.settings") as mock_settings:
+        mock_settings.SESSION_RECORDING_REDIS_URL = "redis://settings-redis:6379"
+        assert _redis_url(config) == "redis://settings-redis:6379"
 
 
 def test_redis_key_without_suffix():

--- a/posthog/temporal/tests/export_recording/test_types.py
+++ b/posthog/temporal/tests/export_recording/test_types.py
@@ -5,15 +5,13 @@ from posthog.temporal.export_recording.types import ExportContext, ExportRecordi
 
 def test_redis_config_defaults():
     config = RedisConfig()
-    assert config.redis_host == "localhost"
-    assert config.redis_port == 6379
+    assert config.redis_url is None
     assert config.redis_ttl == 3600 * 6
 
 
 def test_redis_config_custom_values():
-    config = RedisConfig(redis_host="redis.example.com", redis_port=6380, redis_ttl=7200)
-    assert config.redis_host == "redis.example.com"
-    assert config.redis_port == 6380
+    config = RedisConfig(redis_url="redis://custom-redis:6380", redis_ttl=7200)
+    assert config.redis_url == "redis://custom-redis:6380"
     assert config.redis_ttl == 7200
 
 
@@ -21,17 +19,15 @@ def test_export_recording_input_creation():
     recording_id = UUID("01938a67-1234-7000-8000-000000000001")
     input = ExportRecordingInput(exported_recording_id=recording_id)
     assert input.exported_recording_id == recording_id
-    assert input.redis_config.redis_host == "localhost"
-    assert input.redis_config.redis_port == 6379
+    assert input.redis_config.redis_url is None
 
 
 def test_export_recording_input_with_custom_redis_config():
     recording_id = UUID("01938a67-1234-7000-8000-000000000001")
-    redis_config = RedisConfig(redis_host="custom-host", redis_port=6380)
+    redis_config = RedisConfig(redis_url="redis://custom-host:6380")
     input = ExportRecordingInput(exported_recording_id=recording_id, redis_config=redis_config)
     assert input.exported_recording_id == recording_id
-    assert input.redis_config.redis_host == "custom-host"
-    assert input.redis_config.redis_port == 6380
+    assert input.redis_config.redis_url == "redis://custom-host:6380"
 
 
 def test_export_context_creation():

--- a/posthog/temporal/tests/export_recording/test_types.py
+++ b/posthog/temporal/tests/export_recording/test_types.py
@@ -1,31 +1,67 @@
 from uuid import UUID, uuid4
 
-from posthog.temporal.export_recording.types import ExportContext, ExportRecordingInput
+from posthog.temporal.export_recording.types import ExportContext, ExportRecordingInput, RedisConfig
+
+
+def test_redis_config_defaults():
+    config = RedisConfig()
+    assert config.redis_host == "localhost"
+    assert config.redis_port == 6379
+    assert config.redis_ttl == 3600 * 6
+
+
+def test_redis_config_custom_values():
+    config = RedisConfig(redis_host="redis.example.com", redis_port=6380, redis_ttl=7200)
+    assert config.redis_host == "redis.example.com"
+    assert config.redis_port == 6380
+    assert config.redis_ttl == 7200
 
 
 def test_export_recording_input_creation():
     recording_id = UUID("01938a67-1234-7000-8000-000000000001")
     input = ExportRecordingInput(exported_recording_id=recording_id)
     assert input.exported_recording_id == recording_id
+    assert input.redis_config.redis_host == "localhost"
+    assert input.redis_config.redis_port == 6379
+
+
+def test_export_recording_input_with_custom_redis_config():
+    recording_id = UUID("01938a67-1234-7000-8000-000000000001")
+    redis_config = RedisConfig(redis_host="custom-host", redis_port=6380)
+    input = ExportRecordingInput(exported_recording_id=recording_id, redis_config=redis_config)
+    assert input.exported_recording_id == recording_id
+    assert input.redis_config.redis_host == "custom-host"
+    assert input.redis_config.redis_port == 6380
 
 
 def test_export_context_creation():
     export_id = uuid4()
     recording_id = UUID("01938a67-5678-7000-8000-000000000002")
+    redis_config = RedisConfig()
     context = ExportContext(
-        export_id=export_id, exported_recording_id=recording_id, session_id="test-session-id", team_id=67890
+        export_id=export_id,
+        exported_recording_id=recording_id,
+        session_id="test-session-id",
+        team_id=67890,
+        redis_config=redis_config,
     )
     assert context.export_id == export_id
     assert context.exported_recording_id == recording_id
     assert context.session_id == "test-session-id"
     assert context.team_id == 67890
+    assert context.redis_config == redis_config
 
 
 def test_export_context_mutability():
     export_id = uuid4()
     recording_id = UUID("01938a67-9abc-7000-8000-000000000003")
+    redis_config = RedisConfig()
     context = ExportContext(
-        export_id=export_id, exported_recording_id=recording_id, session_id="original-id", team_id=123
+        export_id=export_id,
+        exported_recording_id=recording_id,
+        session_id="original-id",
+        team_id=123,
+        redis_config=redis_config,
     )
     context.session_id = "new-id"
     assert context.session_id == "new-id"

--- a/posthog/temporal/tests/export_recording/test_workflows.py
+++ b/posthog/temporal/tests/export_recording/test_workflows.py
@@ -6,8 +6,23 @@ from posthog.temporal.export_recording.workflows import ExportRecordingWorkflow
 def test_export_recording_workflow_parse_inputs():
     result = ExportRecordingWorkflow.parse_inputs(['{"exported_recording_id": "01938a67-1234-7000-8000-000000000001"}'])
     assert result.exported_recording_id == UUID("01938a67-1234-7000-8000-000000000001")
+    assert result.redis_config.redis_host == "localhost"
+    assert result.redis_config.redis_port == 6379
 
 
 def test_export_recording_workflow_parse_inputs_string_uuid():
     result = ExportRecordingWorkflow.parse_inputs(['{"exported_recording_id": "01938a67-5678-7000-8000-000000000002"}'])
     assert result.exported_recording_id == UUID("01938a67-5678-7000-8000-000000000002")
+
+
+def test_export_recording_workflow_parse_inputs_with_redis_config():
+    result = ExportRecordingWorkflow.parse_inputs(
+        [
+            '{"exported_recording_id": "01938a67-1234-7000-8000-000000000001", '
+            '"redis_config": {"redis_host": "custom-redis", "redis_port": 6380, "redis_ttl": 7200}}'
+        ]
+    )
+    assert result.exported_recording_id == UUID("01938a67-1234-7000-8000-000000000001")
+    assert result.redis_config.redis_host == "custom-redis"
+    assert result.redis_config.redis_port == 6380
+    assert result.redis_config.redis_ttl == 7200

--- a/posthog/temporal/tests/export_recording/test_workflows.py
+++ b/posthog/temporal/tests/export_recording/test_workflows.py
@@ -6,8 +6,7 @@ from posthog.temporal.export_recording.workflows import ExportRecordingWorkflow
 def test_export_recording_workflow_parse_inputs():
     result = ExportRecordingWorkflow.parse_inputs(['{"exported_recording_id": "01938a67-1234-7000-8000-000000000001"}'])
     assert result.exported_recording_id == UUID("01938a67-1234-7000-8000-000000000001")
-    assert result.redis_config.redis_host == "localhost"
-    assert result.redis_config.redis_port == 6379
+    assert result.redis_config.redis_url is None
 
 
 def test_export_recording_workflow_parse_inputs_string_uuid():
@@ -19,10 +18,9 @@ def test_export_recording_workflow_parse_inputs_with_redis_config():
     result = ExportRecordingWorkflow.parse_inputs(
         [
             '{"exported_recording_id": "01938a67-1234-7000-8000-000000000001", '
-            '"redis_config": {"redis_host": "custom-redis", "redis_port": 6380, "redis_ttl": 7200}}'
+            '"redis_config": {"redis_url": "redis://custom-redis:6380", "redis_ttl": 7200}}'
         ]
     )
     assert result.exported_recording_id == UUID("01938a67-1234-7000-8000-000000000001")
-    assert result.redis_config.redis_host == "custom-redis"
-    assert result.redis_config.redis_port == 6380
+    assert result.redis_config.redis_url == "redis://custom-redis:6380"
     assert result.redis_config.redis_ttl == 7200


### PR DESCRIPTION
This PR changes the activities in the recording export workflow to use Redis instead of the local filesystem for intermediate data to avoid issues if activities get scheduled on different workers.