### PR TITLE
fix(customers): Fix person display in power users table

### DIFF
--- a/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
@@ -74,7 +74,9 @@ function PowerUsersTable(): JSX.Element {
         showSourceQueryOptions: false,
         source: {
             kind: NodeKind.ActorsQuery,
-            select: isB2c ? ['person', 'event_count', 'last_seen'] : ['group', 'event_count', 'last_seen'],
+            select: isB2c
+                ? ['person_display_name -- Person', 'event_count', 'last_seen']
+                : ['group', 'event_count', 'last_seen'],
             source: {
                 kind: NodeKind.InsightActorsQuery,
                 source: {
@@ -101,7 +103,7 @@ function PowerUsersTable(): JSX.Element {
             <div className="flex items-center gap-2">
                 <Tooltip
                     title={`Power ${customerLabel.plural} are the ${customerLabel.plural} that performed your activity event most frequently in the past 30 days.`}
-                    // TODO: Add docs link when released
+                    docLink="https://posthog.com/docs/customer-analytics/dashboard-metrics#power-users"
                 >
                     <h2 className="mb-0 ml-1">Power {customerLabel.plural}</h2>
                 </Tooltip>


### PR DESCRIPTION
## Problem

Power users table is not showing people names.

Closes https://github.com/PostHog/posthog/issues/43934
## Changes

1. Improved column naming in the Power Users table by changing `person` to `person_display_name -- Person` for B2C customers, making the column label more descriptive
2. Added documentation link to the Power Users tooltip that points to the relevant section in the PostHog docs

![image.png](https://app.graphite.com/user-attachments/assets/0c835939-ea02-4a6e-8f5e-24a5b2cd85b9.png)

![image.png](https://app.graphite.com/user-attachments/assets/2e2dcdcb-2acc-43ec-99c6-0609782c23c3.png)

## How did you test this code?

The names are now displayed correctly

## Changelog: (features only) Is this feature complete?
No, it is a fix.