### PR TITLE
fix(experiments): don't reload experiment tabs on path change

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -45,7 +45,7 @@ export function Experiment({ tabId }: ExperimentSceneLogicProps): JSX.Element {
     return (
         <BindLogic logic={experimentLogic} props={logicProps}>
             {formMode && ([FORM_MODES.create, FORM_MODES.duplicate] as string[]).includes(formMode) ? (
-                <ExperimentForm />
+                <ExperimentForm tabId={tabId} />
             ) : (
                 <ExperimentView tabId={tabId} />
             )}

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.tsx
@@ -57,6 +57,12 @@ export const ExperimentForm = ({ draftExperiment, tabId }: ExperimentFormProps):
     } = useActions(logic)
 
     const [selectedPanel, setSelectedPanel] = useState<string | null>(null)
+    const handleCancel = (): void => {
+        if (!isEditMode) {
+            clearDraft()
+        }
+        router.actions.push(urls.experiments())
+    }
 
     return (
         <div>
@@ -84,12 +90,7 @@ export const ExperimentForm = ({ draftExperiment, tabId }: ExperimentFormProps):
                                 data-attr="cancel-experiment"
                                 type="secondary"
                                 size="small"
-                                onClick={() => {
-                                    if (!isEditMode) {
-                                        clearDraft()
-                                    }
-                                    router.actions.push(urls.experiments())
-                                }}
+                                onClick={handleCancel}
                             >
                                 Cancel
                             </LemonButton>
@@ -251,9 +252,7 @@ export const ExperimentForm = ({ draftExperiment, tabId }: ExperimentFormProps):
                         data-attr="cancel-experiment"
                         type="secondary"
                         size="small"
-                        onClick={() => {
-                            router.actions.push(urls.experiments())
-                        }}
+                        onClick={handleCancel}
                     >
                         Cancel
                     </LemonButton>

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.tsx
@@ -51,6 +51,7 @@ export const ExperimentForm = ({ draftExperiment, tabId }: ExperimentFormProps):
         setSharedMetrics,
         setExposureCriteria,
         setFeatureFlagConfig,
+        clearDraft,
         saveExperiment,
         validateField,
     } = useActions(logic)
@@ -84,6 +85,9 @@ export const ExperimentForm = ({ draftExperiment, tabId }: ExperimentFormProps):
                                 type="secondary"
                                 size="small"
                                 onClick={() => {
+                                    if (!isEditMode) {
+                                        clearDraft()
+                                    }
                                     router.actions.push(urls.experiments())
                                 }}
                             >

--- a/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/ExperimentForm.tsx
@@ -248,12 +248,7 @@ export const ExperimentForm = ({ draftExperiment, tabId }: ExperimentFormProps):
 
                 <SceneDivider />
                 <div className="flex justify-end gap-2">
-                    <LemonButton
-                        data-attr="cancel-experiment"
-                        type="secondary"
-                        size="small"
-                        onClick={handleCancel}
-                    >
+                    <LemonButton data-attr="cancel-experiment" type="secondary" size="small" onClick={handleCancel}>
                         Cancel
                     </LemonButton>
 

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -92,7 +92,7 @@ const filterExperimentForUpdate = (experiment: Experiment): Partial<Experiment> 
 
 const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000
 
-const draftStorageKey = (tabId?: string): string | null => (tabId ? `experiment-draft-${tabId}` : null)
+const draftStorageKey = (tabId: string): string => `experiment-draft-${tabId}`
 
 type ExperimentDraft = {
     experiment: Experiment
@@ -100,11 +100,10 @@ type ExperimentDraft = {
 }
 
 const readDraftFromStorage = (tabId?: string): Experiment | null => {
-    const key = draftStorageKey(tabId)
-    if (!key || typeof sessionStorage === 'undefined') {
+    if (!tabId || typeof sessionStorage === 'undefined') {
         return null
     }
-    const raw = sessionStorage.getItem(key)
+    const raw = sessionStorage.getItem(draftStorageKey(tabId))
     if (!raw) {
         return null
     }
@@ -113,7 +112,7 @@ const readDraftFromStorage = (tabId?: string): Experiment | null => {
         if (parsed && typeof parsed === 'object' && 'experiment' in parsed && 'timestamp' in parsed) {
             const { experiment, timestamp } = parsed as ExperimentDraft
             if (Date.now() - timestamp > DRAFT_TTL_MS) {
-                sessionStorage.removeItem(key)
+                sessionStorage.removeItem(draftStorageKey(tabId))
                 return null
             }
             return experiment
@@ -125,20 +124,18 @@ const readDraftFromStorage = (tabId?: string): Experiment | null => {
 }
 
 const writeDraftToStorage = (tabId: string | undefined, experiment: Experiment): void => {
-    const key = draftStorageKey(tabId)
-    if (!key || typeof sessionStorage === 'undefined') {
+    if (!tabId || typeof sessionStorage === 'undefined') {
         return
     }
     const draft: ExperimentDraft = { experiment, timestamp: Date.now() }
-    sessionStorage.setItem(key, JSON.stringify(draft))
+    sessionStorage.setItem(draftStorageKey(tabId), JSON.stringify(draft))
 }
 
 const clearDraftStorage = (tabId?: string): void => {
-    const key = draftStorageKey(tabId)
-    if (!key || typeof sessionStorage === 'undefined') {
+    if (!tabId || typeof sessionStorage === 'undefined') {
         return
     }
-    sessionStorage.removeItem(key)
+    sessionStorage.removeItem(draftStorageKey(tabId))
 }
 
 export interface CreateExperimentLogicProps {

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -90,8 +90,7 @@ const filterExperimentForUpdate = (experiment: Experiment): Partial<Experiment> 
     return filtered as Partial<Experiment>
 }
 
-const draftStorageKey = (tabId?: string): string | null =>
-    tabId ? `experiment-draft-${tabId}` : null
+const draftStorageKey = (tabId?: string): string | null => (tabId ? `experiment-draft-${tabId}` : null)
 
 const readDraftFromStorage = (tabId?: string): Experiment | null => {
     const key = draftStorageKey(tabId)

--- a/frontend/src/scenes/experiments/experimentSceneLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.test.ts
@@ -110,24 +110,17 @@ describe('experimentSceneLogic', () => {
         logic.unmount()
     })
 
-    it('delegates loading through the mounted experiment logic', async () => {
+    it('loads experiment data when scene state changes', async () => {
         const logic = experimentSceneLogic({ tabId, experimentId: 789 as any, formMode: FORM_MODES.update })
         logic.mount()
 
         mockModule.experimentLogic.__logic.actions.loadExperiment.mockClear()
-        mockModule.experimentLogic.__logic.actions.loadExposures.mockClear()
 
         await expectLogic(logic, () => {
-            logic.actions.loadExperimentData()
+            logic.actions.setSceneState(789 as any, FORM_MODES.update)
         })
 
         expect(mockModule.experimentLogic.__logic.actions.loadExperiment).toHaveBeenCalledTimes(1)
-
-        await expectLogic(logic, () => {
-            logic.actions.loadExposuresData(true)
-        })
-
-        expect(mockModule.experimentLogic.__logic.actions.loadExposures).toHaveBeenCalledWith(true)
 
         logic.unmount()
     })

--- a/frontend/src/scenes/experiments/experimentSceneLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.tsx
@@ -281,16 +281,6 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
                             name: query.name ?? '',
                         })
                     }
-                } else {
-                    // Only load if this is a different experiment or we have no cached logic yet
-                    const shouldLoad = currentLocation.initial || !matchesExistingLogic
-
-                    if (shouldLoad) {
-                        actions.loadExperimentData()
-                        if (values.isExperimentRunning) {
-                            actions.loadExposuresData()
-                        }
-                    }
                 }
             }
         },
@@ -321,14 +311,6 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
                 }
 
                 actions.setSceneState(parsedId, parsedFormMode)
-
-                // For form modes, always reload to ensure proper data transformation (duplicate/edit)
-                // unless we're just switching back to a tab that already has this exact experiment+formMode loaded
-                const shouldLoad = currentLocation.initial || !matchesExistingLogic
-
-                if (shouldLoad) {
-                    actions.loadExperimentData()
-                }
             }
         },
     })),

