### PR TITLE
fix: toolbar visibility tracking

### DIFF
--- a/frontend/src/toolbar/hedgehog/HedgehogButton.tsx
+++ b/frontend/src/toolbar/hedgehog/HedgehogButton.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 
 import { HedgehogBuddy } from 'lib/components/HedgehogBuddy/HedgehogBuddy'
 import { hedgehogBuddyLogic } from 'lib/components/HedgehogBuddy/hedgehogBuddyLogic'
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
 
@@ -13,6 +14,8 @@ export function HedgehogButton(): JSX.Element {
     const { syncWithHedgehog, setHedgehogActor, toggleMinimized } = useActions(toolbarLogic)
     const { hedgehogConfig } = useValues(hedgehogBuddyLogic)
     const { heatmapEnabled } = useValues(heatmapToolbarMenuLogic)
+
+    const { isVisible: isPageVisible } = usePageVisibility()
 
     useEffect(() => {
         if (heatmapEnabled) {
@@ -35,6 +38,7 @@ export function HedgehogButton(): JSX.Element {
                         syncWithHedgehog()
                     }}
                     onClick={() => toggleMinimized()}
+                    paused={!isPageVisible}
                 />
             )}
         </>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -102,6 +102,12 @@ export default defineConfig(({ mode }) => {
             cors: true, // This disables CORS in dev, key for using ngrok (e.g. for testing Slack integration)
             // Configure origin for proper asset URL generation
             origin: 'http://localhost:8234',
+            proxy: {
+                '/static': {
+                    target: 'http://localhost:8000',
+                    changeOrigin: true,
+                },
+            },
         },
         define: {
             global: 'globalThis',


### PR DESCRIPTION
i was trying to investigate why an active tab can cause an idle tabs memory footprint to grow

but when i added some profiling

the toolbar was spamming me with hedgehog mode animation looping

it is supposed to be asleep in the background

but was demonstrably not

so... not using the isPageVisible hook

just give the toolbar its own tracking  


NB local dev is fighting me , i can't get local to serve toolbar.css but since this is already not working in prod :see_no_evil:

## Changelog: (features only) Is this feature complete?

no