### PR TITLE
fix: validate IP addresses in AllowIPMiddleware

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -44,6 +44,7 @@ from posthog.rate_limit import DecideRateThrottle
 from posthog.rbac.user_access_control import UserAccessControl
 from posthog.settings import PROJECT_SWITCHING_TOKEN_ALLOWLIST, SITE_URL
 from posthog.user_permissions import UserPermissions
+from posthog.utils import _is_valid_ip_address
 
 from products.notebooks.backend.models import Notebook
 
@@ -91,7 +92,22 @@ class AllowIPMiddleware:
         else:
             return []
 
-    def extract_client_ip(self, request: HttpRequest):
+    def _normalize_ip(self, ip: str) -> str | None:
+        """Strip port from IP and validate format."""
+        # IPv6 with port: [2001:db8::1]:8080 -> 2001:db8::1
+        if ip.startswith("["):
+            bracket_end = ip.find("]")
+            if bracket_end != -1:
+                ip = ip[1:bracket_end]
+        # IPv4 with port: 192.168.1.1:8080 -> 192.168.1.1
+        elif ip.count(":") == 1:
+            ip = ip.split(":")[0]
+
+        if not _is_valid_ip_address(ip):
+            return None
+        return ip
+
+    def extract_client_ip(self, request: HttpRequest) -> str | None:
         client_ip = request.META["REMOTE_ADDR"]
         if getattr(settings, "USE_X_FORWARDED_HOST", False):
             forwarded_for = self.get_forwarded_for(request)
@@ -99,12 +115,13 @@ class AllowIPMiddleware:
                 closest_proxy = client_ip
                 client_ip = forwarded_for.pop(0)
                 if settings.TRUST_ALL_PROXIES:
-                    return client_ip
+                    return self._normalize_ip(client_ip)
                 proxies = [closest_proxy, *forwarded_for]
                 for proxy in proxies:
-                    if proxy not in self.trusted_proxies:
+                    normalized = self._normalize_ip(proxy)
+                    if normalized is None or normalized not in self.trusted_proxies:
                         return None
-        return client_ip
+        return self._normalize_ip(client_ip)
 
     def __call__(self, request: HttpRequest):
         response: HttpResponse = self.get_response(request)


### PR DESCRIPTION
**Follow-up to #43847**

The `AllowIPMiddleware` has its own XFF parsing (`extract_client_ip`) that bypassed the IP validation added in `get_ip_address()`. IPs with ports (e.g., `192.168.1.1:8080`) weren't being normalized before use.

**Changes:**
- Add `_normalize_ip()` helper to strip ports and validate IP format
- Apply normalization to all return paths in `extract_client_ip()`
- Fail closed for malformed IPs
- Add tests for port stripping and invalid input handling