--- a/frontend/src/scenes/experiments/experimentSceneLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.tsx
@@ -42,8 +42,6 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
         }),
         setEditMode: (editing: boolean) => ({ editing }),
         resetExperimentState: (experimentConfig: Experiment) => ({ experimentConfig }),
-        loadExperimentData: true,
-        loadExposuresData: (forceRefresh: boolean = false) => ({ forceRefresh }),
     }),
     reducers({
         activeTabKey: [
@@ -199,7 +197,7 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
     listeners(({ actions, sharedListeners, values }) => ({
         setSceneState: (payload, breakpoint, action, previousState) => {
             sharedListeners.ensureExperimentLogicMounted(payload, breakpoint, action, previousState)
-            actions.loadExperimentData()
+            values.experimentLogicRef?.logic.actions.loadExperiment()
         },
         setEditMode: (payload, breakpoint, action, previousState) => {
             sharedListeners.ensureExperimentLogicMounted(payload, breakpoint, action, previousState)
@@ -210,14 +208,6 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
             if (payload.experimentConfig) {
                 values.experimentLogicRef?.logic.actions.resetExperiment(payload.experimentConfig)
             }
-        },
-        loadExperimentData: (payload, breakpoint, action, previousState) => {
-            sharedListeners.ensureExperimentLogicMounted(payload, breakpoint, action, previousState)
-            values.experimentLogicRef?.logic.actions.loadExperiment()
-        },
-        loadExposuresData: (payload, breakpoint, action, previousState) => {
-            sharedListeners.ensureExperimentLogicMounted(payload, breakpoint, action, previousState)
-            values.experimentLogicRef?.logic.actions.loadExposures(payload.forceRefresh)
         },
     })),
     tabAwareActionToUrl(({ values }) => {

--- a/frontend/src/scenes/experiments/experimentSceneLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.tsx
@@ -194,7 +194,7 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
             }
         },
     })),
