### PR TITLE
refactor: Update batch export default retry intervals

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -49,6 +49,9 @@ BatchExportInsertActivity = collections.abc.Callable[
     [InputsType | ComposedInputsType], collections.abc.Awaitable[BatchExportResult]
 ]
 
+INITIAL_RETRY_INTERVAL_SECONDS = 1
+DEFAULT_MAX_RETRY_INTERVAL_SECONDS = 3600
+
 
 async def execute_batch_export_using_internal_stage(
     activity: BatchExportInsertActivity,
@@ -56,8 +59,8 @@ async def execute_batch_export_using_internal_stage(
     interval: str,
     heartbeat_timeout_seconds: int | None = 180,
     maximum_attempts: int = 0,
-    initial_retry_interval_seconds: int = 5,
-    maximum_retry_interval_seconds: int = 120,
+    initial_retry_interval_seconds: int = INITIAL_RETRY_INTERVAL_SECONDS,
+    maximum_retry_interval_seconds: int = DEFAULT_MAX_RETRY_INTERVAL_SECONDS,
     override_start_to_close_timeout_seconds: int | None = None,
 ) -> None:
     """


### PR DESCRIPTION
## Problem

Batch export activities are configured to retry with a backoff with the following parameters:
* Initial retry interval: 5 seconds
* Max retry interval: 2 minutes
* Backoff coefficient: 2

Due to the parameters, we only have a handful of retries until reaching the maximum, which is quite low. If batch exports are still failing with 2 minutes of interval in between, we should continue increasing the interval as the failure is likely to be more medium term (e.g. an incident in the destination) or we could be contributing to it (via added load). So, spacing out retries more and more seems to be the play. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Bump max retry interval to 1 hour.
Reduce initial retry interval to 1 second, so that the first handful of retries go out quickly in case it is a really transient error. The exponential nature of the retry algorithm means we will quickly backoff if this is not the case. 

## TODO

Maybe we should configure different retry intervals for internal stage activity than main activity.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
