### PR TITLE
fix: dashboard refresh blocking

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { useEffect, useReducer } from 'react'
+import { useEffect, useState } from 'react'
 
 import { IconCheck } from '@posthog/icons'
 import { IconRefresh } from '@posthog/icons'
@@ -51,12 +51,12 @@ export function DashboardReloadAction(): JSX.Element {
 
     // Force a re-render when nextAllowedDashboardRefresh is reached, since the blockRefresh
     // selector uses now() which isn't reactive - it only recomputes on dependency changes
-    const [, forceUpdate] = useReducer((x: number) => x + 1, 0)
+    const [, setRenderTrigger] = useState(0)
     useEffect(() => {
         if (nextAllowedDashboardRefresh) {
             const msUntilRefreshAllowed = dayjs(nextAllowedDashboardRefresh).diff(dayjs())
             if (msUntilRefreshAllowed > 0) {
-                const timeoutId = setTimeout(forceUpdate, msUntilRefreshAllowed + 100)
+                const timeoutId = setTimeout(() => setRenderTrigger((n) => n + 1), msUntilRefreshAllowed + 100)
                 return () => clearTimeout(timeoutId)
             }
         }

--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -60,11 +60,21 @@ export function DashboardReloadAction(): JSX.Element {
             <LemonButton
                 onClick={() => triggerDashboardRefresh()}
                 type="secondary"
-                icon={itemsLoading ? <Spinner textColored /> : blockRefresh ? <IconCheck /> : <IconRefresh />}
+                icon={
+                    itemsLoading ? (
+                        <Spinner textColored />
+                    ) : blockRefresh &&
+                      nextAllowedDashboardRefresh &&
+                      dayjs(nextAllowedDashboardRefresh).isAfter(dayjs()) ? (
+                        <IconCheck />
+                    ) : (
+                        <IconRefresh />
+                    )
+                }
                 size="small"
                 data-attr="dashboard-items-action-refresh"
                 disabledReason={
-                    blockRefresh
+                    blockRefresh && nextAllowedDashboardRefresh && dayjs(nextAllowedDashboardRefresh).isAfter(dayjs())
                         ? `Next bulk refresh possible ${dayjs(nextAllowedDashboardRefresh).fromNow()}`
                         : itemsLoading
                           ? 'Loading...'

--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
+import { useEffect, useReducer } from 'react'
 
 import { IconCheck } from '@posthog/icons'
 import { IconRefresh } from '@posthog/icons'
@@ -47,6 +48,19 @@ export function DashboardReloadAction(): JSX.Element {
     usePageVisibilityCb((pageIsVisible) => {
         setPageVisibility(pageIsVisible)
     })
+
+    // Force a re-render when nextAllowedDashboardRefresh is reached, since the blockRefresh
+    // selector uses now() which isn't reactive - it only recomputes on dependency changes
+    const [, forceUpdate] = useReducer((x: number) => x + 1, 0)
+    useEffect(() => {
+        if (nextAllowedDashboardRefresh) {
+            const msUntilRefreshAllowed = dayjs(nextAllowedDashboardRefresh).diff(dayjs())
+            if (msUntilRefreshAllowed > 0) {
+                const timeoutId = setTimeout(forceUpdate, msUntilRefreshAllowed + 100)
+                return () => clearTimeout(timeoutId)
+            }
+        }
+    }, [nextAllowedDashboardRefresh])
 
     const options = INTERVAL_OPTIONS.map((option) => {
         return {


### PR DESCRIPTION
## Problem
dashboard refresh limiting doesn't ever refresh if you leave the browser tab open

## Changes
make it properly refresh if the time has passed