### PR TITLE
feat(capture): implement body read timeout

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
+            - 'eli.r/capture-timed-body-reader'
 
 jobs:
     build:

--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -84,6 +84,9 @@ pub enum CaptureError {
 
     #[error("service unavailable: {0}")]
     ServiceUnavailable(String),
+
+    #[error("client stopped sending data")]
+    BodyReadTimeout,
 }
 
 impl From<serde_json::Error> for CaptureError {
@@ -118,6 +121,7 @@ impl CaptureError {
             CaptureError::RateLimited => "rate_limited",
             CaptureError::EmptyPayloadFiltered => "empty_filtered_payload",
             CaptureError::ServiceUnavailable(_) => "service_unavailable",
+            CaptureError::BodyReadTimeout => "body_read_timeout",
         }
     }
 }
@@ -154,6 +158,8 @@ impl IntoResponse for CaptureError {
             CaptureError::BillingLimit | CaptureError::RateLimited => {
                 (StatusCode::TOO_MANY_REQUESTS, self.to_string())
             }
+
+            CaptureError::BodyReadTimeout => (StatusCode::GATEWAY_TIMEOUT, self.to_string()),
         }
         .into_response()
     }

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -134,6 +134,11 @@ pub struct Config {
     // Set env var to enable; unset to disable.
     pub http1_header_read_timeout_ms: Option<u64>,
 
+    // Body chunk read timeout in milliseconds. If a client stops sending data
+    // for this duration mid-upload, the request is aborted with 504.
+    // Set env var to enable; unset to disable (existing behavior).
+    pub body_chunk_read_timeout_ms: Option<u64>,
+
     #[envconfig(nested = true)]
     pub continuous_profiling: ContinuousProfilingConfig,
 }

--- a/rust/capture/src/extractors.rs
+++ b/rust/capture/src/extractors.rs
@@ -1,0 +1,134 @@
+//! Custom extractors for request body handling
+//!
+//! This module provides utilities for extracting request bodies with
+//! configurable timeouts to prevent slow clients from holding connections.
+
+use std::time::Duration;
+
+use axum::body::Body;
+use bytes::{BufMut, Bytes, BytesMut};
+use futures::StreamExt;
+use tracing::warn;
+
+use crate::api::CaptureError;
+
+const METRIC_BODY_READ_TIMEOUT: &str = "capture_body_read_timeout_total";
+
+/// Extract body bytes from a streaming Body with a per-chunk timeout.
+///
+/// If `chunk_timeout` is None, reads the entire body without timeout (existing behavior).
+/// If `chunk_timeout` is Some, each chunk read is wrapped in a timeout. If no data
+/// arrives within the timeout window, returns `CaptureError::BodyReadTimeout`.
+///
+/// The `limit` parameter enforces a maximum body size during streaming.
+pub async fn extract_body_with_timeout(
+    body: Body,
+    limit: usize,
+    chunk_timeout: Option<Duration>,
+    path: &str,
+) -> Result<Bytes, CaptureError> {
+    let mut stream = body.into_data_stream();
+    let mut buf = BytesMut::with_capacity(std::cmp::min(limit, 64 * 1024)); // Start with 64KB or limit
+
+    loop {
+        let chunk_result = match chunk_timeout {
+            Some(timeout) => {
+                match tokio::time::timeout(timeout, stream.next()).await {
+                    Ok(result) => result,
+                    Err(_elapsed) => {
+                        // Timeout waiting for next chunk
+                        metrics::counter!(METRIC_BODY_READ_TIMEOUT, "path" => path.to_string())
+                            .increment(1);
+                        warn!(
+                            path = path,
+                            bytes_received = buf.len(),
+                            timeout_ms = timeout.as_millis() as u64,
+                            "Body read timeout: client stopped sending data"
+                        );
+                        return Err(CaptureError::BodyReadTimeout);
+                    }
+                }
+            }
+            None => stream.next().await,
+        };
+
+        match chunk_result {
+            Some(Ok(chunk)) => {
+                // Check size limit before appending
+                if buf.len() + chunk.len() > limit {
+                    return Err(CaptureError::EventTooBig(format!(
+                        "Request body exceeds limit of {} bytes",
+                        limit
+                    )));
+                }
+                buf.put(chunk);
+            }
+            Some(Err(e)) => {
+                return Err(CaptureError::RequestDecodingError(format!(
+                    "Error reading request body: {}",
+                    e
+                )));
+            }
+            None => {
+                // Stream complete
+                break;
+            }
+        }
+    }
+
+    Ok(buf.freeze())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use bytes::Bytes;
+    use futures::stream;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_extract_body_no_timeout() {
+        let body = Body::from("hello world");
+        let result = extract_body_with_timeout(body, 1024, None, "/test").await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Bytes::from("hello world"));
+    }
+
+    #[tokio::test]
+    async fn test_extract_body_with_timeout_success() {
+        let body = Body::from("hello world");
+        let timeout = Some(Duration::from_secs(5));
+        let result = extract_body_with_timeout(body, 1024, timeout, "/test").await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Bytes::from("hello world"));
+    }
+
+    #[tokio::test]
+    async fn test_extract_body_exceeds_limit() {
+        let body = Body::from("hello world this is a long message");
+        let result = extract_body_with_timeout(body, 10, None, "/test").await;
+        assert!(matches!(result, Err(CaptureError::EventTooBig(_))));
+    }
+
+    #[tokio::test]
+    async fn test_extract_body_timeout_fires() {
+        // Create a stream that yields one chunk then stalls forever
+        let chunks: Vec<Result<Bytes, std::io::Error>> = vec![Ok(Bytes::from("partial"))];
+        let slow_stream = stream::iter(chunks).chain(stream::pending());
+        let body = Body::from_stream(slow_stream);
+
+        let timeout = Some(Duration::from_millis(50));
+        let result = extract_body_with_timeout(body, 1024, timeout, "/test").await;
+
+        assert!(matches!(result, Err(CaptureError::BodyReadTimeout)));
+    }
+
+    #[tokio::test]
+    async fn test_extract_body_empty() {
+        let body = Body::empty();
+        let result = extract_body_with_timeout(body, 1024, None, "/test").await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+}

