### PR TITLE
fix: restrict 'in' and 'not_in' operators to cohort properties only

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -685,12 +685,7 @@ class FeatureFlagSerializer(
                         detail=f"Invalid value for operator {prop.operator}: {prop.value}", code="invalid_value"
                     )
 
-                if prop.operator in (PropertyOperator.IN_.value, PropertyOperator.NOT_IN.value) and prop.type not in [
-                    "cohort",
-                    "static-cohort",
-                    "precalculated-cohort",
-                    "dynamic-cohort",
-                ]:
+                if prop.operator in (PropertyOperator.IN_.value, PropertyOperator.NOT_IN.value) and prop.type != "cohort":
                     raise serializers.ValidationError(
                         detail=f"The '{prop.operator}' operator is only valid for cohort properties, not '{prop.type}' properties.",
                         code="invalid_operator",

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -685,7 +685,12 @@ class FeatureFlagSerializer(
                         detail=f"Invalid value for operator {prop.operator}: {prop.value}", code="invalid_value"
                     )
 
-                if prop.operator in (PropertyOperator.IN_.value, PropertyOperator.NOT_IN.value) and prop.type != "cohort":
+                if prop.operator in (PropertyOperator.IN_.value, PropertyOperator.NOT_IN.value) and prop.type not in [
+                    "cohort",
+                    "static-cohort",
+                    "precalculated-cohort",
+                    "dynamic-cohort",
+                ]:
                     raise serializers.ValidationError(
                         detail=f"The '{prop.operator}' operator is only valid for cohort properties, not '{prop.type}' properties.",
                         code="invalid_operator",

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -685,6 +685,12 @@ class FeatureFlagSerializer(
                         detail=f"Invalid value for operator {prop.operator}: {prop.value}", code="invalid_value"
                     )
 
+                if prop.operator in (PropertyOperator.IN_.value, PropertyOperator.NOT_IN.value) and prop.type != "cohort":
+                    raise serializers.ValidationError(
+                        detail=f"The '{prop.operator}' operator is only valid for cohort properties, not '{prop.type}' properties.",
+                        code="invalid_operator",
+                    )
+
         payloads = filters.get("payloads", {})
 
         if not isinstance(payloads, dict):

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -278,6 +278,136 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_cant_create_flag_with_in_operator_for_non_cohort_properties(self):
+        """Test that 'in' and 'not_in' operators are rejected for non-cohort property types."""
+        count = FeatureFlag.objects.count()
+
+        # Test 'in' operator with person property (should fail)
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags",
+            {
+                "name": "Beta feature",
+                "key": "beta-x",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 65,
+                            "properties": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["user1@example.com", "user2@example.com"],
+                                    "operator": "in",
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "invalid_operator",
+                "detail": "The 'in' operator is only valid for cohort properties, not 'person' properties.",
+                "attr": "filters",
+            },
+        )
+
+        # Test 'not_in' operator with person property (should fail)
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags",
+            {
+                "name": "Beta feature",
+                "key": "beta-y",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 65,
+                            "properties": [
+                                {
+                                    "key": "country",
+                                    "type": "person",
+                                    "value": ["US", "UK"],
+                                    "operator": "not_in",
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "invalid_operator",
+                "detail": "The 'not_in' operator is only valid for cohort properties, not 'person' properties.",
+                "attr": "filters",
+            },
+        )
+
+        self.assertEqual(FeatureFlag.objects.count(), count)
+
+    def test_can_create_flag_with_in_operator_for_cohort_properties(self):
+        """Test that 'in' and 'not_in' operators are accepted for cohort property types."""
+        cohort = Cohort.objects.create(team=self.team, name="test cohort", created_by=self.user)
+
+        # Test 'in' operator with cohort property (should succeed)
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags",
+            {
+                "name": "Cohort feature",
+                "key": "cohort-feature",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [
+                                {
+                                    "key": "id",
+                                    "type": "cohort",
+                                    "value": cohort.pk,
+                                    "operator": "in",
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["key"], "cohort-feature")
+
+        # Test 'not_in' operator with cohort property (should succeed)
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags",
+            {
+                "name": "Cohort feature not in",
+                "key": "cohort-feature-not-in",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [
+                                {
+                                    "key": "id",
+                                    "type": "cohort",
+                                    "value": cohort.pk,
+                                    "operator": "not_in",
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["key"], "cohort-feature-not-in")
+
     def test_cant_update_flag_with_duplicate_key(self):
         existing_flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="red_button")
         another_feature_flag = FeatureFlag.objects.create(


### PR DESCRIPTION
Closes #43729

### Problem
The `in` and `not_in` operators only work with cohort properties, but the API was accepting them for other property types (person, group, etc.). This created invalid feature flags that couldn't be evaluated correctly.

### Changes
- Added validation in `FeatureFlagSerializer` to reject `in` and `not_in` operators for non-cohort properties
- Returns a clear error message: `"The 'in' operator is only valid for cohort properties, not 'person' properties."`
- Added comprehensive tests for both validation failures and successful cohort usage

### How did you test this code?
Added automated tests in `posthog/api/test/test_feature_flag.py`:
- `test_cant_create_flag_with_in_operator_for_non_cohort_properties` - verifies rejection of `in`/`not_in` for person properties
- `test_can_create_flag_with_in_operator_for_cohort_properties` - verifies acceptance of `in`/`not_in` for cohort properties

All tests pass locally.
