### PR TITLE
feat(phai): generate title and description for insights and sql queries

### DIFF
--- a/ee/hogai/artifacts/manager.py
+++ b/ee/hogai/artifacts/manager.py
@@ -271,7 +271,7 @@ class ArtifactManager(AssistantContextMixin):
                     return VisualizationArtifactContent(
                         query=msg.answer,
                         name=msg.query,
-                        description=msg.plan,
+                        plan=msg.plan,
                     )
                 except ValidationError as e:
                     capture_exception(e)

--- a/ee/hogai/artifacts/test/test_manager.py
+++ b/ee/hogai/artifacts/test/test_manager.py
@@ -161,7 +161,7 @@ class TestArtifactManagerGetEnrichedMessage(BaseTest):
         assert enriched is not None
         assert isinstance(enriched.content, VisualizationArtifactContent)
         self.assertEqual(enriched.content.name, "test query")
-        self.assertEqual(enriched.content.description, "test plan")
+        self.assertEqual(enriched.content.plan, "test plan")
 
     async def test_state_source_without_state_messages_raises(self):
         message = ArtifactRefMessage(
@@ -254,7 +254,7 @@ class TestArtifactManagerGetContentsByMessageId(BaseTest):
 
         self.assertEqual(len(contents), 1)
         self.assertEqual(contents[artifact_msg_id].name, "state query")
-        self.assertEqual(contents[artifact_msg_id].description, "state plan")
+        self.assertEqual(contents[artifact_msg_id].plan, "state plan")
 
 
 class TestArtifactManagerEnrichMessages(BaseTest):

--- a/ee/hogai/chat_agent/funnels/test/test_nodes.py
+++ b/ee/hogai/chat_agent/funnels/test/test_nodes.py
@@ -29,7 +29,7 @@ class TestFunnelsGeneratorNode(BaseTest):
 
         with patch.object(FunnelGeneratorNode, "_model") as generator_model_mock:
             generator_model_mock.return_value = RunnableLambda(
-                lambda _: FunnelsSchemaGeneratorOutput(query=self.schema).model_dump()
+                lambda _: FunnelsSchemaGeneratorOutput(query=self.schema, name="", description="").model_dump()
             )
             # Call through __call__ to ensure config is set before context_manager is created
             new_state = await node(

--- a/ee/hogai/chat_agent/funnels/toolkit.py
+++ b/ee/hogai/chat_agent/funnels/toolkit.py
@@ -23,9 +23,17 @@ def generate_funnel_schema() -> dict:
             "type": "object",
             "properties": {
                 "query": dereference_schema(schema),
+                "name": {
+                    "type": "string",
+                    "description": "Short, concise name of the insight (2-7 words) that will be displayed as a header in the insight tile.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Short, concise description of the insight (1 sentence)",
+                },
             },
             "additionalProperties": False,
-            "required": ["query"],
+            "required": ["query", "name", "description"],
         },
     }
 

--- a/ee/hogai/chat_agent/retention/test/test_nodes.py
+++ b/ee/hogai/chat_agent/retention/test/test_nodes.py
@@ -41,7 +41,7 @@ class TestRetentionGeneratorNode(BaseTest):
 
         with patch.object(RetentionGeneratorNode, "_model") as generator_model_mock:
             generator_model_mock.return_value = RunnableLambda(
-                lambda _: RetentionSchemaGeneratorOutput(query=self.schema).model_dump()
+                lambda _: RetentionSchemaGeneratorOutput(query=self.schema, name="", description="").model_dump()
             )
             # Call through __call__ to ensure config is set before context_manager is created
             new_state = await node(

--- a/ee/hogai/chat_agent/retention/toolkit.py
+++ b/ee/hogai/chat_agent/retention/toolkit.py
@@ -26,9 +26,17 @@ def generate_retention_schema() -> dict:
             "type": "object",
             "properties": {
                 "query": dereference_schema(schema),
+                "name": {
+                    "type": "string",
+                    "description": "Short, concise name of the insight (2-7 words) that will be displayed as a header in the insight tile.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Short, concise description of the insight (1 sentence)",
+                },
             },
             "additionalProperties": False,
-            "required": ["query"],
+            "required": ["query", "name", "description"],
         },
     }
 

