### PR TITLE
fix(ci): add required workflows to master status trigger

### DIFF
--- a/.github/workflows/ci-master-status.yml
+++ b/.github/workflows/ci-master-status.yml
@@ -2,6 +2,17 @@ name: Master CI Status
 
 on:
     workflow_run:
+        workflows:
+            - 'Backend CI'
+            - 'Container Images CI'
+            - 'Node.js CI'
+            - 'Frontend CI'
+            - 'Storybook'
+            - 'Security'
+            - 'shellcheck'
+            - 'Dagster CI'
+            - 'E2E CI Playwright'
+            - 'Rust CI'
         branches: [master]
         types: [completed]
 


### PR DESCRIPTION
**Fix:** Add missing `workflows` list to `workflow_run` trigger.

The `workflow_run` event requires an explicit list of workflows to watch - without it, the workflow never triggers.

Workflows are based on the master branch ruleset required status checks.