### PR TITLE
fix(surveys): make funnel button icon-only for small width insights

### DIFF
--- a/frontend/src/lib/components/Cards/CardMeta.tsx
+++ b/frontend/src/lib/components/Cards/CardMeta.tsx
@@ -87,7 +87,8 @@ export function CardMeta({
                             )}
                         </h5>
                         <div className="CardMeta__controls">
-                            {extraControls}
+                            {extraControls &&
+                                React.cloneElement(extraControls, { ...extraControls.props, _cardWidth: primaryWidth })}
                             {showDetailsControls && setAreDetailsShown && (
                                 <Tooltip title={detailsTooltip}>
                                     <LemonButton

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -166,14 +166,12 @@ export function InsightMeta({
         surveyOpportunity &&
         featureFlags[FEATURE_FLAGS.SURVEYS_FUNNELS_CROSS_SELL] &&
         isSurveyableFunnelInsight(insight) ? (
-            <div className="flex">
-                <SurveyOpportunityButton
-                    insight={insight}
-                    disableAutoPromptSubmit={true}
-                    source={SURVEY_CREATED_SOURCE.INSIGHT_CROSS_SELL}
-                    fromProduct={ProductKey.PRODUCT_ANALYTICS}
-                />
-            </div>
+            <SurveyOpportunityButton
+                insight={insight}
+                disableAutoPromptSubmit={true}
+                source={SURVEY_CREATED_SOURCE.INSIGHT_CROSS_SELL}
+                fromProduct={ProductKey.PRODUCT_ANALYTICS}
+            />
         ) : null
 
     // If user can't view the insight, show minimal interface

--- a/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
@@ -36,6 +36,7 @@ export interface SurveyOpportunityButtonProps {
     disableAutoPromptSubmit?: boolean
     source: SURVEY_CREATED_SOURCE
     fromProduct: ProductKey
+    _cardWidth?: number // injected by insight card meta
 }
 
 export function SurveyOpportunityButton({
@@ -43,7 +44,9 @@ export function SurveyOpportunityButton({
     disableAutoPromptSubmit,
     source,
     fromProduct,
+    _cardWidth,
 }: SurveyOpportunityButtonProps): JSX.Element | null {
+    const showLabel = !_cardWidth || _cardWidth > 480
     const [modalOpen, setModalOpen] = useState(false)
     const { featureFlags } = useValues(featureFlagLogic)
 
@@ -116,8 +119,8 @@ export function SurveyOpportunityButton({
 
     return (
         <>
-            <LemonButton size="xsmall" type="primary" sideIcon={<IconMessage />} onClick={handleClick}>
-                Ask users why
+            <LemonButton size="xsmall" type="primary" icon={<IconMessage />} onClick={handleClick}>
+                {showLabel && 'Ask users why'}
             </LemonButton>
             {shouldUseQuickCreate && (
                 <QuickSurveyModal


### PR DESCRIPTION
## Problem
"ask users why" button breaks things on narrow insights

![image.png](https://app.graphite.com/user-attachments/assets/c946b47a-8017-42de-8df0-403180c25810.png)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
switch to icon-only on small width, like the "show details" button does

https://screen.studio/share/cQpifm2D?state=uploading

![Screenshot 2025-12-17 at 12.53.38 PM.png](https://app.graphite.com/user-attachments/assets/3a0fbbcb-5bca-4c07-aad9-2e32a43f59c4.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
