### PR TITLE
fix(gateway): remove conflicting settings

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -4,8 +4,6 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    host: str = "0.0.0.0"
-    port: int = 8080
     debug: bool = False
 
     database_url: str = "postgres://posthog:posthog@localhost:5432/posthog"


### PR DESCRIPTION
These settings were not used, and they were conflicting with default env vars from k8s - lets remove them