--- a/ee/hogai/chat_agent/schema_generator/nodes.py
+++ b/ee/hogai/chat_agent/schema_generator/nodes.py
@@ -151,7 +151,9 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
         artifact = await self.context_manager.artifacts.create(
             content=VisualizationArtifactContent(
                 query=result.query,
-                description=generated_plan or None,
+                name=result.name,
+                description=result.description,
+                plan=generated_plan,
             ),
             name=state.visualization_title or "Visualization",
         )

--- a/ee/hogai/chat_agent/schema_generator/nodes.py
+++ b/ee/hogai/chat_agent/schema_generator/nodes.py
@@ -213,7 +213,7 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
             content = artifact_contents.get(message.id or "")
             if not content:
                 continue
-            plan = content.description or ""
+            plan = content.plan or ""
             query = content.name or ""
             answer = content.query
 

--- a/ee/hogai/chat_agent/schema_generator/utils.py
+++ b/ee/hogai/chat_agent/schema_generator/utils.py
@@ -9,3 +9,5 @@ Q = TypeVar("Q", AssistantHogQLQuery, AssistantTrendsQuery, AssistantFunnelsQuer
 
 class SchemaGeneratorOutput(BaseModel, Generic[Q]):
     query: Q
+    name: str
+    description: str

--- a/ee/hogai/chat_agent/sql/mixins.py
+++ b/ee/hogai/chat_agent/sql/mixins.py
@@ -83,7 +83,11 @@ class HogQLGeneratorMixin(AssistantContextMixin, HogQLDatabaseMixin):
     def _parse_output(self, output: dict) -> SQLSchemaGeneratorOutput:
         result = parse_pydantic_structured_output(SchemaGeneratorOutput[str])(output)  # type: ignore
         cleaned_query = result.query.rstrip(";").strip() if result.query else ""
-        return SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query=cleaned_query))
+        return SQLSchemaGeneratorOutput(
+            query=AssistantHogQLQuery(query=cleaned_query),
+            name=result.name,
+            description=result.description,
+        )
 
     @database_sync_to_async(thread_sensitive=False)
     def _quality_check_output(self, output: SQLSchemaGeneratorOutput):

--- a/ee/hogai/chat_agent/sql/test/test_nodes.py
+++ b/ee/hogai/chat_agent/sql/test/test_nodes.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from langchain_core.runnables import RunnableConfig, RunnableLambda
 
-from posthog.schema import ArtifactContentType, ArtifactSource, AssistantHogQLQuery, HumanMessage
+from posthog.schema import ArtifactContentType, ArtifactSource, HumanMessage
 
 from ee.hogai.chat_agent.sql.nodes import SQLGeneratorNode
 from ee.hogai.utils.types import AssistantState
@@ -21,10 +21,11 @@ class TestSQLGeneratorNode(NonAtomicBaseTest):
     async def test_node_runs(self):
         node = SQLGeneratorNode(self.team, self.user)
         config = RunnableConfig(configurable={"thread_id": str(self.conversation.id)})
-        answer = AssistantHogQLQuery(query="SELECT 1")
+        # The model should return a dict with query, name, and description
+        answer = {"query": "SELECT 1", "name": "", "description": ""}
 
         with patch.object(SQLGeneratorNode, "_model") as generator_model_mock:
