### PR TITLE
fix(experiments): ship variant modal breaks on web experiments

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -696,7 +696,11 @@ export function ShipVariantModal(): JSX.Element {
             // First test variant selected by default
             setSelectedVariantKey(experiment.parameters.feature_flag_variants[1].key)
         }
-    }, [experiment.id, experiment.parameters.feature_flag_variants.length, experiment.parameters.feature_flag_variants])
+    }, [
+        experiment.id,
+        experiment.parameters?.feature_flag_variants?.length,
+        experiment.parameters?.feature_flag_variants,
+    ])
 
     const aggregationTargetName =
         experiment.filters.aggregation_group_type_index != null

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -561,7 +561,7 @@ export function MetricRowGroup({
             {/* Breakdown Results */}
             {result.breakdown_results?.map((breakdownResult) => {
                 const baselineResult = breakdownResult.baseline
-                const variantResults = breakdownResult.variants
+                const variantResults = breakdownResult.variants || []
 
                 if (variantResults.length === 0) {
                     return (


### PR DESCRIPTION
## Problem

Web (no-code) experiments crash when loading because `ShipVariantModal` useEffect evaluates `experiment.parameters.feature_flag_variants.length` which is missing on no-code experiments.

| uncaught exception |
| - |
| <img width="1276" height="442" alt="image" src="https://github.com/user-attachments/assets/f401dbec-d042-42ba-ad0c-002a42c111b4" /> |

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Added optional chaining to the dependency array and a defensive fallback in `MetricRowGroup` to handle missing data gracefully.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/c7cec7b6-1d55-4490-81e6-c2d54169b917)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
