### PR TITLE
fix: Reapply "feat(product tours): create/edit in toolbar more easily" (#43723)

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlForm.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlForm.tsx
@@ -37,7 +37,13 @@ export function AuthorizedUrlForm({
     return (
         <Form
             logic={authorizedUrlListLogic}
-            props={{ actionId: actionId ?? null, experimentId: experimentId ?? null, type, allowWildCards }}
+            props={{
+                actionId: actionId ?? null,
+                experimentId: experimentId ?? null,
+                productTourId: productTourId ?? null,
+                type,
+                allowWildCards,
+            }}
             formKey="proposedUrl"
             enableFormOnSubmit
             className="w-full deprecated-space-y-2"

--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlForm.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlForm.tsx
@@ -13,18 +13,21 @@ export interface AuthorizedUrlFormProps {
     type: AuthorizedUrlListType
     actionId?: number
     experimentId?: ExperimentIdType
+    productTourId?: string | null
     allowWildCards?: boolean
 }
 
 export function AuthorizedUrlForm({
     actionId,
     experimentId,
+    productTourId,
     type,
     allowWildCards,
 }: AuthorizedUrlFormProps): JSX.Element {
     const logic = authorizedUrlListLogic({
         actionId: actionId ?? null,
         experimentId: experimentId ?? null,
+        productTourId: productTourId ?? null,
         type,
         allowWildCards,
     })

--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -19,6 +19,7 @@ export interface AuthorizedUrlListProps {
     type: AuthorizedUrlListType
     actionId?: number
     experimentId?: ExperimentIdType
+    productTourId?: string | null
     query?: string | null
     allowWildCards?: boolean
     displaySuggestions?: boolean
@@ -30,6 +31,7 @@ export interface AuthorizedUrlListProps {
 export function AuthorizedUrlList({
     actionId,
     experimentId,
+    productTourId,
     query,
     type,
     addText = 'Add new authorized URL',
@@ -41,6 +43,7 @@ export function AuthorizedUrlList({
 }: AuthorizedUrlListProps & { addText?: string }): JSX.Element {
     const logic = authorizedUrlListLogic({
         experimentId: experimentId ?? null,
+        productTourId: productTourId ?? null,
         actionId: actionId ?? null,
         type,
         query,
@@ -57,6 +60,7 @@ export function AuthorizedUrlList({
         <div className="flex flex-col gap-2">
             <EmptyState
                 experimentId={experimentId}
+                productTourId={productTourId}
                 actionId={actionId}
                 type={type}
                 displaySuggestions={displaySuggestions}
@@ -68,6 +72,7 @@ export function AuthorizedUrlList({
                         type={type}
                         actionId={actionId}
                         experimentId={experimentId}
+                        productTourId={productTourId}
                         allowWildCards={allowWildCards}
                     />
                 </div>
@@ -98,6 +103,7 @@ export function AuthorizedUrlList({
                             type={type}
                             actionId={actionId}
                             experimentId={experimentId}
+                            productTourId={productTourId}
                             allowWildCards={allowWildCards}
                         />
                     </div>

--- a/frontend/src/lib/components/AuthorizedUrlList/EmptyState.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/EmptyState.tsx
@@ -13,17 +13,24 @@ import { AuthorizedUrlListType, KeyedAppUrl, authorizedUrlListLogic } from './au
 type EmptyStateProps = {
     type: AuthorizedUrlListType
     experimentId?: ExperimentIdType | null
+    productTourId?: string | null
     actionId?: number | null
     displaySuggestions?: boolean
 }
 
 export function EmptyState({
     experimentId,
+    productTourId,
     actionId,
     type,
     displaySuggestions = true,
 }: EmptyStateProps): JSX.Element | null {
-    const logic = authorizedUrlListLogic({ experimentId: experimentId ?? null, actionId: actionId ?? null, type })
+    const logic = authorizedUrlListLogic({
+        experimentId: experimentId ?? null,
+        productTourId: productTourId ?? null,
+        actionId: actionId ?? null,
+        type,
+    })
     const { urlsKeyed, suggestionsLoading, isAddUrlFormVisible } = useValues(logic)
     const { loadSuggestions } = useActions(logic)
 

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.test.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.test.ts
@@ -39,6 +39,7 @@ describe('the authorized urls list logic', () => {
             type: AuthorizedUrlListType.TOOLBAR_URLS,
             actionId: null,
             experimentId: null,
+            productTourId: null,
             query: null,
         })
         logic.mount()
@@ -139,6 +140,7 @@ describe('the authorized urls list logic', () => {
                 type: AuthorizedUrlListType.RECORDING_DOMAINS,
                 actionId: null,
                 experimentId: null,
+                productTourId: null,
                 query: null,
             })
             logic.mount()

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -245,7 +245,7 @@ export const defaultAuthorizedUrlProperties = {
 export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
     path((key) => ['lib', 'components', 'AuthorizedUrlList', 'authorizedUrlListLogic', key]),
     key((props) => `${props.type}-${props.experimentId}-${props.actionId}-${props.productTourId}`), // Some will be undefined but that's ok, this avoids experiment/action with same ID sharing same store
-    props({} as AuthorizedUrlListLogicProps),
+    props({ ...defaultAuthorizedUrlProperties } as AuthorizedUrlListLogicProps),
     connect(() => ({
         values: [teamLogic, ['currentTeam', 'currentTeamId']],
         actions: [teamLogic, ['updateCurrentTeam']],

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -100,16 +100,37 @@ export const validateProposedUrl = (
     return
 }
 
-function buildToolbarParams(options?: {
+interface BuildToolbarParamsOptions {
     actionId?: number | null
     experimentId?: ExperimentIdType
+    productTourId?: string | null
     userIntent?: ToolbarUserIntent
     toolbarFlagsKey?: string
-}): ToolbarParams {
+}
+
+const _buildToolbarUserIntent = (options?: BuildToolbarParamsOptions): ToolbarUserIntent => {
+    if (options?.userIntent) {
+        return options.userIntent
+    }
+    if (options?.actionId) {
+        return 'edit-action'
+    }
+    if (options?.experimentId) {
+        return 'edit-experiment'
+    }
+    if (options?.productTourId) {
+        if (options.productTourId !== 'new') {
+            return 'edit-product-tour'
+        }
+        return 'add-product-tour'
+    }
+
+    return 'add-action'
+}
+
+function buildToolbarParams(options?: BuildToolbarParamsOptions): ToolbarParams {
     return {
-        userIntent:
-            options?.userIntent ??
-            (options?.actionId ? 'edit-action' : options?.experimentId ? 'edit-experiment' : 'add-action'),
+        userIntent: _buildToolbarUserIntent(options),
         // Make sure to pass the app url, otherwise the api_host will be used by
         // the toolbar, which isn't correct when used behind a reverse proxy as
         // we require e.g. SSO login to the app, which will not work when placed
@@ -117,6 +138,7 @@ function buildToolbarParams(options?: {
         apiURL: apiHostOrigin(),
         ...(options?.actionId ? { actionId: options.actionId } : {}),
         ...(options?.experimentId ? { experimentId: options.experimentId } : {}),
+        ...(options?.productTourId && options.productTourId !== 'new' ? { productTourId: options.productTourId } : {}),
         ...(options?.toolbarFlagsKey ? { toolbarFlagsKey: options.toolbarFlagsKey } : {}),
     }
 }
@@ -127,6 +149,7 @@ export function appEditorUrl(
     options?: {
         actionId?: number | null
         experimentId?: ExperimentIdType
+        productTourId?: string | null
         userIntent?: ToolbarUserIntent
         generateOnly?: boolean
         toolbarFlagsKey?: string
@@ -208,6 +231,7 @@ export interface KeyedAppUrl {
 export interface AuthorizedUrlListLogicProps {
     actionId: number | null
     experimentId: ExperimentIdType | null
+    productTourId: string | null
     type: AuthorizedUrlListType
     allowWildCards?: boolean
 }
@@ -215,11 +239,12 @@ export interface AuthorizedUrlListLogicProps {
 export const defaultAuthorizedUrlProperties = {
     actionId: null,
     experimentId: null,
+    productTourId: null,
 }
 
 export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
     path((key) => ['lib', 'components', 'AuthorizedUrlList', 'authorizedUrlListLogic', key]),
-    key((props) => `${props.type}-${props.experimentId}-${props.actionId}`), // Some will be undefined but that's ok, this avoids experiment/action with same ID sharing same store
+    key((props) => `${props.type}-${props.experimentId}-${props.actionId}-${props.productTourId}`), // Some will be undefined but that's ok, this avoids experiment/action with same ID sharing same store
     props({} as AuthorizedUrlListLogicProps),
     connect(() => ({
         values: [teamLogic, ['currentTeam', 'currentTeamId']],
@@ -454,12 +479,16 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
             },
         ],
         launchUrl: [
-            (_, p) => [p.actionId, p.experimentId],
-            (actionId, experimentId) => (url: string) => {
+            (_, p) => [p.actionId, p.experimentId, p.productTourId],
+            (actionId, experimentId, productTourId) => (url: string) => {
                 if (experimentId) {
                     return appEditorUrl(url, {
                         experimentId,
                     })
+                }
+
+                if (productTourId) {
+                    return appEditorUrl(url, { productTourId })
                 }
 
                 return appEditorUrl(url, {

--- a/frontend/src/lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic.ts
+++ b/frontend/src/lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic.ts
@@ -40,6 +40,8 @@ export const UserIntentVerb: {
     'edit-action': 'edit the action',
     'add-experiment': 'add web experiment',
     'edit-experiment': 'edit the experiment',
+    'add-product-tour': 'add product tour',
+    'edit-product-tour': 'edit the product tour',
 }
 
 export const iframedToolbarBrowserLogic = kea<iframedToolbarBrowserLogicType>([

--- a/frontend/src/scenes/onboarding/web-analytics/OnboardingWebAnalyticsAuthorizedDomainsStep.tsx
+++ b/frontend/src/scenes/onboarding/web-analytics/OnboardingWebAnalyticsAuthorizedDomainsStep.tsx
@@ -16,6 +16,7 @@ export function OnboardingWebAnalyticsAuthorizedDomainsStep({
         authorizedUrlListLogic({
             actionId: null,
             experimentId: null,
+            productTourId: null,
             type: AuthorizedUrlListType.WEB_ANALYTICS,
             allowWildCards: false,
         })

--- a/frontend/src/scenes/product-tours/ProductTours.tsx
+++ b/frontend/src/scenes/product-tours/ProductTours.tsx
@@ -39,7 +39,7 @@ function NewTourButton(): JSX.Element {
                     <AuthorizedUrlList
                         type={AuthorizedUrlListType.TOOLBAR_URLS}
                         addText="Add authorized URL"
-                        query="__posthog_product_tour=new"
+                        productTourId="new"
                     />
                 </div>
             </LemonModal>

--- a/frontend/src/scenes/product-tours/components/EditInToolbarButton.tsx
+++ b/frontend/src/scenes/product-tours/components/EditInToolbarButton.tsx
@@ -34,7 +34,7 @@ export function EditInToolbarButton({
                     <AuthorizedUrlList
                         type={AuthorizedUrlListType.TOOLBAR_URLS}
                         addText="Add authorized URL"
-                        query={`__posthog_product_tour=${tourId}`}
+                        productTourId={tourId}
                     />
                 </div>
             </LemonModal>

--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -409,6 +409,7 @@ const AddAuthorizedUrlForm = (): JSX.Element => {
             props={{
                 actionId: null,
                 experimentId: null,
+                productTourId: null,
                 type: AuthorizedUrlListType.WEB_ANALYTICS,
                 allowWildCards: false,
             }}
@@ -417,7 +418,12 @@ const AddAuthorizedUrlForm = (): JSX.Element => {
         >
             <div className="p-2 flex flex-col gap-2" onClick={(e) => e.stopPropagation()}>
                 <LemonField name="url">
-                    <LemonInput size="small" placeholder="https://example.com" autoFocus />
+                    <LemonInput
+                        size="small"
+                        placeholder="https://example.com"
+                        autoFocus
+                        data-attr="web-authorized-url-input"
+                    />
                 </LemonField>
                 <div className="flex gap-2 justify-end">
                     <LemonButton size="small" type="secondary" onClick={cancelProposingAuthorizedUrl}>

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -124,7 +124,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             ['hasAvailableFeature'],
             preflightLogic,
             ['isDev'],
-            authorizedUrlListLogic({ type: AuthorizedUrlListType.WEB_ANALYTICS, actionId: null, experimentId: null }),
+            authorizedUrlListLogic({
+                type: AuthorizedUrlListType.WEB_ANALYTICS,
+                actionId: null,
+                experimentId: null,
+                productTourId: null,
+            }),
             ['authorizedUrls', 'showProposedURLForm', 'isProposedUrlSubmitting', 'suggestions as urlSuggestions'],
             webAnalyticsHealthLogic,
             ['webAnalyticsHealthStatus'],
@@ -132,7 +137,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         actions: [
             webAnalyticsHealthLogic,
             ['trackTabViewed'],
-            authorizedUrlListLogic({ type: AuthorizedUrlListType.WEB_ANALYTICS, actionId: null, experimentId: null }),
+            authorizedUrlListLogic({
+                type: AuthorizedUrlListType.WEB_ANALYTICS,
+                actionId: null,
+                experimentId: null,
+                productTourId: null,
+            }),
             [
                 'addUrl as addAuthorizedUrl',
                 'newUrl as newAuthorizedUrl',

--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -379,6 +379,10 @@ export function Toolbar(): JSX.Element | null {
         if (userIntent === 'heatmaps') {
             setVisibleMenu('heatmap')
         }
+
+        if (userIntent === 'add-product-tour' || userIntent === 'edit-product-tour') {
+            setVisibleMenu('product-tours')
+        }
     }, [userIntent]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     if (isEmbeddedInApp) {

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -378,7 +378,7 @@ export const productToursLogic = kea<productToursLogicType>([
     })),
 
     connect(() => ({
-        values: [toolbarConfigLogic, ['dataAttributes', 'apiURL']],
+        values: [toolbarConfigLogic, ['dataAttributes', 'apiURL', 'userIntent', 'productTourId']],
     })),
 
     selectors({
@@ -712,10 +712,22 @@ export const productToursLogic = kea<productToursLogicType>([
                 console.warn('[Creation] Failed to capture screenshot:', e)
             }
         },
+        loadToursSuccess: () => {
+            const { userIntent, productTourId } = values
+            if (userIntent === 'edit-product-tour' && productTourId) {
+                actions.selectTour(productTourId)
+                toolbarConfigLogic.actions.clearUserIntent()
+            } else if (userIntent === 'add-product-tour') {
+                actions.startCreation()
+                toolbarConfigLogic.actions.clearUserIntent()
+            }
+        },
     })),
 
     events(({ actions, values, cache }) => ({
         afterMount: () => {
+            actions.loadTours()
+
             // Watch for DOM changes to update highlights when elements appear/disappear
             cache.mutationTimeout = null as ReturnType<typeof setTimeout> | null
             cache.mutationObserver = new MutationObserver(() => {

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -32,6 +32,7 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
         ],
         actionId: [props.actionId || null, { logout: () => null, clearUserIntent: () => null }],
         experimentId: [props.experimentId || null, { logout: () => null, clearUserIntent: () => null }],
+        productTourId: [props.productTourId || null, { logout: () => null, clearUserIntent: () => null }],
         userIntent: [props.userIntent || null, { logout: () => null, clearUserIntent: () => null }],
         buttonVisible: [true, { showButton: () => true, hideButton: () => false, logout: () => false }],
     })),
@@ -74,6 +75,7 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
                 temporaryToken: values.temporaryToken ?? undefined,
                 actionId: values.actionId ?? undefined,
                 experimentId: values.experimentId ?? undefined,
+                productTourId: values.productTourId ?? undefined,
                 userIntent: values.userIntent ?? undefined,
                 posthog: undefined,
             }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -739,7 +739,14 @@ export interface ElementType {
     text?: string
 }
 
-export type ToolbarUserIntent = 'add-action' | 'edit-action' | 'heatmaps' | 'add-experiment' | 'edit-experiment'
+export type ToolbarUserIntent =
+    | 'add-action'
+    | 'edit-action'
+    | 'heatmaps'
+    | 'add-experiment'
+    | 'edit-experiment'
+    | 'add-product-tour'
+    | 'edit-product-tour'
 export type ToolbarSource = 'url' | 'localstorage'
 export type ToolbarVersion = 'toolbar'
 
@@ -759,6 +766,7 @@ export interface ToolbarParams {
     userEmail?: string
     dataAttributes?: string[]
     toolbarFlagsKey?: string
+    productTourId?: string
 }
 
 export interface ToolbarProps extends ToolbarParams {

--- a/playwright/e2e/toolbar.spec.ts
+++ b/playwright/e2e/toolbar.spec.ts
@@ -22,4 +22,10 @@ test.describe('Toolbar', () => {
         await page.getByText('Add authorized URL').click()
         await expect(page).toHaveURL(/.*\/toolbar/)
     })
+
+    test('Can open add authorized URL form', async ({ page }) => {
+        await page.goToMenuItem('toolbar')
+        await page.locator('[data-attr="toolbar-add-url"]').click()
+        await expect(page.locator('[data-attr="url-input"]')).toBeVisible()
+    })
 })

--- a/playwright/e2e/web-analytics.spec.ts
+++ b/playwright/e2e/web-analytics.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '../utils/playwright-test-base'
+
+test.describe('Web Analytics', () => {
+    test('Can open add authorized URL form', async ({ page }) => {
+        await page.goto('/web')
+        // Open the domain filter dropdown
+        await page.getByText('All domains').click()
+        // Click the add button in the dropdown footer
+        await page.getByText('Add authorized URL').click()
+        await expect(page.locator('[data-attr="web-authorized-url-input"]')).toBeVisible()
+    })
+})

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1136,7 +1136,7 @@ class TestUserAPI(APIBaseTest):
         self.maxDiff = None
         assert (
             unquote(locationHeader)
-            == 'http://127.0.0.1:8010#__posthog={"action": "ph_authorize", "token": "token123", "temporaryToken": "tokenvalue", "actionId": null, "experimentId": null, "userIntent": "add-action", "toolbarVersion": "toolbar", "apiURL": "http://testserver", "dataAttributes": ["data-attr"]}'
+            == 'http://127.0.0.1:8010#__posthog={"action": "ph_authorize", "token": "token123", "temporaryToken": "tokenvalue", "actionId": null, "experimentId": null, "productTourId": null, "userIntent": "add-action", "toolbarVersion": "toolbar", "apiURL": "http://testserver", "dataAttributes": ["data-attr"]}'
         )
 
     @patch("posthog.api.user.secrets.token_urlsafe")
@@ -1152,7 +1152,7 @@ class TestUserAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert (
             unquote(response.json()["toolbarParams"])
-            == '{"action": "ph_authorize", "token": "token123", "temporaryToken": "tokenvalue", "actionId": null, "experimentId": null, "userIntent": "add-action", "toolbarVersion": "toolbar", "apiURL": "http://testserver", "dataAttributes": ["data-attr"]}'
+            == '{"action": "ph_authorize", "token": "token123", "temporaryToken": "tokenvalue", "actionId": null, "experimentId": null, "productTourId": null, "userIntent": "add-action", "toolbarVersion": "toolbar", "apiURL": "http://testserver", "dataAttributes": ["data-attr"]}'
         )
 
     @patch("posthog.api.user.secrets.token_urlsafe")
@@ -1183,7 +1183,7 @@ class TestUserAPI(APIBaseTest):
         self.maxDiff = None
         self.assertEqual(
             unquote(locationHeader),
-            'http://127.0.0.1:8010#__posthog={"action": "ph_authorize", "token": "token123", "temporaryToken": "tokenvalue", "actionId": null, "experimentId": "12", "userIntent": "edit-experiment", "toolbarVersion": "toolbar", "apiURL": "http://testserver", "dataAttributes": ["data-attr"]}',
+            'http://127.0.0.1:8010#__posthog={"action": "ph_authorize", "token": "token123", "temporaryToken": "tokenvalue", "actionId": null, "experimentId": "12", "productTourId": null, "userIntent": "edit-experiment", "toolbarVersion": "toolbar", "apiURL": "http://testserver", "dataAttributes": ["data-attr"]}',
         )
 
     @patch("posthog.api.user.secrets.token_urlsafe")

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -789,6 +789,7 @@ def redirect_to_site(request):
         "temporaryToken": request.user.temporary_token,
         "actionId": request.GET.get("actionId"),
         "experimentId": request.GET.get("experimentId"),
+        "productTourId": request.GET.get("productTourId"),
         "userIntent": request.GET.get("userIntent"),
         "toolbarVersion": "toolbar",
         "apiURL": request.build_absolute_uri("/")[:-1],


### PR DESCRIPTION
## Problem

i added a new prop to the authorized domain logic to support product tours, it caused kea errors in prod due to missing props...

sample tickets:

- https://posthoghelp.zendesk.com/agent/tickets/45497 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/47535)
- https://posthoghelp.zendesk.com/agent/tickets/45487 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/47529)

the recordings on these show the error always happened after clicking "add authorized URL"

this button opens the `AuthorizedUrlForm`, which contains a kea form:

```typescript
<Form
  logic={authorizedUrlListLogic}
  props={{
    actionId: actionId ?? null,
    experimentId: experimentId ?? null,
    type,
    allowWildCards,
  }}
/>
```

...i missed adding `productTourId` here, and kea forms do not type-check the props 😥

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- re-applies the [original commit](https://github.com/PostHog/posthog/pull/43623)
- updates all usages of `authorizedUrlListLogic`, whether directly or via `Form`, to include all required props
- adds playwright tests to ensure this form works for toolbar and web analytics pages!!

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

playwright tests - was able to repro the bug with the new tests pre-fix, and verify the tests pass post-fix

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->