### PR TITLE
fix(security): add SSRF validation for slack_incoming_webhook on save

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -16,6 +16,7 @@ from posthog.schema import ProductKey
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import ProjectBackwardCompatBasicSerializer
 from posthog.api.team import TEAM_CONFIG_FIELDS_SET, TeamSerializer, validate_team_attrs
+from posthog.api.utils import raise_if_user_provided_url_unsafe
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.constants import AvailableFeature
 from posthog.event_usage import report_user_action
@@ -83,6 +84,18 @@ class ProjectBackwardCompatSerializer(ProjectBackwardCompatBasicSerializer, User
         if value is None:
             return value
         return [domain for domain in value if domain]
+
+    def validate_slack_incoming_webhook(self, value: str | None) -> str | None:
+        if value is None or value == "":
+            return None
+        if not settings.DEBUG:
+            try:
+                raise_if_user_provided_url_unsafe(value)
+            except ValueError:
+                raise exceptions.ValidationError(
+                    "Invalid webhook URL. Ensure the URL is valid and points to an external server."
+                )
+        return value
 
     class Meta:
         model = Project

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1,7 +1,7 @@
 import json
 from datetime import timedelta
 from functools import cached_property
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, cast
 
 from django.conf import settings
 from django.db import transaction
@@ -17,7 +17,7 @@ from posthog.schema import AttributionMode
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import TeamBasicSerializer
-from posthog.api.utils import action
+from posthog.api.utils import action, raise_if_user_provided_url_unsafe
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.constants import AvailableFeature
 from posthog.event_usage import report_user_action
@@ -301,7 +301,7 @@ class TeamCustomerAnalyticsConfigSerializer(serializers.ModelSerializer):
 
 
 class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin, UserAccessControlSerializerMixin):
-    instance: Optional[Team]
+    instance: Team | None
 
     effective_membership_level = serializers.SerializerMethodField()
     has_group_types = serializers.SerializerMethodField()
@@ -375,7 +375,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
 
         return representation
 
-    def get_effective_membership_level(self, team: Team) -> Optional[OrganizationMembership.Level]:
+    def get_effective_membership_level(self, team: Team) -> OrganizationMembership.Level | None:
         # TODO: Map from user_access_controls
         return self.user_permissions.team(team).effective_membership_level
 
@@ -389,7 +389,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
             .values(*GROUP_TYPE_MAPPING_SERIALIZER_FIELDS)
         )
 
