### PR TITLE
feat(replay): migrate event definition entrypoints to unified replay button

### DIFF
--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -43,7 +43,7 @@ export function eventRowActionsContent(event: EventType): JSX.Element {
             {event.uuid && event.timestamp && <EventCopyLinkButton event={event} />}
             <ViewRecordingButton
                 fullWidth
-                openPlayerIn={RecordingPlayerType.Modal}
+                openPlayerIn={RecordingPlayerType.NewTab}
                 sessionId={event.properties.$session_id}
                 recordingStatus={event.properties.$recording_status}
                 timestamp={event.timestamp}

--- a/frontend/src/scenes/activity/explore/EventDetails.tsx
+++ b/frontend/src/scenes/activity/explore/EventDetails.tsx
@@ -4,7 +4,7 @@ import { ErrorPropertyTabEvent, EventPropertyTabs } from 'lib/components/EventPr
 import { JSONViewer } from 'lib/components/JSONViewer'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { SurveyResponseDisplay } from 'lib/components/SurveyResponseDisplay/SurveyResponseDisplay'
-import ViewRecordingButton from 'lib/components/ViewRecordingButton/ViewRecordingButton'
+import ViewRecordingButton, { RecordingPlayerType } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonTableProps } from 'lib/lemon-ui/LemonTable'
 import { Link } from 'lib/lemon-ui/Link'
@@ -51,6 +51,7 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                             hasRecording={properties.has_recording as boolean | undefined}
                                             size="small"
                                             type="secondary"
+                                            openPlayerIn={RecordingPlayerType.NewTab}
                                             data-attr="conversation-view-session-recording-button"
                                         />
                                     </div>

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -13,11 +13,11 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
+import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
-import { IconPlayCircle } from 'lib/lemon-ui/icons'
 import { DefinitionLogicProps, definitionLogic } from 'scenes/data-management/definition/definitionLogic'
 import { EventDefinitionInsights } from 'scenes/data-management/events/EventDefinitionInsights'
 import { EventDefinitionProperties } from 'scenes/data-management/events/EventDefinitionProperties'
@@ -39,7 +39,6 @@ import {
     FilterLogicalOperator,
     PropertyDefinition,
     PropertyDefinitionVerificationStatus,
-    ReplayTabs,
 } from '~/types'
 
 import { getEventDefinitionIcon, getPropertyDefinitionIcon } from '../events/DefinitionHeader'