-            generator_model_mock.return_value = RunnableLambda(lambda _: answer.model_dump())
+            generator_model_mock.return_value = RunnableLambda(lambda _: answer)
             # Call through __call__ to ensure config is set before context_manager is created
             new_state = await node(
                 AssistantState(

--- a/ee/hogai/chat_agent/sql/test/test_sql_mixins.py
+++ b/ee/hogai/chat_agent/sql/test/test_sql_mixins.py
@@ -43,7 +43,10 @@ class TestSQLMixins(NonAtomicBaseTest):
 
         self.assertIsInstance(result, SQLSchemaGeneratorOutput)
         self.assertEqual(
-            result, SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query="SELECT count() FROM events"))
+            result,
+            SQLSchemaGeneratorOutput(
+                query=AssistantHogQLQuery(query="SELECT count() FROM events"), name="", description=""
+            ),
         )
 
     def test_parse_output_with_empty_query(self):
@@ -90,7 +93,9 @@ class TestSQLMixins(NonAtomicBaseTest):
         """Test successful quality check with simple valid query."""
         mixin = self._node
 
-        valid_output = SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query="SELECT count() FROM events"))
+        valid_output = SQLSchemaGeneratorOutput(
+            query=AssistantHogQLQuery(query="SELECT count() FROM events"), name="", description=""
+        )
 
         # Should not raise any exception for valid SQL
         await mixin._quality_check_output(valid_output)
@@ -100,7 +105,7 @@ class TestSQLMixins(NonAtomicBaseTest):
         mixin = self._node
 
         valid_output = SQLSchemaGeneratorOutput(
-            query=AssistantHogQLQuery(query="SELECT properties FROM events WHERE {filters}")
+            query=AssistantHogQLQuery(query="SELECT properties FROM events WHERE {filters}"), name="", description=""
         )
 
         # Should not raise any exception for valid SQL with placeholders
@@ -110,7 +115,9 @@ class TestSQLMixins(NonAtomicBaseTest):
         """Test quality check failure with an invalid table in the SQL."""
         mixin = self._node
 
-        invalid_output = SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query="SELECT * FROM nowhere"))
+        invalid_output = SQLSchemaGeneratorOutput(
+            query=AssistantHogQLQuery(query="SELECT * FROM nowhere"), name="", description=""
+        )
 
         with self.assertRaises(PydanticOutputParserException) as context:
             await mixin._quality_check_output(invalid_output)
@@ -123,7 +130,7 @@ class TestSQLMixins(NonAtomicBaseTest):
         mixin = self._node
 
         # Create output with None query using model_construct to bypass validation
-        empty_output = SQLSchemaGeneratorOutput.model_construct(query=None)  # type: ignore[arg-type]
+        empty_output = SQLSchemaGeneratorOutput.model_construct(query=None, name="", description="")  # type: ignore[arg-type]
 
         with self.assertRaises(PydanticOutputParserException) as context:
             await mixin._quality_check_output(empty_output)
@@ -135,7 +142,7 @@ class TestSQLMixins(NonAtomicBaseTest):
         """Test quality check failure with blank query string."""
         mixin = self._node
 
-        blank_output = SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query=""))
+        blank_output = SQLSchemaGeneratorOutput(query=AssistantHogQLQuery(query=""), name="", description="")
 
         with self.assertRaises(PydanticOutputParserException) as context:
             await mixin._quality_check_output(blank_output)
@@ -149,7 +156,9 @@ class TestSQLMixins(NonAtomicBaseTest):
 
         # Create a query that will trigger the "no viable alternative" ANTLR error
         invalid_syntax_output = SQLSchemaGeneratorOutput(
-            query=AssistantHogQLQuery(query="SELECT FROM events")  # Missing column
+            query=AssistantHogQLQuery(query="SELECT FROM events"),
+            name="",
+            description="",  # Missing column
         )
 
         with self.assertRaises(PydanticOutputParserException) as context:
@@ -164,7 +173,7 @@ class TestSQLMixins(NonAtomicBaseTest):
         mixin = self._node
 
         invalid_table_output = SQLSchemaGeneratorOutput(
-            query=AssistantHogQLQuery(query="SELECT count() FROM nonexistent_table")
+            query=AssistantHogQLQuery(query="SELECT count() FROM nonexistent_table"), name="", description=""
         )
 
         with self.assertRaises(PydanticOutputParserException) as context:
@@ -180,7 +189,9 @@ class TestSQLMixins(NonAtomicBaseTest):
         complex_output = SQLSchemaGeneratorOutput(
             query=AssistantHogQLQuery(
                 query="SELECT e.event, p.id FROM events e LEFT JOIN persons p ON e.person_id = p.id LIMIT 10"
-            )
+            ),
+            name="",
+            description="",
         )
 
         # Should not raise any exception for valid complex SQL

--- a/ee/hogai/chat_agent/sql/test/test_sql_mixins.py
+++ b/ee/hogai/chat_agent/sql/test/test_sql_mixins.py
@@ -38,7 +38,7 @@ class TestSQLMixins(NonAtomicBaseTest):
         mixin = self._node
 
         # Test direct _parse_output method
-        test_output = {"query": "SELECT count() FROM events"}
+        test_output = {"query": "SELECT count() FROM events", "name": "", "description": ""}
         result = mixin._parse_output(test_output)
 
         self.assertIsInstance(result, SQLSchemaGeneratorOutput)
@@ -53,7 +53,7 @@ class TestSQLMixins(NonAtomicBaseTest):
         """Test parsing with empty query string."""
         mixin = self._node
 
-        test_output = {"query": ""}
+        test_output = {"query": "", "name": "", "description": ""}
         result = mixin._parse_output(test_output)
 
         self.assertIsInstance(result, SQLSchemaGeneratorOutput)
@@ -63,7 +63,7 @@ class TestSQLMixins(NonAtomicBaseTest):
         """Test that semicolons are removed from the end of queries."""
         mixin = self._node
 
-        test_output = {"query": "SELECT count() FROM events;"}
+        test_output = {"query": "SELECT count() FROM events;", "name": "", "description": ""}
         result = mixin._parse_output(test_output)
 
         self.assertIsInstance(result, SQLSchemaGeneratorOutput)
@@ -73,7 +73,7 @@ class TestSQLMixins(NonAtomicBaseTest):
         """Test that multiple semicolons are removed from the end of queries."""
         mixin = self._node
 
-        test_output = {"query": "SELECT count() FROM events;;;"}
+        test_output = {"query": "SELECT count() FROM events;;;", "name": "", "description": ""}
         result = mixin._parse_output(test_output)
 
         self.assertIsInstance(result, SQLSchemaGeneratorOutput)
@@ -83,7 +83,7 @@ class TestSQLMixins(NonAtomicBaseTest):
         """Test that semicolons in the middle of queries are preserved."""
         mixin = self._node
 
-        test_output = {"query": "SELECT 'hello;world' FROM events;"}
+        test_output = {"query": "SELECT 'hello;world' FROM events;", "name": "", "description": ""}
         result = mixin._parse_output(test_output)
 
         self.assertIsInstance(result, SQLSchemaGeneratorOutput)

--- a/ee/hogai/chat_agent/test/test_chat_agent.py
+++ b/ee/hogai/chat_agent/test/test_chat_agent.py
@@ -573,7 +573,9 @@ class TestChatAgent(ClickhouseTestMixin, NonAtomicBaseTest):
             ]
         )
         query = AssistantTrendsQuery(series=[])
-        generator_mock.return_value = RunnableLambda(lambda _: TrendsSchemaGeneratorOutput(query=query))
+        generator_mock.return_value = RunnableLambda(
+            lambda _: TrendsSchemaGeneratorOutput(query=query, name="Test Insight", description="Test Description")
+        )
 
         # First run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
@@ -674,7 +676,9 @@ class TestChatAgent(ClickhouseTestMixin, NonAtomicBaseTest):
                 AssistantFunnelsEventsNode(event="$pageleave"),
             ]
         )
-        generator_mock.return_value = RunnableLambda(lambda _: FunnelsSchemaGeneratorOutput(query=query))
+        generator_mock.return_value = RunnableLambda(
+            lambda _: FunnelsSchemaGeneratorOutput(query=query, name="Test Insight", description="Test Description")
+        )
 
         # First run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
