### PR TITLE
refactor: Move `All Apps` further down on new sidebar

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -217,18 +217,22 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
             collapsedTooltip: 'Activity',
             documentationUrl: 'https://posthog.com/docs/data/events',
         },
-        {
-            identifier: 'Products',
-            label: 'All apps',
-            icon: <IconApps />,
-            onClick: (e?: React.KeyboardEvent) => {
-                if (!e || e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {
-                    handlePanelTriggerClick('Products')
-                }
-            },
-            showChevron: true,
-            collapsedTooltip: ['Open products', 'Close products'],
-        },
+        ...(featureFlags[FEATURE_FLAGS.CUSTOM_PRODUCTS_SIDEBAR] === 'test'
+            ? []
+            : [
+                  {
+                      identifier: 'Products',
+                      label: 'All apps',
+                      icon: <IconApps />,
+                      onClick: (e?: React.KeyboardEvent) => {
+                          if (!e || e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {
+                              handlePanelTriggerClick('Products')
+                          }
+                      },
+                      showChevron: true,
+                      collapsedTooltip: ['Open products', 'Close products'],
+                  },
+              ]),
         {
             identifier: 'DataManagement',
             label: 'Data management',
@@ -279,6 +283,22 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
             showChevron: true,
             collapsedTooltip: ['Open project tree', 'Close project tree'],
         },
+        ...(featureFlags[FEATURE_FLAGS.CUSTOM_PRODUCTS_SIDEBAR] === 'test'
+            ? [
+                  {
+                      identifier: 'Products',
+                      label: 'All apps',
+                      icon: <IconApps />,
+                      onClick: (e?: React.KeyboardEvent) => {
+                          if (!e || e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {
+                              handlePanelTriggerClick('Products')
+                          }
+                      },
+                      showChevron: true,
+                      collapsedTooltip: ['Open products', 'Close products'],
+                  },
+              ]
+            : []),
     ].filter(Boolean)
 
     return (


### PR DESCRIPTION
If people have the new sidebar enabled, let's move "All apps" closer to the list of apps