### PR TITLE
fix(ducklake): Use boto3 for AWS creds instead of DuckDB CREDENTIAL_CHAIN

### DIFF
--- a/posthog/ducklake/storage.py
+++ b/posthog/ducklake/storage.py
@@ -159,15 +159,13 @@ class DuckLakeStorageConfig:
                 is_local=False,
             )
 
-    def to_duckdb_secret_sql(self, secret_name: str = "ducklake_s3") -> str:
+    def to_duckdb_secret_sql(self) -> str:
         """Generate DuckDB CREATE SECRET SQL statement.
-
-        Args:
-            secret_name: Name for the secret (default: "ducklake_s3")
 
         Returns:
             SQL statement to create the S3 secret.
         """
+        secret_name = "ducklake_s3"
         if not self.is_local:
             # Workaround: DuckDB's CREDENTIAL_CHAIN doesn't support IRSA (Web Identity Token).
             # Fetch credentials via boto3 which properly supports IRSA.
@@ -234,7 +232,6 @@ def configure_connection(
     storage_config: DuckLakeStorageConfig | None = None,
     *,
     install_extensions: bool = True,
-    secret_name: str = "ducklake_s3",
 ) -> None:
     """Configure DuckDB connection for DuckLake storage access.
 
@@ -245,7 +242,6 @@ def configure_connection(
         conn: DuckDB connection to configure.
         storage_config: Storage config to use. If None, creates one from runtime.
         install_extensions: Whether to install httpfs and delta extensions.
-        secret_name: Name for the S3 secret.
     """
     if storage_config is None:
         storage_config = DuckLakeStorageConfig.from_runtime()
