### PR TITLE
fix(ci): use latching alarm model for master CI status

### DIFF
--- a/.github/scripts/master-ci-status.js
+++ b/.github/scripts/master-ci-status.js
@@ -1,0 +1,118 @@
+// Master CI Status - Latching alarm model for tracking CI failures on master
+//
+// State structure:
+// {
+//   channel: string,      // Slack channel ID
+//   ts: string,           // Slack message timestamp (thread parent)
+//   since: string,        // ISO timestamp of incident start
+//   commits: string[],    // Ordered list of commit SHAs (index = commit_order)
+//   fail_seq: {[workflow]: number},  // workflow -> commit_order of last failure
+//   ok_seq: {[workflow]: number}     // workflow -> commit_order of last success
+// }
+//
+// A workflow is "known failing" iff fail_seq[w] > ok_seq[w]
+// Resolution occurs when no workflows are known failing
+
+const STATE_FILE = '.master-ci-incident';
+
+function getCommitOrder(state, sha) {
+    const idx = state.commits.indexOf(sha);
+    return idx >= 0 ? idx : state.commits.length;
+}
+
+function getFailingWorkflows(state) {
+    return Object.entries(state.fail_seq)
+        .filter(([wf, order]) => order > (state.ok_seq[wf] ?? -1))
+        .map(([wf]) => wf);
+}
+
+function handleFailure(state, event, order, core, fs) {
+    const isNew = !state;
+
+    if (isNew) {
+        state = {
+            since: new Date().toISOString(),
+            commits: [event.head_sha],
+            fail_seq: { [event.name]: 0 },
+            ok_seq: {},
+        };
+    } else {
+        if (!state.commits.includes(event.head_sha)) {
+            state.commits.push(event.head_sha);
+        }
+        state.fail_seq[event.name] = Math.max(state.fail_seq[event.name] ?? -1, order);
+    }
+
+    const failing = getFailingWorkflows(state);
+    fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+
+    core.setOutput('action', isNew ? 'create' : 'update');
+    core.setOutput('failing_workflows', failing.join(', '));
+    core.setOutput('failing_count', String(failing.length));
+    core.setOutput('commit_count', String(state.commits.length));
+    core.setOutput('save_cache', 'true');
+
+    console.log(`Action: ${isNew ? 'create' : 'update'}`);
+    console.log(`Failing workflows: ${failing.join(', ')}`);
+    console.log(`State:`, JSON.stringify(state, null, 2));
+}
+
+function handleSuccess(state, event, order, core, fs) {
+    if (!state) {
+        core.setOutput('action', 'none');
+        core.setOutput('save_cache', 'false');
+        console.log('No incident exists, nothing to do');
+        return;
+    }
+
+    if (!state.commits.includes(event.head_sha)) {
+        state.commits.push(event.head_sha);
+    }
+    state.ok_seq[event.name] = Math.max(state.ok_seq[event.name] ?? -1, order);
+
+    const failing = getFailingWorkflows(state);
+    const resolved = failing.length === 0;
+
+    fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+
+    core.setOutput('action', resolved ? 'resolve' : 'none');
+    core.setOutput('still_failing', failing.join(', '));
+    core.setOutput('commit_count', String(state.commits.length));
+    core.setOutput('resolved', resolved ? 'true' : 'false');
+    core.setOutput('since', state.since);
+    core.setOutput('channel', state.channel || '');
+    core.setOutput('ts', state.ts || '');
+    core.setOutput('save_cache', resolved ? 'false' : 'true');
+
+    console.log(`Action: ${resolved ? 'resolve' : 'none'}`);
+    console.log(`Still failing: ${failing.join(', ') || 'none'}`);
+    console.log(`State:`, JSON.stringify(state, null, 2));
+}
+
+module.exports = async ({ github, context, core }) => {
+    const fs = require('fs');
+    const event = context.payload.workflow_run;
+
+    console.log(`Processing ${event.name} (${event.conclusion}) for ${event.head_sha.substring(0, 7)}`);
+
+    // Read existing state
+    let state = null;
+    if (fs.existsSync(STATE_FILE)) {
+        try {
+            state = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+            console.log('Loaded existing incident state');
+        } catch (e) {
+            console.log('Failed to parse state file, treating as no incident');
+        }
+    }
+
+    // Get commit order
+    const commitOrder = state ? getCommitOrder(state, event.head_sha) : 0;
+    console.log(`Commit order: ${commitOrder}`);
+
+    if (event.conclusion === 'failure') {
+        handleFailure(state, event, commitOrder, core, fs);
+    } else {
+        handleSuccess(state, event, commitOrder, core, fs);
+    }
+};

--- a/.github/scripts/master-ci-status.test.js
+++ b/.github/scripts/master-ci-status.test.js
@@ -6,6 +6,12 @@ const masterCiStatus = require('./master-ci-status')
 
 const STATE_FILE = '.master-ci-incident'
 
