### PR TITLE
feat(capture-logs): dump last failed request to disk in log capture for debugging

### DIFF
--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -11,9 +11,9 @@ use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use prost::Message;
 use serde::Deserialize;
 use serde_json::json;
-use std::sync::Arc;
 use std::fs::File;
 use std::io::Write;
+use std::sync::Arc;
 
 use crate::kafka::KafkaSink;
 
@@ -121,8 +121,8 @@ pub async fn export_logs_http(
                 //
                 if let Err(e) = File::create("/tmp/last_failed_event.txt").and_then(|mut file|
                     // write the raw message to a file prepended by the token for debugging
-                    file.write_all(token.as_bytes()).and_then(|_| file.write_all(&body))
-                ) {
+                    file.write_all(token.as_bytes()).and_then(|_| file.write_all(&body)))
+                {
                     error!("Failed to write last failed event to file: {}", e);
                 }
                 error!(

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -12,6 +12,8 @@ use prost::Message;
 use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
+use std::fs::File;
+use std::io::Write;
 
 use crate::kafka::KafkaSink;
 
@@ -114,6 +116,15 @@ pub async fn export_logs_http(
         Err(proto_err) => match serde_json::from_slice(&body) {
             Ok(request) => request,
             Err(json_err) => {
+                // Write last failed event to a file
+                // To make this super simple, we literally write a single event to /tmp/last_failed_event.txt
+                //
+                if let Err(e) = File::create("/tmp/last_failed_event.txt").and_then(|mut file|
+                    // write the raw message to a file prepended by the token for debugging
+                    file.write_all(token.as_bytes()).and_then(|_| file.write_all(&body))
+                ) {
+                    error!("Failed to write last failed event to file: {}", e);
+                }
                 error!(
                     "Failed to decode JSON: {} or Protobuf: {}",
                     json_err, proto_err


### PR DESCRIPTION
## Problem

we have a bunch of log capture requests which return 400s due to json deserialization errors, which we have no way of debugging

## Changes

to keep things _super_ simple, we just dump the last failed request to a file under /tmp - to debug things we'll need to copy this file out from pods, we can pull out a bunch over time to get an idea of what the problem could be

longer term we probably want to write to a dql or something for more structured debugging, but this is very low effort and low risk and will help in the short term
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
it's rust - if it compiles it's good - right?

also ran locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
No