### PR TITLE
fix(gateway): always publish prometheus metrics

### DIFF
--- a/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
+++ b/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
@@ -62,7 +62,6 @@ def get_instrumentator() -> Instrumentator:
     return Instrumentator(
         should_group_status_codes=False,
         should_ignore_untemplated=True,
-        should_respect_env_var=True,
         should_instrument_requests_inprogress=True,
         excluded_handlers=["/_liveness", "/_readiness", "/metrics"],
         inprogress_labels=True,


### PR DESCRIPTION
We were only publishing if there was an env var, which is unnecessary, we can just always publish these.