### PR TITLE
fix(gateway): namespace redis keys for rate limits

### DIFF
--- a/services/llm-gateway/src/llm_gateway/rate_limiting/redis_limiter.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/redis_limiter.py
@@ -73,11 +73,11 @@ class RateLimiter:
             return True, None
 
         try:
-            burst_key = f"ratelimit:burst:{key}"
+            burst_key = f"llm_gateway:ratelimit:burst:{key}"
             if not await self._check_redis_limit(burst_key, self.burst_limit, self.burst_window):
                 return False, "burst"
 
-            sustained_key = f"ratelimit:sustained:{key}"
+            sustained_key = f"llm_gateway:ratelimit:sustained:{key}"
             if not await self._check_redis_limit(sustained_key, self.sustained_limit, self.sustained_window):
                 return False, "sustained"
 

--- a/services/llm-gateway/tests/test_rate_limiting.py
+++ b/services/llm-gateway/tests/test_rate_limiting.py
@@ -144,8 +144,8 @@ class TestRateLimiter:
 
         await limiter.check(user_id=123)
 
-        burst_ttl = await fake_redis.ttl("ratelimit:burst:123")
-        sustained_ttl = await fake_redis.ttl("ratelimit:sustained:123")
+        burst_ttl = await fake_redis.ttl("llm_gateway:ratelimit:burst:123")
+        sustained_ttl = await fake_redis.ttl("llm_gateway:ratelimit:sustained:123")
 
         assert 0 < burst_ttl <= 60
         assert 0 < sustained_ttl <= 3600


### PR DESCRIPTION
We are using a shared redis instance, so we should namespace our keys to avoid being a noisy neighbour.