### PR TITLE
feat(goals): add confirmation dialog before deleting a goal and success toast on config save

### DIFF
--- a/products/revenue_analytics/frontend/settings/GoalsConfiguration.tsx
+++ b/products/revenue_analytics/frontend/settings/GoalsConfiguration.tsx
@@ -214,7 +214,10 @@ export function GoalsConfiguration(): JSX.Element {
     }
 
     const handleDeleteGoal = (index: number): void => {
-        deleteGoal(index)
+        const goal = goals[index]
+        if (window.confirm(`Are you sure you want to delete the goal "${goal.name}"?`)) {
+            deleteGoal(index)
+        }
     }
 
     const handleCancelAdd = (): void => {

--- a/products/revenue_analytics/frontend/settings/revenueAnalyticsSettingsLogic.ts
+++ b/products/revenue_analytics/frontend/settings/revenueAnalyticsSettingsLogic.ts
@@ -2,6 +2,8 @@ import { actions, afterMount, connect, kea, listeners, path, reducers, selectors
 import { loaders } from 'kea-loaders'
 import { beforeUnload } from 'kea-router'
 
+import { lemonToast } from '@posthog/lemon-ui'
+
 import { dayjs } from 'lib/dayjs'
 import { objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -309,6 +311,7 @@ export const revenueAnalyticsSettingsLogic = kea<revenueAnalyticsSettingsLogicTy
         const updateCurrentTeam = (): void => {
             if (values.revenueAnalyticsConfig) {
                 actions.updateCurrentTeam({ revenue_analytics_config: values.revenueAnalyticsConfig })
+                lemonToast.success('Revenue analytics config saved')
             }
         }
 


### PR DESCRIPTION
This looked bad without confirmation, add it real quick