### PR TITLE
fix(mm): add waiting to be started status to managed migrations

### DIFF
--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -294,6 +294,7 @@ class BatchImportResponseSerializer(serializers.ModelSerializer):
     end_date = serializers.SerializerMethodField()
     content_type = serializers.SerializerMethodField()
     status_message = serializers.CharField(source="display_status_message", allow_null=True)
+    display_status = serializers.SerializerMethodField()
 
     class Meta:
         model = BatchImport
@@ -302,6 +303,7 @@ class BatchImportResponseSerializer(serializers.ModelSerializer):
             "source_type",
             "content_type",
             "status",
+            "display_status",
             "start_date",
             "end_date",
             "created_by",
@@ -339,6 +341,11 @@ class BatchImportResponseSerializer(serializers.ModelSerializer):
             except User.DoesNotExist:
                 return None
         return None
+
+    def get_display_status(self, obj):
+        if obj.status == BatchImport.Status.RUNNING and obj.lease_id is None:
+            return "waiting_to_start"
+        return obj.status
 
 
 class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):

--- a/products/managed_migrations/frontend/ManagedMigration.tsx
+++ b/products/managed_migrations/frontend/ManagedMigration.tsx
@@ -28,14 +28,16 @@ const STATUS_COLORS = {
     running: 'primary',
     completed: 'success',
     paused: 'danger',
+    waiting_to_start: 'muted',
 } as const
 
+const STATUS_LABELS: Record<string, string> = {
+    waiting_to_start: 'Waiting to start',
+}
+
 function StatusTag({ status }: { status: string }): JSX.Element {
-    return (
-        <LemonTag type={STATUS_COLORS[status as keyof typeof STATUS_COLORS] || 'default'}>
-            {status.charAt(0).toUpperCase() + status.slice(1)}
-        </LemonTag>
-    )
+    const label = STATUS_LABELS[status] ?? status.charAt(0).toUpperCase() + status.slice(1)
+    return <LemonTag type={STATUS_COLORS[status as keyof typeof STATUS_COLORS] || 'default'}>{label}</LemonTag>
 }
 
 export function ManagedMigration(): JSX.Element {
@@ -338,9 +340,9 @@ export function ManagedMigrations(): JSX.Element {
                             },
                             {
                                 title: 'Status',
-                                dataIndex: 'status',
+                                dataIndex: 'display_status',
                                 render: (_: any, migration: ManagedMigration) => (
-                                    <StatusTag status={migration.status} />
+                                    <StatusTag status={migration.display_status} />
                                 ),
                             },
                             {
@@ -353,15 +355,17 @@ export function ManagedMigrations(): JSX.Element {
                                             <LemonProgress
                                                 percent={progress}
                                                 strokeColor={
-                                                    migration.status === 'paused' ? 'var(--danger)' : undefined
+                                                    migration.display_status === 'paused' ? 'var(--danger)' : undefined
                                                 }
                                             />
                                             <span className="text-xs text-muted">
-                                                {migration.status === 'completed'
+                                                {migration.display_status === 'completed'
                                                     ? 'Complete'
-                                                    : migration.status === 'paused'
+                                                    : migration.display_status === 'paused'
                                                       ? 'Paused'
-                                                      : `${completed}/${total}`}
+                                                      : migration.display_status === 'waiting_to_start'
+                                                        ? 'Waiting to start'
+                                                        : `${completed}/${total}`}
                                             </span>
                                         </div>
                                     )
@@ -404,7 +408,7 @@ export function ManagedMigrations(): JSX.Element {
                                 title: 'Actions',
                                 key: 'actions',
                                 render: (_: any, migration: ManagedMigration) => {
-                                    if (migration.status === 'running') {
+                                    if (migration.display_status === 'running') {
                                         return (
                                             <LemonButton
                                                 type="secondary"
@@ -415,7 +419,7 @@ export function ManagedMigrations(): JSX.Element {
                                                 Pause
                                             </LemonButton>
                                         )
-                                    } else if (migration.status === 'paused') {
+                                    } else if (migration.display_status === 'paused') {
                                         return (
                                             <LemonButton
                                                 type="primary"

--- a/products/managed_migrations/frontend/managedMigrationLogic.ts
+++ b/products/managed_migrations/frontend/managedMigrationLogic.ts
@@ -202,12 +202,13 @@ export const managedMigrationLogic = kea<managedMigrationLogicType>([
             }
         },
         loadMigrationsSuccess: () => {
-            const hasRunningMigrations = values.migrations.some(
-                (migration: ManagedMigration) => migration.status === 'running'
+            const hasActiveMigrations = values.migrations.some(
+                (migration: ManagedMigration) =>
+                    migration.display_status === 'running' || migration.display_status === 'waiting_to_start'
             )
-            if (hasRunningMigrations && !values.isPolling) {
+            if (hasActiveMigrations && !values.isPolling) {
                 actions.startPolling()
-            } else if (!hasRunningMigrations && values.isPolling) {
+            } else if (!hasActiveMigrations && values.isPolling) {
                 actions.stopPolling()
             }
         },

--- a/products/managed_migrations/frontend/types.ts
+++ b/products/managed_migrations/frontend/types.ts
@@ -1,9 +1,12 @@
+export type ManagedMigrationStatus = 'paused' | 'completed' | 'running' | 'failed' | 'waiting_to_start'
+
 export interface BaseManagedMigration {
     id: string
     access_key: string
     secret_key: string
     content_type: 'captured' | 'mixpanel' | 'amplitude'
-    status: 'paused' | 'completed' | 'running' | 'failed'
+    status: ManagedMigrationStatus
+    display_status: ManagedMigrationStatus
     created_by: {
         id: number
         uuid: string


### PR DESCRIPTION
## Problem

If all batch-import-workers are in use/busy then a migration job ends up getting queued. Previously, jobs in this state reported as being "Running". This was confusing as users wouldn't see progress being made on their migration.

## Changes

Uses the existence of lease_id on a job to indicate whether or not the job is actually running or if it is waiting to be picked up.

## How did you test this code?

Tested the code locally by initiating a migration job and checking status through different phases. Added some unit tests to the api.

