### PR TITLE
feat(replay): migrate heatmaps to use unified button

### DIFF
--- a/frontend/src/scenes/heatmaps/components/HeatmapRecording.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapRecording.tsx
@@ -3,10 +3,9 @@ import { useRef } from 'react'
 
 import { LemonBanner, LemonDivider, LemonInput, LemonLabel } from '@posthog/lemon-ui'
 
-import { IconOpenInNew } from 'lib/lemon-ui/icons'
+import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { FixedReplayHeatmapBrowser } from 'scenes/heatmaps/components/FixedReplayHeatmapBrowser'
 import { HeatmapsWarnings } from 'scenes/heatmaps/components/HeatmapsWarnings'
-import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 
@@ -53,17 +52,11 @@ export function HeatmapRecording(): JSX.Element {
 
     if (!hasValidReplayIframeData) {
         return (
-            <LemonBanner
-                type="warning"
-                action={{
-                    type: 'secondary',
-                    icon: <IconOpenInNew />,
-                    to: urls.replay(),
-                    children: 'Open session recording',
-                }}
-                dismissKey="heatmaps-no-replay-iframe-data-warning"
-            >
-                This view is based on session recording data. Please open a session recording to view it.
+            <LemonBanner type="warning" dismissKey="heatmaps-no-replay-iframe-data-warning">
+                <div className="flex items-center justify-between gap-4">
+                    <p>This view is based on session recording data. Please open a session recording to view it.</p>
+                    <ViewRecordingsPlaylistButton filters={{}} type="secondary" size="small" />
+                </div>
             </LemonBanner>
         )
     }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

new button in banner instead of "action" param

![Screenshot 2025-12-22 at 10.33.43 AM.png](https://app.graphite.com/user-attachments/assets/9e57c2be-35d9-419c-8237-cccb946e69ba.png)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
