### PR TITLE
fix(ci): publish @posthog/hogvm via Trusted Publisher

### DIFF
--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -157,6 +157,9 @@ jobs:
         runs-on: ubuntu-24.04
         needs: check-package-version
         if: needs.changes.outputs.hog == 'true' && needs.check-package-version.outputs.is-new-version == 'true'
+        permissions:
+            contents: read
+            id-token: write
         env:
             COMMITTED_VERSION: ${{ needs.check-package-version.outputs.committed-version }}
             PUBLISHED_VERSION: ${{ needs.check-package-version.outputs.published-version }}
@@ -185,17 +188,13 @@ jobs:
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Install pnpm
               uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
-            - name: Set up Node 18
+            - name: Set up Node 24
               uses: actions/setup-node@v4
               with:
-                  node-version: 18
+                  node-version: 24
                   cache: 'pnpm'
                   registry-url: https://registry.npmjs.org
             - name: Install package.json dependencies
               run: pnpm --filter=@posthog/hogvm install --frozen-lockfile
             - name: Publish the package in the npm registry
               run: cd common/hogvm/typescript && npm publish --access public
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-            - name: Sleep 60 seconds to allow npm to update the package
-              run: sleep 60


### PR DESCRIPTION
This has been broken since late November.
