### PR TITLE
fix: Make stage activity configurable with different retry interval

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -52,6 +52,7 @@ BatchExportInsertActivity = collections.abc.Callable[
 
 INITIAL_RETRY_INTERVAL_SECONDS = 1
 DEFAULT_MAX_RETRY_INTERVAL_SECONDS = 3600
+DEFAULT_MAX_STAGE_RETRY_INTERVAL_SECONDS = 600
 
 
 async def execute_batch_export_using_internal_stage(
@@ -62,6 +63,7 @@ async def execute_batch_export_using_internal_stage(
     maximum_attempts: int = 0,
     initial_retry_interval_seconds: int = INITIAL_RETRY_INTERVAL_SECONDS,
     maximum_retry_interval_seconds: int = DEFAULT_MAX_RETRY_INTERVAL_SECONDS,
+    maximum_stage_retry_interval_seconds: int = DEFAULT_MAX_STAGE_RETRY_INTERVAL_SECONDS,
     override_start_to_close_timeout_seconds: int | None = None,
     num_partitions: int | None = None,
     is_workflows: bool = False,
@@ -158,7 +160,7 @@ async def execute_batch_export_using_internal_stage(
             heartbeat_timeout=dt.timedelta(seconds=heartbeat_timeout_seconds) if heartbeat_timeout_seconds else None,
             retry_policy=RetryPolicy(
                 initial_interval=dt.timedelta(seconds=initial_retry_interval_seconds),
-                maximum_interval=dt.timedelta(seconds=maximum_retry_interval_seconds),
+                maximum_interval=dt.timedelta(seconds=maximum_stage_retry_interval_seconds),
                 maximum_attempts=maximum_attempts,
                 non_retryable_error_types=["InvalidFilterError"],
             ),


### PR DESCRIPTION
## Problem

Stage activity taking up to 1 hour to retry can mean slow recovery from internal incidents. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Since stage activity failures are rare, I am proposing we lower this to 10 minutes. It's still higher than the 2 minutes we had before, so it does provide more spacing in case there is an issue, but now things should recover faster than with 1 hour. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
