### PR TITLE
fix: make a bunch of timers stop in the background

### DIFF
--- a/frontend/src/layout/navigation/ProjectNotice.tsx
+++ b/frontend/src/layout/navigation/ProjectNotice.tsx
@@ -5,7 +5,7 @@ import { IconGear, IconPlus } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
-import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonBannerAction } from 'lib/lemon-ui/LemonBanner/LemonBanner'
 import { Link } from 'lib/lemon-ui/Link'
@@ -31,8 +31,8 @@ interface ProjectNoticeBlueprint {
 
 function CountDown({ datetime, callback }: { datetime: dayjs.Dayjs; callback?: () => void }): JSX.Element {
     const [now, setNow] = useState(dayjs())
+    const { isVisible: isPageVisible } = usePageVisibility()
 
-    // Format the time difference as 00:00:00
     const duration = dayjs.duration(datetime.diff(now))
     const pastCountdown = duration.seconds() < 0
 
@@ -42,10 +42,15 @@ function CountDown({ datetime, callback }: { datetime: dayjs.Dayjs; callback?: (
           ? duration.format('HH:mm:ss')
           : duration.format('mm:ss')
 
-    useOnMountEffect(() => {
+    useEffect(() => {
+        if (!isPageVisible) {
+            return
+        }
+
+        setNow(dayjs())
         const interval = setInterval(() => setNow(dayjs()), 1000)
         return () => clearInterval(interval)
-    })
+    }, [isPageVisible])
 
     useEffect(() => {
         if (pastCountdown) {

--- a/frontend/src/lib/lemon-ui/LoadingBar/LoadingBar.tsx
+++ b/frontend/src/lib/lemon-ui/LoadingBar/LoadingBar.tsx
@@ -2,6 +2,7 @@ import './LoadingBar.scss'
 
 import { useEffect, useState } from 'react'
 
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { cn } from 'lib/utils/css-classes'
 
 export interface SpinnerProps {
@@ -18,6 +19,7 @@ export interface SpinnerProps {
 /** Smoothly animated spinner for loading states. It does not indicate progress, only that something's happening. */
 export function LoadingBar({ className, loadId, setProgress, progress, wrapperClassName }: SpinnerProps): JSX.Element {
     const [_progress, _setProgress] = useState(0)
+    const { isVisible: isPageVisible } = usePageVisibility()
 
     useEffect(() => {
         if (loadId && progress) {
@@ -34,6 +36,10 @@ export function LoadingBar({ className, loadId, setProgress, progress, wrapperCl
     }, [_progress, loadId, setProgress])
 
     useEffect(() => {
+        if (!isPageVisible) {
+            return
+        }
+
         const interval = setInterval(() => {
             _setProgress((prevProgress) => {
                 let newProgress = prevProgress + 0.005
@@ -52,7 +58,7 @@ export function LoadingBar({ className, loadId, setProgress, progress, wrapperCl
         }, 50)
 
         return () => clearInterval(interval)
-    }, [loadId])
+    }, [loadId, isPageVisible])
 
     return (
         <div className={cn(`progress-outer max-w-120 w-full my-3`, wrapperClassName)} data-attr="loading-bar">

--- a/frontend/src/scenes/data-warehouse/editor/ViewLoadingState.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/ViewLoadingState.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
-import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 
 const VIEW_EMPTY_STATE_COPY = [
     'Resolving joins between your tables…',
@@ -13,8 +13,13 @@ const VIEW_EMPTY_STATE_COPY = [
 export function ViewEmptyState(): JSX.Element {
     const [messageIndex, setMessageIndex] = useState(0)
     const [isMessageVisible, setIsMessageVisible] = useState(true)
+    const { isVisible: isPageVisible } = usePageVisibility()
 
-    useOnMountEffect(() => {
+    useEffect(() => {
+        if (!isPageVisible) {
+            return
+        }
+
         const TOGGLE_INTERVAL = 3000
         const FADE_OUT_DURATION = 300
 
@@ -39,7 +44,7 @@ export function ViewEmptyState(): JSX.Element {
                 clearTimeout(fadeTimeoutId)
             }
         }
-    })
+    }, [isPageVisible])
 
     return (
         <div data-attr="view-empty-state" className="flex flex-col flex-1 items-center justify-center">

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -23,6 +23,7 @@ import { useHogfetti } from 'lib/components/Hogfetti/Hogfetti'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { PropertyFilterButton } from 'lib/components/PropertyFilters/components/PropertyFilterButton'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { IconAreaChart } from 'lib/lemon-ui/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
@@ -275,8 +276,13 @@ export function ResultsHeader(): JSX.Element {
 
 export function EllipsisAnimation(): JSX.Element {
     const [ellipsis, setEllipsis] = useState('.')
+    const { isVisible: isPageVisible } = usePageVisibility()
 
-    useOnMountEffect(() => {
+    useEffect(() => {
+        if (!isPageVisible) {
+            return
+        }
+
         let count = 1
         let direction = 1
 
@@ -290,7 +296,7 @@ export function EllipsisAnimation(): JSX.Element {
         }, 300)
 
         return () => clearInterval(interval)
-    })
+    }, [isPageVisible])
 
     return <span>{ellipsis}</span>
 }

--- a/frontend/src/scenes/experiments/MetricsView/new/ElapsedTime.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ElapsedTime.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useState } from 'react'
 
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
+
 interface ElapsedTimeProps {
     startTime: string | null | undefined
 }
 
 export function ElapsedTime({ startTime }: ElapsedTimeProps): JSX.Element | null {
     const [elapsedSeconds, setElapsedSeconds] = useState<number>(0)
+    const { isVisible: isPageVisible } = usePageVisibility()
 
     useEffect(() => {
-        if (!startTime) {
+        if (!startTime || !isPageVisible) {
             return
         }
 
@@ -24,7 +27,7 @@ export function ElapsedTime({ startTime }: ElapsedTimeProps): JSX.Element | null
         const interval = setInterval(updateElapsed, 1000)
 
         return () => clearInterval(interval)
-    }, [startTime])
+    }, [startTime, isPageVisible])
 
     if (!startTime) {
         return null

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -20,7 +20,7 @@ import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { BuilderHog3 } from 'lib/components/hedgehogs'
 import { dayjs } from 'lib/dayjs'
-import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { Link } from 'lib/lemon-ui/Link'
 import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
@@ -249,8 +249,13 @@ export function StatelessInsightLoadingState({
         inStorybook() || inStorybookTestRunner() ? 0 : Math.floor(Math.random() * LOADING_MESSAGES.length)
     )
     const [isLoadingMessageVisible, setIsLoadingMessageVisible] = useState(true)
+    const { isVisible: isPageVisible } = usePageVisibility()
 
     useEffect(() => {
+        if (!isPageVisible) {
+            return
+        }
+
         const status = pollResponse?.status?.query_progress
         const previousStatus = pollResponse?.previousStatus?.query_progress
         setRowsRead(previousStatus?.rows_read || 0)
@@ -271,10 +276,14 @@ export function StatelessInsightLoadingState({
         }, 100)
 
         return () => clearInterval(interval)
-    }, [pollResponse])
+    }, [pollResponse, isPageVisible])
 
     // Toggle between loading messages every 2.5-3.5 seconds, with 300ms fade out, then change text, keep in sync with the transition duration below
-    useOnMountEffect(() => {
+    useEffect(() => {
+        if (!isPageVisible) {
+            return
+        }
+
         const TOGGLE_INTERVAL_MIN = 2500
         const TOGGLE_INTERVAL_JITTER = 1000
         const FADE_OUT_DURATION = 300
@@ -303,7 +312,7 @@ export function StatelessInsightLoadingState({
         )
 
         return () => clearInterval(interval)
-    })
+    }, [isPageVisible])
 
     const suggestions = suggestion ? (
         suggestion

--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { IconDatabase, IconRefresh } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
@@ -64,12 +65,14 @@ export function AsyncMigrations(): JSX.Element {
         setActiveTab,
     } = useActions(asyncMigrationsLogic)
 
+    const { isVisible: isPageVisible } = usePageVisibility()
+
     useEffect(() => {
-        if (isAnyMigrationRunning) {
+        if (isAnyMigrationRunning && isPageVisible) {
             const interval = setInterval(() => loadAsyncMigrations(), STATUS_RELOAD_INTERVAL_MS)
             return () => clearInterval(interval)
         }
-    }, [isAnyMigrationRunning]) // oxlint-disable-line react-hooks/exhaustive-deps
+    }, [isAnyMigrationRunning, isPageVisible]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     const nameColumn: AsyncMigrationColumnType = {
         title: 'Migration',

--- a/frontend/src/scenes/notebooks/Notebook/NotebookColumnLeft.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookColumnLeft.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LemonWidget } from 'lib/lemon-ui/LemonWidget'
 
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
@@ -43,8 +44,13 @@ export const NotebookNodeSettingsOffset = ({ logic }: { logic: BuiltLogic<notebo
     const { ref } = useValues(logic)
     const offsetRef = useRef<HTMLDivElement>(null)
     const [height, setHeight] = useState(0)
+    const { isVisible: isPageVisible } = usePageVisibility()
 
     useEffect(() => {
+        if (!isPageVisible) {
+            return
+        }
+
         // Interval to check the relative positions of the node and the offset div
         // updating the height so that it always is inline
         const updateHeight = (): void => {
@@ -61,7 +67,7 @@ export const NotebookNodeSettingsOffset = ({ logic }: { logic: BuiltLogic<notebo
         updateHeight()
 
         return () => clearInterval(interval)
-    }, [ref, offsetRef.current, height])
+    }, [ref, offsetRef.current, height, isPageVisible])
 
     return (
         <div

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -19,7 +19,7 @@ import {
 } from '@posthog/icons'
 import { LemonBanner, LemonDivider, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
-import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { playerMetaLogic } from 'scenes/session-recordings/player/player-meta/playerMetaLogic'
@@ -78,21 +78,25 @@ interface SegmentMetaProps {
 
 function LoadingTimer({ operation }: { operation?: string }): JSX.Element {
     const [elapsedSeconds, setElapsedSeconds] = useState(0)
+    const { isVisible: isPageVisible } = usePageVisibility()
 
     useEffect(() => {
         if (operation !== undefined) {
-            setElapsedSeconds(0) // Reset timer only when operation changes and is provided
+            setElapsedSeconds(0)
         }
     }, [operation])
 
-    // Run on mount only to avoid resetting interval
-    useOnMountEffect(() => {
+    useEffect(() => {
+        if (!isPageVisible) {
+            return
+        }
+
         const interval = setInterval(() => {
             setElapsedSeconds((prev) => prev + 1)
         }, 1000)
 
         return () => clearInterval(interval)
-    })
+    }, [isPageVisible])
 
     return <span className="font-mono text-xs text-muted">{elapsedSeconds}s</span>
 }


### PR DESCRIPTION
memory footprint continues to make a sad
tabs not sleeping when in the background makes an extra sad
find more places with timers and make them pause based on visibility

## Changelog: (features only) Is this feature complete?

no
