### PR TITLE
fix(surveys): UI flash on first survey helper

### DIFF
--- a/frontend/src/scenes/surveys/components/empty-state/FirstSurveyHelper.tsx
+++ b/frontend/src/scenes/surveys/components/empty-state/FirstSurveyHelper.tsx
@@ -15,9 +15,13 @@ interface FirstSurveyHelperProps {
 export function FirstSurveyHelper({ onTabChange }: FirstSurveyHelperProps): JSX.Element | null {
     const { survey } = useValues(surveyLogic)
     const { editingSurvey, setSelectedSection, setSurveyValue } = useActions(surveyLogic)
-    const { data } = useValues(surveysLogic)
+    const { data, dataLoading } = useValues(surveysLogic)
 
     const hasOnlyOneSurvey = data.surveys.length <= 1
+
+    if (dataLoading) {
+        return null
+    }
 
     // Only show for first-time users with unstarted surveys
     if (!hasOnlyOneSurvey || survey.start_date) {


### PR DESCRIPTION
## Problem

UI flashes here briefly before surveys data finishes loading

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->