### PR TITLE
fix: development copy script missing from bin/start

### DIFF
--- a/frontend/vite-posthog-js-plugin.ts
+++ b/frontend/vite-posthog-js-plugin.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import type { Plugin } from 'vite'
 
@@ -62,8 +62,7 @@ function copyPostHogJsFiles(): void {
 
     // Copy integration files (e.g., *integration.js*)
     try {
-        const fs = require('fs')
-        const files = fs.readdirSync(nodeModulesPostHogJs)
+        const files = readdirSync(nodeModulesPostHogJs)
         files.forEach((file: string) => {
             if (file.includes('integration') && (file.endsWith('.js') || file.endsWith('.js.map'))) {
                 const from = join(nodeModulesPostHogJs, file)
@@ -77,8 +76,7 @@ function copyPostHogJsFiles(): void {
 
     // Copy recorder files (e.g., *recorder*.js*)
     try {
-        const fs = require('fs')
-        const files = fs.readdirSync(nodeModulesPostHogJs)
+        const files = readdirSync(nodeModulesPostHogJs)
         files.forEach((file: string) => {
             if (file.includes('recorder') && (file.endsWith('.js') || file.endsWith('.js.map'))) {
                 const from = join(nodeModulesPostHogJs, file)

--- a/frontend/vite-posthog-js-plugin.ts
+++ b/frontend/vite-posthog-js-plugin.ts
@@ -1,0 +1,108 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { dirname, join, resolve } from 'path'
+import type { Plugin } from 'vite'
+
+function copyFile(from: string, to: string): void {
+    try {
+        // Ensure target directory exists
+        const toDir = dirname(to)
+        if (!existsSync(toDir)) {
+            mkdirSync(toDir, { recursive: true })
+        }
+
+        // Copy the file
+        const fileContent = readFileSync(from)
+        writeFileSync(to, fileContent)
+    } catch (error) {
+        // Silently fail if file doesn't exist (matches copy-posthog-js script behavior)
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            console.warn(`❌ Could not copy ${from} to ${to}:`, error)
+        }
+    }
+}
+
+function copyPostHogJsFiles(): void {
+    const nodeModulesPostHogJs = resolve('.', 'node_modules/posthog-js/dist')
+    const distDir = resolve('.', 'dist')
+
+    // Ensure dist directory exists
+    if (!existsSync(distDir)) {
+        mkdirSync(distDir, { recursive: true })
+    }
+
+    // Copy specific files (matching frontend/bin/copy-posthog-js)
+    const filesToCopy = [
+        'array.js',
+        'array.js.map',
+        'array.full.js',
+        'array.full.js.map',
+        'array.full.es5.js',
+        'array.full.es5.js.map',
+        'surveys.js',
+        'surveys.js.map',
+        'exception-autocapture.js',
+        'exception-autocapture.js.map',
+        'web-vitals.js',
+        'web-vitals.js.map',
+        'tracing-headers.js',
+        'tracing-headers.js.map',
+        'dead-clicks-autocapture.js',
+        'dead-clicks-autocapture.js.map',
+        'customizations.full.js',
+        'customizations.full.js.map',
+        'product-tours.js',
+        'product-tours.js.map',
+    ]
+
+    filesToCopy.forEach((file) => {
+        const from = join(nodeModulesPostHogJs, file)
+        const to = join(distDir, file)
+        copyFile(from, to)
+    })
+
+    // Copy integration files (e.g., *integration.js*)
+    try {
+        const fs = require('fs')
+        const files = fs.readdirSync(nodeModulesPostHogJs)
+        files.forEach((file: string) => {
+            if (file.includes('integration.js')) {
+                const from = join(nodeModulesPostHogJs, file)
+                const to = join(distDir, file)
+                copyFile(from, to)
+            }
+        })
+    } catch (error) {
+        console.warn(`❌ Could not copy integration files:`, error)
+    }
+
+    // Copy recorder files (e.g., *recorder*.js*)
+    try {
+        const fs = require('fs')
+        const files = fs.readdirSync(nodeModulesPostHogJs)
+        files.forEach((file: string) => {
+            if (file.includes('recorder') && file.endsWith('.js')) {
+                const from = join(nodeModulesPostHogJs, file)
+                const to = join(distDir, file)
+                copyFile(from, to)
+            }
+        })
+    } catch (error) {
+        console.warn(`❌ Could not copy recorder files:`, error)
+    }
+
+    console.info('✅ Copied posthog-js files to dist/')
+}
+
+export function posthogJsPlugin(): Plugin {
+    return {
+        name: 'posthog-js-copy',
+        configureServer() {
+            // Copy posthog-js files when dev server starts
+            copyPostHogJsFiles()
+        },
+        buildStart() {
+            // Also copy when building
+            copyPostHogJsFiles()
+        },
+    }
+}

--- a/frontend/vite-posthog-js-plugin.ts
+++ b/frontend/vite-posthog-js-plugin.ts
@@ -65,7 +65,7 @@ function copyPostHogJsFiles(): void {
         const fs = require('fs')
         const files = fs.readdirSync(nodeModulesPostHogJs)
         files.forEach((file: string) => {
-            if (file.includes('integration.js')) {
+            if (file.includes('integration') && (file.endsWith('.js') || file.endsWith('.js.map'))) {
                 const from = join(nodeModulesPostHogJs, file)
                 const to = join(distDir, file)
                 copyFile(from, to)
@@ -80,7 +80,7 @@ function copyPostHogJsFiles(): void {
         const fs = require('fs')
         const files = fs.readdirSync(nodeModulesPostHogJs)
         files.forEach((file: string) => {
-            if (file.includes('recorder') && file.endsWith('.js')) {
+            if (file.includes('recorder') && (file.endsWith('.js') || file.endsWith('.js.map'))) {
                 const from = join(nodeModulesPostHogJs, file)
                 const to = join(distDir, file)
                 copyFile(from, to)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vite'
 
 // import { toolbarDenylistPlugin } from './vite-toolbar-plugin'
 import { htmlGenerationPlugin } from './vite-html-plugin'
+import { posthogJsPlugin } from './vite-posthog-js-plugin'
 import { publicAssetsPlugin } from './vite-public-assets-plugin'
 
 // https://vitejs.dev/config/
@@ -18,6 +19,8 @@ export default defineConfig(({ mode }) => {
             htmlGenerationPlugin(),
             // Copy public assets to src/assets for development
             publicAssetsPlugin(),
+            // Copy posthog-js files from node_modules to dist for development
+            posthogJsPlugin(),
             {
                 name: 'startup-message',
                 configureServer(server) {


### PR DESCRIPTION
## The Problem                                                                                                         
                                                                                                                      
When a new developer runs bin/start, it calls bin/start-frontend which executes:                           
bin/turbo --filter=@posthog/frontend start-vite                                                                     
                                                                                                                    
The start-vite script in frontend/package.json:44 was running:                                                      
"start-vite": "pnpm build:products && concurrently ... \"vite --host 0.0.0.0\" ..."                                 
                                                                                                                    
However, the old esbuild-based scripts (build and start-http) included an additional step:                          
"build": "pnpm copy-scripts && pnpm build:esbuild"                                                                  
"start-http": "pnpm clean && pnpm copy-scripts && pnpm build:esbuild --dev"                                         
                                                                                                                    
The copy-scripts command (frontend/bin/copy-posthog-js) copies built posthog-js files (array.js, surveys.js,        
recorder files, etc.) from node_modules/posthog-js/dist/ to dist/ so they can be served by PostHog's CDN. This step 
was missing from the vite flow.

Left, was original copy-scripts bash script, right is the new vite plugin
<img width="1797" height="762" alt="image" src="https://github.com/user-attachments/assets/68c7931e-8b8d-4cbf-9511-efef519b79bc" />

## Changes
Add new vite plugin to copy files over
