### PR TITLE
chore: migrate existing broken hogql variables on endpoints

### DIFF
--- a/products/endpoints/backend/migrations/0007_fix_hogql_variable_keys.py
+++ b/products/endpoints/backend/migrations/0007_fix_hogql_variable_keys.py
@@ -1,0 +1,94 @@
+from django.db import migrations
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+def fix_variable_keys(apps, schema_editor):
+    """Fix endpoints where query.variables keys are 'var_0', 'var_1' instead of variableId.
+
+    The frontend was incorrectly saving variables with keys like 'var_0' instead of
+    using the actual variableId. This migration re-keys the variables dict to use
+    the variableId from each variable's value.
+    """
+    Endpoint = apps.get_model("endpoints", "Endpoint")
+    EndpointVersion = apps.get_model("endpoints", "EndpointVersion")
+
+    def rekey_variables(variables: dict) -> tuple[dict, bool]:
+        """Transform variables dict to use variableId as key.
+
+        Returns: (new_variables_dict, was_modified)
+        """
+        if not variables:
+            return variables, False
+
+        needs_fix = any(key.startswith("var_") for key in variables.keys())
+        if not needs_fix:
+            return variables, False
+
+        new_variables = {}
+        for key, value in variables.items():
+            variable_id = value.get("variableId")
+            if variable_id:
+                new_variables[variable_id] = value
+            else:
+                new_variables[key] = value
+
+        return new_variables, True
+
+    endpoints_updated = 0
+    for endpoint in Endpoint.objects.all():
+        query = endpoint.query
+        if not query or query.get("kind") != "HogQLQuery":
+            continue
+
+        variables = query.get("variables", {})
+        new_variables, was_modified = rekey_variables(variables)
+
+        if was_modified:
+            query["variables"] = new_variables
+            endpoint.query = query
+            endpoint.save(update_fields=["query"])
+            endpoints_updated += 1
+
+    versions_updated = 0
+    for version in EndpointVersion.objects.all():
+        query = version.query
+        if not query or query.get("kind") != "HogQLQuery":
+            continue
+
+        variables = query.get("variables", {})
+        new_variables, was_modified = rekey_variables(variables)
+
+        if was_modified:
+            query["variables"] = new_variables
+            version.query = query
+            version.save(update_fields=["query"])
+            versions_updated += 1
+
+    logger.info(
+        "finished_0007_fix_hogql_variable_keys",
+        endpoints_updated=endpoints_updated,
+        versions_updated=versions_updated,
+    )
+
+
+def reverse_migration(apps, schema_editor):
+    """No-op reverse migration.
+
+    We can't reverse this migration because we don't know what the original
+    var_X keys were and they're broken anyways.
+    The new format is correct and backwards compatible.
+    """
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("endpoints", "0006_endpoint_derived_from_insight"),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_variable_keys, reverse_migration),
+    ]

--- a/products/endpoints/backend/migrations/max_migration.txt
+++ b/products/endpoints/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0006_endpoint_derived_from_insight
+0007_fix_hogql_variable_keys


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

#43475 fixed how we save and use variables in endpoints. i'd like to be able to tell customers it now just works.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- go from `"variables": {"var_0": {..., "variableId": "uuid-123"}}` to `"variables": {"uuid-123": {..., "variableId": "uuid-123"}}`

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
ran it locally a few times

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
yep - variables should work on existing endpoints with hogql queries