### PR TITLE
fix: sharing whitelabel

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -638,8 +638,6 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
             if request.method == "GET" and not is_jwt_authenticated:
                 exported_data["type"] = "unlock"
 
-                # Apply whitelabel setting from resource.settings for the unlock page
-                # This must be checked here because we return early for unauthenticated requests
                 settings_data = getattr(resource, "settings", {}) or {}
                 if settings_data.get("whitelabel") and resource.team.organization.is_feature_available(
                     AvailableFeature.WHITE_LABELLING

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -637,6 +637,15 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
 
             if request.method == "GET" and not is_jwt_authenticated:
                 exported_data["type"] = "unlock"
+
+                # Apply whitelabel setting from resource.settings for the unlock page
+                # This must be checked here because we return early for unauthenticated requests
+                settings_data = getattr(resource, "settings", {}) or {}
+                if settings_data.get("whitelabel") and resource.team.organization.is_feature_available(
+                    AvailableFeature.WHITE_LABELLING
+                ):
+                    exported_data["whitelabel"] = True
+
                 # Don't include app_context in the initial unlock page for security
                 # It will be provided after authentication
                 return render_template(

--- a/posthog/api/test/test_share_password_api.py
+++ b/posthog/api/test/test_share_password_api.py
@@ -288,3 +288,35 @@ class TestSharePasswordAPI(APIBaseTest):
         # Should get unlock page (HTML response, not 500 error)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("text/html", response.get("Content-Type", ""))
+
+    @mock_exporter_template
+    def test_unlock_page_respects_whitelabel_setting(self):
+        """
+        Test that the unlock (password login) page respects the whitelabel setting
+        stored in the sharing configuration settings.
+        """
+        # Enable white labelling feature for the organization
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ADVANCED_PERMISSIONS, "name": AvailableFeature.ADVANCED_PERMISSIONS},
+            {"key": AvailableFeature.WHITE_LABELLING, "name": AvailableFeature.WHITE_LABELLING},
+        ]
+        self.organization.save()
+
+        # Set whitelabel in the sharing configuration settings
+        self.sharing_config.settings = {"whitelabel": True}
+        self.sharing_config.save()
+
+        # Create a password so the unlock page is required
+        SharePassword.create_password(
+            sharing_configuration=self.sharing_config, created_by=self.user, raw_password="testpass123"
+        )
+
+        # Access the shared resource without authentication - should show unlock page
+        response = self.client.get(f"/shared/{self.sharing_config.access_token}")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # The unlock page should include whitelabel: true in the exported data
+        response_content = response.content.decode("utf-8")
+        self.assertIn('"type": "unlock"', response_content)
+        self.assertIn('"whitelabel": true', response_content)


### PR DESCRIPTION
## Problem
sharing whitelabel was broken on login page:
https://posthog.slack.com/archives/C045L1VEG87/p1766004722220959

## Changes
fix it and add test

## How did you test this code?
wrote a test