### PR TITLE
feat: Add cohort_id param to realtime cohort calculation

### DIFF
--- a/posthog/admin/admins/realtime_cohort_calculation_admin.py
+++ b/posthog/admin/admins/realtime_cohort_calculation_admin.py
@@ -35,6 +35,12 @@ class RealtimeCohortCalculationForm(forms.Form):
         help_text="Filter cohorts by team_id (optional)",
         label="Team ID",
     )
+    cohort_id = forms.IntegerField(
+        required=False,
+        min_value=1,
+        help_text="Filter to a specific cohort_id (optional)",
+        label="Cohort ID",
+    )
 
 
 def analyze_realtime_cohort_calculation_view(request):
@@ -54,6 +60,8 @@ def analyze_realtime_cohort_calculation_view(request):
             command_args.extend(["--batch-delay-minutes", str(form.cleaned_data["batch_delay_minutes"])])
             if form.cleaned_data.get("team_id"):
                 command_args.extend(["--team-id", str(form.cleaned_data["team_id"])])
+            if form.cleaned_data.get("cohort_id"):
+                command_args.extend(["--cohort-id", str(form.cleaned_data["cohort_id"])])
 
             try:
                 call_command("analyze_realtime_cohort_calculation", *command_args)

--- a/posthog/management/commands/analyze_realtime_cohort_calculation.py
+++ b/posthog/management/commands/analyze_realtime_cohort_calculation.py
@@ -45,12 +45,19 @@ class Command(BaseCommand):
             default=None,
             help="Filter cohorts by team_id (optional)",
         )
+        parser.add_argument(
+            "--cohort-id",
+            type=int,
+            default=None,
+            help="Filter to a specific cohort_id (optional)",
+        )
 
     def handle(self, *args, **options):
         parallelism = options.get("parallelism", 10)
         workflows_per_batch = options.get("workflows_per_batch", 5)
         batch_delay_minutes = options.get("batch_delay_minutes", 5)
         team_id = options.get("team_id")
+        cohort_id = options.get("cohort_id")
 
         logger.info(
             "Starting realtime cohort calculation coordinator",
@@ -58,6 +65,7 @@ class Command(BaseCommand):
             workflows_per_batch=workflows_per_batch,
             batch_delay_minutes=batch_delay_minutes,
             team_id=team_id,
+            cohort_id=cohort_id,
         )
 
         self.run_temporal_workflow(
@@ -65,6 +73,7 @@ class Command(BaseCommand):
             workflows_per_batch=workflows_per_batch,
             batch_delay_minutes=batch_delay_minutes,
             team_id=team_id,
+            cohort_id=cohort_id,
         )
 
         logger.info(
@@ -81,6 +90,7 @@ class Command(BaseCommand):
         workflows_per_batch: int,
         batch_delay_minutes: int,
         team_id: int | None,
+        cohort_id: int | None,
     ) -> None:
         """Run the Temporal workflow for parallel processing."""
 
@@ -94,6 +104,7 @@ class Command(BaseCommand):
                 workflows_per_batch=workflows_per_batch,
                 batch_delay_minutes=batch_delay_minutes,
                 team_id=team_id,
+                cohort_id=cohort_id,
             )
 
             # Generate unique workflow ID

--- a/posthog/templates/admin/realtime_cohort_calculation.html
+++ b/posthog/templates/admin/realtime_cohort_calculation.html
@@ -54,7 +54,14 @@
             {% if form.team_id.help_text %}<p class="help">{{ form.team_id.help_text }}</p>{% endif %}
             {{ form.team_id.errors }}
         </div>
-        
+
+        <div class="form-row">
+            <label for="{{ form.cohort_id.id_for_label }}">{{ form.cohort_id.label }}:</label>
+            {{ form.cohort_id }}
+            {% if form.cohort_id.help_text %}<p class="help">{{ form.cohort_id.help_text }}</p>{% endif %}
+            {{ form.cohort_id.errors }}
+        </div>
+
         <div class="form-row">
             <label for="{{ form.parallelism.id_for_label }}" class="required">
                 {{ form.parallelism.label }}:

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -58,6 +58,7 @@ class RealtimeCohortCalculationWorkflowInputs:
     limit: Optional[int] = None
     offset: int = 0
     team_id: Optional[int] = None
+    cohort_id: Optional[int] = None
 
     @property
     def properties_to_log(self) -> dict[str, Any]:
@@ -65,6 +66,7 @@ class RealtimeCohortCalculationWorkflowInputs:
             "limit": self.limit,
             "offset": self.offset,
             "team_id": self.team_id,
+            "cohort_id": self.cohort_id,
         }
 
 
@@ -88,12 +90,16 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
             if inputs.team_id is not None:
                 queryset = queryset.filter(team_id=inputs.team_id)
 
-            # Apply pagination
-            queryset = (
-                queryset.order_by("id")[inputs.offset : inputs.offset + inputs.limit]
-                if inputs.limit
-                else queryset[inputs.offset :]
-            )
+            # Apply cohort_id filter if provided - skip pagination when filtering by specific cohort
+            if inputs.cohort_id is not None:
+                queryset = queryset.filter(id=inputs.cohort_id)
+            else:
+                # Only apply pagination when not filtering by specific cohort
+                queryset = (
+                    queryset.order_by("id")[inputs.offset : inputs.offset + inputs.limit]
+                    if inputs.limit
+                    else queryset[inputs.offset :]
+                )
 
             return list(queryset)
 

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow_coordinator.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow_coordinator.py
@@ -39,6 +39,7 @@ class RealtimeCohortCalculationCoordinatorWorkflowInputs:
     workflows_per_batch: int = 5  # Number of workflows to start per batch
     batch_delay_minutes: int = 5  # Delay between batches in minutes
     team_id: Optional[int] = None  # Filter by team_id (optional)
+    cohort_id: Optional[int] = None  # Filter to a specific cohort_id (optional)
 
     @property
     def properties_to_log(self) -> dict[str, Any]:
@@ -47,6 +48,7 @@ class RealtimeCohortCalculationCoordinatorWorkflowInputs:
             "workflows_per_batch": self.workflows_per_batch,
             "batch_delay_minutes": self.batch_delay_minutes,
             "team_id": self.team_id,
+            "cohort_id": self.cohort_id,
         }
 
 
@@ -69,6 +71,8 @@ async def get_realtime_cohort_calculation_count_activity(
         queryset = Cohort.objects.filter(deleted=False, cohort_type=CohortType.REALTIME)
         if inputs.team_id is not None:
             queryset = queryset.filter(team_id=inputs.team_id)
+        if inputs.cohort_id is not None:
+            queryset = queryset.filter(id=inputs.cohort_id)
         return queryset.count()
 
     count = await get_cohort_count()
@@ -127,6 +131,7 @@ class RealtimeCohortCalculationCoordinatorWorkflow(PostHogWorkflow):
                         limit=limit,
                         offset=offset,
                         team_id=inputs.team_id,
+                        cohort_id=inputs.cohort_id,
                     ),
                     offset=offset,
                     limit=limit,


### PR DESCRIPTION
## Problem

When testing realtime cohort calculations, it's useful to run the calculation for a specific cohort instead of processing all cohorts. Previously, the workflow only supported filtering by team_id.

## Changes

- Added optional `cohort_id` parameter to the admin form (second parameter after `team_id`)
- Updated management command to accept `--cohort-id` argument
- Modified coordinator and child workflows to filter by cohort_id when provided
- When cohort_id is specified, pagination is skipped and only that specific cohort is processed

## How did you test this code?

- Manually