### PR TITLE
fix(batch-exports): Make 'SqlRoutineException' not retryable

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -112,6 +112,9 @@ NON_RETRYABLE_ERROR_TYPES = (
     "PostgreSQLTransactionError",
     # Raised when a query takes too long.
     "TimeoutError",
+    # Raised when a PostgreSQL stored procedure or function fails.
+    # We don't (at the moment) create or run any ourselves, so it must be something set up by the user.
+    "SqlRoutineException",
 )
 
 


### PR DESCRIPTION
## Problem

`SqlRoutineException` or `sql_routine_exception` (F200) indicates (as far as I can see) that a stored procedure has failed. If we see this in our batch export, it's likely because of a stored proc running as part of a trigger fired-off by one of our queries. There isn't much we can do as we do not manage stored procedures ourselves.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Make `SqlRoutineException` non-retryable.
Also, I've added a nicer error message for timeout errors.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
