### PR TITLE
fix(web-analytics): missing arg for typechecker

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsFilterLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsFilterLogic.ts
@@ -17,7 +17,12 @@ export const webAnalyticsFilterLogic = kea<webAnalyticsFilterLogicType>([
     path(['scenes', 'webAnalytics', 'webAnalyticsFilterLogic']),
     connect(() => ({
         values: [
-            authorizedUrlListLogic({ type: AuthorizedUrlListType.WEB_ANALYTICS, actionId: null, experimentId: null }),
+            authorizedUrlListLogic({
+                type: AuthorizedUrlListType.WEB_ANALYTICS,
+                actionId: null,
+                experimentId: null,
+                productTourId: null,
+            }),
             ['authorizedUrls as authorizedDomains'],
         ],
     })),


### PR DESCRIPTION
## Problem

A required property `productTourId` got added to AuthorizedUrlListLogicProps but not all code that used that type had the field added to it.

## Changes

Adds the productTourId field to webAnalyticsFilterLogic file to get the type checker to pass

## How did you test this code?

CI/unit tests. 
