### PR TITLE
chore(experiments): Highlight `decrease` goal

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -213,6 +213,11 @@ export const MetricHeader = ({
                     <LemonTag type="muted" size="small">
                         {getMetricTag(metric)}
                     </LemonTag>
+                    {metric.goal === 'decrease' && (
+                        <LemonTag type="highlight" size="small">
+                            Goal: Decrease
+                        </LemonTag>
+                    )}
                     {metric.isSharedMetric && (
                         <LemonTag type="option" size="small">
                             Shared


### PR DESCRIPTION
## Problem
When the metric goal is `decrease` and the colors are inverted, users are sometimes confused: https://posthog.slack.com/archives/C07PXH2GTGV/p1766000464825629

## Changes
Highlight when the goal is `decrease`:

<img width="241" height="153" alt="image" src="https://github.com/user-attachments/assets/d7057d61-ac69-4c6f-8c2b-115ba408e6e9" />