### PR TITLE
feat(array): task ui improvements

### DIFF
--- a/products/tasks/frontend/components/TaskDetailPage.tsx
+++ b/products/tasks/frontend/components/TaskDetailPage.tsx
@@ -5,6 +5,7 @@ import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { urls } from 'scenes/urls'
 
 import {
     ScenePanel,
@@ -25,7 +26,7 @@ export interface TaskDetailPageProps {
 
 export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
     const sceneLogic = taskDetailSceneLogic({ taskId })
-    const { task, taskLoading, runs, selectedRunId, selectedRun, runsLoading, logs, shouldPoll } = useValues(sceneLogic)
+    const { task, runs, selectedRunId, selectedRun, runsLoading, logs, shouldPoll } = useValues(sceneLogic)
     const { setSelectedRunId, runTask, deleteTask } = useActions(sceneLogic)
 
     if (!task) {
@@ -86,7 +87,7 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
                                         key={run.id}
                                         run={run}
                                         isSelected={run.id === selectedRunId}
-                                        onClick={() => setSelectedRunId(run.id)}
+                                        onClick={() => setSelectedRunId(run.id, taskId)}
                                     />
                                 ))}
                             </div>
@@ -99,8 +100,13 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
                 name={task?.title}
                 description={task?.description}
                 resourceType={{ type: 'task' }}
-                isLoading={taskLoading}
+                isLoading={false}
                 canEdit={false}