@@ -158,9 +157,8 @@ export function DefinitionView(props: DefinitionLogicProps): JSX.Element {
                 actions={
                     <>
                         {isEvent && (
-                            <LemonButton
-                                type="secondary"
-                                to={urls.replay(ReplayTabs.Home, {
+                            <ViewRecordingsPlaylistButton
+                                filters={{
                                     filter_group: {
                                         type: FilterLogicalOperator.And,
                                         values: [
@@ -177,14 +175,11 @@ export function DefinitionView(props: DefinitionLogicProps): JSX.Element {
                                             },
                                         ],
                                     },
-                                })}
-                                sideIcon={<IconPlayCircle />}
-                                data-attr="event-definition-view-recordings"
+                                }}
+                                type="secondary"
                                 size="small"
-                                targetBlank
-                            >
-                                View recordings
-                            </LemonButton>
+                                data-attr="event-definition-view-recordings"
+                            />
                         )}
                         <LemonButton
                             data-attr="delete-definition"

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -8,11 +8,10 @@ import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { TZLabel } from 'lib/components/TZLabel'
 import { TagSelect } from 'lib/components/TagSelect'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { EVENT_DEFINITIONS_PER_PAGE } from 'lib/constants'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
-import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
-import { IconPlayCircle } from 'lib/lemon-ui/icons'
 import { cn } from 'lib/utils/css-classes'
 import { DefinitionHeader, getEventDefinitionIcon } from 'scenes/data-management/events/DefinitionHeader'
 import { EventDefinitionModal } from 'scenes/data-management/events/EventDefinitionModal'
@@ -25,7 +24,7 @@ import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { EventDefinition, EventDefinitionType, FilterLogicalOperator, ReplayTabs } from '~/types'
+import { EventDefinition, EventDefinitionType, FilterLogicalOperator } from '~/types'
 
 const eventTypeOptions: LemonSelectOptions<EventDefinitionType> = [
     { value: EventDefinitionType.Event, label: 'All events', 'data-attr': 'event-type-option-event' },
@@ -91,41 +90,31 @@ export function EventDefinitionsTable(): JSX.Element {
             : []),
         {
             key: 'actions',
-            width: 0,
+            width: 180,
             render: function RenderActions(_, definition: EventDefinition) {
                 return (
-                    <More
-                        data-attr={`event-definitions-table-more-button-${definition.name}`}
-                        overlay={
-                            <>
-                                <LemonButton
-                                    to={urls.replay(ReplayTabs.Home, {
-                                        filter_group: {
-                                            type: FilterLogicalOperator.And,
-                                            values: [
-                                                {
-                                                    type: FilterLogicalOperator.And,
-                                                    values: [
-                                                        {
-                                                            id: definition.name,
-                                                            type: 'events',
-                                                            order: 0,
-                                                            name: definition.name,
-                                                        },
-                                                    ],
-                                                },
-                                            ],
-                                        },
-                                    })}
-                                    fullWidth
-                                    sideIcon={<IconPlayCircle />}
-                                    data-attr="event-definitions-table-view-recordings"
-                                    targetBlank
-                                >
-                                    View recordings
-                                </LemonButton>
-                            </>
-                        }
+                    <ViewRecordingsPlaylistButton
+                        filters={{
+                            filter_group: {
+                                type: FilterLogicalOperator.And,
+                                values: [
+                                    {
+                                        type: FilterLogicalOperator.And,
+                                        values: [
+                                            {
+                                                id: definition.name,
+                                                type: 'events',
+                                                order: 0,
+                                                name: definition.name,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        }}
+                        size="small"
+                        type="secondary"
+                        data-attr="event-definitions-table-view-recordings"
                     />
                 )
             },

--- a/playwright/e2e/event-definitions.spec.ts
+++ b/playwright/e2e/event-definitions.spec.ts
@@ -10,12 +10,11 @@ test.describe('Event Definitions', () => {
 
         await expect(page.locator('tbody tr .LemonButton').first()).toBeVisible()
         await expect(page.locator('[data-attr=events-definition-table]')).toBeVisible()
-        await page.locator('button[aria-label="more"]').first().click()
 
         const eventName = await page.locator('tbody tr .PropertyKeyInfo__text').first().innerText()
 
-        await expect(page.locator('[data-attr=event-definitions-table-view-recordings]')).toBeVisible()
-        await page.locator('[data-attr=event-definitions-table-view-recordings]').click()
+        await expect(page.locator('[data-attr=event-definitions-table-view-recordings]').first()).toBeVisible()
+        await page.locator('[data-attr=event-definitions-table-view-recordings]').first().click()
         expect(page.url()).toMatch(/replay/)
 
         await page.locator('.LemonButton--has-icon .LemonButton__content').filter({ hasText: 'Filters' }).click()

--- a/products/actions/frontend/components/ActionsTable.tsx
+++ b/products/actions/frontend/components/ActionsTable.tsx
@@ -7,6 +7,7 @@ import api from 'lib/api'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
+import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
@@ -15,7 +16,6 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable/types'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { IconPlayCircle } from 'lib/lemon-ui/icons'
 import { stripHTTP } from 'lib/utils'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { teamLogic } from 'scenes/teamLogic'
@@ -31,7 +31,6 @@ import {
     AvailableFeature,
     ChartDisplayType,
     FilterLogicalOperator,
-    ReplayTabs,
 } from '~/types'
 
 import { actionsLogic } from '../logics/actionsLogic'
@@ -205,8 +204,8 @@ export function ActionsTable(): JSX.Element {
                                 <LemonButton to={urls.duplicateAction(action)} fullWidth>
                                     Duplicate
                                 </LemonButton>
-                                <LemonButton
-                                    to={urls.replay(ReplayTabs.Home, {
+                                <ViewRecordingsPlaylistButton
+                                    filters={{
                                         filter_group: {
                                             type: FilterLogicalOperator.And,
                                             values: [
@@ -223,7 +222,7 @@ export function ActionsTable(): JSX.Element {
                                                 },
                                             ],
                                         },
-                                    })}
+                                    }}
                                     onClick={() => {
                                         addProductIntentForCrossSell({
                                             from: ProductKey.ACTIONS,
@@ -231,13 +230,9 @@ export function ActionsTable(): JSX.Element {
                                             intent_context: ProductIntentContext.ACTION_VIEW_RECORDINGS,
                                         })
                                     }}
-                                    sideIcon={<IconPlayCircle />}
                                     fullWidth
                                     data-attr="action-table-view-recordings"
-                                    targetBlank
-                                >
-                                    View recordings
-                                </LemonButton>
+                                />
                                 <LemonButton to={tryInInsightsUrl(action)} fullWidth targetBlank>
                                     Try out in Insights
                                 </LemonButton>

--- a/products/actions/frontend/pages/ActionEdit.tsx
+++ b/products/actions/frontend/pages/ActionEdit.tsx
@@ -3,13 +3,14 @@ import { Form } from 'kea-forms'
 import { router } from 'kea-router'
 import { useEffect } from 'react'
 
-import { IconInfo, IconPlus, IconRewindPlay, IconTrash } from '@posthog/icons'
+import { IconInfo, IconPlus, IconTrash } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { NotFound } from 'lib/components/NotFound'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
 import { SceneTags } from 'lib/components/Scenes/SceneTags'
 import { SceneActivityIndicator } from 'lib/components/Scenes/SceneUpdateActivityInfo'
+import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -35,13 +36,7 @@ import { tagsModel } from '~/models/tagsModel'
 import { Query } from '~/queries/Query/Query'
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { NodeKind, ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
-import {
-    AccessControlLevel,
-    AccessControlResourceType,
-    ActionStepType,
-    FilterLogicalOperator,
-    ReplayTabs,
-} from '~/types'
+import { AccessControlLevel, AccessControlResourceType, ActionStepType, FilterLogicalOperator } from '~/types'
 
 import { ActionHogFunctions } from '../components/ActionHogFunctions'
 import { ActionStep } from '../components/ActionStep'
@@ -139,42 +134,34 @@ export function ActionEdit({ action: loadedAction, id, actionLoading }: ActionEd
 
                     <ScenePanelActionsSection>
                         {id && (
-                            <>
-                                <Link
-                                    to={urls.replay(ReplayTabs.Home, {
-                                        filter_group: {
-                                            type: FilterLogicalOperator.And,
-                                            values: [
-                                                {
-                                                    type: FilterLogicalOperator.And,
-                                                    values: [
-                                                        {
-                                                            id: id,
-                                                            type: 'actions',
-                                                            order: 0,
-                                                            name: action.name,
-                                                        },
-                                                    ],
-                                                },
-                                            ],
-                                        },
-                                    })}
-                                    onClick={() => {
-                                        addProductIntentForCrossSell({
-                                            from: ProductKey.ACTIONS,
-                                            to: ProductKey.SESSION_REPLAY,
-                                            intent_context: ProductIntentContext.ACTION_VIEW_RECORDINGS,
-                                        })
-                                    }}
-                                    data-attr={`${RESOURCE_TYPE}-view-recordings`}
-                                    buttonProps={{
-                                        menuItem: true,
-                                    }}
-                                >
-                                    <IconRewindPlay />
-                                    View recordings
-                                </Link>
-                            </>
+                            <ViewRecordingsPlaylistButton
+                                filters={{
+                                    filter_group: {
+                                        type: FilterLogicalOperator.And,
+                                        values: [
+                                            {
+                                                type: FilterLogicalOperator.And,
+                                                values: [
+                                                    {
+                                                        id: id,
+                                                        type: 'actions',
+                                                        order: 0,
+                                                        name: action.name,
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                }}
+                                onClick={() => {
+                                    addProductIntentForCrossSell({
+                                        from: ProductKey.ACTIONS,
+                                        to: ProductKey.SESSION_REPLAY,
+                                        intent_context: ProductIntentContext.ACTION_VIEW_RECORDINGS,
+                                    })
+                                }}
+                                data-attr={`${RESOURCE_TYPE}-view-recordings`}
+                            />
                         )}
                     </ScenePanelActionsSection>
                     <ScenePanelDivider />


### PR DESCRIPTION
## Problem

Unifying entrypoints to replay throughout the product
Also, this was the ONLY item in the overflow menu.... so i just made it its own column??

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- use new unified button
- remove 3 dot menu and just create column with replay entrypoint

## How did you test this code?

[event_def_entrypoints.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/38c8a01d-049e-4857-97be-5d495b3efc7b.mov" />](https://app.graphite.com/user-attachments/video/38c8a01d-049e-4857-97be-5d495b3efc7b.mov)

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
