### PR TITLE
fix(web-analytics): correct day index conversion active hours export

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsExportUtils.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsExportUtils.ts
@@ -61,6 +61,12 @@ export function exportTableData(tableData: string[][], format: ExporterFormat): 
     }
 }
 
+function convertClickHouseDayToStandard(clickHouseDay: number): number {
+    // ClickHouse toDayOfWeek: 1=Mon, 2=Tue, ..., 7=Sun
+    // Standard array indices: 0=Sun, 1=Mon, ..., 6=Sat
+    return clickHouseDay % 7
+}
+
 class CalendarHeatmapAdapter implements ExportAdapter {
     constructor(
         private response: TrendsQueryResponse,
@@ -87,14 +93,16 @@ class CalendarHeatmapAdapter implements ExportAdapter {
             .fill(0)
             .map(() => Array(numCols).fill(0))
         data.forEach((item: EventsHeatMapDataResult) => {
-            if (item.row < numRows && item.column < numCols) {
-                matrix[item.row][item.column] = item.value
+            const standardDay = convertClickHouseDayToStandard(item.row)
+            if (standardDay < numRows && item.column < numCols) {
+                matrix[standardDay][item.column] = item.value
             }
         })
 
         const rowAggMap: Record<number, number> = {}
         rowAggregations.forEach((item: EventsHeatMapRowAggregationResult) => {
-            rowAggMap[item.row] = item.value
+            const standardDay = convertClickHouseDayToStandard(item.row)
+            rowAggMap[standardDay] = item.value
         })
 
         const colAggArray: number[] = Array(numCols).fill(0)


### PR DESCRIPTION
## Problem

Context: https://posthoghelp.zendesk.com/agent/tickets/45448 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/47604)

We were having problems for some sunday exports not showing any data on the "Copy as CSV/Excel" due to the missing treatment. I am not 100% sure why we don't do that before returning the data, so I am just following the convention here for the quick fix and will check a better approach after.

## Changes

Standarize the 0-index/1-index-based clickhouse/js.

## How did you test this code?

Manually and then a simple unit test

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