-    listeners(({ actions, sharedListeners, values }) => ({
+    listeners(({ sharedListeners, values }) => ({
         setSceneState: (payload, breakpoint, action, previousState) => {
             sharedListeners.ensureExperimentLogicMounted(payload, breakpoint, action, previousState)
             values.experimentLogicRef?.logic.actions.loadExperiment()

--- a/frontend/src/scenes/experiments/experimentSceneLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.tsx
@@ -253,11 +253,12 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
                     existingProps?.experimentId === parsedId && existingProps?.formMode === formMode
                 const isSameSceneState = values.experimentId === parsedId && values.formMode === formMode
 
+                actions.setEditMode(false)
+
                 if (!currentLocation.initial && matchesExistingLogic && isSameSceneState) {
                     return
                 }
 
-                actions.setEditMode(false)
                 actions.setSceneState(parsedId, formMode)
 
                 if (parsedId === 'new') {
@@ -295,6 +296,8 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
                 const matchesExistingLogic =
                     existingProps?.experimentId === parsedId && existingProps?.formMode === parsedFormMode
                 const isSameSceneState = values.experimentId === parsedId && values.formMode === parsedFormMode
+
+                actions.setEditMode(false)
 
                 if (!currentLocation.initial && matchesExistingLogic && isSameSceneState) {
                     return

--- a/frontend/src/scenes/experiments/experimentSceneLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.tsx
@@ -255,15 +255,19 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
 
             const didPathChange = currentLocation.initial || currentLocation.pathname !== previousLocation?.pathname
 
-            actions.setEditMode(false)
-
             if (id && didPathChange) {
                 const parsedId = id === 'new' ? 'new' : parseInt(id)
                 const formMode = parsedId === 'new' ? FORM_MODES.create : FORM_MODES.update
                 const existingProps = values.experimentLogicRef?.props
                 const matchesExistingLogic =
                     existingProps?.experimentId === parsedId && existingProps?.formMode === formMode
+                const isSameSceneState = values.experimentId === parsedId && values.formMode === formMode
 
+                if (!currentLocation.initial && matchesExistingLogic && isSameSceneState) {
+                    return
+                }
+
+                actions.setEditMode(false)
                 actions.setSceneState(parsedId, formMode)
 
                 if (parsedId === 'new') {
@@ -310,6 +314,11 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
                 const existingProps = values.experimentLogicRef?.props
                 const matchesExistingLogic =
                     existingProps?.experimentId === parsedId && existingProps?.formMode === parsedFormMode
+                const isSameSceneState = values.experimentId === parsedId && values.formMode === parsedFormMode
+
+                if (!currentLocation.initial && matchesExistingLogic && isSameSceneState) {
+                    return
+                }
 
                 actions.setSceneState(parsedId, parsedFormMode)
 


### PR DESCRIPTION
## Problem

1. When switching tabs between an experiment and something else than an experiment tab (product analytics f.ex), we trigger a tab reload due to the path change logic. This isn't intentional and it's annoying.

2. When switching back and forth from an experiment create form, the form data is lost. That's annoying. 

## Changes

* Don't reload experiment tabs on path change
* Persist create experiment form data in session storage
* Remove redundant code and unused actions

https://github.com/user-attachments/assets/934f5d04-d1ed-4780-9ea6-428a0bf010be

## How did you test this code?

- Tests passes
- Tested locally