@@ -258,7 +254,7 @@ def configure_connection(
     conn.execute("LOAD ducklake")
     conn.execute("LOAD httpfs")
     conn.execute("LOAD delta")
-    conn.execute(storage_config.to_duckdb_secret_sql(secret_name))
+    conn.execute(storage_config.to_duckdb_secret_sql())
 
 
 def ensure_ducklake_bucket_exists(

--- a/posthog/ducklake/storage.py
+++ b/posthog/ducklake/storage.py
@@ -61,6 +61,8 @@ def _get_boto3_credentials() -> tuple[str, str, str | None]:
     if credentials is None:
         raise RuntimeError("No AWS credentials available via boto3")
     frozen = credentials.get_frozen_credentials()
+    if frozen.access_key is None or frozen.secret_key is None:
+        raise RuntimeError("AWS credentials missing access_key or secret_key")
     return frozen.access_key, frozen.secret_key, frozen.token
 
 

--- a/posthog/ducklake/test_storage.py
+++ b/posthog/ducklake/test_storage.py
@@ -259,20 +259,6 @@ class TestDuckLakeStorageConfigEdgeCases:
         assert "key''with''quotes" in sql
         assert "secret''value" in sql
 
-    def test_custom_secret_name(self):
-        config = DuckLakeStorageConfig(
-            access_key="key",
-            secret_key="secret",
-            region="us-east-1",
-            endpoint="",
-            use_ssl=True,
-            url_style="path",
-            is_local=True,
-        )
-        sql = config.to_duckdb_secret_sql(secret_name="custom_s3_secret")
-
-        assert "CREATE OR REPLACE SECRET custom_s3_secret" in sql
-
     def test_explicit_use_local_setup_override(self, monkeypatch):
         monkeypatch.setenv("DUCKLAKE_S3_ACCESS_KEY", "override_key")
         monkeypatch.setenv("DUCKLAKE_S3_SECRET_KEY", "override_secret")

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -2997,55 +2997,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.10
   '''
-  SELECT "posthog_datawarehousetable"."created_by_id",
-         "posthog_datawarehousetable"."created_at",
-         "posthog_datawarehousetable"."updated_at",
-         "posthog_datawarehousetable"."deleted",
-         "posthog_datawarehousetable"."deleted_at",
-         "posthog_datawarehousetable"."id",
-         "posthog_datawarehousetable"."name",
-         "posthog_datawarehousetable"."format",
-         "posthog_datawarehousetable"."team_id",
-         "posthog_datawarehousetable"."url_pattern",
-         "posthog_datawarehousetable"."queryable_folder",
-         "posthog_datawarehousetable"."credential_id",
-         "posthog_datawarehousetable"."external_data_source_id",
-         "posthog_datawarehousetable"."columns",
-         "posthog_datawarehousetable"."row_count",
-         "posthog_datawarehousetable"."size_in_s3_mib",
-         "posthog_datawarehousecredential"."created_by_id",
-         "posthog_datawarehousecredential"."created_at",
-         "posthog_datawarehousecredential"."id",
-         "posthog_datawarehousecredential"."access_key",
-         "posthog_datawarehousecredential"."access_secret",
-         "posthog_datawarehousecredential"."team_id",
-         "posthog_externaldatasource"."created_by_id",
-         "posthog_externaldatasource"."created_at",
-         "posthog_externaldatasource"."updated_at",
-         "posthog_externaldatasource"."deleted",
-         "posthog_externaldatasource"."deleted_at",
-         "posthog_externaldatasource"."id",
-         "posthog_externaldatasource"."source_id",
-         "posthog_externaldatasource"."connection_id",
-         "posthog_externaldatasource"."destination_id",
-         "posthog_externaldatasource"."team_id",
-         "posthog_externaldatasource"."sync_frequency",
-         "posthog_externaldatasource"."status",
-         "posthog_externaldatasource"."source_type",
-         "posthog_externaldatasource"."job_inputs",
-         "posthog_externaldatasource"."are_tables_created",
-         "posthog_externaldatasource"."prefix",
-         "posthog_externaldatasource"."revenue_analytics_enabled"
-  FROM "posthog_datawarehousetable"
-  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
-  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
-  WHERE ("posthog_datawarehousetable"."team_id" = 99999
-         AND NOT ("posthog_datawarehousetable"."deleted"
-                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.11
-  '''
   SELECT "posthog_datawarehousejoin"."created_by_id",
          "posthog_datawarehousejoin"."created_at",
          "posthog_datawarehousejoin"."deleted",
@@ -3064,7 +3015,7 @@
                   AND "posthog_datawarehousejoin"."deleted" IS NOT NULL))
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.12
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.11
   '''
   SELECT "posthog_sessionrecording"."id",
          "posthog_sessionrecording"."session_id",
@@ -3094,7 +3045,7 @@
          AND "posthog_sessionrecording"."team_id" = 99999)
   '''
 # ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.13
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.12
   '''
   SELECT "posthog_sessionrecordingviewed"."session_id"
   FROM "posthog_sessionrecordingviewed"
@@ -3102,6 +3053,18 @@
          AND "posthog_sessionrecordingviewed"."user_id" = 99999
          AND "posthog_sessionrecordingviewed"."session_id" IN ('at_base_time_plus_20',
                                                                'at_base_time'))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.13
+  '''
+  SELECT "posthog_sessionrecordingviewed"."session_id",
+         "posthog_user"."email"
+  FROM "posthog_sessionrecordingviewed"
+  INNER JOIN "posthog_user" ON ("posthog_sessionrecordingviewed"."user_id" = "posthog_user"."id")
+  WHERE ("posthog_sessionrecordingviewed"."session_id" IN ('at_base_time_plus_20',
+                                                           'at_base_time')
+         AND "posthog_sessionrecordingviewed"."team_id" = 99999
+         AND NOT ("posthog_sessionrecordingviewed"."user_id" = 99999))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.14
@@ -3490,19 +3453,6 @@
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.8
   '''
-  SELECT "posthog_teamrevenueanalyticsconfig"."team_id",
-         "posthog_teamrevenueanalyticsconfig"."filter_test_accounts",
-         "posthog_teamrevenueanalyticsconfig"."notified_first_sync",
-         "posthog_teamrevenueanalyticsconfig"."events",
-         "posthog_teamrevenueanalyticsconfig"."goals",
-         "posthog_teamrevenueanalyticsconfig"."base_currency"
-  FROM "posthog_teamrevenueanalyticsconfig"
-  WHERE "posthog_teamrevenueanalyticsconfig"."team_id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.9
-  '''
   SELECT "posthog_externaldatasource"."created_by_id",
          "posthog_externaldatasource"."created_at",
          "posthog_externaldatasource"."updated_at",
@@ -3529,6 +3479,55 @@
          AND "posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL))
