### PR TITLE
fix(survey): Add a default for `archivedResponseUuids` loader

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -858,7 +858,7 @@ export const surveyLogic = kea<surveyLogicType>([
             },
         },
         archivedResponseUuids: [
-            new Set<any>(),
+            new Set<string>(),
             {
                 loadArchivedResponseUuids: async (): Promise<Set<string>> => {
                     if (props.id === NEW_SURVEY.id) {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -857,15 +857,18 @@ export const surveyLogic = kea<surveyLogicType>([
                 return { responsesByQuestion }
             },
         },
-        archivedResponseUuids: {
-            loadArchivedResponseUuids: async (): Promise<Set<string>> => {
-                if (props.id === NEW_SURVEY.id) {
-                    return new Set()
-                }
-                const uuids = await api.surveys.getArchivedResponseUuids(props.id)
-                return new Set(uuids)
+        archivedResponseUuids: [
+            new Set<any>(),
+            {
+                loadArchivedResponseUuids: async (): Promise<Set<string>> => {
+                    if (props.id === NEW_SURVEY.id) {
+                        return new Set()
+                    }
+                    const uuids = await api.surveys.getArchivedResponseUuids(props.id)
+                    return new Set(uuids)
+                },
             },
-        },
+        ],
     })),
     listeners(({ actions, values }) => {
         const reloadAllSurveyResults = debounce((): void => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Closes https://github.com/PostHog/posthog/issues/43657

## Changes

Hmmm I can't replicate for now, but I think `archivedResponseUuids` is initialised as `null`, so setting a default should ensure that `archivedResponseUuids` wouldn't be null  

## How did you test this code?

Since I can't replicate, I don't think I'm testing this correctly!