+// Timestamps for testing (in order: T1 < T2 < T3 < T4)
+const T1 = 1700000000000 // oldest
+const T2 = 1700001000000
+const T3 = 1700002000000
+const T4 = 1700003000000 // newest
+
 function createMocks() {
     const outputs = {}
     const core = {
@@ -18,11 +24,28 @@ function createMocks() {
 
 function createContext(name, conclusion, headSha) {
     return {
+        repo: { owner: 'PostHog', repo: 'posthog' },
         payload: {
             workflow_run: {
                 name,
                 conclusion,
                 head_sha: headSha,
+            },
+        },
+    }
+}
+
+function createGithubMock(commitTs) {
+    return {
+        rest: {
+            repos: {
+                getCommit: jest.fn().mockResolvedValue({
+                    data: {
+                        commit: {
+                            committer: { date: new Date(commitTs).toISOString() },
+                        },
+                    },
+                }),
             },
         },
     }
@@ -39,9 +62,10 @@ describe('master-ci-status', () => {
     describe('new incident (no existing state)', () => {
         it('creates incident on first failure', async () => {
             const { core, outputs } = createMocks()
+            const github = createGithubMock(T1)
             const context = createContext('Backend CI', 'failure', 'abc1234')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
 
             expect(outputs.action).toBe('create')
             expect(outputs.failing_workflows).toBe('Backend CI')
@@ -49,18 +73,29 @@ describe('master-ci-status', () => {
             expect(outputs.commit_count).toBe('1')
             expect(outputs.save_cache).toBe('true')
 
-            // Verify state was written
-            expect(fs.writeFileSync).toHaveBeenCalledWith(
-                STATE_FILE,
-                expect.stringContaining('"fail_seq"')
-            )
+            // Verify state was written with timestamps
+            const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+            expect(writtenState.fail_ts['Backend CI']).toBe(T1)
+            expect(writtenState.sha_ts['abc1234']).toBe(T1)
+        })
+
+        it('creates incident on timed_out', async () => {
+            const { core, outputs } = createMocks()
+            const github = createGithubMock(T1)
+            const context = createContext('Backend CI', 'timed_out', 'abc1234')
+
+            await masterCiStatus({ github, context, core })
+
+            expect(outputs.action).toBe('create')
+            expect(outputs.failing_workflows).toBe('Backend CI')
         })
 
         it('does nothing on success with no incident', async () => {
             const { core, outputs } = createMocks()
+            const github = createGithubMock(T1)
             const context = createContext('Backend CI', 'success', 'abc1234')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
 
             expect(outputs.action).toBe('none')
             expect(outputs.save_cache).toBe('false')
@@ -68,9 +103,21 @@ describe('master-ci-status', () => {
 
         it('ignores cancelled workflows', async () => {
             const { core, outputs } = createMocks()
+            const github = createGithubMock(T1)
             const context = createContext('Backend CI', 'cancelled', 'abc1234')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
+
+            expect(outputs.action).toBe('none')
+            expect(outputs.save_cache).toBe('false')
+        })
+
+        it('ignores skipped workflows', async () => {
+            const { core, outputs } = createMocks()
+            const github = createGithubMock(T1)
+            const context = createContext('Backend CI', 'skipped', 'abc1234')
+
+            await masterCiStatus({ github, context, core })
 
             expect(outputs.action).toBe('none')
             expect(outputs.save_cache).toBe('false')
@@ -82,9 +129,9 @@ describe('master-ci-status', () => {
             channel: 'C123',
             ts: '123.456',
             since: '2025-01-01T00:00:00Z',
-            commits: ['abc1234'],
-            fail_seq: { 'Backend CI': 0 },
-            ok_seq: {},
+            sha_ts: { abc1234: T1 },
+            fail_ts: { 'Backend CI': T1 },
+            ok_ts: {},
         }
 
         beforeEach(() => {
@@ -92,23 +139,28 @@ describe('master-ci-status', () => {
             fs.readFileSync.mockReturnValue(JSON.stringify(existingState))
         })
 
-        it('updates on second failure (same workflow, new commit)', async () => {
+        it('updates on second failure (same workflow, newer commit)', async () => {
             const { core, outputs } = createMocks()
+            const github = createGithubMock(T2) // Newer commit
             const context = createContext('Backend CI', 'failure', 'def5678')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
 
             expect(outputs.action).toBe('update')
             expect(outputs.failing_workflows).toBe('Backend CI')
             expect(outputs.failing_count).toBe('1')
             expect(outputs.commit_count).toBe('2')
+
+            const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+            expect(writtenState.fail_ts['Backend CI']).toBe(T2) // Updated to newer
         })
 
         it('updates on failure of different workflow', async () => {
             const { core, outputs } = createMocks()
+            const github = createGithubMock(T2)
             const context = createContext('Frontend CI', 'failure', 'def5678')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
 
             expect(outputs.action).toBe('update')
             expect(outputs.failing_workflows).toContain('Backend CI')
@@ -118,9 +170,10 @@ describe('master-ci-status', () => {
 
         it('does not resolve when different workflow succeeds', async () => {
             const { core, outputs } = createMocks()
+            const github = createGithubMock(T2)
             const context = createContext('Frontend CI', 'success', 'def5678')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
 
             expect(outputs.action).toBe('none')
             expect(outputs.resolved).toBe('false')
@@ -129,9 +182,10 @@ describe('master-ci-status', () => {
 
         it('resolves when failing workflow succeeds on newer commit', async () => {
             const { core, outputs } = createMocks()
+            const github = createGithubMock(T2) // Newer than T1
             const context = createContext('Backend CI', 'success', 'def5678')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
 
             expect(outputs.action).toBe('resolve')
             expect(outputs.resolved).toBe('true')
@@ -139,14 +193,35 @@ describe('master-ci-status', () => {
             expect(outputs.save_cache).toBe('false')
         })
 
-        it('resolves when failing workflow succeeds on same commit', async () => {
+        it('does NOT resolve when failing workflow succeeds on older commit', async () => {
+            // State: Backend CI failed at T2
+            fs.readFileSync.mockReturnValue(
+                JSON.stringify({
+                    ...existingState,
+                    fail_ts: { 'Backend CI': T2 },
+                })
+            )
+
             const { core, outputs } = createMocks()
+            const github = createGithubMock(T1) // Older than T2
+            const context = createContext('Backend CI', 'success', 'older123')
+
+            await masterCiStatus({ github, context, core })
+
+            // T1 < T2, so ok_ts (T1) is not > fail_ts (T2), still failing
+            expect(outputs.action).toBe('none')
+            expect(outputs.resolved).toBe('false')
+            expect(outputs.still_failing).toBe('Backend CI')
+        })
+
+        it('resolves when failing workflow succeeds on same timestamp', async () => {
+            const { core, outputs } = createMocks()
+            const github = createGithubMock(T1) // Same as fail timestamp
             const context = createContext('Backend CI', 'success', 'abc1234')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
 
-            // ok_seq[Backend CI] = 0, fail_seq[Backend CI] = 0
-            // Latching rule: failing when fail_seq > ok_seq. 0 > 0 is false, so resolved.
+            // ok_ts = T1, fail_ts = T1. T1 > T1 is false, so not failing.
             expect(outputs.action).toBe('resolve')
         })
     })
@@ -156,9 +231,9 @@ describe('master-ci-status', () => {
             channel: 'C123',
             ts: '123.456',
             since: '2025-01-01T00:00:00Z',
-            commits: ['abc1234', 'def5678'],
-            fail_seq: { 'Backend CI': 0, 'Frontend CI': 1 },
-            ok_seq: {},
+            sha_ts: { abc1234: T1, def5678: T2 },
+            fail_ts: { 'Backend CI': T1, 'Frontend CI': T2 },
+            ok_ts: {},
         }
 
         beforeEach(() => {
@@ -168,10 +243,10 @@ describe('master-ci-status', () => {
 
         it('clears one workflow but not the other', async () => {
             const { core, outputs } = createMocks()
-            // New commit (order 2) succeeds for Backend CI
+            const github = createGithubMock(T3) // Newer than both T1 and T2
             const context = createContext('Backend CI', 'success', 'ghi9012')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
 
             expect(outputs.action).toBe('none')
             expect(outputs.resolved).toBe('false')
@@ -179,120 +254,188 @@ describe('master-ci-status', () => {
         })
 
         it('resolves when all workflows cleared', async () => {
-            // First clear Backend CI
+            // Backend CI already cleared
             fs.readFileSync.mockReturnValue(
                 JSON.stringify({
                     ...multiFailState,
-                    commits: ['abc1234', 'def5678', 'ghi9012'],
-                    ok_seq: { 'Backend CI': 2 },
+                    ok_ts: { 'Backend CI': T3 },
                 })
             )
 
             const { core, outputs } = createMocks()
-            // Now clear Frontend CI
+            const github = createGithubMock(T4) // Newer than T2
             const context = createContext('Frontend CI', 'success', 'jkl3456')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
 
             expect(outputs.action).toBe('resolve')
             expect(outputs.resolved).toBe('true')
         })
     })
 
-    describe('out-of-order events', () => {
-        it('uses max() for fail_seq - older failure does not overwrite newer', async () => {
+    describe('out-of-order events (timestamp-based)', () => {
+        it('older failure does not overwrite newer failure timestamp', async () => {
             const stateWithNewerFailure = {
                 channel: 'C123',
                 ts: '123.456',
                 since: '2025-01-01T00:00:00Z',
-                commits: ['abc1234', 'def5678'],
-                fail_seq: { 'Backend CI': 1 }, // Failed on commit index 1
-                ok_seq: {},
+                sha_ts: { abc1234: T1, def5678: T2 },
+                fail_ts: { 'Backend CI': T2 }, // Failed at T2
+                ok_ts: {},
             }
 
             fs.existsSync.mockReturnValue(true)
             fs.readFileSync.mockReturnValue(JSON.stringify(stateWithNewerFailure))
 
             const { core } = createMocks()
-            // Older commit (index 0) also fails - should not overwrite
+            const github = createGithubMock(T1) // Older commit
             const context = createContext('Backend CI', 'failure', 'abc1234')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
 
             const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
-            expect(writtenState.fail_seq['Backend CI']).toBe(1) // Still 1, not 0
+            expect(writtenState.fail_ts['Backend CI']).toBe(T2) // Still T2, not T1
         })
 
-        it('uses max() for ok_seq - older success does not overwrite newer', async () => {
+        it('older success does not overwrite newer success timestamp', async () => {
             const stateWithNewerSuccess = {
                 channel: 'C123',
                 ts: '123.456',
                 since: '2025-01-01T00:00:00Z',
-                commits: ['abc1234', 'def5678', 'ghi9012'],
-                fail_seq: { 'Backend CI': 0 },
-                ok_seq: { 'Backend CI': 2 }, // Succeeded on commit index 2
+                sha_ts: { abc1234: T1, def5678: T2, ghi9012: T3 },
+                fail_ts: { 'Backend CI': T1 },
+                ok_ts: { 'Backend CI': T3 }, // Succeeded at T3
             }
 
             fs.existsSync.mockReturnValue(true)
             fs.readFileSync.mockReturnValue(JSON.stringify(stateWithNewerSuccess))
 
             const { core } = createMocks()
-            // Older commit (index 1) also succeeds - should not overwrite
+            const github = createGithubMock(T2) // Older than T3
             const context = createContext('Backend CI', 'success', 'def5678')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
 
             const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
-            expect(writtenState.ok_seq['Backend CI']).toBe(2) // Still 2, not 1
+            expect(writtenState.ok_ts['Backend CI']).toBe(T3) // Still T3, not T2
+        })
+
+        it('newer success clears older failure', async () => {
+            const state = {
+                channel: 'C123',
+                ts: '123.456',
+                since: '2025-01-01T00:00:00Z',
+                sha_ts: { abc1234: T1 },
+                fail_ts: { 'Backend CI': T1 },
+                ok_ts: {},
+            }
+
+            fs.existsSync.mockReturnValue(true)
+            fs.readFileSync.mockReturnValue(JSON.stringify(state))
+
+            const { core, outputs } = createMocks()
+            const github = createGithubMock(T2) // Newer than T1
+            const context = createContext('Backend CI', 'success', 'def5678')
+
+            await masterCiStatus({ github, context, core })
+
+            expect(outputs.action).toBe('resolve')
+            const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+            expect(writtenState.ok_ts['Backend CI']).toBe(T2)
         })
     })
 
-    describe('commit ordering', () => {
-        it('assigns correct order to new commits', async () => {
-            const state = {
-                channel: 'C123',
-                ts: '123.456',
-                since: '2025-01-01T00:00:00Z',
-                commits: ['abc1234', 'def5678'],
-                fail_seq: { 'Backend CI': 0 },
-                ok_seq: {},
-            }
-
+    describe('state validation', () => {
+        it('handles missing fields gracefully', async () => {
+            // Old format or corrupted state
             fs.existsSync.mockReturnValue(true)
-            fs.readFileSync.mockReturnValue(JSON.stringify(state))
+            fs.readFileSync.mockReturnValue(
+                JSON.stringify({
+                    channel: 'C123',
+                    ts: '123.456',
+                    since: '2025-01-01T00:00:00Z',
+                    // Missing sha_ts, fail_ts, ok_ts
+                })
+            )
 
-            const { core } = createMocks()
-            const context = createContext('Backend CI', 'success', 'ghi9012') // New commit
+            const { core, outputs } = createMocks()
+            const github = createGithubMock(T1)
+            const context = createContext('Backend CI', 'success', 'abc1234')
 
-            await masterCiStatus({ github: {}, context, core })
+            // Should not throw
+            await masterCiStatus({ github, context, core })
 
-            const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
-            expect(writtenState.commits).toContain('ghi9012')
-            expect(writtenState.commits.indexOf('ghi9012')).toBe(2)
-            expect(writtenState.ok_seq['Backend CI']).toBe(2)
+            expect(outputs.action).toBe('resolve') // No failures tracked = resolved
         })
 
-        it('reuses order for existing commits', async () => {
+        it('handles JSON parse error', async () => {
+            fs.existsSync.mockReturnValue(true)
+            fs.readFileSync.mockReturnValue('not valid json')
+
+            const { core, outputs } = createMocks()
+            const github = createGithubMock(T1)
+            const context = createContext('Backend CI', 'failure', 'abc1234')
+
+            // Should not throw, treat as new incident
+            await masterCiStatus({ github, context, core })
+
+            expect(outputs.action).toBe('create')
+        })
+    })
+
+    describe('state pruning', () => {
+        it('prunes old SHAs after success clears them', async () => {
+            // State with multiple SHAs and one workflow with ok_ts
             const state = {
                 channel: 'C123',
                 ts: '123.456',
                 since: '2025-01-01T00:00:00Z',
-                commits: ['abc1234', 'def5678'],
-                fail_seq: { 'Backend CI': 0 },
-                ok_seq: {},
+                sha_ts: { sha1: T1, sha2: T2, sha3: T3 },
+                fail_ts: { 'Backend CI': T3 },
+                ok_ts: { 'Frontend CI': T2 }, // Frontend passed at T2
             }
 
             fs.existsSync.mockReturnValue(true)
             fs.readFileSync.mockReturnValue(JSON.stringify(state))
 
             const { core } = createMocks()
-            const context = createContext('Frontend CI', 'success', 'def5678') // Existing commit
+            const github = createGithubMock(T4)
+            const context = createContext('Backend CI', 'success', 'sha4')
 
-            await masterCiStatus({ github: {}, context, core })
+            await masterCiStatus({ github, context, core })
+
+            // After Backend CI succeeds at T4, ok_ts has Frontend CI: T2, Backend CI: T4
+            // min(ok_ts) = T2, so sha1 (T1 < T2) should be pruned
+            const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+            expect(writtenState.sha_ts.sha1).toBeUndefined() // Pruned (T1 < T2)
+            expect(writtenState.sha_ts.sha2).toBe(T2) // Kept (T2 >= T2)
+            expect(writtenState.sha_ts.sha3).toBe(T3) // Kept (T3 > T2)
+            expect(writtenState.sha_ts.sha4).toBe(T4) // New SHA added
+        })
+
+        it('does not prune when no ok_ts exists', async () => {
+            const state = {
+                channel: 'C123',
+                ts: '123.456',
+                since: '2025-01-01T00:00:00Z',
+                sha_ts: { sha1: T1, sha2: T2 },
+                fail_ts: { 'Backend CI': T2 },
+                ok_ts: {},
+            }
+
+            fs.existsSync.mockReturnValue(true)
+            fs.readFileSync.mockReturnValue(JSON.stringify(state))
+
+            const { core } = createMocks()
+            const github = createGithubMock(T3)
+            const context = createContext('Frontend CI', 'failure', 'sha3')
+
+            await masterCiStatus({ github, context, core })
 
             const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
-            expect(writtenState.commits.length).toBe(2) // No new commit added
-            expect(writtenState.ok_seq['Frontend CI']).toBe(1) // Order of def5678
+            expect(writtenState.sha_ts.sha1).toBe(T1) // Still there
+            expect(writtenState.sha_ts.sha2).toBe(T2) // Still there
+            expect(writtenState.sha_ts.sha3).toBe(T3) // New SHA added
         })
     })
 })

--- a/.github/scripts/master-ci-status.test.js
+++ b/.github/scripts/master-ci-status.test.js
@@ -1,0 +1,289 @@
+const fs = require('fs')
+
+jest.mock('fs')
+
+const masterCiStatus = require('./master-ci-status')
+
+const STATE_FILE = '.master-ci-incident'
+
+function createMocks() {
+    const outputs = {}
+    const core = {
+        setOutput: jest.fn((key, value) => {
+            outputs[key] = value
+        }),
+    }
+    return { core, outputs }
+}
+
+function createContext(name, conclusion, headSha) {
+    return {
+        payload: {
+            workflow_run: {
+                name,
+                conclusion,
+                head_sha: headSha,
+            },
+        },
+    }
+}
+
+describe('master-ci-status', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        fs.existsSync.mockReturnValue(false)
+        fs.readFileSync.mockReturnValue('{}')
+        fs.writeFileSync.mockImplementation(() => {})
+    })
+
+    describe('new incident (no existing state)', () => {
+        it('creates incident on first failure', async () => {
+            const { core, outputs } = createMocks()
+            const context = createContext('Backend CI', 'failure', 'abc1234')
+
+            await masterCiStatus({ github: {}, context, core })
+
+            expect(outputs.action).toBe('create')
+            expect(outputs.failing_workflows).toBe('Backend CI')
+            expect(outputs.failing_count).toBe('1')
+            expect(outputs.commit_count).toBe('1')
+            expect(outputs.save_cache).toBe('true')
+
+            // Verify state was written
+            expect(fs.writeFileSync).toHaveBeenCalledWith(
+                STATE_FILE,
+                expect.stringContaining('"fail_seq"')
+            )
+        })
+
+        it('does nothing on success with no incident', async () => {
+            const { core, outputs } = createMocks()
+            const context = createContext('Backend CI', 'success', 'abc1234')
+
+            await masterCiStatus({ github: {}, context, core })
+
+            expect(outputs.action).toBe('none')
+            expect(outputs.save_cache).toBe('false')
+        })
+    })
+
+    describe('existing incident', () => {
+        const existingState = {
+            channel: 'C123',
+            ts: '123.456',
+            since: '2025-01-01T00:00:00Z',
+            commits: ['abc1234'],
+            fail_seq: { 'Backend CI': 0 },
+            ok_seq: {},
+        }
+
+        beforeEach(() => {
+            fs.existsSync.mockReturnValue(true)
+            fs.readFileSync.mockReturnValue(JSON.stringify(existingState))
+        })
+
+        it('updates on second failure (same workflow, new commit)', async () => {
+            const { core, outputs } = createMocks()
+            const context = createContext('Backend CI', 'failure', 'def5678')
+
+            await masterCiStatus({ github: {}, context, core })
+
+            expect(outputs.action).toBe('update')
+            expect(outputs.failing_workflows).toBe('Backend CI')
+            expect(outputs.failing_count).toBe('1')
+            expect(outputs.commit_count).toBe('2')
+        })
+
+        it('updates on failure of different workflow', async () => {
+            const { core, outputs } = createMocks()
+            const context = createContext('Frontend CI', 'failure', 'def5678')
+
+            await masterCiStatus({ github: {}, context, core })
+
+            expect(outputs.action).toBe('update')
+            expect(outputs.failing_workflows).toContain('Backend CI')
+            expect(outputs.failing_workflows).toContain('Frontend CI')
+            expect(outputs.failing_count).toBe('2')
+        })
+
+        it('does not resolve when different workflow succeeds', async () => {
+            const { core, outputs } = createMocks()
+            const context = createContext('Frontend CI', 'success', 'def5678')
+
+            await masterCiStatus({ github: {}, context, core })
+
+            expect(outputs.action).toBe('none')
+            expect(outputs.resolved).toBe('false')
+            expect(outputs.still_failing).toBe('Backend CI')
+        })
+
+        it('resolves when failing workflow succeeds on newer commit', async () => {
+            const { core, outputs } = createMocks()
+            const context = createContext('Backend CI', 'success', 'def5678')
+
+            await masterCiStatus({ github: {}, context, core })
+
+            expect(outputs.action).toBe('resolve')
+            expect(outputs.resolved).toBe('true')
+            expect(outputs.still_failing).toBe('')
+            expect(outputs.save_cache).toBe('false')
+        })
+
+        it('does not resolve when failing workflow succeeds on same commit', async () => {
+            // Same commit order (0) - ok_seq would equal fail_seq, not greater
+            const { core, outputs } = createMocks()
+            const context = createContext('Backend CI', 'success', 'abc1234')
+
+            await masterCiStatus({ github: {}, context, core })
+
+            // ok_seq[Backend CI] = 0, fail_seq[Backend CI] = 0
+            // 0 > 0 is false, so not failing anymore
+            expect(outputs.action).toBe('resolve')
+        })
+    })
+
+    describe('multiple workflows failing', () => {
+        const multiFailState = {
+            channel: 'C123',
+            ts: '123.456',
+            since: '2025-01-01T00:00:00Z',
+            commits: ['abc1234', 'def5678'],
+            fail_seq: { 'Backend CI': 0, 'Frontend CI': 1 },
+            ok_seq: {},
+        }
+
+        beforeEach(() => {
+            fs.existsSync.mockReturnValue(true)
+            fs.readFileSync.mockReturnValue(JSON.stringify(multiFailState))
+        })
+
+        it('clears one workflow but not the other', async () => {
+            const { core, outputs } = createMocks()
+            // New commit (order 2) succeeds for Backend CI
+            const context = createContext('Backend CI', 'success', 'ghi9012')
+
+            await masterCiStatus({ github: {}, context, core })
+
+            expect(outputs.action).toBe('none')
+            expect(outputs.resolved).toBe('false')
+            expect(outputs.still_failing).toBe('Frontend CI')
+        })
+
+        it('resolves when all workflows cleared', async () => {
+            // First clear Backend CI
+            fs.readFileSync.mockReturnValue(
+                JSON.stringify({
+                    ...multiFailState,
+                    commits: ['abc1234', 'def5678', 'ghi9012'],
+                    ok_seq: { 'Backend CI': 2 },
+                })
+            )
+
+            const { core, outputs } = createMocks()
+            // Now clear Frontend CI
+            const context = createContext('Frontend CI', 'success', 'jkl3456')
+
+            await masterCiStatus({ github: {}, context, core })
+
+            expect(outputs.action).toBe('resolve')
+            expect(outputs.resolved).toBe('true')
+        })
+    })
+
+    describe('out-of-order events', () => {
+        it('uses max() for fail_seq - older failure does not overwrite newer', async () => {
+            const stateWithNewerFailure = {
+                channel: 'C123',
+                ts: '123.456',
+                since: '2025-01-01T00:00:00Z',
+                commits: ['abc1234', 'def5678'],
+                fail_seq: { 'Backend CI': 1 }, // Failed on commit index 1
+                ok_seq: {},
+            }
+
+            fs.existsSync.mockReturnValue(true)
+            fs.readFileSync.mockReturnValue(JSON.stringify(stateWithNewerFailure))
+
+            const { core } = createMocks()
+            // Older commit (index 0) also fails - should not overwrite
+            const context = createContext('Backend CI', 'failure', 'abc1234')
+
+            await masterCiStatus({ github: {}, context, core })
+
+            const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+            expect(writtenState.fail_seq['Backend CI']).toBe(1) // Still 1, not 0
+        })
+
+        it('uses max() for ok_seq - older success does not overwrite newer', async () => {
+            const stateWithNewerSuccess = {
+                channel: 'C123',
+                ts: '123.456',
+                since: '2025-01-01T00:00:00Z',
+                commits: ['abc1234', 'def5678', 'ghi9012'],
+                fail_seq: { 'Backend CI': 0 },
+                ok_seq: { 'Backend CI': 2 }, // Succeeded on commit index 2
+            }
+
+            fs.existsSync.mockReturnValue(true)
+            fs.readFileSync.mockReturnValue(JSON.stringify(stateWithNewerSuccess))
+
+            const { core } = createMocks()
+            // Older commit (index 1) also succeeds - should not overwrite
+            const context = createContext('Backend CI', 'success', 'def5678')
+
+            await masterCiStatus({ github: {}, context, core })
+
+            const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+            expect(writtenState.ok_seq['Backend CI']).toBe(2) // Still 2, not 1
+        })
+    })
+
+    describe('commit ordering', () => {
+        it('assigns correct order to new commits', async () => {
+            const state = {
+                channel: 'C123',
+                ts: '123.456',
+                since: '2025-01-01T00:00:00Z',
+                commits: ['abc1234', 'def5678'],
+                fail_seq: { 'Backend CI': 0 },
+                ok_seq: {},
+            }
+
+            fs.existsSync.mockReturnValue(true)
+            fs.readFileSync.mockReturnValue(JSON.stringify(state))
+
+            const { core } = createMocks()
+            const context = createContext('Backend CI', 'success', 'ghi9012') // New commit
+
+            await masterCiStatus({ github: {}, context, core })
+
+            const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+            expect(writtenState.commits).toContain('ghi9012')
+            expect(writtenState.commits.indexOf('ghi9012')).toBe(2)
+            expect(writtenState.ok_seq['Backend CI']).toBe(2)
+        })
+
+        it('reuses order for existing commits', async () => {
+            const state = {
+                channel: 'C123',
+                ts: '123.456',
+                since: '2025-01-01T00:00:00Z',
+                commits: ['abc1234', 'def5678'],
+                fail_seq: { 'Backend CI': 0 },
+                ok_seq: {},
+            }
+
+            fs.existsSync.mockReturnValue(true)
+            fs.readFileSync.mockReturnValue(JSON.stringify(state))
+
+            const { core } = createMocks()
+            const context = createContext('Frontend CI', 'success', 'def5678') // Existing commit
+
+            await masterCiStatus({ github: {}, context, core })
+
+            const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+            expect(writtenState.commits.length).toBe(2) // No new commit added
+            expect(writtenState.ok_seq['Frontend CI']).toBe(1) // Order of def5678
+        })
+    })
+})

--- a/.github/workflows/ci-master-status.yml
+++ b/.github/workflows/ci-master-status.yml
@@ -17,7 +17,6 @@ on:
         types: [completed]
 
 env:
-    # #flakey-tests channel until we're confident, then move to a more visible channel
     SLACK_CHANNEL: 'C09ADEV3AJD'
 
 permissions:
@@ -27,14 +26,11 @@ permissions:
 jobs:
     check-master-status:
         runs-on: ubuntu-latest
-        # Only run for actual master push events, not PR merges
         if: github.event.workflow_run.event == 'push'
         steps:
             - uses: actions/checkout@v4
 
-            # Restore incident state from cache
             - name: Restore incident state
-              id: cache
               uses: actions/cache/restore@v4
               with:
                   path: .master-ci-incident
@@ -45,20 +41,20 @@ jobs:
               run: |
                   if [ -f .master-ci-incident ]; then
                     echo "exists=true" >> $GITHUB_OUTPUT
-                    echo "channel=$(jq -r '.channel' .master-ci-incident)" >> $GITHUB_OUTPUT
-                    echo "ts=$(jq -r '.ts' .master-ci-incident)" >> $GITHUB_OUTPUT
-                    echo "since=$(jq -r '.since' .master-ci-incident)" >> $GITHUB_OUTPUT
-                    echo "failCount=$(jq -r '.failCount // 1' .master-ci-incident)" >> $GITHUB_OUTPUT
-                    echo "commitCount=$(jq -r '.commitCount // 1' .master-ci-incident)" >> $GITHUB_OUTPUT
-                    echo "commits=$(jq -c '.commits // []' .master-ci-incident)" >> $GITHUB_OUTPUT
-                    echo "Current incident:"
-                    cat .master-ci-incident
+                    echo "channel=$(jq -r '.channel // empty' .master-ci-incident)" >> $GITHUB_OUTPUT
+                    echo "ts=$(jq -r '.ts // empty' .master-ci-incident)" >> $GITHUB_OUTPUT
                   else
                     echo "exists=false" >> $GITHUB_OUTPUT
-                    echo "No active incident"
                   fi
 
-            # Get commit info for better messages
+            - name: Process workflow event
+              id: process
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const script = require('./.github/scripts/master-ci-status.js');
+                      await script({ github, context, core });
+
             - name: Get commit info
               id: commit
               uses: actions/github-script@v7
@@ -70,19 +66,15 @@ jobs:
                         repo: context.repo.repo,
                         ref: sha
                       });
-                      const shortSha = sha.substring(0, 7);
-                      const message = commit.commit.message.split('\n')[0].substring(0, 50);
-                      const author = commit.author?.login || commit.commit.author.name;
-                      core.setOutput('short_sha', shortSha);
-                      core.setOutput('message', message);
-                      core.setOutput('author', author);
+                      core.setOutput('short_sha', sha.substring(0, 7));
+                      core.setOutput('message', commit.commit.message.split('\n')[0].substring(0, 50));
+                      core.setOutput('author', commit.author?.login || commit.commit.author.name);
                       core.setOutput('url', commit.html_url);
 
-            # ============ ON FAILURE ============
+            # ============ SLACK: CREATE ============
 
-            # New incident - post initial alert
             - name: Post new incident to Slack
-              if: github.event.workflow_run.conclusion == 'failure' && steps.incident.outputs.exists == 'false'
+              if: steps.process.outputs.action == 'create'
               id: slack_new
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
@@ -91,16 +83,16 @@ jobs:
                   errors: true
                   payload: |
                       channel: "${{ env.SLACK_CHANNEL }}"
-                      text: ":red_circle: Master is red (1 commit, 1 workflow failing)"
+                      text: ":red_circle: Master is red (1 workflow failing)"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":red_circle: *Master is red* (1 commit, 1 workflow failing)"
+                            text: ":red_circle: *Master is red* (1 workflow failing)"
                         - type: "section"
                           fields:
                             - type: "mrkdwn"
-                              text: "*Workflow*\n${{ github.event.workflow_run.name }}"
+                              text: "*Failing*\n${{ github.event.workflow_run.name }}"
                             - type: "mrkdwn"
                               text: "*Author*\n${{ steps.commit.outputs.author }}"
                         - type: "section"
@@ -112,47 +104,23 @@ jobs:
                             - type: "button"
                               text:
                                 type: "plain_text"
-                                text: "View failing run →"
+                                text: "View run"
                               url: "${{ github.event.workflow_run.html_url }}"
 
-            - name: Save new incident state
-              if: github.event.workflow_run.conclusion == 'failure' && steps.incident.outputs.exists == 'false'
+            - name: Save Slack info to state
+              if: steps.process.outputs.action == 'create'
               run: |
-                  jq -n \
+                  jq \
                     --arg channel "${{ steps.slack_new.outputs.channel_id }}" \
                     --arg ts "${{ steps.slack_new.outputs.ts }}" \
-                    --arg since "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-                    --arg firstFailure "${{ github.event.workflow_run.name }}" \
-                    --arg firstCommit "${{ github.event.workflow_run.head_sha }}" \
-                    --argjson failCount 1 \
-                    --argjson commitCount 1 \
-                    '{channel: $channel, ts: $ts, since: $since, firstFailure: $firstFailure, failCount: $failCount, commitCount: $commitCount, commits: [$firstCommit]}' > .master-ci-incident
-                  cat .master-ci-incident
+                    '. + {channel: $channel, ts: $ts}' \
+                    .master-ci-incident > .master-ci-incident.tmp
+                  mv .master-ci-incident.tmp .master-ci-incident
 
-            # Existing incident - update message count and add thread reply
-            - name: Update incident counts
-              if: github.event.workflow_run.conclusion == 'failure' && steps.incident.outputs.exists == 'true'
-              id: new_count
-              run: |
-                  # Always increment workflow fail count
-                  fail_count=$(( ${{ steps.incident.outputs.failCount }} + 1 ))
-                  echo "failCount=$fail_count" >> $GITHUB_OUTPUT
+            # ============ SLACK: UPDATE ============
 
-                  # Check if this commit is new
-                  current_sha="${{ github.event.workflow_run.head_sha }}"
-                  if jq -e --arg sha "$current_sha" '.commits | index($sha)' .master-ci-incident > /dev/null 2>&1; then
-                    # Commit already tracked
-                    echo "commitCount=${{ steps.incident.outputs.commitCount }}" >> $GITHUB_OUTPUT
-                    echo "is_new_commit=false" >> $GITHUB_OUTPUT
-                  else
-                    # New commit
-                    commit_count=$(( ${{ steps.incident.outputs.commitCount }} + 1 ))
-                    echo "commitCount=$commit_count" >> $GITHUB_OUTPUT
-                    echo "is_new_commit=true" >> $GITHUB_OUTPUT
-                  fi
-
-            - name: Update Slack message with new count
-              if: github.event.workflow_run.conclusion == 'failure' && steps.incident.outputs.exists == 'true'
+            - name: Update Slack message
+              if: steps.process.outputs.action == 'update'
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: chat.update
@@ -161,32 +129,32 @@ jobs:
                   payload: |
                       channel: "${{ steps.incident.outputs.channel }}"
                       ts: "${{ steps.incident.outputs.ts }}"
-                      text: ":red_circle: Master is red (${{ steps.new_count.outputs.commitCount }} commits, ${{ steps.new_count.outputs.failCount }} workflows failing)"
+                      text: ":red_circle: Master is red (${{ steps.process.outputs.failing_count }} workflow(s) failing)"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":red_circle: *Master is red* (${{ steps.new_count.outputs.commitCount }} commits, ${{ steps.new_count.outputs.failCount }} workflows failing)"
+                            text: ":red_circle: *Master is red* (${{ steps.process.outputs.failing_count }} workflow(s) failing)"
                         - type: "section"
                           fields:
                             - type: "mrkdwn"
-                              text: "*Latest*\n${{ github.event.workflow_run.name }}"
+                              text: "*Failing*\n${{ steps.process.outputs.failing_workflows }}"
                             - type: "mrkdwn"
-                              text: "*Author*\n${{ steps.commit.outputs.author }}"
+                              text: "*Commits*\n${{ steps.process.outputs.commit_count }}"
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: "*Commit*\n<${{ steps.commit.outputs.url }}|${{ steps.commit.outputs.short_sha }}> ${{ steps.commit.outputs.message }}"
+                            text: "*Latest*\n<${{ steps.commit.outputs.url }}|${{ steps.commit.outputs.short_sha }}> ${{ steps.commit.outputs.message }} (${{ steps.commit.outputs.author }})"
                         - type: "actions"
                           elements:
                             - type: "button"
                               text:
                                 type: "plain_text"
-                                text: "View failing run →"
+                                text: "View run"
                               url: "${{ github.event.workflow_run.html_url }}"
 
-            - name: Thread reply with failure details
-              if: github.event.workflow_run.conclusion == 'failure' && steps.incident.outputs.exists == 'true'
+            - name: Thread reply with failure
+              if: steps.process.outputs.action == 'update'
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: chat.postMessage
@@ -194,84 +162,40 @@ jobs:
                   payload: |
                       channel: "${{ steps.incident.outputs.channel }}"
                       thread_ts: "${{ steps.incident.outputs.ts }}"
-                      text: "Also failing: *${{ github.event.workflow_run.name }}* (${{ steps.commit.outputs.short_sha }})\n<${{ github.event.workflow_run.html_url }}|View run →>"
+                      text: "Also failing: *${{ github.event.workflow_run.name }}* (${{ steps.commit.outputs.short_sha }})\n<${{ github.event.workflow_run.html_url }}|View run>"
 
-            - name: Update incident state with new counts
-              if: github.event.workflow_run.conclusion == 'failure' && steps.incident.outputs.exists == 'true'
-              run: |
-                  current_sha="${{ github.event.workflow_run.head_sha }}"
-                  jq \
-                    --argjson failCount ${{ steps.new_count.outputs.failCount }} \
-                    --argjson commitCount ${{ steps.new_count.outputs.commitCount }} \
-                    --arg newCommit "$current_sha" \
-                    '.failCount = $failCount | .commitCount = $commitCount | if (.commits | index($newCommit)) then . else .commits += [$newCommit] end' \
-                    .master-ci-incident > .master-ci-incident.tmp
-                  mv .master-ci-incident.tmp .master-ci-incident
-                  cat .master-ci-incident
+            # ============ SLACK: RESOLVE ============
 
-            # ============ ON SUCCESS ============
-
-            - name: Check if all workflows are green
-              if: github.event.workflow_run.conclusion == 'success' && steps.incident.outputs.exists == 'true'
-              id: check_green
-              uses: actions/github-script@v7
-              with:
-                  script: |
-                      const { data } = await github.rest.checks.listForRef({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        ref: '${{ github.event.workflow_run.head_sha }}'
-                      });
-
-                      const failing = data.check_runs.filter(c =>
-                        c.status === 'completed' &&
-                        c.conclusion !== 'success' &&
-                        c.conclusion !== 'skipped' &&
-                        c.name !== 'check-master-status'
-                      );
-
-                      core.setOutput('all_green', failing.length === 0 ? 'true' : 'false');
-                      core.setOutput('still_failing', failing.map(c => c.name).join(', '));
-                      console.log('Failing checks:', failing.map(c => c.name));
-
-            - name: Calculate incident duration
-              if: github.event.workflow_run.conclusion == 'success' && steps.incident.outputs.exists == 'true' && steps.check_green.outputs.all_green == 'true'
+            - name: Calculate duration
+              if: steps.process.outputs.action == 'resolve'
               id: duration
               run: |
-                  since="${{ steps.incident.outputs.since }}"
+                  since="${{ steps.process.outputs.since }}"
                   now=$(date +%s)
                   then=$(date -d "$since" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$since" +%s 2>/dev/null || echo "$now")
                   mins=$(( (now - then) / 60 ))
                   echo "mins=$mins" >> $GITHUB_OUTPUT
 
-                  # Pluralization
-                  commit_count="${{ steps.incident.outputs.commitCount }}"
-                  if [ "$commit_count" = "1" ]; then
-                    echo "commit_word=commit" >> $GITHUB_OUTPUT
-                  else
-                    echo "commit_word=commits" >> $GITHUB_OUTPUT
-                  fi
-
-            - name: Update Slack message to resolved
-              if: github.event.workflow_run.conclusion == 'success' && steps.incident.outputs.exists == 'true' && steps.check_green.outputs.all_green == 'true'
+            - name: Update Slack to resolved
+              if: steps.process.outputs.action == 'resolve'
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: chat.update
                   token: ${{ secrets.SLACK_BOT_TOKEN }}
                   errors: true
                   payload: |
-                      channel: "${{ steps.incident.outputs.channel }}"
-                      ts: "${{ steps.incident.outputs.ts }}"
-                      text: ":large_green_circle: Master is green (was red for ~${{ steps.duration.outputs.mins }} min, ${{ steps.incident.outputs.commitCount }} ${{ steps.duration.outputs.commit_word }} affected)"
+                      channel: "${{ steps.process.outputs.channel }}"
+                      ts: "${{ steps.process.outputs.ts }}"
+                      text: ":large_green_circle: Master is green (was red for ~${{ steps.duration.outputs.mins }} min)"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":large_green_circle: *Master is green* (was red for ~${{ steps.duration.outputs.mins }} min, ${{ steps.incident.outputs.commitCount }} ${{ steps.duration.outputs.commit_word }} affected)"
+                            text: ":large_green_circle: *Master is green* (was red for ~${{ steps.duration.outputs.mins }} min, ${{ steps.process.outputs.commit_count }} commits affected)"
                         - type: "section"
                           fields:
                             - type: "mrkdwn"
-                              text: "*Fixed after*\n${{ github.event.workflow_run.name }} passed"
+                              text: "*Resolved by*\n${{ github.event.workflow_run.name }} passed"
                             - type: "mrkdwn"
                               text: "*Author*\n${{ steps.commit.outputs.author }}"
                         - type: "section"
@@ -280,38 +204,38 @@ jobs:
                             text: "*Commit*\n<${{ steps.commit.outputs.url }}|${{ steps.commit.outputs.short_sha }}> ${{ steps.commit.outputs.message }}"
 
             - name: Thread reply with resolution
-              if: github.event.workflow_run.conclusion == 'success' && steps.incident.outputs.exists == 'true' && steps.check_green.outputs.all_green == 'true'
+              if: steps.process.outputs.action == 'resolve'
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: chat.postMessage
                   token: ${{ secrets.SLACK_BOT_TOKEN }}
                   payload: |
-                      channel: "${{ steps.incident.outputs.channel }}"
-                      thread_ts: "${{ steps.incident.outputs.ts }}"
+                      channel: "${{ steps.process.outputs.channel }}"
+                      thread_ts: "${{ steps.process.outputs.ts }}"
                       text: ":white_check_mark: Resolved: *${{ github.event.workflow_run.name }}* passed (${{ steps.commit.outputs.short_sha }})"
 
-            - name: Clear incident state
-              if: github.event.workflow_run.conclusion == 'success' && steps.incident.outputs.exists == 'true' && steps.check_green.outputs.all_green == 'true'
+            - name: Clear state on resolution
+              if: steps.process.outputs.action == 'resolve'
               run: rm -f .master-ci-incident
 
-            # ============ SAVE CACHE ============
+            # ============ CACHE ============
 
             - name: Delete old cache
-              if: github.event.workflow_run.conclusion == 'failure'
+              if: steps.process.outputs.save_cache == 'true'
               continue-on-error: true
               env:
                   GH_TOKEN: ${{ github.token }}
               run: gh cache delete master-ci-incident || true
 
             - name: Save incident to cache
-              if: github.event.workflow_run.conclusion == 'failure'
+              if: steps.process.outputs.save_cache == 'true'
               uses: actions/cache/save@v4
               with:
                   path: .master-ci-incident
                   key: master-ci-incident
 
             - name: Delete cache on resolution
-              if: github.event.workflow_run.conclusion == 'success' && steps.incident.outputs.exists == 'true' && steps.check_green.outputs.all_green == 'true'
+              if: steps.process.outputs.action == 'resolve'
               continue-on-error: true
               env:
                   GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
**Refactors master CI status alerts to use a latching alarm model with per-workflow failure tracking.**

Fixes false resolutions where unrelated workflows passing would clear the incident.

**Changes**
- Extract logic to `.github/scripts/master-ci-status.js` for testability
- Track `fail_seq[workflow]` and `ok_seq[workflow]` instead of simple counts
- A workflow is "known failing" iff `fail_seq > ok_seq`
- Resolution when no workflows are known failing
- Pending checks don't block resolution (the latch handles continuously failing workflows)
- Uses `max()` for out-of-order event handling

**Testing**
- 13 Jest tests covering: new incidents, updates, resolution, multiple workflows, out-of-order events
- Run: `./frontend/node_modules/.bin/jest --testMatch='**/.github/**/*.test.js' --rootDir=.`