### PR TITLE
fix(exports): retry on ProtocolError

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -112,6 +112,9 @@ async def deliver_subscription_report_async(
 
     logger.info("deliver_subscription_report_async.generating_assets", subscription_id=subscription_id)
     insights, assets = await generate_assets_async(subscription)
+    logger.info(
+        "deliver_subscription_report_async.assets_generated", subscription_id=subscription_id, asset_count=len(assets)
+    )
 
     # Only count system failures in metrics, not user config errors
     failed_assets = [a for a in assets if _has_asset_failed(a)]

--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -112,15 +112,25 @@ async def deliver_subscription_report_async(
 
     logger.info("deliver_subscription_report_async.generating_assets", subscription_id=subscription_id)
     insights, assets = await generate_assets_async(subscription)
-    logger.info(
-        "deliver_subscription_report_async.assets_generated", subscription_id=subscription_id, asset_count=len(assets)
-    )
 
     # Only count system failures in metrics, not user config errors
     failed_assets = [a for a in assets if _has_asset_failed(a)]
     system_failures = [a for a in failed_assets if not is_user_query_error_type(a.exception_type)]
     if system_failures:
         get_subscription_failure_metric(subscription.target_type, "temporal", failure_type="asset_generation").add(1)
+        logger.warn(
+            "deliver_subscription_report_async.failed_asset_generation",
+            subscription_id=subscription_id,
+            asset_count=len(assets),
+            assets=[
+                {
+                    "exported_asset_id": a.id,
+                    "exception_type": a.exception_type,
+                    "content_location": a.content_location,
+                }
+                for a in assets
+            ],
+        )
 
     if not assets:
         logger.warning("deliver_subscription_report_async.no_assets", subscription_id=subscription_id)

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -7,6 +7,7 @@ import structlog
 import posthoganalytics
 from celery import current_task, shared_task
 from prometheus_client import Counter, Histogram
+from urllib3.exceptions import ProtocolError
 
 from posthog.hogql.errors import (
     QueryError,
@@ -52,6 +53,7 @@ EXCEPTIONS_TO_RETRY = (
     CHQueryErrorS3Error,
     CHQueryErrorTooManySimultaneousQueries,
     OperationalError,
+    ProtocolError,
 )
 
 USER_QUERY_ERRORS = (


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Occasionally a subscription's export will fail because of a ProtocolError when Selenium is making a request to Chrome. This appears to be a transient error that isn't correlated with a specific insight/dashboard or load. 

In the past 7 days, this error has happened 5 times. 

<img width="1216" height="217" alt="Screenshot 2025-12-18 at 3 37 21 PM" src="https://github.com/user-attachments/assets/4432463b-9adc-40cc-8e8d-dfda89f11713" />
From: https://grafana.prod-us.posthog.dev/goto/c6a7F9Gvg?orgId=1

## Changes

Previously we were not retrying on this error, but we should.

Also add a log where we emit the asset_generation failure metric so its easy to go find which assets failed. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added unit test. 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
