### PR TITLE
chore: refactor endpoints usage tab

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -49,7 +49,6 @@ export const productScenes: Record<string, () => Promise<any>> = {
     EarlyAccessFeatures: () => import('../../products/early_access_features/frontend/EarlyAccessFeatures'),
     EarlyAccessFeature: () => import('../../products/early_access_features/frontend/EarlyAccessFeature'),
     EndpointsScene: () => import('../../products/endpoints/frontend/EndpointsScene'),
-    EndpointsUsage: () => import('../../products/endpoints/frontend/EndpointsUsage'),
     EndpointScene: () => import('../../products/endpoints/frontend/EndpointScene'),
     ErrorTracking: () => import('../../products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene'),
     ErrorTrackingIssue: () =>
@@ -254,13 +253,6 @@ export const productConfiguration: Record<string, any> = {
         iconType: 'endpoints',
         description: 'Define queries your application will use via the API and monitor their cost and usage.',
     },
-    EndpointsUsage: {
-        projectBased: true,
-        name: 'Endpoints usage',
-        activityScope: 'Endpoints',
-        layout: 'app-container',
-        iconType: 'endpoints',
-    },
     EndpointScene: { projectBased: true, name: 'Endpoint', activityScope: 'Endpoint' },
     ErrorTracking: {
         projectBased: true,
@@ -444,14 +436,36 @@ export const productUrls = {
     endpoints: (): string => '/endpoints',
     endpoint: (name: string): string => `/endpoints/${name}`,
     endpointsUsage: (params?: {
+        endpointFilter?: string[]
         dateFrom?: string
         dateTo?: string
-        requestNameBreakdownEnabled?: string
-        requestNameFilter?: string[]
+        materializationType?: 'materialized' | 'inline'
+        interval?: string
+        breakdownBy?: string
     }): string => {
-        const queryParams = new URLSearchParams(params as Record<string, string>)
-        const stringifiedParams = queryParams.toString()
-        return `/endpoints/usage${stringifiedParams ? `?${stringifiedParams}` : ''}`
+        if (!params) {
+            return '/endpoints/usage'
+        }
+        const searchParams: Record<string, string> = {}
+        if (params.endpointFilter?.length) {
+            searchParams.endpointFilter = params.endpointFilter.join(',')
+        }
+        if (params.dateFrom) {
+            searchParams.dateFrom = params.dateFrom
+        }
+        if (params.dateTo) {
+            searchParams.dateTo = params.dateTo
+        }
+        if (params.materializationType) {
+            searchParams.materializationType = params.materializationType
+        }
+        if (params.interval) {
+            searchParams.interval = params.interval
+        }
+        if (params.breakdownBy) {
+            searchParams.breakdownBy = params.breakdownBy
+        }
+        return combineUrl('/endpoints/usage', searchParams).url
     },
     errorTracking: (params = {}): string => combineUrl('/error_tracking', params).url,
     errorTrackingConfiguration: (params = {}): string => combineUrl('/error_tracking/configuration', params).url,
@@ -1026,7 +1040,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconType: 'endpoints',
         iconColor: ['var(--color-product-endpoints-light)'] as FileSystemIconColor,
         sceneKey: 'EndpointsScene',
-        sceneKeys: ['EndpointsScene', 'EndpointsUsage', 'EndpointScene'],
+        sceneKeys: ['EndpointsScene', 'EndpointScene'],
     },
     {
         path: 'Error tracking',
@@ -1339,7 +1353,7 @@ export const getTreeItemsMetadata = (): FileSystemImport[] => [
         sceneKey: 'EndpointsScene',
         flag: FEATURE_FLAGS.ENDPOINTS,
         tags: ['beta'],
-        sceneKeys: ['EndpointsScene', 'EndpointsUsage', 'EndpointScene'],
+        sceneKeys: ['EndpointsScene', 'EndpointScene'],
     },
     {
         path: 'Event definitions',

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -23,6 +23,7 @@ import {
 } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
+import { EndpointsUsageOverviewNode, EndpointsUsageTrendsNode } from 'products/endpoints/frontend/nodes'
 import {
     RevenueAnalyticsGrossRevenueNode,
     RevenueAnalyticsMRRNode,
@@ -37,6 +38,8 @@ import { WebVitalsPathBreakdown } from '../nodes/WebVitals/WebVitalsPathBreakdow
 import {
     isDataTableNode,
     isDataVisualizationNode,
+    isEndpointsUsageOverviewQuery,
+    isEndpointsUsageTrendsQuery,
     isHogQuery,
     isInsightVizNode,
     isMarketingAnalyticsAggregatedQuery,
@@ -218,6 +221,24 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
     } else if (isRevenueAnalyticsTopCustomersQuery(query)) {
         component = (
             <RevenueAnalyticsTopCustomersNode
+                attachTo={props.attachTo}
+                query={query}
+                cachedResults={props.cachedResults}
+                context={queryContext}
+            />
+        )
+    } else if (isEndpointsUsageOverviewQuery(query)) {
+        component = (
+            <EndpointsUsageOverviewNode
+                attachTo={props.attachTo}
+                query={query}
+                cachedResults={props.cachedResults}
+                context={queryContext}
+            />
+        )
+    } else if (isEndpointsUsageTrendsQuery(query)) {
+        component = (
+            <EndpointsUsageTrendsNode
                 attachTo={props.attachTo}
                 query={query}
                 cachedResults={props.cachedResults}

--- a/frontend/src/queries/nodes/DataTable/queryFeatures.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.ts
@@ -1,6 +1,7 @@
 import { Node } from '~/queries/schema/schema-general'
 import {
     isActorsQuery,
+    isEndpointsUsageTableQuery,
     isEventsQuery,
     isGroupsQuery,
     isHogQLQuery,
@@ -144,6 +145,13 @@ export function getQueryFeatures(query: Node): Set<QueryFeature> {
         features.add(QueryFeature.testAccountFilters)
         features.add(QueryFeature.supportTracesFilters)
         features.add(QueryFeature.columnConfigurator)
+    }
+
+    if (isEndpointsUsageTableQuery(query)) {
+        features.add(QueryFeature.columnsInResponse)
+        features.add(QueryFeature.resultIsArrayOfArrays)
+        features.add(QueryFeature.displayResponseError)
+        features.add(QueryFeature.hideLoadNextButton)
     }
 
     return features

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -583,6 +583,15 @@
                 },
                 {
                     "$ref": "#/definitions/UsageMetricsQuery"
+                },
+                {
+                    "$ref": "#/definitions/EndpointsUsageOverviewQuery"
+                },
+                {
+                    "$ref": "#/definitions/EndpointsUsageTableQuery"
+                },
+                {
+                    "$ref": "#/definitions/EndpointsUsageTrendsQuery"
                 }
             ]
         },
@@ -2957,6 +2966,246 @@
                 "results": {
                     "items": {
                         "$ref": "#/definitions/EmbeddingDistance"
+                    },
+                    "type": "array"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cache_key",
+                "is_cached",
+                "last_refresh",
+                "next_allowed_client_refresh",
+                "results",
+                "timezone"
+            ],
+            "type": "object"
+        },
+        "CachedEndpointsUsageOverviewQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "cache_key": {
+                    "type": "string"
+                },
+                "cache_target_age": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "calculation_trigger": {
+                    "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "is_cached": {
+                    "type": "boolean"
+                },
+                "last_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "next_allowed_client_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "query_metadata": {
+                    "type": "object"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "items": {
+                        "$ref": "#/definitions/EndpointsUsageOverviewItem"
+                    },
+                    "type": "array"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cache_key",
+                "is_cached",
+                "last_refresh",
+                "next_allowed_client_refresh",
+                "results",
+                "timezone"
+            ],
+            "type": "object"
+        },
+        "CachedEndpointsUsageTableQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "cache_key": {
+                    "type": "string"
+                },
+                "cache_target_age": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "calculation_trigger": {
+                    "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                    "type": "string"
+                },
+                "columns": {
+                    "items": {},
+                    "type": "array"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hasMore": {
+                    "type": "boolean"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "is_cached": {
+                    "type": "boolean"
+                },
+                "last_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "limit": {
+                    "$ref": "#/definitions/integer"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "next_allowed_client_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "offset": {
+                    "$ref": "#/definitions/integer"
+                },
+                "query_metadata": {
+                    "type": "object"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "items": {},
+                    "type": "array"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                },
+                "types": {
+                    "items": {},
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cache_key",
+                "is_cached",
+                "last_refresh",
+                "next_allowed_client_refresh",
+                "results",
+                "timezone"
+            ],
+            "type": "object"
+        },
+        "CachedEndpointsUsageTrendsQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "cache_key": {
+                    "type": "string"
+                },
+                "cache_target_age": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "calculation_trigger": {
+                    "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "is_cached": {
+                    "type": "boolean"
+                },
+                "last_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "next_allowed_client_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "query_metadata": {
+                    "type": "object"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "items": {
+                        "type": "object"
                     },
                     "type": "array"
                 },
@@ -10077,6 +10326,61 @@
                             },
                             "required": ["results"],
                             "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "columns": {
+                                    "items": {},
+                                    "type": "array"
+                                },
+                                "error": {
+                                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                                    "type": "string"
+                                },
+                                "hasMore": {
+                                    "type": "boolean"
+                                },
+                                "hogql": {
+                                    "description": "Generated HogQL query.",
+                                    "type": "string"
+                                },
+                                "limit": {
+                                    "$ref": "#/definitions/integer"
+                                },
+                                "modifiers": {
+                                    "$ref": "#/definitions/HogQLQueryModifiers",
+                                    "description": "Modifiers used when performing the query"
+                                },
+                                "offset": {
+                                    "$ref": "#/definitions/integer"
+                                },
+                                "query_status": {
+                                    "$ref": "#/definitions/QueryStatus",
+                                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                                },
+                                "resolved_date_range": {
+                                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                                    "description": "The date range used for the query"
+                                },
+                                "results": {
+                                    "items": {},
+                                    "type": "array"
+                                },
+                                "timings": {
+                                    "description": "Measured timings for different parts of the query generation process",
+                                    "items": {
+                                        "$ref": "#/definitions/QueryTiming"
+                                    },
+                                    "type": "array"
+                                },
+                                "types": {
+                                    "items": {},
+                                    "type": "array"
+                                }
+                            },
+                            "required": ["results"],
+                            "type": "object"
                         }
                     ]
                 },
@@ -10261,6 +10565,9 @@
                         },
                         {
                             "$ref": "#/definitions/TraceQuery"
+                        },
+                        {
+                            "$ref": "#/definitions/EndpointsUsageTableQuery"
                         }
                     ],
                     "description": "Source of the events"
@@ -11482,6 +11789,351 @@
                     "description": "Specific endpoint version to execute. If not provided, the latest version is used."
                 }
             },
