### PR TITLE
chore(workflows): Move workflow/destination lag metrics out of global metrics file

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.test.ts
@@ -2,7 +2,6 @@ import { mockFetch } from '~/tests/helpers/mocks/request.mock'
 
 import { DateTime } from 'luxon'
 
-import { destinationE2eLagMsSummary } from '~/main/ingestion-queues/metrics'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { UUIDT } from '~/utils/utils'
 
@@ -17,6 +16,7 @@ import {
 } from '../_tests/fixtures'
 import { compileHog } from '../templates/compiler'
 import { CyclotronJobInvocationHogFunction, HogFunctionInvocationGlobalsWithInputs, HogFunctionType } from '../types'
+import { destinationE2eLagMsSummary } from '../utils'
 import { CdpCyclotronWorker } from './cdp-cyclotron-worker.consumer'
 
 jest.setTimeout(1000)

--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -6,7 +6,6 @@ import { ExecResult, convertHogToJS } from '@posthog/hogvm'
 
 import { instrumented } from '~/common/tracing/tracing-utils'
 import { ACCESS_TOKEN_PLACEHOLDER } from '~/config/constants'
-import { destinationE2eLagMsSummary } from '~/main/ingestion-queues/metrics'
 import {
     CyclotronInvocationQueueParametersEmailSchema,
     CyclotronInvocationQueueParametersFetchSchema,
@@ -29,6 +28,7 @@ import {
     MinimalAppMetric,
     MinimalLogEntry,
 } from '../types'
+import { destinationE2eLagMsSummary } from '../utils'
 import { createAddLogFunction, sanitizeLogMessage } from '../utils'
 import { execHog } from '../utils/hog-exec'
 import { convertToHogFunctionFilterGlobal, filterFunctionInstrumented } from '../utils/hog-function-filtering'

--- a/plugin-server/src/cdp/services/hogflows/hogflow-utils.ts
+++ b/plugin-server/src/cdp/services/hogflows/hogflow-utils.ts
@@ -1,8 +1,8 @@
 import { DateTime } from 'luxon'
+import { Summary } from 'prom-client'
 
 import { CyclotronJobInvocationHogFlow, CyclotronJobInvocationResult } from '~/cdp/types'
 import { filterFunctionInstrumented } from '~/cdp/utils/hog-function-filtering'
-import { workflowE2eLagMsSummary } from '~/main/ingestion-queues/metrics'
 import { HogFlow, HogFlowAction } from '~/schema/hogflow'
 
 export const findActionById = (hogFlow: HogFlow, id: string): HogFlowAction => {
@@ -110,6 +110,12 @@ const DELAY_ACTION_TYPES: HogFlowAction['type'][] = ['delay', 'wait_until_condit
 export function hasDelayActions(actions: HogFlowAction[]): boolean {
     return actions.some((action) => DELAY_ACTION_TYPES.includes(action.type))
 }
+
+const workflowE2eLagMsSummary = new Summary({
+    name: 'workflow_e2e_lag_ms',
+    help: 'Time difference in ms between event capture time and workflow finishing time',
+    percentiles: [0.5, 0.9, 0.95, 0.99],
+})
 
 /**
  * Intended to measure the time between when the event was captured and when the workflow finished.

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
@@ -2,8 +2,6 @@ import { Histogram } from 'prom-client'
 
 import { PluginEvent, ProcessedPluginEvent, RetryError, StorageExtension } from '@posthog/plugin-scaffold'
 
-import { destinationE2eLagMsSummary } from '~/main/ingestion-queues/metrics'
-
 import { Hub } from '../../types'
 import { PostgresUse } from '../../utils/db/postgres'
 import { GeoIp } from '../../utils/geoip'
@@ -19,6 +17,7 @@ import {
     LegacyTransformationPluginMeta,
 } from '../legacy-plugins/types'
 import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult } from '../types'
+import { destinationE2eLagMsSummary } from '../utils'
 import { CDP_TEST_ID, createAddLogFunction, isLegacyPluginHogFunction } from '../utils'
 import { createInvocationResult } from '../utils/invocation-utils'
 import { cdpTrackedFetch } from './hog-executor.service'

--- a/plugin-server/src/cdp/services/native-destination-executor.service.ts
+++ b/plugin-server/src/cdp/services/native-destination-executor.service.ts
@@ -1,6 +1,5 @@
 import { Histogram } from 'prom-client'
 
-import { destinationE2eLagMsSummary } from '~/main/ingestion-queues/metrics'
 import { PluginsServerConfig } from '~/types'
 import { parseJSON } from '~/utils/json-parse'
 
@@ -8,6 +7,7 @@ import { logger } from '../../utils/logger'
 import { FetchOptions, FetchResponse } from '../../utils/request'
 import { NATIVE_HOG_FUNCTIONS_BY_ID } from '../templates'
 import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult, Response } from '../types'
+import { destinationE2eLagMsSummary } from '../utils'
 import { CDP_TEST_ID, createAddLogFunction, isNativeHogFunction } from '../utils'
 import { createInvocationResult } from '../utils/invocation-utils'
 import { cdpTrackedFetch, getNextRetryTime, isFetchResponseRetriable } from './hog-executor.service'

--- a/plugin-server/src/cdp/services/segment-destination-executor.service.ts
+++ b/plugin-server/src/cdp/services/segment-destination-executor.service.ts
@@ -1,7 +1,6 @@
 import { Histogram } from 'prom-client'
 import { ReadableStream } from 'stream/web'
 
-import { destinationE2eLagMsSummary } from '~/main/ingestion-queues/metrics'
 import { PluginsServerConfig } from '~/types'
 
 import { parseJSON } from '../../utils/json-parse'
@@ -9,6 +8,7 @@ import { FetchOptions, FetchResponse, Response } from '../../utils/request'
 import { LegacyPluginLogger } from '../legacy-plugins/types'
 import { SEGMENT_DESTINATIONS_BY_ID } from '../segment/segment-templates'
 import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult } from '../types'
+import { destinationE2eLagMsSummary } from '../utils'
 import { CDP_TEST_ID, createAddLogFunction, isSegmentPluginHogFunction } from '../utils'
 import { createInvocationResult } from '../utils/invocation-utils'
 import { cdpTrackedFetch, getNextRetryTime, isFetchResponseRetriable } from './hog-executor.service'

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon'
+import { Summary } from 'prom-client'
 import { gunzip, gzip } from 'zlib'
 
 import { sanitizeForUTF8 } from '~/utils/strings'
@@ -294,3 +295,9 @@ export const createAddLogFunction = (logs: MinimalLogEntry[]) => {
         })
     }
 }
+
+export const destinationE2eLagMsSummary = new Summary({
+    name: 'destination_e2e_lag_ms',
+    help: 'Time difference in ms between event capture time and destination finishing time',
+    percentiles: [0.5, 0.9, 0.95, 0.99],
+})

--- a/plugin-server/src/main/ingestion-queues/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/metrics.ts
@@ -49,18 +49,6 @@ export const kafkaConsumerEventRequestPendingMsSummary = new Summary({
     percentiles: [0.5, 0.9, 0.95, 0.99],
 })
 
-export const workflowE2eLagMsSummary = new Summary({
-    name: 'workflow_e2e_lag_ms',
-    help: 'Time difference in ms between event capture time and workflow finishing time',
-    percentiles: [0.5, 0.9, 0.95, 0.99],
-})
-
-export const destinationE2eLagMsSummary = new Summary({
-    name: 'destination_e2e_lag_ms',
-    help: 'Time difference in ms between event capture time and destination finishing time',
-    percentiles: [0.5, 0.9, 0.95, 0.99],
-})
-
 export const cookielessRedisErrorCounter = new Counter({
     name: 'cookieless_redis_error',
     help: 'Count redis errors.',


### PR DESCRIPTION
## Problem

We shouldn't pollute that space, so now we don't anymore
