### PR TITLE
fix(embed): add result message emitting for callback flows

### DIFF
--- a/rust/common/types/src/lib.rs
+++ b/rust/common/types/src/lib.rs
@@ -41,6 +41,9 @@ pub mod embedding {
     pub use crate::embeddings::EmbeddingModel;
     pub use crate::embeddings::EmbeddingRecord;
     pub use crate::embeddings::EmbeddingRequest;
+    pub use crate::embeddings::EmbeddingResponse;
+    pub use crate::embeddings::EmbeddingResult;
+    pub use crate::embeddings::ModelResult;
 }
 
 pub mod format {

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -408,6 +408,7 @@ impl OutputErrProps {
                 EmbeddingModel::OpenAITextEmbeddingLarge,
                 EmbeddingModel::OpenAITextEmbeddingSmall,
             ],
+            metadata: Default::default(),
         }
     }
 }

--- a/rust/embedding-worker/src/config.rs
+++ b/rust/embedding-worker/src/config.rs
@@ -21,6 +21,11 @@ pub struct Config {
     #[envconfig(nested = true)]
     pub kafka: KafkaConfig,
 
+    // To other services, like ET, that want to take some action after a document is embedded and written to CH
+    #[envconfig(default = "document_embedding_results")]
+    pub response_topic: String,
+
+    // To clickhouse
     #[envconfig(default = "clickhouse_document_embeddings")]
     pub output_topic: String,
 

--- a/rust/embedding-worker/src/main.rs
+++ b/rust/embedding-worker/src/main.rs
@@ -176,7 +176,7 @@ async fn main() {
         // Write the embedding records to CH
         let records: Vec<EmbeddingRecord> = responses
             .into_iter()
-            .flat_map(|response| Vec::<EmbeddingRecord>::from(response))
+            .flat_map(Vec::<EmbeddingRecord>::from)
             .collect();
 
         let emit_results = txn

--- a/rust/embedding-worker/src/main.rs
+++ b/rust/embedding-worker/src/main.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use common_kafka::kafka_consumer::RecvErr;
 use common_metrics::{serve, setup_metrics_routes};
-use common_types::embedding::EmbeddingRequest;
+use common_types::embedding::{EmbeddingRecord, EmbeddingRequest};
 use embedding_worker::{
     ad_hoc::{handle_ad_hoc_request, AdHocEmbeddingRequest, AdHocEmbeddingResponse},
     app_context::AppContext,
@@ -144,7 +144,7 @@ async fn main() {
             };
         }
 
-        let embeddings = match handle_batch(to_process, &offsets, context.clone()).await {
+        let responses = match handle_batch(to_process, &offsets, context.clone()).await {
             Ok(embeddings) => embeddings,
             Err(failure) => {
                 error!("Error handling batch: {failure}");
@@ -160,20 +160,40 @@ async fn main() {
             }
         };
 
-        let results = txn
+        // Write the callback messages
+        let emit_results = txn
             .send_keyed_iter_to_kafka(
-                &context.config.output_topic,
+                &context.config.response_topic,
                 |_| Some(Uuid::now_v7().to_string()),
-                embeddings,
+                &responses,
             )
             .await;
 
-        for result in results.into_iter() {
-            result.expect("We can emit to kafka");
+        for res in emit_results.into_iter() {
+            res.expect("We can emit to kafka");
+        }
+
+        // Write the embedding records to CH
+        let records: Vec<EmbeddingRecord> = responses
+            .into_iter()
+            .flat_map(|response| Vec::<EmbeddingRecord>::from(response))
+            .collect();
+
+        let emit_results = txn
+            .send_keyed_iter_to_kafka(
+                &context.config.output_topic,
+                |_| Some(Uuid::now_v7().to_string()),
+                &records,
+            )
+            .await;
+
+        for res in emit_results.into_iter() {
+            res.expect("We can emit to kafka");
         }
 
         let metadata = context.kafka_consumer.metadata();
 
+        // Associate the embedding request records with the offsets
         match txn.associate_offsets(offsets, &metadata) {
             Ok(_) => {}
             Err(e) => {
@@ -185,6 +205,7 @@ async fn main() {
             }
         }
 
+        // Commit the transaction
         match txn.commit() {
             Ok(_) => {}
             Err(e) => {


### PR DESCRIPTION
Allows for flows that need to embed some document, and then do something with it once it's embedded, like error tracking auto-merging, or I'm sure other stuff.

Also exposes the metadata column

Depends on https://github.com/PostHog/posthog-cloud-infra/pull/6095