### PR TITLE
fix(ci): Use GitHub app for auto-assign-reviewers action

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
     contents: read
-    pull-requests: write
 
 jobs:
     assign-reviewers:
@@ -24,10 +23,19 @@ jobs:
         if: github.event.pull_request.draft == false
 
         steps:
+            # GitHub app token is required because GITHUB_TOKEN can't assign team members as reviewers (requires org-level permission)
+            - name: Get app token
+              id: app-token
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
+              with:
+                  app_id: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_APP_ID }}
+                  private_key: ${{ secrets.GH_APP_POSTHOG_ASSIGN_REVIEWERS_PRIVATE_KEY }}
+
             - name: Checkout master branch
               uses: actions/checkout@v6
               with:
                   ref: master
+                  token: ${{ steps.app-token.outputs.token }}
 
             # We're always running against master branch, but the PR might not be against master
             # so we need to fetch both the head and base branches.
@@ -44,7 +52,7 @@ jobs:
             # Script runs from master branch (protected), but can diff against PR branch
             - name: Run reviewer assignment script
               env:
-                  GITHUB_TOKEN: ${{ github.token }}
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   GITHUB_REPOSITORY: ${{ github.repository }}
                   BASE_SHA: ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
Team assignment fails when using the `GITHUB_TOKEN`. The GITHUB_TOKEN lacks the organization-level "members" permission in order to see and assign team members.

Follow up to #43742.