### PR TITLE
fix(experiments): Validate control variant in PostHog AI experiment creation

### DIFF
--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -93,6 +93,13 @@ Examples:
                     f"Feature flag '{feature_flag_key}' must have at least 2 variants for an experiment (e.g., control and test)"
                 )
 
+            # Validate that the first variant is "control" - required for experiment statistics
+            if variants[0].get("key") != "control":
+                raise ValueError(
+                    f"Feature flag '{feature_flag_key}' must have 'control' as the first variant. "
+                    f"Found '{variants[0].get('key')}' instead. Please update the feature flag variants."
+                )
+
             # If flag already exists and is already used by another experiment, raise error
             existing_experiment_with_flag = Experiment.objects.filter(feature_flag=feature_flag, deleted=False).first()
             if existing_experiment_with_flag:


### PR DESCRIPTION
## Problem

The Max AI CreateExperimentTool was bypassing the validation that requires the first feature flag variant to be named "control". This allowed users to create experiments with non-standard variant names (e.g., "baseline"), which then caused 500 errors when querying experiment metrics because the query runner hardcodes CONTROL_VARIANT_KEY = "control".

## Changes

- Add validation that first variant must be "control" in max_tools.py
- Update existing test to use proper "control" variant
- Add new test for the validation error case

We should consider allowing the usage of the first variant as the baseline if possible, to prevent similar issues later.

## How did you test this code?

Updated tests

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
