### PR TITLE
chore: add ingestion lag histogram

### DIFF
--- a/plugin-server/src/ingestion/event-processing/emit-event-step.test.ts
+++ b/plugin-server/src/ingestion/event-processing/emit-event-step.test.ts
@@ -3,7 +3,7 @@ import { Message } from 'node-rdkafka'
 import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
 import { createTestMessage } from '../../../tests/helpers/kafka-message'
 import { KafkaProducerWrapper } from '../../kafka/producer'
-import { ingestionLagGauge } from '../../main/ingestion-queues/metrics'
+import { ingestionLagGauge, ingestionLagHistogram } from '../../main/ingestion-queues/metrics'
 import { EventHeaders, ProjectId, RawKafkaEvent, TimestampFormat } from '../../types'
 import { MessageSizeTooLarge } from '../../utils/db/error'
 import { castTimestampOrNow } from '../../utils/utils'
@@ -41,6 +41,7 @@ jest.mock('../../main/ingestion-queues/metrics', () => ({
 const mockCaptureIngestionWarning = jest.mocked(captureIngestionWarning)
 const mockEventProcessedAndIngestedCounter = jest.mocked(eventProcessedAndIngestedCounter)
 const mockIngestionLagGauge = jest.mocked(ingestionLagGauge)
+const mockIngestionLagHistogram = jest.mocked(ingestionLagHistogram)
 
 describe('emit-event-step', () => {
     let mockKafkaProducer: jest.Mocked<KafkaProducerWrapper>
@@ -362,6 +363,7 @@ describe('emit-event-step', () => {
     describe('ingestion lag metric', () => {
         const FAKE_NOW_MS = 1702654321987 // 2023-12-15T14:32:01.987Z
         let mockSetFn: jest.Mock
+        let mockObserveFn: jest.Mock
 
         const createMessage = (overrides: Partial<Message> = {}): Message => ({
             value: Buffer.from('test-value'),
@@ -384,7 +386,9 @@ describe('emit-event-step', () => {
             jest.setSystemTime(FAKE_NOW_MS)
 
             mockSetFn = jest.fn()
+            mockObserveFn = jest.fn()
             mockIngestionLagGauge.labels.mockReturnValue({ set: mockSetFn } as any)
+            mockIngestionLagHistogram.labels.mockReturnValue({ observe: mockObserveFn } as any)
         })
 
         afterEach(() => {
@@ -485,6 +489,90 @@ describe('emit-event-step', () => {
                 topic: 'test-topic',
                 partition: '0',
                 groupId: 'test-group-id',
+            })
+        })
+
+        describe('histogram', () => {
+            it('should observe lag in histogram with correct labels', async () => {
+                const captureTime = new Date(FAKE_NOW_MS - 5432)
+                const step = createEmitEventStep(config)
+                const input = {
+                    eventToEmit: mockRawEvent,
+                    inputHeaders: createHeaders({ now: captureTime }),
+                    inputMessage: createMessage(),
+                }
+
+                await step(input)
+
+                expect(mockIngestionLagHistogram.labels).toHaveBeenCalledWith({
+                    groupId: 'test-group-id',
+                    partition: '5',
+                })
+                expect(mockObserveFn).toHaveBeenCalledTimes(1)
+                expect(mockObserveFn).toHaveBeenCalledWith(5432)
+            })
+
+            it('should use custom groupId in histogram labels', async () => {
+                const customConfig = { ...config, groupId: 'custom-consumer-group' }
+                const step = createEmitEventStep(customConfig)
+                const input = {
+                    eventToEmit: mockRawEvent,
+                    inputHeaders: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+                    inputMessage: createMessage({ partition: 3 }),
+                }
+
+                await step(input)
+
+                expect(mockIngestionLagHistogram.labels).toHaveBeenCalledWith({
+                    groupId: 'custom-consumer-group',
+                    partition: '3',
+                })
+                expect(mockObserveFn).toHaveBeenCalledWith(1000)
+            })
+
+            it('should not observe histogram when inputHeaders.now is missing', async () => {
+                const step = createEmitEventStep(config)
+                const input = {
+                    eventToEmit: mockRawEvent,
+                    inputHeaders: createHeaders(),
+                    inputMessage: createMessage(),
+                }
+
+                await step(input)
+
+                expect(mockIngestionLagHistogram.labels).not.toHaveBeenCalled()
+                expect(mockObserveFn).not.toHaveBeenCalled()
+            })
+
+            it('should not observe histogram when inputMessage.partition is undefined', async () => {
+                const step = createEmitEventStep(config)
+                const input = {
+                    eventToEmit: mockRawEvent,
+                    inputHeaders: createHeaders({ now: new Date(FAKE_NOW_MS - 1000) }),
+                    inputMessage: createMessage({ partition: undefined as unknown as number }),
+                }
+
+                await step(input)
+
+                expect(mockIngestionLagHistogram.labels).not.toHaveBeenCalled()
+                expect(mockObserveFn).not.toHaveBeenCalled()
+            })
+
+            it('should handle partition 0 correctly in histogram', async () => {
+                const step = createEmitEventStep(config)
+                const input = {
+                    eventToEmit: mockRawEvent,
+                    inputHeaders: createHeaders({ now: new Date(FAKE_NOW_MS - 2500) }),
+                    inputMessage: createMessage({ partition: 0 }),
+                }
+
+                await step(input)
+
+                expect(mockIngestionLagHistogram.labels).toHaveBeenCalledWith({
+                    groupId: 'test-group-id',
+                    partition: '0',
+                })
+                expect(mockObserveFn).toHaveBeenCalledWith(2500)
             })
         })
     })

--- a/plugin-server/src/ingestion/event-processing/emit-event-step.test.ts
+++ b/plugin-server/src/ingestion/event-processing/emit-event-step.test.ts
@@ -24,11 +24,16 @@ jest.mock('../../worker/ingestion/event-pipeline/metrics', () => ({
     },
 }))
 
-// Mock the ingestion lag gauge
+// Mock the ingestion lag metrics
 jest.mock('../../main/ingestion-queues/metrics', () => ({
     ingestionLagGauge: {
         labels: jest.fn().mockReturnValue({
             set: jest.fn(),
+        }),
+    },
+    ingestionLagHistogram: {
+        labels: jest.fn().mockReturnValue({
+            observe: jest.fn(),
         }),
     },
 }))

--- a/plugin-server/src/ingestion/event-processing/emit-event-step.ts
+++ b/plugin-server/src/ingestion/event-processing/emit-event-step.ts
@@ -1,7 +1,7 @@
 import { Message } from 'node-rdkafka'
 
 import { KafkaProducerWrapper } from '../../kafka/producer'
-import { ingestionLagGauge } from '../../main/ingestion-queues/metrics'
+import { ingestionLagGauge, ingestionLagHistogram } from '../../main/ingestion-queues/metrics'
 import { EventHeaders, RawKafkaEvent } from '../../types'
 import { MessageSizeTooLarge } from '../../utils/db/error'
 import { eventProcessedAndIngestedCounter } from '../../worker/ingestion/event-pipeline/metrics'
@@ -34,6 +34,7 @@ export function createEmitEventStep<T extends EmitEventStepInput>(
             ingestionLagGauge
                 .labels({ topic: inputMessage.topic, partition: String(inputMessage.partition), groupId })
                 .set(lag)
+            ingestionLagHistogram.labels({ groupId, partition: String(inputMessage.partition) }).observe(lag)
         }
 
         // TODO: It's not great that we put the produce outcome in side effects, we should probably await it here

--- a/plugin-server/src/main/ingestion-queues/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/metrics.ts
@@ -1,5 +1,5 @@
 // Metrics that make sense across all Kafka consumers
-import { Counter, Gauge, Summary } from 'prom-client'
+import { Counter, Gauge, Histogram, Summary } from 'prom-client'
 
 export const kafkaRebalancePartitionCount = new Gauge({
     name: 'kafka_rebalance_partition_count',
@@ -65,4 +65,11 @@ export const ingestionLagGauge = new Gauge({
     name: 'ingestion_lag_ms',
     help: 'Time difference in ms between event capture time (now header) and ingestion time',
     labelNames: ['topic', 'partition', 'groupId'],
+})
+
+export const ingestionLagHistogram = new Histogram({
+    name: 'ingestion_lag_ms_histogram',
+    help: 'Distribution of ingestion lag per event in ms',
+    labelNames: ['groupId', 'partition'],
+    buckets: [1000, 2000, 5000, 10000, 30000, 60000, 120000, 300000, 600000, 900000],
 })


### PR DESCRIPTION
## Problem

We would like to start building some service level indicators for ingestion.

## Changes

Adds a histogram for per-event ingestion latency.

## How did you test this code?

Added unit tests