### PR TITLE
chore(product tours): add tabs to edit page

### DIFF
--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -15,6 +15,7 @@ import {
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { FeatureFlagReleaseConditions } from 'scenes/feature-flags/FeatureFlagReleaseConditions'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 import { SurveyMatchTypeLabels } from 'scenes/surveys/constants'
@@ -26,16 +27,24 @@ import { PropertyDefinitionType, SurveyMatchType } from '~/types'
 
 import { AutoShowSection } from './components/AutoShowSection'
 import { EditInToolbarButton } from './components/EditInToolbarButton'
-import { productTourLogic } from './productTourLogic'
+import { ProductTourEditTab, productTourLogic } from './productTourLogic'
 
 function InlineCode({ text }: { text: string }): JSX.Element {
     return <code className="border border-1 border-primary rounded-xs px-1 py-0.5 text-xs">{text}</code>
 }
 
 export function ProductTourEdit({ id }: { id: string }): JSX.Element {
-    const { productTour, productTourLoading, productTourForm, targetingFlagFilters, isProductTourFormSubmitting } =
-        useValues(productTourLogic({ id }))
-    const { editingProductTour, setProductTourFormValue, submitProductTourForm } = useActions(productTourLogic({ id }))
+    const {
+        productTour,
+        productTourLoading,
+        productTourForm,
+        targetingFlagFilters,
+        isProductTourFormSubmitting,
+        editTab,
+    } = useValues(productTourLogic({ id }))
+    const { editingProductTour, setProductTourFormValue, submitProductTourForm, setEditTab } = useActions(
+        productTourLogic({ id })
+    )
 
     // Load recent URLs from property definitions
     const { options } = useValues(propertyDefinitionsModel)
@@ -94,197 +103,205 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                     }
                 />
 
-                <div className="space-y-6 max-w-3xl">
-                    <LemonField name="name" label="Name">
-                        <LemonInput
-                            placeholder="Tour name"
-                            value={productTourForm.name}
-                            onChange={(value) => setProductTourFormValue('name', value)}
-                        />
-                    </LemonField>
+                <LemonTabs
+                    activeKey={editTab}
+                    onChange={(newTab) => setEditTab(newTab as ProductTourEditTab)}
+                    tabs={[{ key: ProductTourEditTab.Configuration, label: 'Configuration' }]}
+                />
 
-                    <LemonField name="description" label="Description">
-                        <LemonInput
-                            placeholder="Optional description"
-                            value={productTourForm.description}
-                            onChange={(value) => setProductTourFormValue('description', value)}
-                        />
-                    </LemonField>
-
-                    <LemonDivider />
-
-                    <div>
-                        <h3 className="font-semibold mb-4">
-                            Tour URLs&nbsp;
-                            <Tooltip title="Tour will only display on URLs matching these conditions.">
-                                <IconInfo />
-                            </Tooltip>
-                        </h3>
-                        <div className="flex gap-2">
-                            <LemonSelect
-                                value={conditions.urlMatchType || SurveyMatchType.Contains}
-                                onChange={(value) => {
-                                    setProductTourFormValue('content', {
-                                        ...productTourForm.content,
-                                        conditions: {
-                                            ...conditions,
-                                            urlMatchType: value,
-                                        },
-                                    })
-                                }}
-                                options={urlMatchTypeOptions}
+                {editTab === ProductTourEditTab.Configuration && (
+                    <div className="space-y-6 max-w-3xl">
+                        <LemonField name="name" label="Name">
+                            <LemonInput
+                                placeholder="Tour name"
+                                value={productTourForm.name}
+                                onChange={(value) => setProductTourFormValue('name', value)}
                             />
-                            <LemonInputSelect
-                                className="flex-1"
-                                mode="single"
-                                value={conditions.url ? [conditions.url] : []}
-                                onChange={(val) => {
-                                    setProductTourFormValue('content', {
-                                        ...productTourForm.content,
-                                        conditions: {
-                                            ...conditions,
-                                            url: val[0] || undefined,
-                                        },
-                                    })
-                                }}
-                                onInputChange={(newInput) => {
-                                    loadPropertyValues({
-                                        type: PropertyDefinitionType.Event,
-                                        endpoint: undefined,
-                                        propertyKey: '$current_url',
-                                        newInput: newInput.trim(),
-                                        eventNames: [],
-                                        properties: [],
-                                    })
-                                }}
-                                placeholder="e.g. /dashboard or https://example.com/app"
-                                allowCustomValues
-                                loading={urlOptions?.status === 'loading'}
-                                options={(urlOptions?.values || []).map(({ name }) => ({
-                                    key: String(name),
-                                    label: String(name),
-                                    value: String(name),
-                                }))}
-                                data-attr="product-tour-url-input"
+                        </LemonField>
+
+                        <LemonField name="description" label="Description">
+                            <LemonInput
+                                placeholder="Optional description"
+                                value={productTourForm.description}
+                                onChange={(value) => setProductTourFormValue('description', value)}
                             />
-                        </div>
-                        {conditions.urlMatchType === SurveyMatchType.Exact && (
-                            <div className="flex flex-col gap-2 mt-2 text-secondary text-sm">
-                                <p className="m-0">
-                                    When using <InlineCode text="= equals" />, trailing slashes will be removed before
-                                    URL comparison.
-                                </p>
-                                <p className="m-0">
-                                    Example: <InlineCode text="https://posthog.com/" /> will also match{' '}
-                                    <InlineCode text="https://posthog.com" />, and vice versa.
-                                </p>
-                            </div>
-                        )}
-                    </div>
+                        </LemonField>
 
-                    <LemonDivider />
+                        <LemonDivider />
 
-                    <div>
-                        <h3 className="font-semibold mb-2">Display conditions</h3>
-                        <p className="text-secondary text-sm mb-4">
-                            Configure how and when this tour is shown to users.
-                        </p>
-
-                        <div className="space-y-4">
-                            <div className="border rounded p-4 bg-surface-primary">
-                                <div className="flex items-center justify-between">
-                                    <div>
-                                        <h4 className="font-semibold">Auto-show this tour</h4>
-                                        <p className="text-secondary text-sm mb-0">
-                                            Automatically show this tour to users who match your conditions
-                                        </p>
-                                    </div>
-                                    <LemonSwitch
-                                        checked={productTourForm.auto_launch}
-                                        onChange={(checked) => setProductTourFormValue('auto_launch', checked)}
-                                    />
-                                </div>
-
-                                {productTourForm.auto_launch && (
-                                    <div className="mt-4 pt-4 border-t space-y-4">
-                                        <div>
-                                            <h5 className="font-semibold mb-3">
-                                                Who to show&nbsp;
-                                                <Tooltip title="Only auto-show the tour to users who match these conditions">
-                                                    <IconInfo />
-                                                </Tooltip>
-                                            </h5>
-                                            <BindLogic
-                                                logic={featureFlagLogic}
-                                                props={{
-                                                    id: productTour.internal_targeting_flag?.id
-                                                        ? String(productTour.internal_targeting_flag.id)
-                                                        : 'new',
-                                                }}
-                                            >
-                                                <FeatureFlagReleaseConditions
-                                                    id={
-                                                        productTour.internal_targeting_flag?.id
-                                                            ? String(productTour.internal_targeting_flag.id)
-                                                            : 'new'
-                                                    }
-                                                    excludeTitle={true}
-                                                    filters={
-                                                        targetingFlagFilters || {
-                                                            groups: [
-                                                                {
-                                                                    variant: '',
-                                                                    rollout_percentage: 100,
-                                                                    properties: [],
-                                                                },
-                                                            ],
-                                                        }
-                                                    }
-                                                    onChange={(filters) => {
-                                                        setProductTourFormValue('targeting_flag_filters', filters)
-                                                    }}
-                                                />
-                                            </BindLogic>
-                                        </div>
-
-                                        <LemonDivider />
-
-                                        <AutoShowSection
-                                            conditions={conditions}
-                                            onChange={(newConditions) => {
-                                                setProductTourFormValue('content', {
-                                                    ...productTourForm.content,
-                                                    conditions: newConditions,
-                                                })
-                                            }}
-                                        />
-                                    </div>
-                                )}
-                            </div>
-
-                            <div className="border rounded p-4 bg-surface-primary">
-                                <h4 className="font-semibold mb-2">Manual trigger</h4>
-                                <p className="text-secondary text-sm mb-4">
-                                    Show this tour when users click an element matching this CSS selector.
-                                </p>
-                                <LemonInput
-                                    className="font-mono"
-                                    value={conditions.selector || ''}
+                        <div>
+                            <h3 className="font-semibold mb-4">
+                                Tour URLs&nbsp;
+                                <Tooltip title="Tour will only display on URLs matching these conditions.">
+                                    <IconInfo />
+                                </Tooltip>
+                            </h3>
+                            <div className="flex gap-2">
+                                <LemonSelect
+                                    value={conditions.urlMatchType || SurveyMatchType.Contains}
                                     onChange={(value) => {
                                         setProductTourFormValue('content', {
                                             ...productTourForm.content,
                                             conditions: {
                                                 ...conditions,
-                                                selector: value,
+                                                urlMatchType: value,
                                             },
                                         })
                                     }}
-                                    placeholder="e.g. #help-button or .tour-trigger"
+                                    options={urlMatchTypeOptions}
                                 />
+                                <LemonInputSelect
+                                    className="flex-1"
+                                    mode="single"
+                                    value={conditions.url ? [conditions.url] : []}
+                                    onChange={(val) => {
+                                        setProductTourFormValue('content', {
+                                            ...productTourForm.content,
+                                            conditions: {
+                                                ...conditions,
+                                                url: val[0] || undefined,
+                                            },
+                                        })
+                                    }}
+                                    onInputChange={(newInput) => {
+                                        loadPropertyValues({
+                                            type: PropertyDefinitionType.Event,
+                                            endpoint: undefined,
+                                            propertyKey: '$current_url',
+                                            newInput: newInput.trim(),
+                                            eventNames: [],
+                                            properties: [],
+                                        })
+                                    }}
+                                    placeholder="e.g. /dashboard or https://example.com/app"
+                                    allowCustomValues
+                                    loading={urlOptions?.status === 'loading'}
+                                    options={(urlOptions?.values || []).map(({ name }) => ({
+                                        key: String(name),
+                                        label: String(name),
+                                        value: String(name),
+                                    }))}
+                                    data-attr="product-tour-url-input"
+                                />
+                            </div>
+                            {conditions.urlMatchType === SurveyMatchType.Exact && (
+                                <div className="flex flex-col gap-2 mt-2 text-secondary text-sm">
+                                    <p className="m-0">
+                                        When using <InlineCode text="= equals" />, trailing slashes will be removed
+                                        before URL comparison.
+                                    </p>
+                                    <p className="m-0">
+                                        Example: <InlineCode text="https://posthog.com/" /> will also match{' '}
+                                        <InlineCode text="https://posthog.com" />, and vice versa.
+                                    </p>
+                                </div>
+                            )}
+                        </div>
+
+                        <LemonDivider />
+
+                        <div>
+                            <h3 className="font-semibold mb-2">Display conditions</h3>
+                            <p className="text-secondary text-sm mb-4">
+                                Configure how and when this tour is shown to users.
+                            </p>
+
+                            <div className="space-y-4">
+                                <div className="border rounded p-4 bg-surface-primary">
+                                    <div className="flex items-center justify-between">
+                                        <div>
+                                            <h4 className="font-semibold">Auto-show this tour</h4>
+                                            <p className="text-secondary text-sm mb-0">
+                                                Automatically show this tour to users who match your conditions
+                                            </p>
+                                        </div>
+                                        <LemonSwitch
+                                            checked={productTourForm.auto_launch}
+                                            onChange={(checked) => setProductTourFormValue('auto_launch', checked)}
+                                        />
+                                    </div>
+
+                                    {productTourForm.auto_launch && (
+                                        <div className="mt-4 pt-4 border-t space-y-4">
+                                            <div>
+                                                <h5 className="font-semibold mb-3">
+                                                    Who to show&nbsp;
+                                                    <Tooltip title="Only auto-show the tour to users who match these conditions">
+                                                        <IconInfo />
+                                                    </Tooltip>
+                                                </h5>
+                                                <BindLogic
+                                                    logic={featureFlagLogic}
+                                                    props={{
+                                                        id: productTour.internal_targeting_flag?.id
+                                                            ? String(productTour.internal_targeting_flag.id)
+                                                            : 'new',
+                                                    }}
+                                                >
+                                                    <FeatureFlagReleaseConditions
+                                                        id={
+                                                            productTour.internal_targeting_flag?.id
+                                                                ? String(productTour.internal_targeting_flag.id)
+                                                                : 'new'
+                                                        }
+                                                        excludeTitle={true}
+                                                        filters={
+                                                            targetingFlagFilters || {
+                                                                groups: [
+                                                                    {
+                                                                        variant: '',
+                                                                        rollout_percentage: 100,
+                                                                        properties: [],
+                                                                    },
+                                                                ],
+                                                            }
+                                                        }
+                                                        onChange={(filters) => {
+                                                            setProductTourFormValue('targeting_flag_filters', filters)
+                                                        }}
+                                                    />
+                                                </BindLogic>
+                                            </div>
+
+                                            <LemonDivider />
+
+                                            <AutoShowSection
+                                                conditions={conditions}
+                                                onChange={(newConditions) => {
+                                                    setProductTourFormValue('content', {
+                                                        ...productTourForm.content,
+                                                        conditions: newConditions,
+                                                    })
+                                                }}
+                                            />
+                                        </div>
+                                    )}
+                                </div>
+
+                                <div className="border rounded p-4 bg-surface-primary">
+                                    <h4 className="font-semibold mb-2">Manual trigger</h4>
+                                    <p className="text-secondary text-sm mb-4">
+                                        Show this tour when users click an element matching this CSS selector.
+                                    </p>
+                                    <LemonInput
+                                        className="font-mono"
+                                        value={conditions.selector || ''}
+                                        onChange={(value) => {
+                                            setProductTourFormValue('content', {
+                                                ...productTourForm.content,
+                                                conditions: {
+                                                    ...conditions,
+                                                    selector: value,
+                                                },
+                                            })
+                                        }}
+                                        placeholder="e.g. #help-button or .tour-trigger"
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
+                )}
             </SceneContent>
         </Form>
     )

