### PR TITLE
feat: Add prompt to open surveys when there's no matching SDK

### DIFF
--- a/frontend/src/scenes/onboarding/error-tracking/source-maps/SourceMapsSDKInstructionsMap.tsx
+++ b/frontend/src/scenes/onboarding/error-tracking/source-maps/SourceMapsSDKInstructionsMap.tsx
@@ -1,4 +1,4 @@
-import { allSDKs } from 'scenes/onboarding/sdks/allSDKs'
+import { ALL_SDKS } from 'scenes/onboarding/sdks/allSDKs'
 
 import { SDKInstructionsMap, SDKKey } from '~/types'
 
@@ -10,6 +10,6 @@ export const SourceMapsSDKInstructions: SDKInstructionsMap = {
     [SDKKey.NUXT_JS]: NuxtSourceMapsInstructions,
 }
 
-export const automatedSourceMapsTechnologies = allSDKs.filter((sdk) =>
+export const automatedSourceMapsTechnologies = ALL_SDKS.filter((sdk) =>
     [SDKKey.NEXT_JS, SDKKey.NUXT_JS].includes(sdk.key as SDKKey)
 )

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep.tsx
@@ -175,6 +175,27 @@ export function OnboardingInstallStep({
                                 <strong>{sdk.name}</strong>
                             </LemonCard>
                         ))}
+
+                        {/* This will open a survey to collect feedback on the SDKs we don't support yet */}
+                        {/* https://us.posthog.com/project/2/surveys/019b47ab-5f19-0000-7f31-4f9681cde589 */}
+                        {searchTerm && (
+                            <LemonCard className="p-4 cursor-pointer flex flex-col items-start justify-center col-span-1 sm:col-span-2">
+                                <div className="flex flex-col items-start gap-2">
+                                    <span className="mb-2 text-muted">
+                                        Don&apos;t see your SDK listed? We are always looking to expand our list of
+                                        supported SDKs.
+                                    </span>
+                                    <LemonButton
+                                        data-attr="onboarding-reach-out-to-us-button"
+                                        type="secondary"
+                                        size="small"
+                                        targetBlank
+                                    >
+                                        Reach out to us
+                                    </LemonButton>
+                                </div>
+                            </LemonCard>
+                        )}
                     </div>
                 </div>
             </div>

--- a/frontend/src/scenes/onboarding/sdks/allSDKs.tsx
+++ b/frontend/src/scenes/onboarding/sdks/allSDKs.tsx
@@ -40,7 +40,7 @@ import vueImage from './logos/vue.svg'
 import webflowImage from './logos/webflow.svg'
 import wordpressImage from './logos/wordpress.svg'
 
-export const allSDKs: SDK[] = [
+export const ALL_SDKS: SDK[] = [
     // Web
     {
         name: 'Next.js',

--- a/frontend/src/scenes/onboarding/sdks/sdksLogic.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdksLogic.tsx
@@ -14,7 +14,7 @@ import { hogql } from '~/queries/utils'
 import { SDK, SDKInstructionsMap, SDKTag } from '~/types'
 
 import { onboardingLogic } from '../onboardingLogic'
-import { allSDKs } from './allSDKs'
+import { ALL_SDKS } from './allSDKs'
 import type { sdksLogicType } from './sdksLogicType'
 
 /*
@@ -27,14 +27,16 @@ To add SDK instructions for your product:
 */
 
 const getSourceOptions = (availableSDKInstructionsMap: SDKInstructionsMap): LemonSelectOptions<string> => {
-    const filteredSDKsTags = allSDKs
-        .filter((sdk) => Object.keys(availableSDKInstructionsMap).includes(sdk.key))
-        .flatMap((sdk) => sdk.tags)
+    const filteredSDKsTags = ALL_SDKS.filter((sdk) =>
+        Object.keys(availableSDKInstructionsMap).includes(sdk.key)
+    ).flatMap((sdk) => sdk.tags)
+
     const uniqueTags = filteredSDKsTags.filter((item, index) => filteredSDKsTags.indexOf(item) === index)
     const selectOptions = uniqueTags.map((tag) => ({
         label: tag,
         value: tag,
     }))
+
     return selectOptions
 }
 
@@ -234,14 +236,14 @@ export const sdksLogic = kea<sdksLogicType>([
     }),
     listeners(({ actions, values }) => ({
         filterSDKs: () => {
-            const filteredSDks: SDK[] = allSDKs
-                .filter((sdk) => {
-                    if (!values.sourceFilter || !sdk) {
-                        return true
-                    }
-                    return sdk.tags.includes(values.sourceFilter as SDKTag)
-                })
-                .filter((sdk) => Object.keys(values.availableSDKInstructionsMap).includes(sdk.key))
+            const availableSDKKeys = Object.keys(values.availableSDKInstructionsMap)
+            const filteredSDks: SDK[] = ALL_SDKS.filter((sdk) => {
+                if (!values.sourceFilter || !sdk) {
+                    return true
+                }
+                return sdk.tags.includes(values.sourceFilter as SDKTag)
+            }).filter((sdk) => availableSDKKeys.includes(sdk.key))
+
             actions.setSDKs(filteredSDks)
             actions.setSourceOptions(getSourceOptions(values.availableSDKInstructionsMap))
         },
@@ -292,7 +294,7 @@ export const sdksLogic = kea<sdksLogicType>([
     }),
     urlToAction(({ actions }) => ({
         '/onboarding/:productKey': (_productKey, { sdk }) => {
-            const matchedSDK = allSDKs.find((s) => s.key === sdk)
+            const matchedSDK = ALL_SDKS.find((s) => s.key === sdk)
             if (matchedSDK) {
                 actions.setSelectedSDK(matchedSDK)
             }


### PR DESCRIPTION
People sometimes searched for some type of SDK during onboarding and immediately dropped because we didn't support it.

Instead, let's add a new button to have people submitted a survey to us when that happens



![image.png](https://app.graphite.com/user-attachments/assets/d633c939-631b-452f-9438-b20327977cbd.png)

