### PR TITLE
feat(workflows): Change email-node testing panel to optimize for sending an email to yourself to see how it looks

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanel.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanel.tsx
@@ -15,6 +15,7 @@ import { HogFlowEditorPanelBuildDetail } from './HogFlowEditorPanelBuildDetail'
 import { HogFlowEditorPanelLogs } from './HogFlowEditorPanelLogs'
 import { HogFlowEditorPanelMetrics } from './HogFlowEditorPanelMetrics'
 import { HogFlowEditorPanelVariables } from './HogFlowEditorPanelVariables'
+import { EmailActionTestContent } from './testing/HogFlowEditorNotificationPanelTest'
 import { HogFlowEditorPanelTest } from './testing/HogFlowEditorPanelTest'
 
 export function HogFlowEditorPanel(): JSX.Element | null {
@@ -113,7 +114,12 @@ export function HogFlowEditorPanel(): JSX.Element | null {
                     <>{!selectedNode ? <HogFlowEditorPanelBuild /> : <HogFlowEditorPanelBuildDetail />}</>
                 )}
                 {mode === 'variables' && <HogFlowEditorPanelVariables />}
-                {mode === 'test' && <HogFlowEditorPanelTest />}
+                {mode === 'test' &&
+                    (selectedNode?.data?.type === 'function_email' ? (
+                        <EmailActionTestContent />
+                    ) : (
+                        <HogFlowEditorPanelTest />
+                    ))}
                 {mode === 'metrics' && <HogFlowEditorPanelMetrics />}
                 {mode === 'logs' && <HogFlowEditorPanelLogs />}
             </div>

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorNotificationPanelTest.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorNotificationPanelTest.tsx
@@ -1,0 +1,393 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+import { useEffect } from 'react'
+
+import { IconInfo, IconPlayFilled, IconTestTube } from '@posthog/icons'
+import {
+    LemonBanner,
+    LemonButton,
+    LemonDialog,
+    LemonDivider,
+    LemonInput,
+    LemonLabel,
+    LemonSwitch,
+    Popover,
+    ProfilePicture,
+    Spinner,
+    Tooltip,
+} from '@posthog/lemon-ui'
+
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { isEmail } from 'lib/utils'
+import { HogFunctionTestEditor } from 'scenes/hog-functions/configuration/HogFunctionTest'
+import { LogsViewerTable } from 'scenes/hog-functions/logs/LogsViewer'
+import { asDisplay } from 'scenes/persons/person-utils'
+
+import { PersonType } from '~/types'
+
+import { renderWorkflowLogMessage } from '../../../logs/log-utils'
+import { TRIGGER_NODE_ID, workflowLogic } from '../../../workflowLogic'
+import { hogFlowEditorLogic } from '../../hogFlowEditorLogic'
+import { hogFlowEditorNotificationTestLogic } from './hogFlowEditorNotificationTestLogic'
+import { reorderGlobalsForEmailAction } from './hogFlowEditorNotificationTestLogic'
+
+export function EmailActionTestContent(): JSX.Element | null {
+    const { workflow, selectedNode } = useValues(hogFlowEditorLogic)
+    const { setSelectedNodeId } = useActions(hogFlowEditorLogic)
+    const { logicProps } = useValues(workflowLogic)
+
+    const {
+        isTestInvocationSubmitting,
+        testResult,
+        nextActionId,
+        testInvocation,
+        personSelectorOpen,
+        personSearchTerm,
+        samplePersons,
+        personSearchResults,
+        samplePersonsLoading,
+        personSearchResultsLoading,
+        sampleGlobals,
+        sampleGlobalsLoading,
+        sampleGlobalsError,
+        emailAddressOverride,
+    } = useValues(hogFlowEditorNotificationTestLogic(logicProps))
+    const {
+        submitTestInvocation,
+        setTestResult,
+        setPersonSelectorOpen,
+        setPersonSearchTerm,
+        clearPersonSearch,
+        loadSamplePersonByDistinctId,
+        setEmailAddressOverride,
+        setSampleGlobals,
+    } = useActions(hogFlowEditorNotificationTestLogic(logicProps))
+
+    const emailInput = emailAddressOverride ?? sampleGlobals?.person?.properties?.email ?? ''
+
+    const isLoading = samplePersonsLoading || (sampleGlobalsLoading && !sampleGlobals)
+
+    const handlePersonSelect = (person: PersonType): void => {
+        const distinctId = person.distinct_ids?.[0]
+        if (distinctId) {
+            loadSamplePersonByDistinctId({ distinctId })
+            setPersonSelectorOpen(false)
+            clearPersonSearch()
+        }
+    }
+
+    useEffect(() => {
+        setTestResult(null)
+    }, [selectedNode?.id, setTestResult])
+
+    if (!selectedNode) {
+        return (
+            <div className="m-8 text-center flex flex-col gap-2 items-center">
+                <h1>
+                    <IconTestTube className="mr-2" />
+                    Test your workflow
+                </h1>
+
+                <p>Step through each action in your workflow and see how it behaves.</p>
+
+                <LemonButton type="primary" onClick={() => setSelectedNodeId(TRIGGER_NODE_ID)}>
+                    Start testing
+                </LemonButton>
+            </div>
+        )
+    }
+
+    return (
+        <Form
+            logic={hogFlowEditorNotificationTestLogic}
+            props={logicProps}
+            formKey="testInvocation"
+            enableFormOnSubmit
+            className="flex overflow-hidden flex-col flex-1"
+        >
+            <div className="flex gap-2 items-center p-2">
+                <LemonField name="mock_async_functions" className="flex-1">
+                    {({ value, onChange }) => (
+                        <LemonSwitch
+                            onChange={(v) => onChange(!v)}
+                            checked={!value}
+                            data-attr="toggle-workflow-test-panel-new-mocking"
+                            className="whitespace-nowrap"
+                            size="small"
+                            bordered
+                            label={
+                                <Tooltip
+                                    title={
+                                        <>
+                                            When disabled, message deliveries and other async actions will not be
+                                            called. Instead they will be mocked out and logged.
+                                        </>
+                                    }
+                                >
+                                    <span className="flex gap-2">
+                                        Make real HTTP requests
+                                        <IconInfo className="text-lg" />
+                                    </span>
+                                </Tooltip>
+                            }
+                        />
+                    )}
+                </LemonField>
+                {testResult ? (
+                    <>
+                        <div className="flex-1" />
+                        <LemonButton
+                            type="secondary"
+                            onClick={() => setTestResult(null)}
+                            loading={isTestInvocationSubmitting}
+                            size="small"
+                            data-attr="clear-workflow-test-panel-new-result"
+                        >
+                            Clear test result
+                        </LemonButton>
+
+                        {nextActionId ? (
+                            <LemonButton
+                                type="primary"
+                                onClick={() => setSelectedNodeId(nextActionId)}
+                                icon={<IconPlayFilled />}
+                                loading={isTestInvocationSubmitting}
+                                size="small"
+                                data-attr="continue-workflow-test-panel-new"
+                            >
+                                Go to next step
+                            </LemonButton>
+                        ) : null}
+                    </>
+                ) : (
+                    <>
+                        <div className="flex-1" />
+
+                        <LemonButton
+                            type="primary"
+                            data-attr="test-workflow-panel-new"
+                            onClick={() => {
+                                const shouldShowConfirmation = !testInvocation?.mock_async_functions
+
+                                if (shouldShowConfirmation) {
+                                    LemonDialog.open({
+                                        title: 'Confirm email test',
+                                        description: `This will send an email to ${emailInput}, do you want to proceed?`,
+                                        primaryButton: {
+                                            children: 'Send email',
+                                            type: 'primary',
+                                            onClick: () => {
+                                                submitTestInvocation()
+                                            },
+                                        },
+                                        secondaryButton: {
+                                            children: 'Cancel',
+                                        },
+                                    })
+                                } else {
+                                    submitTestInvocation()
+                                }
+                            }}
+                            loading={isTestInvocationSubmitting}
+                            disabledReason={
+                                !sampleGlobals
+                                    ? 'Must load person to run test'
+                                    : !isEmail(emailInput)
+                                      ? 'Must enter a valid email address'
+                                      : undefined
+                            }
+                            size="small"
+                        >
+                            Run test
+                        </LemonButton>
+                    </>
+                )}
+            </div>
+            <LemonDivider className="my-0" />
+            <div className="flex flex-col flex-1 overflow-y-auto">
+                <div className="flex-0 bg-surface-secondary p-2">
+                    {sampleGlobalsError ? (
+                        <div>
+                            <LemonBanner type="info" className="mb-2">
+                                {sampleGlobalsError}
+                            </LemonBanner>
+                        </div>
+                    ) : null}
+
+                    {/* Select person dropdown at the top */}
+                    <div className="mb-4">
+                        <LemonLabel>Select person</LemonLabel>
+                        <Popover
+                            overlay={
+                                <div className="p-2 min-w-80">
+                                    <LemonInput
+                                        type="search"
+                                        placeholder="Search by name, email, or distinct ID"
+                                        value={personSearchTerm}
+                                        onChange={setPersonSearchTerm}
+                                        autoFocus
+                                        className="mb-2"
+                                    />
+                                    {personSearchResultsLoading || samplePersonsLoading ? (
+                                        <div className="p-4 text-center">
+                                            <Spinner />
+                                        </div>
+                                    ) : (
+                                        <div className="max-h-64 overflow-y-auto">
+                                            {/* Show sample persons when not searching */}
+                                            {!personSearchTerm.trim() && samplePersons.length > 0 ? (
+                                                <>
+                                                    {samplePersons.map((person: PersonType) => (
+                                                        <LemonButton
+                                                            key={person.id}
+                                                            fullWidth
+                                                            size="small"
+                                                            onClick={() => handlePersonSelect(person)}
+                                                            className="justify-start"
+                                                        >
+                                                            <ProfilePicture
+                                                                name={asDisplay(person)}
+                                                                size="sm"
+                                                                className="mr-2"
+                                                            />
+                                                            <div className="flex-1 text-left">
+                                                                <div className="font-semibold">{asDisplay(person)}</div>
+                                                                {person.properties?.email ? (
+                                                                    <div className="text-xs text-muted">
+                                                                        {person.properties.email}
+                                                                    </div>
+                                                                ) : null}
+                                                            </div>
+                                                        </LemonButton>
+                                                    ))}
+                                                </>
+                                            ) : null}
+                                            {/* Show search results */}
+                                            {personSearchTerm.trim() && personSearchResults.length === 0 ? (
+                                                <div className="p-4 text-center text-muted text-sm">
+                                                    No persons found
+                                                </div>
+                                            ) : (
+                                                personSearchResults.map((person: PersonType) => (
+                                                    <LemonButton
+                                                        key={person.id}
+                                                        fullWidth
+                                                        size="small"
+                                                        onClick={() => handlePersonSelect(person)}
+                                                        className="justify-start"
+                                                    >
+                                                        <ProfilePicture
+                                                            name={asDisplay(person)}
+                                                            size="sm"
+                                                            className="mr-2"
+                                                        />
+                                                        <div className="flex-1 text-left">
+                                                            <div className="font-semibold">{asDisplay(person)}</div>
+                                                            {person.properties?.email ? (
+                                                                <div className="text-xs text-muted">
+                                                                    {person.properties.email}
+                                                                </div>
+                                                            ) : null}
+                                                        </div>
+                                                    </LemonButton>
+                                                ))
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+                            }
+                            visible={personSelectorOpen}
+                            onClickOutside={() => setPersonSelectorOpen(false)}
+                            placement="bottom-start"
+                        >
+                            <LemonButton
+                                type="secondary"
+                                onClick={() => setPersonSelectorOpen(!personSelectorOpen)}
+                                tooltip="Select a person to load test data"
+                                size="small"
+                                loading={sampleGlobalsLoading}
+                                className="mt-1"
+                            >
+                                {sampleGlobals?.person?.name ? asDisplay(sampleGlobals.person) : 'Select person'}
+                            </LemonButton>
+                        </Popover>
+                    </div>
+
+                    {/* Person details */}
+                    {isLoading ? (
+                        <div className="flex gap-2 items-center mb-4">
+                            <Spinner />
+                            <div className="text-muted">Loading person...</div>
+                        </div>
+                    ) : sampleGlobals?.person ? (
+                        <div className="flex gap-2 items-center mb-4">
+                            <ProfilePicture name={asDisplay(sampleGlobals.person)} />
+                            <div className="flex-1">
+                                <div className="font-semibold mb-2">{sampleGlobals.person.name || 'Sample Person'}</div>
+                                <LemonLabel>Email address</LemonLabel>
+                                <LemonInput
+                                    value={emailInput}
+                                    onChange={setEmailAddressOverride}
+                                    placeholder="Enter email address"
+                                    type="email"
+                                    className="mt-1"
+                                />
+                            </div>
+                        </div>
+                    ) : null}
+
+                    {/* Person Properties */}
+                    {sampleGlobals ? (
+                        <>
+                            <div className="text-sm mt-2">
+                                Here are all the global variables you can use in your workflow:
+                            </div>
+                            <div className="flex-col gap-2 my-3 max-h-48 overflow-auto">
+                                <HogFunctionTestEditor
+                                    value={JSON.stringify(reorderGlobalsForEmailAction(sampleGlobals), null, 2)}
+                                    onChange={setSampleGlobals}
+                                />
+                            </div>
+                        </>
+                    ) : null}
+                </div>
+                <LemonDivider className="my-0" />
+                <div className="flex flex-col flex-1 gap-2 p-2">
+                    <h3 className="mb-0">Test results</h3>
+                    {!testResult ? (
+                        <div className="text-muted text-sm">No tests run yet</div>
+                    ) : (
+                        <>
+                            <LemonBanner
+                                type={
+                                    testResult.status === 'success'
+                                        ? 'success'
+                                        : testResult.status === 'skipped'
+                                          ? 'warning'
+                                          : 'error'
+                                }
+                            >
+                                {testResult.status === 'success'
+                                    ? 'Success'
+                                    : testResult.status === 'skipped'
+                                      ? 'Workflow was skipped because the event did not match the filter criteria'
+                                      : 'Error: ' + testResult.errors?.join(', ')}
+                            </LemonBanner>
+
+                            <div className="flex flex-col gap-2">
+                                <LemonLabel>Logs</LemonLabel>
+
+                                <LogsViewerTable
+                                    instanceLabel="workflow run"
+                                    renderMessage={(m) => renderWorkflowLogMessage(workflow, m)}
+                                    dataSource={testResult.logs ?? []}
+                                    renderColumns={(columns) => columns.filter((column) => column.key !== 'instanceId')}
+                                />
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+        </Form>
+    )
+}

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorNotificationPanelTest.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorNotificationPanelTest.tsx
@@ -63,7 +63,7 @@ export function EmailActionTestContent(): JSX.Element | null {
         setSampleGlobals,
     } = useActions(hogFlowEditorNotificationTestLogic(logicProps))
 
-    const emailInput = emailAddressOverride ?? sampleGlobals?.person?.properties?.email ?? ''
+    const emailInput = emailAddressOverride || sampleGlobals?.person?.properties?.email || ''
 
     const isLoading = samplePersonsLoading || (sampleGlobalsLoading && !sampleGlobals)
 

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorNotificationTestLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorNotificationTestLogic.test.ts
@@ -1,0 +1,227 @@
+import { resetContext } from 'kea'
+import { expectLogic, testUtilsPlugin } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { CyclotronJobInvocationGlobals } from '~/types'
+
+import { workflowLogic } from '../../../workflowLogic'
+import { hogFlowEditorNotificationTestLogic } from './hogFlowEditorNotificationTestLogic'
+
+jest.mock('~/queries/query', () => {
+    const actual = jest.requireActual('~/queries/query')
+    return {
+        ...actual,
+        performQuery: jest.fn().mockResolvedValue({ results: [] }),
+    }
+})
+
+describe('hogFlowEditorNotificationTestLogic', () => {
+    let logic: ReturnType<typeof hogFlowEditorNotificationTestLogic.build>
+    let workflowLogicInstance: ReturnType<typeof workflowLogic.build>
+
+    beforeEach(() => {
+        resetContext({
+            plugins: [testUtilsPlugin],
+        })
+
+        useMocks({
+            get: {
+                '/api/environments/:team_id/persons/': { results: [] },
+                '/api/environments/@current/hog_flows/test-workflow-id/': {
+                    id: 'test-workflow-id',
+                    team_id: 1,
+                    name: 'Test Workflow',
+                    status: 'draft',
+                    actions: [],
+                    edges: [],
+                },
+                '/api/environments/@current/messaging_categories': [],
+            },
+        })
+
+        initKeaTests()
+
+        workflowLogicInstance = workflowLogic({ id: 'test-workflow-id' })
+        workflowLogicInstance.mount()
+
+        logic = hogFlowEditorNotificationTestLogic({ id: 'test-workflow-id' })
+        logic.mount()
+    })
+
+    describe('setSampleGlobals reducer', () => {
+        it('should parse valid JSON and update sampleGlobals', async () => {
+            const validGlobals: CyclotronJobInvocationGlobals = {
+                event: {
+                    uuid: 'test-uuid',
+                    distinct_id: 'test-distinct-id',
+                    timestamp: '2024-01-01T00:00:00Z',
+                    elements_chain: '',
+                    url: '',
+                    event: '$pageview',
+                    properties: {},
+                },
+                person: {
+                    id: 'person-1',
+                    properties: { email: 'test@example.com' },
+                    name: 'Test Person',
+                    url: '',
+                },
+                groups: {},
+                project: { id: 1, name: 'Test', url: '' },
+                source: { name: 'Test', url: '' },
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.setSampleGlobals(JSON.stringify(validGlobals, null, 2))
+            }).toMatchValues({
+                sampleGlobals: validGlobals,
+            })
+        })
+
+        it('should preserve state when JSON is invalid', async () => {
+            const initialGlobals: CyclotronJobInvocationGlobals = {
+                event: {
+                    uuid: 'test-uuid',
+                    distinct_id: 'test-distinct-id',
+                    timestamp: '2024-01-01T00:00:00Z',
+                    elements_chain: '',
+                    url: '',
+                    event: '$pageview',
+                    properties: {},
+                },
+                person: {
+                    id: 'person-1',
+                    properties: {},
+                    name: 'Test Person',
+                    url: '',
+                },
+                groups: {},
+                project: { id: 1, name: 'Test', url: '' },
+                source: { name: 'Test', url: '' },
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.setSampleGlobals(JSON.stringify(initialGlobals, null, 2))
+            }).toMatchValues({
+                sampleGlobals: initialGlobals,
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.setSampleGlobals('invalid json {')
+            }).toMatchValues({
+                sampleGlobals: initialGlobals,
+            })
+        })
+
+        it('should preserve state when globals is null', async () => {
+            const initialGlobals: CyclotronJobInvocationGlobals = {
+                event: {
+                    uuid: 'test-uuid',
+                    distinct_id: 'test-distinct-id',
+                    timestamp: '2024-01-01T00:00:00Z',
+                    elements_chain: '',
+                    url: '',
+                    event: '$pageview',
+                    properties: {},
+                },
+                person: {
+                    id: 'person-1',
+                    properties: {},
+                    name: 'Test Person',
+                    url: '',
+                },
+                groups: {},
+                project: { id: 1, name: 'Test', url: '' },
+                source: { name: 'Test', url: '' },
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.setSampleGlobals(JSON.stringify(initialGlobals, null, 2))
+            }).toMatchValues({
+                sampleGlobals: initialGlobals,
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.setSampleGlobals(null)
+            }).toMatchValues({
+                sampleGlobals: initialGlobals,
+            })
+        })
+    })
+
+    describe('emailAddressOverride reducer', () => {
+        it('should update email override when person changes', async () => {
+            const globalsWithEmail: CyclotronJobInvocationGlobals = {
+                event: {
+                    uuid: 'test-uuid',
+                    distinct_id: 'test-distinct-id',
+                    timestamp: '2024-01-01T00:00:00Z',
+                    elements_chain: '',
+                    url: '',
+                    event: '$pageview',
+                    properties: {},
+                },
+                person: {
+                    id: 'person-1',
+                    properties: { email: 'new@example.com' },
+                    name: 'Test Person',
+                    url: '',
+                },
+                groups: {},
+                project: { id: 1, name: 'Test', url: '' },
+                source: { name: 'Test', url: '' },
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.loadSamplePersonByDistinctIdSuccess(globalsWithEmail)
+            }).toMatchValues({
+                emailAddressOverride: 'new@example.com',
+            })
+        })
+    })
+
+    describe('loadSamplePersonByDistinctIdSuccess listener', () => {
+        it('should reorder globals with person first', async () => {
+            const globals: CyclotronJobInvocationGlobals = {
+                event: {
+                    uuid: 'test-uuid',
+                    distinct_id: 'test-distinct-id',
+                    timestamp: '2024-01-01T00:00:00Z',
+                    elements_chain: '',
+                    url: '',
+                    event: '$pageview',
+                    properties: {},
+                },
+                person: {
+                    id: 'person-1',
+                    properties: { email: 'test@example.com' },
+                    name: 'Test Person',
+                    url: '',
+                },
+                groups: {},
+                project: { id: 1, name: 'Test', url: '' },
+                source: { name: 'Test', url: '' },
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.loadSamplePersonByDistinctIdSuccess(globals)
+            })
+                .toDispatchActions(['setSampleGlobals'])
+                .toMatchValues({
+                    sampleGlobals: globals,
+                    emailAddressOverride: 'test@example.com',
+                })
+
+            // Verify that the form was updated with reordered globals
+            const formValue = logic.values.testInvocation?.globals
+            expect(formValue).toBeTruthy()
+            if (formValue) {
+                const parsed = JSON.parse(formValue)
+                const keys = Object.keys(parsed)
+                expect(keys[0]).toBe('person')
+                expect(keys[1]).toBe('event')
+            }
+        })
+    })
+})

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorNotificationTestLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorNotificationTestLogic.ts
@@ -1,0 +1,432 @@
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers } from 'kea'
+import { forms } from 'kea-forms'
+import { loaders } from 'kea-loaders'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
+import { uuid } from 'lib/utils'
+
+import { performQuery } from '~/queries/query'
+import { EventsQuery, NodeKind } from '~/queries/schema/schema-general'
+import { hogql } from '~/queries/utils'
+import { CyclotronJobInvocationGlobals, FilterLogicalOperator, PersonType, PropertyFilterType } from '~/types'
+
+import { WorkflowLogicProps, workflowLogic } from '../../../workflowLogic'
+import { hogFlowEditorLogic } from '../../hogFlowEditorLogic'
+import { HogflowTestResult } from '../../steps/types'
+import type { hogFlowEditorNotificationTestLogicType } from './hogFlowEditorNotificationTestLogicType'
+import { HogflowTestInvocation, hogFlowEditorTestLogic } from './hogFlowEditorTestLogic'
+
+// Time range constants for event search
+const STANDARD_SEARCH_RANGE = `-7d`
+
+const createGlobalsFromResponse = (
+    event: any,
+    person: any,
+    teamId: number,
+    workflowName?: string | null
+): CyclotronJobInvocationGlobals => ({
+    event: {
+        uuid: event.uuid,
+        distinct_id: event.distinct_id,
+        timestamp: event.timestamp,
+        elements_chain: event.elements_chain || '',
+        url: event.url || '',
+        event: event.event,
+        properties: event.properties,
+    },
+    person: person
+        ? {
+              id: person.id,
+              properties: person.properties,
+              name: person.name || 'Unknown person',
+              url: `${window.location.origin}/person/${person.id}`,
+          }
+        : undefined,
+    groups: {},
+    project: {
+        id: teamId,
+        name: 'Default project',
+        url: `${window.location.origin}/project/${teamId}`,
+    },
+    source: {
+        name: workflowName ?? 'Unnamed',
+        url: window.location.href.split('#')[0],
+    },
+})
+
+export const hogFlowEditorNotificationTestLogic = kea<hogFlowEditorNotificationTestLogicType>([
+    path((key) => [
+        'products',
+        'workflows',
+        'frontend',
+        'Workflows',
+        'hogflows',
+        'panel',
+        'testing',
+        'hogFlowEditorNotificationTestLogic',
+        key,
+    ]),
+    props({} as WorkflowLogicProps),
+    key((props) => `${props.id}`),
+    connect((props: WorkflowLogicProps) => ({
+        values: [
+            workflowLogic(props),
+            ['workflow', 'workflowSanitized'],
+            hogFlowEditorLogic,
+            ['selectedNodeId'],
+            hogFlowEditorTestLogic(props),
+            ['sampleGlobalsError'],
+        ],
+        actions: [
+            hogFlowEditorTestLogic(props),
+            ['setSampleGlobalsError', 'setSampleGlobals'],
+            hogFlowEditorLogic,
+            ['setSelectedNodeId'],
+        ],
+    })),
+    actions({
+        setPersonSelectorOpen: (open: boolean) => ({ open }),
+        setPersonSearchTerm: (term: string) => ({ term }),
+        loadSamplePersons: true,
+        searchPersons: (searchTerm: string) => ({ searchTerm }),
+        clearPersonSearch: true,
+        loadSamplePersonByDistinctId: (payload: { distinctId: string }) => ({
+            distinctId: payload.distinctId,
+        }),
+        loadSamplePersonByDistinctIdSuccess: (sampleGlobals: CyclotronJobInvocationGlobals | null) => ({
+            sampleGlobals,
+        }),
+        loadSamplePersonByDistinctIdFailure: (error: string, errorObject?: any) => ({ error, errorObject }),
+        setEmailAddressOverride: (email: string) => ({ email }),
+        setSampleGlobals: (globals?: string | null) => ({ globals: globals ?? null }),
+        setTestResult: (testResult: HogflowTestResult | null) => ({ testResult }),
+        setNextActionId: (nextActionId: string | null) => ({ nextActionId }),
+    }),
+    reducers({
+        personSelectorOpen: [
+            false as boolean,
+            {
+                setPersonSelectorOpen: (_, { open }) => open,
+                loadSamplePersonByDistinctIdSuccess: () => false,
+            },
+        ],
+        personSearchTerm: [
+            '' as string,
+            {
+                setPersonSearchTerm: (_, { term }) => term,
+                clearPersonSearch: () => '',
+            },
+        ],
+        emailAddressOverride: [
+            null as string | null,
+            {
+                setEmailAddressOverride: (_, { email }) => email,
+                loadSamplePersonByDistinctIdSuccess: (_, { sampleGlobals }) => {
+                    // Update email override when person changes
+                    return sampleGlobals?.person?.properties?.email ?? null
+                },
+            },
+        ],
+        testResult: [
+            null as HogflowTestResult | null,
+            {
+                setTestResult: (_, { testResult }) => testResult,
+            },
+        ],
+        nextActionId: [
+            null as string | null,
+            {
+                setNextActionId: (_, { nextActionId }) => nextActionId,
+            },
+        ],
+        sampleGlobals: [
+            null as CyclotronJobInvocationGlobals | null,
+            {
+                setSampleGlobals: (previousGlobals, { globals }) => {
+                    try {
+                        return globals ? JSON.parse(globals) : previousGlobals
+                    } catch {
+                        return previousGlobals
+                    }
+                },
+                loadSamplePersonByDistinctIdSuccess: (_, { sampleGlobals }) => sampleGlobals,
+            },
+        ],
+        sampleGlobalsLoading: [
+            false as boolean,
+            {
+                loadSamplePersonByDistinctId: () => true,
+                loadSamplePersonByDistinctIdSuccess: () => false,
+                loadSamplePersonByDistinctIdFailure: () => false,
+            },
+        ],
+    }),
+    loaders(() => ({
+        samplePersons: [
+            [] as PersonType[],
+            {
+                loadSamplePersons: async () => {
+                    const response = await api.persons.list({ limit: 5 })
+                    if (!response.results || response.results.length === 0) {
+                        return []
+                    }
+                    return response.results
+                },
+            },
+        ],
+        personSearchResults: [
+            [] as PersonType[],
+            {
+                searchPersons: async ({ searchTerm }) => {
+                    if (!searchTerm.trim()) {
+                        return []
+                    }
+                    try {
+                        const response = await api.persons.list({ search: searchTerm.trim(), limit: 10 })
+                        return response.results
+                    } catch (error) {
+                        console.error('Failed to search persons:', error)
+                        return []
+                    }
+                },
+            },
+        ],
+    })),
+    forms(({ actions, values }) => ({
+        testInvocation: {
+            defaults: {
+                mock_async_functions: false,
+            } as HogflowTestInvocation,
+            errors: (data: HogflowTestInvocation) => {
+                const errors: Record<string, string> = {}
+                try {
+                    JSON.parse(JSON.stringify(data.globals))
+                } catch {
+                    errors.globals = 'Invalid JSON'
+                }
+                return errors
+            },
+            submit: async (testInvocation: HogflowTestInvocation) => {
+                try {
+                    const parsedGlobals = JSON.parse(testInvocation.globals)
+
+                    // Override email in person properties if emailAddressOverride is set
+                    if (values.emailAddressOverride && parsedGlobals.person) {
+                        parsedGlobals.person = {
+                            ...parsedGlobals.person,
+                            properties: {
+                                ...parsedGlobals.person.properties,
+                                email: values.emailAddressOverride,
+                            },
+                        }
+                    }
+
+                    const apiResponse = await api.hogFlows.createTestInvocation(values.workflow.id, {
+                        configuration: values.workflowSanitized,
+                        globals: {
+                            ...parsedGlobals,
+                            variables: values.workflow.variables?.reduce(
+                                (acc, variable) => {
+                                    acc[variable.key] = variable.default
+                                    return acc
+                                },
+                                {} as Record<string, any>
+                            ),
+                        },
+                        mock_async_functions: testInvocation.mock_async_functions,
+                        current_action_id: values.selectedNodeId ?? undefined,
+                    })
+
+                    const result: HogflowTestResult = {
+                        ...apiResponse,
+                        logs: apiResponse.logs?.map((log) => ({
+                            ...log,
+                            instanceId: 'test',
+                            timestamp: dayjs(log.timestamp),
+                        })),
+                    }
+
+                    actions.setTestResult(result)
+                    const nextActionId = result.nextActionId
+                    if (nextActionId && nextActionId !== values.selectedNodeId) {
+                        actions.setNextActionId(nextActionId)
+                    }
+
+                    return values.testInvocation
+                } catch (error: any) {
+                    console.error('Workflow test error:', error)
+                    lemonToast.error('Error testing workflow')
+                    throw error
+                }
+            },
+        },
+    })),
+    listeners(({ actions, values }) => ({
+        loadSamplePersonByDistinctId: async ({ distinctId }) => {
+            try {
+                // First, get the person by distinct_id
+                const personResponse = await api.persons.list({ distinct_id: distinctId, limit: 1 })
+                if (!personResponse?.results?.[0]) {
+                    actions.setSampleGlobalsError(`No person found with distinct_id: ${distinctId}`)
+                    actions.loadSamplePersonByDistinctIdFailure('Failed to load person')
+                    return
+                }
+
+                const person = personResponse.results[0]
+
+                // Find the most recent event for this person
+                const query: EventsQuery = {
+                    kind: NodeKind.EventsQuery,
+                    fixedProperties: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    type: PropertyFilterType.HogQL,
+                                    key: hogql`distinct_id = ${distinctId}`,
+                                },
+                            ],
+                        },
+                    ],
+                    select: ['*', 'person'],
+                    after: STANDARD_SEARCH_RANGE,
+                    limit: 1,
+                    orderBy: ['timestamp DESC'],
+                    modifiers: {
+                        personsOnEventsMode: 'person_id_no_override_properties_on_events',
+                    },
+                }
+
+                const eventResponse = await performQuery(query)
+                let event = eventResponse?.results?.[0]?.[0]
+
+                if (!event) {
+                    // If no event found, create a minimal example event
+                    event = {
+                        uuid: uuid(),
+                        distinct_id: distinctId,
+                        timestamp: dayjs().toISOString(),
+                        elements_chain: '',
+                        url: `${window.location.origin}/project/${values.workflow.team_id}/events/`,
+                        event: '$pageview',
+                        properties: {
+                            $current_url: window.location.href.split('#')[0],
+                        },
+                    }
+                }
+
+                actions.setSampleGlobalsError(null)
+                const globals = createGlobalsFromResponse(event, person, values.workflow.team_id, values.workflow.name)
+                actions.loadSamplePersonByDistinctIdSuccess(globals)
+            } catch (error: any) {
+                actions.setSampleGlobalsError(`Failed to load person: ${error.message || 'Unknown error'}`)
+                actions.loadSamplePersonByDistinctIdFailure('Failed to load person')
+            }
+        },
+        setPersonSearchTerm: async ({ term }, breakpoint) => {
+            // Debounce search - wait 300ms before searching
+            await breakpoint(300)
+
+            if (term === values.personSearchTerm && term.trim()) {
+                actions.searchPersons(term)
+            } else if (!term.trim()) {
+                actions.searchPersons('')
+            }
+        },
+        setPersonSelectorOpen: ({ open }) => {
+            if (open && values.samplePersons.length === 0) {
+                actions.loadSamplePersons()
+            }
+        },
+        loadSamplePersonsSuccess: ({ samplePersons }) => {
+            if (samplePersons.length > 0 && !values.sampleGlobals) {
+                const firstPerson = samplePersons[0]
+                const distinctId = firstPerson.distinct_ids?.[0]
+                if (distinctId) {
+                    actions.loadSamplePersonByDistinctId({ distinctId })
+                }
+            }
+        },
+        loadSamplePersonsFailure: () => {
+            // Only create example person if loading fails
+            if (!values.sampleGlobals) {
+                const exampleGlobals = {
+                    event: {
+                        uuid: uuid(),
+                        distinct_id: uuid(),
+                        timestamp: dayjs().toISOString(),
+                        elements_chain: '',
+                        url: `${window.location.origin}/project/${values.workflow.team_id}/events/`,
+                        event: '$pageview',
+                        properties: {
+                            $current_url: window.location.href.split('#')[0],
+                            $browser: 'Chrome',
+                            this_is_an_example_event: true,
+                        },
+                    },
+                    person: {
+                        id: uuid(),
+                        properties: {
+                            email: '',
+                        },
+                        name: 'Example person',
+                        url: `${window.location.origin}/person/${uuid()}`,
+                    },
+                    groups: {},
+                    project: {
+                        id: values.workflow.team_id,
+                        name: 'Default project',
+                        url: `${window.location.origin}/project/${values.workflow.team_id}`,
+                    },
+                    source: {
+                        name: values.workflow.name ?? 'Unnamed',
+                        url: window.location.href.split('#')[0],
+                    },
+                }
+                actions.setSampleGlobals(JSON.stringify(exampleGlobals, null, 2))
+            }
+        },
+        setSampleGlobals: () => {
+            if (values.sampleGlobals) {
+                actions.setTestInvocationValue('globals', JSON.stringify(values.sampleGlobals, null, 2))
+            }
+        },
+        loadSamplePersonByDistinctIdSuccess: ({ sampleGlobals }) => {
+            // Reorder with person first before setting
+            if (sampleGlobals) {
+                const reorderedGlobals = reorderGlobalsForEmailAction(sampleGlobals)
+                actions.setSampleGlobals(JSON.stringify(reorderedGlobals, null, 2))
+            }
+
+            if (sampleGlobals?.person?.properties?.email) {
+                actions.setEmailAddressOverride(sampleGlobals.person.properties.email)
+            }
+        },
+    })),
+    afterMount(({ actions }) => {
+        // Load sample persons on mount
+        actions.loadSamplePersons()
+    }),
+])
+
+export function reorderGlobalsForEmailAction(globals: CyclotronJobInvocationGlobals): CyclotronJobInvocationGlobals {
+    // Reorder globals to show person before event for email actions,
+    // because that's where we expect users to want to make changes
+    return Object.fromEntries(
+        Object.entries(globals).sort(([keyA], [keyB]) => {
+            const order: Record<string, number> = {
+                person: 0,
+                event: 1,
+            }
+            const orderA = order[keyA] ?? 2
+            const orderB = order[keyB] ?? 2
+            if (orderA !== orderB) {
+                return orderA - orderB
+            }
+            return keyA.localeCompare(keyB)
+        })
+    ) as CyclotronJobInvocationGlobals
+}

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
@@ -37,10 +37,11 @@ export interface HogflowTestInvocation {
     mock_async_functions: boolean
 }
 