+                forceBackTo={{
+                    key: 'tasks',
+                    name: 'Tasks',
+                    path: urls.taskTracker(),
+                }}
                 actions={
                     <div className="flex items-center gap-2">
                         <LemonButton

--- a/products/tasks/frontend/logics/taskDetailSceneLogic.test.ts
+++ b/products/tasks/frontend/logics/taskDetailSceneLogic.test.ts
@@ -72,7 +72,10 @@ describe('taskDetailSceneLogic', () => {
             await expectLogic(logicA).toFinishAllListeners()
             await expectLogic(logicB).toFinishAllListeners()
 
-            const taskAResult = { ...createMockTask('task-A'), latest_run: createMockRun('run-A', TaskRunStatus.QUEUED) }
+            const taskAResult = {
+                ...createMockTask('task-A'),
+                latest_run: createMockRun('run-A', TaskRunStatus.QUEUED),
+            }
             logicA.actions.runTaskSuccess(taskAResult)
             await expectLogic(logicA).toFinishAllListeners()
             await expectLogic(logicB).toFinishAllListeners()

--- a/products/tasks/frontend/logics/taskDetailSceneLogic.test.ts
+++ b/products/tasks/frontend/logics/taskDetailSceneLogic.test.ts
@@ -1,0 +1,141 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { OriginProduct, Task, TaskRun, TaskRunStatus } from '../types'
+import { taskDetailSceneLogic } from './taskDetailSceneLogic'
+import { tasksLogic } from './tasksLogic'
+
+const createMockTask = (id: string): Task => ({
+    id,
+    task_number: 1,
+    slug: `task-${id}`,
+    title: `Task ${id}`,
+    description: 'A test task',
+    origin_product: OriginProduct.USER_CREATED,
+    repository: 'test/repo',
+    github_integration: null,
+    latest_run: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    created_by: null,
+})
+
+const createMockRun = (id: string, status: TaskRunStatus): TaskRun => ({
+    id,
+    task: 'task-123',
+    stage: null,
+    branch: null,
+    status,
+    log_url: null,
+    error_message: null,
+    output: null,
+    state: {},
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    completed_at: null,
+})
+
+describe('taskDetailSceneLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    describe('setSelectedRunId cross-talk prevention', () => {
+        it('only updates selectedRunId for the matching taskId', async () => {
+            const logicA = taskDetailSceneLogic({ taskId: 'task-A' })
+            const logicB = taskDetailSceneLogic({ taskId: 'task-B' })
+            logicA.mount()
+            logicB.mount()
+            await expectLogic(logicA).toFinishAllListeners()
+            await expectLogic(logicB).toFinishAllListeners()
+
+            expect(logicA.values.selectedRunId).toBe(null)
+            expect(logicB.values.selectedRunId).toBe(null)
+
+            logicA.actions.setSelectedRunId('run-A', 'task-A')
+            await expectLogic(logicA).toFinishAllListeners()
+            await expectLogic(logicB).toFinishAllListeners()
+
+            expect(logicA.values.selectedRunId).toBe('run-A')
+            expect(logicB.values.selectedRunId).toBe(null)
+
+            logicA.unmount()
+            logicB.unmount()
+        })
+
+        it('runTaskSuccess only processes events for its own task', async () => {
+            const logicA = taskDetailSceneLogic({ taskId: 'task-A' })
+            const logicB = taskDetailSceneLogic({ taskId: 'task-B' })
+            logicA.mount()
+            logicB.mount()
+            await expectLogic(logicA).toFinishAllListeners()
+            await expectLogic(logicB).toFinishAllListeners()
+
+            const taskAResult = { ...createMockTask('task-A'), latest_run: createMockRun('run-A', TaskRunStatus.QUEUED) }
+            logicA.actions.runTaskSuccess(taskAResult)
+            await expectLogic(logicA).toFinishAllListeners()
+            await expectLogic(logicB).toFinishAllListeners()
+
+            expect(logicA.values.selectedRunId).toBe('run-A')
+            expect(logicB.values.selectedRunId).toBe(null)
+
+            logicA.unmount()
+            logicB.unmount()
+        })
+    })
+
+    describe('updateRun', () => {
+        it('updates run status in runs list when polling', async () => {
+            const logic = taskDetailSceneLogic({ taskId: 'task-123' })
+            logic.mount()
+
+            const initialRun = createMockRun('run-456', TaskRunStatus.QUEUED)
+            logic.actions.loadRunsSuccess([initialRun])
+            expect(logic.values.runs[0].status).toBe(TaskRunStatus.QUEUED)
+
+            const updatedRun = createMockRun('run-456', TaskRunStatus.IN_PROGRESS)
+            logic.actions.updateRun(updatedRun)
+
+            expect(logic.values.runs[0].status).toBe(TaskRunStatus.IN_PROGRESS)
+            logic.unmount()
+        })
+
+        it('does not affect other runs in the list', async () => {
+            const logic = taskDetailSceneLogic({ taskId: 'task-123' })
+            logic.mount()
+
+            const run1 = createMockRun('run-1', TaskRunStatus.COMPLETED)
+            const run2 = createMockRun('run-2', TaskRunStatus.QUEUED)
+            logic.actions.loadRunsSuccess([run1, run2])
+
+            const updatedRun2 = createMockRun('run-2', TaskRunStatus.IN_PROGRESS)
+            logic.actions.updateRun(updatedRun2)
+
+            expect(logic.values.runs[0].status).toBe(TaskRunStatus.COMPLETED)
+            expect(logic.values.runs[1].status).toBe(TaskRunStatus.IN_PROGRESS)
+            logic.unmount()
+        })
+    })
+
+    describe('loadTaskSuccess updates tasksLogic', () => {
+        it('updates sidebar tasks list when task loads', async () => {
+            const tasksLogicInstance = tasksLogic()
+            tasksLogicInstance.mount()
+            const mockTask = createMockTask('task-123')
+            tasksLogicInstance.actions.loadTasksSuccess([mockTask])
+
+            const logic = taskDetailSceneLogic({ taskId: 'task-123' })
+            logic.mount()
+
+            const updatedTask = { ...mockTask, title: 'New Title' }
+            logic.actions.loadTaskSuccess(updatedTask)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(tasksLogicInstance.values.tasks.find((t) => t.id === 'task-123')?.title).toBe('New Title')
+
+            logic.unmount()
+            tasksLogicInstance.unmount()
+        })
+    })
+})

