### PR TITLE
revert: "chore(workflows): add codeowners for destination templates"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,11 +18,6 @@ posthog/clickhouse/migrations/** @PostHog/clickhouse
 # HogQL team owns HogQL changes
 posthog/hogql/** @PostHog/hogql
 
-# CDP templates are owned by the workflows team
-# New templates are often added by OSS contributors, and require prompt code reviews to maintain engagement
-plugin-server/src/cdp/templates/** @PostHog/team-workflows
-posthog/cdp/templates/** @PostHog/team-workflows
-
 # Being open source brings us unwanted problems because Github Actions are untrusted and inherently unsafe
 # so we have to be extra careful with changes here. Let's have the security team own these checks.
 .github/workflows/ci-security.yaml @PostHog/team-security


### PR DESCRIPTION
We don't use codeowners for this.