### PR TITLE
fix(insight): Add truncate to button in filtering dropdown 

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -271,6 +271,7 @@ export function TaxonomicPropertyFilter({
                                     onClick={() => (dropdownOpen ? closeDropdown() : openDropdown())}
                                     size={size}
                                     tooltipDocLink={addFilterDocLink}
+                                    truncate={true}
                                 >
                                     {filterContent ?? (addText || 'Add filter')}
                                 </LemonButton>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Closes https://github.com/PostHog/posthog/issues/43634

## Changes

https://github.com/user-attachments/assets/77320814-3fe7-460c-a6fc-d5c569dcc8c9



## How did you test this code?

1) Create an insight
2) Add a filter group
3) Select a longer option, for example 'Autocapture disabled server-side'
4) The text should be truncated 
