### PR TITLE
fix(phai): thread cancelling

### DIFF
--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -85,7 +85,11 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
         setShowAutocomplete(isSlashCommand)
     }, [question, showAutocomplete])
 
-    let disabledReason = threadLoading && !dataProcessingAccepted ? 'Pending approval' : submissionDisabledReason
+    let disabledReason = !threadLoading
+        ? !dataProcessingAccepted
+            ? 'Pending approval'
+            : submissionDisabledReason
+        : undefined
     if (cancelLoading) {
         disabledReason = 'Cancelling...'
     }
@@ -201,15 +205,15 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                             <LemonButton
                                 type={(isThreadVisible && !question) || threadLoading ? 'secondary' : 'primary'}
                                 onClick={() => {
+                                    if (threadLoading) {
+                                        stopGeneration()
+                                        return
+                                    }
                                     if (submissionDisabledReason) {
                                         textAreaRef?.current?.focus()
                                         return
                                     }
-                                    if (threadLoading) {
-                                        stopGeneration()
-                                    } else {
-                                        askMax(question)
-                                    }
+                                    askMax(question)
                                 }}
                                 tooltip={
                                     disabledReason ? (
@@ -225,8 +229,8 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                                     )
                                 }
                                 loading={threadLoading && !dataProcessingAccepted}
-                                // disabledReason={disabledReason}
-                                className={disabledReason || threadLoading ? 'opacity-[0.5]' : ''}
+                                disabledReason={disabledReason}
+                                className={disabledReason ? 'opacity-[0.5]' : ''}
                                 size="small"
                                 icon={
                                     threadLoading ? (


### PR DESCRIPTION
## Problem

The cancel button only works if there is some input. Let's fix the behavior.

**Before**

![2025-12-23 11 48 28](https://github.com/user-attachments/assets/43204e19-0555-433a-b145-ba1f4971c038)

**After**

![2025-12-23 11 46 20](https://github.com/user-attachments/assets/6e7ad8fb-abef-4f44-b816-0c81a2589e57)

## Changes

- `disabledReason` should only apply when a thread is not in progress.

## How did you test this code?

Manual testing