### PR TITLE
fix: Fix temporal cohort workflow type handling and retry logic

### DIFF
--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
@@ -85,7 +85,7 @@ async def get_person_count_activity(
 
     async with get_client(team_id=inputs.team_id) as client:
         async for row in client.stream_query_as_jsonl(query, query_parameters=query_params):
-            return PersonCountResult(count=row["count"])
+            return PersonCountResult(count=int(row["count"]))
 
     return PersonCountResult(count=0)
 

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -8,6 +8,7 @@ import temporalio.activity
 import temporalio.workflow
 from structlog.contextvars import bind_contextvars
 
+from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.printer import prepare_and_print_ast
 
@@ -110,12 +111,18 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
 
         max_retries = 3
         retry_delay_seconds = 5
+        base_timeout_seconds = 60
+        backoff_factor = 3
 
         @database_sync_to_async
         def build_query(cohort_obj):
             realtime_query = HogQLRealtimeCohortQuery(cohort=cohort_obj, team=cohort_obj.team)
             current_members_query = realtime_query.get_query()
-            hogql_context = HogQLContext(team_id=cohort_obj.team_id, enable_select_queries=True)
+            hogql_context = HogQLContext(
+                team_id=cohort_obj.team_id,
+                enable_select_queries=True,
+                limit_context=LimitContext.COHORT_CALCULATION,
+            )
             current_members_sql, _ = prepare_and_print_ast(current_members_query, hogql_context, "clickhouse")
             return current_members_sql, hogql_context.values
 
@@ -125,7 +132,8 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                 logger.info(f"Processed {idx}/{len(cohorts)} cohorts so far")
             for retry_attempt in range(1, max_retries + 1):
                 try:
-                    cohort_max_execution_time = 60 * retry_attempt
+                    # Exponential backoff: 60s, 180s (3min), 540s (9min)
+                    cohort_max_execution_time = base_timeout_seconds * (backoff_factor ** (retry_attempt - 1))
                     current_members_sql, query_params = await build_query(cohort)
                     query_params = {
                         **query_params,
@@ -206,13 +214,14 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                             attempts=max_retries,
                         )
                     else:
+                        next_timeout = base_timeout_seconds * (backoff_factor**retry_attempt)
                         logger.warning(
-                            f"Error calculating cohort {cohort.id} (attempt {retry_attempt}/{max_retries}): {type(e).__name__}: {str(e)}. Retrying in {retry_delay_seconds}s with {60 * (retry_attempt + 1)}s timeout...",
+                            f"Error calculating cohort {cohort.id} (attempt {retry_attempt}/{max_retries}): {type(e).__name__}: {str(e)}. Retrying in {retry_delay_seconds}s with {next_timeout}s timeout...",
                             cohort_id=cohort.id,
                             error_type=type(e).__name__,
                             error_message=str(e),
                             attempt=retry_attempt,
-                            next_timeout=60 * (retry_attempt + 1),
+                            next_timeout=next_timeout,
                         )
                         await asyncio.sleep(retry_delay_seconds)
 


### PR DESCRIPTION
## Problem

Temporal cohort workflows were failing in production with:
1. Type deserialization errors in backfill coordinator workflow - ClickHouse returns counts as strings in JSON, but Temporal expects int (this is working locally though)
2. Insufficient retry timeouts for realtime cohort calculations - linear timeout increases weren't enough for large cohorts
3. Missing HogQL limit context for cohort calculations

## Changes

**Backfill coordinator workflow:**
- Convert ClickHouse count result to `int` to handle both numeric and string responses from JSONEachRow format

**Realtime cohort workflow:**
- Implement exponential backoff for retry timeouts (60s → 180s → 540s instead of 60s → 120s → 180s)
- Add `LimitContext.COHORT_CALCULATION` to HogQL context for proper query limits