+            "type": "object"
+        },
+        "EndpointsUsageBreakdown": {
+            "enum": ["Endpoint", "MaterializationType", "ApiKey", "Status"],
+            "type": "string"
+        },
+        "EndpointsUsageOrderBy": {
+            "items": [
+                {
+                    "$ref": "#/definitions/EndpointsUsageOrderByField"
+                },
+                {
+                    "$ref": "#/definitions/EndpointsUsageOrderByDirection"
+                }
+            ],
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+        },
+        "EndpointsUsageOrderByDirection": {
+            "enum": ["ASC", "DESC"],
+            "type": "string"
+        },
+        "EndpointsUsageOrderByField": {
+            "enum": ["requests", "bytes_read", "cpu_seconds", "avg_query_duration_ms", "error_rate"],
+            "type": "string"
+        },
+        "EndpointsUsageOverviewItem": {
+            "additionalProperties": false,
+            "properties": {
+                "changeFromPreviousPct": {
+                    "type": ["number", "null"]
+                },
+                "key": {
+                    "$ref": "#/definitions/EndpointsUsageOverviewItemKey"
+                },
+                "previous": {
+                    "type": ["number", "null"]
+                },
+                "value": {
+                    "type": ["number", "null"]
+                }
+            },
+            "required": ["key", "value"],
+            "type": "object"
+        },
+        "EndpointsUsageOverviewItemKey": {
+            "enum": [
+                "total_requests",
+                "total_bytes_read",
+                "total_cpu_seconds",
+                "avg_query_duration_ms",
+                "p95_query_duration_ms",
+                "error_rate",
+                "materialized_requests",
+                "inline_requests"
+            ],
+            "type": "string"
+        },
+        "EndpointsUsageOverviewQuery": {
+            "additionalProperties": false,
+            "properties": {
+                "compareFilter": {
+                    "$ref": "#/definitions/CompareFilter",
+                    "description": "Compare to previous period"
+                },
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "endpointNames": {
+                    "description": "Filter to specific endpoints by name",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "kind": {
+                    "const": "EndpointsUsageOverviewQuery",
+                    "type": "string"
+                },
+                "materializationType": {
+                    "description": "Filter by materialization type",
+                    "enum": ["materialized", "inline", null],
+                    "type": ["string", "null"]
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "response": {
+                    "$ref": "#/definitions/EndpointsUsageOverviewQueryResponse"
+                },
+                "tags": {
+                    "$ref": "#/definitions/QueryLogTags"
+                },
+                "version": {
+                    "description": "version of the node, used for schema migrations",
+                    "type": "number"
+                }
+            },
+            "required": ["kind"],
+            "type": "object"
+        },
+        "EndpointsUsageOverviewQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "items": {
+                        "$ref": "#/definitions/EndpointsUsageOverviewItem"
+                    },
+                    "type": "array"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
+            "type": "object"
+        },
+        "EndpointsUsageTableQuery": {
+            "additionalProperties": false,
+            "properties": {
+                "breakdownBy": {
+                    "$ref": "#/definitions/EndpointsUsageBreakdown"
+                },
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "endpointNames": {
+                    "description": "Filter to specific endpoints by name",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "kind": {
+                    "const": "EndpointsUsageTableQuery",
+                    "type": "string"
+                },
+                "limit": {
+                    "$ref": "#/definitions/integer"
+                },
+                "materializationType": {
+                    "description": "Filter by materialization type",
+                    "enum": ["materialized", "inline", null],
+                    "type": ["string", "null"]
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "offset": {
+                    "$ref": "#/definitions/integer"
+                },
+                "orderBy": {
+                    "$ref": "#/definitions/EndpointsUsageOrderBy"
+                },
+                "response": {
+                    "$ref": "#/definitions/EndpointsUsageTableQueryResponse"
+                },
+                "tags": {
+                    "$ref": "#/definitions/QueryLogTags"
+                },
+                "version": {
+                    "description": "version of the node, used for schema migrations",
+                    "type": "number"
+                }
+            },
+            "required": ["breakdownBy", "kind"],
+            "type": "object"
+        },
+        "EndpointsUsageTableQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "columns": {
+                    "items": {},
+                    "type": "array"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hasMore": {
+                    "type": "boolean"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "limit": {
+                    "$ref": "#/definitions/integer"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "offset": {
+                    "$ref": "#/definitions/integer"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "items": {},
+                    "type": "array"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                },
+                "types": {
+                    "items": {},
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
+            "type": "object"
+        },
+        "EndpointsUsageTrendsQuery": {
+            "additionalProperties": false,
+            "properties": {
+                "breakdownBy": {
+                    "$ref": "#/definitions/EndpointsUsageBreakdown",
+                    "description": "Optional breakdown for stacked charts"
+                },
+                "compareFilter": {
+                    "$ref": "#/definitions/CompareFilter",
+                    "description": "Compare to previous period"
+                },
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "endpointNames": {
+                    "description": "Filter to specific endpoints by name",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "interval": {
+                    "$ref": "#/definitions/IntervalType",
+                    "description": "Time interval"
+                },
+                "kind": {
+                    "const": "EndpointsUsageTrendsQuery",
+                    "type": "string"
+                },
+                "materializationType": {
+                    "description": "Filter by materialization type",
+                    "enum": ["materialized", "inline", null],
+                    "type": ["string", "null"]
+                },
+                "metric": {
+                    "description": "Metric to trend",
+                    "enum": ["bytes_read", "cpu_seconds", "requests", "query_duration", "error_rate"],
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "response": {
+                    "$ref": "#/definitions/EndpointsUsageTrendsQueryResponse"
+                },
+                "tags": {
+                    "$ref": "#/definitions/QueryLogTags"
+                },
+                "version": {
+                    "description": "version of the node, used for schema migrations",
+                    "type": "number"
+                }
+            },
+            "required": ["kind", "metric"],
+            "type": "object"
+        },
+        "EndpointsUsageTrendsQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "items": {
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
             "type": "object"
         },
         "EntityNode": {
@@ -20486,7 +21138,10 @@
                 "TraceQuery",
                 "VectorSearchQuery",
                 "DocumentSimilarityQuery",
-                "UsageMetricsQuery"
+                "UsageMetricsQuery",
+                "EndpointsUsageOverviewQuery",
+                "EndpointsUsageTableQuery",
+                "EndpointsUsageTrendsQuery"
             ],
             "type": "string"
         },
@@ -21632,6 +22287,10 @@
             "additionalProperties": false,
             "description": "Tags that will be added to the Query log comment  *",
             "properties": {
+                "name": {
+                    "description": "Name of the query, preferably unique. For example web_analytics_vitals",
+                    "type": "string"
+                },
                 "productKey": {
                     "description": "Product responsible for this query. Use string, there's no need to churn the Schema when we add a new product *",
                     "type": "string"
@@ -25079,6 +25738,61 @@
                 {
                     "additionalProperties": false,
                     "properties": {
+                        "columns": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hasMore": {
+                            "type": "boolean"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "limit": {
+                            "$ref": "#/definitions/integer"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "offset": {
+                            "$ref": "#/definitions/integer"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
+                        "results": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        },
+                        "types": {
+                            "items": {},
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
                         "error": {
                             "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
                             "type": "string"
@@ -25848,6 +26562,141 @@
                     },
                     "required": ["results"],
                     "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
+                        "results": {
+                            "items": {
+                                "$ref": "#/definitions/EndpointsUsageOverviewItem"
+                            },
+                            "type": "array"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "columns": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hasMore": {
+                            "type": "boolean"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "limit": {
+                            "$ref": "#/definitions/integer"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "offset": {
+                            "$ref": "#/definitions/integer"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
+                        "results": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        },
+                        "types": {
+                            "items": {},
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
+                        "results": {
+                            "items": {
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
                 }
             ]
         },
@@ -26056,6 +26905,15 @@
                 },
                 {
                     "$ref": "#/definitions/UsageMetricsQuery"
+                },
+                {
+                    "$ref": "#/definitions/EndpointsUsageOverviewQuery"
+                },
+                {
+                    "$ref": "#/definitions/EndpointsUsageTableQuery"
+                },
+                {
+                    "$ref": "#/definitions/EndpointsUsageTrendsQuery"
                 }
             ],
             "required": ["kind"],

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -14,6 +14,9 @@ import {
     DataWarehouseNode,
     DatabaseSchemaQuery,
     DateRange,
+    EndpointsUsageOverviewQuery,
+    EndpointsUsageTableQuery,
+    EndpointsUsageTrendsQuery,
     ErrorTrackingIssueCorrelationQuery,
     ErrorTrackingQuery,
     EventsNode,
@@ -193,6 +196,24 @@ export function isRevenueAnalyticsTopCustomersQuery(
     node?: Record<string, any> | null
 ): node is RevenueAnalyticsTopCustomersQuery {
     return node?.kind === NodeKind.RevenueAnalyticsTopCustomersQuery
+}
+
+export function isEndpointsUsageOverviewQuery(node?: Record<string, any> | null): node is EndpointsUsageOverviewQuery {
+    return node?.kind === NodeKind.EndpointsUsageOverviewQuery
+}
+
+export function isEndpointsUsageTableQuery(node?: Record<string, any> | null): node is EndpointsUsageTableQuery {
+    return node?.kind === NodeKind.EndpointsUsageTableQuery
+}
+
+export function isEndpointsUsageTrendsQuery(node?: Record<string, any> | null): node is EndpointsUsageTrendsQuery {
+    return node?.kind === NodeKind.EndpointsUsageTrendsQuery
+}
+
+export function isEndpointsUsageQuery(
+    node?: Record<string, any> | null
+): node is EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery {
+    return isEndpointsUsageOverviewQuery(node) || isEndpointsUsageTableQuery(node) || isEndpointsUsageTrendsQuery(node)
 }
 
 export function isWebOverviewQuery(node?: Record<string, any> | null): node is WebOverviewQuery {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -42,6 +42,7 @@ import {
     getShowValuesOnSeries,
     isDataTableNode,
     isDataVisualizationNode,
+    isEndpointsUsageQuery,
     isFunnelsQuery,
     isHogQuery,
     isInsightQueryWithBreakdown,
@@ -229,10 +230,11 @@ export const insightNavLogic = kea<insightNavLogicType>([
                     })
                 }
 
-                if (activeView === InsightType.JSON) {
+                if (activeView === InsightType.JSON && !isEndpointsUsageQuery(query)) {
                     // only display this tab when it is selected by the provided insight query
                     // don't display it otherwise... humans shouldn't be able to click to select this tab
                     // it only opens when you click the <OpenEditorButton/>
+                    // EndpointsUsage queries should not appear in the insight editor at all
                     const humanFriendlyQueryKind: string | null =
                         typeof query?.kind === 'string'
                             ? identifierToHuman(query.kind.replace(/(Node|Query)$/g, ''), 'title')

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -79,7 +79,7 @@ import {
     QueryBasedInsightModel,
 } from '~/types'
 
-import { EndpointModal } from 'products/endpoints/frontend/EndpointModal'
+import { EndpointFromInsightModal } from 'products/endpoints/frontend/EndpointFromInsightModal'
 
 import { getInsightIconTypeFromQuery, getOverrideWarningPropsForButton } from './utils'
 
@@ -224,7 +224,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                         />
                     )}
                     <NewDashboardModal />
-                    <EndpointModal
+                    <EndpointFromInsightModal
                         isOpen={endpointModalOpen}
                         closeModal={() => setEndpointModalOpen(false)}
                         tabId={insightProps.tabId || ''}

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -552,6 +552,21 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
         icon: IconPieChart,
         inMenu: false,
     },
+    [NodeKind.EndpointsUsageOverviewQuery]: {
+        name: 'Endpoints usage overview',
+        icon: IconPieChart,
+        inMenu: false,
+    },
+    [NodeKind.EndpointsUsageTableQuery]: {
+        name: 'Endpoints usage table',
+        icon: IconPieChart,
+        inMenu: false,
+    },
+    [NodeKind.EndpointsUsageTrendsQuery]: {
+        name: 'Endpoints usage trends',
+        icon: IconPieChart,
+        inMenu: false,
+    },
 }
 
 export const INSIGHT_TYPES_METADATA: Record<InsightType, InsightTypeMetadata> = {

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -152,7 +152,6 @@ export enum Scene {
     Wizard = 'Wizard',
     EarlyAccessFeature = 'EarlyAccessFeature',
     EndpointsScene = 'EndpointsScene',
-    EndpointsUsage = 'EndpointsUsage',
     Game368Hedgehogs = 'Game368Hedgehogs',
     LLMAnalytics = 'LLMAnalytics',
     LLMAnalyticsDataset = 'LLMAnalyticsDataset',

--- a/posthog/hogql_queries/endpoints/__init__.py
+++ b/posthog/hogql_queries/endpoints/__init__.py
@@ -1,0 +1,9 @@
+from posthog.hogql_queries.endpoints.endpoints_usage_overview import EndpointsUsageOverviewQueryRunner
+from posthog.hogql_queries.endpoints.endpoints_usage_table import EndpointsUsageTableQueryRunner
+from posthog.hogql_queries.endpoints.endpoints_usage_trends import EndpointsUsageTrendsQueryRunner
+
+__all__ = [
+    "EndpointsUsageOverviewQueryRunner",
+    "EndpointsUsageTableQueryRunner",
+    "EndpointsUsageTrendsQueryRunner",
+]

--- a/posthog/hogql_queries/endpoints/endpoints_usage_overview.py
+++ b/posthog/hogql_queries/endpoints/endpoints_usage_overview.py
@@ -1,0 +1,186 @@
+from posthog.schema import (
+    CachedEndpointsUsageOverviewQueryResponse,
+    EndpointsUsageOverviewItem,
+    EndpointsUsageOverviewQuery,
+    EndpointsUsageOverviewQueryResponse,
+)
+
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.hogql_queries.endpoints.endpoints_usage_query_runner import EndpointsUsageQueryRunner
+from posthog.hogql_queries.utils.query_previous_period_date_range import QueryPreviousPeriodDateRange
+from posthog.models.filters.mixins.utils import cached_property
+
+
+class EndpointsUsageOverviewQueryRunner(EndpointsUsageQueryRunner[EndpointsUsageOverviewQueryResponse]):
+    """Returns summary metrics for endpoint usage.
+
+    Metrics returned:
+    - total_requests: Total number of endpoint executions
+    - total_bytes_read: Sum of bytes read from storage
+    - total_cpu_seconds: Sum of CPU time consumed
+    - avg_query_duration_ms: Average query duration
+    - p95_query_duration_ms: 95th percentile query duration
+    - error_rate: Percentage of failed executions
+    - materialized_requests: Count of materialized endpoint executions
+    - inline_requests: Count of non-materialized (direct) endpoint executions
+    """
+
+    query: EndpointsUsageOverviewQuery
+    cached_response: CachedEndpointsUsageOverviewQueryResponse
+
+    @cached_property
+    def query_previous_date_range(self) -> QueryPreviousPeriodDateRange | None:
+        if not self.query.compareFilter or not self.query.compareFilter.compare:
+            return None
+
+        from datetime import datetime
+
+        return QueryPreviousPeriodDateRange(
+            date_range=self.query.dateRange,
+            team=self.team,
+            interval=None,
+            now=datetime.now(),
+        )
+
+    def to_query(self) -> ast.SelectQuery:
+        return self._build_query(is_previous=False)
+
+    def _build_query(self, is_previous: bool = False) -> ast.SelectQuery:
+        """Build the overview query for current or previous period."""
+        # Determine date range based on whether this is previous period
+        if is_previous and self.query_previous_date_range:
+            date_from = self.query_previous_date_range.date_from()
+            date_to = self.query_previous_date_range.date_to()
+        else:
+            date_from = self.query_date_range.date_from()
+            date_to = self.query_date_range.date_to()
+
+        # Build WHERE conditions
+        conditions = self._get_base_where_conditions()
+
+        # Override date conditions for this specific period
+        # Remove existing date conditions and add new ones
+        conditions = [c for c in conditions if not self._is_date_condition(c)]
+
+        if date_from:
+            conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=["event_date"]),
+                    right=ast.Constant(value=date_from),
+                )
+            )
+        if date_to:
+            conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.LtEq,
+                    left=ast.Field(chain=["event_date"]),
+                    right=ast.Constant(value=date_to),
+                )
+            )
+
+        where_clause = ast.And(exprs=conditions) if len(conditions) > 1 else conditions[0] if conditions else None
+
+        return ast.SelectQuery(
+            select=[
+                ast.Alias(alias="total_requests", expr=self._get_requests_count_expression()),
+                ast.Alias(alias="total_bytes_read", expr=self._get_bytes_read_expression()),
+                ast.Alias(alias="total_cpu_seconds", expr=self._get_cpu_seconds_expression()),
+                ast.Alias(alias="avg_query_duration_ms", expr=self._get_avg_latency_expression()),
+                ast.Alias(alias="p95_query_duration_ms", expr=self._get_p95_latency_expression()),
+                ast.Alias(alias="error_rate", expr=self._get_error_rate_expression()),
+                ast.Alias(alias="materialized_requests", expr=self._get_materialized_count_expression()),
+                ast.Alias(alias="inline_requests", expr=self._get_inline_count_expression()),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["query_log"])),
+            where=where_clause,
+        )
+
+    def _is_date_condition(self, condition: ast.Expr) -> bool:
+        """Check if a condition is a date-related condition."""
+        if isinstance(condition, ast.CompareOperation):
+            if isinstance(condition.left, ast.Field):
+                return condition.left.chain == ["event_date"]
+        return False
+
+    def _calculate(self) -> EndpointsUsageOverviewQueryResponse:
+        from posthog.clickhouse.query_tagging import tag_queries
+
+        # Execute current period query
+        tag_queries(name="endpoints_usage_overview")
+        response = execute_hogql_query(
+            query_type="endpoints_usage_overview_query",
+            query=self.to_query(),
+            team=self.team,
+            timings=self.timings,
+            modifiers=self.modifiers,
+            limit_context=self.limit_context,
+        )
+
+        # Execute previous period query if comparison is enabled
+        previous_values: dict[str, float] | None = None
+        if self.query_previous_date_range:
+            tag_queries(name="endpoints_usage_overview_previous")
+            previous_response = execute_hogql_query(
+                query_type="endpoints_usage_overview_query_previous",
+                query=self._build_query(is_previous=True),
+                team=self.team,
+                timings=self.timings,
+                modifiers=self.modifiers,
+                limit_context=self.limit_context,
+            )
+            if previous_response.results and len(previous_response.results) > 0:
+                prev_row = previous_response.results[0]
+                previous_values = self._row_to_metrics_dict(prev_row)
+
+        # Build results
+        results: list[EndpointsUsageOverviewItem] = []
+
+        if response.results and len(response.results) > 0:
+            row = response.results[0]
+            current_metrics = self._row_to_metrics_dict(row)
+
+            for key, value in current_metrics.items():
+                item = EndpointsUsageOverviewItem(
+                    key=key,
+                    value=value,
+                )
+
+                if previous_values:
+                    prev_value = previous_values.get(key, 0.0)
+                    item.previous = prev_value
+                    item.changeFromPreviousPct = self._calculate_change_pct(value, prev_value)
+
+                results.append(item)
+
+        return EndpointsUsageOverviewQueryResponse(
+            results=results,
+            timings=response.timings,
+            hogql=response.hogql,
+        )
+
+    def _row_to_metrics_dict(self, row: list) -> dict[str, float]:
+        """Convert a query result row to a metrics dictionary."""
+        from posthog.hogql_queries.endpoints.endpoints_usage_query_runner import safe_float
+
+        metric_keys = [
+            "total_requests",
+            "total_bytes_read",
+            "total_cpu_seconds",
+            "avg_query_duration_ms",
+            "p95_query_duration_ms",
+            "error_rate",
+            "materialized_requests",
+            "inline_requests",
+        ]
+        return {key: safe_float(row[i]) for i, key in enumerate(metric_keys)}
+
+    def _calculate_change_pct(self, current: float, previous: float) -> float:
+        """Calculate percentage change from previous period."""
+        if previous > 0:
+            return ((current - previous) / previous) * 100
+        elif current > 0:
+            return 100.0  # New activity
+        return 0.0

--- a/posthog/hogql_queries/endpoints/endpoints_usage_query_runner.py
+++ b/posthog/hogql_queries/endpoints/endpoints_usage_query_runner.py
@@ -1,0 +1,306 @@
+import typing
+from abc import ABC
+from datetime import datetime
+from typing import Union, cast
+
+from posthog.schema import EndpointsUsageOverviewQuery, EndpointsUsageTableQuery, EndpointsUsageTrendsQuery
+
+from posthog.hogql import ast
+
+from posthog.hogql_queries.query_runner import AnalyticsQueryResponseProtocol, AnalyticsQueryRunner
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.models.filters.mixins.utils import cached_property
+
+EndpointsUsageQueryNode = Union[
+    EndpointsUsageOverviewQuery,
+    EndpointsUsageTableQuery,
+    EndpointsUsageTrendsQuery,
+]
+
+EAR = typing.TypeVar("EAR", bound=AnalyticsQueryResponseProtocol)
+
+
+def safe_float(val: typing.Any) -> float:
+    """Convert value to float, handling None and other edge cases."""
+    if val is None:
+        return 0.0
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+class EndpointsUsageQueryRunner(AnalyticsQueryRunner[EAR], ABC):
+    """Base class for Endpoints usage queries.
+
+    Queries the query_log table for endpoint execution metrics, filtering
+    specifically for endpoint executions (not general API usage).
+    """
+
+    query: EndpointsUsageQueryNode
+    query_type: type[EndpointsUsageQueryNode]
+
+    @cached_property
+    def query_date_range(self) -> QueryDateRange:
+        return QueryDateRange(
+            date_range=self.query.dateRange,
+            team=self.team,
+            interval=None,
+            now=datetime.now(),
+        )
+
+    def _get_base_where_conditions(self) -> list[ast.Expr]:
+        """Build base WHERE conditions for endpoint queries.
+
+        Filters for:
+        - Personal API key requests only (external API calls, not app usage)
+        - Endpoint executions only (identified by having a non-empty name field)
+        - Date range
+        """
+        conditions: list[ast.Expr] = []
+
+        # Only include requests made via personal API keys (external API calls)
+        # This excludes executions from the app itself
+        conditions.append(
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ast.Field(chain=["is_personal_api_key_request"]),
+                right=ast.Constant(value=True),
+            )
+        )
+
+        # Filter for endpoint executions only
+        # Endpoint executions are identified by having a non-empty lc_request_name.
+        # The 'name' field in HogQL maps to lc_request_name in the underlying table.
+        # Non-endpoint queries (like regular HogQL queries) have empty/null names.
+        conditions.append(
+            ast.Call(
+                name="isNotNull",
+                args=[ast.Field(chain=["name"])],
+            )
+        )
+        conditions.append(
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.NotEq,
+                left=ast.Field(chain=["name"]),
+                right=ast.Constant(value=""),
+            )
+        )
+
+        # Date range filter
+        if self.query_date_range.date_from():
+            conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=["event_date"]),
+                    right=ast.Constant(value=self.query_date_range.date_from()),
+                )
+            )
+        if self.query_date_range.date_to():
+            conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.LtEq,
+                    left=ast.Field(chain=["event_date"]),
+                    right=ast.Constant(value=self.query_date_range.date_to()),
+                )
+            )
+
+        # Add endpoint names filter if specified
+        endpoint_names_filter = self._get_endpoint_names_filter()
+        if endpoint_names_filter:
+            conditions.append(endpoint_names_filter)
+
+        # Add materialization type filter if specified
+        materialization_filter = self._get_materialization_filter()
+        if materialization_filter:
+            conditions.append(materialization_filter)
+
+        return conditions
+
+    def _get_endpoint_names_filter(self) -> ast.Expr | None:
+        """Filter to specific endpoints if specified."""
+        endpoint_names = getattr(self.query, "endpointNames", None)
+        if not endpoint_names:
+            return None
+
+        # Create OR condition to match both regular and materialized names
+        name_conditions = []
+        for name in endpoint_names:
+            name_conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["name"]),
+                    right=ast.Constant(value=name),
+                )
+            )
+            # Also match materialized version
+            name_conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["name"]),
+                    right=ast.Constant(value=f"{name}_materialized"),
+                )
+            )
+
+        return ast.Or(exprs=cast(list[ast.Expr], name_conditions))
+
+    def _get_materialization_filter(self) -> ast.Expr | None:
+        """Filter by materialization type if specified."""
+        from posthog.schema import MaterializationType
+
+        mat_type = getattr(self.query, "materializationType", None)
+        if mat_type is None:
+            return None
+
+        if mat_type == MaterializationType.MATERIALIZED:
+            # Name ends with "_materialized"
+            return ast.CompareOperation(
+                op=ast.CompareOperationOp.Like,
+                left=ast.Field(chain=["name"]),
+                right=ast.Constant(value="%_materialized"),
+            )
+        elif mat_type == MaterializationType.INLINE:
+            return ast.Not(
+                expr=ast.CompareOperation(
+                    op=ast.CompareOperationOp.Like,
+                    left=ast.Field(chain=["name"]),
+                    right=ast.Constant(value="%_materialized"),
+                )
+            )
+        else:
+            # Unknown or None value, no filter
+            return None
+
+    def _get_endpoint_name_expression(self) -> ast.Expr:
+        """Get an expression that strips '_materialized' suffix from endpoint names.
+
+        This normalizes endpoint names so we can group materialized and non-materialized
+        executions of the same endpoint together.
+        """
+        return ast.Call(
+            name="replaceRegexpOne",
+            args=[
+                ast.Field(chain=["name"]),
+                ast.Constant(value="_materialized$"),
+                ast.Constant(value=""),
+            ],
+        )
+
+    def _get_is_materialized_expression(self) -> ast.Expr:
+        """Get an expression that returns whether this was a materialized execution."""
+        return ast.Call(
+            name="endsWith",
+            args=[
+                ast.Field(chain=["name"]),
+                ast.Constant(value="_materialized"),
+            ],
+        )
+
+    def _get_breakdown_expression(
+        self, breakdown: typing.Any, default_alias: str = "breakdown"
+    ) -> tuple[ast.Expr, str]:
+        """Get the expression and alias for a breakdown column.
+
+        Shared method used by both Trends and Table runners.
+        """
+        from posthog.schema import EndpointsUsageBreakdown
+
+        if breakdown == EndpointsUsageBreakdown.ENDPOINT:
+            return self._get_endpoint_name_expression(), default_alias
+
+        elif breakdown == EndpointsUsageBreakdown.MATERIALIZATION_TYPE:
+            return (
+                ast.Call(
+                    name="if",
+                    args=[
+                        self._get_is_materialized_expression(),
+                        ast.Constant(value="Materialized execution"),
+                        ast.Constant(value="Direct execution"),
+                    ],
+                ),
+                default_alias,
+            )
+
+        elif breakdown == EndpointsUsageBreakdown.API_KEY:
+            return ast.Field(chain=["api_key_label"]), default_alias
+
+        elif breakdown == EndpointsUsageBreakdown.STATUS:
+            return self._get_status_expression(), default_alias
+
+        else:
+            # Default to endpoint breakdown
+            return self._get_endpoint_name_expression(), default_alias
+
+    def _get_status_expression(self) -> ast.Expr:
+        """Get an expression that returns 'success' or 'error' based on exception_code."""
+        return ast.Call(
+            name="if",
+            args=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["exception_code"]),
+                    right=ast.Constant(value=0),
+                ),
+                ast.Constant(value="success"),
+                ast.Constant(value="error"),
+            ],
+        )
+
+    def _get_error_rate_expression(self) -> ast.Expr:
+        """Get an expression for calculating error rate (ratio of failed requests)."""
+        return ast.ArithmeticOperation(
+            op=ast.ArithmeticOperationOp.Div,
+            left=ast.Call(
+                name="countIf",
+                args=[
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.NotEq,
+                        left=ast.Field(chain=["exception_code"]),
+                        right=ast.Constant(value=0),
+                    )
+                ],
+            ),
+            right=ast.Call(name="count", args=[]),
+        )
+
+    def _get_cpu_seconds_expression(self) -> ast.Expr:
+        """Get an expression for CPU seconds (converted from microseconds)."""
+        return ast.ArithmeticOperation(
+            op=ast.ArithmeticOperationOp.Div,
+            left=ast.Call(name="sum", args=[ast.Field(chain=["cpu_microseconds"])]),
+            right=ast.Constant(value=1000000),
+        )
+
+    def _get_bytes_read_expression(self) -> ast.Expr:
+        """Get an expression for total bytes read."""
+        return ast.Call(name="sum", args=[ast.Field(chain=["read_bytes"])])
+
+    def _get_requests_count_expression(self) -> ast.Expr:
+        """Get an expression for request count."""
+        return ast.Call(name="count", args=[])
+
+    def _get_avg_latency_expression(self) -> ast.Expr:
+        """Get an expression for average query duration in ms."""
+        return ast.Call(name="avg", args=[ast.Field(chain=["query_duration_ms"])])
+
+    def _get_p95_latency_expression(self) -> ast.Expr:
+        """Get an expression for 95th percentile query duration in ms."""
+        return ast.Call(
+            name="quantile",
+            params=[ast.Constant(value=0.95)],
+            args=[ast.Field(chain=["query_duration_ms"])],
+        )
+
+    def _get_materialized_count_expression(self) -> ast.Expr:
+        """Get an expression for count of materialized requests."""
+        return ast.Call(
+            name="countIf",
+            args=[self._get_is_materialized_expression()],
+        )
+
+    def _get_inline_count_expression(self) -> ast.Expr:
+        """Get an expression for count of inline (non-materialized) requests."""
+        return ast.Call(
+            name="countIf",
+            args=[ast.Not(expr=self._get_is_materialized_expression())],
+        )