@@ -778,7 +782,9 @@ class TestChatAgent(ClickhouseTestMixin, NonAtomicBaseTest):
                 returningEntity=AssistantRetentionActionsNode(name=action.name, id=action.id),
             )
         )
-        generator_mock.return_value = RunnableLambda(lambda _: RetentionSchemaGeneratorOutput(query=query))
+        generator_mock.return_value = RunnableLambda(
+            lambda _: RetentionSchemaGeneratorOutput(query=query, name="Test Insight", description="Test Description")
+        )
 
         # First run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
@@ -874,7 +880,9 @@ class TestChatAgent(ClickhouseTestMixin, NonAtomicBaseTest):
             )
         )
         query = AssistantHogQLQuery(query="SELECT 1")
-        generator_mock.return_value = RunnableLambda(lambda _: query.model_dump())
+        generator_mock.return_value = RunnableLambda(
+            lambda _: {"query": "SELECT 1", "name": "Test Insight", "description": "Test Description"}
+        )
 
         # First run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
@@ -1160,7 +1168,9 @@ class TestChatAgent(ClickhouseTestMixin, NonAtomicBaseTest):
             )
         )
         query = AssistantTrendsQuery(series=[])
-        generator_mock.return_value = RunnableLambda(lambda _: TrendsSchemaGeneratorOutput(query=query))
+        generator_mock.return_value = RunnableLambda(
+            lambda _: TrendsSchemaGeneratorOutput(query=query, name="Test Insight", description="Test Description")
+        )
 
         # Create a graph that only uses the root node
         graph = AssistantGraph(self.team, self.user).compile_full_graph()
@@ -1273,7 +1283,9 @@ class TestChatAgent(ClickhouseTestMixin, NonAtomicBaseTest):
                 )
             ]
         )
-        generator_mock.return_value = RunnableLambda(lambda _: TrendsSchemaGeneratorOutput(query=query))
+        generator_mock.return_value = RunnableLambda(
+            lambda _: TrendsSchemaGeneratorOutput(query=query, name="Test Insight", description="Test Description")
+        )
 
         # Run in insights tool mode
         output, _ = await self._run_assistant_graph(
@@ -1561,7 +1573,9 @@ class TestChatAgent(ClickhouseTestMixin, NonAtomicBaseTest):
             ]
         )
         query = AssistantTrendsQuery(series=[])
-        generator_mock.return_value = RunnableLambda(lambda _: TrendsSchemaGeneratorOutput(query=query))
+        generator_mock.return_value = RunnableLambda(
+            lambda _: TrendsSchemaGeneratorOutput(query=query, name="Test Insight", description="Test Description")
+        )
 
         query_executor_mock.return_value = PartialAssistantState(
             messages=[

--- a/ee/hogai/chat_agent/trends/test/test_nodes.py
+++ b/ee/hogai/chat_agent/trends/test/test_nodes.py
@@ -25,7 +25,7 @@ class TestTrendsGeneratorNode(BaseTest):
 
         with patch.object(TrendsGeneratorNode, "_model") as generator_model_mock:
             generator_model_mock.return_value = RunnableLambda(
-                lambda _: TrendsSchemaGeneratorOutput(query=self.schema).model_dump()
+                lambda _: TrendsSchemaGeneratorOutput(query=self.schema, name="", description="").model_dump()
             )
             # Call through __call__ to ensure config is set before context_manager is created
             new_state = await node(

--- a/ee/hogai/chat_agent/trends/toolkit.py
+++ b/ee/hogai/chat_agent/trends/toolkit.py
@@ -23,9 +23,17 @@ def generate_trends_schema() -> dict:
             "type": "object",
             "properties": {
                 "query": dereference_schema(schema),
+                "name": {
+                    "type": "string",
+                    "description": "Short, concise name of the insight (2-7 words) that will be displayed as a header in the insight tile.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Short, concise description of the insight (1 sentence)",
+                },
             },
             "additionalProperties": False,
-            "required": ["query"],
+            "required": ["query", "name", "description"],
         },
     }
 

--- a/ee/hogai/context/insight/context.py
+++ b/ee/hogai/context/insight/context.py
@@ -74,6 +74,7 @@ class InsightContext:
             insight_description=self.description,
             query_schema=query_schema,
             results=results,
+            include_url_reminder=self.insight_id is None,
         )
 
     async def format_schema(self, prompt_template: str = INSIGHT_RESULT_TEMPLATE) -> str:
