### PR TITLE
fix: fixed async webhook handler processing default

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -9,7 +9,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
         case null:
             return {
                 ingestionV2Combined: true,
-                processAsyncWebhooksHandlers: true,
+                processAsyncWebhooksHandlers: false,
                 sessionRecordingBlobIngestionV2: true,
                 sessionRecordingBlobIngestionV2Overflow: config.SESSION_RECORDING_OVERFLOW_ENABLED,
                 appManagementSingleton: true,


### PR DESCRIPTION
## Problem

`plugin-server` keeps on dying locally. ([thread](https://posthog.slack.com/archives/C0113360FFV/p1766418471675869))

## Changes

* setting `false` on `processAsyncWebhooksHandlers` fixes it.
