### PR TITLE
chore(ci): switch scheduled actions to use GitHub app

### DIFF
--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -6,15 +6,23 @@ on:
     workflow_dispatch:
 
 permissions:
-    contents: write
-    pull-requests: write
+    contents: read
 
 jobs:
     update-browserslist-database:
         runs-on: ubuntu-latest
         steps:
+            - name: Get app token
+              id: app-token
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
+              with:
+                  app_id: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_PRIVATE_KEY }}
+
             - name: Checkout repository
               uses: actions/checkout@v4
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Configure git
               run: |
@@ -34,14 +42,14 @@ jobs:
               id: update-browserlist
               uses: c2corg/browserslist-update-action@a76abb476199caea5399f9e28ff3f16e491ec566 # v2
               with:
-                  github_token: ${{ secrets.POSTHOG_BOT_PAT }} # This token has permission to open PRs
+                  github_token: ${{ steps.app-token.outputs.token }}
                   commit_message: 'build: update Browserslist db'
                   title: 'build: update Browserslist db'
                   labels: 'dependencies'
 
             - name: Enable automerge
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   PR_NUMBER: ${{ steps.update-browserlist.outputs.pr_number }}
               run: |
                   gh pr merge "$PR_NUMBER" --auto --merge

--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -9,17 +9,23 @@ on:
 
 permissions:
     contents: read
-    pull-requests: write
 
 jobs:
     update-ai-costs:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Get app token
+              id: app-token
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
+              with:
+                  app_id: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_PRIVATE_KEY }}
+
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  token: ${{ secrets.POSTHOG_BOT_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Install pnpm
               uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
@@ -63,7 +69,7 @@ jobs:
               if: steps.check-changes.outputs.changes == 'true'
               uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v5
               with:
-                  token: ${{ secrets.POSTHOG_BOT_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   commit-message: 'chore(llma): update LLM costs'
                   title: 'chore(llma): Update LLM costs'
                   body: |

--- a/.github/workflows/update-bot-ips.yml
+++ b/.github/workflows/update-bot-ips.yml
@@ -8,17 +8,23 @@ on:
 
 permissions:
     contents: read
-    pull-requests: write
 
 jobs:
     update-bot-ips:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Get app token
+              id: app-token
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
+              with:
+                  app_id: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_POSTHOG_SCHEDULED_ACTIONS_PRIVATE_KEY }}
+
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  token: ${{ secrets.POSTHOG_BOT_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Run update script
               run: |
@@ -40,7 +46,7 @@ jobs:
               if: steps.check-changes.outputs.changes == 'true'
               uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v5
               with:
-                  token: ${{ secrets.POSTHOG_BOT_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   commit-message: 'Update bot IPs from GoodBots repository'
                   title: '🤖 Update bot IPs from GoodBots repository'
                   body: |


### PR DESCRIPTION
The last remaining CI jobs using a PAT.

The "Scheduled Actions (posthog)" app is the one GH app with identical permissions to our "Tests (posthog)" app. I'm choosing to keep them separate for now, since our "Tests" app runs against PRs and is thus more likely to leak. This doesn't matter much now given that the perms are the same, but if the perms ever diverge then we'll be glad these are separate. Of course the perms may never diverge and I wasted an extra 10 minutes setting up another app.