### PR TITLE
perf(flags): Optimize hypercache verification with batch Redis reads

### DIFF
--- a/playwright/e2e/surveys/quickcreate.spec.ts
+++ b/playwright/e2e/surveys/quickcreate.spec.ts
@@ -231,7 +231,7 @@ test.describe('Quick create survey from feature flag', () => {
         await responsePromise
         await page.waitForURL(/project\/(\d+)\/surveys\/([\w-]+)/)
         await expect(page.locator('.scene-tab-title').first()).toContainText(name)
-        await expect(page.locator('[data-attr="launch-survey"]')).toBeVisible()
+        await expect(page.locator('[data-attr="launch-survey"]').first()).toBeVisible()
     })
 
     test('warning shown when surveys are disabled', async ({ page }) => {

--- a/posthog/storage/hypercache_verifier.py
+++ b/posthog/storage/hypercache_verifier.py
@@ -60,7 +60,7 @@ class VerificationResult:
 
 def verify_and_fix_all_teams(
     config: HyperCacheManagementConfig,
-    verify_team_fn: Callable[[Team, dict | None], dict],
+    verify_team_fn: Callable[[Team, dict | None, dict | None], dict],
     cache_type: str,
     chunk_size: int | None = None,
 ) -> VerificationResult:
@@ -73,7 +73,7 @@ def verify_and_fix_all_teams(
 
     Args:
         config: HyperCache management configuration with update_fn
-        verify_team_fn: Function that takes (team, batch_data) and returns
+        verify_team_fn: Function that takes (team, db_batch_data, cache_batch_data) and returns
             a dict with 'status' ("match", "miss", "mismatch") and 'issue' type
         cache_type: Name for metrics/logging (e.g., "team_metadata", "flags")
         chunk_size: Number of teams to process per batch. Defaults to
@@ -106,7 +106,7 @@ def verify_and_fix_all_teams(
 def _verify_and_fix_batch(
     teams: list[Team],
     config: HyperCacheManagementConfig,
-    verify_team_fn: Callable[[Team, dict | None], dict],
+    verify_team_fn: Callable[[Team, dict | None, dict | None], dict],
     cache_type: str,
     result: VerificationResult,
 ) -> None:
@@ -116,17 +116,20 @@ def _verify_and_fix_batch(
     Args:
         teams: List of Team objects to verify
         config: HyperCache management configuration
-        verify_team_fn: Function to verify a single team
+        verify_team_fn: Function to verify a single team (team, db_batch_data, cache_batch_data)
         cache_type: Name for metrics/logging
         result: VerificationResult to accumulate stats
     """
-    # Batch-load data if supported
-    batch_data = None
+    # Batch-load DB data if supported
+    db_batch_data = None
     if config.hypercache.batch_load_fn:
         try:
-            batch_data = config.hypercache.batch_load_fn(teams)
+            db_batch_data = config.hypercache.batch_load_fn(teams)
         except Exception as e:
             logger.warning("Batch load failed, falling back to individual loads", error=str(e))
+
+    # Batch-read cached values using MGET (single Redis round trip)
+    cache_batch_data = config.hypercache.batch_get_from_cache(teams)
 
     # Batch-check expiry tracking
     expiry_status = batch_check_expiry_tracking(teams, config)
@@ -135,7 +138,7 @@ def _verify_and_fix_batch(
         result.total += 1
 
         try:
-            verification = verify_team_fn(team, batch_data)
+            verification = verify_team_fn(team, db_batch_data, cache_batch_data)
         except Exception as e:
             result.errors += 1
             logger.exception("Error verifying team", team_id=team.id, error=str(e))
@@ -153,6 +156,7 @@ def _verify_and_fix_batch(
                     issue_type="expiry_missing",
                     cache_type=cache_type,
                     result=result,
+                    db_data=db_batch_data.get(team.id) if db_batch_data else None,
                 )
 
         elif status == "miss":
@@ -162,6 +166,7 @@ def _verify_and_fix_batch(
                 issue_type="cache_miss",
                 cache_type=cache_type,
                 result=result,
+                db_data=db_batch_data.get(team.id) if db_batch_data else None,
             )
 
         elif status == "mismatch":
@@ -172,16 +177,19 @@ def _verify_and_fix_batch(
                 cache_type=cache_type,
                 result=result,
                 verification=verification,
+                db_data=db_batch_data.get(team.id) if db_batch_data else None,
             )
 
 
 def _fix_and_record(
+    *,
     team: Team,
     config: HyperCacheManagementConfig,
     issue_type: str,
     cache_type: str,
     result: VerificationResult,
     verification: dict | None = None,
+    db_data: dict | None = None,
 ) -> None:
     """
     Fix a team's cache and record the result.
@@ -193,6 +201,7 @@ def _fix_and_record(
         cache_type: Cache type for metrics
         result: VerificationResult to update
         verification: Optional verification result dict containing diff info
+        db_data: Pre-loaded DB data to avoid redundant query during fix
     """
     # Log what's being fixed, including diff details for mismatches
     log_kwargs: dict = {"team_id": team.id, "issue_type": issue_type, "cache_type": cache_type}
@@ -204,7 +213,13 @@ def _fix_and_record(
     logger.info("Fixing cache entry", **log_kwargs)
 
     try:
-        success = config.update_fn(team)
+        # If we have pre-loaded DB data, write it directly to cache to avoid redundant DB query
+        if db_data is not None:
+            config.hypercache.set_cache_value(team, db_data)
+            success = True
+        else:
+            # Fall back to update_fn which will load from DB
+            success = config.update_fn(team)
     except Exception as e:
         success = False
         logger.exception("Error fixing cache", team_id=team.id, issue_type=issue_type, error=str(e))
@@ -228,7 +243,7 @@ def _fix_and_record(
 
 def _run_verification_for_cache(
     config: HyperCacheManagementConfig,
-    verify_team_fn: Callable[[Team, dict | None], dict],
+    verify_team_fn: Callable[[Team, dict | None, dict | None], dict],
     cache_type: str,
 ) -> VerificationResult:
     """

--- a/posthog/storage/hypercache_verifier.py
+++ b/posthog/storage/hypercache_verifier.py
@@ -129,7 +129,11 @@ def _verify_and_fix_batch(
             logger.warning("Batch load failed, falling back to individual loads", error=str(e))
 
     # Batch-read cached values using MGET (single Redis round trip)
-    cache_batch_data = config.hypercache.batch_get_from_cache(teams)
+    try:
+        cache_batch_data = config.hypercache.batch_get_from_cache(teams)
+    except Exception as e:
+        logger.warning("Batch cache read failed, falling back to individual lookups", error=str(e))
+        cache_batch_data = {}
 
     # Batch-check expiry tracking
     expiry_status = batch_check_expiry_tracking(teams, config)

--- a/posthog/storage/test/test_hypercache_verifier.py
+++ b/posthog/storage/test/test_hypercache_verifier.py
@@ -188,6 +188,68 @@ class TestFixAndRecord(BaseTest):
         assert result.cache_miss_fixed == 0
         assert result.fix_failed == 1
 
+    def test_uses_db_data_directly_when_provided(self):
+        """Test that _fix_and_record uses db_data to set cache directly, bypassing update_fn."""
+        mock_config = MagicMock()
+        db_data = {"flags": ["flag1", "flag2"]}
+
+        result = VerificationResult()
+
+        _fix_and_record(
+            team=self.team,
+            config=mock_config,
+            issue_type="cache_miss",
+            cache_type="test_cache",
+            result=result,
+            db_data=db_data,
+        )
+
+        # Should call set_cache_value with db_data, NOT update_fn
+        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, db_data)
+        mock_config.update_fn.assert_not_called()
+        assert result.cache_miss_fixed == 1
+
+    def test_falls_back_to_update_fn_when_db_data_is_none(self):
+        """Test that _fix_and_record falls back to update_fn when db_data is None."""
+        mock_config = MagicMock()
+        mock_config.update_fn.return_value = True
+
+        result = VerificationResult()
+
+        _fix_and_record(
+            team=self.team,
+            config=mock_config,
+            issue_type="cache_miss",
+            cache_type="test_cache",
+            result=result,
+            db_data=None,
+        )
+
+        # Should call update_fn, NOT set_cache_value
+        mock_config.update_fn.assert_called_once_with(self.team)
+        mock_config.hypercache.set_cache_value.assert_not_called()
+        assert result.cache_miss_fixed == 1
+
+    def test_db_data_set_cache_value_exception_increments_fix_failed(self):
+        """Test that exceptions in set_cache_value (db_data path) increment fix_failed."""
+        mock_config = MagicMock()
+        mock_config.hypercache.set_cache_value.side_effect = Exception("Redis error")
+        db_data = {"flags": ["flag1"]}
+
+        result = VerificationResult()
+
+        _fix_and_record(
+            team=self.team,
+            config=mock_config,
+            issue_type="cache_miss",
+            cache_type="test_cache",
+            result=result,
+            db_data=db_data,
+        )
+
+        assert result.cache_miss_fixed == 0
+        assert result.fix_failed == 1
+
 
 @override_settings(FLAGS_REDIS_URL="redis://test")
 class TestVerifyAndFixBatch(BaseTest):
@@ -197,11 +259,12 @@ class TestVerifyAndFixBatch(BaseTest):
         """Test that cache match status doesn't trigger a fix."""
         mock_config = MagicMock()
         mock_config.hypercache.batch_load_fn = None
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
         mock_config.hypercache.get_cache_identifier.return_value = str(self.team.id)
 
         result = VerificationResult()
 
-        def verify_fn(team, batch_data):
+        def verify_fn(team, db_batch_data, cache_batch_data):
             return {"status": "match", "issue": None}
 
         with patch(
@@ -223,11 +286,12 @@ class TestVerifyAndFixBatch(BaseTest):
         """Test that cache miss status triggers a fix."""
         mock_config = MagicMock()
         mock_config.hypercache.batch_load_fn = None
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
         mock_config.update_fn.return_value = True
 
         result = VerificationResult()
 
-        def verify_fn(team, batch_data):
+        def verify_fn(team, db_batch_data, cache_batch_data):
             return {"status": "miss", "issue": "CACHE_MISS"}
 
         with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={}):
@@ -241,17 +305,19 @@ class TestVerifyAndFixBatch(BaseTest):
 
         assert result.total == 1
         assert result.cache_miss_fixed == 1
+        # When db_batch_data is None (no batch_load_fn), it falls back to update_fn
         mock_config.update_fn.assert_called_once_with(self.team)
 
     def test_mismatch_status_triggers_fix(self):
         """Test that cache mismatch status triggers a fix."""
         mock_config = MagicMock()
         mock_config.hypercache.batch_load_fn = None
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
         mock_config.update_fn.return_value = True
 
         result = VerificationResult()
 
-        def verify_fn(team, batch_data):
+        def verify_fn(team, db_batch_data, cache_batch_data):
             return {"status": "mismatch", "issue": "DATA_MISMATCH"}
 
         with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={}):
@@ -270,12 +336,13 @@ class TestVerifyAndFixBatch(BaseTest):
         """Test that missing expiry tracking triggers fix even when cache matches."""
         mock_config = MagicMock()
         mock_config.hypercache.batch_load_fn = None
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
         mock_config.hypercache.get_cache_identifier.return_value = str(self.team.id)
         mock_config.update_fn.return_value = True
 
         result = VerificationResult()
 
-        def verify_fn(team, batch_data):
+        def verify_fn(team, db_batch_data, cache_batch_data):
             return {"status": "match", "issue": None}
 
         # Expiry status shows team is NOT tracked (False)
@@ -292,16 +359,18 @@ class TestVerifyAndFixBatch(BaseTest):
 
         assert result.total == 1
         assert result.expiry_missing_fixed == 1
+        # When db_batch_data is None (no batch_load_fn), it falls back to update_fn
         mock_config.update_fn.assert_called_once_with(self.team)
 
     def test_verification_error_increments_errors(self):
         """Test that verification errors are counted."""
         mock_config = MagicMock()
         mock_config.hypercache.batch_load_fn = None
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
 
         result = VerificationResult()
 
-        def verify_fn(team, batch_data):
+        def verify_fn(team, db_batch_data, cache_batch_data):
             raise Exception("Verification failed")
 
         with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={}):
@@ -319,15 +388,16 @@ class TestVerifyAndFixBatch(BaseTest):
 
     def test_batch_load_fn_called_when_available(self) -> None:
         mock_config = MagicMock()
-        mock_batch_data: dict = {self.team.id: {"flags": []}}
-        mock_config.hypercache.batch_load_fn.return_value = mock_batch_data
+        mock_db_batch_data: dict = {self.team.id: {"flags": []}}
+        mock_config.hypercache.batch_load_fn.return_value = mock_db_batch_data
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
         mock_config.hypercache.get_cache_identifier.return_value = str(self.team.id)
 
         result = VerificationResult()
-        received_batch_data = []
+        received_db_batch_data = []
 
-        def verify_fn(team, batch_data):
-            received_batch_data.append(batch_data)
+        def verify_fn(team, db_batch_data, cache_batch_data):
+            received_db_batch_data.append(db_batch_data)
             return {"status": "match", "issue": None}
 
         with patch(
@@ -342,7 +412,60 @@ class TestVerifyAndFixBatch(BaseTest):
             )
 
         mock_config.hypercache.batch_load_fn.assert_called_once_with([self.team])
-        assert received_batch_data[0] == mock_batch_data
+        mock_config.hypercache.batch_get_from_cache.assert_called_once_with([self.team])
+        assert received_db_batch_data[0] == mock_db_batch_data
+
+    def test_fix_uses_db_batch_data_directly(self):
+        """Test that fixes use pre-loaded db_batch_data to avoid redundant DB queries."""
+        mock_config = MagicMock()
+        mock_db_batch_data: dict = {self.team.id: {"flags": ["flag1", "flag2"]}}
+        mock_config.hypercache.batch_load_fn.return_value = mock_db_batch_data
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
+
+        result = VerificationResult()
+
+        def verify_fn(team, db_batch_data, cache_batch_data):
+            return {"status": "miss", "issue": "CACHE_MISS"}
+
+        with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={}):
+            _verify_and_fix_batch(
+                teams=[self.team],
+                config=mock_config,
+                verify_team_fn=verify_fn,
+                cache_type="test_cache",
+                result=result,
+            )
+
+        # Should call set_cache_value with db_batch_data, NOT update_fn
+        mock_config.hypercache.set_cache_value.assert_called_once_with(self.team, {"flags": ["flag1", "flag2"]})
+        mock_config.update_fn.assert_not_called()
+        assert result.cache_miss_fixed == 1
+
+    def test_fix_falls_back_to_update_fn_without_batch_load(self):
+        """Test that fixes fall back to update_fn when batch_load_fn is not available."""
+        mock_config = MagicMock()
+        mock_config.hypercache.batch_load_fn = None
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
+        mock_config.update_fn.return_value = True
+
+        result = VerificationResult()
+
+        def verify_fn(team, db_batch_data, cache_batch_data):
+            return {"status": "miss", "issue": "CACHE_MISS"}
+
+        with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={}):
+            _verify_and_fix_batch(
+                teams=[self.team],
+                config=mock_config,
+                verify_team_fn=verify_fn,
+                cache_type="test_cache",
+                result=result,
+            )
+
+        # Should call update_fn, NOT set_cache_value
+        mock_config.update_fn.assert_called_once_with(self.team)
+        mock_config.hypercache.set_cache_value.assert_not_called()
+        assert result.cache_miss_fixed == 1
 
 
 @override_settings(FLAGS_REDIS_URL="redis://test")
@@ -353,9 +476,10 @@ class TestVerifyAndFixAllTeams(BaseTest):
         """Test that all teams are processed in chunks."""
         mock_config = MagicMock()
         mock_config.hypercache.batch_load_fn = None
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
         mock_config.hypercache.get_cache_identifier.side_effect = lambda t: str(t.id)
 
-        def verify_fn(team, batch_data):
+        def verify_fn(team, db_batch_data, cache_batch_data):
             return {"status": "match", "issue": None}
 
         with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={}):
@@ -373,9 +497,10 @@ class TestVerifyAndFixAllTeams(BaseTest):
         """Test that results are aggregated across all chunks."""
         mock_config = MagicMock()
         mock_config.hypercache.batch_load_fn = None
+        mock_config.hypercache.batch_get_from_cache.return_value = {}
         mock_config.update_fn.return_value = True
 
-        def verify_fn(team, batch_data):
+        def verify_fn(team, db_batch_data, cache_batch_data):
             return {"status": "miss", "issue": "CACHE_MISS"}
 
         with patch("posthog.storage.hypercache_verifier.batch_check_expiry_tracking", return_value={}):

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -86,7 +86,7 @@ def _run_cache_verification(cache_type: CacheType) -> None:
 @shared_task(
     ignore_result=True,
     queue=CeleryQueue.DEFAULT.value,
-    soft_time_limit=4 * 60 * 60 - 300,  # 3h 55min warning
+    soft_time_limit=3 * 60 * 60 + 30 * 60,  # 3h 30min soft limit
     time_limit=4 * 60 * 60,  # 4 hour hard limit (distributed lock prevents overlap)
 )
 def verify_and_fix_flags_cache_task() -> None:
@@ -105,7 +105,7 @@ def verify_and_fix_flags_cache_task() -> None:
 @shared_task(
     ignore_result=True,
     queue=CeleryQueue.DEFAULT.value,
-    soft_time_limit=4 * 60 * 60 - 300,  # 3h 55min warning
+    soft_time_limit=3 * 60 * 60 + 30 * 60,  # 3h 30min soft limit
     time_limit=4 * 60 * 60,  # 4 hour hard limit (distributed lock prevents overlap)
 )
 def verify_and_fix_team_metadata_cache_task() -> None:


### PR DESCRIPTION
## Problem

The hypercache verification task performs `O(n)` Redis calls per batch when verifying team caches (one `GET` per team). For large deployments with 200K+ teams, this creates significant Redis load and slow verification times. Additionally, when fixing cache entries, the task re-queries the database even though it already loaded the data during verification.

## Changes

- Add `batch_get_from_cache()` method to `HyperCache` that uses Redis `MGET` to fetch all cached values in a single round trip
- Update verification functions to accept pre-loaded cache data alongside DB data
- Pass pre-loaded DB data directly to `set_cache_value()` when fixing caches, eliminating redundant DB queries
- Increase soft time limit window from 5 to 30 minutes to accommodate larger deployments

For a batch of 1000 teams, this reduces Redis operations from ~1000 individual `GET` calls to 1 `MGET` call.

## How did you test this code?

- Added unit tests for `batch_get_from_cache()` covering:
  - All hits, all misses, and partial hit scenarios
  - Empty value markers (HyperCacheStoreMissing)
  - Verification that `get_many` (MGET) is used instead of individual gets
  - No S3 fallback behavior (verification-specific optimization)
- Added unit tests for the fix path using pre-loaded DB data
- Updated existing verifier tests to use the new function signatures
