### PR TITLE
refactor(blobby): pass all headers to restrictions

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.test.ts
@@ -80,8 +80,14 @@ describe('SessionRecordingRestrictionHandler', () => {
 
             expect(result).toEqual(messages)
             expect(restrictionManager.getAppliedRestrictions).toHaveBeenCalledWith('token-1', {
+                token: 'token-1',
                 distinct_id: 'user-1',
                 session_id: undefined,
+                timestamp: undefined,
+                event: undefined,
+                uuid: undefined,
+                force_disable_person_processing: false,
+                historical_migration: false,
             })
             expect(SessionRecordingIngesterMetrics.observeDroppedByRestrictions).not.toHaveBeenCalled()
             expect(SessionRecordingIngesterMetrics.observeOverflowedByRestrictions).not.toHaveBeenCalled()
@@ -290,8 +296,14 @@ describe('SessionRecordingRestrictionHandler', () => {
 
             expect(result).toEqual(messages)
             expect(restrictionManager.getAppliedRestrictions).toHaveBeenCalledWith('token-1', {
+                token: 'token-1',
                 distinct_id: 'user-1',
                 session_id: 'session-123',
+                timestamp: undefined,
+                event: undefined,
+                uuid: undefined,
+                force_disable_person_processing: false,
+                historical_migration: false,
             })
         })
 
@@ -349,8 +361,42 @@ describe('SessionRecordingRestrictionHandler', () => {
 
             expect(result).toEqual(messages)
             expect(restrictionManager.getAppliedRestrictions).toHaveBeenCalledWith('token-1', {
+                token: 'token-1',
                 distinct_id: undefined,
                 session_id: 'session-123',
+                timestamp: undefined,
+                event: undefined,
+                uuid: undefined,
+                force_disable_person_processing: false,
+                historical_migration: false,
+            })
+        })
+
+        it('passes event name and uuid to restriction manager when present in headers', () => {
+            const messages: Message[] = [
+                createMessage({
+                    headers: [
+                        { token: 'token-1' },
+                        { distinct_id: 'user-1' },
+                        { session_id: 'session-123' },
+                        { event: '$snapshot' },
+                        { uuid: 'event-uuid-456' },
+                    ],
+                }),
+            ]
+
+            const result = handler.applyRestrictions(messages)
+
+            expect(result).toEqual(messages)
+            expect(restrictionManager.getAppliedRestrictions).toHaveBeenCalledWith('token-1', {
+                token: 'token-1',
+                distinct_id: 'user-1',
+                session_id: 'session-123',
+                timestamp: undefined,
+                event: '$snapshot',
+                uuid: 'event-uuid-456',
+                force_disable_person_processing: false,
+                historical_migration: false,
             })
         })
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/session-recording-restriction-handler.ts
@@ -36,7 +36,7 @@ export class SessionRecordingRestrictionHandler {
                 continue
             }
 
-            const restrictions = this.restrictionManager.getAppliedRestrictions(token, { distinct_id, session_id })
+            const restrictions = this.restrictionManager.getAppliedRestrictions(token, headers)
 
             // Check if this message should be dropped
             if (restrictions.has(Restriction.DROP_EVENT)) {


### PR DESCRIPTION
## Problem

I forgot to pass all headers to event restrictions, so Blobby doesn't support event uuid and name.

## Changes

Passes all headers instead of just distinct id and session id, like we do in analytics.

## How did you test this code?

- Tests for the event restrictions manager