### PR TITLE
fix: bump timeout for export to support long recordings

### DIFF
--- a/posthog/temporal/export_recording/workflows.py
+++ b/posthog/temporal/export_recording/workflows.py
@@ -65,8 +65,8 @@ class ExportRecordingWorkflow(PostHogWorkflow):
                 workflow.execute_activity(
                     export_recording_data,
                     export_context,
-                    start_to_close_timeout=timedelta(minutes=30),
-                    schedule_to_close_timeout=timedelta(hours=3),
+                    start_to_close_timeout=timedelta(hours=3),
+                    schedule_to_close_timeout=timedelta(hours=6),
                     retry_policy=common.RetryPolicy(
                         maximum_attempts=2,
                         initial_interval=timedelta(minutes=1),


### PR DESCRIPTION
Timeout is only 30 minutes which is not enough if there are may thousands of snapshots.