### PR TITLE
fix(dp): mcc accounts to work the same as client ones

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/posthog/temporal/data_imports/sources/google_ads/google_ads.py
@@ -70,7 +70,7 @@ def google_ads_client(config: GoogleAdsSourceConfigUnion, team_id: int) -> Googl
 
         login_customer_id: str | None = None
         if config.is_mcc_account and config.is_mcc_account.enabled:
-            login_customer_id = config.is_mcc_account.mcc_client_id
+            login_customer_id = clean_customer_id(config.is_mcc_account.mcc_client_id)
 
         client = GoogleAdsClient.load_from_dict(
             {

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -126,7 +126,7 @@ class GoogleAdsSource(SimpleSource[GoogleAdsSourceConfig | GoogleAdsServiceAccou
                                     label="Managers customer ID",
                                     type=SourceFieldInputConfigType.TEXT,
                                     required=True,
-                                    placeholder="",
+                                    placeholder="123-456-7890",
                                 )
                             ],
                         ),
@@ -144,6 +144,15 @@ class GoogleAdsSource(SimpleSource[GoogleAdsSourceConfig | GoogleAdsServiceAccou
                 "Please enter a valid Google Ads customer ID. This should be 10-digits and in XXX-XXX-XXXX format."
             )
             is_valid = False
+
+        is_mcc_account = job_inputs.get("is_mcc_account", {})
+        if is_mcc_account.get("enabled"):
+            mcc_client_id = is_mcc_account.get("mcc_client_id", "")
+            if mcc_client_id and not re.match(r"^\d{3}-\d{3}-\d{4}$", mcc_client_id):
+                errors.append(
+                    "Please enter a valid Google Ads manager customer ID. This should be 10-digits and in XXX-XXX-XXXX format."
+                )
+                is_valid = False
 
         return is_valid, errors
 


### PR DESCRIPTION
## Problem
We changed the customer id format but not the mcc one, which introduced confusion for the customers.

## Changes
Add same verification and clean up to mcc as the one we have for client id