### PR TITLE
chore(ci): Switch clickhouse-udfs Action from PAT to GitHub app

### DIFF
--- a/.github/workflows/clickhouse-udfs.yml
+++ b/.github/workflows/clickhouse-udfs.yml
@@ -1,10 +1,6 @@
 name: ClickHouse UDFs
 
 on:
-    # TODO just adding for testing, remove before merge
-    pull_request:
-        branches:
-            - master
     push:
         branches:
             - master

--- a/.github/workflows/clickhouse-udfs.yml
+++ b/.github/workflows/clickhouse-udfs.yml
@@ -1,6 +1,10 @@
 name: ClickHouse UDFs
 
 on:
+    # TODO just adding for testing, remove before merge
+    pull_request:
+        branches:
+            - master
     push:
         branches:
             - master

--- a/.github/workflows/clickhouse-udfs.yml
+++ b/.github/workflows/clickhouse-udfs.yml
@@ -11,10 +11,17 @@ jobs:
     trigger_udfs_workflow:
         runs-on: ubuntu-24.04
         steps:
+            - name: Get app token
+              id: app-token
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
+              with:
+                  app_id: ${{ secrets.GH_APP_POSTHOG_CLOUD_INFRA_WORKFLOW_TRIGGER_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_POSTHOG_CLOUD_INFRA_WORKFLOW_TRIGGER_PRIVATE_KEY }}
+
             - name: Trigger UDFs Workflow
               uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1
               with:
                   workflow: .github/workflows/clickhouse-udfs.yml
                   repo: posthog/posthog-cloud-infra
-                  token: ${{ secrets.POSTHOG_BOT_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   ref: refs/heads/main

--- a/.github/workflows/clickhouse-udfs.yml
+++ b/.github/workflows/clickhouse-udfs.yml
@@ -23,9 +23,10 @@ jobs:
                   private_key: ${{ secrets.GH_APP_POSTHOG_CLOUD_INFRA_WORKFLOW_TRIGGER_PRIVATE_KEY }}
 
             - name: Trigger UDFs Workflow
-              uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1
-              with:
-                  workflow: .github/workflows/clickhouse-udfs.yml
-                  repo: posthog/posthog-cloud-infra
-                  token: ${{ steps.app-token.outputs.token }}
-                  ref: refs/heads/main
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: |
+                  gh workflow run clickhouse-udfs.yml \
+                    -R posthog/posthog-cloud-infra \
+                    --ref main


### PR DESCRIPTION
PATs are bad. Also this PAT no longer has access to that private repo.

This GitHub app only has permissions to trigger Actions in `posthog-cloud-infra`. It does not have access to code or PRs.