@@ -86,6 +87,7 @@ class InsightContext:
             insight_id=self.insight_id,
             insight_description=self.description,
             query_schema=query_schema,
+            include_url_reminder=self.insight_id is None,
         )
 
     async def _get_effective_query(self):

--- a/ee/hogai/context/insight/prompts.py
+++ b/ee/hogai/context/insight/prompts.py
@@ -40,7 +40,9 @@ The current date and time is {{{utc_datetime_display}}} UTC, which is {{{project
 Assume currency values are in {{currency}} and ALWAYS include the proper prefix when displaying values that are likely to be currency values.
 {{/currency}}
 It's expected that the data point for the current period may show a drop in value, as data collection for it is still ongoing. Do not point this out.
-Do not copy the results table as the user sees it in the UI.
+Do not copy the results table as the user sees it in the UI.{{#include_url_reminder}}
+This insight cannot be accessed via a URL.
+{{/include_url_reminder}}
 </system_reminder>
 """.strip()
 

--- a/ee/hogai/tools/execute_sql/test/test_tool.py
+++ b/ee/hogai/tools/execute_sql/test/test_tool.py
@@ -1,0 +1,60 @@
+from posthog.test.base import ClickhouseTestMixin, NonAtomicBaseTest, _create_event
+from unittest.mock import AsyncMock, patch
+
+from langchain_core.runnables import RunnableConfig
+
+from posthog.schema import ArtifactContentType, AssistantToolCallMessage
+
+from ee.hogai.context.context import AssistantContextManager
+from ee.hogai.tools.execute_sql.tool import ExecuteSQLTool
+from ee.hogai.utils.types import AssistantState
+from ee.hogai.utils.types.base import NodePath
+from ee.models import Conversation
+
+
+class TestExecuteSQLTool(ClickhouseTestMixin, NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        self.tool_call_id = "test_tool_call_id"
+        self.conversation = Conversation.objects.create(user=self.user, team=self.team)
+
+    async def _create_tool(self, state: AssistantState | None = None):
+        if state is None:
+            state = AssistantState(messages=[])
+
+        config: RunnableConfig = RunnableConfig(configurable={"thread_id": str(self.conversation.id)})
+        context_manager = AssistantContextManager(team=self.team, user=self.user, config=config)
+
+        with patch.object(context_manager, "get_group_names", AsyncMock(return_value=["organization", "project"])):
+            tool = await ExecuteSQLTool.create_tool_class(
+                team=self.team,
+                user=self.user,
+                state=state,
+                config=config,
+                context_manager=context_manager,
+                node_path=(NodePath(name="test_node", tool_call_id=self.tool_call_id, message_id="test"),),
+            )
+        return tool
+
+    async def test_successful_sql_execution_returns_messages(self):
+        _create_event(team=self.team, distinct_id="user1", event="test_event")
+        _create_event(team=self.team, distinct_id="user2", event="test_event")
+        _create_event(team=self.team, distinct_id="user3", event="another_event")
+
+        tool = await self._create_tool()
+
+        result_text, artifact_messages = await tool._arun_impl(
+            query="SELECT event, count() as count FROM events GROUP BY event ORDER BY count DESC",
+            name="Event counts",
+            description="Count events by type",
+        )
+
+        self.assertEqual(result_text, "")
+        self.assertIsNotNone(artifact_messages)
+        self.assertEqual(len(artifact_messages.messages), 2)
+        self.assertEqual(artifact_messages.messages[0].content_type, ArtifactContentType.VISUALIZATION)
+        self.assertIsInstance(artifact_messages.messages[1], AssistantToolCallMessage)
+        self.assertIn("test_event", artifact_messages.messages[1].content)
+        self.assertIn("another_event", artifact_messages.messages[1].content)

--- a/ee/hogai/tools/execute_sql/tool.py
+++ b/ee/hogai/tools/execute_sql/tool.py
@@ -34,6 +34,10 @@ from .prompts import (
 
 class ExecuteSQLToolArgs(BaseModel):
     query: str = Field(description="The final SQL query to be executed.")
+    name: str = Field(
+        description="Short, concise name of the query (2-5 words) that will be displayed as a header in the query tile."
+    )
+    description: str = Field(description="Short, concise description of the query (1 sentence)")
 
 
 class ExecuteSQLTool(HogQLGeneratorMixin, MaxTool):
@@ -72,8 +76,10 @@ class ExecuteSQLTool(HogQLGeneratorMixin, MaxTool):
 
         # Display an ephemeral visualization message to the user.
         artifact = await self._context_manager.artifacts.create(
-            content=VisualizationArtifactContent(query=parsed_query.query),
-            name="SQL Query",
+            VisualizationArtifactContent(
+                query=parsed_query.query, name=parsed_query.name, description=parsed_query.description
+            ),
+            "SQL Query",
         )
         artifact_message = self._context_manager.artifacts.create_message(
             artifact_id=artifact.short_id,

--- a/ee/hogai/tools/execute_sql/tool.py
+++ b/ee/hogai/tools/execute_sql/tool.py
@@ -65,8 +65,8 @@ class ExecuteSQLTool(HogQLGeneratorMixin, MaxTool):
         )
         return cls(team=team, user=user, state=state, node_path=node_path, config=config, description=prompt)
 
-    async def _arun_impl(self, query: str) -> tuple[str, ToolMessagesArtifact | None]:
-        parsed_query = self._parse_output({"query": query})
+    async def _arun_impl(self, query: str, name: str, description: str) -> tuple[str, ToolMessagesArtifact | None]:
+        parsed_query = self._parse_output({"query": query, "name": name, "description": description})
         try:
             await self._quality_check_output(
                 output=parsed_query,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -31092,6 +31092,9 @@
                 "name": {
                     "type": ["string", "null"]
                 },
+                "plan": {
+                    "type": ["string", "null"]
+                },
                 "query": {
                     "anyOf": [
                         {

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -277,6 +277,7 @@ export interface VisualizationArtifactContent {
     query: AnyAssistantGeneratedQuery | AssistantQuerySchema
     name?: string | null
     description?: string | null
+    plan?: string | null
 }
 
 export interface NotebookArtifactContent {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -17242,6 +17242,7 @@ class VisualizationArtifactContent(BaseModel):
     )
     description: str | None = None
     name: str | None = None
+    plan: str | None = None
     query: (
         AssistantTrendsQuery
         | AssistantFunnelsQuery

--- a/products/data_warehouse/backend/test/test_max_tools.py
+++ b/products/data_warehouse/backend/test/test_max_tools.py
@@ -25,7 +25,9 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
         }
 
         mock_result = {
-            "output": FinalAnswerArgs(query="SELECT AVG(properties.$session_length) FROM events"),
+            "output": FinalAnswerArgs(
+                query="SELECT AVG(properties.$session_length) FROM events", name="", description=""
+            ),
             "intermediate_steps": None,
         }
 
@@ -35,7 +37,9 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
                 HogQLGeneratorTool,
                 "_parse_output",
                 return_value=SQLSchemaGeneratorOutput(
-                    query=AssistantHogQLQuery(query="SELECT AVG(properties.$session_length) FROM events")
+                    query=AssistantHogQLQuery(query="SELECT AVG(properties.$session_length) FROM events"),
+                    name="",
+                    description="",
                 ),
             ),
         ):
@@ -63,7 +67,9 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
         }
 
         mock_result = {
-            "output": FinalAnswerArgs(query="SELECT properties FROM events WHERE {filters} AND {custom_filter}"),
+            "output": FinalAnswerArgs(
+                query="SELECT properties FROM events WHERE {filters} AND {custom_filter}", name="", description=""
+            ),
             "intermediate_steps": None,
         }
 
@@ -73,7 +79,11 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
                 HogQLGeneratorTool,
                 "_parse_output",
                 return_value=SQLSchemaGeneratorOutput(
-                    query=AssistantHogQLQuery(query="SELECT properties FROM events WHERE {filters} AND {custom_filter}")
+                    query=AssistantHogQLQuery(
+                        query="SELECT properties FROM events WHERE {filters} AND {custom_filter}"
+                    ),
+                    name="",
+                    description="",
                 ),
             ),
         ):
@@ -109,7 +119,7 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
         ):
             mock_graph = AsyncMock()
             mock_graph.ainvoke.return_value = {
-                "output": FinalAnswerArgs(query="SELECT count() FROM events"),
+                "output": FinalAnswerArgs(query="SELECT count() FROM events", name="", description=""),
                 "intermediate_steps": None,
             }
 
@@ -147,7 +157,7 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
 
         # Mock the graph to return same result that fails quality check every time
         mock_result = {
-            "output": FinalAnswerArgs(query="SELECT suspicious_query FROM events"),
+            "output": FinalAnswerArgs(query="SELECT suspicious_query FROM events", name="", description=""),
             "intermediate_steps": None,
         }
 
@@ -238,7 +248,7 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
         }
 
         graph_result = {
-            "output": FinalAnswerArgs(query="SELECT count() FROM events;"),
+            "output": FinalAnswerArgs(query="SELECT count() FROM events;", name="", description=""),
             "intermediate_steps": None,
         }
 
@@ -274,7 +284,7 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
         }
 
         graph_result = {
-            "output": FinalAnswerArgs(query="SELECT count() FROM events;;;"),
+            "output": FinalAnswerArgs(query="SELECT count() FROM events;;;", name="", description=""),
             "intermediate_steps": None,
         }
 
@@ -310,7 +320,7 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
         }
 
         graph_result = {
-            "output": FinalAnswerArgs(query="SELECT 'hello;world' FROM events;"),
+            "output": FinalAnswerArgs(query="SELECT 'hello;world' FROM events;", name="", description=""),
             "intermediate_steps": None,
         }
 

--- a/products/data_warehouse/backend/test/test_max_tools.py
+++ b/products/data_warehouse/backend/test/test_max_tools.py
@@ -258,6 +258,8 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
         ):
             mock_parse_result = Mock()
             mock_parse_result.query = "SELECT count() FROM events;"
+            mock_parse_result.name = ""
+            mock_parse_result.description = ""
             mock_parse.return_value = lambda x: mock_parse_result
             mock_graph = AsyncMock()
             mock_graph.ainvoke.return_value = graph_result
@@ -294,6 +296,8 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
         ):
             mock_parse_result = Mock()
             mock_parse_result.query = "SELECT count() FROM events;;;"
+            mock_parse_result.name = ""
+            mock_parse_result.description = ""
             mock_parse.return_value = lambda x: mock_parse_result
             mock_graph = AsyncMock()
             mock_graph.ainvoke.return_value = graph_result
@@ -330,6 +334,8 @@ class TestDataWarehouseMaxTools(NonAtomicBaseTest):
         ):
             mock_parse_result = Mock()
             mock_parse_result.query = "SELECT 'hello;world' FROM events;"
+            mock_parse_result.name = ""
+            mock_parse_result.description = ""
             mock_parse.return_value = lambda x: mock_parse_result
             mock_graph = AsyncMock()
             mock_graph.ainvoke.return_value = graph_result


### PR DESCRIPTION
## Problem

We don't currently generate titles and descriptions for insights, but it's important in dashboards to have those fields to keep the dashboard experience coherent.

## Changes

- Added generation of titles and descriptions to insights generated by PostHog AI.

## How did you test this code?

Manual tests & unit tests

