### PR TITLE
feat(capture): Add body read timeout extractor to capture-ai endpoint

### DIFF
--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -1,8 +1,9 @@
-use axum::body::Bytes;
-use axum::extract::State;
+use axum::body::Body;
+use axum::extract::{MatchedPath, State};
 use axum::http::HeaderMap;
 use axum::response::Json;
 use axum_client_ip::InsecureClientIp;
+use bytes::Bytes;
 use common_types::{CapturedEvent, HasEventName};
 use flate2::read::GzDecoder;
 use futures::stream;
@@ -24,6 +25,7 @@ const AI_BLOB_TOTAL_BYTES_PER_EVENT: &str = "capture_ai_blob_total_bytes_per_eve
 const AI_BLOB_EVENTS_TOTAL: &str = "capture_ai_blob_events_total";
 
 use crate::api::{CaptureError, CaptureResponse, CaptureResponseCode};
+use crate::extractors::extract_body_with_timeout;
 use crate::prometheus::report_dropped_events;
 use crate::router::State as AppState;
 use crate::timestamp;
@@ -108,19 +110,28 @@ struct ParsedMultipartData {
 pub async fn ai_handler(
     State(state): State<AppState>,
     ip: Option<InsecureClientIp>,
+    path: MatchedPath,
     headers: HeaderMap,
-    body: Bytes,
+    body: Body,
 ) -> Result<Json<AIEndpointResponse>, CaptureError> {
     debug!("Received request to /i/v0/ai endpoint");
+
+    // Extract body with timed streaming (same pattern as analytics/recordings handlers)
+    // Use 110% of ai_max_sum_of_parts_bytes to account for multipart overhead (matches DefaultBodyLimit layer)
+    let body_limit = (state.ai_max_sum_of_parts_bytes as f64 * 1.1) as usize;
+    let body = extract_body_with_timeout(
+        body,
+        body_limit,
+        state.body_chunk_read_timeout,
+        path.as_str(),
+    )
+    .await?;
 
     // Check for empty body
     if body.is_empty() {
         warn!("AI endpoint received empty body");
         return Err(CaptureError::EmptyPayload);
     }
-
-    // Note: Request body size limit is enforced by Axum's DefaultBodyLimit layer
-    // (110% of ai_max_sum_of_parts_bytes to account for multipart overhead)
 
     // Check for Content-Encoding header and decompress if needed
     let content_encoding = headers


### PR DESCRIPTION
## Problem
We want `capture-ai` to be protected from stalled requests observed in production in `capture` and `capture-replay` endpoints.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement body read timeout extractor for `capture-ai` endpoint

_Note: because the timeout configuration env var is not present in prod deploys for `capure-ai` yet, this change will land as disabled (no-op) when merged._

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, CI, and already running (enabled and disabled) in other production capture endpoints. Safe no-op change at this stage.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
