### PR TITLE
fix(surveys): flaky test

### DIFF
--- a/playwright/e2e/surveys/quickcreate.spec.ts
+++ b/playwright/e2e/surveys/quickcreate.spec.ts
@@ -231,7 +231,7 @@ test.describe('Quick create survey from feature flag', () => {
         await responsePromise
         await page.waitForURL(/project\/(\d+)\/surveys\/([\w-]+)/)
         await expect(page.locator('.scene-tab-title').first()).toContainText(name)
-        await expect(page.locator('[data-attr="launch-survey"]').first()).toBeVisible()
+        await expect(page.locator('[data-attr="launch-survey"]').getByText('Launch', { exact: true })).toBeVisible()
     })
 
     test('warning shown when surveys are disabled', async ({ page }) => {


### PR DESCRIPTION
## Problem
test is flaky when the "first survey helper" appears, which causes two launch buttons to be visible
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
get more specific on the target button

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
CI passes 🤞 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
