### PR TITLE
chore(embed): cleanup old embeddings MV

### DIFF
--- a/posthog/clickhouse/migrations/0192_cleanup_old_embeddings_mvs.py
+++ b/posthog/clickhouse/migrations/0192_cleanup_old_embeddings_mvs.py
@@ -1,0 +1,12 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+from products.error_tracking.backend.embedding import DOCUMENT_EMBEDDINGS_MV
+
+# Has been replaced by the buffer table MV as of 0191
+operations = [
+    run_sql_with_exceptions(
+        f"DROP TABLE IF EXISTS {DOCUMENT_EMBEDDINGS_MV}",
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0191_model_specific_embedding_tables
+0192_cleanup_old_embeddings_mvs


### PR DESCRIPTION
We don't want any _new_ data flowing into the historical tables. Once the data is migrated, I'll delete the data tables themselves as well, but for now this just brings dev in alignment with the manual fix daniel did in prod for me