+  '''
+# ---
+# name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.9
+  '''
+  SELECT "posthog_datawarehousetable"."created_by_id",
+         "posthog_datawarehousetable"."created_at",
+         "posthog_datawarehousetable"."updated_at",
+         "posthog_datawarehousetable"."deleted",
+         "posthog_datawarehousetable"."deleted_at",
+         "posthog_datawarehousetable"."id",
+         "posthog_datawarehousetable"."name",
+         "posthog_datawarehousetable"."format",
+         "posthog_datawarehousetable"."team_id",
+         "posthog_datawarehousetable"."url_pattern",
+         "posthog_datawarehousetable"."queryable_folder",
+         "posthog_datawarehousetable"."credential_id",
+         "posthog_datawarehousetable"."external_data_source_id",
+         "posthog_datawarehousetable"."columns",
+         "posthog_datawarehousetable"."row_count",
+         "posthog_datawarehousetable"."size_in_s3_mib",
+         "posthog_datawarehousecredential"."created_by_id",
+         "posthog_datawarehousecredential"."created_at",
+         "posthog_datawarehousecredential"."id",
+         "posthog_datawarehousecredential"."access_key",
+         "posthog_datawarehousecredential"."access_secret",
+         "posthog_datawarehousecredential"."team_id",
+         "posthog_externaldatasource"."created_by_id",
+         "posthog_externaldatasource"."created_at",
+         "posthog_externaldatasource"."updated_at",
+         "posthog_externaldatasource"."deleted",
+         "posthog_externaldatasource"."deleted_at",
+         "posthog_externaldatasource"."id",
+         "posthog_externaldatasource"."source_id",
+         "posthog_externaldatasource"."connection_id",
+         "posthog_externaldatasource"."destination_id",
+         "posthog_externaldatasource"."team_id",
+         "posthog_externaldatasource"."sync_frequency",
+         "posthog_externaldatasource"."status",
+         "posthog_externaldatasource"."source_type",
+         "posthog_externaldatasource"."job_inputs",
+         "posthog_externaldatasource"."are_tables_created",
+         "posthog_externaldatasource"."prefix",
+         "posthog_externaldatasource"."revenue_analytics_enabled"
+  FROM "posthog_datawarehousetable"
+  LEFT OUTER JOIN "posthog_datawarehousecredential" ON ("posthog_datawarehousetable"."credential_id" = "posthog_datawarehousecredential"."id")
+  LEFT OUTER JOIN "posthog_externaldatasource" ON ("posthog_datawarehousetable"."external_data_source_id" = "posthog_externaldatasource"."id")
+  WHERE ("posthog_datawarehousetable"."team_id" = 99999
+         AND NOT ("posthog_datawarehousetable"."deleted"
+                  AND "posthog_datawarehousetable"."deleted" IS NOT NULL))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending


### PR DESCRIPTION
## Problem

DuckDB's CREDENTIAL_CHAIN provider doesn't support IRSA (Web Identity Token) authentication, causing it to fall back to the EKS node role instead of the pod's service account role.

See: https://github.com/duckdb/duckdb-aws/issues/31

## Changes

This change fetches AWS credentials via boto3 (which properly supports IRSA) and passes them explicitly to DuckDB.

## How did you test this code?

Verify old way breaks
```
kubectl exec -it <ducklake temporal worker id> -n posthog -- python3 -c "
import boto3
import duckdb

conn = duckdb.connect()
conn.execute('INSTALL aws; LOAD aws')
conn.execute('INSTALL httpfs; LOAD httpfs')
conn.execute('INSTALL delta; LOAD delta')
conn.execute('''
    CREATE SECRET s3_secret (
        TYPE S3,
        PROVIDER CREDENTIAL_CHAIN,
        REGION 'us-east-1'
    )
''')
try:
    result = conn.execute(\"SELECT count(*) FROM delta_scan('s3://<delta lake table uri>')\").fetchone()
    print('Success:', result)
except Exception as e:
    print('Error:', e)
"
```

verified new way works
```
kubectl exec -it <ducklake temporal worker id> -n posthog -- python3 -c "
import boto3
import duckdb

# Get IRSA credentials via boto3
session = boto3.Session()
creds = session.get_credentials().get_frozen_credentials()

conn = duckdb.connect()
conn.execute('INSTALL httpfs; LOAD httpfs')
conn.execute('INSTALL delta; LOAD delta')
conn.execute(f'''
    CREATE SECRET s3_secret (
        TYPE S3,
        KEY_ID '{creds.access_key}',
        SECRET '{creds.secret_key}',
        SESSION_TOKEN '{creds.token}',
        REGION 'us-east-1'
    )
''')
try:
    result = conn.execute(\"SELECT count(*) FROM delta_scan('s3://<delta lake table uri>')\").fetchone()
    print('Success:', result)
except Exception as e:
    print('Error:', e)
"
```

also updated unit test `pytest posthog/ducklake/test_storage.py`

## Changelog: (features only) Is this feature complete?

No - this is a bug fix, not a feature.
