### PR TITLE
fix: values re-rendering in trends

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -2,10 +2,11 @@ import './InsightsTable.scss'
 
 import { useActions, useValues } from 'kea'
 import { compare as compareFn } from 'natural-orderby'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { LemonTable, LemonTableColumn } from 'lib/lemon-ui/LemonTable'
 import { COUNTRY_CODE_TO_LONG_NAME } from 'lib/utils/geography/country'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { teamLogic } from 'scenes/teamLogic'
@@ -16,7 +17,7 @@ import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { extractExpressionComment } from '~/queries/nodes/DataTable/utils'
 import { isValidBreakdown } from '~/queries/utils'
-import { ChartDisplayType } from '~/types'
+import { ChartDisplayType, TrendsFilterType } from '~/types'
 
 import { entityFilterLogic } from '../../filters/ActionFilter/entityFilterLogic'
 import { AggregationColumnItem, AggregationColumnTitle } from './columns/AggregationColumn'
@@ -285,6 +286,11 @@ export function InsightsTable({
         })
     }
 
+    const renderCount = useCallback(
+        (value: number) => formatAggregationAxisValue(trendsFilter as Partial<TrendsFilterType>, value),
+        [trendsFilter]
+    )
+
     const valueColumns: LemonTableColumn<IndexedTrendResult, any>[] = useMemo(() => {
         // Don't show value columns for non-time-series displays like WorldMap and Heatmap
         if (display === ChartDisplayType.WorldMap || display === ChartDisplayType.CalendarHeatmap) {
@@ -324,13 +330,21 @@ export function InsightsTable({
                 />
             ),
             render: (_, item: IndexedTrendResult) => {
-                return <ValueColumnItem index={index} item={item} trendsFilter={trendsFilter} />
+                return (
+                    <ValueColumnItem
+                        index={index}
+                        item={item}
+                        isStickiness={isStickiness}
+                        renderCount={renderCount}
+                        formatPropertyValueForDisplay={formatPropertyValueForDisplay}
+                    />
+                )
             },
             key: `data-${index}`,
             sorter: (a: IndexedTrendResult, b: IndexedTrendResult) => dataSorter(a, b, index),
             align: 'right',
         }))
-    }, [indexedResults, trendsFilter, isStickiness, compareFilter?.compare, interval]) // oxlint-disable-line react-hooks/exhaustive-deps
+    }, [indexedResults, renderCount, formatPropertyValueForDisplay, isStickiness, compareFilter?.compare, interval]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     columns.push(...valueColumns)
 

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/ValueColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/ValueColumn.tsx
@@ -1,15 +1,12 @@
-import { useValues } from 'kea'
+import { ReactNode, memo } from 'react'
 
 import { DateDisplay } from 'lib/components/DateDisplay'
-import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
-import { insightLogic } from 'scenes/insights/insightLogic'
 import { formatAggregationValue } from 'scenes/insights/utils'
-import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
-import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { ResolvedDateRangeResponse, TrendsFilter } from '~/queries/schema/schema-general'
-import { IntervalType, TrendsFilterType } from '~/types'
+import { FormatPropertyValueForDisplayFunction } from '~/models/propertyDefinitionsModel'
+import { ResolvedDateRangeResponse } from '~/queries/schema/schema-general'
+import { IntervalType } from '~/types'
 
 type ValueColumnTitleProps = {
     index: number
@@ -48,17 +45,22 @@ export function ValueColumnTitle({
 type ValueColumnItemProps = {
     index: number
     item: IndexedTrendResult
-    trendsFilter: TrendsFilter | null | undefined
+    isStickiness: boolean
+    renderCount: (value: number) => ReactNode
+    formatPropertyValueForDisplay: FormatPropertyValueForDisplayFunction
 }
 
-export function ValueColumnItem({ index, item, trendsFilter }: ValueColumnItemProps): JSX.Element {
-    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
-    const { insightProps } = useValues(insightLogic)
-    const { isStickiness } = useValues(trendsDataLogic(insightProps))
+export const ValueColumnItem = memo(function ValueColumnItem({
+    index,
+    item,
+    isStickiness,
+    renderCount,
+    formatPropertyValueForDisplay,
+}: ValueColumnItemProps): JSX.Element {
     const formattedValue = formatAggregationValue(
         item.action?.math_property,
         item.data[index],
-        (value) => formatAggregationAxisValue(trendsFilter as Partial<TrendsFilterType>, value),
+        renderCount,
         formatPropertyValueForDisplay
     )
     return (
@@ -73,4 +75,4 @@ export function ValueColumnItem({ index, item, trendsFilter }: ValueColumnItemPr
             )}
         </span>
     )
-}
+})


### PR DESCRIPTION
i was (very meta) running memory tracing in the  browser while i was changing my insight that tracks memory usage in the browser

and i saw we were absolutely hammering updates to these components  
  
(this is no slam dunk - my after tab was somehow using 3GB memory)

## before

![2025-12-19 19.11.38.gif](https://app.graphite.com/user-attachments/assets/c83dcbbf-e968-45b6-aacb-9761b84348d1.gif)

## after

![2025-12-19 19.15.29.gif](https://app.graphite.com/user-attachments/assets/5faf7b81-cfb0-4559-9a3a-9e94425884e0.gif)



so...

Changes Made

ValueColumn.tsx:

- don't subscribe to the logic from every cell in the table when we can pass props from parent: isStickiness, renderCount, formatPropertyValueForDisplay
- Wrapped component in React.memo to prevent unnecessary re-renders

InsightsTable.tsx:

- Added useCallback for renderCount - creates one stable function instead of new functions per render
- Passes memoized values to ValueColumnItem
- Updated useMemo dependencies to include the memoized callback

Related to #32479