-    def get_live_events_token(self, team: Team) -> Optional[str]:
+    def get_live_events_token(self, team: Team) -> str | None:
         return encode_jwt(
             {"team_id": team.id, "api_token": team.api_token},
             timedelta(days=7),
@@ -599,6 +599,16 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         if value is None:
             return value
         return [domain for domain in value if domain]
+
+    def validate_slack_incoming_webhook(self, value: str | None) -> str | None:
+        if value is None or value == "":
+            return value
+        if not settings.DEBUG:
+            try:
+                raise_if_user_provided_url_unsafe(value)
+            except ValueError as e:
+                raise exceptions.ValidationError(f"Invalid webhook URL: {e}")
+        return value
 
     def validate_receive_org_level_activity_logs(self, value: bool | None) -> bool | None:
         if value is None:
@@ -1337,7 +1347,7 @@ class RootTeamViewSet(TeamViewSet):
 
 
 def validate_team_attrs(
-    attrs: dict[str, Any], view: TeamAndOrgViewSetMixin, request: request.Request, instance: Optional[Team | Project]
+    attrs: dict[str, Any], view: TeamAndOrgViewSetMixin, request: request.Request, instance: Team | Project | None
 ) -> dict[str, Any]:
     if "primary_dashboard" in attrs:
         if not instance:

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -602,7 +602,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
 
     def validate_slack_incoming_webhook(self, value: str | None) -> str | None:
         if value is None or value == "":
-            return value
+            return None
         if not settings.DEBUG:
             try:
                 raise_if_user_provided_url_unsafe(value)

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -606,8 +606,10 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         if not settings.DEBUG:
             try:
                 raise_if_user_provided_url_unsafe(value)
-            except ValueError as e:
-                raise exceptions.ValidationError(f"Invalid webhook URL: {e}")
+            except ValueError:
+                raise exceptions.ValidationError(
+                    "Invalid webhook URL. Ensure the URL is valid and points to an external server."
+                )
         return value
 
     def validate_receive_org_level_activity_logs(self, value: bool | None) -> bool | None:

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -380,6 +380,37 @@ def team_api_test_factory():
             self.team.refresh_from_db()
             self.assertNotEqual(self.team.timezone, "America/I_Dont_Exist")
 
+        @parameterized.expand(
+            [
+                ("null_value", None, True),
+                ("empty_string", "", True),
+                ("valid_slack_url", "https://hooks.slack.com/services/T00/B00/XXX", True),
+                ("valid_external_url", "https://example.com/webhook", True),
+                ("localhost", "http://localhost/webhook", False),
+                ("localhost_with_port", "http://localhost:8080/webhook", False),
+                ("loopback_ip", "http://127.0.0.1/webhook", False),
+                ("internal_ip_192", "http://192.168.1.1/webhook", False),
+                ("internal_ip_10", "http://10.0.0.1/webhook", False),
+                ("internal_ip_172", "http://172.16.0.1/webhook", False),
+            ]
+        )
+        @override_settings(DEBUG=False)
+        def test_slack_incoming_webhook_ssrf_validation(
+            self, _name: str, webhook_url: str | None, should_succeed: bool
+        ):
+            """Test that slack_incoming_webhook rejects internal/private IPs (CVE-2025-1521)."""
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/",
+                {"slack_incoming_webhook": webhook_url},
+            )
+            if should_succeed:
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.team.refresh_from_db()
+                self.assertEqual(self.team.slack_incoming_webhook, webhook_url if webhook_url else None)
+            else:
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertIn("Invalid webhook URL", response.json().get("attr", "") or str(response.json()))
+
         def test_cant_update_team_from_another_org(self):
             org = Organization.objects.create(name="New Org")
             team = Team.objects.create(organization=org, name="Default project")

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -409,7 +409,8 @@ def team_api_test_factory():
                 self.assertEqual(self.team.slack_incoming_webhook, webhook_url if webhook_url else None)
             else:
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-                self.assertIn("Invalid webhook URL", response.json().get("attr", "") or str(response.json()))
+                response_data = response.json()
+                self.assertIn("Invalid webhook URL", response_data.get("detail", "") or str(response_data))
 
         def test_cant_update_team_from_another_org(self):
             org = Organization.objects.create(name="New Org")


### PR DESCRIPTION
## Summary

- Adds SSRF validation to the `slack_incoming_webhook` field when saving via PATCH on the Team/Project API
- Previously, URL validation was only applied during the `test_slack_webhook` endpoint, allowing bypass by directly PATCHing the project settings

## Context

This addresses part of the vulnerability chain described in [ZDI-25-096 (CVE-2025-1521)](https://mdisec.com/inside-posthog-how-ssrf-a-clickhouse-sql-escaping-0day-and-default-postgresql-credentials-formed-an-rce-chain-zdi-25-099-zdi-25-097-zdi-25-096/).

While the execution layer (plugin-server and Rust hook-worker) already has SSRF protection in production, this adds defense-in-depth by validating URLs at the storage layer as well.

## Changes

- Added `validate_slack_incoming_webhook()` method to `TeamSerializer` in `posthog/api/team.py`
- Uses the existing `raise_if_user_provided_url_unsafe()` function (same validation as `test_slack_webhook` endpoint)
- Validation is skipped in DEBUG mode (consistent with other SSRF checks)

## Test plan

- [x] Verify that saving a valid external webhook URL (e.g., `https://hooks.slack.com/...`) works
- [x] Verify that saving an internal IP URL (e.g., `http://127.0.0.1:8123`) is rejected with validation error
- [x] Verify that clearing the webhook (setting to `null` or `""`) works
- [x] Verify existing `test_slack_webhook` endpoint still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)