### PR TITLE
fix(array): update task run status in the workflow

### DIFF
--- a/products/tasks/backend/temporal/__init__.py
+++ b/products/tasks/backend/temporal/__init__.py
@@ -14,6 +14,7 @@ from .process_task.activities import (
     get_task_processing_context,
     post_slack_update,
     track_workflow_event,
+    update_task_run_status,
 )
 from .process_task.workflow import ProcessTaskWorkflow
 
@@ -30,6 +31,7 @@ ACTIVITIES = [
     cleanup_sandbox,
     track_workflow_event,
     post_slack_update,
+    update_task_run_status,
     # create_snapshot activities
     get_snapshot_context,
     snapshot_create_sandbox,

--- a/products/tasks/backend/temporal/process_task/activities/__init__.py
+++ b/products/tasks/backend/temporal/process_task/activities/__init__.py
@@ -8,6 +8,7 @@ from .get_sandbox_for_repository import (
 from .get_task_processing_context import TaskProcessingContext, get_task_processing_context
 from .post_slack_update import PostSlackUpdateInput, post_slack_update
 from .track_workflow_event import TrackWorkflowEventInput, track_workflow_event
+from .update_task_run_status import UpdateTaskRunStatusInput, update_task_run_status
 
 __all__ = [
     "CleanupSandboxInput",
@@ -18,10 +19,12 @@ __all__ = [
     "PostSlackUpdateInput",
     "TaskProcessingContext",
     "TrackWorkflowEventInput",
+    "UpdateTaskRunStatusInput",
     "cleanup_sandbox",
     "execute_task_in_sandbox",
     "get_sandbox_for_repository",
     "get_task_processing_context",
     "post_slack_update",
     "track_workflow_event",
+    "update_task_run_status",
 ]

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -1,0 +1,54 @@
+import pytest
+
+from asgiref.sync import async_to_sync
+
+from products.tasks.backend.models import TaskRun
+from products.tasks.backend.temporal.process_task.activities.update_task_run_status import (
+    UpdateTaskRunStatusInput,
+    update_task_run_status,
+)
+
+
+class TestUpdateTaskRunStatusActivity:
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "status,sets_completed_at",
+        [
+            (TaskRun.Status.IN_PROGRESS, False),
+            (TaskRun.Status.COMPLETED, True),
+            (TaskRun.Status.FAILED, True),
+            (TaskRun.Status.CANCELLED, False),
+        ],
+    )
+    def test_updates_status(self, activity_environment, test_task_run, status, sets_completed_at):
+        input_data = UpdateTaskRunStatusInput(run_id=str(test_task_run.id), status=status)
+        async_to_sync(activity_environment.run)(update_task_run_status, input_data)
+
+        test_task_run.refresh_from_db()
+        assert test_task_run.status == status
+        if sets_completed_at:
+            assert test_task_run.completed_at is not None
+        else:
+            assert test_task_run.completed_at is None
+
+    @pytest.mark.django_db
+    def test_updates_error_message(self, activity_environment, test_task_run):
+        error_msg = "Something went wrong"
+        input_data = UpdateTaskRunStatusInput(
+            run_id=str(test_task_run.id),
+            status=TaskRun.Status.FAILED,
+            error_message=error_msg,
+        )
+        async_to_sync(activity_environment.run)(update_task_run_status, input_data)
+
+        test_task_run.refresh_from_db()
+        assert test_task_run.error_message == error_msg
+
+    @pytest.mark.django_db
+    def test_handles_non_existent_task_run(self, activity_environment):
+        non_existent_run_id = "550e8400-e29b-41d4-a716-446655440000"
+        input_data = UpdateTaskRunStatusInput(
+            run_id=non_existent_run_id,
+            status=TaskRun.Status.IN_PROGRESS,
+        )
+        async_to_sync(activity_environment.run)(update_task_run_status, input_data)

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from django.utils import timezone
+
+from temporalio import activity
+
+from posthog.temporal.common.utils import asyncify
+
+from products.tasks.backend.models import TaskRun
+from products.tasks.backend.temporal.observability import log_with_activity_context
+
+
+@dataclass
+class UpdateTaskRunStatusInput:
+    run_id: str
+    status: str
+    error_message: Optional[str] = None
+
+
+@activity.defn
+@asyncify
+def update_task_run_status(input: UpdateTaskRunStatusInput) -> None:
+    """Update the status of a task run."""
+    log_with_activity_context(
+        "Updating task run status",
+        run_id=input.run_id,
+        status=input.status,
+    )
+
+    try:
+        task_run = TaskRun.objects.get(id=input.run_id)
+    except TaskRun.DoesNotExist:
+        activity.logger.warning(f"TaskRun {input.run_id} not found for status update")
+        return
+
+    task_run.status = input.status
+
+    if input.error_message:
+        task_run.error_message = input.error_message
+
+    if input.status in [TaskRun.Status.COMPLETED, TaskRun.Status.FAILED]:
+        task_run.completed_at = timezone.now()
+
+    task_run.save(update_fields=["status", "error_message", "completed_at", "updated_at"])
+
+    log_with_activity_context(
+        "Task run status updated",
+        run_id=input.run_id,
+        status=input.status,
+    )

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -23,6 +23,7 @@ from products.tasks.backend.temporal.process_task.activities import (
     get_sandbox_for_repository,
     get_task_processing_context,
     track_workflow_event,
+    update_task_run_status,
 )
 from products.tasks.backend.temporal.process_task.workflow import (
     ProcessTaskInput,
@@ -69,6 +70,7 @@ class TestProcessTaskWorkflow:
                         execute_task_in_sandbox,
                         cleanup_sandbox,
                         track_workflow_event,
+                        update_task_run_status,
                     ],
                     workflow_runner=UnsandboxedWorkflowRunner(),
                     activity_executor=ThreadPoolExecutor(max_workers=10),

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -29,6 +29,7 @@ from .activities.get_task_processing_context import (
 )
 from .activities.post_slack_update import PostSlackUpdateInput, post_slack_update
 from .activities.track_workflow_event import TrackWorkflowEventInput, track_workflow_event
+from .activities.update_task_run_status import UpdateTaskRunStatusInput, update_task_run_status
 
 
 @dataclass
@@ -76,6 +77,9 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         try:
             self._context = await self._get_task_processing_context(input)
 
+            # Update status to in_progress
+            await self._update_task_run_status("in_progress")
+
             await self._track_workflow_event(
                 "process_task_workflow_started",
                 {
@@ -109,6 +113,9 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 },
             )
 
+            # Update status to completed
+            await self._update_task_run_status("completed")
+
             await self._post_slack_update()
 
             return ProcessTaskOutput(
@@ -119,12 +126,14 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             )
 
         except asyncio.CancelledError:
+            await self._update_task_run_status("cancelled")
             if sandbox_id:
                 await self._cleanup_sandbox(sandbox_id)
                 sandbox_id = None
             raise
 
         except Exception as e:
+            error_message = str(e)[:500]
             if self._context:
                 await self._track_workflow_event(
                     "process_task_workflow_failed",
@@ -132,10 +141,12 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                         "run_id": run_id,
                         "task_id": self.context.task_id,
                         "error_type": type(e).__name__,
-                        "error_message": str(e)[:500],
+                        "error_message": error_message,
                         "sandbox_id": sandbox_id,
                     },
                 )
+                # Update status to failed
+                await self._update_task_run_status("failed", error_message=error_message)
                 await self._post_slack_update()
 
             return ProcessTaskOutput(
@@ -194,6 +205,18 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             track_input,
             start_to_close_timeout=timedelta(minutes=2),
             retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+
+    async def _update_task_run_status(self, status: str, error_message: Optional[str] = None) -> None:
+        await workflow.execute_activity(
+            update_task_run_status,
+            UpdateTaskRunStatusInput(
+                run_id=self.context.run_id,
+                status=status,
+                error_message=error_message,
+            ),
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
     async def _trigger_snapshot_workflow(self) -> None:

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -76,8 +76,6 @@ class ProcessTaskWorkflow(PostHogWorkflow):
 
         try:
             self._context = await self._get_task_processing_context(input)
-
-            # Update status to in_progress
             await self._update_task_run_status("in_progress")
 
             await self._track_workflow_event(
@@ -113,9 +111,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 },
             )
 
-            # Update status to completed
             await self._update_task_run_status("completed")
-
             await self._post_slack_update()
 
             return ProcessTaskOutput(
@@ -145,7 +141,6 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                         "sandbox_id": sandbox_id,
                     },
                 )
-                # Update status to failed
                 await self._update_task_run_status("failed", error_message=error_message)
                 await self._post_slack_update()
 


### PR DESCRIPTION
We don’t want to rely on the agent updating the status of the task run, we should do this ourselves in the temporal workflow.