### PR TITLE
fix(mm): clears lease metadata when user resumes job through UI

### DIFF
--- a/posthog/api/batch_imports.py
+++ b/posthog/api/batch_imports.py
@@ -460,7 +460,21 @@ class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         batch_import.status = BatchImport.Status.RUNNING
         batch_import.status_message = "Resumed by user"
-        batch_import.save(update_fields=["status", "status_message", "updated_at"])
+        batch_import.lease_id = None
+        batch_import.leased_until = None
+        batch_import.backoff_attempt = 0
+        batch_import.backoff_until = None
+        batch_import.save(
+            update_fields=[
+                "status",
+                "status_message",
+                "lease_id",
+                "leased_until",
+                "backoff_attempt",
+                "backoff_until",
+                "updated_at",
+            ]
+        )
 
         return Response({"status": "resumed"})
 


### PR DESCRIPTION
## Problem

A resume/pause button got added to the managed migrations UI, but was only half-working. When we "Resume" a job, we need to clear the lease metadata so that it is possible for the job to get picked up again.

## Changes

Clears the lease metadata for a batch import job when a user resumes a job through the API

## How did you test this code?

Tested locally, unit tests were added.
