### PR TITLE
chore(ci): specify explicit workflow permissions

### DIFF
--- a/.github/workflows/codespaces.yml
+++ b/.github/workflows/codespaces.yml
@@ -22,6 +22,9 @@ jobs:
     build:
         name: Build Codespaces image
         runs-on: ubuntu-24.04
+        permissions:
+          contents: read
+          packages: write
 
         # Build on master and PRs with the label 'codespaces-build' only
         if: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'codespaces-build')  }}

--- a/.github/workflows/codespaces.yml
+++ b/.github/workflows/codespaces.yml
@@ -23,8 +23,8 @@ jobs:
         name: Build Codespaces image
         runs-on: ubuntu-24.04
         permissions:
-          contents: read
-          packages: write
+            contents: read
+            packages: write
 
         # Build on master and PRs with the label 'codespaces-build' only
         if: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'codespaces-build')  }}


### PR DESCRIPTION
This is the last remaining workflow in this repo without explicit permissions that also requires elevated permissions beyond `contents: read`.