### PR TITLE
fix(dp): Use 127.0.0.1 instead of 0.0.0.0 for SSH tunnel local connections

### DIFF
--- a/posthog/temporal/data_imports/sources/common/mixins.py
+++ b/posthog/temporal/data_imports/sources/common/mixins.py
@@ -21,7 +21,7 @@ class SSHTunnelMixin:
                 if tunnel is None:
                     raise Exception("Can't open tunnel to SSH server")
 
-                yield "127.0.0.1", tunnel.local_bind_port
+                yield tunnel.local_bind_host, tunnel.local_bind_port
         else:
             yield config.host, config.port
 
@@ -34,7 +34,7 @@ class SSHTunnelMixin:
                 with ssh_tunnel.get_tunnel(config.host, config.port) as tunnel:
                     if tunnel is None:
                         raise Exception("Can't open tunnel to SSH server")
-                    yield "127.0.0.1", tunnel.local_bind_port
+                    yield tunnel.local_bind_host, tunnel.local_bind_port
 
             return with_ssh_func
 

--- a/posthog/temporal/data_imports/sources/common/mixins.py
+++ b/posthog/temporal/data_imports/sources/common/mixins.py
@@ -21,7 +21,7 @@ class SSHTunnelMixin:
                 if tunnel is None:
                     raise Exception("Can't open tunnel to SSH server")
 
-                yield tunnel.local_bind_host, tunnel.local_bind_port
+                yield "127.0.0.1", tunnel.local_bind_port
         else:
             yield config.host, config.port
 
@@ -31,10 +31,10 @@ class SSHTunnelMixin:
 
             @contextmanager
             def with_ssh_func():
-                with ssh_tunnel.get_tunnel(config.host, config.port) as t:
-                    if t is None:
+                with ssh_tunnel.get_tunnel(config.host, config.port) as tunnel:
+                    if tunnel is None:
                         raise Exception("Can't open tunnel to SSH server")
-                    yield t.local_bind_host, t.local_bind_port
+                    yield "127.0.0.1", tunnel.local_bind_port
 
             return with_ssh_func
 

--- a/products/data_warehouse/backend/models/ssh_tunnel.py
+++ b/products/data_warehouse/backend/models/ssh_tunnel.py
@@ -161,6 +161,7 @@ class SSHTunnel:
                 ssh_username=self.username,
                 ssh_password=self.password,
                 remote_bind_address=(remote_host, remote_port),
+                local_bind_address=("127.0.0.1",),
             )
         else:
             return SSHTunnelForwarder(
@@ -169,4 +170,5 @@ class SSHTunnel:
                 ssh_pkey=self.parse_private_key(),
                 ssh_private_key_password=self.passphrase,
                 remote_bind_address=(remote_host, remote_port),
+                local_bind_address=("127.0.0.1",),
             )


### PR DESCRIPTION
## Problem
 When creating an SSH tunnel, the `sshtunnel` library binds to `0.0.0.0` by default, and we were using `tunnel.local_bind_host` (which returns `0.0.0.0`) as the host to connect to. While connecting to `0.0.0.0` works on most systems, it can fail in containerized/Kubernetes environments due to network namespace isolation.

[Example of workflow failing because of this](https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/019b41ce-e409-0000-a76e-9f2c3fe9f986-2025-12-21T16%3A47%3A18Z/019b41ce-ed29-709e-bc46-07ea44955640/history)
[Issue raised by user](https://posthoghelp.zendesk.com/agent/tickets/45638)

## Changes
  * Fixed SSH tunnel local bind host to use `127.0.0.1` instead of `tunnel.local_bind_host` (which returns `0.0.0.0`)
  * Updated both `with_ssh_tunnel()` and `make_ssh_tunnel_func()` methods in `SSHTunnelMixin`

## How did you test this code?


## Changelog: (features only) Is this feature complete?

