### PR TITLE
refactor: Optimize realtime cohorts by merging sibling property groups

### DIFF
--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -786,7 +786,7 @@ class HogQLRealtimeCohortQuery(HogQLCohortQuery):
 
                 # Collect hashes: property may already be merged (has multiple hashes) or single hash
                 if hasattr(child, "_merged_condition_hashes"):
-                    mergeable_by_key[key].extend(getattr(child, "_merged_condition_hashes", []))
+                    mergeable_by_key[key].extend(child._merged_condition_hashes)
                 elif hasattr(child, "conditionHash") and child.conditionHash:
                     mergeable_by_key[key].append(child.conditionHash)
                 else:

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 from datetime import datetime
 from numbers import Number
 from typing import Literal, Optional, Union, cast
@@ -586,6 +586,9 @@ class HogQLRealtimeCohortQuery(HogQLCohortQuery):
     different tables for realtime cohort calculation.
     """
 
+    # Operators that support merging into IN clauses
+    MERGEABLE_OPERATORS = {"icontains", "not_icontains", "exact", "is_not"}
+
     def __init__(
         self,
         cohort_query: Optional[CohortQuery] = None,
@@ -594,6 +597,223 @@ class HogQLRealtimeCohortQuery(HogQLCohortQuery):
     ):
         super().__init__(cohort_query=cohort_query, cohort=cohort, team=team)
         self.cohort = cohort
+        # Preprocess to merge properties with same key and operator
+        self.property_groups = self._preprocess_property_groups(self.property_groups)  # type: ignore[assignment]
+
+    def _is_mergeable_property(self, prop: Property) -> bool:
+        """Check if a property can be merged with others."""
+        return (
+            prop.type == "person"
+            and prop.operator in self.MERGEABLE_OPERATORS
+            and not prop.negation
+            and hasattr(prop, "conditionHash")
+            and bool(prop.conditionHash)
+        )
+
+    def _deduplicate_hashes(self, hashes: list[str]) -> list[str]:
+        """
+        Deduplicate hashes while preserving order.
+
+        Deduplication is necessary for an edge case: if the same filter appears twice
+        (e.g., user accidentally added "email contains @gmail.com" twice), we need to
+        ensure the count matches the distinct conditions in the GROUP BY condition query.
+        Without deduplication, HAVING matching_count = 2 would fail because IN would only
+        match 1 distinct condition.
+        """
+        seen: set[str] = set()
+        unique_hashes: list[str] = []
+        for h in hashes:
+            if h not in seen:
+                seen.add(h)
+                unique_hashes.append(h)
+        return unique_hashes
+
+    def _create_merged_property(self, template: Property, unique_hashes: list[str], is_or_group: bool) -> Property:
+        """Create a merged property from a template with multiple condition hashes."""
+        merged_prop = template.copy() if hasattr(template, "copy") else Property(**template.to_dict())
+        merged_prop._merged_condition_hashes = unique_hashes  # type: ignore[union-attr]
+        merged_prop._is_or_group = is_or_group  # type: ignore[union-attr]
+        return merged_prop
+
+    def _unwrap_single_property_groups(
+        self, prop_or_group: Union[Property, PropertyGroup]
+    ) -> Union[Property, PropertyGroup]:
+        """
+        Unwrap PropertyGroups that contain only a single child.
+
+        FOSSCohortQuery.unwrap_cohort creates nested PropertyGroups like:
+        PropertyGroup(AND) -> PropertyGroup(AND) -> Property
+
+        This unwraps them to just: Property
+        """
+        if not isinstance(prop_or_group, PropertyGroup):
+            return prop_or_group
+
+        # Recursively unwrap children first
+        unwrapped_values: list[Union[Property, PropertyGroup]] = [
+            self._unwrap_single_property_groups(v) for v in prop_or_group.values
+        ]
+        prop_or_group.values = unwrapped_values  # type: ignore[assignment]
+
+        # If this group has only one child, return the child instead
+        if len(prop_or_group.values) == 1:
+            return prop_or_group.values[0]
+
+        return prop_or_group
+
+    def _preprocess_property_groups(self, prop_group: Optional[PropertyGroup]) -> Optional[PropertyGroup]:
+        """
+        Preprocess property groups to merge person properties with same key and operator.
+
+        For example, multiple email contains filters become a single merged property with
+        multiple conditionHashes that will be queried with IN clause.
+        """
+
+        if not prop_group or not isinstance(prop_group, PropertyGroup):
+            return prop_group
+
+        # First, unwrap deeply nested single-property groups
+        unwrapped = self._unwrap_single_property_groups(prop_group)
+        if not isinstance(unwrapped, PropertyGroup):
+            # If unwrapping resulted in a single Property, wrap it back in a PropertyGroup
+            # so it can be processed normally
+            single_property_group = PropertyGroup(type=PropertyOperatorType.AND, values=[unwrapped])
+            return single_property_group
+        prop_group = unwrapped
+
+        # Process both AND and OR groups for merging
+        is_and_group = prop_group.type == PropertyOperatorType.AND
+        is_or_group = prop_group.type == PropertyOperatorType.OR
+
+        if not is_and_group and not is_or_group:
+            # For other group types, just recursively process children
+            processed_values: list[Union[Property, PropertyGroup]] = [
+                cast(Union[Property, PropertyGroup], self._preprocess_property_groups(v))
+                if isinstance(v, PropertyGroup)
+                else v
+                for v in prop_group.values
+            ]
+            prop_group.values = processed_values  # type: ignore[assignment]
+            return prop_group
+
+        # Group person properties by (key, operator)
+        groups: dict[tuple[str, str], list[Property]] = defaultdict(list)
+        non_mergeable: list[Union[Property, PropertyGroup]] = []
+
+        for value in prop_group.values:
+            if isinstance(value, PropertyGroup):
+                processed = self._preprocess_property_groups(value)
+                if processed is not None:
+                    non_mergeable.append(processed)
+            elif isinstance(value, Property):
+                if self._is_mergeable_property(value):
+                    key = (value.key, str(value.operator))
+                    groups[key].append(value)
+                else:
+                    non_mergeable.append(value)
+
+        # Merge groups with 2+ properties
+        merged_values: list[Union[Property, PropertyGroup]] = []
+        for props in groups.values():
+            if len(props) >= 2:
+                # Collect and deduplicate hashes
+                hashes = [p.conditionHash for p in props if p.conditionHash]
+                unique_hashes = self._deduplicate_hashes(hashes)
+                # Create merged property
+                merged_prop = self._create_merged_property(props[0], unique_hashes, is_or_group)
+                merged_values.append(merged_prop)
+            else:
+                merged_values.extend(props)
+
+        merged_values.extend(non_mergeable)
+        prop_group.values = merged_values  # type: ignore[assignment]
+
+        # After merging within groups, also merge sibling single-property groups
+        prop_group = self._merge_sibling_single_property_groups(prop_group)
+
+        return prop_group
+
+    def _merge_sibling_single_property_groups(self, prop_group: PropertyGroup) -> PropertyGroup:
+        """
+        Merge sibling single-property groups under an OR that have the same key and operator.
+
+        Example:
+        OR:
+          - AND: [email icontains @gmail.com, email is_not user2@gmail.com]
+          - OR: [email icontains yahoo.com]  # single property
+          - OR: [email icontains @protonmail.com, email icontains @live.com]  # already merged
+
+        Result: Last two groups merge into one with 3 hashes (yahoo + protonmail + live).
+        """
+        if prop_group.type != PropertyOperatorType.OR:
+            return prop_group
+
+        # Collect hashes by (key, operator) and track templates for creating merged properties
+        mergeable_by_key: dict[tuple[str, str], list[str]] = defaultdict(list)
+        first_property_by_key: dict[tuple[str, str], Property] = {}
+        other_values: list[Union[Property, PropertyGroup]] = []
+
+        for value in prop_group.values:
+            # Extract child from single-value groups or plain properties
+            child = None
+            if isinstance(value, PropertyGroup) and len(value.values) == 1:
+                child = value.values[0]
+            elif isinstance(value, Property):
+                child = value
+            else:
+                # Multi-value groups can't be merged
+                other_values.append(value)
+                continue
+
+            if isinstance(child, Property) and self._is_mergeable_property(child):
+                key = (child.key, str(child.operator))
+
+                # Collect hashes: property may already be merged (has multiple hashes) or single hash
+                if hasattr(child, "_merged_condition_hashes"):
+                    mergeable_by_key[key].extend(getattr(child, "_merged_condition_hashes", []))
+                elif hasattr(child, "conditionHash") and child.conditionHash:
+                    mergeable_by_key[key].append(child.conditionHash)
+                else:
+                    other_values.append(value)
+                    continue
+
+                # Save first property as template for merged property
+                if key not in first_property_by_key:
+                    first_property_by_key[key] = child
+            else:
+                other_values.append(value)
+
+        # Create merged properties for each (key, operator) with 2+ unique hashes
+        merged_values: list[Union[Property, PropertyGroup]] = []
+        for key, hashes in mergeable_by_key.items():
+            unique_hashes = self._deduplicate_hashes(hashes)
+
+            if len(unique_hashes) >= 2:
+                template = first_property_by_key[key]
+                merged_prop = self._create_merged_property(template, unique_hashes, is_or_group=True)
+                merged_values.append(merged_prop)
+            elif len(unique_hashes) == 1:
+                # Single hash after dedup: wrap back in group to preserve structure
+                template = first_property_by_key[key]
+                single_prop = template.copy() if hasattr(template, "copy") else Property(**template.to_dict())
+                if hasattr(single_prop, "_merged_condition_hashes"):
+                    delattr(single_prop, "_merged_condition_hashes")
+                merged_values.append(PropertyGroup(type=PropertyOperatorType.OR, values=[single_prop]))
+
+        merged_values.extend(other_values)
+        prop_group.values = merged_values  # type: ignore[assignment]
+        return prop_group
+
+    def _should_combine_person_properties(self) -> bool:
+        """
+        Disable person property combining optimization for realtime cohorts.
+
+        Each person property in realtime cohorts has its own conditionHash in
+        precalculated_person_properties, so we can't combine them into a single
+        query like the parent class does with the person table. Instead, we rely
+        on individual get_person_condition calls which query precalculated_person_properties.
+        """
+        return False
 
     def get_performed_event_condition(self, prop: Property, first_time: bool = False) -> ast.SelectQuery:
         """
