### PR TITLE
feat: Implement a success page for oauth native protocol

### DIFF
--- a/frontend/src/scenes/oauth/OAuthAuthorize.tsx
+++ b/frontend/src/scenes/oauth/OAuthAuthorize.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 
-import { IconCheck, IconWarning } from '@posthog/icons'
+import { IconCheck, IconCheckCircle, IconWarning } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Spinner } from 'lib/lemon-ui/Spinner'
@@ -20,6 +20,19 @@ export const OAuthAuthorizeError = ({ title, description }: { title: string; des
     )
 }
 
+export const OAuthAuthorizeSuccess = ({ appName }: { appName: string }): JSX.Element => {
+    return (
+        <div className="flex flex-col items-center justify-center h-full gap-4 py-12">
+            <IconCheckCircle className="text-success text-4xl" />
+            <div className="text-xl font-semibold">Authorization successful</div>
+            <div className="text-sm text-muted text-center">
+                <p>{appName} has been authorized.</p>
+                <p className="mt-2">You can close this window.</p>
+            </div>
+        </div>
+    )
+}
+
 export const OAuthAuthorize = (): JSX.Element => {
     const {
         scopeDescriptions,
@@ -32,6 +45,7 @@ export const OAuthAuthorize = (): JSX.Element => {
         isCanceling,
         redirectDomain,
         requiredAccessLevel,
+        authorizationComplete,
     } = useValues(oauthAuthorizeLogic)
     const { cancel, submitOauthAuthorization } = useActions(oauthAuthorizeLogic)
 
@@ -50,6 +64,10 @@ export const OAuthAuthorize = (): JSX.Element => {
                 description="The application requesting access to your data does not exist."
             />
         )
+    }
+
+    if (authorizationComplete) {
+        return <OAuthAuthorizeSuccess appName={oauthApplication.name} />
     }
 
     return (


### PR DESCRIPTION
## Problem

The auth page hangs around forever because there's no page redirect for native protocol oauth.

## Changes

Implement a success page for oauth when using native protocol so they are not stuck on the authorization grant page after opening the native app link.

## How did you test this code?

Manually, locally

<img width="1448" height="818" alt="Screenshot 2025-12-22 at 7 36 54 PM" src="https://github.com/user-attachments/assets/992264ea-51ff-4348-9695-dd53a5f0f728" />
