### PR TITLE
fix: Don't apply CH throttle to person delete endpoints

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -230,6 +230,13 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         PersonsBreakGlassSustainedThrottle,
     ]
     lifecycle_class = Lifecycle
+
+    def get_throttles(self):
+        # Delete operations don't touch ClickHouse, so exclude ClickHouse throttle
+        if self.action in ("destroy", "bulk_delete"):
+            return [throttle() for throttle in self.throttle_classes if throttle is not ClickHouseBurstRateThrottle]
+        return super().get_throttles()
+
     stickiness_class = Stickiness
 
     def safely_get_queryset(self, queryset):

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -234,8 +234,15 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def get_throttles(self):
         # Delete operations don't touch ClickHouse, so exclude ClickHouse throttle
         if self.action in ("destroy", "bulk_delete"):
-            return [throttle() for throttle in self.throttle_classes if throttle is not ClickHouseBurstRateThrottle]
-        return super().get_throttles()
+            return [
+                PersonsBreakGlassBurstThrottle(),
+                PersonsBreakGlassSustainedThrottle(),
+            ]
+        return [
+            ClickHouseBurstRateThrottle(),
+            PersonsBreakGlassBurstThrottle(),
+            PersonsBreakGlassSustainedThrottle(),
+        ]
 
     stickiness_class = Stickiness
 


### PR DESCRIPTION
## Problem

The `destroy` and `bulk_delete` person API endpoints are throttled by `ClickHouseBurstRateThrottle`, but these operations don't actually query ClickHouse, as they only write to PostgreSQL and Kafka.

## Changes

- Override `get_throttles()` to exclude `ClickHouseBurstRateThrottle` for delete operations, leaving only the persons-specific throttles

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
