### PR TITLE
fix(phai): sync queryset filtering in search and read_data

### DIFF
--- a/ee/hogai/tools/full_text_search/test/test_tool.py
+++ b/ee/hogai/tools/full_text_search/test/test_tool.py
@@ -1,10 +1,12 @@
 from posthog.test.base import NonAtomicBaseTest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from django.conf import settings
 
 from langchain_core.runnables import RunnableConfig
 from parameterized import parameterized
+
+from posthog.models import Action, Cohort, Dashboard, Experiment, FeatureFlag, Insight, Survey
 
 from ee.hogai.context import AssistantContextManager
 from ee.hogai.core.shared_prompts import HYPERLINK_USAGE_INSTRUCTIONS
@@ -13,14 +15,11 @@ from ee.hogai.utils.types.base import AssistantState
 
 
 class TestEntitySearchToolkit(NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
     def setUp(self):
         super().setUp()
-        self.team = Mock()
-        self.team.id = 123
-        self.team.project_id = 456
-        self.team.organization = Mock()
-        self.team.organization.id = 789
-        self.user = Mock()
+
         self.toolkit = EntitySearchTool(
             team=self.team,
             user=self.user,
@@ -228,3 +227,125 @@ class TestEntitySearchToolkit(NonAtomicBaseTest):
     def test_omit_none_values(self, input_obj, expected_output):
         result = self.toolkit._omit_none_values(input_obj)
         assert result == expected_output
+
+    async def test_insight_filters_exclude_deleted(self):
+        await Insight.objects.acreate(
+            team=self.team, name="active insight", deleted=False, saved=True, created_by=self.user
+        )
+        await Insight.objects.acreate(
+            team=self.team, name="deleted insight", deleted=True, saved=True, created_by=self.user
+        )
+
+        result = await self.toolkit.execute(query="insight", search_kind=FTSKind.INSIGHTS)
+
+        # Deleted insights should not appear
+        assert "deleted insight" not in result
+
+    async def test_insight_filters_exclude_unsaved(self):
+        await Insight.objects.acreate(
+            team=self.team, name="saved insight", deleted=False, saved=True, created_by=self.user
+        )
+        await Insight.objects.acreate(
+            team=self.team, name="unsaved insight", deleted=False, saved=False, created_by=self.user
+        )
+
+        result = await self.toolkit.execute(query="insight", search_kind=FTSKind.INSIGHTS)
+
+        # Unsaved insights should not appear
+        assert "unsaved insight" not in result
+
+    async def test_dashboard_filters_exclude_deleted(self):
+        await Dashboard.objects.acreate(team=self.team, name="active dashboard", deleted=False, created_by=self.user)
+        await Dashboard.objects.acreate(team=self.team, name="deleted dashboard", deleted=True, created_by=self.user)
+
+        result = await self.toolkit.execute(query="dashboard", search_kind=FTSKind.DASHBOARDS)
+
+        assert "deleted dashboard" not in result
+
+    async def test_experiment_filters_exclude_deleted(self):
+        flag1 = await FeatureFlag.objects.acreate(team=self.team, key="flag1", created_by=self.user)
+        flag2 = await FeatureFlag.objects.acreate(team=self.team, key="flag2", created_by=self.user)
+        await Experiment.objects.acreate(
+            team=self.team, name="active experiment", deleted=False, created_by=self.user, feature_flag=flag1
+        )
+        await Experiment.objects.acreate(
+            team=self.team, name="deleted experiment", deleted=True, created_by=self.user, feature_flag=flag2
+        )
+
+        result = await self.toolkit.execute(query="experiment", search_kind=FTSKind.EXPERIMENTS)
+
+        assert "deleted experiment" not in result
+
+    async def test_feature_flag_filters_exclude_deleted(self):
+        await FeatureFlag.objects.acreate(
+            team=self.team, key="active_flag", name="active flag", deleted=False, created_by=self.user
+        )
+        await FeatureFlag.objects.acreate(
+            team=self.team, key="deleted_flag", name="deleted flag", deleted=True, created_by=self.user
+        )
+
+        result = await self.toolkit.execute(query="flag", search_kind=FTSKind.FEATURE_FLAGS)
+
+        assert "deleted_flag" not in result
+        assert "deleted" not in result.lower() or "active" in result.lower()
+
+    async def test_action_filters_exclude_deleted(self):
+        await Action.objects.acreate(team=self.team, name="active action", deleted=False, created_by=self.user)
+        await Action.objects.acreate(team=self.team, name="deleted action", deleted=True, created_by=self.user)
+
+        result = await self.toolkit.execute(query="action", search_kind=FTSKind.ACTIONS)
+
+        assert "deleted action" not in result
+
+    async def test_cohort_filters_exclude_deleted(self):
+        await Cohort.objects.acreate(team=self.team, name="active cohort", deleted=False, created_by=self.user)
+        await Cohort.objects.acreate(team=self.team, name="deleted cohort", deleted=True, created_by=self.user)
+
+        result = await self.toolkit.execute(query="cohort", search_kind=FTSKind.COHORTS)
+
+        assert "deleted cohort" not in result
+
+    async def test_survey_filters_exclude_archived(self):
+        await Survey.objects.acreate(
+            team=self.team,
+            name="active survey",
+            archived=False,
+            created_by=self.user,
+            type=Survey.SurveyType.POPOVER,
+        )
+        await Survey.objects.acreate(
+            team=self.team,
+            name="archived survey",
+            archived=True,
+            created_by=self.user,
+            type=Survey.SurveyType.POPOVER,
+        )
+
+        result = await self.toolkit.execute(query="survey", search_kind=FTSKind.SURVEYS)
+
+        assert "archived survey" not in result
+
+    async def test_all_entity_types_respect_filters_exclude_deleted(self):
+        # Create deleted items across multiple entity types
+        await Insight.objects.acreate(
+            team=self.team, name="deleted insight", deleted=True, saved=True, created_by=self.user
+        )
+        await Dashboard.objects.acreate(team=self.team, name="deleted dashboard", deleted=True, created_by=self.user)
+        await Action.objects.acreate(team=self.team, name="deleted action", deleted=True, created_by=self.user)
+        await Cohort.objects.acreate(team=self.team, name="deleted cohort", deleted=True, created_by=self.user)
+        await Survey.objects.acreate(
+            team=self.team,
+            name="archived survey",
+            archived=True,
+            created_by=self.user,
+            type=Survey.SurveyType.POPOVER,
+        )
+
+        result = await self.toolkit.execute(query="deleted", search_kind=FTSKind.ALL)
+
+        # All deleted/archived items should be filtered out
+        assert "deleted insight" not in result
+        assert "deleted dashboard" not in result
+        assert "deleted action" not in result
+        assert "deleted cohort" not in result
+        assert "archived survey" not in result

--- a/ee/hogai/tools/full_text_search/tool.py
+++ b/ee/hogai/tools/full_text_search/tool.py
@@ -27,36 +27,43 @@ ENTITY_MAP: dict[str, EntityConfig] = {
         "klass": Insight,
         "search_fields": {"name": "A", "description": "C", "query_metadata": "B"},
         "extra_fields": ["name", "description", "query_metadata", "query"],
+        "filters": {"deleted": False, "saved": True},
     },
     "dashboard": {
         "klass": Dashboard,
         "search_fields": {"name": "A", "description": "C"},
         "extra_fields": ["name", "description"],
+        "filters": {"deleted": False},
     },
     "experiment": {
         "klass": Experiment,
         "search_fields": {"name": "A", "description": "C"},
         "extra_fields": ["name", "description"],
+        "filters": {"deleted": False},
     },
     "feature_flag": {
         "klass": FeatureFlag,
         "search_fields": {"key": "A", "name": "C"},
         "extra_fields": ["key", "name"],
+        "filters": {"deleted": False},
     },
     "action": {
         "klass": Action,
         "search_fields": {"name": "A", "description": "C"},
         "extra_fields": ["name", "description"],
+        "filters": {"deleted": False},
     },
     "cohort": {
         "klass": Cohort,
         "search_fields": {"name": "A", "description": "C", "filters": "B"},
         "extra_fields": ["name", "description", "filters"],
+        "filters": {"deleted": False},
     },
     "survey": {
         "klass": Survey,
         "search_fields": {"name": "A", "description": "C"},
         "extra_fields": ["name", "description"],
+        "filters": {"archived": False},
     },
     "error_tracking_issue": {
         "klass": ErrorTrackingIssue,


### PR DESCRIPTION
## Problem

The search tool returns all entities: deleted and unsaved. It causes [this](https://us.posthog.com/project/2/error_tracking/019b2be7-5544-7bc2-b6d6-5d6801ea0b5f?timestamp=2025-12-18%2003:51:19.895000-08:00) error.

## Changes

- Added the `filters` parameter with custom queryset filters.
- Updated the search tool to sync it with the read_data tool.

## How did you test this code?

Unit tests & manual testing

