### PR TITLE
fix: remove duplicate last hour

### DIFF
--- a/products/error_tracking/frontend/components/IssueFilters/DateRange.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/DateRange.tsx
@@ -1,19 +1,12 @@
 import { useActions, useValues } from 'kea'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
-import { dayjs } from 'lib/dayjs'
-import { DATE_FORMAT, dateMapping } from 'lib/utils'
+import { dateMapping } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 
 import { issueFiltersLogic } from './issueFiltersLogic'
 
 const errorTrackingDateOptions = dateMapping.filter((dm) => !['Yesterday', 'All time', 'Today'].includes(dm.key))
-
-errorTrackingDateOptions.unshift({
-    key: 'Last hour',
-    values: ['-1h'],
-    getFormattedDate: (date: dayjs.Dayjs): string => date.subtract(1, 'h').format(DATE_FORMAT),
-})
 
 export const DateRangeFilter = ({
     className,


### PR DESCRIPTION
We've recently added "Last hour" option to the default date mappings. This caused a duplicate because in error tracking we were appending that manually.

Removed that manual append