### PR TITLE
fix(ci): grant permissions required by nested Actions

### DIFF
--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -593,6 +593,9 @@ jobs:
         needs: changes
         if: needs.changes.outputs.label_removed == 'true'
         uses: ./.github/workflows/cleanup-hobby-preview.yml
+        # these permissions are required by cleanup-hobby-preview.yml
+        permissions:
+            deployments: write
         with:
             pr_number: ${{ github.event.pull_request.number }}
         secrets: inherit

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -57,6 +57,11 @@ jobs:
     deploy_preview:
         name: Deploy preview environment
         uses: ./.github/workflows/pr-preview-deploy.yml
+        # these permissions are required by pr-preview-deploy.yml
+        permissions:
+            id-token: write
+            contents: read
+            deployments: write
         needs: [posthog_build, changes]
         secrets: inherit
         if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') && needs.changes.outputs.docker_files == 'true' }}

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -10,6 +10,9 @@ jobs:
         name: Cleanup hobby preview deployment
         if: contains(github.event.pull_request.labels.*.name, 'hobby-preview')
         uses: ./.github/workflows/cleanup-hobby-preview.yml
+        # these permissions are required by cleanup-hobby-preview.yml
+        permissions:
+            deployments: write
         with:
             pr_number: '${{ github.event.pull_request.number }}'
         secrets: inherit


### PR DESCRIPTION
When a workflow calls another workflow, the nested workflow can only request a subset of the parent workflow's perms.