### PR TITLE
feat(gateway): add base url support openai

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
 
     anthropic_api_key: str | None = None
     openai_api_key: str | None = None
+    openai_api_base_url: str | None = None  # Used for regional endpoints
     gemini_api_key: str | None = None
 
     # Used to send gateway errors to error tracking

--- a/services/llm-gateway/src/llm_gateway/main.py
+++ b/services/llm-gateway/src/llm_gateway/main.py
@@ -110,6 +110,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         os.environ["ANTHROPIC_API_KEY"] = settings.anthropic_api_key
     if settings.openai_api_key:
         os.environ["OPENAI_API_KEY"] = settings.openai_api_key
+    if settings.openai_api_base_url:
+        os.environ["OPENAI_BASE_URL"] = settings.openai_api_base_url
     if settings.gemini_api_key:
         os.environ["GEMINI_API_KEY"] = settings.gemini_api_key
 


### PR DESCRIPTION
Adds support for using a custom base url for openai, which we will use for regional support for the US / EU cloud regions.