### PR TITLE
fix(gateway): init with env vars

### DIFF
--- a/services/llm-gateway/src/llm_gateway/main.py
+++ b/services/llm-gateway/src/llm_gateway/main.py
@@ -8,7 +8,6 @@ from contextlib import asynccontextmanager
 from contextvars import ContextVar
 
 import asyncpg
-import litellm
 import structlog
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -108,9 +107,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     settings = get_settings()
 
     if settings.anthropic_api_key:
-        litellm.anthropic_key = settings.anthropic_api_key
+        os.environ["ANTHROPIC_API_KEY"] = settings.anthropic_api_key
     if settings.openai_api_key:
-        litellm.openai_key = settings.openai_api_key
+        os.environ["OPENAI_API_KEY"] = settings.openai_api_key
     if settings.gemini_api_key:
         os.environ["GEMINI_API_KEY"] = settings.gemini_api_key
 


### PR DESCRIPTION
The initialization is inconsistent depending on which method in litellm you use, lets just use env vars.