### PR TITLE
fix: use singular recording for activity live text if there is one recording

### DIFF
--- a/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
+++ b/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
@@ -160,7 +160,7 @@ export function LiveRecordingsCount({ pollIntervalMs = 30000 }: LiveCountProps):
                         <strong>{humanFriendlyLargeNumber(activeRecordings)}</strong>
                     </span>
                     <span className="hidden min-[660px]:inline">
-                        {activeRecordings === 1 ? 'recendly active recording' : 'recently active recordings'}
+                        {activeRecordings === 1 ? 'recently active recording' : 'recently active recordings'}
                     </span>
                 </div>
             </Tooltip>

--- a/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
+++ b/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
@@ -9,7 +9,7 @@ import { Tooltip } from '@posthog/lemon-ui'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
-import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils'
+import { humanFriendlyLargeNumber, humanFriendlyNumber, pluralize } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -160,7 +160,7 @@ export function LiveRecordingsCount({ pollIntervalMs = 30000 }: LiveCountProps):
                         <strong>{humanFriendlyLargeNumber(activeRecordings)}</strong>
                     </span>
                     <span className="hidden min-[660px]:inline">
-                        {activeRecordings === 1 ? 'recently active recording' : 'recently active recordings'}
+                        recently active {pluralize(activeRecordings, 'recording', undefined, false)}
                     </span>
                 </div>
             </Tooltip>

--- a/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
+++ b/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
@@ -159,7 +159,9 @@ export function LiveRecordingsCount({ pollIntervalMs = 30000 }: LiveCountProps):
                     <span className="text-xs font-medium whitespace-nowrap" data-attr="live-recordings-count">
                         <strong>{humanFriendlyLargeNumber(activeRecordings)}</strong>
                     </span>
-                    <span className="hidden min-[660px]:inline">recently active recordings</span>
+                    <span className="hidden min-[660px]:inline">
+                        {activeRecordings === 1 ? 'recendly active recording' : 'recently active recordings'}
+                    </span>
                 </div>
             </Tooltip>
         </FlaggedFeature>


### PR DESCRIPTION
## Problem

Small text change to make it more smoother looking

## Changes
Before:
<img width="1072" height="336" alt="image" src="https://github.com/user-attachments/assets/5e87cebb-4fd6-4183-9cc8-fa3b7ad164f4" />
After:
<img width="388" height="148" alt="Screenshot 2025-12-23 at 15 25 04" src="https://github.com/user-attachments/assets/c6c12c2f-6eac-47a0-8bc7-76631c5a4322" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Just a simple ternary to display plural word, just saw on locally that it works as intended

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