--- a/posthog/hogql_queries/endpoints/endpoints_usage_table.py
+++ b/posthog/hogql_queries/endpoints/endpoints_usage_table.py
@@ -1,0 +1,128 @@
+from typing import Literal, cast
+
+from posthog.schema import (
+    CachedEndpointsUsageTableQueryResponse,
+    EndpointsUsageBreakdown,
+    EndpointsUsageTableQuery,
+    EndpointsUsageTableQueryResponse,
+)
+
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.hogql_queries.endpoints.endpoints_usage_query_runner import EndpointsUsageQueryRunner
+
+
+class EndpointsUsageTableQueryRunner(EndpointsUsageQueryRunner[EndpointsUsageTableQueryResponse]):
+    """Returns breakdown table for endpoint usage.
+
+    Supports breaking down by:
+    - Endpoint: Group by endpoint name
+    - MaterializationType: Group by materialized vs inline
+    - ApiKey: Group by API key
+    - Status: Group by success vs error
+    """
+
+    query: EndpointsUsageTableQuery
+    cached_response: CachedEndpointsUsageTableQueryResponse
+
+    def to_query(self) -> ast.SelectQuery:
+        # Build WHERE conditions
+        conditions = self._get_base_where_conditions()
+        where_clause = ast.And(exprs=conditions) if len(conditions) > 1 else conditions[0] if conditions else None
+
+        # Get breakdown expression and alias
+        breakdown_expr, breakdown_alias = self._get_table_breakdown_expression()
+
+        # Build ORDER BY
+        order_by = self._get_order_by()
+
+        # Build LIMIT and OFFSET
+        limit = self.query.limit or 100
+        offset = self.query.offset or 0
+
+        return ast.SelectQuery(
+            select=[
+                ast.Alias(alias=breakdown_alias, expr=breakdown_expr),
+                ast.Alias(alias="requests", expr=self._get_requests_count_expression()),
+                ast.Alias(alias="bytes_read", expr=self._get_bytes_read_expression()),
+                ast.Alias(alias="cpu_seconds", expr=self._get_cpu_seconds_expression()),
+                ast.Alias(alias="avg_query_duration_ms", expr=self._get_avg_latency_expression()),
+                ast.Alias(alias="error_rate", expr=self._get_error_rate_expression()),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["query_log"])),
+            where=where_clause,
+            group_by=[breakdown_expr],
+            order_by=order_by,
+            limit=ast.Constant(value=limit),
+            offset=ast.Constant(value=offset),
+        )
+
+    def _get_table_breakdown_expression(self) -> tuple[ast.Expr, str]:
+        """Get the expression and alias for the table breakdown column.
+
+        Unlike the base class method which uses a uniform alias, this returns
+        context-specific aliases for the table display (e.g., 'endpoint', 'execution_type').
+        """
+        breakdown = self.query.breakdownBy
+        alias_map = {
+            EndpointsUsageBreakdown.ENDPOINT: "endpoint",
+            EndpointsUsageBreakdown.MATERIALIZATION_TYPE: "execution_type",
+            EndpointsUsageBreakdown.API_KEY: "api_key",
+            EndpointsUsageBreakdown.STATUS: "status",
+        }
+        alias = alias_map.get(breakdown, "endpoint")
+        expr, _ = super()._get_breakdown_expression(breakdown, alias)
+        return expr, alias
+
+    def _get_order_by(self) -> list[ast.OrderExpr]:
+        """Build ORDER BY clause based on query settings."""
+        order_by = self.query.orderBy
+
+        if not order_by:
+            # Default: order by requests descending
+            return [ast.OrderExpr(expr=ast.Field(chain=["requests"]), order="DESC")]
+
+        field_name, direction = order_by
+
+        # Map field names to column aliases
+        field_map = {
+            "requests": "requests",
+            "bytes_read": "bytes_read",
+            "cpu_seconds": "cpu_seconds",
+            "avg_latency": "avg_query_duration_ms",
+            "error_rate": "error_rate",
+        }
+
+        column = field_map.get(field_name, "requests")
+        order_direction = direction if direction in ("ASC", "DESC") else "DESC"
+
+        return [ast.OrderExpr(expr=ast.Field(chain=[column]), order=cast(Literal["ASC", "DESC"], order_direction))]
+
+    def _calculate(self) -> EndpointsUsageTableQueryResponse:
+        from posthog.clickhouse.query_tagging import tag_queries
+
+        tag_queries(name="endpoints_usage_table")
+        response = execute_hogql_query(
+            query_type="endpoints_usage_table_query",
+            query=self.to_query(),
+            team=self.team,
+            timings=self.timings,
+            modifiers=self.modifiers,
+            limit_context=self.limit_context,
+        )
+
+        # Determine if there are more results
+        limit = self.query.limit or 100
+        has_more = len(response.results) >= limit if response.results else False
+
+        return EndpointsUsageTableQueryResponse(
+            results=response.results or [],
+            columns=response.columns,
+            types=response.types,
+            hasMore=has_more,
+            limit=limit,
+            offset=self.query.offset or 0,
+            timings=response.timings,
+            hogql=response.hogql,
+        )

--- a/posthog/hogql_queries/endpoints/endpoints_usage_trends.py
+++ b/posthog/hogql_queries/endpoints/endpoints_usage_trends.py
@@ -1,0 +1,161 @@
+from datetime import datetime
+from typing import cast
+
+from posthog.schema import (
+    CachedEndpointsUsageTrendsQueryResponse,
+    EndpointsUsageTrendsQuery,
+    EndpointsUsageTrendsQueryResponse,
+    IntervalType,
+)
+
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.hogql_queries.endpoints.endpoints_usage_query_runner import EndpointsUsageQueryRunner
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.models.filters.mixins.utils import cached_property
+
+
+class EndpointsUsageTrendsQueryRunner(EndpointsUsageQueryRunner[EndpointsUsageTrendsQueryResponse]):
+    """Returns time-series data for endpoint usage.
+
+    Metrics available:
+    - bytes_read: Sum of bytes read per time bucket
+    - cpu_seconds: Sum of CPU seconds per time bucket
+    - requests: Count of requests per time bucket
+    - latency: Average latency per time bucket
+
+    Can optionally break down by endpoint, materialization type, API key, or status.
+    """
+
+    query: EndpointsUsageTrendsQuery
+    cached_response: CachedEndpointsUsageTrendsQueryResponse
+
+    @cached_property
+    def query_date_range(self) -> QueryDateRange:
+        return QueryDateRange(
+            date_range=self.query.dateRange,
+            team=self.team,
+            interval=self.query.interval or IntervalType.DAY,
+            now=datetime.now(),
+        )
+
+    def to_query(self) -> ast.SelectQuery:
+        # Build WHERE conditions
+        conditions = self._get_base_where_conditions()
+        where_clause = ast.And(exprs=conditions) if len(conditions) > 1 else conditions[0] if conditions else None
+
+        # Get date bucket expression based on interval
+        date_bucket_expr = self._get_date_bucket_expression()
+
+        # Get metric expression
+        metric_expr = self._get_metric_expression()
+
+        # Build select columns
+        select_columns = [
+            ast.Alias(alias="date", expr=date_bucket_expr),
+            ast.Alias(alias="value", expr=metric_expr),
+        ]
+
+        # Add breakdown column if specified
+        group_by_columns: list[ast.Expr] = [date_bucket_expr]
+
+        if self.query.breakdownBy:
+            breakdown_expr, breakdown_alias = self._get_breakdown_expression(self.query.breakdownBy, "breakdown")
+            select_columns.insert(1, ast.Alias(alias=breakdown_alias, expr=breakdown_expr))
+            group_by_columns.append(breakdown_expr)
+
+        return ast.SelectQuery(
+            select=cast(list[ast.Expr], select_columns),
+            select_from=ast.JoinExpr(table=ast.Field(chain=["query_log"])),
+            where=where_clause,
+            group_by=group_by_columns,
+            order_by=[
+                ast.OrderExpr(expr=ast.Field(chain=["date"]), order="ASC"),
+            ],
+        )
+
+    def _get_date_bucket_expression(self) -> ast.Expr:
+        """Get the expression for date bucketing based on interval."""
+        interval = self.query.interval or IntervalType.DAY
+
+        if interval == IntervalType.HOUR:
+            return ast.Call(
+                name="toStartOfHour",
+                args=[ast.Field(chain=["event_time"])],
+            )
+        elif interval == IntervalType.DAY:
+            return ast.Field(chain=["event_date"])
+        elif interval == IntervalType.WEEK:
+            return ast.Call(
+                name="toStartOfWeek",
+                args=[ast.Field(chain=["event_date"])],
+            )
+        elif interval == IntervalType.MONTH:
+            return ast.Call(
+                name="toStartOfMonth",
+                args=[ast.Field(chain=["event_date"])],
+            )
+        else:
+            # Default to day
+            return ast.Field(chain=["event_date"])
+
+    def _get_metric_expression(self) -> ast.Expr:
+        """Get the expression for the selected metric."""
+        metric = self.query.metric
+
+        if metric == "bytes_read":
+            return self._get_bytes_read_expression()
+        elif metric == "cpu_seconds":
+            return self._get_cpu_seconds_expression()
+        elif metric == "requests":
+            return self._get_requests_count_expression()
+        elif metric == "query_duration":
+            return self._get_avg_latency_expression()
+        elif metric == "error_rate":
+            return self._get_error_rate_expression()
+        else:
+            return self._get_requests_count_expression()
+
+    def _calculate(self) -> EndpointsUsageTrendsQueryResponse:
+        from posthog.clickhouse.query_tagging import tag_queries
+
+        tag_queries(name="endpoints_usage_trends")
+        response = execute_hogql_query(
+            query_type="endpoints_usage_trends_query",
+            query=self.to_query(),
+            team=self.team,
+            timings=self.timings,
+            modifiers=self.modifiers,
+            limit_context=self.limit_context,
+        )
+
+        # Transform results into the expected format
+        # Each row is: [date, (breakdown,)? value]
+        results: list[dict] = []
+
+        if response.results:
+            has_breakdown = self.query.breakdownBy is not None
+
+            for row in response.results:
+                if has_breakdown:
+                    results.append(
+                        {
+                            "date": str(row[0]) if row[0] else None,
+                            "breakdown": row[1],
+                            "value": float(row[2]) if row[2] is not None else 0,
+                        }
+                    )
+                else:
+                    results.append(
+                        {
+                            "date": str(row[0]) if row[0] else None,
+                            "value": float(row[1]) if row[1] is not None else 0,
+                        }
+                    )
+
+        return EndpointsUsageTrendsQueryResponse(
+            results=results,
+            timings=response.timings,
+            hogql=response.hogql,
+        )

