### PR TITLE
fix: handle non-DRF exceptions in Vercel error mixin

### DIFF
--- a/ee/api/vercel/test/test_error_mixin_bug.py
+++ b/ee/api/vercel/test/test_error_mixin_bug.py
@@ -1,0 +1,72 @@
+"""Test to reproduce the handle_exception returning None bug"""
+
+from unittest.mock import patch
+
+from django.test import RequestFactory
+
+from rest_framework import exceptions, viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from ee.api.vercel.test.base import VercelTestBase
+from ee.api.vercel.vercel_error_mixin import VercelErrorResponseMixin
+
+
+class _TestViewSet(VercelErrorResponseMixin, viewsets.GenericViewSet):
+    authentication_classes = []
+    permission_classes = []
+
+    def test_action(self, request: Request) -> Response:
+        raise ValueError("This is a non-DRF exception")
+
+
+class TestVercelErrorMixinBug(VercelTestBase):
+    def test_handle_exception_with_non_drf_exception_returns_response(self):
+        factory = RequestFactory()
+        django_request = factory.put("/test/")
+
+        viewset = _TestViewSet()
+        viewset.action = "test_action"
+        viewset.format_kwarg = None
+        viewset.request = Request(django_request)
+
+        exc = ValueError("Non-DRF exception")
+        response = viewset.handle_exception(exc)
+
+        self.assertIsNotNone(response)
+        self.assertIsInstance(response, Response)
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.data["error"]["code"], "internal_error")
+        self.assertEqual(response.data["error"]["message"], "An internal error occurred. Please try again.")
+        self.assertNotIn("Non-DRF exception", response.data["error"]["message"])
+
+    def test_handle_exception_with_drf_exception_returns_response(self):
+        factory = RequestFactory()
+        django_request = factory.put("/test/")
+
+        viewset = _TestViewSet()
+        viewset.action = "test_action"
+        viewset.format_kwarg = None
+        viewset.request = Request(django_request)
+
+        exc = exceptions.ValidationError("DRF exception")
+        response = viewset.handle_exception(exc)
+
+        self.assertIsNotNone(response)
+        self.assertIsInstance(response, Response)
+        self.assertEqual(response.status_code, 400)
+
+    def test_viewset_dispatch_with_non_drf_exception(self):
+        factory = RequestFactory()
+        django_request = factory.put("/test/")
+
+        viewset = _TestViewSet.as_view({"put": "test_action"})
+
+        with patch.object(_TestViewSet, "test_action", side_effect=ValueError("Test error")):
+            response = viewset(django_request)
+
+            self.assertIsNotNone(response)
+            self.assertEqual(response.status_code, 500)
+            self.assertEqual(response.data["error"]["code"], "internal_error")
+            self.assertEqual(response.data["error"]["message"], "An internal error occurred. Please try again.")
+            self.assertNotIn("Test error", response.data["error"]["message"])


### PR DESCRIPTION
## Problem
Previously, VercelErrorResponseMixin.handle_exception() would return None when a non-DRF exception was raised (like ValueError, KeyError, etc.). This caused Django to fail with:
'Expected a Response, HttpResponse or StreamingHttpResponse to be returned from the view, but received a <class 'NoneType'>'

We got this error https://us.posthog.com/project/2/error_tracking/019b3318-cee5-7cc3-9901-42dcec99839b?timestamp=2025-12-18%2012%3A14%3A04.274000-08%3A00 and I think it buried another error.

## Changes
- Always return a Response object from handle_exception()
- Log non-DRF exceptions to structlog
- Send non-DRF exceptions to error tracking
- Return generic error message to Vercel (no internal details leaked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
