### PR TITLE
chore(ci): switch Releaser action to use GitHub app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,7 @@
 
 name: Release
 permissions:
-    'contents': 'write'
-    'id-token': 'write'
+    contents: read
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -219,15 +218,21 @@ jobs:
             - build-global-artifacts
         # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
         if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
-        env:
-            GH_TOKEN: ${{ secrets.POSTHOG_BOT_PAT }}
         runs-on: 'ubuntu-22.04'
         outputs:
             val: ${{ steps.host.outputs.manifest }}
         steps:
+            - name: Get app token
+              id: app-token
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
+              with:
+                  app_id: ${{ secrets.GH_APP_POSTHOG_RELEASER_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_POSTHOG_RELEASER_PRIVATE_KEY }}
+
             - uses: actions/checkout@v4
               with:
                   submodules: recursive
+                  token: ${{ steps.app-token.outputs.token }}
             - name: Install cached dist
               uses: actions/download-artifact@v4
               with:
@@ -271,6 +276,7 @@ jobs:
                   ANNOUNCEMENT_TITLE: '${{ fromJson(steps.host.outputs.manifest).announcement_title }}'
                   ANNOUNCEMENT_BODY: '${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}'
                   RELEASE_COMMIT: '${{ github.sha }}'
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
                   # Write and read notes from a file to avoid quoting breaking things
                   echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
@@ -285,6 +291,8 @@ jobs:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             PLAN: ${{ needs.plan.outputs.val }}
         if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+        permissions:
+            id-token: write
         steps:
             - name: Fetch npm packages
               uses: actions/download-artifact@v4
@@ -317,8 +325,6 @@ jobs:
         # "host" however must run to completion, no skipping allowed!
         if: ${{ always() && needs.host.result == 'success' && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') }}
         runs-on: 'ubuntu-22.04'
-        env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
             - uses: actions/checkout@v4
               with:


### PR DESCRIPTION
This specific app requires the `workflows: write` permission since we're releasing a specific commit hash.

https://github.blog/changelog/2023-11-02-github-actions-enforcing-workflow-scope-when-creating-a-release/
