### PR TITLE
fix: no internal ips in hobby deploys

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -333,7 +333,6 @@ services:
             PERSONS_URL: 'postgres://posthog:posthog@db:5432/posthog'
             MAXMIND_DB_PATH: '/share/GeoLite2-City.mmdb'
             REDIS_URL: 'redis://redis:6379/'
-            ALLOW_INTERNAL_IPS: 'true'
             RUST_LOG: 'info'
         depends_on:
             kafka:


### PR DESCRIPTION
Seems like a copy-paste error, we shouldn't allow cymbal to hit internal IPs in hobby deploys