### PR TITLE
fix: reactivate inactive users in Vercel installation

### DIFF
--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -990,10 +990,14 @@ class VercelIntegration:
     def _find_or_create_user_by_email(
         email: str, name: str | None, organization: Organization, level: OrganizationMembership.Level
     ) -> tuple[User, bool]:
-        user = User.objects.filter(email=email, is_active=True).first()
+        user = User.objects.filter(email=email).first()
         created = False
 
-        if not user:
+        if user:
+            if not user.is_active:
+                user.is_active = True
+                user.save(update_fields=["is_active"])
+        else:
             first_name = ""
             if name:
                 first_name = name.split()[0] if name.split() else name


### PR DESCRIPTION
## Problem

When creating a Vercel installation, if a user with the same email exists but is inactive (`is_active=False`), the code would try to create a new user and hit a unique constraint violation:

```
django.db.utils.IntegrityError: duplicate key value violates unique constraint "posthog_user_email_af269794_uniq"
DETAIL:  Key (email)=(hey@posthog.com) already exists.
```

[Production logs showing the error](https://us.posthog.com/project/2/logs?filterGroup=%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22key%22%3A%22message%22%2C%22value%22%3A%22Unhandled+exception+in+Vercel+API%22%2C%22operator%22%3A%22icontains%22%2C%22type%22%3A%22log%22%7D%5D%7D%5D%7D&linkToLogId=019b36e4-fa25-74c2-858e-b446f9f74667&dateRange=%7B%22date_from%22%3A%222025-12-19T13%3A55%3A28.445Z%22%2C%22date_to%22%3A%222025-12-19T13%3A55%3A46.378Z%22%2C%22explicitDate%22%3Atrue%7D&initialLogsLimit=6)

## Changes

In `_find_or_create_user_by_email()`:
- Query once for user by email (no `is_active` filter)
- If user exists and is inactive, reactivate them
- Otherwise create new user

This prevents the duplicate key error while keeping the database efficient with a single query.

## Test plan

Added test `test_upsert_installation_reactivates_inactive_user` that:
- Creates an inactive user
- Attempts to create a Vercel installation with that email
- Verifies the user is reactivated instead of causing an IntegrityError

All 47 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)