### PR TITLE
fix: backfill precalculated-person-properties query syntax error

### DIFF
--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -109,22 +109,34 @@ async def backfill_precalculated_person_properties_activity(
             # Query person table for current batch with their distinct_ids
             persons_query = """
                 SELECT
-                    p.id as person_id,
+                    p.person_id,
                     p.properties,
-                    groupArray(pdi.distinct_id) as distinct_ids
-                FROM person FINAL p
+                    pdi.distinct_ids
+                FROM (
+                    SELECT
+                        id as person_id,
+                        argMax(properties, version) as properties
+                    FROM person
+                    WHERE team_id = %(team_id)s
+                    GROUP BY id
+                    HAVING argMax(is_deleted, version) = 0
+                ) p
                 INNER JOIN (
                     SELECT
                         person_id,
-                        distinct_id
-                    FROM person_distinct_id FINAL
-                    WHERE team_id = %(team_id)s
-                      AND is_deleted = 0
-                ) pdi ON p.id = pdi.person_id
-                WHERE p.team_id = %(team_id)s
-                  AND p.is_deleted = 0
-                GROUP BY p.id, p.properties
-                ORDER BY p.id
+                        groupArray(distinct_id) as distinct_ids
+                    FROM (
+                        SELECT
+                            argMax(person_id, version) as person_id,
+                            distinct_id
+                        FROM person_distinct_id2
+                        WHERE team_id = %(team_id)s
+                        GROUP BY distinct_id
+                        HAVING argMax(is_deleted, version) = 0
+                    )
+                    GROUP BY person_id
+                ) pdi ON p.person_id = pdi.person_id
+                ORDER BY p.person_id
                 LIMIT %(limit)s
                 OFFSET %(offset)s
                 FORMAT JSONEachRow


### PR DESCRIPTION
## Problem

The backfill workflow for precalculated person properties was failing with a ClickHouse syntax error:

```
Code: 62. DB::Exception: Syntax error: failed at position 196 (p) (line 6, col 35): p\n                INNER JOIN (\n                    SELECT\n                        person_id,\n                        distinct_id\n                    FROM person_dist... Expected one of: SAMPLE, table, table function, subquery or list of joined tables, array join, LEFT ARRAY JOIN, INNER, ARRAY JOIN, GLOBAL, LOCAL, ANY, ALL, ASOF, SEMI, ANTI, ONLY, LEFT, RIGHT, FULL, CROSS, PASTE, JOIN, token, OpeningRoundBracket, PREWHERE, WHERE, GROUP BY, WITH, HAVING, WINDOW, QUALIFY, ORDER BY, LIMIT, OFFSET, FETCH, SETTINGS, UNION, EXCEPT, INTERSECT, INTO OUTFILE, FORMAT, ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR) (version 25.8.12.129 (official build))\n
```

The issue was caused by invalid ClickHouse SQL: `FROM person FINAL p`

ClickHouse does not allow aliasing a table directly after the `FINAL` modifier. The parser encounters `p` and fails because it expects a clause keyword, not an alias.

## Changes

Replaced `FINAL` pattern with subquery using `argMax`

## How did you test this code?

- Manual
