### PR TITLE
fix(workflows): preserve variables between workflow test steps

### DIFF
--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -490,6 +490,7 @@ export class CdpApi {
                 status: result.error ? 'error' : 'success',
                 errors: result.error ? [result.error] : [],
                 logs: [...result.logs, ...logs],
+                variables: result.invocation.state.variables ?? {},
             })
         } catch (e) {
             console.error(e)

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.test.ts
@@ -1,0 +1,159 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { hogFlowEditorTestLogic } from './hogFlowEditorTestLogic'
+
+describe('hogFlowEditorTestLogic', () => {
+    let logic: ReturnType<typeof hogFlowEditorTestLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    describe('accumulatedVariables reducer', () => {
+        beforeEach(() => {
+            logic = hogFlowEditorTestLogic({ id: 'test-workflow' })
+            logic.mount()
+        })
+
+        it('starts with empty object', () => {
+            expect(logic.values.accumulatedVariables).toEqual({})
+        })
+
+        it('merges variables from test result', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setTestResult({
+                    status: 'success',
+                    nextActionId: 'next-step',
+                    variables: { has_chat_runs: 'true', count: 5 },
+                })
+            }).toMatchValues({
+                accumulatedVariables: { has_chat_runs: 'true', count: 5 },
+            })
+        })
+
+        it('accumulates variables across multiple test results', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setTestResult({
+                    status: 'success',
+                    nextActionId: 'step-2',
+                    variables: { var1: 'value1' },
+                })
+            }).toMatchValues({
+                accumulatedVariables: { var1: 'value1' },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.setTestResult({
+                    status: 'success',
+                    nextActionId: 'step-3',
+                    variables: { var2: 'value2' },
+                })
+            }).toMatchValues({
+                accumulatedVariables: { var1: 'value1', var2: 'value2' },
+            })
+        })
+
+        it('overwrites existing variables with new values', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setTestResult({
+                    status: 'success',
+                    nextActionId: 'step-2',
+                    variables: { counter: 1 },
+                })
+            }).toMatchValues({
+                accumulatedVariables: { counter: 1 },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.setTestResult({
+                    status: 'success',
+                    nextActionId: 'step-3',
+                    variables: { counter: 2 },
+                })
+            }).toMatchValues({
+                accumulatedVariables: { counter: 2 },
+            })
+        })
+
+        it('does not modify state when test result has no variables', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setTestResult({
+                    status: 'success',
+                    nextActionId: 'step-2',
+                    variables: { existing: 'value' },
+                })
+            }).toMatchValues({
+                accumulatedVariables: { existing: 'value' },
+            })
+
+            const stateBefore = logic.values.accumulatedVariables
+
+            await expectLogic(logic, () => {
+                logic.actions.setTestResult({
+                    status: 'success',
+                    nextActionId: 'step-3',
+                    // No variables in this result
+                })
+            })
+
+            // State reference should be the same (no unnecessary re-render)
+            expect(logic.values.accumulatedVariables).toBe(stateBefore)
+        })
+
+        it('resets on resetAccumulatedVariables action', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setTestResult({
+                    status: 'success',
+                    nextActionId: 'step-2',
+                    variables: { var1: 'value1' },
+                })
+            }).toMatchValues({
+                accumulatedVariables: { var1: 'value1' },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.resetAccumulatedVariables()
+            }).toMatchValues({
+                accumulatedVariables: {},
+            })
+        })
+
+        it('resets on loadSampleGlobals action', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setTestResult({
+                    status: 'success',
+                    nextActionId: 'step-2',
+                    variables: { var1: 'value1' },
+                })
+            }).toMatchValues({
+                accumulatedVariables: { var1: 'value1' },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadSampleGlobals({})
+            }).toMatchValues({
+                accumulatedVariables: {},
+            })
+        })
+
+        it('resets on loadSampleEventByName action', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setTestResult({
+                    status: 'success',
+                    nextActionId: 'step-2',
+                    variables: { var1: 'value1' },
+                })
+            }).toMatchValues({
+                accumulatedVariables: { var1: 'value1' },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadSampleEventByName({ eventName: '$pageview' })
+            }).toMatchValues({
+                accumulatedVariables: {},
+            })
+        })
+    })
+})

--- a/products/workflows/frontend/Workflows/hogflows/steps/types.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/types.ts
@@ -282,4 +282,5 @@ export interface HogflowTestResult {
     logs?: LogEntry[]
     nextActionId: string | null
     errors?: string[]
+    variables?: Record<string, any>
 }


### PR DESCRIPTION
## Problem

re: https://posthog.slack.com/archives/C06GG249PR6/p1766150742005159

Variable updates were not preserved across steps during tests, which made it hard/impossible to test a workflow that branches on the value of a variable changed by the workflow.

## Changes

- Backend: Return variables from invocation state in test API response
- Frontend: Track accumulated variables across step tests in new accumulatedVariables reducer
- Variables from previous steps now carry forward when testing subsequent steps
- Variables reset when loading fresh sample events (new test session)

## How did you test this code?

- Added unit tests for the accumulatedVariables reducer (8 tests covering accumulation, overwrites, and reset behavior)
- Manual testing: created workflow with set_variable → conditional_branch, verified variable persists when clicking "go to next step"

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
