### PR TITLE
feat(graceful-shutdown): add graceful shutdown logic using Kubernetes preStop marker file

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -502,6 +502,13 @@ API_QUERIES_ENABLED = get_from_env("API_QUERIES_ENABLED", False, type_cast=str_t
 LIVESTREAM_HOST = get_from_env("LIVESTREAM_HOST", "")
 
 ####
+# Graceful shutdown
+
+# Marker file created by Kubernetes preStop hook to signal pod is shutting down.
+# When this file exists, the /_readyz endpoint returns 503 to stop receiving new traffic.
+PRESTOP_MARKER_FILE = get_from_env("PRESTOP_MARKER_FILE", "/tmp/posthog_prestop")
+
+####
 # Local dev
 
 # disables frontend side navigation hooks to make hot-reload work seamlessly

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -1,3 +1,4 @@
+import os
 import random
 import logging
 from contextlib import contextmanager
@@ -366,6 +367,48 @@ def simulate_cache_cannot_connect():
             django_redis.exceptions.ConnectionInterrupted(mock.Mock())
         )
         yield
+
+
+@contextmanager
+def simulate_prestop_marker():
+    """
+    Simulates the prestop marker file existing by mocking os.path.exists.
+    """
+    original_exists = os.path.exists
+
+    def mock_exists(path):
+        if path == "/tmp/posthog_prestop":
+            return True
+        return original_exists(path)
+
+    with patch("posthog.health.os.path.exists", side_effect=mock_exists):
+        yield
+
+
+def test_readyz_returns_503_when_prestop_marker_exists(client: Client):
+    with simulate_prestop_marker():
+        resp = get_readyz(client)
+
+    assert resp.status_code == 503
+    assert resp.json() == {"shutting_down": True}
+
+
+@pytest.mark.django_db
+def test_readyz_returns_503_when_prestop_marker_exists_with_role(client: Client):
+    with simulate_prestop_marker():
+        resp = get_readyz(client, role="web")
+
+    assert resp.status_code == 503
+    assert resp.json() == {"shutting_down": True}
+
+
+@pytest.mark.django_db
+def test_readyz_skips_prestop_check_when_setting_is_empty(client: Client):
+    with patch("posthog.health.settings.PRESTOP_MARKER_FILE", ""):
+        with simulate_prestop_marker():
+            resp = get_readyz(client)
+
+    assert resp.status_code == 200
 
 
 @pytest.fixture(autouse=True)

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -14,7 +14,7 @@ from django.db import (
     Error as DjangoDatabaseError,
     connections,
 )
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.test import Client
 
 import psycopg2
@@ -389,8 +389,9 @@ def test_readyz_returns_503_when_prestop_marker_exists(client: Client):
     with simulate_prestop_marker():
         resp = get_readyz(client)
 
+    assert isinstance(resp, JsonResponse)
     assert resp.status_code == 503
-    assert resp.json() == {"shutting_down": True}
+    assert resp.json() == {"shutting_down": True}  # type: ignore[attr-defined]
 
 
 @pytest.mark.django_db
@@ -398,8 +399,9 @@ def test_readyz_returns_503_when_prestop_marker_exists_with_role(client: Client)
     with simulate_prestop_marker():
         resp = get_readyz(client, role="web")
 
+    assert isinstance(resp, JsonResponse)
     assert resp.status_code == 503
-    assert resp.json() == {"shutting_down": True}
+    assert resp.json() == {"shutting_down": True}  # type: ignore[attr-defined]
 
 
 @pytest.mark.django_db
@@ -408,6 +410,7 @@ def test_readyz_skips_prestop_check_when_setting_is_empty(client: Client):
         with simulate_prestop_marker():
             resp = get_readyz(client)
 
+    assert isinstance(resp, JsonResponse)
     assert resp.status_code == 200
 
 


### PR DESCRIPTION
## Problem

requests are send to pods that are being killed, let's mark them as not ready

## Changes

/_readyz returns 503 when a prestop hook is created 

## How did you test this code?

added tests