### PR TITLE
fix(surveys): Fix survey hypercache tests by clearing S3 object storage

### DIFF
--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -31,7 +31,7 @@ from posthog.constants import AvailableFeature
 from posthog.models import Action, FeatureFlag, Person, Team
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.organization import Organization
-from posthog.models.surveys.survey import MAX_ITERATION_COUNT, Survey
+from posthog.models.surveys.survey import MAX_ITERATION_COUNT, Survey, surveys_hypercache
 from posthog.models.surveys.survey_response_archive import SurveyResponseArchive
 
 from products.product_tours.backend.models import ProductTour
@@ -3369,6 +3369,11 @@ class TestSurveysAPIList(BaseTest, QueryMatchingTest):
         )
         self.client.logout()
 
+        # Clear the surveys hypercache to ensure we're testing against fresh data.
+        # The hypercache stores data in both Redis/LocMemCache AND S3 object storage,
+        # and cache.clear() only clears the former.
+        surveys_hypercache.clear_cache(self.team.api_token)
+
         with self.settings(SURVEYS_API_USE_HYPERCACHE_TOKENS=[self.team.api_token]):
             # First time builds the remote config which uses a bunch of queries
             with self.assertNumQueries(3):
@@ -3397,6 +3402,11 @@ class TestSurveysAPIList(BaseTest, QueryMatchingTest):
             questions=[{"type": "open", "question": "Why's a hedgehog?"}],
         )
         self.client.logout()
+
+        # Clear the surveys hypercache to ensure we're testing against fresh data.
+        # The hypercache stores data in both Redis/LocMemCache AND S3 object storage,
+        # and cache.clear() only clears the former.
+        surveys_hypercache.clear_cache(self.team.api_token)
 
         with self.settings(SURVEYS_API_USE_HYPERCACHE_TOKENS=[self.team.api_token]):
             cache_response = self._get_surveys(token=self.team.api_token).json()


### PR DESCRIPTION
## Problem

These tests:

```bash
python -m pytest posthog/api/test/test_survey.py::TestSurveysAPIList::test_list_surveys_uses_hypercache posthog/api/test/test_survey.py::TestSurveysAPIList::test_hypercache_surveys_match_api_endpoint -v
```

...were failing because they were reading stale survey data from S3 object storage. The `HyperCache` has a multi-tier caching strategy:

1. Redis/LocMemCache
2. S3 object storage
3. Database

The test `setUp` was calling `cache.clear()` which only clears `LocMemCache`, not `S3`. Previous test runs had written survey data to S3, and subsequent runs were reading this stale data instead of querying the database.

## Changes

Adds `surveys_hypercache.clear_cache()` calls to clear both cache tiers before the `HyperCache` assertions.

## How did you test this code?

Unit Tests

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

It's a unit test change only.