--- a/posthog/hogql_queries/endpoints/test/__snapshots__/test_endpoints_usage_query_runners.ambr
+++ b/posthog/hogql_queries/endpoints/test/__snapshots__/test_endpoints_usage_query_runners.ambr
@@ -1,0 +1,263 @@
+# serializer version: 1
+# name: TestEndpointsUsageOverviewQueryRunner.test_overview_query_sql
+  '''
+  SELECT count() AS total_requests,
+         sum(read_bytes) AS total_bytes_read,
+         divide(sum(cpu_microseconds), 1000000) AS total_cpu_seconds,
+         avg(query_duration_ms) AS avg_query_duration_ms,
+         quantile(0.95)(query_duration_ms) AS p95_query_duration_ms,
+         divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate,
+         countIf(endsWith(name, '_materialized')) AS materialized_requests,
+         countIf(not(endsWith(name, '_materialized'))) AS inline_requests
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  LIMIT 50000
+  '''
+# ---
+# name: TestEndpointsUsageOverviewQueryRunner.test_overview_query_with_endpoint_filter_sql
+  '''
+  SELECT count() AS total_requests,
+         sum(read_bytes) AS total_bytes_read,
+         divide(sum(cpu_microseconds), 1000000) AS total_cpu_seconds,
+         avg(query_duration_ms) AS avg_query_duration_ms,
+         quantile(0.95)(query_duration_ms) AS p95_query_duration_ms,
+         divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate,
+         countIf(endsWith(name, '_materialized')) AS materialized_requests,
+         countIf(not(endsWith(name, '_materialized'))) AS inline_requests
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), or(equals(name, 'my-endpoint'), equals(name, 'my-endpoint_materialized')), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  LIMIT 50000
+  '''
+# ---
+# name: TestEndpointsUsageOverviewQueryRunner.test_overview_query_with_materialization_filter_sql
+  '''
+  SELECT count() AS total_requests,
+         sum(read_bytes) AS total_bytes_read,
+         divide(sum(cpu_microseconds), 1000000) AS total_cpu_seconds,
+         avg(query_duration_ms) AS avg_query_duration_ms,
+         quantile(0.95)(query_duration_ms) AS p95_query_duration_ms,
+         divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate,
+         countIf(endsWith(name, '_materialized')) AS materialized_requests,
+         countIf(not(endsWith(name, '_materialized'))) AS inline_requests
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), like(name, '%_materialized'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  LIMIT 50000
+  '''
+# ---
+# name: TestEndpointsUsageTableQueryRunner.test_table_query_by_api_key_sql
+  '''
+  SELECT api_key_label AS api_key,
+         count() AS requests,
+         sum(read_bytes) AS bytes_read,
+         divide(sum(cpu_microseconds), 1000000) AS cpu_seconds,
+         avg(query_duration_ms) AS avg_query_duration_ms,
+         divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY api_key_label
+  ORDER BY requests DESC
+  LIMIT 100
+  OFFSET 0
+  '''
+# ---
+# name: TestEndpointsUsageTableQueryRunner.test_table_query_by_endpoint_sql
+  '''
+  SELECT replaceRegexpOne(name, '_materialized$', '') AS endpoint,
+         count() AS requests,
+         sum(read_bytes) AS bytes_read,
+         divide(sum(cpu_microseconds), 1000000) AS cpu_seconds,
+         avg(query_duration_ms) AS avg_query_duration_ms,
+         divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY replaceRegexpOne(name, '_materialized$', '')
+  ORDER BY requests DESC
+  LIMIT 100
+  OFFSET 0
+  '''
+# ---
+# name: TestEndpointsUsageTableQueryRunner.test_table_query_by_materialization_type_sql
+  '''
+  SELECT if(endsWith(name, '_materialized'), 'Materialized execution', 'Direct execution') AS execution_type,
+         count() AS requests,
+         sum(read_bytes) AS bytes_read,
+         divide(sum(cpu_microseconds), 1000000) AS cpu_seconds,
+         avg(query_duration_ms) AS avg_query_duration_ms,
+         divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY if(endsWith(name, '_materialized'), 'Materialized execution', 'Direct execution')
+  ORDER BY requests DESC
+  LIMIT 100
+  OFFSET 0
+  '''
+# ---
+# name: TestEndpointsUsageTableQueryRunner.test_table_query_by_status_sql
+  '''
+  SELECT if(equals(exception_code, 0), 'success', 'error') AS status,
+         count() AS requests,
+         sum(read_bytes) AS bytes_read,
+         divide(sum(cpu_microseconds), 1000000) AS cpu_seconds,
+         avg(query_duration_ms) AS avg_query_duration_ms,
+         divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY if(equals(exception_code, 0), 'success', 'error')
+  ORDER BY requests DESC
+  LIMIT 100
+  OFFSET 0
+  '''
+# ---
+# name: TestEndpointsUsageTableQueryRunner.test_table_query_with_materialization_filter_sql
+  '''
+  SELECT replaceRegexpOne(name, '_materialized$', '') AS endpoint,
+         count() AS requests,
+         sum(read_bytes) AS bytes_read,
+         divide(sum(cpu_microseconds), 1000000) AS cpu_seconds,
+         avg(query_duration_ms) AS avg_query_duration_ms,
+         divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')), not(like(name, '%_materialized')))
+  GROUP BY replaceRegexpOne(name, '_materialized$', '')
+  ORDER BY requests DESC
+  LIMIT 100
+  OFFSET 0
+  '''
+# ---
+# name: TestEndpointsUsageTableQueryRunner.test_table_query_with_order_by_sql
+  '''
+  SELECT replaceRegexpOne(name, '_materialized$', '') AS endpoint,
+         count() AS requests,
+         sum(read_bytes) AS bytes_read,
+         divide(sum(cpu_microseconds), 1000000) AS cpu_seconds,
+         avg(query_duration_ms) AS avg_query_duration_ms,
+         divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY replaceRegexpOne(name, '_materialized$', '')
+  ORDER BY bytes_read ASC
+  LIMIT 100
+  OFFSET 0
+  '''
+# ---
+# name: TestEndpointsUsageTableQueryRunner.test_table_query_with_pagination_sql
+  '''
+  SELECT replaceRegexpOne(name, '_materialized$', '') AS endpoint,
+         count() AS requests,
+         sum(read_bytes) AS bytes_read,
+         divide(sum(cpu_microseconds), 1000000) AS cpu_seconds,
+         avg(query_duration_ms) AS avg_query_duration_ms,
+         divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY replaceRegexpOne(name, '_materialized$', '')
+  ORDER BY requests DESC
+  LIMIT 50
+  OFFSET 25
+  '''
+# ---
+# name: TestEndpointsUsageTrendsQueryRunner.test_trends_query_bytes_read_metric_sql
+  '''
+  SELECT event_date AS date,
+         sum(read_bytes) AS value
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY event_date
+  ORDER BY date ASC
+  LIMIT 50000
+  '''
+# ---
+# name: TestEndpointsUsageTrendsQueryRunner.test_trends_query_cpu_seconds_metric_sql
+  '''
+  SELECT event_date AS date,
+         divide(sum(cpu_microseconds), 1000000) AS value
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY event_date
+  ORDER BY date ASC
+  LIMIT 50000
+  '''
+# ---
+# name: TestEndpointsUsageTrendsQueryRunner.test_trends_query_error_rate_metric_sql
+  '''
+  SELECT event_date AS date,
+         divide(countIf(notEquals(exception_code, 0)), count()) AS value
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY event_date
+  ORDER BY date ASC
+  LIMIT 50000
+  '''
+# ---
+# name: TestEndpointsUsageTrendsQueryRunner.test_trends_query_hourly_interval_sql
+  '''
+  SELECT toStartOfHour(event_time) AS date,
+         count() AS value
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 12:59:59.999999')))
+  GROUP BY toStartOfHour(event_time)
+  ORDER BY date ASC
+  LIMIT 50000
+  '''
+# ---
+# name: TestEndpointsUsageTrendsQueryRunner.test_trends_query_requests_metric_sql
+  '''
+  SELECT event_date AS date,
+         count() AS value
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY event_date
+  ORDER BY date ASC
+  LIMIT 50000
+  '''
+# ---
+# name: TestEndpointsUsageTrendsQueryRunner.test_trends_query_weekly_interval_sql
+  '''
+  SELECT toStartOfWeek(event_date) AS date,
+         count() AS value
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2023-12-16 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY toStartOfWeek(event_date)
+  ORDER BY date ASC
+  LIMIT 50000
+  '''
+# ---
+# name: TestEndpointsUsageTrendsQueryRunner.test_trends_query_with_endpoint_breakdown_sql
+  '''
+  SELECT event_date AS date,
+         replaceRegexpOne(name, '_materialized$', '') AS breakdown,
+         count() AS value
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY event_date,
+           replaceRegexpOne(name, '_materialized$', '')
+  ORDER BY date ASC
+  LIMIT 50000
+  '''
+# ---
+# name: TestEndpointsUsageTrendsQueryRunner.test_trends_query_with_materialization_breakdown_sql
+  '''
+  SELECT event_date AS date,
+         if(endsWith(name, '_materialized'), 'Materialized execution', 'Direct execution') AS breakdown,
+         count() AS value
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY event_date,
+           if(endsWith(name, '_materialized'), 'Materialized execution', 'Direct execution')
+  ORDER BY date ASC
+  LIMIT 50000
+  '''
+# ---
+# name: TestEndpointsUsageTrendsQueryRunner.test_trends_query_with_status_breakdown_sql
+  '''
+  SELECT event_date AS date,
+         if(equals(exception_code, 0), 'success', 'error') AS breakdown,
+         count() AS value
+  FROM query_log
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  GROUP BY event_date,
+           if(equals(exception_code, 0), 'success', 'error')
+  ORDER BY date ASC
+  LIMIT 50000
+  '''
+# ---

