### PR TITLE
fix: make sure replay temporal workers are redeployed when needed

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -265,7 +265,7 @@ jobs:
             - name: Check for changes that affect session replay temporal worker
               id: check_changes_session_replay_temporal_worker
               run: |
-                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/enforce_max_replay_retention|^posthog/temporal/delete_recordings|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/enforce_max_replay_retention|^posthog/temporal/delete_recordings|^posthog/temporal/export_recording|^posthog/temporal/import_recording|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
 
             - name: Check for changes that affect weekly digest temporal worker
               id: check_changes_weekly_digest_temporal_worker

--- a/posthog/temporal/export_recording/activities.py
+++ b/posthog/temporal/export_recording/activities.py
@@ -138,7 +138,7 @@ async def export_recording_data_prefix(input: ExportContext) -> None:
     recording_blocks = await database_sync_to_async(list_blocks)(recording)
 
     if not recording_blocks:
-        logger.warning("No recording blocks found, skipping prefix export")
+        logger.warning("No recording blocks found, skipping prefix export...")
         return
 
     first_block = recording_blocks[0]


### PR DESCRIPTION
Added import and export workflows to trigger script in CICD.