### PR TITLE
fix(ci-hobby): use correct token env var in HobbyTester init

### DIFF
--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -42,7 +42,7 @@ class HobbyTester:
         ssh_private_key=None,
     ):
         if not token:
-            token = os.getenv("DIGITAL_OCEAN_HOBBY_TOKEN")
+            token = os.getenv("DIGITALOCEAN_TOKEN")
         self.token = token
         self.branch = branch
         self.sha = sha


### PR DESCRIPTION
b4b812f47f changed the fallback env var from `DIGITALOCEAN_TOKEN` to `DIGITAL_OCEAN_HOBBY_TOKEN`, but the workflow passes `DIGITALOCEAN_TOKEN`. This caused test/fetch-logs commands to fail with `'NoneType' object has no attribute 'ip_address'` because the droplet couldn't be loaded without a token.