### PR TITLE
chore(kafka-deduplicator): versioned checkpoint bucket prefix

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -159,7 +159,7 @@ pub struct Config {
 
     pub s3_bucket: Option<String>,
 
-    #[envconfig(default = "deduplication-checkpoints")]
+    #[envconfig(default = "v1")]
     pub s3_key_prefix: String,
 
     // how often to perform a full checkpoint vs. incremental

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -159,7 +159,7 @@ pub struct Config {
 
     pub s3_bucket: Option<String>,
 
-    #[envconfig(default = "v1")]
+    #[envconfig(default = "checkpoints_v1")]
     pub s3_key_prefix: String,
 
     // how often to perform a full checkpoint vs. incremental


### PR DESCRIPTION
## Problem
Shorten and version default checkpoint key prefix. **Merge this prior to the corresponding export enablement PR**
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* shorten S3 bucket prefix default to version tag
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally & CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
