### PR TITLE
feat(logs): persist display settings locally instead of in url

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -37,7 +37,9 @@ export function LogsScene(): JSX.Element {
     const { runQuery, fetchNextLogsPage, setOrderBy, addFilter, setDateRange } = useActions(logsLogic)
 
     useEffect(() => {
-        runQuery()
+        if (parsedLogs.length === 0) {
+            runQuery()
+        }
     }, [runQuery])
 
     return (

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -8,9 +8,9 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
-import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
-
-import type { logsViewerLogicType, logsViewerSettingsLogicType } from './logsViewerLogicType'
+import { LogsOrderBy, ParsedLogMessage } from '../../types'
+import type { logsViewerLogicType } from './logsViewerLogicType'
+import { logsViewerSettingsLogic } from './logsViewerSettingsLogic'
 
 export interface VisibleLogsTimeRange {
     date_from: string
@@ -28,47 +28,6 @@ export interface LogsViewerLogicProps {
     orderBy: LogsOrderBy
     onAddFilter?: (key: string, value: string, operator?: PropertyOperator, type?: PropertyFilterType) => void
 }
-
-// Shared logic for user preferences which should be used across all tabs+windows
-const logsViewerSettingsLogic = kea<logsViewerSettingsLogicType>([
-    path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'logsViewerSettingsLogic']),
-
-    actions({
-        // Timezone (IANA string, e.g. "UTC", "America/New_York")
-        setTimezone: (timezone: string) => ({ timezone }),
-
-        // Display options
-        setWrapBody: (wrapBody: boolean) => ({ wrapBody }),
-        setPrettifyJson: (prettifyJson: boolean) => ({ prettifyJson }),
-    }),
-
-    reducers(({}) => ({
-        // Timezone selection (IANA string, persisted)
-        timezone: [
-            'UTC',
-            { persist: true },
-            {
-                setTimezone: (_, { timezone }) => timezone,
-            },
-        ],
-
-        wrapBody: [
-            true,
-            { persist: true },
-            {
-                setWrapBody: (_, { wrapBody }) => wrapBody,
-            },
-        ],
-
-        prettifyJson: [
-            true,
-            { persist: true },
-            {
-                setPrettifyJson: (_, { prettifyJson }) => prettifyJson,
-            },
-        ],
-    })),
-])
 
 export const logsViewerLogic = kea<logsViewerLogicType>([
     path((tabId) => ['products', 'logs', 'frontend', 'components', 'LogsViewer', 'logsViewerLogic', tabId]),

--- a/products/logs/frontend/components/LogsViewer/logsViewerSettingsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerSettingsLogic.ts
@@ -1,0 +1,44 @@
+import { actions, kea, path, reducers } from 'kea'
+
+import type { logsViewerSettingsLogicType } from './logsViewerSettingsLogicType'
+
+// Shared logic for user preferences which should be used across all tabs+windows
+export const logsViewerSettingsLogic = kea<logsViewerSettingsLogicType>([
+    path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'logsViewerSettingsLogic']),
+
+    actions({
+        // Timezone (IANA string, e.g. "UTC", "America/New_York")
+        setTimezone: (timezone: string) => ({ timezone }),
+
+        // Display options
+        setWrapBody: (wrapBody: boolean) => ({ wrapBody }),
+        setPrettifyJson: (prettifyJson: boolean) => ({ prettifyJson }),
+    }),
+
+    reducers(({}) => ({
+        // Timezone selection (IANA string, persisted)
+        timezone: [
+            'UTC',
+            { persist: true },
+            {
+                setTimezone: (_, { timezone }) => timezone,
+            },
+        ],
+
+        wrapBody: [
+            true,
+            { persist: true },
+            {
+                setWrapBody: (_, { wrapBody }) => wrapBody,
+            },
+        ],
+
+        prettifyJson: [
+            true,
+            { persist: true },
+            {
+                setPrettifyJson: (_, { prettifyJson }) => prettifyJson,
+            },
+        ],
+    })),
+])

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -37,8 +37,6 @@ const DEFAULT_SEVERITY_LEVELS = [] as LogsQuery['severityLevels']
 const DEFAULT_SERVICE_NAMES = [] as LogsQuery['serviceNames']
 const DEFAULT_HIGHLIGHTED_LOG_ID = null as string | null
 const DEFAULT_ORDER_BY = 'latest' as LogsQuery['orderBy']
-const DEFAULT_WRAP_BODY = true
-const DEFAULT_PRETTIFY_JSON = true
 const DEFAULT_LOGS_PAGE_SIZE: number = 250
 const DEFAULT_INITIAL_LOGS_LIMIT = null as number | null
 const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
@@ -205,8 +203,6 @@ export const logsLogic = kea<logsLogicType>([
         setSearchTerm: (searchTerm: LogsQuery['searchTerm']) => ({ searchTerm }),
         setSeverityLevels: (severityLevels: LogsQuery['severityLevels']) => ({ severityLevels }),
         setServiceNames: (serviceNames: LogsQuery['serviceNames']) => ({ serviceNames }),
-        setWrapBody: (wrapBody: boolean) => ({ wrapBody }),
-        setPrettifyJson: (prettifyJson: boolean) => ({ prettifyJson }),
         setLiveLogsCheckpoint: (liveLogsCheckpoint: string | null) => ({ liveLogsCheckpoint }),
 
         setFilterGroup: (filterGroup: UniversalFiltersGroup, openFilterOnInsert: boolean = true) => ({
@@ -299,13 +295,6 @@ export const logsLogic = kea<logsLogicType>([
                 setFilterGroup: (_, { filterGroup }) => filterGroup,
             },
         ],
-        wrapBody: [
-            DEFAULT_WRAP_BODY as boolean,
-            { persist: true },
-            {
-                setWrapBody: (_, { wrapBody }) => wrapBody,
-            },
-        ],
         liveLogsCheckpoint: [
             null as string | null,
             { persist: false },
@@ -319,13 +308,6 @@ export const logsLogic = kea<logsLogicType>([
             {
                 setLiveTailExpired: (_, { liveTailExpired }) => liveTailExpired,
                 fetchLogsSuccess: () => false,
-            },
-        ],
-        prettifyJson: [
-            DEFAULT_PRETTIFY_JSON as boolean,
-            { persist: true },
-            {
-                setPrettifyJson: (_, { prettifyJson }) => prettifyJson,
             },
         ],
         logsAbortController: [

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -93,12 +93,6 @@ export const logsLogic = kea<logsLogicType>([
             if (params.orderBy && !equal(params.orderBy, values.orderBy)) {
                 actions.setOrderBy(params.orderBy)
             }
-            if (params.wrapBody !== undefined && params.wrapBody !== values.wrapBody) {
-                actions.setWrapBody(params.wrapBody)
-            }
-            if (params.prettifyJson !== undefined && params.prettifyJson !== values.prettifyJson) {
-                actions.setPrettifyJson(params.prettifyJson)
-            }
             if (+params.logsPageSize && +params.logsPageSize !== values.logsPageSize) {
                 actions.setLogsPageSize(+params.logsPageSize)
             }
@@ -148,21 +142,6 @@ export const logsLogic = kea<logsLogicType>([
             })
         }
 
-        const updateUrlWithDisplayPreferences = (): [
-            string,
-            Params,
-            Record<string, any>,
-            {
-                replace: boolean
-            },
-        ] => {
-            return syncSearchParams(router, (params: Params) => {
-                updateSearchParams(params, 'wrapBody', values.wrapBody, DEFAULT_WRAP_BODY)
-                updateSearchParams(params, 'prettifyJson', values.prettifyJson, DEFAULT_PRETTIFY_JSON)
-                return params
-            })
-        }
-
         const updateUrlWithPageSize = (): [
             string,
             Params,
@@ -202,8 +181,6 @@ export const logsLogic = kea<logsLogicType>([
             setOrderBy: () => buildUrlAndRunQuery(),
             setLogsPageSize: () => updateUrlWithPageSize(),
             setHighlightedLogId: () => updateHighlightURL(),
-            setWrapBody: () => updateUrlWithDisplayPreferences(),
-            setPrettifyJson: () => updateUrlWithDisplayPreferences(),
         }
     }),
 
@@ -324,6 +301,7 @@ export const logsLogic = kea<logsLogicType>([
         ],
         wrapBody: [
             DEFAULT_WRAP_BODY as boolean,
+            { persist: true },
             {
                 setWrapBody: (_, { wrapBody }) => wrapBody,
             },
@@ -345,6 +323,7 @@ export const logsLogic = kea<logsLogicType>([
         ],
         prettifyJson: [
             DEFAULT_PRETTIFY_JSON as boolean,
+            { persist: true },
             {
                 setPrettifyJson: (_, { prettifyJson }) => prettifyJson,
             },


### PR DESCRIPTION
## Problem

every single time i use logs i have to manually click to my preference (no wrap, no json) - this is persisted in the URL but not locally

I don't want this in the URL when i share it, i want whoever i send it to to have their own display preferences and use that

## Changes

persist display preferences locally, don't update the url, use a shared logic so preferences are shared between tabs+windows, and particularly in new windows
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
no
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
