### PR TITLE
chore(clickhouse): move experiments dagster to offline

### DIFF
--- a/posthog/dags/common/common.py
+++ b/posthog/dags/common/common.py
@@ -25,16 +25,18 @@ class JobOwners(str, Enum):
 def dagster_tags(
     context: dagster.OpExecutionContext | dagster.AssetCheckExecutionContext | dagster.AssetExecutionContext,
 ) -> DagsterTags:
-    r = context.run
-    tags = DagsterTags(
-        job_name=r.job_name,
-        run_id=r.run_id,
-        tags=r.tags,
-        root_run_id=r.root_run_id,
-        parent_run_id=r.parent_run_id,
-        job_snapshot_id=r.job_snapshot_id,
-        execution_plan_snapshot_id=r.execution_plan_snapshot_id,
-    )
+    tags = DagsterTags()
+    with suppress(Exception):
+        r = context.run
+        tags = DagsterTags(
+            job_name=r.job_name,
+            run_id=r.run_id,
+            tags=r.tags,
+            root_run_id=r.root_run_id,
+            parent_run_id=r.parent_run_id,
+            job_snapshot_id=r.job_snapshot_id,
+            execution_plan_snapshot_id=r.execution_plan_snapshot_id,
+        )
 
     with suppress(Exception):
         if isinstance(context, dagster.AssetCheckExecutionContext):

--- a/products/experiments/dags/experiment_regular_metrics_timeseries.py
+++ b/products/experiments/dags/experiment_regular_metrics_timeseries.py
@@ -19,7 +19,8 @@ import dagster
 from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentQuery, ExperimentRatioMetric
 
 from posthog.clickhouse.client.connection import Workload
-from posthog.dags.common import JobOwners
+from posthog.clickhouse.query_tagging import tags_context
+from posthog.dags.common import JobOwners, dagster_tags
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
 from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
@@ -108,8 +109,11 @@ def experiment_regular_metrics_timeseries(context: dagster.AssetExecutionContext
             metric=metric_obj,
         )
 
-        query_runner = ExperimentQueryRunner(query=experiment_query, team=experiment.team, workload=Workload.OFFLINE)
-        result = query_runner._calculate()
+        with tags_context(dagster=dagster_tags(context)):
+            query_runner = ExperimentQueryRunner(
+                query=experiment_query, team=experiment.team, workload=Workload.OFFLINE
+            )
+            result = query_runner._calculate()
 
         result = remove_step_sessions_from_experiment_result(result)
 
@@ -282,6 +286,7 @@ experiment_regular_metrics_timeseries_job = dagster.define_asset_job(
     name="experiment_regular_metrics_timeseries_job",
     selection=[experiment_regular_metrics_timeseries],
     tags={"owner": JobOwners.TEAM_EXPERIMENTS.value},
+    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 2}),
 )
 
 

--- a/products/experiments/dags/experiment_regular_metrics_timeseries.py
+++ b/products/experiments/dags/experiment_regular_metrics_timeseries.py
@@ -18,6 +18,7 @@ import dagster
 
 from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentQuery, ExperimentRatioMetric
 
+from posthog.clickhouse.client.connection import Workload
 from posthog.dags.common import JobOwners
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
@@ -107,7 +108,7 @@ def experiment_regular_metrics_timeseries(context: dagster.AssetExecutionContext
             metric=metric_obj,
         )
 
-        query_runner = ExperimentQueryRunner(query=experiment_query, team=experiment.team)
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=experiment.team, workload=Workload.OFFLINE)
         result = query_runner._calculate()
 
         result = remove_step_sessions_from_experiment_result(result)
