### PR TITLE
chore: drop retries from APP queries

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -253,7 +253,7 @@ class EventViewSet(
                 next_url = self._build_next_url(request, query_result[limit - 1]["timestamp"], order_by)
             headers = None
             if settings.PATCH_EVENT_LIST_MAX_OFFSET > 0:
-                headers = {"X-PostHog-Warn": "https://posthog.com/docs/events_list-upcoming-changes"}
+                headers = {"X-PostHog-Warn": "https://posthog.com/docs/api/events"}
             elif deprecate_offset and offset:
                 headers = {
                     "X-PostHog-Warn": (

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -224,7 +224,7 @@ def get_api_team_rate_limiter():
             # The default timeout for an API query on ClickHouse is 10s. p99 duration is 19s,
             # 30 seconds should be enough for some other query to finish. If the query cannot get a slot in this period,
             # the user should contact us about increasing the quota.
-            retry_timeout=30.0,
+            retry_timeout=15.0,
         )
     return __API_CONCURRENT_QUERY_PER_TEAM
 

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -222,7 +222,7 @@ def get_api_team_rate_limiter():
             # the slot is free.
             retry=0.134,
             # The default timeout for an API query on ClickHouse is 10s. p99 duration is 19s,
-            # 30 seconds should be enough for some other query to finish. If the query cannot get a slot in this period,
+            # 15 seconds should be enough for some other query to finish. If the query cannot get a slot in this period,
             # the user should contact us about increasing the quota.
             retry_timeout=15.0,
         )

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -107,7 +107,7 @@ class QueryTags(BaseModel):
     query_type: Optional[str] = None
 
     rate_limit_bypass: Optional[int] = None
-    rate_limit_wait: Optional[int] = None
+    rate_limit_wait_ms: Optional[int] = None
 
     route_id: Optional[str] = None
     workload: Optional[str] = None  # enum connection.Workload

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -106,6 +106,9 @@ class QueryTags(BaseModel):
     query_time_range_days: Optional[int] = None
     query_type: Optional[str] = None
 
+    rate_limit_bypass: Optional[int] = None
+    rate_limit_wait: Optional[int] = None
+
     route_id: Optional[str] = None
     workload: Optional[str] = None  # enum connection.Workload
     dashboard_id: Optional[int] = None

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -205,6 +205,10 @@ class PersonalApiKeyRateThrottle(SimpleRateThrottle):
                     tags={"team_id": team_id, "route": route},
                 )
                 RATE_LIMIT_BYPASSED_COUNTER.labels(team_id=team_id, path=route, route=route).inc()
+
+                from posthog.clickhouse.query_tagging import tag_queries
+
+                tag_queries(rate_limit_bypass=1)
                 return True
             else:
                 scope = getattr(self, "scope", None)


### PR DESCRIPTION
It's Python and we don't handle request interruptions correctly. Therefore we may be executing way too many queries.

Additionally:
 - update URL for events deprecation header
 - API (personal access token) decrease timeout for waiting on concurrency to 15 seconds
 - track all queries that bypass rate limiting
 - track how long API queries had to wait in queue