### PR TITLE
fix: don't include things that you don't include

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -41,7 +41,6 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ra
 from posthog.schema import (
     MatchedRecordingEvent,
     MatchingEventsResponse,
-    NodeKind,
     ProductIntentContext,
     ProductKey,
     PropertyFilterType,
@@ -1390,6 +1389,51 @@ class SessionRecordingViewSet(
         return Response(response_data)
 
 
+@tracer.start_as_current_span("load_recording_if_matches_filters")
+def _load_recording_if_matches_filters(
+    session_id: str,
+    query: RecordingsQuery,
+    team: Team,
+    allow_event_property_expansion: bool,
+) -> SessionRecording | None:
+    """
+    Check if a specific recording matches the current filters (ignoring pagination).
+    Returns the recording if it matches, None otherwise.
+    """
+    prepend_check_query = query.model_copy(
+        update={
+            "session_ids": [session_id],
+            "session_recording_id": None,
+            "limit": 1,
+            "offset": 0,
+            "after": None,
+        }
+    )
+    ch_query_result = SessionRecordingListFromQuery(
+        query=prepend_check_query,
+        team=team,
+        hogql_query_modifiers=None,
+        allow_event_property_expansion=allow_event_property_expansion,
+    ).run()
+
+    if not ch_query_result.results:
+        return None
+
+    s3_persisted_recording = (
+        SessionRecording.objects.filter(team=team, session_id=session_id)
+        .exclude(Q(object_storage_path=None) & Q(full_recording_v2_path=None))
+        .first()
+    )
+    if s3_persisted_recording:
+        return s3_persisted_recording
+
+    prepend_recordings = SessionRecording.get_or_build_from_clickhouse(team, ch_query_result.results)
+    if prepend_recordings and not prepend_recordings[0].deleted:
+        return prepend_recordings[0]
+
+    return None
+
+
 # TODO i guess this becomes the query runner for our _internal_ use of RecordingsQuery
 def list_recordings_from_query(
     query: RecordingsQuery, user: User | None, team: Team, allow_event_property_expansion: bool = False
@@ -1423,37 +1467,15 @@ def list_recordings_from_query(
             ]
         else:
             # We need to fetch this specific recording alongside the filtered results
-            # Create a separate query to fetch just this recording
-            with timer("load_prepend_recording"), tracer.start_as_current_span("load_prepend_recording"):
-                s3_persisted_recording = (
-                    SessionRecording.objects.filter(team=team, session_id=session_recording_id_to_prepend)
-                    .exclude(Q(object_storage_path=None) & Q(full_recording_v2_path=None))
-                    .first()
+            with timer("load_prepend_recording"):
+                prepend_recording = _load_recording_if_matches_filters(
+                    session_recording_id_to_prepend,
+                    query,
+                    team,
+                    allow_event_property_expansion,
                 )
-
-                if s3_persisted_recording:
-                    recordings.append(s3_persisted_recording)
-                else:
-                    # Try to load from ClickHouse
-                    # Optimize query by searching only within the team's retention period
-                    retention_period = team.session_recording_retention_period or "90d"
-                    ch_query_result = SessionRecordingListFromQuery(
-                        query=RecordingsQuery(
-                            kind=NodeKind.RECORDINGS_QUERY,
-                            session_ids=[session_recording_id_to_prepend],
-                            date_from=f"-{retention_period}",
-                            date_to=None,
-                        ),
-                        team=team,
-                        hogql_query_modifiers=None,
-                        allow_event_property_expansion=allow_event_property_expansion,
-                    ).run()
-                    if ch_query_result.results:
-                        prepend_recordings = SessionRecording.get_or_build_from_clickhouse(
-                            team, ch_query_result.results
-                        )
-                        if prepend_recordings and not prepend_recordings[0].deleted:
-                            recordings.append(prepend_recordings[0])
+                if prepend_recording:
+                    recordings.append(prepend_recording)
 
     if all_session_ids:
         with timer("load_persisted_recordings"), tracer.start_as_current_span("load_persisted_recordings"):

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1633,3 +1633,85 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
         # Verify no PostgreSQL record was created (since it wasn't found)
         assert not SessionRecording.objects.filter(team=self.team, session_id=session_id_2).exists()
+
+    @parameterized.expand(
+        [
+            (
+                "recording_on_later_page_is_included_when_matches_filters",
+                # Create 5 recordings, request page 1 with limit 2, but ask for session_recording_id from page 3
+                # The requested recording matches date filters, so should be included
+                {
+                    "recordings": [
+                        {"session_id": "session_1", "days_ago": 1},
+                        {"session_id": "session_2", "days_ago": 1},
+                        {"session_id": "session_3", "days_ago": 1},
+                        {"session_id": "session_4", "days_ago": 1},
+                        {"session_id": "session_5", "days_ago": 1},
+                    ],
+                    "date_from": "-3d",
+                    "limit": 2,
+                    "session_recording_id": "session_5",
+                },
+                # session_5 matches the date filter (-3d) even though it would be on a later page
+                # so it should be prepended to results
+                ["session_5"],  # must be in results
+                [],  # must NOT be in results
+            ),
+            (
+                "recording_outside_date_range_is_excluded",
+                # Create a recording from 10 days ago, request with date_from=-3d
+                # The recording doesn't match the date filter, so should NOT be included
+                {
+                    "recordings": [
+                        {"session_id": "recent_session", "days_ago": 1},
+                        {"session_id": "old_session", "days_ago": 10},
+                    ],
+                    "date_from": "-3d",
+                    "session_recording_id": "old_session",
+                },
+                ["recent_session"],  # must be in results
+                ["old_session"],  # must NOT be in results - doesn't match date filter
+            ),
+        ]
+    )
+    def test_session_recording_id_respects_filters(
+        self,
+        _name: str,
+        config: dict,
+        must_be_in_results: list[str],
+        must_not_be_in_results: list[str],
+    ):
+        """
+        Test that session_recording_id only includes recordings that match the current filters.
+
+        A recording should be prepended to results if:
+        - It matches all filters (date range, properties, etc.) but is on a different page
+
+        A recording should NOT be included if:
+        - It doesn't match the filters (e.g., outside date range)
+        """
+        base_time = now()
+
+        for rec in config["recordings"]:
+            recording_time = base_time - relativedelta(days=rec["days_ago"])
+            self.produce_replay_summary("user1", rec["session_id"], recording_time)
+
+        params = {"date_from": config["date_from"]}
+        if "limit" in config:
+            params["limit"] = config["limit"]
+        if "session_recording_id" in config:
+            params["session_recording_id"] = config["session_recording_id"]
+
+        params_string = urlencode(params)
+        response = self.client.get(f"/api/projects/{self.team.id}/session_recordings?{params_string}")
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+
+        session_ids = [r["id"] for r in response_data["results"]]
+
+        for expected in must_be_in_results:
+            assert expected in session_ids, f"Expected {expected} to be in results, but got {session_ids}"
+
+        for unexpected in must_not_be_in_results:
+            assert unexpected not in session_ids, f"Expected {unexpected} to NOT be in results, but got {session_ids}"


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/43247 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46973)

when the URL has sessionRecordingId in it
we assume it's from a different page of the current filters
and include that ID in the results

but if it isn't from a different page
then it looks broken

so, check the current filters _could_ load it on any page 