### PR TITLE
chore(ci): remove exclusion rule

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -140,7 +140,6 @@ jobs:
                     --config "p/trailofbits" \
                     --config "p/github-actions" \
                     --exclude-rule dockerfile.security.no-sudo-in-dockerfile.no-sudo-in-dockerfile \
-                    --exclude-rule trailofbits.yaml.github-actions.aws-secret-key.aws-secret-key \
                     --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport \
                     --exclude-rule trailofbits.yaml.docker-compose.port-all-interfaces.port-all-interfaces \
                     --error \


### PR DESCRIPTION
We're now using OIDC for AWS.

