### PR TITLE
fix: handle null survey appearance + fix django admin

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -569,6 +569,11 @@ export const surveyLogic = kea<surveyLogicType>([
                 if (props.id && props.id !== 'new') {
                     try {
                         const survey = await api.surveys.get(props.id)
+                        // patch surveys with a potentially null appearance...
+                        // pending root cause on _how_ these get to be null
+                        if (!survey.appearance) {
+                            survey.appearance = defaultSurveyAppearance
+                        }
                         const currentFilters = values.answerFilters
                         actions.reportSurveyViewed(survey)
                         // Initialize answer filters for all questions - first for index-based, then for id-based

--- a/posthog/admin/admins/survey_admin.py
+++ b/posthog/admin/admins/survey_admin.py
@@ -20,12 +20,12 @@ class SurveyAdmin(admin.ModelAdmin):
     readonly_fields = ("linked_flag", "targeting_flag", "internal_targeting_flag", "internal_response_sampling_flag")
     ordering = ("-created_at",)
 
-    def get_readonly_fields(self, request, obj=None):
-        readonly_fields = list(super().get_readonly_fields(request, obj))
-        # only on individual change page
+    def get_exclude(self, request, obj=None):
+        exclude = list(super().get_exclude(request, obj) or [])
+        # Exclude actions on change page to prevent loading all Action objects
         if obj:
-            readonly_fields.append("actions")
-        return readonly_fields
+            exclude.append("actions")
+        return exclude
 
     def get_form(self, request, obj=None, change=False, **kwargs):
         form = super().get_form(request, obj, **kwargs)
@@ -38,7 +38,6 @@ class SurveyAdmin(admin.ModelAdmin):
             "iteration_start_dates",
             "current_iteration",
             "current_iteration_start_date",
-            "actions",
         ]:
             if field in form.base_fields:
                 form.base_fields[field].required = False


### PR DESCRIPTION
## Problem
- survey appearance being null breaks things
- django admin for surveys does not work

https://posthoghelp.zendesk.com/agent/tickets/45540 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/47041)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- adds default survey appearance when fetching from API, if the appearance is null
- removes actions from surveys django admin - this is a hopeful fix :)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
