### PR TITLE
fix: validate IP address format in get_ip_address()

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -625,6 +625,11 @@ class TestGetIpAddress(TestCase):
             # Valid IPv6
             ("::1", None, "::1"),
             ("2001:db8::1", None, "2001:db8::1"),
+            # Valid IPv6 with port (bracketed format)
+            (None, "[2001:db8::1]:8080", "2001:db8::1"),
+            (None, "[::1]:443", "::1"),
+            # IPv6 with brackets but no port
+            (None, "[2001:db8::1]", "2001:db8::1"),
             # Invalid/malformed - should return empty string
             (None, "not-an-ip", ""),
             (None, "192.168.1", ""),

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -28,6 +28,7 @@ from posthog.utils import (
     get_available_timezones_with_offsets,
     get_compare_period_dates,
     get_default_event_name,
+    get_ip_address,
     get_short_user_agent,
     load_data_from_request,
     refresh_requested_by_client,
@@ -607,3 +608,38 @@ class TestStrToIntSet(TestCase):
     )
     def test_str_to_int_set(self, value, expected):
         assert str_to_int_set(value) == expected
+
+
+class TestGetIpAddress(TestCase):
+    @parameterized.expand(
+        [
+            # Valid IPv4
+            ("192.168.1.1", None, "192.168.1.1"),
+            ("8.8.8.8", None, "8.8.8.8"),
+            # Valid IPv4 via X-Forwarded-For
+            (None, "192.168.1.1", "192.168.1.1"),
+            (None, "192.168.1.1, 10.0.0.1", "192.168.1.1"),
+            (None, " 192.168.1.1 , 10.0.0.1", "192.168.1.1"),
+            # Valid IPv4 with port (Azure gateway format)
+            (None, "192.168.1.1:8080", "192.168.1.1"),
+            # Valid IPv6
+            ("::1", None, "::1"),
+            ("2001:db8::1", None, "2001:db8::1"),
+            # Invalid/malformed - should return empty string
+            (None, "not-an-ip", ""),
+            (None, "192.168.1", ""),
+            (None, "malicious.payload.here", ""),
+            # Empty cases
+            (None, None, ""),
+            (None, "", ""),
+            ("", None, ""),
+        ]
+    )
+    def test_get_ip_address(self, remote_addr, x_forwarded_for, expected):
+        request = HttpRequest()
+        request.META = {}
+        if remote_addr is not None:
+            request.META["REMOTE_ADDR"] = remote_addr
+        if x_forwarded_for is not None:
+            request.META["HTTP_X_FORWARDED_FOR"] = x_forwarded_for
+        assert get_ip_address(request) == expected

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -709,7 +709,15 @@ def get_ip_address(request: HttpRequest) -> str:
         return ""
 
     # Strip port from ip address as Azure gateway handles x-forwarded-for incorrectly
-    if len(ip.split(":")) == 2:
+    # IPv6 with port: [2001:db8::1]:8080 -> 2001:db8::1
+    # IPv4 with port: 192.168.1.1:8080 -> 192.168.1.1
+    if ip.startswith("["):
+        # IPv6 with brackets, possibly with port
+        bracket_end = ip.find("]")
+        if bracket_end != -1:
+            ip = ip[1:bracket_end]
+    elif ip.count(":") == 1:
+        # IPv4 with port (single colon)
         ip = ip.split(":")[0]
 
     # Validate IP format to prevent malformed input from reaching downstream code

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -12,6 +12,7 @@ import hashlib
 import secrets
 import datetime
 import datetime as dt
+import ipaddress
 import dataclasses
 from collections.abc import Callable, Generator, Mapping, Sequence
 from contextlib import contextmanager, suppress
@@ -687,19 +688,35 @@ def friendly_time(seconds: float):
     ).strip()
 
 
+def _is_valid_ip_address(ip: str) -> bool:
+    """Validate that a string is a properly formatted IP address."""
+    try:
+        ipaddress.ip_address(ip)
+        return True
+    except ValueError:
+        return False
+
+
 def get_ip_address(request: HttpRequest) -> str:
     """use requestobject to fetch client machine's IP Address"""
     x_forwarded_for = request.headers.get("x-forwarded-for")
     if x_forwarded_for:
-        ip: str | None = x_forwarded_for.split(",")[0]
+        ip: str | None = x_forwarded_for.split(",")[0].strip()
     else:
         ip = request.META.get("REMOTE_ADDR")  # Real IP address of client Machine
 
+    if not ip:
+        return ""
+
     # Strip port from ip address as Azure gateway handles x-forwarded-for incorrectly
-    if ip and len(ip.split(":")) == 2:
+    if len(ip.split(":")) == 2:
         ip = ip.split(":")[0]
 
-    return ip or ""
+    # Validate IP format to prevent malformed input from reaching downstream code
+    if not _is_valid_ip_address(ip):
+        return ""
+
+    return ip
 
 
 def get_short_user_agent(request: HttpRequest) -> str:


### PR DESCRIPTION
**Problem**
The `get_ip_address()` function returns the raw extracted value without validating it's a properly formatted IP address.

**Changes**
- Add IP format validation using Python's `ipaddress` module
- Return empty string for malformed inputs
- Add parameterized tests covering valid IPv4/IPv6 and invalid inputs