### PR TITLE
fix: OAuth callback URL validation in django admin

### DIFF
--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -2,6 +2,7 @@ import enum
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -72,7 +73,10 @@ class OAuthApplication(AbstractApplication):
 
             is_loopback = is_loopback_host(parsed_uri.hostname)
 
-            allowed_schemes = ["http", "https"] if is_loopback else ["https"]
+            all_schemes = settings.OAUTH2_PROVIDER.get("ALLOWED_REDIRECT_URI_SCHEMES", ["https"])
+            # http is only allowed for loopback addresses (localhost, 127.x.x.x)
+            non_loopback_schemes = [s for s in all_schemes if s != "http"]
+            allowed_schemes = all_schemes if is_loopback else non_loopback_schemes
 
             if parsed_uri.scheme not in allowed_schemes:
                 raise ValidationError(

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -1,5 +1,5 @@
 import enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -73,7 +73,7 @@ class OAuthApplication(AbstractApplication):
 
             is_loopback = is_loopback_host(parsed_uri.hostname)
 
-            all_schemes = settings.OAUTH2_PROVIDER.get("ALLOWED_REDIRECT_URI_SCHEMES", ["https"])
+            all_schemes = cast(list[str], settings.OAUTH2_PROVIDER.get("ALLOWED_REDIRECT_URI_SCHEMES", ["https"]))
             # http is only allowed for loopback addresses (localhost, 127.x.x.x)
             non_loopback_schemes = [s for s in all_schemes if s != "http"]
             allowed_schemes = all_schemes if is_loopback else non_loopback_schemes


### PR DESCRIPTION
## Problem
PR PostHog/posthog#43037 allowed `posthog://` for OAuth callback URL settings, but Django admin still blocks saving it because `OAuthApplication.clean()` hardcoded scheme validation.

<img width="843" height="730" alt="Screenshot 2025-12-19 at 16 16 20" src="https://github.com/user-attachments/assets/d7839e2f-1093-4c09-8693-6f83c147ef53" />


## Changes

- Updated callback URL validation

## How did you test this code?
Tests + Manually: 
Open Django Admin -> Create a new OAuth app, enter `posthog://callback`