@@ -785,53 +1005,160 @@ class HogQLRealtimeCohortQuery(HogQLCohortQuery):
         """
         Query precalculated_person_properties using conditionHash for realtime person property matching.
         Table for precalculated person properties evaluations populated by CdpRealtimeCohortsConsumer and backfill workflows.
+
+        If prop has _merged_condition_hashes, uses IN clause to combine multiple conditions.
         """
-        condition_hash = getattr(prop, "conditionHash", None)
-        if not condition_hash:
-            cohort_id = self.cohort.id if self.cohort else "unknown"
-            raise ValueError(
-                f"BUG: Realtime cohort (cohort_id={cohort_id}) has person property without conditionHash. "
-                f"All realtime cohorts MUST have conditionHash for person property filters. Property: {prop}"
+        # Check if this property was merged in preprocessing
+        merged_hashes = getattr(prop, "_merged_condition_hashes", None)
+
+        if merged_hashes:
+            # Check if this is from an OR group (OR semantics) or AND group (AND semantics)
+            is_or_group = getattr(prop, "_is_or_group", False)
+
+            if is_or_group:
+                # OR semantics: At least ONE condition must match
+                # For example: email contains X OR email contains Y
+                query_str = """
+                    SELECT
+                        pdi2.person_id as id
+                    FROM
+                    (
+                        SELECT
+                            distinct_id,
+                            countIf(latest_matches = 1) as matching_count
+                        FROM
+                        (
+                            SELECT
+                                distinct_id,
+                                condition,
+                                argMax(matches, _timestamp) as latest_matches
+                            FROM precalculated_person_properties
+                            WHERE
+                                team_id = {team_id}
+                                AND condition IN {condition_hashes}
+                            GROUP BY distinct_id, condition
+                        )
+                        GROUP BY distinct_id
+                        HAVING matching_count >= 1
+                    ) AS ppp
+                    INNER JOIN
+                    (
+                        SELECT
+                            distinct_id,
+                            argMax(person_id, version) as person_id
+                        FROM raw_person_distinct_ids
+                        WHERE team_id = {team_id}
+                        GROUP BY distinct_id
+                        HAVING argMax(is_deleted, version) = 0
+                    ) AS pdi2 ON pdi2.distinct_id = ppp.distinct_id
+                """
+
+                return cast(
+                    ast.SelectQuery,
+                    parse_select(
+                        query_str,
+                        {
+                            "team_id": ast.Constant(value=self.team.pk),
+                            "condition_hashes": ast.Tuple(exprs=[ast.Constant(value=h) for h in merged_hashes]),
+                        },
+                    ),
+                )
+            else:
+                # AND semantics: ALL conditions must match
+                # For example: email contains X AND email contains Y
+                query_str = """
+                    SELECT
+                        pdi2.person_id as id
+                    FROM
+                    (
+                        SELECT
+                            distinct_id,
+                            countIf(latest_matches = 1) as matching_count
+                        FROM
+                        (
+                            SELECT
+                                distinct_id,
+                                condition,
+                                argMax(matches, _timestamp) as latest_matches
+                            FROM precalculated_person_properties
+                            WHERE
+                                team_id = {team_id}
+                                AND condition IN {condition_hashes}
+                            GROUP BY distinct_id, condition
+                        )
+                        GROUP BY distinct_id
+                        HAVING matching_count = {num_conditions}
+                    ) AS ppp
+                    INNER JOIN
+                    (
+                        SELECT
+                            distinct_id,
+                            argMax(person_id, version) as person_id
+                        FROM raw_person_distinct_ids
+                        WHERE team_id = {team_id}
+                        GROUP BY distinct_id
+                        HAVING argMax(is_deleted, version) = 0
+                    ) AS pdi2 ON pdi2.distinct_id = ppp.distinct_id
+                """
+
+                return cast(
+                    ast.SelectQuery,
+                    parse_select(
+                        query_str,
+                        {
+                            "team_id": ast.Constant(value=self.team.pk),
+                            "condition_hashes": ast.Tuple(exprs=[ast.Constant(value=h) for h in merged_hashes]),
+                            "num_conditions": ast.Constant(value=len(merged_hashes)),
+                        },
+                    ),
+                )
+        else:
+            # Single condition - original logic
+            condition_hash = getattr(prop, "conditionHash", None)
+            if not condition_hash:
+                cohort_id = self.cohort.id if self.cohort else "unknown"
+                raise ValueError(
+                    f"BUG: Realtime cohort (cohort_id={cohort_id}) has person property without conditionHash. "
+                    f"All realtime cohorts MUST have conditionHash for person property filters. Property: {prop}"
+                )
+
+            query_str = """
+                SELECT
+                    pdi2.person_id as id
+                FROM
+                (
+                    SELECT
+                        distinct_id,
+                        argMax(matches, _timestamp) as latest_matches
+                    FROM precalculated_person_properties
+                    WHERE
+                        team_id = {team_id}
+                        AND condition = {condition_hash}
+                    GROUP BY distinct_id
+                    HAVING latest_matches = 1
+                ) AS ppp
+                INNER JOIN
+                (
+                    SELECT
+                        distinct_id,
+                        argMax(person_id, version) as person_id
+                    FROM raw_person_distinct_ids
+                    WHERE team_id = {team_id}
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0
+                ) AS pdi2 ON pdi2.distinct_id = ppp.distinct_id
+            """
+
+            return cast(
+                ast.SelectQuery,
+                parse_select(
+                    query_str,
+                    {
+                        "team_id": ast.Constant(value=self.team.pk),
+                        "condition_hash": ast.Constant(value=condition_hash),
+                    },
+                ),
             )
-
-        # Build query using precalculated_person_properties with argMax pattern
-        query_str = """
-            SELECT
-                pdi2.person_id as id
-            FROM
-            (
-                SELECT
-                    distinct_id,
-                    argMax(matches, _timestamp) as latest_matches
-                FROM precalculated_person_properties
-                WHERE
-                    team_id = {team_id}
-                    AND condition = {condition_hash}
-                GROUP BY distinct_id
-                HAVING latest_matches = 1
-            ) AS ppp
-            INNER JOIN
-            (
-                SELECT
-                    distinct_id,
-                    argMax(person_id, version) as person_id
-                FROM raw_person_distinct_ids
-                WHERE team_id = {team_id}
-                GROUP BY distinct_id
-                HAVING argMax(is_deleted, version) = 0
-            ) AS pdi2 ON pdi2.distinct_id = ppp.distinct_id
-        """
-
-        return cast(
-            ast.SelectQuery,
-            parse_select(
-                query_str,
-                {
-                    "team_id": ast.Constant(value=self.team.pk),
-                    "condition_hash": ast.Constant(value=condition_hash),
-                },
-            ),
-        )
 
     def get_static_cohort_condition(self, prop: Property) -> ast.SelectQuery:
         """

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -640,8 +640,8 @@ class HogQLRealtimeCohortQuery(HogQLCohortQuery):
             raise ValueError(f"Cannot create merged property with empty unique_hashes. Template property: {template}")
 
         merged_prop = deepcopy(template)
-        merged_prop._merged_condition_hashes = unique_hashes  # type: ignore[union-attr]
-        merged_prop._is_or_group = is_or_group  # type: ignore[union-attr]
+        merged_prop._merged_condition_hashes = unique_hashes  # type: ignore[attr-defined]
+        merged_prop._is_or_group = is_or_group  # type: ignore[attr-defined]
         return merged_prop
 
     def _unwrap_single_property_groups(

--- a/posthog/hogql_queries/test/test_hogql_cohort_query.py
+++ b/posthog/hogql_queries/test/test_hogql_cohort_query.py
@@ -430,3 +430,641 @@ class TestHogQLRealtimeCohortQuery(ClickhouseTestMixin, APIBaseTest):
             hogql_query.query_str("clickhouse")
 
         self.assertIn("static cohort", str(context.exception).lower())
+
+    def test_or_group_with_same_key_operator_merges(self) -> None:
+        """
+        Test that OR groups with same key and operator are merged with OR semantics.
+
+        For example: email contains "@gmail.com" OR email contains "@yahoo.com"
+        This should find users whose email contains ANY of these strings (at least one).
+
+        Also tests that properties with different operators or keys are NOT merged.
+        """
+        cohort_filters = {
+            "type": "OR",
+            "values": [
+                {
+                    "type": "OR",
+                    "values": [
+                        # These 3 should merge (same key, operator, not negated)
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@gmail.com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%@gmail.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "a5c1c77ac5bfac89",
+                        },
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": ["@yahoo.com"],
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%@yahoo.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "102924b91ae29fc8",
+                        },
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@live.com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%@live.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "e849069d7a368305",
+                        },
+                        # Different operator - should NOT merge
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "admin@company.com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "admin@company.com",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                15,
+                            ],
+                            "negation": False,
+                            "operator": "exact",
+                            "conditionHash": "different_operator_hash",
+                        },
+                        # Same operator but different value type - should NOT merge
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@hotmail.com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%@hotmail.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "not_icontains",
+                            "conditionHash": "not_icontains_hash",
+                        },
+                        # Different key - should NOT merge
+                        {
+                            "key": "name",
+                            "type": "person",
+                            "value": "John",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%John%",
+                                32,
+                                "name",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "different_key_hash",
+                        },
+                    ],
+                }
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test OR Group Merge", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLRealtimeCohortQuery(cohort=cohort)
+        query_str = hogql_query.query_str("clickhouse")
+
+        # The 3 mergeable email icontains should be in a single merged query with IN clause
+        # Looking at the IN clause specifically
+        in_clause_count = query_str.lower().count("in(precalculated_person_properties.condition,")
+
+        # Should have exactly 1 IN clause for the merged conditions
+        self.assertEqual(in_clause_count, 1, "Should have exactly 1 IN clause for merged conditions")
+
+        # Should have exactly 3 single condition checks (one for each non-mergeable property)
+        single_condition_count = query_str.lower().count("equals(precalculated_person_properties.condition,")
+        self.assertEqual(single_condition_count, 3, "Should have exactly 3 single condition checks")
+
+        # Should use IN clause for merged conditions
+        self.assertIn("in(precalculated_person_properties.condition,", query_str.lower())
+
+        # The merged query should check for at least 1 match
+        self.assertIn("greaterorequals(matching_count, 1)", query_str.lower())
+
+        # Should have UNION DISTINCT since we have non-mergeable properties too
+        self.assertIn("UNION DISTINCT", query_str)
+
+    def test_or_group_with_nested_single_property_groups_merges(self) -> None:
+        """
+        Test that nested OR groups with single properties get merged.
+
+        For example:
+        OR:
+          - Group 1: [email contains "@gmail.com"]
+          - Group 2: [email contains "@yahoo.com"]
+          - Group 3: [email contains "@live.com"]
+
+        These should be unwrapped and merged into a single query.
+        """
+        cohort_filters = {
+            "type": "OR",
+            "values": [
+                # Each of these is a separate OR group with a single property
+                {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@gmail.com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%@gmail.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "nested1_gmail",
+                        },
+                    ],
+                },
+                {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@yahoo.com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%@yahoo.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "nested2_yahoo",
+                        },
+                    ],
+                },
+                {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@live.com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%@live.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "nested3_live",
+                        },
+                    ],
+                },
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Nested OR Groups Merge", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLRealtimeCohortQuery(cohort=cohort)
+        query_str = hogql_query.query_str("clickhouse")
+
+        # All 3 nested single-property groups should be unwrapped and merged
+        # Should have exactly 1 IN clause for all 3 conditions
+        in_clause_count = query_str.lower().count("in(precalculated_person_properties.condition,")
+        self.assertEqual(in_clause_count, 1, "Should have exactly 1 IN clause for merged conditions")
+
+        # Should have no single condition checks (all merged)
+        single_condition_count = query_str.lower().count("equals(precalculated_person_properties.condition,")
+        self.assertEqual(single_condition_count, 0, "Should have no single condition checks (all merged)")
+
+        # Should NOT use UNION DISTINCT since all properties are merged
+        self.assertNotIn("UNION DISTINCT", query_str)
+
+    def test_and_group_with_same_key_operator_merges(self) -> None:
+        """
+        Test that AND groups with same key and operator are merged with AND semantics.
+
+        For example: email contains "@gmail" AND email contains ".com"
+        This should find users whose email contains ALL of these strings (all conditions must match).
+        """
+        cohort_filters = {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@gmail",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%@gmail%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "hash1_gmail",
+                        },
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": ".com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "hash2_dotcom",
+                        },
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "test",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%test%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "hash3_test",
+                        },
+                    ],
+                }
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test AND Group Merge", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLRealtimeCohortQuery(cohort=cohort)
+        query_str = hogql_query.query_str("clickhouse")
+
+        # Should use IN clause to fetch all conditions at once
+        self.assertIn("in(precalculated_person_properties.condition,", query_str.lower())
+        # Should use countIf for counting matches
+        self.assertIn("countif", query_str.lower())
+        # For AND semantics, should check that ALL 3 conditions matched
+        self.assertIn("equals(matching_count, 3)", query_str.lower())
+        # Should NOT use UNION DISTINCT since properties are merged
+        self.assertNotIn("UNION DISTINCT", query_str)
+
+    def test_sibling_single_property_groups_under_or_merge(self) -> None:
+        """
+        Test that sibling single-property groups under a top-level OR are merged together
+        when they have the same key and operator, including already-merged groups.
+
+        For example:
+        OR:
+          - AND: [email icontains @gmail.com, name icontains John]  # can't merge (different keys)
+          - OR: [email icontains yahoo.com]  # single property
+          - OR: [email icontains @protonmail.com, email icontains @live.com]  # already merged within group
+
+        The last two groups should ALL be merged together (yahoo + protonmail + live = 3 hashes).
+        """
+        cohort_filters = {
+            "type": "OR",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@gmail.com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%@gmail.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "hash1_gmail",
+                        },
+                        {
+                            "key": "name",
+                            "type": "person",
+                            "value": "John",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%John%",
+                                32,
+                                "name",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "hash2_john",
+                        },
+                    ],
+                },
+                {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "yahoo.com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%yahoo.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "hash3_yahoo",
+                        },
+                    ],
+                },
+                {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@protonmail.com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%@protonmail.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "hash4_protonmail",
+                        },
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": "@live.com",
+                            "bytecode": [
+                                "_H",
+                                1,
+                                32,
+                                "%@live.com%",
+                                32,
+                                "email",
+                                32,
+                                "properties",
+                                32,
+                                "person",
+                                1,
+                                3,
+                                2,
+                                "toString",
+                                1,
+                                18,
+                            ],
+                            "negation": False,
+                            "operator": "icontains",
+                            "conditionHash": "hash5_live",
+                        },
+                    ],
+                },
+            ],
+        }
+
+        cohort = Cohort.objects.create(
+            team=self.team, name="Test Sibling Single Property Groups Merge", filters={"properties": cohort_filters}
+        )
+
+        hogql_query = HogQLRealtimeCohortQuery(cohort=cohort)
+        query_str = hogql_query.query_str("clickhouse")
+
+        # Should have 1 IN clause for ALL merged email properties (yahoo + protonmail + live = 3 hashes)
+        in_clause_count = query_str.lower().count("in(precalculated_person_properties.condition,")
+        self.assertEqual(in_clause_count, 1, "Should have exactly 1 IN clause for all merged email properties")
+
+        # Verify the IN clause has a tuple with 3 values (all 3 hashes merged)
+        # The pattern will be: tuple(%(hogql_val_X)s, %(hogql_val_Y)s, %(hogql_val_Z)s)
+
+        # Match tuple with exactly 3 comma-separated parameter placeholders
+        tuple_pattern = r"tuple\(%\(hogql_val_\d+\)s,\s*%\(hogql_val_\d+\)s,\s*%\(hogql_val_\d+\)s\)"
+        self.assertRegex(query_str, tuple_pattern, "IN clause should have tuple with 3 values")
+
+        # Should use UNION DISTINCT since we have multiple top-level groups
+        self.assertIn("UNION DISTINCT", query_str)
+
+        # Should have INTERSECT DISTINCT for the AND group (email + name)
+        self.assertIn("INTERSECT DISTINCT", query_str)

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -2997,6 +2997,55 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.10
   '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."queryable_folder",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.11
+  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -3015,7 +3064,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.11
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.12
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -3045,7 +3094,7 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.12
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.13
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
@@ -3055,7 +3104,7 @@
                                                                'at_base_time'))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.13
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.14
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id",
          "posthog_user"."email"
@@ -3065,16 +3114,6 @@
                                                            'at_base_time')
          AND "posthog_sessionrecordingviewed"."team_id" = 99999
          AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.14
-  '''
-  SELECT "posthog_sessionrecordingviewed"."session_id"
-  FROM "posthog_sessionrecordingviewed"
-  WHERE ("posthog_sessionrecordingviewed"."team_id" = 99999
-         AND "posthog_sessionrecordingviewed"."user_id" = 99999
-         AND "posthog_sessionrecordingviewed"."session_id" IN ('at_base_time_plus_20',
-                                                               'at_base_time'))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.15
@@ -3451,6 +3490,19 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.8
   '''
+  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
+         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
+         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
+         "posthog_teamrevenueanalyticsconfig"."events",
+         "posthog_teamrevenueanalyticsconfig"."goals",
+         "posthog_teamrevenueanalyticsconfig"."base_currency"
+  FROM "posthog_teamrevenueanalyticsconfig"
+  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.9
+  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -3477,55 +3529,6 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.9
-  '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."queryable_folder",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending


### PR DESCRIPTION
## Problem

Realtime cohort queries were generating inefficient SQL when multiple sibling groups under an OR had the same property key and operator. For example, three email filters would generate three separate SELECT queries combined with UNION DISTINCT, rather than a single query with an IN clause.

This impacts query performance and database load for cohorts with multiple similar filters.

https://us.posthog.com/project/2/cohorts/641
https://us.posthog.com/project/2/cohorts/152079

## Changes

Implemented sibling property group merging optimization for realtime cohorts:

**Before:**
OR:
- OR: [email icontains yahoo.com]
- OR: [email icontains @protonmail.com, email icontains @live.com]
Generated 3 separate queries with UNION DISTINCT.

**After:**
Merges all compatible hashes into a single IN clause with 3 condition hashes.

## How did you test this code?

- Unit tests
- Verified query output matches expected SQL structure