@@ -307,7 +308,7 @@ def experiment_regular_metrics_timeseries_discovery_sensor(context: dagster.Sens
 
 @dagster.schedule(
     job=experiment_regular_metrics_timeseries_job,
-    cron_schedule="5 * * * *",  # Every hour at minute 5 (staggered from saved metrics at minute 0)
+    cron_schedule="11 * * * *",  # Every hour at minute 11 (staggered from saved metrics at minute 0)
     execution_timezone="UTC",
     tags={"owner": JobOwners.TEAM_EXPERIMENTS.value},
 )

--- a/products/experiments/dags/experiment_regular_metrics_timeseries.py
+++ b/products/experiments/dags/experiment_regular_metrics_timeseries.py
@@ -286,7 +286,7 @@ experiment_regular_metrics_timeseries_job = dagster.define_asset_job(
     name="experiment_regular_metrics_timeseries_job",
     selection=[experiment_regular_metrics_timeseries],
     tags={"owner": JobOwners.TEAM_EXPERIMENTS.value},
-    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 2}),
+    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 4}),
 )
 
 

--- a/products/experiments/dags/experiment_saved_metrics_timeseries.py
+++ b/products/experiments/dags/experiment_saved_metrics_timeseries.py
@@ -291,7 +291,7 @@ experiment_saved_metrics_timeseries_job = dagster.define_asset_job(
     name="experiment_saved_metrics_timeseries_job",
     selection=[experiment_saved_metrics_timeseries],
     tags={"owner": JobOwners.TEAM_EXPERIMENTS.value},
-    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 2}),
+    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 4}),
 )
 
 

--- a/products/experiments/dags/experiment_saved_metrics_timeseries.py
+++ b/products/experiments/dags/experiment_saved_metrics_timeseries.py
@@ -16,6 +16,7 @@ import dagster
 
 from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentQuery, ExperimentRatioMetric
 
+from posthog.clickhouse.client.connection import Workload
 from posthog.dags.common import JobOwners
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
@@ -113,7 +114,9 @@ def experiment_saved_metrics_timeseries(context: dagster.AssetExecutionContext) 
             metric=metric_obj,
         )
 
-        query_runner = ExperimentQueryRunner(query=experiment_query, team=experiment.team, user_facing=False)
+        query_runner = ExperimentQueryRunner(
+            query=experiment_query, team=experiment.team, user_facing=False, workload=Workload.OFFLINE
+        )
         result = query_runner._calculate()
 
         result = remove_step_sessions_from_experiment_result(result)

--- a/products/experiments/dags/experiment_saved_metrics_timeseries.py
+++ b/products/experiments/dags/experiment_saved_metrics_timeseries.py
@@ -17,7 +17,8 @@ import dagster
 from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentQuery, ExperimentRatioMetric
 
 from posthog.clickhouse.client.connection import Workload
-from posthog.dags.common import JobOwners
+from posthog.clickhouse.query_tagging import tags_context
+from posthog.dags.common import JobOwners, dagster_tags
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
 from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
@@ -40,6 +41,7 @@ EXPERIMENT_SAVED_METRICS_PARTITIONS_NAME = "experiment_saved_metrics"
 experiment_saved_metrics_partitions_def = dagster.DynamicPartitionsDefinition(
     name=EXPERIMENT_SAVED_METRICS_PARTITIONS_NAME
 )
+
 
 # =============================================================================
 # Asset
@@ -114,10 +116,11 @@ def experiment_saved_metrics_timeseries(context: dagster.AssetExecutionContext) 
             metric=metric_obj,
         )
 
-        query_runner = ExperimentQueryRunner(
-            query=experiment_query, team=experiment.team, user_facing=False, workload=Workload.OFFLINE
-        )
-        result = query_runner._calculate()
+        with tags_context(dagster=dagster_tags(context)):
+            query_runner = ExperimentQueryRunner(
+                query=experiment_query, team=experiment.team, user_facing=False, workload=Workload.OFFLINE
+            )
+            result = query_runner._calculate()
 
         result = remove_step_sessions_from_experiment_result(result)
 
