### PR TITLE
fix(web-analytics): normalize domain filter to match dropdown options

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsFilterLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsFilterLogic.ts
@@ -23,7 +23,7 @@ export const webAnalyticsFilterLogic = kea<webAnalyticsFilterLogicType>([
                 experimentId: null,
                 productTourId: null,
             }),
-            ['authorizedUrls as authorizedDomains'],
+            ['authorizedUrls as rawAuthorizedUrls'],
         ],
     })),
     actions({
@@ -164,6 +164,34 @@ export const webAnalyticsFilterLogic = kea<webAnalyticsFilterLogicType>([
     }),
     selectors({
         hasHostFilter: [(s) => [s.rawWebAnalyticsFilters], (filters) => filters.some((f) => f.key === '$host')],
+        authorizedDomains: [
+            (s) => [s.rawAuthorizedUrls],
+            (rawAuthorizedUrls: string[]): string[] => {
+                // Normalize URLs to domains:
+                // - Convert URLs to domains using url.origin
+                // - Deduplicate by hostname+port
+                // - Prefer https over http
+                const urlsByDomain = new Map<string, URL[]>()
+
+                for (const urlStr of rawAuthorizedUrls) {
+                    try {
+                        const url = new URL(urlStr)
+                        const key = url.host
+                        if (!urlsByDomain.has(key)) {
+                            urlsByDomain.set(key, [])
+                        }
+                        urlsByDomain.get(key)!.push(url)
+                    } catch {
+                        // Skip URLs that can't be parsed
+                    }
+                }
+
+                return Array.from(urlsByDomain.values()).map((urls) => {
+                    const preferredUrl = urls.find((url) => url.protocol === 'https:') ?? urls[0]
+                    return preferredUrl.origin
+                })
+            },
+        ],
         validatedDomainFilter: [
             (s) => [s.domainFilter, s.authorizedDomains],
             (domainFilter: string | null, authorizedDomains: string[]): string | null => {

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -138,6 +138,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 'compareFilter',
                 'hasHostFilter',
                 'validatedDomainFilter',
+                'authorizedDomains',
             ],
         ],
         actions: [
@@ -723,37 +724,6 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 },
                 embedded: false,
             }),
-        ],
-        authorizedDomains: [
-            (s) => [s.authorizedUrls],
-            (authorizedUrls) => {
-                // There are a couple problems with the raw `authorizedUrls` which we need to fix here:
-                // - They are URLs, we want domains
-                // - There might be duplicates, so clean them up
-                // - There might be duplicates across http/https, so clean them up
-
-                // First create URL objects and group them by hostname+port
-                const urlsByDomain = new Map<string, URL[]>()
-
-                for (const urlStr of authorizedUrls) {
-                    try {
-                        const url = new URL(urlStr)
-                        const key = url.host // hostname + port if present
-                        if (!urlsByDomain.has(key)) {
-                            urlsByDomain.set(key, [])
-                        }
-                        urlsByDomain.get(key)!.push(url)
-                    } catch {
-                        // Silently skip URLs that can't be parsed
-                    }
-                }
-
-                // For each domain, prefer https over http
-                return Array.from(urlsByDomain.values()).map((urls) => {
-                    const preferredUrl = urls.find((url) => url.protocol === 'https:') ?? urls[0]
-                    return preferredUrl.origin
-                })
-            },
         ],
     }),
     selectors(({ actions }) => ({


### PR DESCRIPTION
## Problem

The domain dropdown was reverting to "All domains" because the validation logic used raw `app_urls` (e.g., `https://example.com/`) while the dropdown displayed normalized domains (e.g., `https://example.com`). This mismatch caused `authorizedDomains.includes(domainFilter)` to return false.

## Changes

Fixed by moving the `authorizedDomains` selector from `webAnalyticsLogic` to `webAnalyticsFilterLogic`, ensuring both the dropdown and validation use the same normalized domain format.

## How did you test this code?

locally

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