--- a/products/tasks/frontend/logics/taskDetailSceneLogic.ts
+++ b/products/tasks/frontend/logics/taskDetailSceneLogic.ts
@@ -35,8 +35,11 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
     key((props) => props.taskId),
 
     connect((props: TaskDetailSceneLogicProps) => ({
-        values: [taskLogic(props), ['task', 'taskLoading']],
-        actions: [taskLogic(props), ['loadTask', 'loadTaskSuccess', 'runTask', 'runTaskSuccess', 'deleteTask', 'updateTask']],
+        values: [taskLogic(props), ['task']],
+        actions: [
+            taskLogic(props),
+            ['loadTask', 'loadTaskSuccess', 'runTask', 'runTaskSuccess', 'deleteTask', 'updateTask'],
+        ],
     })),
 
     actions({

--- a/products/tasks/frontend/logics/taskDetailSceneLogic.ts
+++ b/products/tasks/frontend/logics/taskDetailSceneLogic.ts
@@ -36,46 +36,55 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
 
     connect((props: TaskDetailSceneLogicProps) => ({
         values: [taskLogic(props), ['task', 'taskLoading']],
-        actions: [taskLogic(props), ['loadTask', 'runTask', 'deleteTask', 'updateTask']],
+        actions: [taskLogic(props), ['loadTask', 'loadTaskSuccess', 'runTask', 'runTaskSuccess', 'deleteTask', 'updateTask']],
     })),
 
     actions({
-        setSelectedRunId: (runId: TaskRun['id'] | null) => ({ runId }),
+        setSelectedRunId: (runId: TaskRun['id'] | null, taskId: string) => ({ runId, taskId }),
         selectLatestRun: true,
+        clearShouldSelectLatestRun: true,
         startPolling: true,
         stopPolling: true,
         setLogs: (logs: string) => ({ logs }),
+        updateRun: (run: TaskRun) => ({ run }),
     }),
 
-    reducers({
+    reducers(({ props }) => ({
         selectedRunId: [
             null as TaskRun['id'] | null,
             {
-                setSelectedRunId: (_, { runId }) => runId,
+                setSelectedRunId: (state, { runId, taskId }) => (taskId === props.taskId ? runId : state),
             },
         ],
         shouldSelectLatestRun: [
             false,
             {
                 selectLatestRun: () => true,
-                loadRunsSuccess: () => false,
+                clearShouldSelectLatestRun: () => false,
             },
         ],
         logs: [
             '' as string,
             {
-                setSelectedRunId: () => '',
+                setSelectedRunId: (state, { taskId }) => (taskId === props.taskId ? '' : state),
                 setLogs: (_, { logs }) => logs,
             },
         ],
         isInitialLogsLoad: [
             true as boolean,
             {
-                setSelectedRunId: () => true,
+                setSelectedRunId: (state, { taskId }) => (taskId === props.taskId ? true : state),
                 setLogs: () => false,
             },
         ],
-    }),
+        runs: [
+            [] as TaskRun[],
+            {
+                updateRun: (state: TaskRun[], { run }: { run: TaskRun }) =>
+                    state.map((r) => (r.id === run.id ? run : r)),
+            },
+        ],
+    })),
 
     loaders(({ props, values, actions }) => ({
         runs: [
@@ -170,31 +179,50 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
         ],
     }),
 
-    listeners(({ actions, values }) => ({
-        setSelectedRunId: () => {
+    listeners(({ actions, values, props }) => ({
+        setSelectedRunId: ({ taskId }) => {
+            if (taskId !== props.taskId) {
+                return
+            }
             actions.stopPolling()
             actions.loadSelectedRun()
         },
-        runTaskSuccess: () => {
-            actions.selectLatestRun()
+        runTaskSuccess: ({ task }) => {
+            if (task?.id !== props.taskId) {
+                return
+            }
+            if (task?.latest_run) {
+                actions.setSelectedRunId(task.latest_run.id, props.taskId)
+            }
             actions.loadRuns()
         },
         loadRunsSuccess: ({ runs }) => {
-            if (values.shouldSelectLatestRun && runs.length > 0) {
-                actions.setSelectedRunId(runs[0].id)
+            const shouldSelect = values.shouldSelectLatestRun
+            if (shouldSelect) {
+                actions.clearShouldSelectLatestRun()
+            }
+            if (shouldSelect && runs.length > 0) {
+                actions.setSelectedRunId(runs[0].id, props.taskId)
             } else if (values.selectedRunId) {
                 actions.loadSelectedRun()
             }
         },
         loadSelectedRunSuccess: ({ selectedRunData }) => {
             if (selectedRunData) {
-                tasksLogic.findMounted()?.actions.updateTaskRun(values.taskId, selectedRunData)
+                actions.updateRun(selectedRunData)
             }
+            actions.loadTask()
             if (values.shouldPoll) {
                 actions.startPolling()
             } else {
                 actions.stopPolling()
             }
+        },
+        loadTaskSuccess: ({ task }) => {
+            if (task?.id !== props.taskId) {
+                return
+            }
+            tasksLogic.findMounted()?.actions.updateTask(task)
         },
         loadLogsSuccess: ({ rawLogs }) => {
             if (rawLogs) {
@@ -234,11 +262,15 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
         }
     }),
 
-    urlToAction(({ actions, values }) => ({
-        [urls.taskDetail(':taskId')]: (_, searchParams) => {
+    urlToAction(({ actions, values, props }) => ({
+        [urls.taskDetail(':taskId')]: (params, searchParams) => {
+            const { taskId: urlTaskId } = params
+            if (urlTaskId !== props.taskId) {
+                return
+            }
             const runIdFromUrl = searchParams.runId
             if (runIdFromUrl && runIdFromUrl !== values.selectedRunId) {
-                actions.setSelectedRunId(runIdFromUrl)
+                actions.setSelectedRunId(runIdFromUrl, props.taskId)
             }
         },
     })),

--- a/products/tasks/frontend/logics/taskLogic.test.ts
+++ b/products/tasks/frontend/logics/taskLogic.test.ts
@@ -1,0 +1,89 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { OriginProduct, Task, TaskRunStatus } from '../types'
+import { taskLogic } from './taskLogic'
+import { tasksLogic } from './tasksLogic'
+
+const createMockTask = (id: string): Task => ({
+    id,
+    task_number: 1,
+    slug: `task-${id}`,
+    title: `Task ${id}`,
+    description: 'A test task',
+    origin_product: OriginProduct.USER_CREATED,
+    repository: 'test/repo',
+    github_integration: null,
+    latest_run: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    created_by: null,
+})
+
+describe('taskLogic', () => {
+    let logic: ReturnType<typeof taskLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    describe('loadTaskSuccess', () => {
+        it('updates tasksLogic with fresh task', async () => {
+            const tasksLogicInstance = tasksLogic()
+            tasksLogicInstance.mount()
+            const mockTask = createMockTask('task-123')
+            tasksLogicInstance.actions.loadTasksSuccess([mockTask])
+
+            logic = taskLogic({ taskId: 'task-123' })
+            logic.mount()
+
+            const updatedTask = { ...mockTask, title: 'Updated Title' }
+            logic.actions.loadTaskSuccess(updatedTask)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(tasksLogicInstance.values.tasks.find((t) => t.id === 'task-123')?.title).toBe('Updated Title')
+            tasksLogicInstance.unmount()
+        })
+    })
+
+    describe('runTaskSuccess', () => {
+        it('updates tasksLogic with task including new run', async () => {
+            const tasksLogicInstance = tasksLogic()
+            tasksLogicInstance.mount()
+            const mockTask = createMockTask('task-123')
+            tasksLogicInstance.actions.loadTasksSuccess([mockTask])
+
+            logic = taskLogic({ taskId: 'task-123' })
+            logic.mount()
+
+            const taskWithRun: Task = {
+                ...mockTask,
+                latest_run: {
+                    id: 'run-456',
+                    task: 'task-123',
+                    stage: null,
+                    branch: null,
+                    status: TaskRunStatus.QUEUED,
+                    log_url: null,
+                    error_message: null,
+                    output: null,
+                    state: {},
+                    created_at: '2024-01-01T00:00:00Z',
+                    updated_at: '2024-01-01T00:00:00Z',
+                    completed_at: null,
+                },
+            }
+            logic.actions.runTaskSuccess(taskWithRun)
+            await expectLogic(logic).toFinishAllListeners()
+
+            const updated = tasksLogicInstance.values.tasks.find((t) => t.id === 'task-123')
+            expect(updated?.latest_run?.id).toBe('run-456')
+            tasksLogicInstance.unmount()
+        })
+    })
+})

--- a/products/tasks/frontend/logics/taskLogic.ts
+++ b/products/tasks/frontend/logics/taskLogic.ts
@@ -46,10 +46,21 @@ export const taskLogic = kea<taskLogicType>([
             },
         ],
     })),
-
-    listeners(({ actions }) => ({
+    listeners(({ values }) => ({
+        loadTaskSuccess: () => {
+            if (values.task) {
+                tasksLogic.findMounted()?.actions.updateTask(values.task)
+            }
+        },
         runTaskSuccess: () => {
-            actions.loadTask()
+            if (values.task) {
+                tasksLogic.findMounted()?.actions.updateTask(values.task)
+            }
+        },
+        updateTaskSuccess: () => {
+            if (values.task) {
+                tasksLogic.findMounted()?.actions.updateTask(values.task)
+            }
         },
     })),
 ])

--- a/products/tasks/frontend/logics/taskTrackerSceneLogic.ts
+++ b/products/tasks/frontend/logics/taskTrackerSceneLogic.ts
@@ -178,7 +178,12 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
 
                 const newTask = await api.tasks.create(taskData)
                 lemonToast.success('Task created successfully')
-                router.actions.push(`/tasks/${newTask.id}`)
+
+                // Auto-run the task after creation
+                const taskWithRun = await api.tasks.run(newTask.id)
+                const runId = taskWithRun.latest_run?.id
+                router.actions.push(`/tasks/${newTask.id}` + (runId ? `?runId=${runId}` : ''))
+
                 actions.submitNewTaskSuccess()
                 actions.resetNewTaskData()
                 actions.closeCreateModal()

--- a/products/tasks/frontend/logics/tasksLogic.test.ts
+++ b/products/tasks/frontend/logics/tasksLogic.test.ts
@@ -1,0 +1,58 @@
+import { initKeaTests } from '~/test/init'
+
+import { OriginProduct, Task } from '../types'
+import { tasksLogic } from './tasksLogic'
+
+const createMockTask = (id: string): Task => ({
+    id,
+    task_number: 1,
+    slug: `task-${id}`,
+    title: `Task ${id}`,
+    description: 'A test task',
+    origin_product: OriginProduct.USER_CREATED,
+    repository: 'test/repo',
+    github_integration: null,
+    latest_run: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    created_by: null,
+})
+
+describe('tasksLogic', () => {
+    let logic: ReturnType<typeof tasksLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = tasksLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    describe('updateTask', () => {
+        it('replaces task in list', () => {
+            const task1 = createMockTask('task-1')
+            const task2 = createMockTask('task-2')
+            logic.actions.loadTasksSuccess([task1, task2])
+
+            const updatedTask = { ...task1, title: 'Updated Title' }
+            logic.actions.updateTask(updatedTask)
+
+            expect(logic.values.tasks.find((t) => t.id === 'task-1')?.title).toBe('Updated Title')
+            expect(logic.values.tasks).toHaveLength(2)
+        })
+
+        it('does not add task if not already in list', () => {
+            const task1 = createMockTask('task-1')
+            logic.actions.loadTasksSuccess([task1])
+
+            const unknownTask = createMockTask('unknown')
+            logic.actions.updateTask(unknownTask)
+
+            expect(logic.values.tasks).toHaveLength(1)
+            expect(logic.values.tasks[0].id).toBe('task-1')
+        })
+    })
+})

--- a/products/tasks/frontend/logics/tasksLogic.ts
+++ b/products/tasks/frontend/logics/tasksLogic.ts
@@ -6,7 +6,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 
-import { Task, TaskRun, TaskUpsertProps } from '../types'
+import { Task, TaskUpsertProps } from '../types'
 import type { tasksLogicType } from './tasksLogicType'
 
 export const tasksLogic = kea<tasksLogicType>([
@@ -14,7 +14,7 @@ export const tasksLogic = kea<tasksLogicType>([
 
     actions({
         openTask: (taskId: Task['id']) => ({ taskId }),
-        updateTaskRun: (taskId: Task['id'], run: TaskRun) => ({ taskId, run }),
+        updateTask: (task: Task) => ({ task }),
     }),
 
     loaders(({ values }) => ({
@@ -41,8 +41,8 @@ export const tasksLogic = kea<tasksLogicType>([
 
     reducers({
         tasks: {
-            updateTaskRun: (state, { taskId, run }) =>
-                state.map((task) => (task.id === taskId ? { ...task, latest_run: run } : task)),
+            updateTask: (state, { task }) =>
+                state.map((t) => (t.id === task.id ? task : t)),
         },
     }),
 

--- a/products/tasks/frontend/logics/tasksLogic.ts
+++ b/products/tasks/frontend/logics/tasksLogic.ts
@@ -41,8 +41,7 @@ export const tasksLogic = kea<tasksLogicType>([
 
     reducers({
         tasks: {
-            updateTask: (state, { task }) =>
-                state.map((t) => (t.id === task.id ? task : t)),
+            updateTask: (state, { task }) => state.map((t) => (t.id === task.id ? task : t)),
         },
     }),
 


### PR DESCRIPTION
make the task ui more usable in PostHog:
- make the kea logics update task / task run status when we're polling for it in task details
- add a back button on task page
- run task automatically after creating one in the ui