--- a/posthog/hogql_queries/endpoints/test/test_endpoints_usage_query_runners.py
+++ b/posthog/hogql_queries/endpoints/test/test_endpoints_usage_query_runners.py
@@ -1,0 +1,344 @@
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
+
+from parameterized import parameterized
+
+from posthog.schema import (
+    DateRange,
+    EndpointsUsageBreakdown,
+    EndpointsUsageOverviewQuery,
+    EndpointsUsageTableQuery,
+    EndpointsUsageTrendsQuery,
+    IntervalType,
+    MaterializationType,
+)
+
+from posthog.hogql.printer import to_printed_hogql
+
+from posthog.hogql_queries.endpoints.endpoints_usage_overview import EndpointsUsageOverviewQueryRunner
+from posthog.hogql_queries.endpoints.endpoints_usage_query_runner import safe_float
+from posthog.hogql_queries.endpoints.endpoints_usage_table import EndpointsUsageTableQueryRunner
+from posthog.hogql_queries.endpoints.endpoints_usage_trends import EndpointsUsageTrendsQueryRunner
+
+
+class TestSafeFloat(APIBaseTest):
+    @parameterized.expand(
+        [
+            (None, 0.0),
+            (0, 0.0),
+            (1, 1.0),
+            (1.5, 1.5),
+            ("1.5", 1.5),
+            ("invalid", 0.0),
+            ([], 0.0),
+            ({}, 0.0),
+            (float("inf"), float("inf")),
+        ]
+    )
+    def test_safe_float_conversions(self, input_val, expected):
+        result = safe_float(input_val)
+        self.assertEqual(result, expected)
+
+
+class TestEndpointsUsageOverviewQueryRunner(ClickhouseTestMixin, QueryMatchingTest, APIBaseTest):
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_overview_query_sql(self):
+        query = EndpointsUsageOverviewQuery(
+            kind="EndpointsUsageOverviewQuery",
+            dateRange=DateRange(date_from="-7d"),
+        )
+        runner = EndpointsUsageOverviewQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_overview_query_with_endpoint_filter_sql(self):
+        query = EndpointsUsageOverviewQuery(
+            kind="EndpointsUsageOverviewQuery",
+            dateRange=DateRange(date_from="-7d"),
+            endpointNames=["my-endpoint"],
+        )
+        runner = EndpointsUsageOverviewQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_overview_query_with_materialization_filter_sql(self):
+        query = EndpointsUsageOverviewQuery(
+            kind="EndpointsUsageOverviewQuery",
+            dateRange=DateRange(date_from="-7d"),
+            materializationType=MaterializationType.MATERIALIZED,
+        )
+        runner = EndpointsUsageOverviewQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_row_to_metrics_dict(self):
+        query = EndpointsUsageOverviewQuery(
+            kind="EndpointsUsageOverviewQuery",
+            dateRange=DateRange(date_from="-7d"),
+        )
+        runner = EndpointsUsageOverviewQueryRunner(query=query, team=self.team)
+
+        row = [100, 5000, 1.5, 50.0, 95.0, 0.05, 60, 40]
+        result = runner._row_to_metrics_dict(row)
+
+        assert result == {
+            "total_requests": 100.0,
+            "total_bytes_read": 5000.0,
+            "total_cpu_seconds": 1.5,
+            "avg_query_duration_ms": 50.0,
+            "p95_query_duration_ms": 95.0,
+            "error_rate": 0.05,
+            "materialized_requests": 60.0,
+            "inline_requests": 40.0,
+        }
+
+    @parameterized.expand(
+        [
+            (100.0, 50.0, 100.0),
+            (50.0, 100.0, -50.0),
+            (100.0, 0.0, 100.0),
+            (0.0, 100.0, -100.0),
+            (0.0, 0.0, 0.0),
+        ]
+    )
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_calculate_change_pct(self, current, previous, expected):
+        query = EndpointsUsageOverviewQuery(
+            kind="EndpointsUsageOverviewQuery",
+            dateRange=DateRange(date_from="-7d"),
+        )
+        runner = EndpointsUsageOverviewQueryRunner(query=query, team=self.team)
+
+        result = runner._calculate_change_pct(current, previous)
+
+        assert result == expected
+
+
+class TestEndpointsUsageTrendsQueryRunner(ClickhouseTestMixin, QueryMatchingTest, APIBaseTest):
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_trends_query_requests_metric_sql(self):
+        query = EndpointsUsageTrendsQuery(
+            kind="EndpointsUsageTrendsQuery",
+            dateRange=DateRange(date_from="-7d"),
+            metric="requests",
+        )
+        runner = EndpointsUsageTrendsQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_trends_query_bytes_read_metric_sql(self):
+        query = EndpointsUsageTrendsQuery(
+            kind="EndpointsUsageTrendsQuery",
+            dateRange=DateRange(date_from="-7d"),
+            metric="bytes_read",
+        )
+        runner = EndpointsUsageTrendsQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_trends_query_cpu_seconds_metric_sql(self):
+        query = EndpointsUsageTrendsQuery(
+            kind="EndpointsUsageTrendsQuery",
+            dateRange=DateRange(date_from="-7d"),
+            metric="cpu_seconds",
+        )
+        runner = EndpointsUsageTrendsQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_trends_query_error_rate_metric_sql(self):
+        query = EndpointsUsageTrendsQuery(
+            kind="EndpointsUsageTrendsQuery",
+            dateRange=DateRange(date_from="-7d"),
+            metric="error_rate",
+        )
+        runner = EndpointsUsageTrendsQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_trends_query_hourly_interval_sql(self):
+        query = EndpointsUsageTrendsQuery(
+            kind="EndpointsUsageTrendsQuery",
+            dateRange=DateRange(date_from="-7d"),
+            metric="requests",
+            interval=IntervalType.HOUR,
+        )
+        runner = EndpointsUsageTrendsQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_trends_query_weekly_interval_sql(self):
+        query = EndpointsUsageTrendsQuery(
+            kind="EndpointsUsageTrendsQuery",
+            dateRange=DateRange(date_from="-30d"),
+            metric="requests",
+            interval=IntervalType.WEEK,
+        )
+        runner = EndpointsUsageTrendsQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_trends_query_with_endpoint_breakdown_sql(self):
+        query = EndpointsUsageTrendsQuery(
+            kind="EndpointsUsageTrendsQuery",
+            dateRange=DateRange(date_from="-7d"),
+            metric="requests",
+            breakdownBy=EndpointsUsageBreakdown.ENDPOINT,
+        )
+        runner = EndpointsUsageTrendsQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_trends_query_with_materialization_breakdown_sql(self):
+        query = EndpointsUsageTrendsQuery(
+            kind="EndpointsUsageTrendsQuery",
+            dateRange=DateRange(date_from="-7d"),
+            metric="requests",
+            breakdownBy=EndpointsUsageBreakdown.MATERIALIZATION_TYPE,
+        )
+        runner = EndpointsUsageTrendsQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_trends_query_with_status_breakdown_sql(self):
+        query = EndpointsUsageTrendsQuery(
+            kind="EndpointsUsageTrendsQuery",
+            dateRange=DateRange(date_from="-7d"),
+            metric="requests",
+            breakdownBy=EndpointsUsageBreakdown.STATUS,
+        )
+        runner = EndpointsUsageTrendsQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+
+class TestEndpointsUsageTableQueryRunner(ClickhouseTestMixin, QueryMatchingTest, APIBaseTest):
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_table_query_by_endpoint_sql(self):
+        query = EndpointsUsageTableQuery(
+            kind="EndpointsUsageTableQuery",
+            dateRange=DateRange(date_from="-7d"),
+            breakdownBy=EndpointsUsageBreakdown.ENDPOINT,
+        )
+        runner = EndpointsUsageTableQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_table_query_by_materialization_type_sql(self):
+        query = EndpointsUsageTableQuery(
+            kind="EndpointsUsageTableQuery",
+            dateRange=DateRange(date_from="-7d"),
+            breakdownBy=EndpointsUsageBreakdown.MATERIALIZATION_TYPE,
+        )
+        runner = EndpointsUsageTableQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_table_query_by_api_key_sql(self):
+        query = EndpointsUsageTableQuery(
+            kind="EndpointsUsageTableQuery",
+            dateRange=DateRange(date_from="-7d"),
+            breakdownBy=EndpointsUsageBreakdown.API_KEY,
+        )
+        runner = EndpointsUsageTableQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_table_query_by_status_sql(self):
+        query = EndpointsUsageTableQuery(
+            kind="EndpointsUsageTableQuery",
+            dateRange=DateRange(date_from="-7d"),
+            breakdownBy=EndpointsUsageBreakdown.STATUS,
+        )
+        runner = EndpointsUsageTableQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_table_query_with_pagination_sql(self):
+        query = EndpointsUsageTableQuery(
+            kind="EndpointsUsageTableQuery",
+            dateRange=DateRange(date_from="-7d"),
+            breakdownBy=EndpointsUsageBreakdown.ENDPOINT,
+            limit=50,
+            offset=25,
+        )
+        runner = EndpointsUsageTableQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_table_query_with_order_by_sql(self):
+        query = EndpointsUsageTableQuery(
+            kind="EndpointsUsageTableQuery",
+            dateRange=DateRange(date_from="-7d"),
+            breakdownBy=EndpointsUsageBreakdown.ENDPOINT,
+            orderBy=["bytes_read", "ASC"],
+        )
+        runner = EndpointsUsageTableQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_table_query_with_materialization_filter_sql(self):
+        query = EndpointsUsageTableQuery(
+            kind="EndpointsUsageTableQuery",
+            dateRange=DateRange(date_from="-7d"),
+            breakdownBy=EndpointsUsageBreakdown.ENDPOINT,
+            materializationType=MaterializationType.INLINE,
+        )
+        runner = EndpointsUsageTableQueryRunner(query=query, team=self.team)
+
+        hogql = to_printed_hogql(runner.to_query(), self.team)
+
+        self.assertQueryMatchesSnapshot(hogql)

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -17,6 +17,9 @@ from posthog.schema import (
     ChartDisplayType,
     DashboardFilter,
     DateRange,
+    EndpointsUsageOverviewQuery,
+    EndpointsUsageTableQuery,
+    EndpointsUsageTrendsQuery,
     EventsQuery,
     EventTaxonomyQuery,
     ExperimentExposureQuery,
@@ -181,6 +184,9 @@ RunnableQueryNode = Union[
     MarketingAnalyticsAggregatedQuery,
     ActorsPropertyTaxonomyQuery,
     UsageMetricsQuery,
+    EndpointsUsageOverviewQuery,
+    EndpointsUsageTableQuery,
+    EndpointsUsageTrendsQuery,
 ]
 
 
@@ -780,6 +786,39 @@ def get_query_runner(
         from products.customer_analytics.backend.hogql_queries.usage_metrics_query_runner import UsageMetricsQueryRunner
 
         return UsageMetricsQueryRunner(
+            query=query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+        )
+
+    if kind == "EndpointsUsageOverviewQuery":
+        from .endpoints.endpoints_usage_overview import EndpointsUsageOverviewQueryRunner
+
+        return EndpointsUsageOverviewQueryRunner(
+            query=query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+        )
+
+    if kind == "EndpointsUsageTableQuery":
+        from .endpoints.endpoints_usage_table import EndpointsUsageTableQueryRunner
+
+        return EndpointsUsageTableQueryRunner(
+            query=query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+        )
+
+    if kind == "EndpointsUsageTrendsQuery":
+        from .endpoints.endpoints_usage_trends import EndpointsUsageTrendsQueryRunner
+
+        return EndpointsUsageTrendsQueryRunner(
             query=query,
             team=team,
             timings=timings,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1171,6 +1171,51 @@ class EndpointRefreshMode(StrEnum):
     DIRECT = "direct"
 
 
+class EndpointsUsageBreakdown(StrEnum):
+    ENDPOINT = "Endpoint"
+    MATERIALIZATION_TYPE = "MaterializationType"
+    API_KEY = "ApiKey"
+    STATUS = "Status"
+
+
+class EndpointsUsageOrderByDirection(StrEnum):
+    ASC = "ASC"
+    DESC = "DESC"
+
+
+class EndpointsUsageOrderByField(StrEnum):
+    REQUESTS = "requests"
+    BYTES_READ = "bytes_read"
+    CPU_SECONDS = "cpu_seconds"
+    AVG_QUERY_DURATION_MS = "avg_query_duration_ms"
+    ERROR_RATE = "error_rate"
+
+
+class EndpointsUsageOverviewItemKey(StrEnum):
+    TOTAL_REQUESTS = "total_requests"
+    TOTAL_BYTES_READ = "total_bytes_read"
+    TOTAL_CPU_SECONDS = "total_cpu_seconds"
+    AVG_QUERY_DURATION_MS = "avg_query_duration_ms"
+    P95_QUERY_DURATION_MS = "p95_query_duration_ms"
+    ERROR_RATE = "error_rate"
+    MATERIALIZED_REQUESTS = "materialized_requests"
+    INLINE_REQUESTS = "inline_requests"
+
+
+class MaterializationType(Enum):
+    MATERIALIZED = "materialized"
+    INLINE = "inline"
+    NONE_TYPE_NONE = None
+
+
+class Metric(StrEnum):
+    BYTES_READ = "bytes_read"
+    CPU_SECONDS = "cpu_seconds"
+    REQUESTS = "requests"
+    QUERY_DURATION = "query_duration"
+    ERROR_RATE = "error_rate"
+
+
 class EntityType(StrEnum):
     ACTIONS = "actions"
     EVENTS = "events"
@@ -2492,6 +2537,9 @@ class NodeKind(StrEnum):
     VECTOR_SEARCH_QUERY = "VectorSearchQuery"
     DOCUMENT_SIMILARITY_QUERY = "DocumentSimilarityQuery"
     USAGE_METRICS_QUERY = "UsageMetricsQuery"
+    ENDPOINTS_USAGE_OVERVIEW_QUERY = "EndpointsUsageOverviewQuery"
+    ENDPOINTS_USAGE_TABLE_QUERY = "EndpointsUsageTableQuery"
+    ENDPOINTS_USAGE_TRENDS_QUERY = "EndpointsUsageTrendsQuery"
 
 
 class NonIntegratedConversionsColumnsSchemaNames(StrEnum):
@@ -2801,6 +2849,9 @@ class QueryLogTags(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    name: str | None = Field(
+        default=None, description="Name of the query, preferably unique. For example web_analytics_vitals"
+    )
     productKey: str | None = Field(
         default=None,
         description=(
@@ -2827,7 +2878,7 @@ class QueryResponseAlternative7(BaseModel):
     stdout: str | None = None
 
 
-class QueryResponseAlternative75(BaseModel):
+class QueryResponseAlternative76(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -4486,6 +4537,16 @@ class EmbeddingDistance(BaseModel):
     distance: float
     origin: EmbeddingRecord | None = None
     result: EmbeddingRecord
+
+
+class EndpointsUsageOverviewItem(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    changeFromPreviousPct: float | None = None
+    key: EndpointsUsageOverviewItemKey
+    previous: float | None = None
+    value: float | None = None
 
 
 class ErrorTrackingExternalReferenceIntegration(BaseModel):
@@ -7026,6 +7087,107 @@ class CachedDocumentSimilarityQueryResponse(BaseModel):
     )
 
 
+class CachedEndpointsUsageOverviewQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: AwareDatetime | None = None
+    calculation_trigger: str | None = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    error: str | None = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: AwareDatetime
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    next_allowed_client_refresh: AwareDatetime
+    query_metadata: dict[str, Any] | None = None
+    query_status: QueryStatus | None = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[EndpointsUsageOverviewItem]
+    timezone: str
+    timings: list[QueryTiming] | None = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class CachedEndpointsUsageTableQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: AwareDatetime | None = None
+    calculation_trigger: str | None = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    columns: list | None = None
+    error: str | None = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: AwareDatetime
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    next_allowed_client_refresh: AwareDatetime
+    offset: int | None = None
+    query_metadata: dict[str, Any] | None = None
+    query_status: QueryStatus | None = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list
+    timezone: str
+    timings: list[QueryTiming] | None = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: list | None = None
+
+
+class CachedEndpointsUsageTrendsQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: AwareDatetime | None = None
+    calculation_trigger: str | None = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    error: str | None = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: AwareDatetime
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    next_allowed_client_refresh: AwareDatetime
+    query_metadata: dict[str, Any] | None = None
+    query_status: QueryStatus | None = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[dict[str, Any]]
+    timezone: str
+    timings: list[QueryTiming] | None = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
 class CachedErrorTrackingBreakdownsQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -9170,6 +9332,33 @@ class Response25(BaseModel):
     )
 
 
+class Response26(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: list | None = None
+    error: str | None = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
+    query_status: QueryStatus | None = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list
+    timings: list[QueryTiming] | None = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: list | None = None
+
+
 class DataWarehouseNode(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -9342,6 +9531,77 @@ class EndpointRunRequest(BaseModel):
     )
     version: int | None = Field(
         default=None, description="Specific endpoint version to execute. If not provided, the latest version is used."
+    )
+
+
+class EndpointsUsageOverviewQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[EndpointsUsageOverviewItem]
+    timings: list[QueryTiming] | None = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class EndpointsUsageTableQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: list | None = None
+    error: str | None = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
+    query_status: QueryStatus | None = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list
+    timings: list[QueryTiming] | None = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: list | None = None
+
+
+class EndpointsUsageTrendsQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[dict[str, Any]]
+    timings: list[QueryTiming] | None = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
     )
 
 
@@ -11727,6 +11987,33 @@ class QueryResponseAlternative64(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    columns: list | None = None
+    error: str | None = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
+    query_status: QueryStatus | None = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list
+    timings: list[QueryTiming] | None = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: list | None = None
+
+
+class QueryResponseAlternative65(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
     error: str | None = Field(
         default=None,
         description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
@@ -11746,7 +12033,7 @@ class QueryResponseAlternative64(BaseModel):
     )
 
 
-class QueryResponseAlternative65(BaseModel):
+class QueryResponseAlternative66(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -11769,7 +12056,7 @@ class QueryResponseAlternative65(BaseModel):
     )
 
 
-class QueryResponseAlternative67(BaseModel):
+class QueryResponseAlternative68(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -11791,7 +12078,7 @@ class QueryResponseAlternative67(BaseModel):
     )
 
 
-class QueryResponseAlternative68(BaseModel):
+class QueryResponseAlternative69(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -11813,7 +12100,7 @@ class QueryResponseAlternative68(BaseModel):
     )
 
 
-class QueryResponseAlternative70(BaseModel):
+class QueryResponseAlternative71(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -11840,7 +12127,7 @@ class QueryResponseAlternative70(BaseModel):
     types: list | None = None
 
 
-class QueryResponseAlternative72(BaseModel):
+class QueryResponseAlternative73(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -11867,7 +12154,7 @@ class QueryResponseAlternative72(BaseModel):
     )
 
 
-class QueryResponseAlternative73(BaseModel):
+class QueryResponseAlternative74(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -11890,7 +12177,7 @@ class QueryResponseAlternative73(BaseModel):
     )
 
 
-class QueryResponseAlternative74(BaseModel):
+class QueryResponseAlternative75(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -11912,7 +12199,7 @@ class QueryResponseAlternative74(BaseModel):
     )
 
 
-class QueryResponseAlternative76(BaseModel):
+class QueryResponseAlternative77(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -11934,7 +12221,7 @@ class QueryResponseAlternative76(BaseModel):
     )
 
 
-class QueryResponseAlternative77(BaseModel):
+class QueryResponseAlternative78(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -11956,7 +12243,7 @@ class QueryResponseAlternative77(BaseModel):
     )
 
 
-class QueryResponseAlternative78(BaseModel):
+class QueryResponseAlternative79(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -11978,7 +12265,7 @@ class QueryResponseAlternative78(BaseModel):
     )
 
 
-class QueryResponseAlternative79(BaseModel):
+class QueryResponseAlternative80(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -12004,7 +12291,7 @@ class QueryResponseAlternative79(BaseModel):
     )
 
 
-class QueryResponseAlternative81(BaseModel):
+class QueryResponseAlternative82(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -12026,7 +12313,7 @@ class QueryResponseAlternative81(BaseModel):
     )
 
 
-class QueryResponseAlternative82(BaseModel):
+class QueryResponseAlternative83(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -12043,6 +12330,77 @@ class QueryResponseAlternative82(BaseModel):
         default=None, description="The date range used for the query"
     )
     results: list[UsageMetric]
+    timings: list[QueryTiming] | None = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class QueryResponseAlternative84(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[EndpointsUsageOverviewItem]
+    timings: list[QueryTiming] | None = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class QueryResponseAlternative85(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: list | None = None
+    error: str | None = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: bool | None = None
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    limit: int | None = None
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
+    query_status: QueryStatus | None = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list
+    timings: list[QueryTiming] | None = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: list | None = None
+
+
+class QueryResponseAlternative86(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[dict[str, Any]]
     timings: list[QueryTiming] | None = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
@@ -13348,6 +13706,59 @@ class DocumentSimilarityQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
+class EndpointsUsageOverviewQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    compareFilter: CompareFilter | None = Field(default=None, description="Compare to previous period")
+    dateRange: DateRange | None = None
+    endpointNames: list[str] | None = Field(default=None, description="Filter to specific endpoints by name")
+    kind: Literal["EndpointsUsageOverviewQuery"] = "EndpointsUsageOverviewQuery"
+    materializationType: MaterializationType | None = Field(default=None, description="Filter by materialization type")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    response: EndpointsUsageOverviewQueryResponse | None = None
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class EndpointsUsageTableQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdownBy: EndpointsUsageBreakdown
+    dateRange: DateRange | None = None
+    endpointNames: list[str] | None = Field(default=None, description="Filter to specific endpoints by name")
+    kind: Literal["EndpointsUsageTableQuery"] = "EndpointsUsageTableQuery"
+    limit: int | None = None
+    materializationType: MaterializationType | None = Field(default=None, description="Filter by materialization type")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = None
+    orderBy: list[EndpointsUsageOrderByField | EndpointsUsageOrderByDirection] | None = None
+    response: EndpointsUsageTableQueryResponse | None = None
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class EndpointsUsageTrendsQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdownBy: EndpointsUsageBreakdown | None = Field(
+        default=None, description="Optional breakdown for stacked charts"
+    )
+    compareFilter: CompareFilter | None = Field(default=None, description="Compare to previous period")
+    dateRange: DateRange | None = None
+    endpointNames: list[str] | None = Field(default=None, description="Filter to specific endpoints by name")
+    interval: IntervalType | None = Field(default=None, description="Time interval")
+    kind: Literal["EndpointsUsageTrendsQuery"] = "EndpointsUsageTrendsQuery"
+    materializationType: MaterializationType | None = Field(default=None, description="Filter by materialization type")
+    metric: Metric = Field(..., description="Metric to trend")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    response: EndpointsUsageTrendsQueryResponse | None = None
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
 class ErrorTrackingBreakdownsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -13890,7 +14301,7 @@ class QueryResponseAlternative17(BaseModel):
     )
 
 
-class QueryResponseAlternative66(BaseModel):
+class QueryResponseAlternative67(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -15713,7 +16124,7 @@ class ProductAnalyticsInsightQueryNode(
     root: TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery
 
 
-class QueryResponseAlternative71(BaseModel):
+class QueryResponseAlternative72(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -15796,7 +16207,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative66
         | QueryResponseAlternative67
         | QueryResponseAlternative68
-        | QueryResponseAlternative70
+        | QueryResponseAlternative69
         | QueryResponseAlternative71
         | QueryResponseAlternative72
         | QueryResponseAlternative73
@@ -15806,8 +16217,12 @@ class QueryResponseAlternative(
         | QueryResponseAlternative77
         | QueryResponseAlternative78
         | QueryResponseAlternative79
-        | QueryResponseAlternative81
+        | QueryResponseAlternative80
         | QueryResponseAlternative82
+        | QueryResponseAlternative83
+        | QueryResponseAlternative84
+        | QueryResponseAlternative85
+        | QueryResponseAlternative86
     ]
 ):
     root: (
@@ -15874,7 +16289,7 @@ class QueryResponseAlternative(
         | QueryResponseAlternative66
         | QueryResponseAlternative67
         | QueryResponseAlternative68
-        | QueryResponseAlternative70
+        | QueryResponseAlternative69
         | QueryResponseAlternative71
         | QueryResponseAlternative72
         | QueryResponseAlternative73
@@ -15884,8 +16299,12 @@ class QueryResponseAlternative(
         | QueryResponseAlternative77
         | QueryResponseAlternative78
         | QueryResponseAlternative79
-        | QueryResponseAlternative81
+        | QueryResponseAlternative80
         | QueryResponseAlternative82
+        | QueryResponseAlternative83
+        | QueryResponseAlternative84
+        | QueryResponseAlternative85
+        | QueryResponseAlternative86
     )
 
 
@@ -16400,6 +16819,7 @@ class DataTableNode(BaseModel):
         | Response23
         | Response24
         | Response25
+        | Response26
         | None
     ) = None
     showActions: bool | None = Field(default=None, description="Show the kebab menu at the end of the row")
@@ -16472,6 +16892,7 @@ class DataTableNode(BaseModel):
         | ExperimentTrendsQuery
         | TracesQuery
         | TraceQuery
+        | EndpointsUsageTableQuery
     ) = Field(..., description="Source of the events")
     tags: QueryLogTags | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
@@ -16551,6 +16972,9 @@ class HogQLAutocomplete(BaseModel):
         | TraceQuery
         | VectorSearchQuery
         | UsageMetricsQuery
+        | EndpointsUsageOverviewQuery
+        | EndpointsUsageTableQuery
+        | EndpointsUsageTrendsQuery
         | None
     ) = Field(default=None, description="Query in whose context to validate.")
     startPosition: int = Field(..., description="Start position of the editor word")
@@ -16620,6 +17044,9 @@ class HogQLMetadata(BaseModel):
         | TraceQuery
         | VectorSearchQuery
         | UsageMetricsQuery
+        | EndpointsUsageOverviewQuery
+        | EndpointsUsageTableQuery
+        | EndpointsUsageTrendsQuery
         | None
     ) = Field(
         default=None,
@@ -16732,6 +17159,9 @@ class MaxInsightContext(BaseModel):
         | TraceQuery
         | VectorSearchQuery
         | UsageMetricsQuery
+        | EndpointsUsageOverviewQuery
+        | EndpointsUsageTableQuery
+        | EndpointsUsageTrendsQuery
     ) = Field(..., discriminator="kind")
     type: Literal["insight"] = "insight"
     variablesOverride: dict[str, HogQLVariable] | None = None
@@ -16831,6 +17261,9 @@ class QueryRequest(BaseModel):
         | TraceQuery
         | VectorSearchQuery
         | UsageMetricsQuery
+        | EndpointsUsageOverviewQuery
+        | EndpointsUsageTableQuery
+        | EndpointsUsageTrendsQuery
     ) = Field(
         ...,
         description=(
@@ -16927,6 +17360,9 @@ class QuerySchemaRoot(
         | TraceQuery
         | VectorSearchQuery
         | UsageMetricsQuery
+        | EndpointsUsageOverviewQuery
+        | EndpointsUsageTableQuery
+        | EndpointsUsageTrendsQuery
     ]
 ):
     root: (
@@ -16997,6 +17433,9 @@ class QuerySchemaRoot(
         | TraceQuery
         | VectorSearchQuery
         | UsageMetricsQuery
+        | EndpointsUsageOverviewQuery
+        | EndpointsUsageTableQuery
+        | EndpointsUsageTrendsQuery
     ) = Field(..., discriminator="kind")
 
 
@@ -17072,6 +17511,9 @@ class QueryUpgradeRequest(BaseModel):
         | TraceQuery
         | VectorSearchQuery
         | UsageMetricsQuery
+        | EndpointsUsageOverviewQuery
+        | EndpointsUsageTableQuery
+        | EndpointsUsageTrendsQuery
     ) = Field(..., discriminator="kind")
 
 
@@ -17147,6 +17589,9 @@ class QueryUpgradeResponse(BaseModel):
         | TraceQuery
         | VectorSearchQuery
         | UsageMetricsQuery
+        | EndpointsUsageOverviewQuery
+        | EndpointsUsageTableQuery
+        | EndpointsUsageTrendsQuery
     ) = Field(..., discriminator="kind")
 
 
@@ -17345,6 +17790,9 @@ class VisualizationArtifactContent(BaseModel):
         | TraceQuery
         | VectorSearchQuery
         | UsageMetricsQuery
+        | EndpointsUsageOverviewQuery
+        | EndpointsUsageTableQuery
+        | EndpointsUsageTrendsQuery
     )
 
 

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -783,7 +783,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             names_list = ",".join(validated_names)
 
             query = HogQLQuery(
-                query=f"select name, max(query_start_time) as last_executed_at from query_log where name in ({names_list}) and endpoint like '%/endpoints/%' and query_start_time >= (today() - interval 6 month) group by name",
+                query=f"select name, max(query_start_time) as last_executed_at from query_log where name in ({names_list}) and endpoint like '%/endpoints/%' and is_personal_api_key_request and query_start_time >= (today() - interval 6 month) group by name",
                 name="get_endpoints_last_execution_times",
             )
             hogql_runner = HogQLQueryRunner(

--- a/products/endpoints/frontend/EndpointFromInsightModal.tsx
+++ b/products/endpoints/frontend/EndpointFromInsightModal.tsx
@@ -15,7 +15,7 @@ import { HogQLQuery, InsightQueryNode } from '~/queries/schema/schema-general'
 import { endpointLogic } from './endpointLogic'
 import { endpointsLogic } from './endpointsLogic'
 
-export interface EndpointModalProps {
+export interface EndpointFromInsightModalProps {
     isOpen: boolean
     closeModal: () => void
     tabId: string
@@ -23,13 +23,13 @@ export interface EndpointModalProps {
     insightShortId?: string
 }
 
-export function EndpointModal({
+export function EndpointFromInsightModal({
     isOpen,
     closeModal,
     tabId,
     insightQuery,
     insightShortId,
-}: EndpointModalProps): JSX.Element {
+}: EndpointFromInsightModalProps): JSX.Element {
     const {
         createEndpoint,
         updateEndpoint,

--- a/products/endpoints/frontend/EndpointHeader.tsx
+++ b/products/endpoints/frontend/EndpointHeader.tsx
@@ -14,14 +14,14 @@ export interface EndpointSceneHeaderProps {
 }
 
 export const EndpointSceneHeader = ({ tabId }: EndpointSceneHeaderProps): JSX.Element => {
-    const { endpoint, endpointLoading, localQuery } = useValues(endpointSceneLogic({ tabId }))
-    const { endpointName, endpointDescription, cacheAge, syncFrequency, isMaterialized } = useValues(
-        endpointLogic({ tabId })
+    const { endpoint, endpointLoading, localQuery, cacheAge, syncFrequency, isMaterialized } = useValues(
+        endpointSceneLogic({ tabId })
     )
-    const { setEndpointDescription, updateEndpoint, setCacheAge, setSyncFrequency, setIsMaterialized } = useActions(
-        endpointLogic({ tabId })
+    const { endpointName, endpointDescription } = useValues(endpointLogic({ tabId }))
+    const { setEndpointDescription, updateEndpoint } = useActions(endpointLogic({ tabId }))
+    const { setLocalQuery, setCacheAge, setSyncFrequency, setIsMaterialized } = useActions(
+        endpointSceneLogic({ tabId })
     )
-    const { setLocalQuery } = useActions(endpointSceneLogic({ tabId }))
 
     const hasNameChange = endpointName && endpointName !== endpoint?.name
     const hasDescriptionChange = endpointDescription !== null && endpointDescription !== endpoint?.description

--- a/products/endpoints/frontend/EndpointScene.tsx
+++ b/products/endpoints/frontend/EndpointScene.tsx
@@ -16,10 +16,10 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { ActivityScope } from '~/types'
 
 import { EndpointSceneHeader } from './EndpointHeader'
-import { EndpointQuery } from './EndpointQuery'
 import { EndpointConfiguration } from './endpoint-tabs/EndpointConfiguration'
 import { EndpointOverview } from './endpoint-tabs/EndpointOverview'
 import { EndpointPlayground } from './endpoint-tabs/EndpointPlayground'
+import { EndpointQuery } from './endpoint-tabs/EndpointQuery'
 import { endpointLogic } from './endpointLogic'
 import { EndpointTab, endpointSceneLogic } from './endpointSceneLogic'
 

--- a/products/endpoints/frontend/Endpoints.tsx
+++ b/products/endpoints/frontend/Endpoints.tsx
@@ -150,7 +150,7 @@ export const EndpointsTable = ({ tabId }: EndpointsTableProps): JSX.Element => {
                         <>
                             <LemonButton
                                 onClick={() => {
-                                    router.actions.push(urls.endpointsUsage({ requestNameFilter: [record.name] }))
+                                    router.actions.push(urls.endpointsUsage({ endpointFilter: [record.name] }))
                                 }}
                                 fullWidth
                             >

--- a/products/endpoints/frontend/EndpointsScene.tsx
+++ b/products/endpoints/frontend/EndpointsScene.tsx
@@ -27,16 +27,16 @@ import { OverlayForNewEndpointMenu } from './newEndpointMenu'
 
 const ENDPOINTS_PRODUCT_DESCRIPTION =
     'Create reusable SQL queries and expose them as API endpoints. Query your data programmatically from any application. Note: Endpoints is in beta - features and APIs may change.'
-const ENDPOINTS_API_USAGE_PRODUCT_DESCRIPTION =
-    'Monitor API request volume, response times, and costs for your endpoints. Track which endpoints are most used and identify performance issues.'
+const ENDPOINTS_USAGE_PRODUCT_DESCRIPTION =
+    'Monitor endpoint execution metrics including bytes read, CPU usage, and query duration. Compare materialized vs inline executions.'
 
 export const scene: SceneExport = {
     component: EndpointsScene,
-    logic: endpointsUsageLogic,
+    logic: endpointsLogic,
 }
 
 export function EndpointsScene({ tabId }: { tabId?: string }): JSX.Element {
-    const { activeTab } = useValues(endpointsUsageLogic({ tabId: tabId || '' }))
+    const { activeTab } = useValues(endpointsLogic({ tabId: tabId || '' }))
 
     const tabs: LemonTab<string>[] = [
         {
@@ -55,73 +55,81 @@ export function EndpointsScene({ tabId }: { tabId?: string }): JSX.Element {
     return (
         <BindLogic logic={endpointsUsageLogic} props={{ key: 'endpointsUsageScene', tabId: tabId || '' }}>
             <BindLogic logic={endpointsLogic} props={{ key: 'endpointsLogic', tabId: tabId || '' }}>
-                <SceneContent>
-                    <SceneTitleSection
-                        name={sceneConfigurations[Scene.EndpointsScene].name}
-                        description={sceneConfigurations[Scene.EndpointsScene].description}
-                        resourceType={{
-                            type: sceneConfigurations[Scene.EndpointsScene].iconType || 'default_icon_type',
-                        }}
-                        actions={
-                            <AppShortcut
-                                name="EndpointsNew"
-                                keybind={[keyBinds.new]}
-                                intent="New endpoint"
-                                interaction="click"
-                                scope={Scene.EndpointsScene}
-                            >
-                                <LemonButton
-                                    type="primary"
-                                    to={urls.sqlEditor(undefined, undefined, undefined, undefined, OutputTab.Endpoint)}
-                                    sideAction={{
-                                        dropdown: {
-                                            placement: 'bottom-end',
-                                            className: 'new-endpoint-overlay',
-                                            actionable: true,
-                                            overlay: <OverlayForNewEndpointMenu dataAttr="new-endpoint-option" />,
-                                        },
-                                        'data-attr': 'new-endpoint-dropdown',
-                                    }}
-                                    data-attr="new-endpoint-button"
-                                    size="small"
-                                    icon={<IconPlusSmall />}
+                <BindLogic logic={endpointsUsageLogic} props={{ key: 'endpointsUsageLogic', tabId: tabId || '' }}>
+                    <SceneContent>
+                        <SceneTitleSection
+                            name={sceneConfigurations[Scene.EndpointsScene].name}
+                            description={sceneConfigurations[Scene.EndpointsScene].description}
+                            resourceType={{
+                                type: sceneConfigurations[Scene.EndpointsScene].iconType || 'default_icon_type',
+                            }}
+                            actions={
+                                <AppShortcut
+                                    name="EndpointsNew"
+                                    keybind={[keyBinds.new]}
+                                    intent="New endpoint"
+                                    interaction="click"
+                                    scope={Scene.EndpointsScene}
                                 >
-                                    New
-                                </LemonButton>
-                            </AppShortcut>
-                        }
-                    />
-                    <LemonBanner
-                        type="warning"
-                        dismissKey="endpoints-beta-banner"
-                        action={{ children: 'Send feedback', id: 'endpoints-feedback-button' }}
-                    >
-                        <p>
-                            Endpoints is in beta and it may not be fully reliable. We are actively working on it and it
-                            may change while we work with you on what works best. Please let us know what you'd like to
-                            see here and/or report any issues directly to us!
-                        </p>
-                    </LemonBanner>
-                    <ProductIntroduction
-                        productName="endpoints"
-                        productKey={ProductKey.ENDPOINTS}
-                        thingName="endpoint"
-                        description={
-                            activeTab === 'endpoints'
-                                ? ENDPOINTS_PRODUCT_DESCRIPTION
-                                : ENDPOINTS_API_USAGE_PRODUCT_DESCRIPTION
-                        }
-                        docsURL="https://posthog.com/docs/endpoints"
-                        customHog={BigLeaguesHog}
-                        isEmpty={false}
-                        action={() =>
-                            router.actions.push(
-                                urls.sqlEditor(undefined, undefined, undefined, undefined, OutputTab.Endpoint)
-                            )
-                        }
-                    />
-                    <LemonTabs activeKey={activeTab} data-attr="endpoints-tabs" tabs={tabs} sceneInset />
-                </SceneContent>
+                                    <LemonButton
+                                        type="primary"
+                                        to={urls.sqlEditor(
+                                            undefined,
+                                            undefined,
+                                            undefined,
+                                            undefined,
+                                            OutputTab.Endpoint
+                                        )}
+                                        sideAction={{
+                                            dropdown: {
+                                                placement: 'bottom-end',
+                                                className: 'new-endpoint-overlay',
+                                                actionable: true,
+                                                overlay: <OverlayForNewEndpointMenu dataAttr="new-endpoint-option" />,
+                                            },
+                                            'data-attr': 'new-endpoint-dropdown',
+                                        }}
+                                        data-attr="new-endpoint-button"
+                                        size="small"
+                                        icon={<IconPlusSmall />}
+                                    >
+                                        New
+                                    </LemonButton>
+                                </AppShortcut>
+                            }
+                        />
+                        <LemonBanner
+                            type="warning"
+                            dismissKey="endpoints-beta-banner"
+                            action={{ children: 'Send feedback', id: 'endpoints-feedback-button' }}
+                        >
+                            <p>
+                                Endpoints is in beta and it may not be fully reliable. We are actively working on it and
+                                it may change while we work with you on what works best. Please let us know what you'd
+                                like to see here and/or report any issues directly to us!
+                            </p>
+                        </LemonBanner>
+                        <ProductIntroduction
+                            productName="endpoints"
+                            productKey={ProductKey.ENDPOINTS}
+                            thingName="endpoint"
+                            description={
+                                activeTab === 'usage'
+                                    ? ENDPOINTS_USAGE_PRODUCT_DESCRIPTION
+                                    : ENDPOINTS_PRODUCT_DESCRIPTION
+                            }
+                            docsURL="https://posthog.com/docs/endpoints"
+                            customHog={BigLeaguesHog}
+                            isEmpty={false}
+                            action={() =>
+                                router.actions.push(
+                                    urls.sqlEditor(undefined, undefined, undefined, undefined, OutputTab.Endpoint)
+                                )
+                            }
+                        />
+                        <LemonTabs activeKey={activeTab} data-attr="endpoints-tabs" tabs={tabs} sceneInset />
+                    </SceneContent>
+                </BindLogic>
             </BindLogic>
         </BindLogic>
     )

--- a/products/endpoints/frontend/EndpointsUsage.tsx
+++ b/products/endpoints/frontend/EndpointsUsage.tsx
@@ -1,61 +1,118 @@
-import clsx from 'clsx'
 import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { Link } from 'lib/lemon-ui/Link'
+import { humanFriendlyDuration, humanFriendlyNumber, humanizeBytes } from 'lib/utils'
+import { urls } from 'scenes/urls'
 
 import { Query } from '~/queries/Query/Query'
+import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
+import { QueryContext } from '~/queries/types'
 
 import { EndpointsUsageFilters } from './EndpointsUsageFilters'
-import { EndpointsUsageQueryTile } from './common'
 import { endpointsUsageLogic } from './endpointsUsageLogic'
 
 export function EndpointsUsage({ tabId }: { tabId: string }): JSX.Element {
-    const { tiles } = useValues(endpointsUsageLogic({ tabId }))
+    const {
+        overviewQuery,
+        requestsTrendsQuery,
+        bytesReadTrendsQuery,
+        cpuSecondsTrendsQuery,
+        queryDurationTrendsQuery,
+        errorRateTrendsQuery,
+        endpointTableQuery,
+    } = useValues(endpointsUsageLogic({ tabId }))
+
+    const tableContext: QueryContext<DataTableNode> = useMemo(
+        () => ({
+            columns: {
+                endpoint: {
+                    title: 'Endpoint',
+                    render: ({ value }) => {
+                        if (!value || typeof value !== 'string') {
+                            return <>{value}</>
+                        }
+                        return <Link to={urls.endpoint(value)}>{value}</Link>
+                    },
+                },
+                requests: {
+                    title: 'Executions',
+                    render: ({ value }) => <>{humanFriendlyNumber(value as number)}</>,
+                },
+                bytes_read: {
+                    title: 'Bytes read',
+                    render: ({ value }) => <>{humanizeBytes(value as number)}</>,
+                },
+                cpu_seconds: {
+                    title: 'CPU time',
+                    render: ({ value }) => <>{humanFriendlyDuration(value as number)}</>,
+                },
+                avg_query_duration_ms: {
+                    title: 'Avg query duration',
+                    render: ({ value }) => <>{humanFriendlyDuration((value as number) / 1000)}</>,
+                },
+                error_rate: {
+                    title: 'Error rate',
+                    render: ({ value }) => <>{((value as number) * 100).toFixed(2)}%</>,
+                },
+            },
+        }),
+        []
+    )
 
     return (
         <>
             <EndpointsUsageFilters tabId={tabId} />
-            <EndpointsUsageTiles tiles={tiles} />
-        </>
-    )
-}
-
-const EndpointsUsageTiles = (props: { tiles: EndpointsUsageQueryTile[] }): JSX.Element => {
-    const { tiles } = props
-    return (
-        <div className="mt-4 grid grid-cols-1 md:grid-cols-4 gap-x-4 gap-y-8">
-            {tiles.map((tile, i) => {
-                if (tile.kind === 'query') {
-                    return <EndpointsUsageQueryTileItem key={i} tile={tile} />
-                }
-                return null
-            })}
-        </div>
-    )
-}
-
-const EndpointsUsageQueryTileItem = ({ tile }: { tile: EndpointsUsageQueryTile }): JSX.Element => {
-    const { query, title, layout } = tile
-
-    return (
-        <div
-            className={clsx(
-                'col-span-1 row-span-1 flex flex-col',
-                layout.colSpanClassName ?? 'md:col-span-6',
-                layout.rowSpanClassName ?? 'md:row-span-1',
-                layout.orderWhenLargeClassName ?? 'xxl:order-12',
-                layout.className
-            )}
-        >
-            {title && (
-                <div className="flex flex-row items-center mb-3">
-                    <h2>{title}</h2>
+            <div className="mt-4 grid grid-cols-1 md:grid-cols-4 gap-x-4 gap-y-8">
+                <div className="col-span-1 md:col-span-4 flex flex-col">
+                    <h2 className="mb-3">Overview</h2>
+                    <Query query={overviewQuery} readOnly />
                 </div>
-            )}
 
-            <Query
-                key={`${tile.tileId}-${query.kind === 'DataVisualizationNode' ? JSON.stringify(query.chartSettings?.seriesBreakdownColumn) : 'no-breakdown'}`}
-                query={query}
-                readOnly={true}
-            />
-        </div>
+                {/* Row 1: Executions, Error rate, Query duration */}
+                <div className="col-span-1 md:col-span-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="flex flex-col">
+                        <h2 className="mb-3">Executions over time</h2>
+                        <Query query={requestsTrendsQuery} readOnly />
+                    </div>
+                    <div className="flex flex-col">
+                        <h2 className="mb-3">Error rate over time</h2>
+                        <Query query={errorRateTrendsQuery} readOnly />
+                    </div>
+                    <div className="flex flex-col">
+                        <h2 className="mb-3">Query duration over time</h2>
+                        <Query query={queryDurationTrendsQuery} readOnly />
+                    </div>
+                </div>
+
+                {/* Row 2: CPU time, Bytes read */}
+                <div className="col-span-1 md:col-span-2 flex flex-col">
+                    <h2 className="mb-3">CPU time over time</h2>
+                    <Query query={cpuSecondsTrendsQuery} readOnly />
+                </div>
+
+                <div className="col-span-1 md:col-span-2 flex flex-col">
+                    <h2 className="mb-3">Bytes read over time</h2>
+                    <Query query={bytesReadTrendsQuery} readOnly />
+                </div>
+
+                <div className="col-span-1 md:col-span-4 flex flex-col">
+                    <h2 className="mb-3">Endpoints breakdown</h2>
+                    <Query
+                        query={
+                            {
+                                kind: NodeKind.DataTableNode,
+                                source: endpointTableQuery,
+                                full: true,
+                                showActions: false,
+                                embedded: false,
+                            } as DataTableNode
+                        }
+                        context={tableContext}
+                        readOnly
+                    />
+                </div>
+            </div>
+        </>
     )
 }

--- a/products/endpoints/frontend/common.ts
+++ b/products/endpoints/frontend/common.ts
@@ -1,7 +1,6 @@
 import { PostHogComDocsURL } from 'lib/lemon-ui/Link/Link'
 
-import { NodeKind, QuerySchema } from '~/queries/schema/schema-general'
-import { InsightLogicProps } from '~/types'
+import { NodeKind } from '~/queries/schema/schema-general'
 
 /**
  * Converts a NodeKind query type to a user-friendly display name by removing the 'Query' suffix.
@@ -11,59 +10,8 @@ export function humanizeQueryKind(kind: NodeKind | string): string {
     return kind.endsWith('Query') ? kind.slice(0, -5) : kind
 }
 
-export const INITIAL_DATE_FROM = '-7d' as string
-export const INITIAL_DATE_TO = null as string | null
-export const INITIAL_REQUEST_NAME_BREAKDOWN_ENABLED = false as boolean
-
-export interface EndpointsUsageTileLayout {
-    /** The class has to be spelled out without interpolation, as otherwise Tailwind can't pick it up. */
-    colSpanClassName?: `md:col-span-${number}` | 'md:col-span-full'
-    /** The class has to be spelled out without interpolation, as otherwise Tailwind can't pick it up. */
-    rowSpanClassName?: `md:row-span-${number}`
-    /** The class has to be spelled out without interpolation, as otherwise Tailwind can't pick it up. */
-    orderWhenLargeClassName?: `xxl:order-${number}`
-    className?: string
-}
-
-export enum EndpointsUsageTileId {
-    API_QUERIES_COUNT = 'API_QUERIES_COUNT',
-    API_READ_TB = 'API_READ_TB',
-    API_CPU_SECONDS = 'API_CPU_SECONDS',
-    API_QUERIES_PER_KEY = 'API_QUERIES_PER_KEY',
-    API_LAST_20_QUERIES = 'API_LAST_20_QUERIES',
-    API_EXPENSIVE_QUERIES = 'API_EXPENSIVE_QUERIES',
-    API_FAILED_QUERIES = 'API_FAILED_QUERIES',
-}
-
-export const loadPriorityMap: Record<EndpointsUsageTileId, number> = {
-    [EndpointsUsageTileId.API_QUERIES_COUNT]: 1,
-    [EndpointsUsageTileId.API_READ_TB]: 2,
-    [EndpointsUsageTileId.API_CPU_SECONDS]: 3,
-    [EndpointsUsageTileId.API_QUERIES_PER_KEY]: 4,
-    [EndpointsUsageTileId.API_LAST_20_QUERIES]: 5,
-    [EndpointsUsageTileId.API_EXPENSIVE_QUERIES]: 6,
-    [EndpointsUsageTileId.API_FAILED_QUERIES]: 7,
-}
-
-export interface EndpointsUsageBaseTile {
-    tileId: EndpointsUsageTileId
-    layout: EndpointsUsageTileLayout
-    docs?: EndpointsDocs
-}
-
 export interface EndpointsDocs {
     url?: PostHogComDocsURL
     title: string
     description: string | JSX.Element
-}
-
-export interface EndpointsUsageQueryTile extends EndpointsUsageBaseTile {
-    kind: 'query'
-    title?: string
-    query: QuerySchema
-    showIntervalSelect?: boolean
-    control?: JSX.Element
-    insightProps: InsightLogicProps
-    canOpenModal?: boolean
-    canOpenInsight?: boolean
 }

--- a/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointConfiguration.tsx
@@ -9,6 +9,7 @@ import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { DataWarehouseSyncInterval } from '~/types'
 
 import { endpointLogic } from '../endpointLogic'
+import { endpointSceneLogic } from '../endpointSceneLogic'
 
 interface EndpointConfigurationProps {
     tabId: string
@@ -50,16 +51,10 @@ function getStatusTagType(status: string | undefined): 'success' | 'danger' | 'w
 }
 
 export function EndpointConfiguration({ tabId }: EndpointConfigurationProps): JSX.Element {
-    const { setCacheAge, setSyncFrequency, setIsMaterialized, loadMaterializationStatus } = useActions(
-        endpointLogic({ tabId })
-    )
-    const {
-        endpoint,
-        cacheAge,
-        syncFrequency,
-        isMaterialized: localIsMaterialized,
-        materializationStatusLoading,
-    } = useValues(endpointLogic({ tabId }))
+    const { loadMaterializationStatus } = useActions(endpointLogic({ tabId }))
+    const { endpoint, materializationStatusLoading } = useValues(endpointLogic({ tabId }))
+    const { setCacheAge, setSyncFrequency, setIsMaterialized } = useActions(endpointSceneLogic({ tabId }))
+    const { cacheAge, syncFrequency, isMaterialized: localIsMaterialized } = useValues(endpointSceneLogic({ tabId }))
 
     if (!endpoint) {
         return <></>

--- a/products/endpoints/frontend/endpoint-tabs/EndpointQuery.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointQuery.tsx
@@ -14,8 +14,8 @@ import { Query } from '~/queries/Query/Query'
 import { HogQLQuery, HogQLVariable, Node } from '~/queries/schema/schema-general'
 import { isHogQLQuery } from '~/queries/utils'
 
-import { endpointLogic } from './endpointLogic'
-import { endpointSceneLogic } from './endpointSceneLogic'
+import { endpointLogic } from '../endpointLogic'
+import { endpointSceneLogic } from '../endpointSceneLogic'
 
 function formatVariableValue(variable: HogQLVariable): { text: string; isPlaceholder: boolean } {
     if (variable.value === undefined || variable.value === null || variable.value === '') {

--- a/products/endpoints/frontend/endpointLogic.tsx
+++ b/products/endpoints/frontend/endpointLogic.tsx
@@ -11,7 +11,7 @@ import { urls } from 'scenes/urls'
 
 import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
 import { EndpointRequest } from '~/queries/schema/schema-general'
-import { DataWarehouseSyncInterval, EndpointType } from '~/types'
+import { EndpointType } from '~/types'
 
 import type { endpointLogicType } from './endpointLogicType'
 import { endpointsLogic } from './endpointsLogic'
@@ -36,9 +36,6 @@ export const endpointLogic = kea<endpointLogicType>([
         setSelectedCodeExampleVersion: (version: number | null) => ({ version }),
         setIsUpdateMode: (isUpdateMode: boolean) => ({ isUpdateMode }),
         setSelectedEndpointName: (selectedEndpointName: string | null) => ({ selectedEndpointName }),
-        setCacheAge: (cacheAge: number | null) => ({ cacheAge }),
-        setSyncFrequency: (syncFrequency: DataWarehouseSyncInterval | null) => ({ syncFrequency }),
-        setIsMaterialized: (isMaterialized: boolean | null) => ({ isMaterialized }),
         createEndpoint: (request: EndpointRequest) => ({ request }),
         createEndpointSuccess: (response: any) => ({ response }),
         createEndpointFailure: () => ({}),
@@ -77,24 +74,6 @@ export const endpointLogic = kea<endpointLogicType>([
                 setSelectedEndpointName: (_, { selectedEndpointName }) => selectedEndpointName,
             },
         ],
-        cacheAge: [
-            null as number | null,
-            {
-                setCacheAge: (_, { cacheAge }) => cacheAge,
-            },
-        ],
-        syncFrequency: [
-            '24hour' as DataWarehouseSyncInterval | null,
-            {
-                setSyncFrequency: (_, { syncFrequency }) => syncFrequency,
-            },
-        ],
-        isMaterialized: [
-            null as boolean | null,
-            {
-                setIsMaterialized: (_, { isMaterialized }) => isMaterialized,
-            },
-        ],
     }),
     loaders(({ actions, values }) => ({
         endpoint: [
@@ -116,11 +95,6 @@ export const endpointLogic = kea<endpointLogicType>([
                         console.error('Failed to fetch last execution time:', error)
                     }
 
-                    // TODO: This does not belong here. Refactor to the endpointSceneLogic?
-                    actions.setCacheAge(endpoint.cache_age_seconds ?? null)
-                    actions.setSyncFrequency(endpoint.materialization?.sync_frequency ?? null)
-                    actions.setIsMaterialized(endpoint.is_materialized ?? null)
-
                     return endpoint
                 },
             },
@@ -133,11 +107,6 @@ export const endpointLogic = kea<endpointLogicType>([
                         return null
                     }
                     const materializationStatus = await api.endpoint.getMaterializationStatus(name)
-
-                    // Update the local state if needed
-                    if (materializationStatus?.sync_frequency) {
-                        actions.setSyncFrequency(materializationStatus.sync_frequency)
-                    }
 
                     // Update the endpoint object with the new materialization status
                     if (values.endpoint) {

--- a/products/endpoints/frontend/endpointSceneLogic.tsx
+++ b/products/endpoints/frontend/endpointSceneLogic.tsx
@@ -10,7 +10,7 @@ import { urls } from 'scenes/urls'
 
 import { DataTableNode, EndpointRunRequest, InsightVizNode, Node, NodeKind } from '~/queries/schema/schema-general'
 import { isHogQLQuery, isInsightQueryNode } from '~/queries/utils'
-import { Breadcrumb, EndpointType } from '~/types'
+import { Breadcrumb, DataWarehouseSyncInterval, EndpointType } from '~/types'
 
 import { endpointLogic } from './endpointLogic'
 import type { endpointSceneLogicType } from './endpointSceneLogicType'
@@ -66,6 +66,9 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
         setLocalQuery: (query: Node | null) => ({ query }),
         setActiveTab: (tab: EndpointTab) => ({ tab }),
         setPayloadJson: (value: string) => ({ value }),
+        setCacheAge: (cacheAge: number | null) => ({ cacheAge }),
+        setSyncFrequency: (syncFrequency: DataWarehouseSyncInterval | null) => ({ syncFrequency }),
+        setIsMaterialized: (isMaterialized: boolean | null) => ({ isMaterialized }),
     }),
     reducers({
         localQuery: [
@@ -85,6 +88,24 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             '' as string,
             {
                 setPayloadJson: (_, { value }) => value,
+            },
+        ],
+        cacheAge: [
+            null as number | null,
+            {
+                setCacheAge: (_, { cacheAge }) => cacheAge,
+            },
+        ],
+        syncFrequency: [
+            '24hour' as DataWarehouseSyncInterval | null,
+            {
+                setSyncFrequency: (_, { syncFrequency }) => syncFrequency,
+            },
+        ],
+        isMaterialized: [
+            null as boolean | null,
+            {
+                setIsMaterialized: (_, { isMaterialized }) => isMaterialized,
             },
         ],
     }),
@@ -163,6 +184,9 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
         loadEndpointSuccess: ({ endpoint }: { endpoint: EndpointType | null; payload?: string }) => {
             const initialPayload = generateInitialPayloadJson(endpoint)
             actions.setPayloadJson(initialPayload)
+            actions.setCacheAge(endpoint?.cache_age_seconds ?? null)
+            actions.setSyncFrequency(endpoint?.materialization?.sync_frequency ?? null)
+            actions.setIsMaterialized(endpoint?.is_materialized ?? null)
         },
     })),
     tabAwareUrlToAction(({ actions, values }) => ({

--- a/products/endpoints/frontend/endpointsLogic.tsx
+++ b/products/endpoints/frontend/endpointsLogic.tsx
@@ -11,6 +11,8 @@ import { EndpointType } from '~/types'
 
 import type { endpointsLogicType } from './endpointsLogicType'
 
+export type EndpointsTab = 'endpoints' | 'usage'
+
 export interface EndpointsFilters {
     search: string
 }
@@ -29,6 +31,7 @@ export const endpointsLogic = kea<endpointsLogicType>([
     key((props) => props.tabId),
     actions({
         setFilters: (filters: Partial<EndpointsFilters>) => ({ filters }),
+        setActiveTab: (activeTab: EndpointsTab) => ({ activeTab }),
     }),
     loaders(() => ({
         allEndpoints: [
@@ -62,6 +65,12 @@ export const endpointsLogic = kea<endpointsLogicType>([
                 setFilters: (state, { filters }) => ({ ...state, ...filters }),
             },
         ],
+        activeTab: [
+            'endpoints' as EndpointsTab,
+            {
+                setActiveTab: (_, { activeTab }) => activeTab,
+            },
+        ],
     }),
     selectors({
         endpoints: [
@@ -85,7 +94,11 @@ export const endpointsLogic = kea<endpointsLogicType>([
 
     tabAwareUrlToAction(({ actions }) => ({
         [urls.endpoints()]: () => {
+            actions.setActiveTab('endpoints')
             actions.loadEndpoints()
+        },
+        [urls.endpointsUsage()]: () => {
+            actions.setActiveTab('usage')
         },
     })),
 ])

--- a/products/endpoints/frontend/nodes/EndpointsUsageOverviewNode.tsx
+++ b/products/endpoints/frontend/nodes/EndpointsUsageOverviewNode.tsx
@@ -1,0 +1,194 @@
+import { BuiltLogic, LogicWrapper, useValues } from 'kea'
+import { useState } from 'react'
+
+import { LemonSkeleton } from '@posthog/lemon-ui'
+
+import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
+import { humanFriendlyDuration, humanFriendlyNumber, humanizeBytes } from 'lib/utils'
+import { cn } from 'lib/utils/css-classes'
+
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import {
+    AnyResponseType,
+    EndpointsUsageOverviewItem,
+    EndpointsUsageOverviewQuery,
+    EndpointsUsageOverviewQueryResponse,
+} from '~/queries/schema/schema-general'
+import { QueryContext } from '~/queries/types'
+
+const HEIGHT_CLASS = 'h-24'
+
+type MetricKey =
+    | 'total_requests'
+    | 'total_bytes_read'
+    | 'total_cpu_seconds'
+    | 'avg_query_duration_ms'
+    | 'p95_query_duration_ms'
+    | 'error_rate'
+    | 'materialized_requests'
+    | 'inline_requests'
+
+const LABEL_FROM_KEY: Record<MetricKey, string> = {
+    total_requests: 'Total executions',
+    total_bytes_read: 'Total bytes read',
+    total_cpu_seconds: 'CPU seconds',
+    avg_query_duration_ms: 'Avg duration',
+    p95_query_duration_ms: 'P95 duration',
+    error_rate: 'Error rate',
+    materialized_requests: 'Materialized executions',
+    inline_requests: 'Direct executions',
+}
+
+const PRIMARY_METRICS: MetricKey[] = ['total_requests', 'total_bytes_read', 'total_cpu_seconds']
+const SECONDARY_METRICS: MetricKey[] = [
+    'avg_query_duration_ms',
+    'p95_query_duration_ms',
+    'error_rate',
+    'materialized_requests',
+    'inline_requests',
+]
+
+type Item = {
+    key: MetricKey
+    label: string
+    loading: boolean
+    item?: EndpointsUsageOverviewItem
+}
+
+let uniqueNode = 0
+export function EndpointsUsageOverviewNode(props: {
+    query: EndpointsUsageOverviewQuery
+    cachedResults?: AnyResponseType
+    context: QueryContext
+    attachTo?: LogicWrapper | BuiltLogic
+}): JSX.Element | null {
+    const { onData, loadPriority, dataNodeCollectionId } = props.context.insightProps ?? {}
+    const [key] = useState(() => `EndpointsUsageOverview.${uniqueNode++}`)
+    const logic = dataNodeLogic({
+        query: props.query,
+        key,
+        cachedResults: props.cachedResults,
+        loadPriority,
+        onData,
+        dataNodeCollectionId: dataNodeCollectionId ?? key,
+    })
+
+    useAttachedLogic(logic, props.attachTo)
+
+    const { response, responseLoading } = useValues(logic)
+    const queryResponse = response as EndpointsUsageOverviewQueryResponse | undefined
+
+    const responseByKey = (queryResponse?.results?.reduce(
+        (acc, item) => {
+            acc[item.key as MetricKey] = item
+            return acc
+        },
+        {} as Record<MetricKey, EndpointsUsageOverviewItem>
+    ) ?? {}) as Record<MetricKey, EndpointsUsageOverviewItem>
+
+    const primaryResults: Item[] = PRIMARY_METRICS.map((metricKey) => ({
+        key: metricKey,
+        label: LABEL_FROM_KEY[metricKey],
+        loading: responseLoading,
+        item: responseByKey[metricKey],
+    }))
+
+    const secondaryResults: Item[] = SECONDARY_METRICS.map((metricKey) => ({
+        key: metricKey,
+        label: LABEL_FROM_KEY[metricKey],
+        loading: responseLoading,
+        item: responseByKey[metricKey],
+    }))
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="flex flex-row flex-wrap md:flex-nowrap w-full gap-2">
+                {primaryResults.map((item, index) => (
+                    <div key={item?.key ?? index} className={cn(HEIGHT_CLASS, 'flex-1 min-w-[200px]')}>
+                        <ItemCell item={item} isPrimary />
+                    </div>
+                ))}
+            </div>
+            <div className="flex flex-row flex-wrap md:flex-nowrap w-full gap-2">
+                {secondaryResults.map((item, index) => (
+                    <div key={item?.key ?? index} className={cn(HEIGHT_CLASS, 'flex-1 min-w-[150px]')}>
+                        <ItemCell item={item} isPrimary={false} />
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+const ItemCell = ({ item, isPrimary }: { item: Item; isPrimary: boolean }): JSX.Element => {
+    const value: React.ReactNode = item.loading ? (
+        <LemonSkeleton className="w-1/3 h-6" />
+    ) : (
+        <div
+            className={cn(
+                'w-full flex-1 flex items-center justify-center',
+                isPrimary ? 'text-2xl font-bold' : 'text-xl'
+            )}
+        >
+            {item.item ? formatItem(item.item) : <span className="text-muted text-sm">No data</span>}
+        </div>
+    )
+
+    // TODO: See how Web Analytics does this
+    const changeIndicator =
+        !item.loading && item.item?.changeFromPreviousPct != null ? (
+            <div
+                className={cn(
+                    'text-xs',
+                    item.item.changeFromPreviousPct > 0
+                        ? 'text-success'
+                        : item.item.changeFromPreviousPct < 0
+                          ? 'text-danger'
+                          : 'text-muted'
+                )}
+            >
+                {item.item.changeFromPreviousPct > 0 ? '+' : ''}
+                {item.item.changeFromPreviousPct.toFixed(1)}%
+            </div>
+        ) : null
+
+    return (
+        <div className="flex flex-col items-center text-center justify-around w-full h-full border p-2 bg-surface-primary rounded">
+            <div className="font-medium text-xs text-muted uppercase">{item.label}</div>
+            {value}
+            {changeIndicator}
+        </div>
+    )
+}
+
+const formatItem = (item: EndpointsUsageOverviewItem): string => {
+    const value = item.value
+
+    if (value === null || value === undefined) {
+        return '0'
+    }
+
+    switch (item.key) {
+        case 'total_requests':
+        case 'materialized_requests':
+        case 'inline_requests':
+            return humanFriendlyNumber(value)
+
+        case 'total_bytes_read':
+            return humanizeBytes(value)
+
+        case 'total_cpu_seconds':
+            return humanFriendlyDuration(value)
+
+        case 'avg_query_duration_ms':
+        case 'p95_query_duration_ms':
+            // Convert ms to seconds for humanFriendlyDuration
+            return humanFriendlyDuration(value / 1000)
+
+        case 'error_rate':
+            return `${(value * 100).toFixed(2)}%`
+
+        default:
+            return humanFriendlyNumber(value)
+    }
+}

--- a/products/endpoints/frontend/nodes/EndpointsUsageTrendsNode.tsx
+++ b/products/endpoints/frontend/nodes/EndpointsUsageTrendsNode.tsx
@@ -1,0 +1,268 @@
+import { BuiltLogic, LogicWrapper, useValues } from 'kea'
+import { useState } from 'react'
+
+import { LemonSkeleton } from '@posthog/lemon-ui'
+
+import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
+
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { LineGraph } from '~/queries/nodes/DataVisualization/Components/Charts/LineGraph'
+import { AxisSeries } from '~/queries/nodes/DataVisualization/dataVisualizationLogic'
+import {
+    AnyResponseType,
+    EndpointsUsageTrendsQuery,
+    EndpointsUsageTrendsQueryResponse,
+} from '~/queries/schema/schema-general'
+import { QueryContext } from '~/queries/types'
+import { ChartDisplayType } from '~/types'
+
+type TrendsDataPoint = {
+    date: string
+    value: number
+    breakdown?: string
+}
+
+let uniqueNode = 0
+export function EndpointsUsageTrendsNode(props: {
+    query: EndpointsUsageTrendsQuery
+    cachedResults?: AnyResponseType
+    context: QueryContext
+    attachTo?: LogicWrapper | BuiltLogic
+}): JSX.Element | null {
+    const { onData, loadPriority, dataNodeCollectionId } = props.context.insightProps ?? {}
+    const [key] = useState(() => `EndpointsUsageTrends.${uniqueNode++}`)
+    const logic = dataNodeLogic({
+        query: props.query,
+        key,
+        cachedResults: props.cachedResults,
+        loadPriority,
+        onData,
+        dataNodeCollectionId: dataNodeCollectionId ?? key,
+    })
+
+    useAttachedLogic(logic, props.attachTo)
+
+    const { response, responseLoading } = useValues(logic)
+    const queryResponse = response as EndpointsUsageTrendsQueryResponse | undefined
+
+    if (responseLoading) {
+        return (
+            <div className="border rounded bg-bg-light p-4 h-60">
+                <LemonSkeleton className="w-full h-full" />
+            </div>
+        )
+    }
+
+    const results = queryResponse?.results as TrendsDataPoint[] | undefined
+
+    if (!results || results.length === 0) {
+        return (
+            <div className="flex items-center justify-center h-60 border rounded bg-bg-light text-muted">
+                No data available for this period
+            </div>
+        )
+    }
+
+    const { xData, yData } = transformDataForLineGraph(results, props.query.metric)
+
+    // Use area chart for CPU time and bytes read (sparkline-like), line chart for others
+    const chartType =
+        props.query.metric === 'cpu_seconds' || props.query.metric === 'bytes_read'
+            ? ChartDisplayType.ActionsAreaGraph
+            : ChartDisplayType.ActionsLineGraph
+
+    return (
+        <div className="border rounded bg-bg-light p-2 h-60">
+            <LineGraph
+                xData={xData}
+                yData={yData}
+                visualizationType={chartType}
+                chartSettings={{
+                    showLegend: yData.length > 1,
+                }}
+            />
+        </div>
+    )
+}
+
+interface ScaleFactor {
+    divisor: number
+    label: string
+    suffix: string
+    decimalPlaces: number
+}
+
+function getScaleFactor(values: number[], metric: string): ScaleFactor {
+    if (values.length === 0) {
+        return { divisor: 1, label: getMetricLabel(metric), suffix: '', decimalPlaces: 0 }
+    }
+
+    const maxValue = Math.max(...values)
+
+    if (metric === 'bytes_read') {
+        if (maxValue >= 1024 * 1024 * 1024) {
+            return { divisor: 1024 * 1024 * 1024, label: 'Bytes read (GB)', suffix: ' GB', decimalPlaces: 2 }
+        } else if (maxValue >= 1024 * 1024) {
+            return { divisor: 1024 * 1024, label: 'Bytes read (MB)', suffix: ' MB', decimalPlaces: 2 }
+        } else if (maxValue >= 1024) {
+            return { divisor: 1024, label: 'Bytes read (KB)', suffix: ' KB', decimalPlaces: 2 }
+        }
+        return { divisor: 1, label: 'Bytes read (B)', suffix: ' B', decimalPlaces: 0 }
+    }
+
+    if (metric === 'query_duration') {
+        if (maxValue >= 60000) {
+            return { divisor: 60000, label: 'Query duration (min)', suffix: ' min', decimalPlaces: 2 }
+        } else if (maxValue >= 1000) {
+            return { divisor: 1000, label: 'Query duration (s)', suffix: ' s', decimalPlaces: 2 }
+        }
+        return { divisor: 1, label: 'Query duration (ms)', suffix: ' ms', decimalPlaces: 0 }
+    }
+
+    if (metric === 'cpu_seconds') {
+        if (maxValue >= 60) {
+            return { divisor: 60, label: 'CPU time (min)', suffix: ' min', decimalPlaces: 2 }
+        }
+        return { divisor: 1, label: 'CPU time (s)', suffix: ' s', decimalPlaces: 2 }
+    }
+
+    if (metric === 'error_rate') {
+        // Error rate comes as 0-1, display as percentage
+        return { divisor: 0.01, label: 'Error rate (%)', suffix: '%', decimalPlaces: 2 }
+    }
+
+    return { divisor: 1, label: getMetricLabel(metric), suffix: '', decimalPlaces: 0 }
+}
+
+function scaleMetricData(
+    values: number[],
+    metric: string
+): {
+    values: number[]
+    label: string
+    settings: { formatting: { suffix: string; decimalPlaces: number } }
+} {
+    const { divisor, label, suffix, decimalPlaces } = getScaleFactor(values, metric)
+    return {
+        values: values.map((v) => v / divisor),
+        label,
+        settings: { formatting: { suffix, decimalPlaces } },
+    }
+}
+
+function transformDataForLineGraph(
+    results: TrendsDataPoint[],
+    metric: string
+): {
+    xData: AxisSeries<string>
+    yData: AxisSeries<number>[]
+} {
+    const hasBreakdown = results.some((r) => r.breakdown !== undefined)
+
+    if (hasBreakdown) {
+        // Group by breakdown value
+        const breakdowns = [...new Set(results.map((r) => r.breakdown || 'unknown'))]
+
+        // Group by date
+        const dateGroups = results.reduce(
+            (acc, point) => {
+                const dateKey = point.date
+                if (!acc[dateKey]) {
+                    acc[dateKey] = {}
+                }
+                acc[dateKey][point.breakdown || 'unknown'] = point.value
+                return acc
+            },
+            {} as Record<string, Record<string, number>>
+        )
+
+        const dates = Object.keys(dateGroups).sort()
+
+        // Determine scale based on all values for consistency across breakdowns
+        const allValues = results.map((r) => r.value)
+        const scaleFactor = getScaleFactor(allValues, metric)
+
+        return {
+            xData: {
+                column: {
+                    name: 'date',
+                    type: { name: 'DATE', isNumerical: false },
+                    label: 'Date',
+                    dataIndex: 0,
+                },
+                data: dates.map(formatDate),
+            },
+            yData: breakdowns.map((breakdown, index) => {
+                const breakdownValues = dates.map((date) => dateGroups[date][breakdown] || 0)
+                return {
+                    column: {
+                        name: breakdown,
+                        type: { name: 'FLOAT', isNumerical: true },
+                        label: breakdown,
+                        dataIndex: index + 1,
+                    },
+                    data: breakdownValues.map((v) => v / scaleFactor.divisor),
+                    settings: {
+                        formatting: {
+                            suffix: scaleFactor.suffix,
+                            decimalPlaces: scaleFactor.decimalPlaces,
+                        },
+                    },
+                }
+            }),
+        }
+    }
+
+    // Simple case - no breakdown
+    const rawValues = results.map((r) => r.value)
+    const { values: scaledValues, label: scaledLabel, settings } = scaleMetricData(rawValues, metric)
+
+    return {
+        xData: {
+            column: {
+                name: 'date',
+                type: { name: 'DATE', isNumerical: false },
+                label: 'Date',
+                dataIndex: 0,
+            },
+            data: results.map((r) => formatDate(r.date)),
+        },
+        yData: [
+            {
+                column: {
+                    name: metric,
+                    type: { name: 'FLOAT', isNumerical: true },
+                    label: scaledLabel,
+                    dataIndex: 1,
+                },
+                data: scaledValues,
+                settings,
+            },
+        ],
+    }
+}
+
+function formatDate(dateStr: string): string {
+    try {
+        const date = new Date(dateStr)
+        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    } catch {
+        return dateStr
+    }
+}
+
+function getMetricLabel(metric: string): string {
+    switch (metric) {
+        case 'bytes_read':
+            return 'Bytes read'
+        case 'cpu_seconds':
+            return 'CPU time'
+        case 'query_duration':
+            return 'Query duration'
+        case 'error_rate':
+            return 'Error rate'
+        case 'requests':
+        default:
+            return 'Executions'
+    }
+}

--- a/products/endpoints/frontend/nodes/index.ts
+++ b/products/endpoints/frontend/nodes/index.ts
@@ -1,0 +1,2 @@
+export { EndpointsUsageOverviewNode } from './EndpointsUsageOverviewNode'
+export { EndpointsUsageTrendsNode } from './EndpointsUsageTrendsNode'

--- a/products/endpoints/manifest.tsx
+++ b/products/endpoints/manifest.tsx
@@ -1,3 +1,5 @@
+import { combineUrl } from 'kea-router'
+
 import { FEATURE_FLAGS } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
@@ -18,14 +20,6 @@ export const manifest: ProductManifest = {
             iconType: 'endpoints',
             description: 'Define queries your application will use via the API and monitor their cost and usage.',
         },
-        EndpointsUsage: {
-            import: () => import('./frontend/EndpointsUsage'),
-            projectBased: true,
-            name: 'Endpoints usage',
-            activityScope: 'Endpoints',
-            layout: 'app-container',
-            iconType: 'endpoints',
-        },
         EndpointScene: {
             import: () => import('./frontend/EndpointScene'),
             projectBased: true,
@@ -35,7 +29,6 @@ export const manifest: ProductManifest = {
     },
     routes: {
         '/endpoints': ['EndpointsScene', 'endpoints'],
-        // EndpointsScene stays first as scene for Usage!
         '/endpoints/usage': ['EndpointsScene', 'endpointsUsage'],
         '/endpoints/:name': ['EndpointScene', 'endpoint'],
     },
@@ -43,14 +36,36 @@ export const manifest: ProductManifest = {
         endpoints: (): string => '/endpoints',
         endpoint: (name: string): string => `/endpoints/${name}`,
         endpointsUsage: (params?: {
+            endpointFilter?: string[]
             dateFrom?: string
             dateTo?: string
-            requestNameBreakdownEnabled?: string
-            requestNameFilter?: string[]
+            materializationType?: 'materialized' | 'inline'
+            interval?: string
+            breakdownBy?: string
         }): string => {
-            const queryParams = new URLSearchParams(params as Record<string, string>)
-            const stringifiedParams = queryParams.toString()
-            return `/endpoints/usage${stringifiedParams ? `?${stringifiedParams}` : ''}`
+            if (!params) {
+                return '/endpoints/usage'
+            }
+            const searchParams: Record<string, string> = {}
+            if (params.endpointFilter?.length) {
+                searchParams.endpointFilter = params.endpointFilter.join(',')
+            }
+            if (params.dateFrom) {
+                searchParams.dateFrom = params.dateFrom
+            }
+            if (params.dateTo) {
+                searchParams.dateTo = params.dateTo
+            }
+            if (params.materializationType) {
+                searchParams.materializationType = params.materializationType
+            }
+            if (params.interval) {
+                searchParams.interval = params.interval
+            }
+            if (params.breakdownBy) {
+                searchParams.breakdownBy = params.breakdownBy
+            }
+            return combineUrl('/endpoints/usage', searchParams).url
         },
     },
     fileSystemTypes: {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

the `Usage` tab on Endpoints is useless atm, as it shows pretty much all API requests. didn't make sense for that to be there

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- create a new Endpoints `Usage` tab that shows more relevant charts,
- and create the corresponding Query runner for these queries woohoo

![image.png](https://app.graphite.com/user-attachments/assets/0ddd950a-ac5e-45e8-802f-f3c038f9b591.png)



## How did you test this code?

locallyyy

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->

yeah why not :))