### PR TITLE
fix(cdp): meta ads template parsing

### DIFF
--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -35,13 +35,37 @@ if (not empty(inputs.eventSourceUrl)) {
 
 for (let key, value in inputs.userData) {
     if (not empty(value)) {
-        body.data.1.user_data[key] := value
+        // Handle array values passed as JSON strings
+        if (typeof(value) == 'string' and startsWith(value, '[')) {
+            // Try to parse as JSON array
+            try {
+                let parsed := jsonParse(value)
+                body.data.1.user_data[key] := parsed
+            } catch (e) {
+                // If parsing fails, keep as string
+                body.data.1.user_data[key] := value
+            }
+        } else {
+            body.data.1.user_data[key] := value
+        }
     }
 }
 
 for (let key, value in inputs.customData) {
     if (not empty(value)) {
-        body.data.1.custom_data[key] := value
+        // Handle array values passed as JSON strings
+        if (typeof(value) == 'string' and startsWith(value, '[')) {
+            // Try to parse as JSON array
+            try {
+                let parsed := jsonParse(value)
+                body.data.1.custom_data[key] := parsed
+            } catch (e) {
+                // If parsing fails, keep as string
+                body.data.1.custom_data[key] := value
+            }
+        } else {
+            body.data.1.custom_data[key] := value
+        }
     }
 }
 

--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -33,39 +33,27 @@ if (not empty(inputs.eventSourceUrl)) {
     body.data.1.event_source_url := inputs.eventSourceUrl
 }
 
+// Helper function to parse JSON arrays from string values
+fn parseValueIfArray(value) {
+    if (typeof(value) == 'string' and startsWith(value, '[')) {
+        try {
+            return jsonParse(value)
+        } catch {
+            return value
+        }
+    }
+    return value
+}
+
 for (let key, value in inputs.userData) {
     if (not empty(value)) {
-        // Handle array values passed as JSON strings
-        if (typeof(value) == 'string' and startsWith(value, '[')) {
-            // Try to parse as JSON array
-            try {
-                let parsed := jsonParse(value)
-                body.data.1.user_data[key] := parsed
-            } catch (e) {
-                // If parsing fails, keep as string
-                body.data.1.user_data[key] := value
-            }
-        } else {
-            body.data.1.user_data[key] := value
-        }
+        body.data.1.user_data[key] := parseValueIfArray(value)
     }
 }
 
 for (let key, value in inputs.customData) {
     if (not empty(value)) {
-        // Handle array values passed as JSON strings
-        if (typeof(value) == 'string' and startsWith(value, '[')) {
-            // Try to parse as JSON array
-            try {
-                let parsed := jsonParse(value)
-                body.data.1.custom_data[key] := parsed
-            } catch (e) {
-                // If parsing fails, keep as string
-                body.data.1.custom_data[key] := value
-            }
-        } else {
-            body.data.1.custom_data[key] := value
-        }
+        body.data.1.custom_data[key] := parseValueIfArray(value)
     }
 }
 

--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -35,9 +35,9 @@ if (not empty(inputs.eventSourceUrl)) {
 
 // Helper function to parse JSON arrays from string values
 fn parseValueIfArray(value) {
-    if (typeof(value) == 'string' and startsWith(value, '[')) {
+    if (typeof(value) == 'string' and startsWith(trim(value), '[')) {
         try {
-            return jsonParse(value)
+            return jsonParse(trim(value))
         } catch {
             return value
         }

--- a/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
@@ -56,3 +56,41 @@ class TestTemplateMetaAds(BaseHogFunctionTemplateTest):
                 },
             },
         )
+
+    def test_function_handles_arrays_in_custom_data(self):
+        self.mock_fetch_response = lambda *args: {"status": 200, "body": {"ok": True}}  # type: ignore
+        inputs = self._inputs(
+            customData={
+                "currency": "USD",
+                "price": "15",
+                "content_ids": '["product123", "product456"]',  # JSON array as string
+                "contents": '[{"id": "product123", "quantity": 2}]',  # Array of objects
+            }
+        )
+        self.run_function(inputs)
+
+        call = self.get_mock_fetch_calls()[0]
+        custom_data = call[1]["body"]["data"][0]["custom_data"]
+
+        # Verify arrays are properly parsed
+        assert custom_data["currency"] == "USD"
+        assert custom_data["price"] == "15"
+        assert custom_data["content_ids"] == ["product123", "product456"]
+        assert custom_data["contents"] == [{"id": "product123", "quantity": 2}]
+
+    def test_function_handles_arrays_in_user_data(self):
+        self.mock_fetch_response = lambda *args: {"status": 200, "body": {"ok": True}}  # type: ignore
+        inputs = self._inputs(
+            userData={
+                "em": "3edfaed7454eedb3c72bad566901af8bfbed1181816dde6db91dfff0f0cffa98",
+                "external_id": '["user123", "crm456"]',  # Multiple IDs as array
+            }
+        )
+        self.run_function(inputs)
+
+        call = self.get_mock_fetch_calls()[0]
+        user_data = call[1]["body"]["data"][0]["user_data"]
+
+        # Verify arrays are properly parsed
+        assert user_data["em"] == "3edfaed7454eedb3c72bad566901af8bfbed1181816dde6db91dfff0f0cffa98"
+        assert user_data["external_id"] == ["user123", "crm456"]

--- a/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
@@ -94,3 +94,27 @@ class TestTemplateMetaAds(BaseHogFunctionTemplateTest):
         # Verify arrays are properly parsed
         assert user_data["em"] == "3edfaed7454eedb3c72bad566901af8bfbed1181816dde6db91dfff0f0cffa98"
         assert user_data["external_id"] == ["user123", "crm456"]
+
+    def test_function_handles_arrays_with_leading_spaces(self):
+        self.mock_fetch_response = lambda *args: {"status": 200, "body": {"ok": True}}  # type: ignore
+        inputs = self._inputs(
+            userData={
+                "em": "3edfaed7454eedb3c72bad566901af8bfbed1181816dde6db91dfff0f0cffa98",
+                "external_id": '  ["user123", "crm456"]  ',  # Array with leading/trailing spaces
+            },
+            customData={
+                "currency": "USD",
+                "content_ids": ' ["product123", "product456"] ',  # Array with spaces
+                "contents": '  [{"id": "product123", "quantity": 2}]',  # Array with leading spaces
+            },
+        )
+        self.run_function(inputs)
+
+        call = self.get_mock_fetch_calls()[0]
+        user_data = call[1]["body"]["data"][0]["user_data"]
+        custom_data = call[1]["body"]["data"][0]["custom_data"]
+
+        # Verify arrays with spaces are properly parsed
+        assert user_data["external_id"] == ["user123", "crm456"]
+        assert custom_data["content_ids"] == ["product123", "product456"]
+        assert custom_data["contents"] == [{"id": "product123", "quantity": 2}]


### PR DESCRIPTION
## Problem


In the Meta Ads template, when users tried to pass array values to Facebook's Conversions API (as required by their documentation for fields like content_ids), the template treated the entire input as a string literal.

For example:
```
  - User enters: ["product123", "product456"] in the custom_data field
  - Facebook API received: "[\"product123\", \"product456\"]" (a string)
  - Facebook API expected: ["product123", "product456"] (an actual array)
 ```

This prevented proper integration with Facebook's API.

c.f. https://posthog.com/questions/can-t-add-arrays

## Changes

  Modified the template to detect and parse JSON array strings in both userData and customData
  dictionaries:

  1. Detection: Check if a value is a string starting with [ (indicating potential JSON array)
  2. Parsing: Use jsonParse() to convert the string to an actual array
  3. Fallback: Keep the value as a string if parsing fails (for non-JSON data)

## How did you test this code?

- added tests & made sure existing tests don't break