### PR TITLE
fix(capture-logs): fix empty values breaking json parsing

### DIFF
--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -21,6 +21,7 @@ use tracing::{debug, error, instrument};
 
 // due to a bug in the otel proto rust library we need to patch the json to support (valid) empty Values
 // see https://github.com/open-telemetry/opentelemetry-rust/issues/1253
+// FIXME: remove once upstream has fixed the issue, OR we should fork upstream and fix the issue ourselves
 fn patch_otel_json(v: &mut Value) {
     match v {
         Value::Object(map) => {
@@ -29,8 +30,7 @@ fn patch_otel_json(v: &mut Value) {
             if let Some(inner) = map.get_mut("value") {
                 if inner.is_object()
                     && inner
-                        .as_object()
-                        .and_then(|obj| Some(obj.is_empty()))
+                        .as_object().map(|obj| obj.is_empty())
                         .unwrap_or(false)
                 {
                     *inner = Value::Null;

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -28,10 +28,7 @@ fn patch_otel_json(v: &mut Value) {
             // In OTel, AnyValue is usually a field named "value"
             // If we find "value": {}, change it to "value": null
             if let Some(inner) = map.get_mut("value") {
-                if inner.is_object()
-                    && inner
-                        .as_object().map(|obj| obj.is_empty())
-                        .unwrap_or(false)
+                if inner.is_object() && inner.as_object().map(|obj| obj.is_empty()).unwrap_or(false)
                 {
                     *inner = Value::Null;
                 }

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -27,7 +27,12 @@ fn patch_otel_json(v: &mut Value) {
             // In OTel, AnyValue is usually a field named "value"
             // If we find "value": {}, change it to "value": null
             if let Some(inner) = map.get_mut("value") {
-                if inner.is_object() && inner.as_object().unwrap().is_empty() {
+                if inner.is_object()
+                    && inner
+                        .as_object()
+                        .and_then(|obj| Some(obj.is_empty()))
+                        .unwrap_or(false)
+                {
                     *inner = Value::Null;
                 }
             }

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -10,7 +10,7 @@ use limiters::token_dropper::TokenDropper;
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use prost::Message;
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::fs::File;
 use std::io::Write;
 use std::sync::Arc;
@@ -18,6 +18,39 @@ use std::sync::Arc;
 use crate::kafka::KafkaSink;
 
 use tracing::{debug, error, instrument};
+
+// due to a bug in the otel proto rust library we need to patch the json to support (valid) empty Values
+// see https://github.com/open-telemetry/opentelemetry-rust/issues/1253
+fn patch_otel_json(v: &mut Value) {
+    match v {
+        Value::Object(map) => {
+            // In OTel, AnyValue is usually a field named "value"
+            // If we find "value": {}, change it to "value": null
+            if let Some(inner) = map.get_mut("value") {
+                if inner.is_object() && inner.as_object().unwrap().is_empty() {
+                    *inner = Value::Null;
+                }
+            }
+            // Recurse through all other keys
+            for (_, val) in map.iter_mut() {
+                patch_otel_json(val);
+            }
+        }
+        Value::Array(arr) => {
+            for val in arr.iter_mut() {
+                patch_otel_json(val);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn parse_otel_message(json_bytes: &Bytes) -> Result<ExportLogsServiceRequest, anyhow::Error> {
+    let mut v: Value = serde_json::from_slice(json_bytes)?;
+    patch_otel_json(&mut v);
+    let result: ExportLogsServiceRequest = serde_json::from_value(v)?;
+    Ok(result)
+}
 
 #[derive(Clone)]
 pub struct Service {
@@ -113,7 +146,7 @@ pub async fn export_logs_http(
     // We do this over relying on Content-Type headers to be as permissive as possible in what we accept.
     let export_request = match ExportLogsServiceRequest::decode(body.as_ref()) {
         Ok(request) => request,
-        Err(proto_err) => match serde_json::from_slice(&body) {
+        Err(proto_err) => match parse_otel_message(&body) {
             Ok(request) => request,
             Err(json_err) => {
                 // Write last failed event to a file


### PR DESCRIPTION
## Problem

otel rust library doesn't parse what the spec says is valid json: ({"value": {}} https://github.com/open-telemetry/opentelemetry-rust/issues/1253

## Changes

dynamically patch the json to replace {"value": {}} with {"value": null} which it does correctly parse

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

ran locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