-const createExampleEvent = (
+export const createExampleEvent = (
     teamId?: number,
     workflowName?: string | null,
-    eventName: string = '$pageview'
+    eventName: string = '$pageview',
+    email: string = 'example@posthog.com'
 ): CyclotronJobInvocationGlobals => ({
     event: {
         uuid: uuid(),
@@ -58,7 +59,7 @@ const createExampleEvent = (
     person: {
         id: uuid(),
         properties: {
-            email: 'example@posthog.com',
+            email,
         },
         name: 'Example person',
         url: `${window.location.origin}/person/${uuid()}`,
@@ -75,7 +76,7 @@ const createExampleEvent = (
     },
 })
 
-const createGlobalsFromResponse = (
+export const createGlobalsFromResponse = (
     event: any,
     person: any,
     teamId: number,


### PR DESCRIPTION

## Problem

Fixes https://github.com/PostHog/posthog/issues/43226

Users find it hard to test our email-nodes and wish for a way to easily send an email to themselves

## Changes

[email-tester.webm](https://github.com/user-attachments/assets/458bbf75-dcae-4b75-82de-a01a42527881)

* New panel & logic for notification-based nodes (only for email for now, but should be extended for eg. SMS)
* Duplicates some logic from the old one, but has enough differences to IMO make WET apply here instead of trying to wrangle shared logic
* Email test panel defaults to sending a real email instead of running the test mocked, because this is what we expect users to normally want to do
* Email test panel lets you select a user and tries to get a recent event for that user
* Email test panel lets you overwrite the email address you want to send to
* Email test panel sorts "person" to the top, instead of event data, because we expect users to want to edit that

## How did you test this code?

Mostly manually, with some automated testing