### PR TITLE
chore(workflows): logging papercut fixes

### DIFF
--- a/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
+++ b/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
@@ -25,8 +25,8 @@ import { LogEntryLevel } from '~/types'
 
 import type { logsViewerLogicType } from './logsViewerLogicType'
 
-export const ALL_LOG_LEVELS: LogEntryLevel[] = ['DEBUG', 'LOG', 'INFO', 'WARNING', 'ERROR']
-export const DEFAULT_LOG_LEVELS: LogEntryLevel[] = ['DEBUG', 'LOG', 'INFO', 'WARNING', 'ERROR']
+export const ALL_LOG_LEVELS: LogEntryLevel[] = ['DEBUG', 'LOG', 'INFO', 'WARN', 'ERROR']
+export const DEFAULT_LOG_LEVELS: LogEntryLevel[] = ['DEBUG', 'LOG', 'INFO', 'WARN', 'ERROR']
 export const POLLING_INTERVAL = 5000
 export const LOG_VIEWER_LIMIT = 100
 

--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -675,7 +675,7 @@ export class HogExecutorService {
                 message += ` Retrying in ${backoffMs}ms.`
             }
 
-            addLog('warn', message)
+            addLog('error', message)
 
             if (canRetry && result.invocation.state.attempts < this.hub.CDP_FETCH_RETRIES) {
                 await fetchResponse?.dump()

--- a/plugin-server/src/cdp/services/messaging/recipient-preferences.service.test.ts
+++ b/plugin-server/src/cdp/services/messaging/recipient-preferences.service.test.ts
@@ -220,7 +220,7 @@ describe('RecipientPreferencesService', () => {
                 const invocation = createFunctionStepInvocation(action)
 
                 await expect(service.shouldSkipAction(invocation, action)).rejects.toThrow(
-                    'No identifier found for message action email'
+                    `No recipient identifier found for message action [Action:${action.id}]. Check that the message 'to' field is set correctly for this person.`
                 )
             })
 
@@ -372,7 +372,7 @@ describe('RecipientPreferencesService', () => {
                 const invocation = createFunctionStepInvocation(action)
 
                 await expect(service.shouldSkipAction(invocation, action)).rejects.toThrow(
-                    'No identifier found for message action sms'
+                    `No recipient identifier found for message action [Action:${action.id}]. Check that the message 'to' field is set correctly for this person.`
                 )
             })
 

--- a/plugin-server/src/cdp/services/messaging/recipient-preferences.service.ts
+++ b/plugin-server/src/cdp/services/messaging/recipient-preferences.service.ts
@@ -37,7 +37,9 @@ export class RecipientPreferencesService {
         }
 
         if (!identifier) {
-            throw new Error(`No identifier found for message action ${action.id}`)
+            throw new Error(
+                `No recipient identifier found for message action [Action:${action.id}]. Check that the message 'to' field is set correctly for this person.`
+            )
         }
 
         try {


### PR DESCRIPTION
## Problem

Three fixes / tweaks:
- when we fail our HTTP fetches, we mark this as an error in the destination metrics, BUT we were only logging with a `warn`, which isn't intuitive for finding + fixing your destination errors
- `WARNING` log filters on the frontend don't actually filter to warning level app metrics because they're under `warn`, not `warning`
- The recipient identifier error log is not super explanatory

## How did you test this code?

updated tests

Verified the warning logs working now: 
<img width="550" height="375" alt="Screenshot 2025-12-17 at 7 03 12 PM" src="https://github.com/user-attachments/assets/02eb8143-0af4-4d9d-9808-4c166fb35914" />
