### PR TITLE
fix: duplicate label when duplicating series

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
@@ -92,4 +92,30 @@ describe('entityFilterLogic', () => {
                 .toMatchValues({ modalVisible: true })
         })
     })
+
+    describe('duplicating filters', () => {
+        it('preserves custom_name when duplicating', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.duplicateFilter({
+                    id: '$pageview',
+                    name: '$pageview',
+                    custom_name: 'My custom label',
+                    order: 0,
+                    type: 'events',
+                })
+            }).toDispatchActions(['duplicateFilter', 'setFilters'])
+
+            expect(logic.props.setFilters).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    events: expect.arrayContaining([
+                        expect.objectContaining({
+                            id: '$pageview',
+                            custom_name: 'My custom label',
+                            order: 1,
+                        }),
+                    ]),
+                })
+            )
+        })
+    })
 })

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -300,7 +300,6 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
             newFilters.splice(order + 1, 0, {
                 ...filter,
                 uuid: uuid(),
-                custom_name: undefined,
                 order: order + 1,
             } as LocalFilter)
             actions.setFilters(newFilters)


### PR DESCRIPTION
i made a funnel using autocapture
i named my step
then i duplicated the step
the name didn't duplicate 
i was going to duplicate 9 times
so i'd have had to type the name 9 times

that _felt_ wrong

ofc it might be on purpose in which case :homer-hedge.meme:

## after


![2025-12-19 08.12.46.gif](https://app.graphite.com/user-attachments/assets/32922308-892c-44bc-8248-523bd7ba16f5.gif)

## Changelog: (features only) Is this feature complete?

no
