### PR TITLE
fix(cdp): make sure transformation properties propagate to successive…

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -174,7 +174,6 @@ export class HogTransformerService {
 
         for (const hogFunction of teamHogFunctions) {
             const transformationIdentifier = `${hogFunction.name} (${hogFunction.id})`
-
             // Check if function is in a degraded state, but only if hogwatcher is enabled
             if (shouldRunHogWatcher) {
                 const functionState = this.cachedStates[hogFunction.id]
@@ -195,6 +194,7 @@ export class HogTransformerService {
                 }
             }
 
+            // Recreate globals for each transformation to include changes from previous transformations
             const globals = this.createInvocationGlobals(event)
             const filterGlobals = convertToHogFunctionFilterGlobal(globals)
 

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -310,16 +310,21 @@ export class HogTransformerService {
         }
 
         // Use direct property assignment instead of spreading to avoid copying the entire object
-        if (transformationsFailed.length > 0) {
-            event.properties!.$transformations_failed = transformationsFailed
-        }
-
-        if (transformationsSkipped.length > 0) {
-            event.properties!.$transformations_skipped = transformationsSkipped
-        }
-
-        if (transformationsSucceeded.length > 0) {
-            event.properties!.$transformations_succeeded = transformationsSucceeded
+        if (
+            transformationsFailed.length > 0 ||
+            transformationsSkipped.length > 0 ||
+            transformationsSucceeded.length > 0
+        ) {
+            event.properties = event.properties || {}
+            if (transformationsFailed.length > 0) {
+                event.properties.$transformations_failed = transformationsFailed
+            }
+            if (transformationsSkipped.length > 0) {
+                event.properties.$transformations_skipped = transformationsSkipped
+            }
+            if (transformationsSucceeded.length > 0) {
+                event.properties.$transformations_succeeded = transformationsSucceeded
+            }
         }
 
         return {


### PR DESCRIPTION
## Problem

#43902 reverted all changes in #43565. 

This PR keeps all relevant changes from #43565 while adding a critical test `'should allow second transformation to read property added by first transformation'`

## Changes

- Re-add #43565 changes
- Ensure globals are updated between transformations

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
