### PR TITLE
chore(capture): instrument decompress and deserialize capture times for both modes

### DIFF
--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -66,8 +66,16 @@ pub async fn handle_event_payload(
     debug!("entering handle_event_payload");
 
     // Extract payload bytes and metadata using shared helper
-    let (data, compression, lib_version) =
-        extract_payload_bytes(query_params, headers, method, body)?;
+    let extract_start_time = std::time::Instant::now();
+    let result = extract_payload_bytes(query_params, headers, method, body);
+    let (data, compression, lib_version) = match result {
+        Ok((d, c, lv)) => (d, c, lv),
+        Err(e) => {
+            return Err(e);
+        }
+    };
+    metrics::histogram!("capture_debug_analytics_decompress_seconds")
+        .record(extract_start_time.elapsed().as_secs_f64());
 
     Span::current().record("compression", format!("{compression}"));
     Span::current().record("lib_version", &lib_version);
@@ -89,10 +97,15 @@ pub async fn handle_event_payload(
     let maybe_batch_token = request.get_batch_token();
 
     // consumes the parent request, so it's no longer in scope to extract metadata from
-    let mut events = match request.events(path.as_str()) {
+    let events_start_time = std::time::Instant::now();
+    let result = request.events(path.as_str());
+    let mut events = match result {
         Ok(events) => events,
         Err(e) => return Err(e),
     };
+    metrics::histogram!("capture_debug_analytics_deserialize_seconds")
+        .record(events_start_time.elapsed().as_secs_f64());
+
     Span::current().record("batch_size", events.len());
 
     let token = match extract_and_verify_token(&events, maybe_batch_token) {

--- a/rust/capture/src/prometheus.rs
+++ b/rust/capture/src/prometheus.rs
@@ -26,7 +26,7 @@ pub fn report_internal_error_metrics(err_type: &'static str, stage_tag: &'static
 pub fn setup_metrics_recorder(role: String, capture_mode: &'static str) -> PrometheusHandle {
     // Ok I broke it at the end, but the limit on our ingress is 60 and that's a nicer way of reaching it
     const EXPONENTIAL_SECONDS: &[f64] = &[
-        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
     ];
     const BATCH_SIZES: &[f64] = &[
         1.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0,
@@ -56,6 +56,11 @@ pub fn setup_metrics_recorder(role: String, capture_mode: &'static str) -> Prome
         .set_buckets_for_metric(
             Matcher::Suffix("capture_full_payload_size".to_string()),
             PAYLOAD_SIZES,
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Prefix("capture_debug_".to_string()),
+            EXPONENTIAL_SECONDS,
         )
         .unwrap()
         .install_recorder()


### PR DESCRIPTION
## Problem
Before trying to apply timeouts on these operations in `capture-rs` we should measure. Will also help narrow if this is where low cardinality of stalled events are getting stuck and timing out in prod.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add histogram buckets and measurements for these ops in both modes
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
