### PR TITLE
fix(workflows): Calculate next action after delay/time-window instead of before

### DIFF
--- a/plugin-server/src/cdp/services/hogflows/actions/delay.ts
+++ b/plugin-server/src/cdp/services/hogflows/actions/delay.ts
@@ -14,6 +14,9 @@ export class DelayHandler implements ActionHandler {
         // Check if we're resuming from a delay (queueScheduledAt was cleared when queue consumed the job)
         const isResuming = !invocation.queueScheduledAt && this.isResumingFromDelay(invocation, action)
 
+        // TODOdin: This delay action is run and logged with every batch consumed and thus creates VERY noisy logs for extended delays
+        // How do we avoid this on master? (is it the delay queue? Is it consuming but just not logging the delayed-function-invocation?)
+        // How does this look for wait_until_time_window?
         if (isResuming) {
             const nextAction = findContinueAction(invocation)
             result.logs.push({

--- a/plugin-server/src/cdp/services/hogflows/actions/delay.ts
+++ b/plugin-server/src/cdp/services/hogflows/actions/delay.ts
@@ -14,9 +14,6 @@ export class DelayHandler implements ActionHandler {
         // Check if we're resuming from a delay (queueScheduledAt was cleared when queue consumed the job)
         const isResuming = !invocation.queueScheduledAt && this.isResumingFromDelay(invocation, action)
 
-        // TODOdin: This delay action is run and logged with every batch consumed and thus creates VERY noisy logs for extended delays
-        // How do we avoid this on master? (is it the delay queue? Is it consuming but just not logging the delayed-function-invocation?)
-        // How does this look for wait_until_time_window?
         if (isResuming) {
             const nextAction = findContinueAction(invocation)
             result.logs.push({

--- a/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -1104,7 +1104,7 @@ describe('Hogflow Executor', () => {
                     {
                         finished: false,
                         scheduledAt: DateTime.fromISO('2025-01-01T02:00:00.000Z').toUTC(),
-                        nextActionId: 'exit',
+                        nextActionId: 'delay',
                     },
                 ],
                 [

--- a/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/plugin-server/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -167,6 +167,7 @@ export class HogFlowExecutorService {
 
             // Here we could be continuing the hog function side of things?
             result = await this.executeCurrentAction(nextInvocation)
+            console.log({ action: result.invocation.state.currentAction?.id, finished: result.finished })
 
             if (result.finished) {
                 if (result.error) {
@@ -340,6 +341,7 @@ export class HogFlowExecutorService {
             }
 
             try {
+                console.log('Executing handler', { action: currentAction.name })
                 const handlerResult = await handler.execute({
                     invocation,
                     action: currentAction,


### PR DESCRIPTION
## Problem
Fixes https://github.com/PostHog/posthog/issues/43086

Currently when moving through a delay step, an invocation will determine the next-step-after-the-delay, move to it, and THEN go on a pause. Instead, it should not evaluate the next step until the delay has expired.

## Changes

Delay and wait-until actions now wait for their delay to expire / their time-window to be reached 

When running locally, delays previously didn't actually run with delay; they just went back to kafka and the worker got triggered again immediately without waiting for the delay. With this change, the flow still bounces between kafka and the worker with every iteration, but since it hasn't moved on to the next action yet it just runs the delay node again, which is causing noisy logs locally.

Logs from delay node:
<img width="993" height="1120" alt="image" src="https://github.com/user-attachments/assets/449a3381-06e7-4e91-97ff-00ea4aa0c6bb" />

Logs from wait-until-time-window
<img width="832" height="516" alt="image" src="https://github.com/user-attachments/assets/c38e17bd-0fc9-43c4-bf2e-ba660d6ddddd" />



## How did you test this code?

Manually and with automated tests