--- a/rust/capture/src/extractors.rs
+++ b/rust/capture/src/extractors.rs
@@ -57,16 +57,14 @@ pub async fn extract_body_with_timeout(
                 // Check size limit before appending
                 if buf.len() + chunk.len() > limit {
                     return Err(CaptureError::EventTooBig(format!(
-                        "Request body exceeds limit of {} bytes",
-                        limit
+                        "Request body exceeds limit of {limit} bytes"
                     )));
                 }
                 buf.put(chunk);
             }
             Some(Err(e)) => {
                 return Err(CaptureError::RequestDecodingError(format!(
-                    "Error reading request body: {}",
-                    e
+                    "Error reading request body: {e}"
                 )));
             }
             None => {

--- a/rust/capture/src/lib.rs
+++ b/rust/capture/src/lib.rs
@@ -3,6 +3,7 @@ pub mod ai_s3;
 pub mod api;
 pub mod config;
 pub mod events;
+pub mod extractors;
 pub mod limiters;
 pub mod metrics_middleware;
 pub mod payload;

--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -28,16 +28,11 @@ use crate::{
     fields(
         method,
         path,
-        user_agent,
-        content_type,
-        content_encoding,
-        x_request_id,
         token,
+        ip,
         historical_migration,
-        lib_version,
         compression,
-        params_lib_version,
-        params_compression,
+        lib_version,
         batch_size
     )
 )]
