### PR TITLE
chore(cdp): add logs for quota limiting

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
@@ -381,6 +381,33 @@ describe('CdpDatawarehouseEventsConsumer', () => {
                     }),
                 ])
             )
+
+            // Check that quota_limited log entries were produced
+            const logEntries = mockProducerObserver.getProducedKafkaMessagesForTopic('log_entries_test')
+            expect(logEntries).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        topic: 'log_entries_test',
+                        value: expect.objectContaining({
+                            log_source: 'hog_function',
+                            log_source_id: fnFetchNoFilters.id,
+                            level: 'error',
+                            message: 'Function invocation blocked due to quota limit',
+                            team_id: team2.id,
+                        }),
+                    }),
+                    expect.objectContaining({
+                        topic: 'log_entries_test',
+                        value: expect.objectContaining({
+                            log_source: 'hog_function',
+                            log_source_id: fnDataWarehouseFunction.id,
+                            level: 'error',
+                            message: 'Function invocation blocked due to quota limit',
+                            team_id: team2.id,
+                        }),
+                    }),
+                ])
+            )
         })
 
         it('should not filter out functions when team is not quota limited', async () => {

--- a/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -430,6 +430,33 @@ describe.each([
                         }),
                     ])
                 )
+
+                // Check that quota_limited log entries were produced
+                const logEntries = mockProducerObserver.getProducedKafkaMessagesForTopic('log_entries_test')
+                expect(logEntries).toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({
+                            topic: 'log_entries_test',
+                            value: expect.objectContaining({
+                                log_source: 'hog_function',
+                                log_source_id: fnFetchNoFilters.id,
+                                level: 'error',
+                                message: 'Function invocation blocked due to quota limit',
+                                team_id: team2.id,
+                            }),
+                        }),
+                        expect.objectContaining({
+                            topic: 'log_entries_test',
+                            value: expect.objectContaining({
+                                log_source: 'hog_function',
+                                log_source_id: fnPrinterPageviewFilters.id,
+                                level: 'error',
+                                message: 'Function invocation blocked due to quota limit',
+                                team_id: team2.id,
+                            }),
+                        }),
+                    ])
+                )
             })
 
             it('should not filter out functions when team is not quota limited', async () => {

--- a/plugin-server/src/cdp/consumers/quota-limiting-helper.ts
+++ b/plugin-server/src/cdp/consumers/quota-limiting-helper.ts
@@ -1,6 +1,8 @@
+import { DateTime } from 'luxon'
+
 import { QuotaResource } from '../../common/services/quota-limiting.service'
 import { HogFunctionMonitoringService } from '../services/monitoring/hog-function-monitoring.service'
-import { CyclotronJobInvocationHogFunction } from '../types'
+import { CyclotronJobInvocationHogFunction, LogEntry } from '../types'
 import { counterQuotaLimited } from './metrics'
 
 export interface QuotaLimitingContext {
@@ -35,6 +37,19 @@ export async function shouldBlockInvocationDueToQuota(
             },
             'hog_function'
         )
+
+        const logEntry: LogEntry = {
+            team_id: item.teamId,
+            log_source: 'hog_function',
+            log_source_id: item.functionId,
+            instance_id: item.id,
+            timestamp: DateTime.now(),
+            level: 'error',
+            message: 'Function invocation blocked due to quota limit',
+        }
+
+        context.hogFunctionMonitoringService.queueLogs([logEntry], 'hog_function')
+
         return true
     }
 


### PR DESCRIPTION
## Problem

After implementing quota limiting for CDP functions (#43564), quota-limited invocations were invisible in the UI. When functions hit their quota limit, they were silently blocked with only metrics being recorded - no log entries were created for users to see.

## Changes

Modified the quota limiting helper to create error-level log entries when blocking invocations. These logs now appear in the HogFunction logs viewer with the message "Function invocation blocked due to quota limit" and display as failures.

## How did you test this code?

- added tests
