### PR TITLE
fix: Apply separate throttle for person deletion endpoints

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -135,12 +135,12 @@ def get_person_name_helper(
 
 
 class PersonsDeleteBurstThrottle(PersonalApiKeyRateThrottle):
-    scope = "persons_burst"
+    scope = "persons_delete_burst"
     rate = "480/minute"
 
 
 class PersonsDeleteSustainedThrottle(PersonalApiKeyRateThrottle):
-    scope = "persons_sustained"
+    scope = "persons_delete_sustained"
     rate = "4800/hour"
 
 

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -32,6 +32,7 @@ from posthog.api.documentation import PersonPropertiesSerializer, extend_schema
 from posthog.api.insight import capture_legacy_api_call
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action, format_paginated_url, get_pk_or_uuid, get_target_entity
+from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.constants import INSIGHT_FUNNELS, LIMIT, OFFSET, FunnelVizType
 from posthog.decorators import cached_by_filters
 from posthog.logging.timing import timed
@@ -62,7 +63,7 @@ from posthog.queries.stickiness import Stickiness
 from posthog.queries.trends.lifecycle import Lifecycle
 from posthog.queries.trends.trends_actors import TrendsActors
 from posthog.queries.util import get_earliest_timestamp
-from posthog.rate_limit import ClickHouseBurstRateThrottle, PersonalApiKeyRateThrottle
+from posthog.rate_limit import ClickHouseBurstRateThrottle, PersonalApiKeyRateThrottle, UserOrEmailRateThrottle
 from posthog.renderers import SafeJSONRenderer
 from posthog.settings import EE_AVAILABLE
 from posthog.tasks.split_person import split_person
@@ -132,6 +133,16 @@ def get_person_name_helper(
         # Prefer non-UUID distinct IDs (presumably from user identification) over UUIDs
         return sorted(distinct_ids, key=is_anonymous_id)[0]
     return str(person_pk)
+
+
+class PersonsWebBurstThrottle(UserOrEmailRateThrottle):
+    scope = "persons_burst"
+    rate = "180/minute"
+
+
+class PersonsWebSustainedThrottle(UserOrEmailRateThrottle):
+    scope = "persons_sustained"
+    rate = "1200/hour"
 
 
 class PersonsDeleteBurstThrottle(PersonalApiKeyRateThrottle):
@@ -224,24 +235,21 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     queryset = Person.objects.all()
     serializer_class = PersonSerializer
     pagination_class = PersonLimitOffsetPagination
-    throttle_classes = [
-        ClickHouseBurstRateThrottle,
-        PersonsDeleteBurstThrottle,
-        PersonsDeleteSustainedThrottle,
-    ]
     lifecycle_class = Lifecycle
 
     def get_throttles(self):
-        # Delete operations don't touch ClickHouse, so exclude ClickHouse throttle
-        if self.action in ("destroy", "bulk_delete", "delete_events", "delete_recordings"):
-            return [
-                PersonsDeleteBurstThrottle(),
-                PersonsDeleteSustainedThrottle(),
-            ]
+        # API is commonly used for data deletion, so we want to throttle that less aggressively
+        if isinstance(self.request.successful_authenticator, PersonalAPIKeyAuthentication):
+            if self.action in ("destroy", "bulk_delete", "delete_events", "delete_recordings"):
+                return [PersonsDeleteBurstThrottle(), PersonsDeleteSustainedThrottle()]
+            else:
+                return [ClickHouseBurstRateThrottle()]
+
+        # We have seen issues in the past with the app hammering the API so for app authenticated requests
+        # we still want some throttle protection
         return [
-            ClickHouseBurstRateThrottle(),
-            PersonsDeleteBurstThrottle(),
-            PersonsDeleteSustainedThrottle(),
+            PersonsWebBurstThrottle(),
+            PersonsWebSustainedThrottle(),
         ]
 
     stickiness_class = Stickiness

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -136,12 +136,12 @@ def get_person_name_helper(
 
 class PersonsDeleteBurstThrottle(PersonalApiKeyRateThrottle):
     scope = "persons_burst"
-    rate = "180/minute"
+    rate = "480/minute"
 
 
 class PersonsDeleteSustainedThrottle(PersonalApiKeyRateThrottle):
     scope = "persons_sustained"
-    rate = "1200/hour"
+    rate = "4800/hour"
 
 
 class PersonSerializer(serializers.HyperlinkedModelSerializer):

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -1124,7 +1124,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         create_person(team_id=self.team.pk, version=0)
 
         returned_ids = []
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             response = self.client.get("/api/person/?limit=10").json()
         self.assertEqual(len(response["results"]), 9)
         returned_ids += [x["distinct_ids"][0] for x in response["results"]]

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -653,18 +653,6 @@ class SetupWizardQueryRateThrottle(SimpleRateThrottle):
         return f"throttle_wizard_query_{sha_hash}"
 
 
-class BreakGlassBurstThrottle(UserOrEmailRateThrottle):
-    # Throttle class that can be applied when a bug is causing too many requests to hit and an endpoint, e.g. a bug in the frontend hitting an endpoint in a loop.
-    # Prefer making a subclass of this for specific endpoints, and setting a scope
-    rate = "15/minute"
-
-
-class BreakGlassSustainedThrottle(UserOrEmailRateThrottle):
-    # Throttle class that can be applied when a bug is causing too many requests to hit and an endpoint, e.g. a bug in the frontend hitting an endpoint in a loop
-    # Prefer making a subclass of this for specific endpoints, and setting a scope
-    rate = "75/hour"
-
-
 class SymbolSetUploadBurstRateThrottle(PersonalApiKeyRateThrottle):
     scope = "symbol_set_upload_burst"
     rate = "1200/minute"


### PR DESCRIPTION
## Problem

We are not applying Personal API key throttling correctly for the person endpoints, this PR should solve it

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
