### PR TITLE
feat: Add batch assert version to person updates

### DIFF
--- a/plugin-server/src/ingestion/ingestion-e2e.test.ts
+++ b/plugin-server/src/ingestion/ingestion-e2e.test.ts
@@ -212,8 +212,12 @@ const createTestWithTeamIngester = (baseConfig: Partial<PluginsServerConfig> = {
     }
 }
 
-describe.each([{ PERSONS_PREFETCH_ENABLED: false }, { PERSONS_PREFETCH_ENABLED: true }])(
-    'Event Pipeline E2E tests (prefetch=$PERSONS_PREFETCH_ENABLED)',
+describe.each([
+    { PERSONS_PREFETCH_ENABLED: false, PERSON_BATCH_WRITING_DB_WRITE_MODE: 'NO_ASSERT' as const },
+    { PERSONS_PREFETCH_ENABLED: true, PERSON_BATCH_WRITING_DB_WRITE_MODE: 'NO_ASSERT' as const },
+    { PERSONS_PREFETCH_ENABLED: true, PERSON_BATCH_WRITING_DB_WRITE_MODE: 'ASSERT_VERSION' as const },
+])(
+    'Event Pipeline E2E tests (prefetch=$PERSONS_PREFETCH_ENABLED, dbWriteMode=$PERSON_BATCH_WRITING_DB_WRITE_MODE)',
     (prefetchConfig) => {
         const testWithTeamIngester = createTestWithTeamIngester(prefetchConfig)
         let clickhouse: Clickhouse
@@ -1621,353 +1625,347 @@ describe.each([{ PERSONS_PREFETCH_ENABLED: false }, { PERSONS_PREFETCH_ENABLED: 
             return queryResult.map((warning: any) => ({ ...warning, details: parseJSON(warning.details) }))
         }
 
-        // TODO: Re-enable after re-adding FK constraints to posthog_persondistinctid
-        // testWithTeamIngester('alias events ordering scenario 1: original order', {}, async (ingester, hub, team) => {
-        //     const testName = DateTime.now().toFormat('yyyy-MM-dd-HH-mm-ss')
-        //     const user1DistinctId = 'user1-distinct-id'
-        //     const user2DistinctId = 'user2-distinct-id'
-        //     const user3DistinctId = 'user3-distinct-id'
+        testWithTeamIngester('alias events ordering scenario 1: original order', {}, async (ingester, hub, team) => {
+            const testName = DateTime.now().toFormat('yyyy-MM-dd-HH-mm-ss')
+            const user1DistinctId = 'user1-distinct-id'
+            const user2DistinctId = 'user2-distinct-id'
+            const user3DistinctId = 'user3-distinct-id'
 
-        //     const events = [
-        //         // User 1 creation
-        //         new EventBuilder(team, user1DistinctId)
-        //             .withEvent('$identify')
-        //             .withProperties({
-        //                 $set: {
-        //                     name: 'User 1',
-        //                     email: `user1-${user1DistinctId}@example.com`,
-        //                     age: 30,
-        //                     test_name: testName,
-        //                 },
-        //             })
-        //             .build(),
-        //         new EventBuilder(team, user1DistinctId)
-        //             .withEvent('$identify')
-        //             .withProperties({
-        //                 $set: {
-        //                     new_name: 'User 1 - Updated',
-        //                 },
-        //             })
-        //             .build(),
-        //         // User 2 creation
-        //         new EventBuilder(team, user2DistinctId)
-        //             .withEvent('$identify')
-        //             .withProperties({
-        //                 $set: {
-        //                     name: 'User 2',
-        //                     email: `user2-${user2DistinctId}@example.com`,
-        //                     age: 30,
-        //                     test_name: testName,
-        //                 },
-        //             })
-        //             .build(),
-        //         new EventBuilder(team, user2DistinctId)
-        //             .withEvent('$identify')
-        //             .withProperties({
-        //                 $set: {
-        //                     new_name: 'User 2 - Updated',
-        //                 },
-        //             })
-        //             .build(),
-        //         // Merge users: alias user1 -> user2
-        //         new EventBuilder(team, user1DistinctId)
-        //             .withEvent('$create_alias')
-        //             .withProperties({
-        //                 distinct_id: user1DistinctId,
-        //                 alias: user2DistinctId,
-        //             })
-        //             .build(),
+            const events = [
+                // User 1 creation
+                new EventBuilder(team, user1DistinctId)
+                    .withEvent('$identify')
+                    .withProperties({
+                        $set: {
+                            name: 'User 1',
+                            email: `user1-${user1DistinctId}@example.com`,
+                            age: 30,
+                            test_name: testName,
+                        },
+                    })
+                    .build(),
+                new EventBuilder(team, user1DistinctId)
+                    .withEvent('$identify')
+                    .withProperties({
+                        $set: {
+                            new_name: 'User 1 - Updated',
+                        },
+                    })
+                    .build(),
+                // User 2 creation
+                new EventBuilder(team, user2DistinctId)
+                    .withEvent('$identify')
+                    .withProperties({
+                        $set: {
+                            name: 'User 2',
+                            email: `user2-${user2DistinctId}@example.com`,
+                            age: 30,
+                            test_name: testName,
+                        },
+                    })
+                    .build(),
+                new EventBuilder(team, user2DistinctId)
+                    .withEvent('$identify')
+                    .withProperties({
+                        $set: {
+                            new_name: 'User 2 - Updated',
+                        },
+                    })
+                    .build(),
+                // Merge users: alias user1 -> user2
+                new EventBuilder(team, user1DistinctId)
+                    .withEvent('$create_alias')
+                    .withProperties({
+                        distinct_id: user1DistinctId,
+                        alias: user2DistinctId,
+                    })
+                    .build(),
 
-        //         // Create alias for user2 -> user3
-        //         new EventBuilder(team, user2DistinctId)
-        //             .withEvent('$create_alias')
-        //             .withProperties({
-        //                 distinct_id: user2DistinctId,
-        //                 alias: user3DistinctId,
-        //             })
-        //             .build(),
-        //     ]
+                // Create alias for user2 -> user3
+                new EventBuilder(team, user2DistinctId)
+                    .withEvent('$create_alias')
+                    .withProperties({
+                        distinct_id: user2DistinctId,
+                        alias: user3DistinctId,
+                    })
+                    .build(),
+            ]
 
-        //     await ingester.handleKafkaBatch(createKafkaMessages(events))
-        //     await waitForKafkaMessages(hub)
+            await ingester.handleKafkaBatch(createKafkaMessages(events))
+            await waitForKafkaMessages(hub)
 
-        //     await waitForExpect(async () => {
-        //         const events = await fetchEvents(hub, team.id)
-        //         expect(events.length).toBe(6)
+            await waitForExpect(async () => {
+                const events = await fetchEvents(hub, team.id)
+                expect(events.length).toBe(6)
 
-        //         // TODO: Add specific assertions based on expected behavior
-        //         // All events should be processed without errors
-        //         expect(events).toBeDefined()
-        //     })
+                // All events should be processed without errors
+                expect(events).toBeDefined()
+            })
 
-        //     // fetch the person properties
-        //     await waitForExpect(async () => {
-        //         const persons = await fetchPostgresPersons(hub.db, team.id)
-        //         expect(persons.length).toBe(1)
-        //         const personsClickhouse = await fetchPersons(hub, team.id)
-        //         expect(personsClickhouse.length).toBe(1)
-        //         expect(persons[0].properties).toMatchObject(
-        //             expect.objectContaining({
-        //                 name: 'User 1',
-        //                 new_name: 'User 1 - Updated',
-        //                 email: `user1-${user1DistinctId}@example.com`,
-        //                 age: 30,
-        //                 test_name: testName,
-        //             })
-        //         )
-        //         expect(personsClickhouse[0].properties).toMatchObject(
-        //             expect.objectContaining({
-        //                 name: 'User 1',
-        //                 new_name: 'User 1 - Updated',
-        //                 email: `user1-${user1DistinctId}@example.com`,
-        //                 age: 30,
-        //                 test_name: testName,
-        //             })
-        //         )
-        //         const distinctIdsPersons = await fetchDistinctIds(hub.db.postgres, {
-        //             id: persons[0].id,
-        //             team_id: team.id,
-        //         } as InternalPerson)
-        //         expect(distinctIdsPersons.length).toBe(3)
-        //         // Except distinctids to match the ids, in any order
-        //         expect(distinctIdsPersons.map((distinctId) => distinctId.distinct_id)).toEqual(
-        //             expect.arrayContaining([user1DistinctId, user2DistinctId, user3DistinctId])
-        //         )
-        //     })
-        // })
+            // fetch the person properties
+            await waitForExpect(async () => {
+                const persons = await fetchPostgresPersons(hub.db, team.id)
+                expect(persons.length).toBe(1)
+                const personsClickhouse = await fetchPersons(hub, team.id)
+                expect(personsClickhouse.length).toBe(1)
+                expect(persons[0].properties).toMatchObject(
+                    expect.objectContaining({
+                        name: 'User 1',
+                        new_name: 'User 1 - Updated',
+                        email: `user1-${user1DistinctId}@example.com`,
+                        age: 30,
+                        test_name: testName,
+                    })
+                )
+                expect(personsClickhouse[0].properties).toMatchObject(
+                    expect.objectContaining({
+                        name: 'User 1',
+                        new_name: 'User 1 - Updated',
+                        email: `user1-${user1DistinctId}@example.com`,
+                        age: 30,
+                        test_name: testName,
+                    })
+                )
+                const distinctIdsPersons = await fetchDistinctIds(hub.db.postgres, {
+                    id: persons[0].id,
+                    team_id: team.id,
+                } as InternalPerson)
+                expect(distinctIdsPersons.length).toBe(3)
+                // Expect distinctids to match the ids, in any order
+                expect(distinctIdsPersons.map((distinctId) => distinctId.distinct_id)).toEqual(
+                    expect.arrayContaining([user1DistinctId, user2DistinctId, user3DistinctId])
+                )
+            })
+        })
 
-        // TODO: Re-enable after re-adding FK constraints to posthog_persondistinctid
-        // testWithTeamIngester('alias events ordering scenario 2: alias first', {}, async (ingester, hub, team) => {
-        //     const testName = DateTime.now().toFormat('yyyy-MM-dd-HH-mm-ss')
-        //     const user1DistinctId = 'user1-distinct-id'
-        //     const user2DistinctId = 'user2-distinct-id'
-        //     const user3DistinctId = 'user3-distinct-id'
+        testWithTeamIngester('alias events ordering scenario 2: alias first', {}, async (ingester, hub, team) => {
+            const testName = DateTime.now().toFormat('yyyy-MM-dd-HH-mm-ss')
+            const user1DistinctId = 'user1-distinct-id'
+            const user2DistinctId = 'user2-distinct-id'
+            const user3DistinctId = 'user3-distinct-id'
 
-        //     const events = [
-        //         // User 1 creation
-        //         new EventBuilder(team, user1DistinctId)
-        //             .withEvent('$identify')
-        //             .withProperties({
-        //                 $set: {
-        //                     name: 'User 1',
-        //                     email: `user1-${user1DistinctId}@example.com`,
-        //                     age: 30,
-        //                     test_name: testName,
-        //                 },
-        //             })
-        //             .build(),
-        //         new EventBuilder(team, user1DistinctId)
-        //             .withEvent('$identify')
-        //             .withProperties({
-        //                 $set: {
-        //                     new_name: 'User 1 - Updated',
-        //                 },
-        //             })
-        //             .build(),
-        //         // User 2 creation
-        //         new EventBuilder(team, user2DistinctId)
-        //             .withProperties({
-        //                 anon_distinct_id: user2DistinctId,
-        //                 $set: {
-        //                     name: 'User 2',
-        //                     email: `user2-${user2DistinctId}@example.com`,
-        //                     age: 30,
-        //                     test_name: testName,
-        //                 },
-        //             })
-        //             .build(),
-        //         new EventBuilder(team, user2DistinctId)
-        //             .withEvent('$identify')
-        //             .withProperties({
-        //                 $set: {
-        //                     new_name: 'User 2 - Updated',
-        //                 },
-        //             })
-        //             .build(),
+            const events = [
+                // User 1 creation
+                new EventBuilder(team, user1DistinctId)
+                    .withEvent('$identify')
+                    .withProperties({
+                        $set: {
+                            name: 'User 1',
+                            email: `user1-${user1DistinctId}@example.com`,
+                            age: 30,
+                            test_name: testName,
+                        },
+                    })
+                    .build(),
+                new EventBuilder(team, user1DistinctId)
+                    .withEvent('$identify')
+                    .withProperties({
+                        $set: {
+                            new_name: 'User 1 - Updated',
+                        },
+                    })
+                    .build(),
+                // User 2 creation
+                new EventBuilder(team, user2DistinctId)
+                    .withProperties({
+                        anon_distinct_id: user2DistinctId,
+                        $set: {
+                            name: 'User 2',
+                            email: `user2-${user2DistinctId}@example.com`,
+                            age: 30,
+                            test_name: testName,
+                        },
+                    })
+                    .build(),
+                new EventBuilder(team, user2DistinctId)
+                    .withEvent('$identify')
+                    .withProperties({
+                        $set: {
+                            new_name: 'User 2 - Updated',
+                        },
+                    })
+                    .build(),
 
-        //         // Create alias for user2 -> user3
-        //         new EventBuilder(team, user2DistinctId)
-        //             .withEvent('$create_alias')
-        //             .withProperties({
-        //                 distinct_id: user2DistinctId,
-        //                 alias: user3DistinctId,
-        //             })
-        //             .build(),
+                // Create alias for user2 -> user3
+                new EventBuilder(team, user2DistinctId)
+                    .withEvent('$create_alias')
+                    .withProperties({
+                        distinct_id: user2DistinctId,
+                        alias: user3DistinctId,
+                    })
+                    .build(),
 
-        //         // Merge users: alias user1 -> user2
-        //         new EventBuilder(team, user1DistinctId)
-        //             .withEvent('$create_alias')
-        //             .withProperties({
-        //                 distinct_id: user1DistinctId,
-        //                 alias: user2DistinctId,
-        //             })
-        //             .build(),
-        //     ]
+                // Merge users: alias user1 -> user2
+                new EventBuilder(team, user1DistinctId)
+                    .withEvent('$create_alias')
+                    .withProperties({
+                        distinct_id: user1DistinctId,
+                        alias: user2DistinctId,
+                    })
+                    .build(),
+            ]
 
-        //     await ingester.handleKafkaBatch(createKafkaMessages(events))
-        //     await waitForKafkaMessages(hub)
+            await ingester.handleKafkaBatch(createKafkaMessages(events))
+            await waitForKafkaMessages(hub)
 
-        //     await waitForExpect(async () => {
-        //         const events = await fetchEvents(hub, team.id)
-        //         expect(events.length).toBe(6)
+            await waitForExpect(async () => {
+                const events = await fetchEvents(hub, team.id)
+                expect(events.length).toBe(6)
 
-        //         // TODO: Add specific assertions based on expected behavior
-        //         // All events should be processed without errors
-        //         expect(events).toBeDefined()
-        //     })
+                // All events should be processed without errors
+                expect(events).toBeDefined()
+            })
 
-        //     // fetch the person properties
-        //     await waitForExpect(async () => {
-        //         const persons = await fetchPostgresPersons(hub.db, team.id)
-        //         expect(persons.length).toBe(1)
-        //         const personsClickhouse = await fetchPersons(hub, team.id)
-        //         expect(personsClickhouse.length).toBe(1)
-        //         expect(persons[0].properties).toMatchObject(
-        //             expect.objectContaining({
-        //                 name: 'User 1',
-        //                 new_name: 'User 1 - Updated',
-        //                 email: `user1-${user1DistinctId}@example.com`,
-        //                 age: 30,
-        //                 test_name: testName,
-        //             })
-        //         )
-        //         expect(personsClickhouse[0].properties).toMatchObject(
-        //             expect.objectContaining({
-        //                 name: 'User 1',
-        //                 new_name: 'User 1 - Updated',
-        //                 email: `user1-${user1DistinctId}@example.com`,
-        //                 age: 30,
-        //                 test_name: testName,
-        //             })
-        //         )
-        //         const distinctIdsPersons = await fetchDistinctIds(hub.db.postgres, {
-        //             id: persons[0].id,
-        //             team_id: team.id,
-        //         } as InternalPerson)
-        //         expect(distinctIdsPersons.length).toBe(3)
-        //         // Except distinctids to match the ids, in any order
-        //         expect(distinctIdsPersons.map((distinctId) => distinctId.distinct_id)).toEqual(
-        //             expect.arrayContaining([user1DistinctId, user2DistinctId, user3DistinctId])
-        //         )
-        //     })
-        // })
+            // fetch the person properties
+            await waitForExpect(async () => {
+                const persons = await fetchPostgresPersons(hub.db, team.id)
+                expect(persons.length).toBe(1)
+                const personsClickhouse = await fetchPersons(hub, team.id)
+                expect(personsClickhouse.length).toBe(1)
+                expect(persons[0].properties).toMatchObject(
+                    expect.objectContaining({
+                        name: 'User 1',
+                        new_name: 'User 1 - Updated',
+                        email: `user1-${user1DistinctId}@example.com`,
+                        age: 30,
+                        test_name: testName,
+                    })
+                )
+                expect(personsClickhouse[0].properties).toMatchObject(
+                    expect.objectContaining({
+                        name: 'User 1',
+                        new_name: 'User 1 - Updated',
+                        email: `user1-${user1DistinctId}@example.com`,
+                        age: 30,
+                        test_name: testName,
+                    })
+                )
+                const distinctIdsPersons = await fetchDistinctIds(hub.db.postgres, {
+                    id: persons[0].id,
+                    team_id: team.id,
+                } as InternalPerson)
+                expect(distinctIdsPersons.length).toBe(3)
+                // Expect distinctids to match the ids, in any order
+                expect(distinctIdsPersons.map((distinctId) => distinctId.distinct_id)).toEqual(
+                    expect.arrayContaining([user1DistinctId, user2DistinctId, user3DistinctId])
+                )
+            })
+        })
 
-        // TODO: Re-enable after re-adding FK constraints to posthog_persondistinctid
-        // testWithTeamIngester('alias events ordering scenario 2: user 2 first', {}, async (ingester, hub, team) => {
-        //     const testName = DateTime.now().toFormat('yyyy-MM-dd-HH-mm-ss')
-        //     const user1DistinctId = 'user1-distinct-id'
-        //     const user2DistinctId = 'user2-distinct-id'
-        //     const user3DistinctId = 'user3-distinct-id'
+        testWithTeamIngester('alias events ordering scenario 2: user 2 first', {}, async (ingester, hub, team) => {
+            const testName = DateTime.now().toFormat('yyyy-MM-dd-HH-mm-ss')
+            const user1DistinctId = 'user1-distinct-id'
+            const user2DistinctId = 'user2-distinct-id'
+            const user3DistinctId = 'user3-distinct-id'
 
-        //     const events = [
-        //         // User 2 creation
-        //         new EventBuilder(team, user2DistinctId)
-        //             .withProperties({
-        //                 anon_distinct_id: user2DistinctId,
-        //                 $set: {
-        //                     name: 'User 2',
-        //                     email: `user2-${user2DistinctId}@example.com`,
-        //                     age: 30,
-        //                     test_name: testName,
-        //                 },
-        //             })
-        //             .build(),
-        //         new EventBuilder(team, user2DistinctId)
-        //             .withEvent('$identify')
-        //             .withProperties({
-        //                 $set: {
-        //                     new_name: 'User 2 - Updated',
-        //                 },
-        //             })
-        //             .build(),
+            const events = [
+                // User 2 creation
+                new EventBuilder(team, user2DistinctId)
+                    .withProperties({
+                        anon_distinct_id: user2DistinctId,
+                        $set: {
+                            name: 'User 2',
+                            email: `user2-${user2DistinctId}@example.com`,
+                            age: 30,
+                            test_name: testName,
+                        },
+                    })
+                    .build(),
+                new EventBuilder(team, user2DistinctId)
+                    .withEvent('$identify')
+                    .withProperties({
+                        $set: {
+                            new_name: 'User 2 - Updated',
+                        },
+                    })
+                    .build(),
 
-        //         // Create alias for user2 -> user3
-        //         new EventBuilder(team, user2DistinctId)
-        //             .withEvent('$create_alias')
-        //             .withProperties({
-        //                 distinct_id: user2DistinctId,
-        //                 alias: user3DistinctId,
-        //             })
-        //             .build(),
+                // Create alias for user2 -> user3
+                new EventBuilder(team, user2DistinctId)
+                    .withEvent('$create_alias')
+                    .withProperties({
+                        distinct_id: user2DistinctId,
+                        alias: user3DistinctId,
+                    })
+                    .build(),
 
-        //         // User 1 creation
-        //         new EventBuilder(team, user1DistinctId)
-        //             .withEvent('$identify')
-        //             .withProperties({
-        //                 $set: {
-        //                     name: 'User 1',
-        //                     email: `user1-${user1DistinctId}@example.com`,
-        //                     age: 30,
-        //                     test_name: testName,
-        //                 },
-        //             })
-        //             .build(),
-        //         new EventBuilder(team, user1DistinctId)
-        //             .withEvent('$identify')
-        //             .withProperties({
-        //                 $set: {
-        //                     new_name: 'User 1 - Updated',
-        //                 },
-        //             })
-        //             .build(),
+                // User 1 creation
+                new EventBuilder(team, user1DistinctId)
+                    .withEvent('$identify')
+                    .withProperties({
+                        $set: {
+                            name: 'User 1',
+                            email: `user1-${user1DistinctId}@example.com`,
+                            age: 30,
+                            test_name: testName,
+                        },
+                    })
+                    .build(),
+                new EventBuilder(team, user1DistinctId)
+                    .withEvent('$identify')
+                    .withProperties({
+                        $set: {
+                            new_name: 'User 1 - Updated',
+                        },
+                    })
+                    .build(),
 
-        //         // Merge users: alias user1 -> user2
-        //         new EventBuilder(team, user1DistinctId)
-        //             .withEvent('$create_alias')
-        //             .withProperties({
-        //                 distinct_id: user1DistinctId,
-        //                 alias: user2DistinctId,
-        //             })
-        //             .build(),
-        //     ]
+                // Merge users: alias user1 -> user2
+                new EventBuilder(team, user1DistinctId)
+                    .withEvent('$create_alias')
+                    .withProperties({
+                        distinct_id: user1DistinctId,
+                        alias: user2DistinctId,
+                    })
+                    .build(),
+            ]
 
-        //     await ingester.handleKafkaBatch(createKafkaMessages(events))
-        //     await waitForKafkaMessages(hub)
+            await ingester.handleKafkaBatch(createKafkaMessages(events))
+            await waitForKafkaMessages(hub)
 
-        //     await waitForExpect(async () => {
-        //         const events = await fetchEvents(hub, team.id)
-        //         expect(events.length).toBe(6)
+            await waitForExpect(async () => {
+                const events = await fetchEvents(hub, team.id)
+                expect(events.length).toBe(6)
 
-        //         // TODO: Add specific assertions based on expected behavior
-        //         // All events should be processed without errors
-        //         expect(events).toBeDefined()
-        //     })
+                // All events should be processed without errors
+                expect(events).toBeDefined()
+            })
 
-        //     // fetch the person properties
-        //     await waitForExpect(async () => {
-        //         const persons = await fetchPostgresPersons(hub.db, team.id)
-        //         expect(persons.length).toBe(1)
-        //         const personsClickhouse = await fetchPersons(hub, team.id)
-        //         expect(personsClickhouse.length).toBe(1)
-        //         expect(persons[0].properties).toMatchObject(
-        //             expect.objectContaining({
-        //                 name: 'User 1',
-        //                 new_name: 'User 1 - Updated',
-        //                 email: `user1-${user1DistinctId}@example.com`,
-        //                 age: 30,
-        //                 test_name: testName,
-        //             })
-        //         )
-        //         expect(personsClickhouse[0].properties).toMatchObject(
-        //             expect.objectContaining({
-        //                 name: 'User 1',
-        //                 new_name: 'User 1 - Updated',
-        //                 email: `user1-${user1DistinctId}@example.com`,
-        //                 age: 30,
-        //                 test_name: testName,
-        //             })
-        //         )
-        //         const distinctIdsPersons = await fetchDistinctIds(hub.db.postgres, {
-        //             id: persons[0].id,
-        //             team_id: team.id,
-        //         } as InternalPerson)
-        //         expect(distinctIdsPersons.length).toBe(3)
-        //         // Except distinctids to match the ids, in any order
-        //         expect(distinctIdsPersons.map((distinctId) => distinctId.distinct_id)).toEqual(
-        //             expect.arrayContaining([user1DistinctId, user2DistinctId, user3DistinctId])
-        //         )
-        //     })
-        // })
+            // fetch the person properties
+            await waitForExpect(async () => {
+                const persons = await fetchPostgresPersons(hub.db, team.id)
+                expect(persons.length).toBe(1)
+                const personsClickhouse = await fetchPersons(hub, team.id)
+                expect(personsClickhouse.length).toBe(1)
+                expect(persons[0].properties).toMatchObject(
+                    expect.objectContaining({
+                        name: 'User 1',
+                        new_name: 'User 1 - Updated',
+                        email: `user1-${user1DistinctId}@example.com`,
+                        age: 30,
+                        test_name: testName,
+                    })
+                )
+                expect(personsClickhouse[0].properties).toMatchObject(
+                    expect.objectContaining({
+                        name: 'User 1',
+                        new_name: 'User 1 - Updated',
+                        email: `user1-${user1DistinctId}@example.com`,
+                        age: 30,
+                        test_name: testName,
+                    })
+                )
+                const distinctIdsPersons = await fetchDistinctIds(hub.db.postgres, {
+                    id: persons[0].id,
+                    team_id: team.id,
+                } as InternalPerson)
+                expect(distinctIdsPersons.length).toBe(3)
+                // Expect distinctids to match the ids, in any order
+                expect(distinctIdsPersons.map((distinctId) => distinctId.distinct_id)).toEqual(
+                    expect.arrayContaining([user1DistinctId, user2DistinctId, user3DistinctId])
+                )
+            })
+        })
 
         testWithTeamIngester(
             'alias events ordering scenario 2: user 2 first, separate batch',

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -82,6 +82,13 @@ export const personOptimisticUpdateConflictsPerBatchCounter = new Counter({
     help: 'Number of optimistic update conflicts per batch',
 })
 
+export const personBatchRetryAttemptsHistogram = new Histogram({
+    name: 'person_batch_retry_attempts',
+    help: 'Number of retry attempts per batch flush in ASSERT_VERSION mode',
+    labelNames: ['outcome'], // outcome: success, fallback
+    buckets: [0, 1, 2, 3, 4, 5], // 0 = no retries needed, up to max retries
+})
+
 // Flush instrumentation metrics
 export const personFlushOperationsCounter = new Counter({
     name: 'person_flush_operations_total',

--- a/plugin-server/src/worker/ingestion/persons/repositories/batch-update-utils.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/batch-update-utils.ts
@@ -1,0 +1,138 @@
+import { TopicMessage } from '../../../../kafka/producer'
+import { InternalPerson, RawPerson } from '../../../../types'
+import { generateKafkaPersonUpdateMessage, sanitizeJsonbValue } from '../../../../utils/db/utils'
+import { NoRowsUpdatedError } from '../../../../utils/utils'
+import { PersonUpdate } from '../person-update-batch'
+import { PersonPropertiesSizeViolationError } from './person-repository'
+
+/** Prepared arrays for batch update UNNEST queries */
+export interface BatchUpdateArrays {
+    uuids: string[]
+    teamIds: number[]
+    properties: string[]
+    propertiesLastUpdatedAt: string[]
+    propertiesLastOperation: string[]
+    isIdentified: boolean[]
+    createdAt: string[]
+}
+
+/** Result of a batch update operation for a single person */
+export interface BatchUpdateResult {
+    success: boolean
+    version?: number
+    kafkaMessage?: TopicMessage
+    error?: Error
+}
+
+/**
+ * Prepare arrays for batch update UNNEST queries.
+ * Calculates final properties by applying set and unset operations.
+ */
+export function prepareBatchUpdateArrays(personUpdates: PersonUpdate[]): BatchUpdateArrays {
+    const arrays: BatchUpdateArrays = {
+        uuids: [],
+        teamIds: [],
+        properties: [],
+        propertiesLastUpdatedAt: [],
+        propertiesLastOperation: [],
+        isIdentified: [],
+        createdAt: [],
+    }
+
+    for (const update of personUpdates) {
+        arrays.uuids.push(update.uuid)
+        arrays.teamIds.push(update.team_id)
+
+        // Calculate final properties by applying set and unset operations
+        const finalProperties = { ...update.properties }
+        Object.entries(update.properties_to_set).forEach(([key, value]) => {
+            finalProperties[key] = value
+        })
+        update.properties_to_unset.forEach((key) => {
+            delete finalProperties[key]
+        })
+
+        arrays.properties.push(sanitizeJsonbValue(finalProperties))
+        arrays.propertiesLastUpdatedAt.push(sanitizeJsonbValue(update.properties_last_updated_at))
+        arrays.propertiesLastOperation.push(sanitizeJsonbValue(update.properties_last_operation))
+        arrays.isIdentified.push(update.is_identified)
+        arrays.createdAt.push(update.created_at.toISO()!)
+    }
+
+    return arrays
+}
+
+/**
+ * Process batch update results and build the result map.
+ */
+export function processBatchUpdateResults(
+    personUpdates: PersonUpdate[],
+    rows: RawPerson[],
+    isVersionAssert: boolean,
+    toPerson: (row: RawPerson) => InternalPerson
+): Map<string, BatchUpdateResult> {
+    const results = new Map<string, BatchUpdateResult>()
+
+    // Build a map of uuid -> updated person for quick lookup
+    const updatedPersonsByUuid = new Map<string, InternalPerson>()
+    for (const row of rows) {
+        const person = toPerson(row)
+        updatedPersonsByUuid.set(person.uuid, person)
+    }
+
+    // Process results for each input update
+    for (const update of personUpdates) {
+        const updatedPerson = updatedPersonsByUuid.get(update.uuid)
+        if (updatedPerson) {
+            results.set(update.uuid, {
+                success: true,
+                version: updatedPerson.version,
+                kafkaMessage: generateKafkaPersonUpdateMessage(updatedPerson),
+            })
+        } else {
+            // Person was not found/updated
+            const errorMessage = isVersionAssert
+                ? `Person with uuid="${update.uuid}" version mismatch (expected ${update.version})`
+                : `Person with uuid="${update.uuid}" and team_id="${update.team_id}" was not updated`
+            results.set(update.uuid, {
+                success: false,
+                error: new NoRowsUpdatedError(errorMessage),
+            })
+        }
+    }
+
+    return results
+}
+
+/**
+ * Handle batch update errors and populate the results map.
+ */
+export function handleBatchUpdateError(
+    personUpdates: PersonUpdate[],
+    error: unknown,
+    isPropertiesSizeConstraintViolation: (error: unknown) => boolean
+): Map<string, BatchUpdateResult> {
+    const results = new Map<string, BatchUpdateResult>()
+
+    if (isPropertiesSizeConstraintViolation(error)) {
+        for (const update of personUpdates) {
+            results.set(update.uuid, {
+                success: false,
+                error: new PersonPropertiesSizeViolationError(
+                    `Batch update failed due to properties size constraint`,
+                    update.team_id,
+                    update.id
+                ),
+            })
+        }
+    } else {
+        for (const update of personUpdates) {
+            results.set(update.uuid, {
+                success: false,
+                error: error instanceof Error ? error : new Error(String(error)),
+            })
+        }
+    }
+
+    return results
+}

--- a/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
+++ b/plugin-server/src/worker/ingestion/persons/repositories/person-repository.ts
@@ -66,7 +66,8 @@ export interface PersonRepository {
     updatePersonAssertVersion(personUpdate: PersonUpdate): Promise<[number | undefined, TopicMessage[]]>
 
     /**
-     * Batch update multiple persons in a single query using UNNEST.
+     * Batch update multiple persons in a single query using UNNEST (NO_ASSERT mode).
+     * Does NOT check versions - always overwrites with provided values.
      * Returns results indexed by person UUID, each containing:
      * - success: boolean indicating if the update succeeded
      * - version: the new version if successful
@@ -74,6 +75,19 @@ export interface PersonRepository {
      * - error: error details if the update failed
      */
     updatePersonsBatch(
+        personUpdates: PersonUpdate[]
+    ): Promise<Map<string, { success: boolean; version?: number; kafkaMessage?: TopicMessage; error?: Error }>>
+
+    /**
+     * Batch update multiple persons with version assertion (ASSERT_VERSION mode).
+     * Only updates rows where the version matches the expected version.
+     * Returns results indexed by person UUID, each containing:
+     * - success: boolean indicating if the update succeeded (version matched)
+     * - version: the new version if successful
+     * - kafkaMessage: the Kafka message to send if successful
+     * - error: error details if the update failed (version mismatch or other error)
+     */
+    updatePersonsBatchAssertVersion(
         personUpdates: PersonUpdate[]
     ): Promise<Map<string, { success: boolean; version?: number; kafkaMessage?: TopicMessage; error?: Error }>>
 

--- a/plugin-server/tests/helpers/clickhouse.ts
+++ b/plugin-server/tests/helpers/clickhouse.ts
@@ -80,7 +80,6 @@ export class Clickhouse {
 
         await Promise.allSettled([
             this.truncate('person_static_cohort'),
-            this.truncate('sharded_session_recording_events'),
             this.truncate('events_dead_letter_queue'),
             this.truncate('groups'),
             this.truncate('ingestion_warnings'),
@@ -95,7 +94,6 @@ export class Clickhouse {
         for (let i = 0; i < maxDelayCount; i++) {
             try {
                 await this.query('SELECT 1')
-                console.log(`ClickHouse healthy after ${Math.round((performance.now() - timer) / 100) / 10}s`)
                 return
             } catch (error) {
                 console.log(


### PR DESCRIPTION
## Problem

The current person updates are not assert versions. Without version assertions, concurrent updates could silently overwrite each other, leading to lost updates in high-contention scenarios, this is mainly for race conditions during merges .

## Changes

Adds `ASSERT_VERSION` mode to batch person writing with retry logic:

- New `updatePersonsBatchAssertVersion()` SQL method that uses UNNEST with version assertion to detect conflicts
- Batch retry with refresh, when we get a version mismatch, it re-fetches only failed persons and retries as a batch 
- Handles person merges during retry by updating pending updates with new person IDs/UUIDs
- Fallback to individual updates only after max retries exhausted or on properties size violations (there's no easy way around the later)

Of note: Successfully updated persons are never retried. Only persons that failed due to version mismatch are included in subsequent retry attempts.

Also has a bit of a refactor:
- Extracted `batch-update-utils.ts` with shared batch preparation and result processing logic
- Extracted helper methods in `BatchWritingPersonsStore` for clearer separation of concerns

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
