### PR TITLE
feat(batch-exports): add rows and bytes exported to runs list

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportRuns.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportRuns.tsx
@@ -156,7 +156,7 @@ function BatchExportLatestRuns({ id }: BatchExportRunsLogicProps): JSX.Element {
                         title: 'Rows exported',
                         key: 'rowsExported',
                         render: (_, run) => {
-                            if (!run.records_completed) {
+                            if (run.records_completed == null) {
                                 return ''
                             }
                             return humanFriendlyNumber(run.records_completed)
@@ -166,7 +166,7 @@ function BatchExportLatestRuns({ id }: BatchExportRunsLogicProps): JSX.Element {
                         title: 'Bytes exported',
                         key: 'bytesExported',
                         render: (_, run) => {
-                            if (!run.bytes_exported) {
+                            if (run.bytes_exported == null) {
                                 return ''
                             }
                             return humanizeBytes(run.bytes_exported)

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportRuns.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportRuns.tsx
@@ -262,6 +262,26 @@ export function BatchExportRunsGrouped({
                                         render: (_, run) => run.id,
                                     },
                                     {
+                                        title: 'Rows exported',
+                                        key: 'rowsExported',
+                                        render: (_, run) => {
+                                            if (run.records_completed == null) {
+                                                return ''
+                                            }
+                                            return humanFriendlyNumber(run.records_completed)
+                                        },
+                                    },
+                                    {
+                                        title: 'Bytes exported',
+                                        key: 'bytesExported',
+                                        render: (_, run) => {
+                                            if (run.bytes_exported == null) {
+                                                return ''
+                                            }
+                                            return humanizeBytes(run.bytes_exported)
+                                        },
+                                    },
+                                    {
                                         title: 'Run start',
                                         key: 'runStart',
                                         tooltip: 'Date and time when this BatchExport run started',

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportRuns.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportRuns.tsx
@@ -8,6 +8,7 @@ import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { NotFound } from 'lib/components/NotFound'
 import { TZLabel } from 'lib/components/TZLabel'
 import { IconCancel } from 'lib/lemon-ui/icons'
+import { humanFriendlyNumber, humanizeBytes } from 'lib/utils'
 
 import { BatchExportConfiguration, BatchExportRun, GroupedBatchExportRuns } from '~/types'
 
@@ -149,6 +150,26 @@ function BatchExportLatestRuns({ id }: BatchExportRunsLogicProps): JSX.Element {
                                     formatTime="HH:mm:ss"
                                 />
                             )
+                        },
+                    },
+                    {
+                        title: 'Rows exported',
+                        key: 'rowsExported',
+                        render: (_, run) => {
+                            if (!run.records_completed) {
+                                return ''
+                            }
+                            return humanFriendlyNumber(run.records_completed)
+                        },
+                    },
+                    {
+                        title: 'Bytes exported',
+                        key: 'bytesExported',
+                        render: (_, run) => {
+                            if (!run.bytes_exported) {
+                                return ''
+                            }
+                            return humanizeBytes(run.bytes_exported)
                         },
                     },
                     {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5309,6 +5309,8 @@ export type RawBatchExportRun = {
     data_interval_start?: string
     data_interval_end: string
     last_updated_at?: string
+    records_completed?: number
+    bytes_exported?: number
 }
 
 export type BatchExportRun = {
@@ -5327,6 +5329,8 @@ export type BatchExportRun = {
     data_interval_start?: Dayjs
     data_interval_end: Dayjs
     last_updated_at?: Dayjs
+    records_completed?: number
+    bytes_exported?: number
 }
 
 export type GroupedBatchExportRuns = {


### PR DESCRIPTION
## Problem

We don't display useful metrics such as rows exported and bytes exported in the front end.

## Changes

Enhanced `BatchExportLatestRuns` component to display rows exported and bytes exported using human-friendly formats.

Works when there are runs with no data exported and old runs where we weren't recording this information:

<img width="1562" height="318" alt="image" src="https://github.com/user-attachments/assets/121f546e-644e-4049-8447-d0c855a0dbf0" />

Have also updated the `BatchExportRunsGrouped` component:

<img width="1564" height="419" alt="image" src="https://github.com/user-attachments/assets/b8a8b4f3-a140-4d78-bc73-9a3180e5ace1" />



## How did you test this code?

Tested using local stack.

## Changelog: (features only) Is this feature complete?

Yes, this is just a small UI change.
