### PR TITLE
chore(ci): fetch diffed files from GitHub's API

### DIFF
--- a/.github/scripts/assign-reviewers.js
+++ b/.github/scripts/assign-reviewers.js
@@ -1,12 +1,10 @@
 #!/usr/bin/env node
 
 const fs = require('fs')
-const { execSync } = require('child_process')
 
 function parseCodeowners(codeownersPath) {
     if (!fs.existsSync(codeownersPath)) {
-        console.info('No CODEOWNERS file found')
-        return []
+        throw new Error(`No CODEOWNERS file found at "${codeownersPath}"`)
     }
 
     const content = fs.readFileSync(codeownersPath, 'utf8')
@@ -52,28 +50,26 @@ function fileMatchesPattern(filePath, pattern) {
     return regex.test(filePath)
 }
 
-function getChangedFiles() {
-    try {
-        const { BASE_SHA, HEAD_SHA } = process.env
-        
-        if (!BASE_SHA || !HEAD_SHA) {
-            console.error('BASE_SHA and HEAD_SHA environment variables are required')
-            return []
+async function getChangedFiles() {
+    const { BASE_SHA, HEAD_SHA, GITHUB_TOKEN, GITHUB_REPOSITORY } = process.env
+
+    const response = await fetch(
+        `https://api.github.com/repos/${GITHUB_REPOSITORY}/compare/${BASE_SHA}...${HEAD_SHA}`,
+        {
+            headers: {
+                Authorization: `token ${GITHUB_TOKEN}`,
+                Accept: 'application/vnd.github.v3+json',
+            },
         }
+    )
 
-        const output = execSync(`git diff --name-only ${BASE_SHA}...${HEAD_SHA}`, {
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'ignore'],
-        })
-
-        return output
-            .trim()
-            .split('\n')
-            .filter((file) => file.length > 0)
-    } catch (error) {
-        console.error('Failed to get changed files:', error.message)
-        return []
+    if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`GitHub API error: ${response.status} ${response.statusText}\n${errorText}`)
     }
+
+    const data = await response.json()
+    return (data.files || []).map((file) => file.filename)
 }
 
 function parseOwners(owners) {
@@ -96,10 +92,10 @@ function parseOwners(owners) {
     }
 }
 
-function getReviewersForChangedFiles() {
+async function getReviewersForChangedFiles() {
     const codeownersPath = '.github/CODEOWNERS-soft'
     const rules = parseCodeowners(codeownersPath)
-    const changedFiles = getChangedFiles()
+    const changedFiles = await getChangedFiles()
 
     console.info(`Found ${changedFiles.length} changed files:`)
     changedFiles.forEach((file) => console.info(`  ${file}`))
@@ -150,10 +146,6 @@ function getReviewersForChangedFiles() {
 async function assignReviewers(teams, users) {
     const { GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER } = process.env
 
-    if (!GITHUB_TOKEN || !GITHUB_REPOSITORY || !PR_NUMBER) {
-        throw new Error('Missing required environment variables: GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER')
-    }
-
     if (teams.length === 0 && users.length === 0) {
         console.info('ℹ️  No reviewers to assign')
         return
@@ -171,35 +163,41 @@ async function assignReviewers(teams, users) {
 
     console.info('Assigning reviewers with payload:', JSON.stringify(payload, null, 2))
 
-    try {
-        const response = await fetch(
-            `https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers`,
-            {
-                method: 'POST',
-                headers: {
-                    Authorization: `token ${GITHUB_TOKEN}`,
-                    Accept: 'application/vnd.github.v3+json',
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(payload),
-            }
-        )
-
-        if (!response.ok) {
-            const errorText = await response.text()
-            throw new Error(`GitHub API error: ${response.status} ${response.statusText}\n${errorText}`)
+    const response = await fetch(
+        `https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers`,
+        {
+            method: 'POST',
+            headers: {
+                Authorization: `token ${GITHUB_TOKEN}`,
+                Accept: 'application/vnd.github.v3+json',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload),
         }
+    )
 
-        console.info('✅ Reviewers assigned successfully')
-    } catch (error) {
-        console.error('Failed to assign reviewers:', error.message)
-        process.exit(1)
+    if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`GitHub API error: ${response.status} ${response.statusText}\n${errorText}`)
     }
+
+    console.info('✅ Reviewers assigned successfully')
 }
 
 async function main() {
+    const { BASE_SHA, HEAD_SHA, GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER } = process.env
+    const requiredEnvVars = { BASE_SHA, HEAD_SHA, GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER }
+    const missing = Object.entries(requiredEnvVars)
+        .filter(([, value]) => !value)
+        .map(([name]) => name)
+
+    if (missing.length > 0) {
+        console.error(`Missing required environment variables: ${missing.join(', ')}`)
+        process.exit(1)
+    }
+
     try {
-        const { teams, users } = getReviewersForChangedFiles()
+        const { teams, users } = await getReviewersForChangedFiles()
 
         console.info()
         console.info(`Teams to add: ${teams.join(', ') || 'none'}`)

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -34,20 +34,15 @@ jobs:
             - name: Checkout master branch
               uses: actions/checkout@v6
               with:
-                  ref: master
                   token: ${{ steps.app-token.outputs.token }}
-
-            # We're always running against master branch, but the PR might not be against master
-            # so we need to fetch both the head and base branches.
-            - name: Fetch head and base branches
-              run: |
-                  git fetch origin ${{ github.event.pull_request.head.sha }}
-                  git fetch origin ${{ github.event.pull_request.base.sha }}
+                  # this value MUST be set to `master` to avoid executing untrusted code.
+                  # we execute assign-reviewers.js below from whatever branch is checked out
+                  ref: master
 
             - name: Setup Node.js
               uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
               with:
-                  node-version: '20'
+                  node-version: '24'
 
             # Script runs from master branch (protected), but can diff against PR branch
             - name: Run reviewer assignment script


### PR DESCRIPTION
By using GitHub's API, we no longer need to check out the commits, reducing the chance for error.

This was motivated by CodeQL still [flagging this code](https://github.com/PostHog/posthog/security/code-scanning/40755) as containing a critical finding. Rather than dismiss the alert, we can use a safer pattern than involves us never checking out the untrusted code.