### PR TITLE
refactor: cache event restrictions correctly

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -317,7 +317,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         GROUP_BATCH_WRITING_OPTIMISTIC_UPDATE_RETRY_INTERVAL_MS: 50,
         GROUP_BATCH_WRITING_MAX_OPTIMISTIC_UPDATE_RETRIES: 5,
         PERSONS_PREFETCH_ENABLED: false,
-        USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG: false,
 
         // SES (Workflows email sending)
         SES_ENDPOINT: isTestEnv() || isDevEnv() ? 'http://localhost:4566' : '',

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -126,7 +126,7 @@ export class IngestionConsumer {
         this.tokenDistinctIdsToForceOverflow = hub.INGESTION_FORCE_OVERFLOW_BY_TOKEN_DISTINCT_ID.split(',').filter(
             (x) => !!x
         )
-        this.eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+        this.eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
             pipeline: 'analytics',
             staticDropEventTokens: this.tokenDistinctIdsToDrop,
             staticSkipPersonTokens: this.tokenDistinctIdsToSkipPersons,

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -115,7 +115,7 @@ export class SessionRecordingIngester {
 
         const teamService = new TeamService(postgres)
 
-        this.eventIngestionRestrictionManager = new EventIngestionRestrictionManager(this.hub, {
+        this.eventIngestionRestrictionManager = new EventIngestionRestrictionManager(this.hub.redisPool, {
             pipeline: 'session_recordings',
         })
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -465,7 +465,6 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig,
     CDP_HOG_WATCHER_SAMPLE_RATE: number
     // for enablement/sampling of expensive person JSONB sizes; value in [0,1]
     PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
-    USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG: boolean
 
     // SES (Workflows email sending)
     SES_ENDPOINT: string

--- a/plugin-server/src/utils/background-refresher.ts
+++ b/plugin-server/src/utils/background-refresher.ts
@@ -37,12 +37,22 @@ export class BackgroundRefresher<T> {
         if (!this.cachedValue) {
             await this.refresh()
         }
+        this.refreshIfStale()
+        return this.cachedValue!
+    }
 
-        if (Date.now() - this.lastRefreshTime > this.maxAgeMs) {
-            // We trigger the refresh but we don't use it
+    /**
+     * Returns the cached value, or undefined if not yet loaded.
+     * Triggers a background refresh if the cache is stale or empty.
+     */
+    public tryGet(): T | undefined {
+        this.refreshIfStale()
+        return this.cachedValue
+    }
+
+    private refreshIfStale(): void {
+        if (!this.cachedValue || Date.now() - this.lastRefreshTime > this.maxAgeMs) {
             void this.refresh().catch(this.errorHandler)
         }
-
-        return this.cachedValue!
     }
 }

--- a/plugin-server/src/utils/event-ingestion-restriction-manager.test.ts
+++ b/plugin-server/src/utils/event-ingestion-restriction-manager.test.ts
@@ -336,19 +336,21 @@ describe('EventIngestionRestrictionManager', () => {
             expect(eventIngestionRestrictionManager.getAppliedRestrictions()).toEqual(new Set())
         })
 
-        it('includes DROP_EVENT if token is in static drop list', () => {
+        it('includes DROP_EVENT if token is in static drop list', async () => {
             eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
                 staticDropEventTokens: ['static-drop-token'],
             })
+            await eventIngestionRestrictionManager.forceRefresh()
             expect(eventIngestionRestrictionManager.getAppliedRestrictions('static-drop-token')).toContain(
                 Restriction.DROP_EVENT
             )
         })
 
-        it('includes DROP_EVENT if token:distinctId is in static drop list', () => {
+        it('includes DROP_EVENT if token:distinctId is in static drop list', async () => {
             eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
                 staticDropEventTokens: ['static-drop-token:distinct_id:123'],
             })
+            await eventIngestionRestrictionManager.forceRefresh()
             expect(
                 eventIngestionRestrictionManager.getAppliedRestrictions('static-drop-token', { distinct_id: '123' })
             ).toContain(Restriction.DROP_EVENT)
@@ -401,19 +403,21 @@ describe('EventIngestionRestrictionManager', () => {
             expect(eventIngestionRestrictionManager.getAppliedRestrictions()).toEqual(new Set())
         })
 
-        it('includes SKIP_PERSON_PROCESSING if token is in static skip list', () => {
+        it('includes SKIP_PERSON_PROCESSING if token is in static skip list', async () => {
             eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
                 staticSkipPersonTokens: ['static-skip-token'],
             })
+            await eventIngestionRestrictionManager.forceRefresh()
             expect(eventIngestionRestrictionManager.getAppliedRestrictions('static-skip-token')).toContain(
                 Restriction.SKIP_PERSON_PROCESSING
             )
         })
 
-        it('includes SKIP_PERSON_PROCESSING if token:distinctId is in static skip list', () => {
+        it('includes SKIP_PERSON_PROCESSING if token:distinctId is in static skip list', async () => {
             eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
                 staticSkipPersonTokens: ['static-skip-token:distinct_id:123'],
             })
+            await eventIngestionRestrictionManager.forceRefresh()
             expect(
                 eventIngestionRestrictionManager.getAppliedRestrictions('static-skip-token', { distinct_id: '123' })
             ).toContain(Restriction.SKIP_PERSON_PROCESSING)
@@ -468,19 +472,21 @@ describe('EventIngestionRestrictionManager', () => {
             expect(eventIngestionRestrictionManager.getAppliedRestrictions()).toEqual(new Set())
         })
 
-        it('includes FORCE_OVERFLOW if token is in static overflow list', () => {
+        it('includes FORCE_OVERFLOW if token is in static overflow list', async () => {
             eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
                 staticForceOverflowTokens: ['static-overflow-token'],
             })
+            await eventIngestionRestrictionManager.forceRefresh()
             expect(eventIngestionRestrictionManager.getAppliedRestrictions('static-overflow-token')).toContain(
                 Restriction.FORCE_OVERFLOW
             )
         })
 
-        it('includes FORCE_OVERFLOW if token:distinctId is in static overflow list', () => {
+        it('includes FORCE_OVERFLOW if token:distinctId is in static overflow list', async () => {
             eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
                 staticForceOverflowTokens: ['static-overflow-token:distinct_id:123'],
             })
+            await eventIngestionRestrictionManager.forceRefresh()
             expect(
                 eventIngestionRestrictionManager.getAppliedRestrictions('static-overflow-token', { distinct_id: '123' })
             ).toContain(Restriction.FORCE_OVERFLOW)
@@ -535,19 +541,21 @@ describe('EventIngestionRestrictionManager', () => {
             expect(eventIngestionRestrictionManager.getAppliedRestrictions()).toEqual(new Set())
         })
 
-        it('includes REDIRECT_TO_DLQ if token is in static DLQ list', () => {
+        it('includes REDIRECT_TO_DLQ if token is in static DLQ list', async () => {
             eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
                 staticRedirectToDlqTokens: ['static-dlq-token'],
             })
+            await eventIngestionRestrictionManager.forceRefresh()
             expect(eventIngestionRestrictionManager.getAppliedRestrictions('static-dlq-token')).toContain(
                 Restriction.REDIRECT_TO_DLQ
             )
         })
 
-        it('includes REDIRECT_TO_DLQ if token:distinctId is in static DLQ list', () => {
+        it('includes REDIRECT_TO_DLQ if token:distinctId is in static DLQ list', async () => {
             eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
                 staticRedirectToDlqTokens: ['static-dlq-token:distinct_id:123'],
             })
+            await eventIngestionRestrictionManager.forceRefresh()
             expect(
                 eventIngestionRestrictionManager.getAppliedRestrictions('static-dlq-token', { distinct_id: '123' })
             ).toContain(Restriction.REDIRECT_TO_DLQ)
@@ -1193,13 +1201,14 @@ describe('EventIngestionRestrictionManager', () => {
     })
 
     describe('multiple restrictions for same entity', () => {
-        it('returns multiple restrictions when token matches multiple static lists', () => {
+        it('returns multiple restrictions when token matches multiple static lists', async () => {
             eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
                 staticDropEventTokens: ['multi-token'],
                 staticSkipPersonTokens: ['multi-token'],
                 staticForceOverflowTokens: ['multi-token'],
                 staticRedirectToDlqTokens: ['multi-token'],
             })
+            await eventIngestionRestrictionManager.forceRefresh()
             const restrictions = eventIngestionRestrictionManager.getAppliedRestrictions('multi-token')
             expect(restrictions).toContain(Restriction.DROP_EVENT)
             expect(restrictions).toContain(Restriction.SKIP_PERSON_PROCESSING)

--- a/plugin-server/src/utils/event-ingestion-restriction-manager.test.ts
+++ b/plugin-server/src/utils/event-ingestion-restriction-manager.test.ts
@@ -1,8 +1,8 @@
+import { Pool as GenericPool } from 'generic-pool'
 import { Redis } from 'ioredis'
 
 import {
     EventIngestionRestrictionManager,
-    EventIngestionRestrictionManagerHub,
     REDIS_KEY_PREFIX,
     RedisRestrictionType,
     Restriction,
@@ -72,7 +72,7 @@ function setupDynamicConfig(
 }
 
 describe('EventIngestionRestrictionManager', () => {
-    let hub: EventIngestionRestrictionManagerHub
+    let hub: { redisPool: GenericPool<Redis> }
     let redisClient: Redis
     let pipelineMock: any
     let eventIngestionRestrictionManager: EventIngestionRestrictionManager
@@ -93,11 +93,10 @@ describe('EventIngestionRestrictionManager', () => {
         redisClient.pipeline = jest.fn().mockReturnValue(pipelineMock)
 
         hub = {
-            USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG: true,
             redisPool: require('./db/redis').createRedisPool(),
         }
 
-        eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+        eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
             staticDropEventTokens: [],
             staticSkipPersonTokens: [],
             staticForceOverflowTokens: [],
@@ -111,12 +110,12 @@ describe('EventIngestionRestrictionManager', () => {
 
     describe('constructor', () => {
         it('initializes with default values if no options provided', () => {
-            const manager = new EventIngestionRestrictionManager(hub)
+            const manager = new EventIngestionRestrictionManager(hub.redisPool)
             expect(manager).toBeDefined()
         })
 
         it('initializes with provided options', () => {
-            const manager = new EventIngestionRestrictionManager(hub, {
+            const manager = new EventIngestionRestrictionManager(hub.redisPool, {
                 staticDropEventTokens: ['token1'],
                 staticSkipPersonTokens: ['token2'],
                 staticForceOverflowTokens: ['token3'],
@@ -126,28 +125,6 @@ describe('EventIngestionRestrictionManager', () => {
     })
 
     describe('dynamic config loading from Redis', () => {
-        beforeEach(() => {
-            hub.USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG = true
-        })
-
-        it('does not call Redis when dynamic config is disabled', async () => {
-            hub.USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG = false
-            const manager = new EventIngestionRestrictionManager(hub)
-
-            await manager.forceRefresh()
-
-            expect(hub.redisPool.acquire).not.toHaveBeenCalled()
-        })
-
-        it('never calls Redis through dynamicConfigRefresher when USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG is false', () => {
-            hub.USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG = false
-            const manager = new EventIngestionRestrictionManager(hub)
-
-            manager.getAppliedRestrictions('test-token')
-
-            expect(hub.redisPool.acquire).not.toHaveBeenCalled()
-        })
-
         it('fetches and parses Redis data correctly', async () => {
             pipelineMock.exec.mockResolvedValueOnce([
                 [
@@ -320,7 +297,7 @@ describe('EventIngestionRestrictionManager', () => {
                 [null, null],
             ])
 
-            const manager = new EventIngestionRestrictionManager(hub, {
+            const manager = new EventIngestionRestrictionManager(hub.redisPool, {
                 pipeline: 'session_recordings',
             })
             await manager.forceRefresh()
@@ -337,7 +314,7 @@ describe('EventIngestionRestrictionManager', () => {
         })
 
         it('includes DROP_EVENT if token is in static drop list', async () => {
-            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
                 staticDropEventTokens: ['static-drop-token'],
             })
             await eventIngestionRestrictionManager.forceRefresh()
@@ -347,18 +324,13 @@ describe('EventIngestionRestrictionManager', () => {
         })
 
         it('includes DROP_EVENT if token:distinctId is in static drop list', async () => {
-            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
                 staticDropEventTokens: ['static-drop-token:distinct_id:123'],
             })
             await eventIngestionRestrictionManager.forceRefresh()
             expect(
                 eventIngestionRestrictionManager.getAppliedRestrictions('static-drop-token', { distinct_id: '123' })
             ).toContain(Restriction.DROP_EVENT)
-        })
-
-        it('returns empty array if dynamic config is disabled', () => {
-            hub.USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG = false
-            expect(eventIngestionRestrictionManager.getAppliedRestrictions('token')).toEqual(new Set())
         })
 
         it('returns empty array if dynamic set is not defined', async () => {
@@ -404,7 +376,7 @@ describe('EventIngestionRestrictionManager', () => {
         })
 
         it('includes SKIP_PERSON_PROCESSING if token is in static skip list', async () => {
-            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
                 staticSkipPersonTokens: ['static-skip-token'],
             })
             await eventIngestionRestrictionManager.forceRefresh()
@@ -414,18 +386,13 @@ describe('EventIngestionRestrictionManager', () => {
         })
 
         it('includes SKIP_PERSON_PROCESSING if token:distinctId is in static skip list', async () => {
-            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
                 staticSkipPersonTokens: ['static-skip-token:distinct_id:123'],
             })
             await eventIngestionRestrictionManager.forceRefresh()
             expect(
                 eventIngestionRestrictionManager.getAppliedRestrictions('static-skip-token', { distinct_id: '123' })
             ).toContain(Restriction.SKIP_PERSON_PROCESSING)
-        })
-
-        it('returns empty array if dynamic config is disabled', () => {
-            hub.USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG = false
-            expect(eventIngestionRestrictionManager.getAppliedRestrictions('token')).toEqual(new Set())
         })
 
         it('returns empty array if dynamic set is not defined', async () => {
@@ -473,7 +440,7 @@ describe('EventIngestionRestrictionManager', () => {
         })
 
         it('includes FORCE_OVERFLOW if token is in static overflow list', async () => {
-            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
                 staticForceOverflowTokens: ['static-overflow-token'],
             })
             await eventIngestionRestrictionManager.forceRefresh()
@@ -483,18 +450,13 @@ describe('EventIngestionRestrictionManager', () => {
         })
 
         it('includes FORCE_OVERFLOW if token:distinctId is in static overflow list', async () => {
-            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
                 staticForceOverflowTokens: ['static-overflow-token:distinct_id:123'],
             })
             await eventIngestionRestrictionManager.forceRefresh()
             expect(
                 eventIngestionRestrictionManager.getAppliedRestrictions('static-overflow-token', { distinct_id: '123' })
             ).toContain(Restriction.FORCE_OVERFLOW)
-        })
-
-        it('returns empty array if dynamic config is disabled', () => {
-            hub.USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG = false
-            expect(eventIngestionRestrictionManager.getAppliedRestrictions('token')).toEqual(new Set())
         })
 
         it('returns empty array if dynamic set is not defined', async () => {
@@ -542,7 +504,7 @@ describe('EventIngestionRestrictionManager', () => {
         })
 
         it('includes REDIRECT_TO_DLQ if token is in static DLQ list', async () => {
-            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
                 staticRedirectToDlqTokens: ['static-dlq-token'],
             })
             await eventIngestionRestrictionManager.forceRefresh()
@@ -552,18 +514,13 @@ describe('EventIngestionRestrictionManager', () => {
         })
 
         it('includes REDIRECT_TO_DLQ if token:distinctId is in static DLQ list', async () => {
-            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
                 staticRedirectToDlqTokens: ['static-dlq-token:distinct_id:123'],
             })
             await eventIngestionRestrictionManager.forceRefresh()
             expect(
                 eventIngestionRestrictionManager.getAppliedRestrictions('static-dlq-token', { distinct_id: '123' })
             ).toContain(Restriction.REDIRECT_TO_DLQ)
-        })
-
-        it('returns empty array if dynamic config is disabled', () => {
-            hub.USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG = false
-            expect(eventIngestionRestrictionManager.getAppliedRestrictions('token')).toEqual(new Set())
         })
 
         it('returns empty array if dynamic set is not defined', async () => {
@@ -1202,7 +1159,7 @@ describe('EventIngestionRestrictionManager', () => {
 
     describe('multiple restrictions for same entity', () => {
         it('returns multiple restrictions when token matches multiple static lists', async () => {
-            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
                 staticDropEventTokens: ['multi-token'],
                 staticSkipPersonTokens: ['multi-token'],
                 staticForceOverflowTokens: ['multi-token'],
@@ -1263,7 +1220,7 @@ describe('EventIngestionRestrictionManager', () => {
         })
 
         it('combines static and dynamic restrictions', async () => {
-            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub, {
+            eventIngestionRestrictionManager = new EventIngestionRestrictionManager(hub.redisPool, {
                 staticDropEventTokens: ['combo-token'],
                 staticSkipPersonTokens: [],
                 staticForceOverflowTokens: [],


### PR DESCRIPTION
## Problem

We are generating constant Redis calls because the background refresher callback incorrectly returns void.

## Changes

- Refactors the callback to return the restrictions map
- Removes the flag for switching on dynamic restrictions, as it's not useful anymore

## How did you test this code?

- Updated relevant tests
- Existing regression tests
