### PR TITLE
perf(flags): Skip DB loads for teams without flags during verification

### DIFF
--- a/posthog/storage/test/test_hypercache_manager.py
+++ b/posthog/storage/test/test_hypercache_manager.py
@@ -499,3 +499,74 @@ class TestPushHypercacheStatsMetrics(BaseTest):
 
         mock_logger.warning.assert_called_once()
         assert "Failed to push hypercache stats" in str(mock_logger.warning.call_args)
+
+
+class TestConfigValidation(BaseTest):
+    """Test HyperCacheManagementConfig validation."""
+
+    def test_both_optimization_fields_none_is_valid(self):
+        """Config with both optimization fields None is valid."""
+        # Should not raise
+        config = create_test_config()
+        assert config.get_team_ids_needing_full_verification_fn is None
+        assert config.empty_cache_value is None
+
+    def test_both_optimization_fields_set_is_valid(self):
+        """Config with both optimization fields set is valid."""
+        hypercache = create_test_hypercache()
+
+        def update_fn(team, ttl=None):
+            return True
+
+        def get_team_ids():
+            return {1, 2, 3}
+
+        # Should not raise
+        config = HyperCacheManagementConfig(
+            hypercache=hypercache,
+            update_fn=update_fn,
+            cache_name="test_cache",
+            get_team_ids_needing_full_verification_fn=get_team_ids,
+            empty_cache_value={"flags": []},
+        )
+        assert config.get_team_ids_needing_full_verification_fn is not None
+        assert config.empty_cache_value is not None
+
+    def test_only_team_ids_fn_set_raises_error(self):
+        """Config with only get_team_ids_needing_full_verification_fn raises ValueError."""
+        hypercache = create_test_hypercache()
+
+        def update_fn(team, ttl=None):
+            return True
+
+        def get_team_ids():
+            return {1, 2, 3}
+
+        with self.assertRaises(ValueError) as context:
+            HyperCacheManagementConfig(
+                hypercache=hypercache,
+                update_fn=update_fn,
+                cache_name="test_cache",
+                get_team_ids_needing_full_verification_fn=get_team_ids,
+                empty_cache_value=None,  # Missing!
+            )
+
+        assert "both get_team_ids_needing_full_verification_fn and empty_cache_value" in str(context.exception)
+
+    def test_only_empty_cache_value_set_raises_error(self):
+        """Config with only empty_cache_value raises ValueError."""
+        hypercache = create_test_hypercache()
+
+        def update_fn(team, ttl=None):
+            return True
+
+        with self.assertRaises(ValueError) as context:
+            HyperCacheManagementConfig(
+                hypercache=hypercache,
+                update_fn=update_fn,
+                cache_name="test_cache",
+                get_team_ids_needing_full_verification_fn=None,  # Missing!
+                empty_cache_value={"flags": []},
+            )
+
+        assert "both get_team_ids_needing_full_verification_fn and empty_cache_value" in str(context.exception)

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -26,7 +26,7 @@ logger = structlog.get_logger(__name__)
 CacheType = Literal["flags", "team_metadata"]
 
 # Lock timeout matches time_limit to ensure lock is released if task is killed
-LOCK_TIMEOUT_SECONDS = 4 * 60 * 60  # 4 hours
+LOCK_TIMEOUT_SECONDS = 60 * 60  # 1 hour
 
 
 def _run_cache_verification(cache_type: CacheType) -> None:
@@ -86,8 +86,8 @@ def _run_cache_verification(cache_type: CacheType) -> None:
 @shared_task(
     ignore_result=True,
     queue=CeleryQueue.DEFAULT.value,
-    soft_time_limit=3 * 60 * 60 + 30 * 60,  # 3h 30min soft limit
-    time_limit=4 * 60 * 60,  # 4 hour hard limit (distributed lock prevents overlap)
+    soft_time_limit=45 * 60,  # 45 min soft limit
+    time_limit=60 * 60,  # 1 hour hard limit
 )
 def verify_and_fix_flags_cache_task() -> None:
     """
@@ -105,8 +105,8 @@ def verify_and_fix_flags_cache_task() -> None:
 @shared_task(
     ignore_result=True,
     queue=CeleryQueue.DEFAULT.value,
-    soft_time_limit=3 * 60 * 60 + 30 * 60,  # 3h 30min soft limit
-    time_limit=4 * 60 * 60,  # 4 hour hard limit (distributed lock prevents overlap)
+    soft_time_limit=45 * 60,  # 45 min soft limit
+    time_limit=60 * 60,  # 1 hour hard limit
 )
 def verify_and_fix_team_metadata_cache_task() -> None:
     """

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -198,14 +198,14 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     # HyperCache verification - split into separate tasks for independent time budgets
-    # Tasks have 4-hour time limits to handle large deployments, so expiry must match
+    # Tasks have 1-hour time limits, so expiry must match
     # Team metadata cache verification - hourly at minute 20
     add_periodic_task_with_expiry(
         sender,
         crontab(hour="*", minute="20"),
         verify_and_fix_team_metadata_cache_task.s(),
         name="verify and fix team metadata cache",
-        expires_seconds=4 * 60 * 60,
+        expires_seconds=60 * 60,
     )
 
     # Flags cache verification - hourly at minute 40
@@ -214,7 +214,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="*", minute="40"),
         verify_and_fix_flags_cache_task.s(),
         name="verify and fix flags cache",
-        expires_seconds=4 * 60 * 60,
+        expires_seconds=60 * 60,
     )
 
     # Update events table partitions twice a week


### PR DESCRIPTION
## Problem

The flags cache verification task is not completing. My leading two theories are it is OOMing or running too long and getting killed by deployments. Meanwhile the team metadata verification task completes without issues.

I noticed we were loading flag data from the database for all ~238K teams when only ~20K actually have flags. For the ~90% of teams with zero flags, we were doing expensive DB queries and comparisons for no reason.

## Changes

1. **Skip DB loads for teams without flags** (`hypercache_verifier.py`, `flags_cache.py`, `hypercache_manager.py`)
   - Pre-compute which teams have flags (one query returning ~20K IDs)
   - Split each batch into teams needing full verification vs teams with no flags
   - Only load DB data for teams with flags (~10% of total)
   - Fast-path verify teams without flags by checking cache equals `{"flags": []}`

2. **Reduce timeout from 4 hours to 1 hour** (`hypercache_verification.py`, `scheduled.py`)
   - Hard limit: 1 hour (was 4 hours)
   - Soft limit: 45 minutes (was 3h 30min)
   - Lock timeout and task expiry updated to match
   
Reducing timeout seems counterintuitive, but if it times out, we get an exception we can handler (Soft limit) rather than a `SIGKILL` which doesn't run our `finally` block. Plus, we want this to run in minutes at most and better to focus on that.

3. **Add batch-level progress logging** (`hypercache_verifier.py`)
   - Log progress every 10 batches to observe task is working
   - Always log batches that have fixes for visibility

## How did you test this code?

- Ran existing test suites:
  - `pytest posthog/tasks/test/test_hypercache_verification.py` - all 8 tests pass
  - `pytest posthog/models/feature_flag/test/test_flags_cache.py` - all 68 tests pass
- Verified the management command works with verbose output showing diffs

## Changelog: (features only) Is this feature complete?

No - this is a backend performance fix, not a user-facing feature.
