### PR TITLE
feat(workflows): Improve template delete button and hide scope selection from non-staff users

### DIFF
--- a/products/workflows/frontend/Workflows/SaveAsTemplateModal.tsx
+++ b/products/workflows/frontend/Workflows/SaveAsTemplateModal.tsx
@@ -19,7 +19,6 @@ export function SaveAsTemplateModal(props: WorkflowTemplateLogicProps = {}): JSX
             onClose={hideSaveAsTemplateModal}
             isOpen={saveAsTemplateModalVisible}
             title="Save as template"
-            description="The actions in the template will be reset to default inputs."
             footer={
                 <>
                     <LemonButton type="secondary" onClick={hideSaveAsTemplateModal}>

--- a/products/workflows/frontend/Workflows/SaveAsTemplateModal.tsx
+++ b/products/workflows/frontend/Workflows/SaveAsTemplateModal.tsx
@@ -4,10 +4,12 @@ import { Form } from 'kea-forms'
 import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonTextArea } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
+import { userLogic } from 'scenes/userLogic'
 
 import { WorkflowTemplateLogicProps, workflowTemplateLogic } from './workflowTemplateLogic'
 
 export function SaveAsTemplateModal(props: WorkflowTemplateLogicProps = {}): JSX.Element {
+    const { user } = useValues(userLogic)
     const logic = workflowTemplateLogic(props)
     const { saveAsTemplateModalVisible, isTemplateFormSubmitting, templateForm } = useValues(logic)
     const { hideSaveAsTemplateModal, submitTemplateForm } = useActions(logic)
@@ -48,15 +50,17 @@ export function SaveAsTemplateModal(props: WorkflowTemplateLogicProps = {}): JSX
                         <LemonInput placeholder="https://example.com/image.png" />
                     </LemonField>
 
-                    <LemonField name="scope" label="Scope">
-                        <LemonSelect
-                            value={templateForm.scope}
-                            options={[
-                                { value: 'team', label: 'Team only' },
-                                { value: 'global', label: 'Official (visible to everyone)' },
-                            ]}
-                        />
-                    </LemonField>
+                    {user?.is_staff && (
+                        <LemonField name="scope" label="Scope">
+                            <LemonSelect
+                                value={templateForm.scope}
+                                options={[
+                                    { value: 'team', label: 'Team only' },
+                                    { value: 'global', label: 'Official (visible to everyone)' },
+                                ]}
+                            />
+                        </LemonField>
+                    )}
                 </div>
             </Form>
         </LemonModal>

--- a/products/workflows/frontend/Workflows/WorkflowTemplateChooser.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowTemplateChooser.tsx
@@ -5,10 +5,12 @@ import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
 import { IconTrash } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonTag } from '@posthog/lemon-ui'
+import { LemonDialog, LemonTag } from '@posthog/lemon-ui'
 
 import { FallbackCoverImage } from 'lib/components/FallbackCoverImage/FallbackCoverImage'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 
@@ -107,6 +109,7 @@ function TemplateItem({
     'data-attr': string
 }): JSX.Element {
     const [isHovering, setIsHovering] = useState(false)
+    const [isMenuOpen, setIsMenuOpen] = useState(false)
 
     const scopeTag = template.scope === 'global' ? 'official' : template.scope === 'team' ? 'team' : null
 
@@ -119,13 +122,30 @@ function TemplateItem({
             data-attr={dataAttr}
         >
             {onDelete && (
-                <div className="absolute top-2 right-2 z-10">
-                    <LemonButton
-                        icon={<IconTrash />}
+                <div className="absolute top-2 right-2 z-10" onClick={(e) => e.stopPropagation()}>
+                    <More
                         size="small"
-                        status="danger"
-                        onClick={onDelete}
-                        tooltip="Delete template"
+                        className="bg-white/20 dark:bg-white/10 backdrop-blur-sm hover:bg-white/40 dark:hover:bg-white/20 transition-colors"
+                        dropdown={{
+                            visible: isMenuOpen,
+                            onVisibilityChange: setIsMenuOpen,
+                            closeOnClickInside: true,
+                        }}
+                        overlay={
+                            <LemonMenuOverlay
+                                items={[
+                                    {
+                                        label: 'Delete',
+                                        status: 'danger' as const,
+                                        icon: <IconTrash />,
+                                        onClick: (e) => {
+                                            setIsMenuOpen(false)
+                                            onDelete(e)
+                                        },
+                                    },
+                                ]}
+                            />
+                        }
                     />
                 </div>
             )}

--- a/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
@@ -3,6 +3,7 @@ import { forms } from 'kea-forms'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { userLogic } from 'scenes/userLogic'
 
 import { workflowLogic } from './workflowLogic'
 import type { workflowTemplateLogicType } from './workflowTemplateLogicType'
@@ -17,7 +18,7 @@ export const workflowTemplateLogic = kea<workflowTemplateLogicType>([
     props({ id: 'new' } as WorkflowTemplateLogicProps),
     key((props) => props.id || 'new'),
     connect(() => ({
-        values: [workflowLogic, ['workflow']],
+        values: [workflowLogic, ['workflow'], userLogic, ['user']],
     })),
     actions({
         showSaveAsTemplateModal: true,
@@ -45,13 +46,18 @@ export const workflowTemplateLogic = kea<workflowTemplateLogicType>([
                     return
                 }
 
+                let scope: 'team' | 'global' = 'team'
+                if (values.user?.is_staff) {
+                    scope = formValues.scope ?? 'team'
+                }
+
                 try {
                     await api.hogFlowTemplates.createHogFlowTemplate({
                         ...workflow,
                         name: formValues.name || workflow.name || '',
                         description: formValues.description || workflow.description || '',
                         image_url: formValues.image_url || undefined,
-                        scope: formValues.scope || 'team',
+                        scope,
                     })
                     lemonToast.success('Workflow template created')
                     actions.hideSaveAsTemplateModal()


### PR DESCRIPTION
## Problem

The delete button looked bad and wasn't very extensible (eg. with an "edit" button), and non-staff users were able to select "global" scope when creating a template, which would fail in the backend since only staff users are supposed to create those.

## Changes

[white-bg-template-delete.webm](https://github.com/user-attachments/assets/bd4002c7-2d74-421c-91fd-dd27f61ea0d8)


<img width="467" height="587" alt="image" src="https://github.com/user-attachments/assets/ddcd96c9-fa59-4c9d-b866-3687f95e618b" />
<img width="467" height="499" alt="image" src="https://github.com/user-attachments/assets/b3ee72ec-e9ee-4cd0-9649-612324a09897" />


## How did you test this code?

Manually


