### PR TITLE
fix: remove workflows_push

### DIFF
--- a/ee/hogai/tools/read_billing_tool/tool.py
+++ b/ee/hogai/tools/read_billing_tool/tool.py
@@ -35,7 +35,6 @@ USAGE_TYPES = [
     {"label": "PostHog AI", "value": "ai_credits_used_in_period"},
     {"label": "Workflow Emails", "value": "workflow_emails_sent_in_period"},
     {"label": "Workflow Destinations", "value": "workflow_billable_invocations_in_period"},
-    {"label": "Workflow Push", "value": "workflow_push_sent_in_period"},
 ]
 
 

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -19,13 +19,7 @@ export const isProductVariantPrimary = (productType: string): boolean =>
     ['session_replay', 'realtime_destinations', 'data_warehouse', 'workflows_emails'].includes(productType)
 
 export const isProductVariantSecondary = (productType: string): boolean =>
-    [
-        'mobile_replay',
-        'batch_exports',
-        'data_warehouse_historical',
-        'workflows_destinations',
-        'workflows_push',
-    ].includes(productType)
+    ['mobile_replay', 'batch_exports', 'data_warehouse_historical', 'workflows_destinations'].includes(productType)
 
 export const calculateFreeTier = (product: BillingProductV2Type | BillingProductV2AddonType): number => {
     // If subscribed and has tiers, check if the first tier is free

--- a/frontend/src/scenes/billing/constants.ts
+++ b/frontend/src/scenes/billing/constants.ts
@@ -17,7 +17,6 @@ export const USAGE_TYPES = [
     { label: 'PostHog AI', value: 'ai_credits_used_in_period' },
     { label: 'Workflow Emails', value: 'workflow_emails_sent_in_period' },
     { label: 'Workflow Destinations', value: 'workflow_billable_invocations_in_period' },
-    { label: 'Workflow Push', value: 'workflow_push_sent_in_period' },
 ] as const
 
 export type UsageTypeOption = (typeof USAGE_TYPES)[number]


### PR DESCRIPTION
## Problem

Some usage and limit calculation utils assume only 1 standalone priced add-on, which was causing `Too many usage keys` error.: https://us.posthog.com/project/2/error_tracking/019b458a-7bb5-7333-a780-83ad589949a6

## Changes

Removing workflows push product for now since it's not available to users anyway, until we figure out a solution for this.

## How did you test this code?

n/a