### PR TITLE
fix(logs): fix log link 1-off time error

### DIFF
--- a/products/logs/backend/sparkline_query_runner.py
+++ b/products/logs/backend/sparkline_query_runner.py
@@ -49,7 +49,12 @@ class SparklineQueryRunner(LogsQueryRunner):
                                      {date_to_start_of_interval}) / {interval_count} + 1
                                     )
                         )
-                    WHERE time_bucket >= {date_from} and time_bucket <= toStartOfInterval({date_to} - toIntervalSecond(1), {one_interval_period})
+                    WHERE
+                        time_bucket >= {date_from_start_of_interval} and
+                        time_bucket <= greatest(
+                            {date_from_start_of_interval},
+                            toStartOfInterval({date_to} - toIntervalSecond(1), {one_interval_period})
+                        )
                 ) AS am
                 LEFT JOIN (
                     SELECT
@@ -57,7 +62,7 @@ class SparklineQueryRunner(LogsQueryRunner):
                         severity_text,
                         count() AS event_count
                     FROM logs
-                    WHERE {where} AND time >= {date_from} AND time < {date_to}
+                    WHERE {where} AND time >= {date_from_start_of_interval} AND time <= {date_to}
                     GROUP BY severity_text, time
                 ) AS ac ON am.time_bucket = ac.time
                 ORDER BY time asc, severity_text asc

--- a/products/logs/backend/test/test_sparkline_query_runner.py
+++ b/products/logs/backend/test/test_sparkline_query_runner.py
@@ -1,0 +1,63 @@
+import os
+import json
+
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from rest_framework import status
+
+from posthog.clickhouse.client import sync_execute
+
+
+class TestSparklineQueryRunner(ClickhouseTestMixin, APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = True
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        with open(os.path.join(os.path.dirname(__file__), "test_logs_schema.sql")) as f:
+            schema_sql = f.read()
+        for sql in schema_sql.split(";"):
+            if not sql.strip():
+                continue
+            sync_execute(sql)
+        with open(os.path.join(os.path.dirname(__file__), "test_logs.jsonnd")) as f:
+            sql = ""
+            for line in f:
+                log_item = json.loads(line)
+                log_item["team_id"] = cls.team.id
+                sql += json.dumps(log_item) + "\n"
+            sync_execute(f"""
+                INSERT INTO logs
+                FORMAT JSONEachRow
+                {sql}
+            """)
+
+    def _make_sparkline_api_request(self, query_params, expected_status=status.HTTP_200_OK):
+        response = self.client.post(f"/api/projects/{self.team.id}/logs/sparkline", data={"query": query_params})
+        self.assertEqual(response.status_code, expected_status)
+        return response.json() if expected_status == status.HTTP_200_OK else response
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_sparkline_single_log(self):
+        query_params = {
+            "dateRange": {"date_from": "2025-12-16T10:23:16.449937Z", "date_to": "2025-12-16T10:23:16.449937Z"},
+            "filterGroup": {"type": "AND", "values": [{"type": "AND", "values": []}]},
+        }
+
+        response = self._make_sparkline_api_request(query_params)
+
+        self.assertEqual(len(response), 1)
+        self.assertEqual(response[0]["count"], 1)
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_sparkline_near_full(self):
+        query_params = {
+            "dateRange": {"date_from": "2025-12-16T09:00:00.000000Z", "date_to": "2025-12-16T10:31:35.692143Z"},
+            "filterGroup": {"type": "AND", "values": [{"type": "AND", "values": []}]},
+        }
+
+        response = self._make_sparkline_api_request(query_params)
+
+        self.assertEqual(len(response), 49)
+        self.assertEqual(sum(r["count"] for r in response), 900)

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -295,12 +295,12 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
                 if (orderBy === 'latest') {
                     return {
                         date_from: dayjs(lastTimestamp).toISOString(),
-                        date_to: dayjs(firstTimestamp).toISOString(),
+                        date_to: dayjs(firstTimestamp).add(1, 'millisecond').toISOString(),
                     }
                 }
                 return {
                     date_from: dayjs(firstTimestamp).toISOString(),
-                    date_to: dayjs(lastTimestamp).toISOString(),
+                    date_to: dayjs(lastTimestamp).add(1, 'millisecond').toISOString(),
                 }
             },
         ],


### PR DESCRIPTION
## Problem

linking to logs always cut off the last log line from the view, as we set the date_to the last log line timestamp and use `<` not `<=` in the query

## Changes

add 1 millisecond to date_to. Also fixed sparkline queries when the time period is less than 1 second

## How did you test this code?

added sparkline tests, tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