@@ -288,6 +291,7 @@ experiment_saved_metrics_timeseries_job = dagster.define_asset_job(
     name="experiment_saved_metrics_timeseries_job",
     selection=[experiment_saved_metrics_timeseries],
     tags={"owner": JobOwners.TEAM_EXPERIMENTS.value},
+    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 2}),
 )
 
 

--- a/products/experiments/dags/experiment_timeseries_recalculation.py
+++ b/products/experiments/dags/experiment_timeseries_recalculation.py
@@ -214,7 +214,7 @@ experiment_timeseries_recalculation_job = dagster.define_asset_job(
     name="experiment_timeseries_recalculation_job",
     selection=[experiment_timeseries_recalculation],
     tags={"owner": JobOwners.TEAM_EXPERIMENTS.value},
-    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 2}),
+    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 4}),
 )
 
 

--- a/products/experiments/dags/experiment_timeseries_recalculation.py
+++ b/products/experiments/dags/experiment_timeseries_recalculation.py
@@ -15,6 +15,7 @@ from dagster import AssetExecutionContext, RetryPolicy, RunRequest, SkipReason
 
 from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentQuery, ExperimentRatioMetric
 
+from posthog.clickhouse.client.connection import Workload
 from posthog.dags.common import JobOwners
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
 from posthog.models.experiment import ExperimentMetricResult, ExperimentTimeseriesRecalculation
@@ -134,7 +135,7 @@ def experiment_timeseries_recalculation(context: AssetExecutionContext) -> dict[
             query_to_utc = end_of_day_team_tz.astimezone(ZoneInfo("UTC"))
 
             query_runner = ExperimentQueryRunner(
-                query=experiment_query, team=experiment.team, override_end_date=query_to_utc
+                query=experiment_query, team=experiment.team, override_end_date=query_to_utc, workload=Workload.OFFLINE
             )
             result = query_runner._calculate()
             result = remove_step_sessions_from_experiment_result(result)

--- a/products/experiments/dags/experiment_timeseries_recalculation.py
+++ b/products/experiments/dags/experiment_timeseries_recalculation.py
@@ -16,7 +16,8 @@ from dagster import AssetExecutionContext, RetryPolicy, RunRequest, SkipReason
 from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentQuery, ExperimentRatioMetric
 
 from posthog.clickhouse.client.connection import Workload
-from posthog.dags.common import JobOwners
+from posthog.clickhouse.query_tagging import tags_context
+from posthog.dags.common import JobOwners, dagster_tags
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
 from posthog.models.experiment import ExperimentMetricResult, ExperimentTimeseriesRecalculation
 
@@ -134,10 +135,14 @@ def experiment_timeseries_recalculation(context: AssetExecutionContext) -> dict[
             )
             query_to_utc = end_of_day_team_tz.astimezone(ZoneInfo("UTC"))
 
-            query_runner = ExperimentQueryRunner(
-                query=experiment_query, team=experiment.team, override_end_date=query_to_utc, workload=Workload.OFFLINE
-            )
-            result = query_runner._calculate()
+            with tags_context(dagster=dagster_tags(context)):
+                query_runner = ExperimentQueryRunner(
+                    query=experiment_query,
+                    team=experiment.team,
+                    override_end_date=query_to_utc,
+                    workload=Workload.OFFLINE,
+                )
+                result = query_runner._calculate()
             result = remove_step_sessions_from_experiment_result(result)
 
             ExperimentMetricResult.objects.update_or_create(
@@ -209,6 +214,7 @@ experiment_timeseries_recalculation_job = dagster.define_asset_job(
     name="experiment_timeseries_recalculation_job",
     selection=[experiment_timeseries_recalculation],
     tags={"owner": JobOwners.TEAM_EXPERIMENTS.value},
+    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": 2}),
 )
 
 


### PR DESCRIPTION
## Problem

Experiments dagster queries:
 1. run on ONLINE replicas
 2. without limiting parallelism
 3. without proper query tagging

## Changes

 1. move them to offline replica
 2. run at most 4 concurrently
 3. add query tags