--- a/frontend/src/scenes/product-tours/productTourLogic.ts
+++ b/frontend/src/scenes/product-tours/productTourLogic.ts
@@ -85,6 +85,10 @@ export interface ProductTourLogicProps {
     id: string
 }
 
+export enum ProductTourEditTab {
+    Configuration = 'configuration',
+}
+
 export interface ProductTourStats {
     // Unique user counts (primary metrics)
     uniqueShown: number
@@ -129,6 +133,7 @@ export const productTourLogic = kea<productTourLogicType>([
     actions({
         editingProductTour: (editing: boolean) => ({ editing }),
         setDateRange: (dateRange: DateRange) => ({ dateRange }),
+        setEditTab: (tab: ProductTourEditTab) => ({ tab }),
         launchProductTour: true,
         stopProductTour: true,
         resumeProductTour: true,
@@ -297,6 +302,12 @@ export const productTourLogic = kea<productTourLogicType>([
                 editingProductTour: (_, { editing }) => editing,
             },
         ],
+        editTab: [
+            ProductTourEditTab.Configuration as ProductTourEditTab,
+            {
+                setEditTab: (_, { tab }) => tab,
+            },
+        ],
         dateRange: [
             { date_from: '-30d', date_to: null } as DateRange,
             {
@@ -412,9 +423,12 @@ export const productTourLogic = kea<productTourLogicType>([
             if (searchParams.edit) {
                 actions.editingProductTour(true)
             }
+            if (searchParams.tab) {
+                actions.setEditTab(searchParams.tab as ProductTourEditTab)
+            }
         },
     })),
-    actionToUrl(() => ({
+    actionToUrl(({ values }) => ({
         editingProductTour: ({ editing }) => {
             const searchParams = router.values.searchParams
             if (editing) {
@@ -423,6 +437,13 @@ export const productTourLogic = kea<productTourLogicType>([
                 delete searchParams['edit']
             }
             return [router.values.location.pathname, searchParams, router.values.hashParams]
+        },
+        setEditTab: () => {
+            return [
+                router.values.location.pathname,
+                { ...router.values.searchParams, tab: values.editTab },
+                router.values.hashParams,
+            ]
         },
     })),
     afterMount(({ actions, props }) => {


### PR DESCRIPTION
## Problem

adding tabs to product tour edit page - there's still only one tab in this PR, but doing it separately cuz big diff

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->