### PR TITLE
fix(error tracking): Use top level `distinct_id` instead of property from internal events

### DIFF
--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -339,7 +339,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                     value: '{event.properties.description}',
                 },
                 posthog_issue_id: {
-                    value: '{event.properties.distinct_id}',
+                    value: '{event.distinct_id}',
                 },
             },
         },
@@ -356,7 +356,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                     value: '{event.properties.description}',
                 },
                 posthog_issue_id: {
-                    value: '{event.properties.distinct_id}',
+                    value: '{event.distinct_id}',
                 },
             },
         },
@@ -373,7 +373,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                     value: '{event.properties.description}',
                 },
                 posthog_issue_id: {
-                    value: '{event.properties.distinct_id}',
+                    value: '{event.distinct_id}',
                 },
             },
         },


### PR DESCRIPTION
## Problem

[Customers were seeing](https://posthoghelp.zendesk.com/agent/tickets/45513) issue tracker links with user `distinct_id`s in place of the issue ID. We set the `distinct_id` of internal events here:

https://github.com/PostHog/posthog/blob/1394d38f5e522a9f93336a24d2ac3d3a06bfb133/rust/cymbal/src/issue_resolution.rs#L446

But we were using `event.properties.distinct_id` instead of `event.distinct_id` to contruct the URL for issue trakcer issues.

## Changes

Use `event.distinct_id`.