### PR TITLE
feat: add is_impersonated to CH query log

### DIFF
--- a/posthog/clickhouse/migrations/0193_add_lc_is_impersonated_to_query_log_archive.py
+++ b/posthog/clickhouse/migrations/0193_add_lc_is_impersonated_to_query_log_archive.py
@@ -1,0 +1,30 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.query_log_archive import (
+    QUERY_LOG_ARCHIVE_ADD_IS_IMPERSONATED_SQL,
+    QUERY_LOG_ARCHIVE_MV_V4_SQL,
+    QUERY_LOG_ARCHIVE_WRITABLE_DISTRIBUTED_TABLE,
+)
+
+operations = [
+    # Add the lc_is_impersonated column to the tables
+    run_sql_with_exceptions(
+        QUERY_LOG_ARCHIVE_ADD_IS_IMPERSONATED_SQL(),
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR],
+        is_alter_on_replicated_table=True,
+        sharded=False,
+    ),
+    run_sql_with_exceptions(
+        QUERY_LOG_ARCHIVE_ADD_IS_IMPERSONATED_SQL(QUERY_LOG_ARCHIVE_WRITABLE_DISTRIBUTED_TABLE),
+        node_roles=[NodeRole.ENDPOINTS],
+        is_alter_on_replicated_table=False,
+        sharded=False,
+    ),
+    # Update the MV to extract is_impersonated from log_comment
+    run_sql_with_exceptions(
+        QUERY_LOG_ARCHIVE_MV_V4_SQL(),
+        node_roles=[NodeRole.DATA, NodeRole.COORDINATOR, NodeRole.ENDPOINTS],
+        is_alter_on_replicated_table=False,
+        sharded=False,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0192_cleanup_old_embeddings_mvs
+0193_add_lc_is_impersonated_to_query_log_archive

--- a/posthog/clickhouse/query_log_archive.py
+++ b/posthog/clickhouse/query_log_archive.py
@@ -88,6 +88,7 @@ CREATE TABLE IF NOT EXISTS {table_name} (
     lc_org_id String, -- comment 'log_comment[org_id]',
     lc_team_id Int64, -- comment 'log_comment[team_id]',
     lc_user_id Int64, -- comment 'log_comment[user_id]',
+    lc_is_impersonated Bool, -- comment 'log_comment[is_impersonated]',
     lc_session_id String, -- comment 'log_comment[session_id]',
 
     lc_dashboard_id Int64, -- comment 'log_comment[dashboard_id]',
@@ -193,6 +194,7 @@ CREATE TABLE IF NOT EXISTS {table_name} (
     lc_org_id String,
     team_id Int64, -- renamed from lc_team_id, no longer an alias
     lc_user_id Int64,
+    lc_is_impersonated Bool,
     lc_session_id String,
 
     lc_dashboard_id Int64,
@@ -310,6 +312,7 @@ SELECT
     JSONExtractString(log_comment, 'org_id') as lc_org_id,
     JSONExtractInt(log_comment, 'team_id') as team_id,
     JSONExtractInt(log_comment, 'user_id') as lc_user_id,
+    JSONExtractBool(log_comment, 'is_impersonated') as lc_is_impersonated,
     JSONExtractString(log_comment, 'session_id') as lc_session_id,
 
     JSONExtractInt(log_comment, 'dashboard_id') as lc_dashboard_id,
@@ -393,3 +396,10 @@ ALTER TABLE query_log_archive_mv MODIFY QUERY
 ADD_EXCEPTION_NAME_SQL = """
 ALTER TABLE query_log_archive ADD COLUMN IF NOT EXISTS exception_name String ALIAS errorCodeToName(exception_code) AFTER exception_code
 """
+
+
+# V6 - adding lc_is_impersonated for tracking impersonation in queries
+def QUERY_LOG_ARCHIVE_ADD_IS_IMPERSONATED_SQL(table=QUERY_LOG_ARCHIVE_DATA_TABLE):
+    return """
+    ALTER TABLE {table} ADD COLUMN IF NOT EXISTS lc_is_impersonated Bool AFTER lc_user_id
+    """.format(table=table)

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -171,6 +171,8 @@ class QueryTags(BaseModel):
 
     user_email: Optional[str] = None
 
+    is_impersonated: Optional[bool] = None
+
     # constant query tags
     git_commit: Optional[str] = None
     container_hostname: Optional[str] = None

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2707,6 +2707,7 @@
       lc_org_id String,
       team_id Int64, -- renamed from lc_team_id, no longer an alias
       lc_user_id Int64,
+      lc_is_impersonated Bool,
       lc_session_id String,
   
       lc_dashboard_id Int64,
@@ -2820,6 +2821,7 @@
       JSONExtractString(log_comment, 'org_id') as lc_org_id,
       JSONExtractInt(log_comment, 'team_id') as team_id,
       JSONExtractInt(log_comment, 'user_id') as lc_user_id,
+      JSONExtractBool(log_comment, 'is_impersonated') as lc_is_impersonated,
       JSONExtractString(log_comment, 'session_id') as lc_session_id,
   
       JSONExtractInt(log_comment, 'dashboard_id') as lc_dashboard_id,
@@ -6325,6 +6327,7 @@
       lc_org_id String,
       team_id Int64, -- renamed from lc_team_id, no longer an alias
       lc_user_id Int64,
+      lc_is_impersonated Bool,
       lc_session_id String,
   
       lc_dashboard_id Int64,

--- a/posthog/hogql/database/schema/query_log_archive.py
+++ b/posthog/hogql/database/schema/query_log_archive.py
@@ -101,9 +101,12 @@ class QueryLogArchiveTable(LazyTable):
 
         fields: list[ast.Expr] = [get_alias(name, chain) for name, chain in requested_fields.items()]
 
+        where_clause = ast.Not(expr=ast.Field(chain=[table_name, "lc_is_impersonated"]))
+
         return ast.SelectQuery(
             select=fields,
             select_from=ast.JoinExpr(table=ast.Field(chain=[table_name])),
+            where=where_clause,
         )
 
 
@@ -130,6 +133,7 @@ class RawQueryLogArchiveTable(Table):
         "exception_code": IntegerDatabaseField(name="exception_code", nullable=False),
         "exception_name": StringDatabaseField(name="exception_name", nullable=False),
         "lc_access_method": StringDatabaseField(name="lc_access_method", nullable=False),
+        "lc_is_impersonated": BooleanDatabaseField(name="lc_is_impersonated", nullable=False),
         "lc_api_key_label": StringDatabaseField(name="lc_api_key_label", nullable=False),
         "lc_api_key_mask": StringDatabaseField(name="lc_api_key_mask", nullable=False),
         "lc_query__kind": StringDatabaseField(name="lc_query__kind", nullable=False),

--- a/posthog/hogql/database/schema/test/test_table_query_log.py
+++ b/posthog/hogql/database/schema/test/test_table_query_log.py
@@ -30,7 +30,7 @@ FROM
     FROM
         query_log_archive
     WHERE
-        equals(query_log_archive.team_id, {self.team.pk})) AS query_log
+        and(equals(query_log_archive.team_id, {self.team.pk}), not(query_log_archive.lc_is_impersonated))) AS query_log
 LIMIT 10 SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0"""
 
         from unittest.mock import ANY

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -337,6 +337,7 @@ class CHQueries:
             kind="request",
             id=request.path,
             route_id=route.route,
+            is_impersonated=is_impersonated_session(request) if user.is_authenticated else None,
             client_query_id=self._get_param(request, "client_query_id"),
             session_id=self._get_param(request, "session_id"),
             http_referer=request.headers.get("referer"),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

sometimes we have to impersonate. these should not show up in the query log for the users.

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- add query tag for is_impersoanted
- add a migration for the query_log_archive to extract the tag
- add where clause to the query_log hogql table

## How did you test this code?

ran things locally

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

nope

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->