### PR TITLE
perf(cdp): adjust instrumentation

### DIFF
--- a/plugin-server/src/common/tracing/tracing-utils.ts
+++ b/plugin-server/src/common/tracing/tracing-utils.ts
@@ -87,29 +87,6 @@ interface FunctionInstrumentationOptions {
     sendException?: boolean
 }
 
-/**
- * Wraps a function in a timeout guard and a prometheus metric.
- */
-/**
- * Lightweight instrumentation for high-frequency operations.
- * Only captures basic metrics without spans or timeouts.
- */
-export async function lightInstrumentFn<T>(key: string, func: () => Promise<T>): Promise<T> {
-    if (defaultConfig.DISABLE_INSTRUMENTATION) {
-        return func()
-    }
-
-    const end = instrumentedFunctionDuration.startTimer({ function: key })
-    try {
-        const result = await func()
-        end({ success: 'true' })
-        return result
-    } catch (error) {
-        end({ success: 'false' })
-        throw error
-    }
-}
-
 export async function instrumentFn<T>(
     options: string | FunctionInstrumentationOptions,
     func: () => Promise<T>

--- a/plugin-server/src/common/tracing/tracing-utils.ts
+++ b/plugin-server/src/common/tracing/tracing-utils.ts
@@ -90,10 +90,35 @@ interface FunctionInstrumentationOptions {
 /**
  * Wraps a function in a timeout guard and a prometheus metric.
  */
+/**
+ * Lightweight instrumentation for high-frequency operations.
+ * Only captures basic metrics without spans or timeouts.
+ */
+export async function lightInstrumentFn<T>(key: string, func: () => Promise<T>): Promise<T> {
+    if (defaultConfig.DISABLE_INSTRUMENTATION) {
+        return func()
+    }
+
+    const end = instrumentedFunctionDuration.startTimer({ function: key })
+    try {
+        const result = await func()
+        end({ success: 'true' })
+        return result
+    } catch (error) {
+        end({ success: 'false' })
+        throw error
+    }
+}
+
 export async function instrumentFn<T>(
     options: string | FunctionInstrumentationOptions,
     func: () => Promise<T>
 ): Promise<T> {
+    // Fast path: skip all instrumentation if disabled
+    if (defaultConfig.DISABLE_INSTRUMENTATION) {
+        return func()
+    }
+
     const key = typeof options === 'string' ? options : options.key
     const timeoutMessage =
         (typeof options === 'string' ? undefined : options.timeoutMessage) ?? `Timeout warning for '${key}'!`

--- a/plugin-server/src/common/tracing/tracing-utils.ts
+++ b/plugin-server/src/common/tracing/tracing-utils.ts
@@ -87,6 +87,10 @@ interface FunctionInstrumentationOptions {
     sendException?: boolean
 }
 
+/**
+ * Wraps a function in a timeout guard and a prometheus metric.
+ */
+
 export async function instrumentFn<T>(
     options: string | FunctionInstrumentationOptions,
     func: () => Promise<T>

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -208,6 +208,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_RATE_LIMITER_REFILL_RATE: 1, // per second request rate limit
         CDP_RATE_LIMITER_TTL: 60 * 60 * 24, // This is really long as it is essentially only important to make sure the key is eventually deleted
         CDP_HOG_FILTERS_TELEMETRY_TEAMS: '',
+        DISABLE_INSTRUMENTATION: false, // Disable OpenTelemetry instrumentation for better performance
         CDP_REDIS_PASSWORD: '',
         CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: true,
         CDP_REDIS_HOST: '127.0.0.1',

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -208,7 +208,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_RATE_LIMITER_REFILL_RATE: 1, // per second request rate limit
         CDP_RATE_LIMITER_TTL: 60 * 60 * 24, // This is really long as it is essentially only important to make sure the key is eventually deleted
         CDP_HOG_FILTERS_TELEMETRY_TEAMS: '',
-        DISABLE_INSTRUMENTATION: false, // Disable OpenTelemetry instrumentation for better performance
+        DISABLE_OPENTELEMETRY_TRACING: false, // Disable OpenTelemetry spans for better performance (keeps metrics and timeouts)
         CDP_REDIS_PASSWORD: '',
         CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: true,
         CDP_REDIS_HOST: '127.0.0.1',

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -176,6 +176,7 @@ export type CdpConfig = {
     CDP_RATE_LIMITER_REFILL_RATE: number // The number of tokens to be refilled per second
     CDP_RATE_LIMITER_TTL: number // The expiry for the rate limit key
     CDP_HOG_FILTERS_TELEMETRY_TEAMS: string
+    DISABLE_INSTRUMENTATION: boolean
     CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_KIND: CyclotronJobQueueKind
     CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: CyclotronJobQueueSource
     CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING: string // A comma-separated list of queue to mode like `hog:kafka,fetch:postgres,*:kafka` with * being the default

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -176,7 +176,7 @@ export type CdpConfig = {
     CDP_RATE_LIMITER_REFILL_RATE: number // The number of tokens to be refilled per second
     CDP_RATE_LIMITER_TTL: number // The expiry for the rate limit key
     CDP_HOG_FILTERS_TELEMETRY_TEAMS: string
-    DISABLE_INSTRUMENTATION: boolean
+    DISABLE_OPENTELEMETRY_TRACING: boolean
     CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_KIND: CyclotronJobQueueKind
     CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: CyclotronJobQueueSource
     CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING: string // A comma-separated list of queue to mode like `hog:kafka,fetch:postgres,*:kafka` with * being the default


### PR DESCRIPTION
### Problem

<img width="1505" height="733" alt="Screenshot 2025-12-19 at 09 54 33" src="https://github.com/user-attachments/assets/36aacafb-f558-4d91-9310-18968b108b11" />


The CDP events/ingestion consumers are spending lots of CPU time on telemetry instrumentation overhead by using `withSpan`. We don't use traces/spans atm so we are paying a pretty hefty price for it.

### Changes

  - Added `DISABLE_OPENTELEMETRY_TRACING` config flag to bypass creation of spans/traces

### Potential Impact

  - CPU usage should go down significantly
  - Keeps basic Prometheus metrics available
