### PR TITLE
fix(gateway): lower worker count

### DIFF
--- a/services/llm-gateway/Dockerfile
+++ b/services/llm-gateway/Dockerfile
@@ -37,7 +37,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
 
 CMD ["gunicorn", "llm_gateway.main:app", \
      "--bind", "0.0.0.0:8080", \
-     "--workers", "4", \
+     "--workers", "2", \
      "--worker-class", "uvicorn.workers.UvicornWorker", \
      "--access-logfile", "-", \
      "--error-logfile", "-"]


### PR DESCRIPTION
we want to use lots of small pods here, instead of lots of workers per pod, this lowers to 2 from 4 to reduce memory overhead