### PR TITLE
fix(experiments): Don't override linked flag when naming experiment

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -255,8 +255,8 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
     listeners(({ values, actions, props }) => ({
         setExperiment: () => {},
         setExperimentValue: ({ name, value }) => {
-            // Only auto-generate flag key in create mode, not when editing
-            if (name === 'name' && !values.featureFlagKeyDirty && values.isCreateMode) {
+            // Only auto-generate flag key when creating a new flag, not when editing or linking an existing flag
+            if (name === 'name' && !values.featureFlagKeyDirty && values.isCreateMode && values.mode === 'create') {
                 const key = generateFeatureFlagKey(value)
                 actions.setFeatureFlagConfig({
                     feature_flag_key: key,


### PR DESCRIPTION
## Problem

If you set a linked flag before naming an experiment, we were overwriting the linked flag with a new flag derived from the experiment name.

(IMO the UX makes it very easy to work through the form without setting a name, only realizing at the end that it's needed!)

https://posthoghelp.zendesk.com/agent/tickets/43957 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46978)

## Changes

Check if `mode` is `link` when deciding to generate a new flag key.

## How did you test this code?

Added tests to cover the case.