### PR TITLE
chore(ci): switch from PAT to default github token

### DIFF
--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -20,14 +20,16 @@ jobs:
     django:
         name: Run Django tests and save test durations
         runs-on: ubuntu-24.04
+        permissions:
+            contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - uses: ./.github/actions/run-backend-tests
               with:
                   concurrency: 1
                   group: 1
-                  token: ${{ secrets.POSTHOG_BOT_PAT }}
+                  token: ${{ github.token }}
                   python-version: '3.12.12'
                   clickhouse-server-image: 'clickhouse/clickhouse-server:25.8.12.129'
                   segment: 'FOSS'


### PR DESCRIPTION
This action doesn't need elevated perms.

Successful test: https://github.com/PostHog/posthog/actions/runs/20319993969/job/58373321926