### PR TITLE
feat(replay): convert error tracking to unified replay button

### DIFF
--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -6,9 +6,9 @@ import { LemonButton, Link } from '@posthog/lemon-ui'
 import { ErrorEventType } from 'lib/components/Errors/types'
 import { getExceptionAttributes, getRecordingStatus, getSessionId } from 'lib/components/Errors/utils'
 import { TZLabel } from 'lib/components/TZLabel'
-import { RecordingPlayerType, useRecordingButton } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
+import ViewRecordingButton from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
-import { IconLink, IconPlayCircle } from 'lib/lemon-ui/icons'
+import { IconLink } from 'lib/lemon-ui/icons'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { cn } from 'lib/utils/css-classes'
 import { PersonDisplay, PersonIcon } from 'scenes/persons/PersonDisplay'
@@ -119,26 +119,23 @@ const Person = ({ person }: { person: ErrorEventType['person'] }): JSX.Element =
 }
 
 const Actions = (record: ErrorEventType): JSX.Element => {
-    const { onClick: onClickRecordingButton, disabledReason } = useRecordingButton({
-        sessionId: getSessionId(record.properties),
-        recordingStatus: getRecordingStatus(record.properties),
-        timestamp: record.timestamp,
-        openPlayerIn: RecordingPlayerType.Modal,
-        hasRecording: record.properties.has_recording as boolean | undefined,
-    })
+    const sessionId = getSessionId(record.properties)
+    const recordingStatus = getRecordingStatus(record.properties)
+    const hasRecording = record.properties.has_recording as boolean | undefined
 
     return (
         <div className="flex justify-end gap-1">
-            <LemonButton
-                size="small"
-                icon={<IconPlayCircle />}
-                onClick={(event) => {
-                    cancelEvent(event)
-                    onClickRecordingButton()
-                }}
-                disabledReason={disabledReason || undefined}
-                tooltip={!disabledReason ? 'View recording' : undefined}
-            />
+            <div className="flex justify-end align-middle items-center" onClick={(event) => cancelEvent(event)}>
+                <ViewRecordingButton
+                    type="secondary"
+                    sessionId={sessionId ?? ''}
+                    recordingStatus={recordingStatus}
+                    hasRecording={hasRecording}
+                    timestamp={record.timestamp}
+                    size="xsmall"
+                    data-attr="error-tracking-view-recording"
+                />
+            </div>
             {record.properties.$ai_trace_id && (
                 <LemonButton
                     size="small"

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -11,6 +11,7 @@ import { LemonDivider } from '@posthog/lemon-ui'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
+import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconRobot } from 'lib/lemon-ui/icons'
 import {
@@ -22,6 +23,7 @@ import {
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { PostHogSDKIssueBanner } from '../../components/Banners/PostHogSDKIssueBanner'
 import { BreakdownsChart } from '../../components/Breakdowns/BreakdownsChart'
@@ -88,6 +90,29 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                 assignee={issue.assignee}
                                                 onChange={updateAssignee}
                                                 disabled={issue.status != 'active'}
+                                            />
+                                            <ViewRecordingsPlaylistButton
+                                                filters={{
+                                                    filter_group: {
+                                                        type: FilterLogicalOperator.And,
+                                                        values: [
+                                                            {
+                                                                type: FilterLogicalOperator.And,
+                                                                values: [
+                                                                    {
+                                                                        key: '$exception_issue_id',
+                                                                        type: PropertyFilterType.Event,
+                                                                        operator: PropertyOperator.Exact,
+                                                                        value: [issue.id],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                }}
+                                                size="small"
+                                                type="secondary"
+                                                data-attr="error-tracking-issue-view-recordings"
                                             />
                                             <IssueStatusButton status={issue.status} onChange={updateStatus} />
                                         </div>


### PR DESCRIPTION
## Problem

Unifying the replay button experience/ component usage! this does it for error tracking. 

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

change existing row-button to use unified button and open in new tab

add a button to the top to open all recordings in a playlist
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

1. navigate to an error
2. click row to see single video new tab
3. click top button to see playlist of this error type (filter applied) in new tab

[error_tracking_2.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/68fca42f-2ff3-4f89-aaf1-0dec15ac7834.mov" />](https://app.graphite.com/user-attachments/video/68fca42f-2ff3-4f89-aaf1-0dec15ac7834.mov)

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