@@ -51,6 +46,12 @@ pub async fn handle_event_payload(
     body: Body,
 ) -> Result<(ProcessingContext, Vec<RawEvent>), CaptureError> {
     let chatty_debug_enabled = headers.get("X-CAPTURE-DEBUG").is_some();
+
+    if chatty_debug_enabled {
+        info!(headers=?headers, "CHATTY: entering handle_event_payload");
+    } else {
+        debug!(headers=?headers, "entering handle_event_payload");
+    }
 
     // this endpoint handles:
     // - GET or POST requests w/payload that is one of:
@@ -72,12 +73,13 @@ pub async fn handle_event_payload(
     )
     .await?;
 
-    // capture arguments and add to logger, processing context
     if chatty_debug_enabled {
-        info!(headers=?headers, "CHATTY: entering handle_event_payload");
+        info!(headers=?headers, "CHATTY: streamed payload body");
     } else {
-        debug!(headers=?headers, "entering handle_event_payload");
+        debug!(headers=?headers, "streamed payload body");
     }
+
+    // capture arguments and add to logger, processing context
     let metadata = extract_and_record_metadata(headers, path.as_str(), state.is_mirror_deploy);
 
     if chatty_debug_enabled {

--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -4,8 +4,6 @@
 //! It extracts and validates event payloads from HTTP requests, handling
 //! decompression, deserialization, and token extraction.
 
-use std::time::Duration;
-
 use axum::body::Body;
 use axum::extract::{MatchedPath, State};
 use axum::http::{HeaderMap, Method};
@@ -66,10 +64,13 @@ pub async fn handle_event_payload(
     //     - lib_version = SDK version that submitted the request
 
     // Extract body with optional chunk timeout
-    let chunk_timeout = state.body_chunk_read_timeout_ms.map(Duration::from_millis);
-    let body =
-        extract_body_with_timeout(body, state.event_size_limit, chunk_timeout, path.as_str())
-            .await?;
+    let body = extract_body_with_timeout(
+        body,
+        state.event_size_limit,
+        state.body_chunk_read_timeout,
+        path.as_str(),
+    )
+    .await?;
 
     // capture arguments and add to logger, processing context
     if chatty_debug_enabled {

--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -4,16 +4,19 @@
 //! It extracts and validates event payloads from HTTP requests, handling
 //! decompression, deserialization, and token extraction.
 
+use std::time::Duration;
+
+use axum::body::Body;
 use axum::extract::{MatchedPath, State};
 use axum::http::{HeaderMap, Method};
 use axum_client_ip::InsecureClientIp;
-use bytes::Bytes;
 use common_types::RawEvent;
 use metrics::counter;
 use tracing::{debug, info, instrument, Span};
 
 use crate::{
     api::CaptureError,
+    extractors::extract_body_with_timeout,
     payload::{extract_and_record_metadata, extract_payload_bytes, EventQuery},
     router,
     utils::extract_and_verify_token,
@@ -47,7 +50,7 @@ pub async fn handle_event_payload(
     headers: &HeaderMap,
     method: &Method,
     path: &MatchedPath,
-    body: Bytes,
+    body: Body,
 ) -> Result<(ProcessingContext, Vec<RawEvent>), CaptureError> {
     let chatty_debug_enabled = headers.get("X-CAPTURE-DEBUG").is_some();
 
@@ -61,6 +64,12 @@ pub async fn handle_event_payload(
     //     - data        = JSON payload which may itself be compressed or base64 encoded or both
     //     - compression = hint to how "data" is encoded or compressed
     //     - lib_version = SDK version that submitted the request
+
+    // Extract body with optional chunk timeout
+    let chunk_timeout = state.body_chunk_read_timeout_ms.map(Duration::from_millis);
+    let body =
+        extract_body_with_timeout(body, state.event_size_limit, chunk_timeout, path.as_str())
+            .await?;
 
     // capture arguments and add to logger, processing context
     if chatty_debug_enabled {

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -4,16 +4,19 @@
 //! Unlike analytics events, recording payloads are deserialized directly to
 //! Vec<RawRecording> to avoid the overhead of going through RawRequest.
 
+use std::time::Duration;
+
+use axum::body::Body;
 use axum::extract::{MatchedPath, State};
 use axum::http::{HeaderMap, Method};
 use axum_client_ip::InsecureClientIp;
-use bytes::Bytes;
 use metrics::counter;
 use tracing::{debug, info, instrument, warn, Span};
 
 use crate::{
     api::CaptureError,
     events::recordings::RawRecording,
+    extractors::extract_body_with_timeout,
     payload::{decompress_payload, extract_and_record_metadata, extract_payload_bytes, EventQuery},
     router,
     v0_request::ProcessingContext,
@@ -47,8 +50,9 @@ pub async fn handle_recording_payload(
     headers: &HeaderMap,
     method: &Method,
     path: &MatchedPath,
-    body: Bytes,
+    body: Body,
 ) -> Result<(ProcessingContext, Vec<RawRecording>), CaptureError> {
+<<<<<<< Updated upstream
     let chatty_debug_enabled = headers.get("X-CAPTURE-DEBUG").is_some();
 
     if chatty_debug_enabled {
@@ -56,6 +60,13 @@ pub async fn handle_recording_payload(
     } else {
         debug!("entering handle_recording_payload");
     }
+=======
+    // Extract body with optional chunk timeout
+    let chunk_timeout = state.body_chunk_read_timeout_ms.map(Duration::from_millis);
+    let body =
+        extract_body_with_timeout(body, state.event_size_limit, chunk_timeout, path.as_str())
+            .await?;
+>>>>>>> Stashed changes
 
     // Extract request metadata using shared helper
     let metadata = extract_and_record_metadata(headers, path.as_str(), state.is_mirror_deploy);

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -67,6 +67,12 @@ pub async fn handle_recording_payload(
     )
     .await?;
 
+    if chatty_debug_enabled {
+        info!(headers=?headers, "CHATTY: streamed payload body");
+    } else {
+        debug!(headers=?headers, "streamed payload body");
+    }
+
     // Extract request metadata using shared helper
     let metadata = extract_and_record_metadata(headers, path.as_str(), state.is_mirror_deploy);
 

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -4,8 +4,6 @@
 //! Unlike analytics events, recording payloads are deserialized directly to
 //! Vec<RawRecording> to avoid the overhead of going through RawRequest.
 
-use std::time::Duration;
-
 use axum::body::Body;
 use axum::extract::{MatchedPath, State};
 use axum::http::{HeaderMap, Method};
@@ -52,7 +50,6 @@ pub async fn handle_recording_payload(
     path: &MatchedPath,
     body: Body,
 ) -> Result<(ProcessingContext, Vec<RawRecording>), CaptureError> {
-<<<<<<< Updated upstream
     let chatty_debug_enabled = headers.get("X-CAPTURE-DEBUG").is_some();
 
     if chatty_debug_enabled {
@@ -60,13 +57,15 @@ pub async fn handle_recording_payload(
     } else {
         debug!("entering handle_recording_payload");
     }
-=======
+
     // Extract body with optional chunk timeout
-    let chunk_timeout = state.body_chunk_read_timeout_ms.map(Duration::from_millis);
-    let body =
-        extract_body_with_timeout(body, state.event_size_limit, chunk_timeout, path.as_str())
-            .await?;
->>>>>>> Stashed changes
+    let body = extract_body_with_timeout(
+        body,
+        state.event_size_limit,
+        state.body_chunk_read_timeout,
+        path.as_str(),
+    )
+    .await?;
 
     // Extract request metadata using shared helper
     let metadata = extract_and_record_metadata(headers, path.as_str(), state.is_mirror_deploy);

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -42,6 +42,7 @@ pub struct State {
     pub verbose_sample_percent: f32,
     pub ai_max_sum_of_parts_bytes: usize,
     pub ai_blob_storage: Option<Arc<dyn BlobStorage>>,
+    pub body_chunk_read_timeout_ms: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -123,6 +124,7 @@ pub fn router<
     ai_max_sum_of_parts_bytes: usize,
     ai_blob_storage: Option<Arc<dyn BlobStorage>>,
     request_timeout_seconds: Option<u64>,
+    body_chunk_read_timeout_ms: Option<u64>,
 ) -> Router {
     let state = State {
         sink: Arc::new(sink),
@@ -139,6 +141,7 @@ pub fn router<
         verbose_sample_percent,
         ai_max_sum_of_parts_bytes,
         ai_blob_storage,
+        body_chunk_read_timeout_ms,
     };
 
     // Very permissive CORS policy, as old SDK versions
@@ -471,5 +474,41 @@ mod tests {
 
         // Clean up
         server_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_body_chunk_timeout_fires_on_stalled_upload() {
+        use crate::extractors::extract_body_with_timeout;
+        use axum::body::Body;
+        use bytes::Bytes;
+        use futures::{stream, StreamExt};
+
+        // Create a stream that yields one chunk then stalls
+        let chunks: Vec<Result<Bytes, std::io::Error>> = vec![Ok(Bytes::from("partial data"))];
+        let slow_stream = stream::iter(chunks).chain(stream::pending());
+        let body = Body::from_stream(slow_stream);
+
+        // Use a short chunk timeout
+        let timeout = Some(StdDuration::from_millis(100));
+        let result = extract_body_with_timeout(body, 1024 * 1024, timeout, "/test").await;
+
+        // Should get a BodyReadTimeout error
+        assert!(matches!(
+            result,
+            Err(crate::api::CaptureError::BodyReadTimeout)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_body_chunk_timeout_disabled_when_none() {
+        use crate::extractors::extract_body_with_timeout;
+        use axum::body::Body;
+
+        // Normal body with no timeout
+        let body = Body::from(r#"{"event": "test"}"#);
+        let result = extract_body_with_timeout(body, 1024 * 1024, None, "/test").await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), r#"{"event": "test"}"#.as_bytes());
     }
 }

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -342,6 +342,7 @@ where
         config.ai_max_sum_of_parts_bytes,
         ai_blob_storage,
         config.request_timeout_seconds,
+        config.body_chunk_read_timeout_ms,
     );
 
     info!("listening on {:?}", listener.local_addr().unwrap());

--- a/rust/capture/src/test_endpoint.rs
+++ b/rust/capture/src/test_endpoint.rs
@@ -1,6 +1,7 @@
-use std::{io::Read, ops::Deref};
+use std::{io::Read, ops::Deref, time::Duration};
 
 use axum::{
+    body::Body,
     debug_handler,
     extract::{MatchedPath, Query, State},
     http::{HeaderMap, Method},
@@ -14,6 +15,7 @@ use tracing::error;
 
 use crate::{
     api::{CaptureError, CaptureResponse, CaptureResponseCode},
+    extractors::extract_body_with_timeout,
     payload::{decompression::GZIP_MAGIC_NUMBERS, Compression, EventFormData, EventQuery},
     router,
     utils::extract_and_verify_token,
@@ -39,8 +41,18 @@ pub async fn test_black_hole(
     headers: HeaderMap,
     _method: Method,
     _path: MatchedPath,
-    body: Bytes,
+    body: Body,
 ) -> Result<Json<CaptureResponse>, CaptureError> {
+    // Extract body with optional chunk timeout
+    let chunk_timeout = state.body_chunk_read_timeout_ms.map(Duration::from_millis);
+    let body = extract_body_with_timeout(
+        body,
+        state.event_size_limit,
+        chunk_timeout,
+        "/test/black_hole",
+    )
+    .await?;
+
     metrics::counter!(REQUEST_SEEN).increment(1);
     let comp = match meta.compression {
         Some(Compression::Gzip) => String::from("gzip"),

--- a/rust/capture/src/test_endpoint.rs
+++ b/rust/capture/src/test_endpoint.rs
@@ -1,4 +1,4 @@
-use std::{io::Read, ops::Deref, time::Duration};
+use std::{io::Read, ops::Deref};
 
 use axum::{
     body::Body,
@@ -44,11 +44,10 @@ pub async fn test_black_hole(
     body: Body,
 ) -> Result<Json<CaptureResponse>, CaptureError> {
     // Extract body with optional chunk timeout
-    let chunk_timeout = state.body_chunk_read_timeout_ms.map(Duration::from_millis);
     let body = extract_body_with_timeout(
         body,
         state.event_size_limit,
-        chunk_timeout,
+        state.body_chunk_read_timeout,
         "/test/black_hole",
     )
     .await?;

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -1,8 +1,8 @@
+use axum::body::Body;
 use axum::extract::{MatchedPath, Query, State};
 use axum::http::{HeaderMap, Method};
 use axum::{debug_handler, Json};
 use axum_client_ip::InsecureClientIp;
-use bytes::Bytes;
 use tracing::{error, instrument, warn, Span};
 
 use crate::{
@@ -25,7 +25,7 @@ pub async fn event(
     headers: HeaderMap,
     method: Method,
     path: MatchedPath,
-    body: Bytes,
+    body: Body,
 ) -> Result<CaptureResponse, CaptureError> {
     let mut params: EventQuery = meta.0;
 
@@ -118,7 +118,7 @@ pub async fn recording(
     headers: HeaderMap,
     method: Method,
     path: MatchedPath,
-    body: Bytes,
+    body: Body,
 ) -> Result<CaptureResponse, CaptureError> {
     let mut params: EventQuery = meta.0;
 

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -996,6 +996,7 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
             26_214_400, // 25MB default for AI endpoint
             None,       // ai_blob_storage
             Some(10),   // request_timeout_seconds
+            None,       // body_chunk_read_timeout_ms
         ),
         sink,
     )

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -92,6 +92,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     ai_s3_secret_access_key: None,
     request_timeout_seconds: Some(10),
     http1_header_read_timeout_ms: Some(5000), // 5 seconds default
+    body_chunk_read_timeout_ms: None,         // disabled by default in tests
     continuous_profiling: ContinuousProfilingConfig {
         continuous_profiling_enabled: false,
         pyroscope_server_address: String::new(),

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -184,6 +184,7 @@ fn setup_ai_test_router() -> Router {
         26_214_400,                       // 25MB default for AI endpoint
         Some(create_mock_blob_storage()), // ai_blob_storage
         Some(10),                         // request_timeout_seconds
+        None,                             // body_chunk_read_timeout_ms
     )
 }
 
@@ -1635,6 +1636,7 @@ fn setup_ai_test_router_with_capturing_sink() -> (Router, CapturingSink) {
         26_214_400,                       // 25MB default for AI endpoint
         Some(create_mock_blob_storage()), // ai_blob_storage
         Some(10),                         // request_timeout_seconds
+        None,                             // body_chunk_read_timeout_ms
     );
 
     (router, sink_clone)
@@ -2537,7 +2539,8 @@ fn setup_ai_test_router_with_token_dropper(token_dropper: TokenDropper) -> (Rout
         0.0_f32,
         26_214_400,
         Some(create_mock_blob_storage()), // ai_blob_storage
-        Some(10),
+        Some(10),                         // request_timeout_seconds
+        None,                             // body_chunk_read_timeout_ms
     );
 
     (router, sink_clone)
@@ -2735,7 +2738,8 @@ fn setup_ai_test_router_with_llm_quota_limited(token: &str) -> (Router, Capturin
         0.0_f32,
         26_214_400,
         Some(create_mock_blob_storage()), // ai_blob_storage
-        Some(10),
+        Some(10),                         // request_timeout_seconds
+        None,                             // body_chunk_read_timeout_ms
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/limiters.rs
+++ b/rust/capture/tests/limiters.rs
@@ -142,6 +142,7 @@ async fn setup_router_with_limits(
         26_214_400,  // ai_max_sum_of_parts_bytes (25MB)
         None,        // ai_blob_storage
         Some(10),    // request_timeout_seconds
+        None,        // body_chunk_read_timeout_ms
     );
 
     (app, sink)
@@ -1182,6 +1183,7 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
         26_214_400,
         None,     // ai_blob_storage
         Some(10), // request_timeout_seconds
+        None,     // body_chunk_read_timeout_ms
     );
 
     let client = TestClient::new(app);
@@ -1260,6 +1262,7 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
         26_214_400,
         None,     // ai_blob_storage
         Some(10), // request_timeout_seconds
+        None,     // body_chunk_read_timeout_ms
     );
 
     let client = TestClient::new(app);
@@ -1342,6 +1345,7 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
         26_214_400,
         None,     // ai_blob_storage
         Some(10), // request_timeout_seconds
+        None,     // body_chunk_read_timeout_ms
     );
 
     let client = TestClient::new(app);
@@ -1761,6 +1765,7 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
         26_214_400,
         None,     // ai_blob_storage
         Some(10), // request_timeout_seconds
+        None,     // body_chunk_read_timeout_ms
     );
 
     let client = TestClient::new(app);


### PR DESCRIPTION
## Problem
Axum/Hyper HTTP server doesn't support a body read timeout out of the box, but `capture-rs` is seeing a small percentage of mostly mobile and Electron-app sourced requests that seem to stall (mostly due to app pause) early in the request handling pipeline.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement a timed body reader that streams the request body in chunks
* Time out body read stream if any chunk takes longer than a threshold
* Add configuration for body read timeout to the app, exposed as env var for tuning
* Related test suite updates

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, CI, mirror deployment
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
