### PR TITLE
feat(kafka-deduplicator): Commit batches only after processing

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4474,6 +4474,7 @@ dependencies = [
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "tempfile",
+ "thiserror 2.0.17",
  "time",
  "tokio",
  "tokio-util",

--- a/rust/kafka-deduplicator/Cargo.toml
+++ b/rust/kafka-deduplicator/Cargo.toml
@@ -36,6 +36,7 @@ rdkafka = { workspace = true }
 rocksdb = "0.24.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 serve-metrics = { path = "../common/serve_metrics" }
 sha2 = "0.10.9"
 strum = "0.27.0"

--- a/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -8,6 +7,7 @@ use crate::kafka::metrics_consts::{
     BATCH_CONSUMER_BATCH_COLLECTION_DURATION_MS, BATCH_CONSUMER_BATCH_FILL_RATIO,
     BATCH_CONSUMER_BATCH_SIZE, BATCH_CONSUMER_KAFKA_ERROR, BATCH_CONSUMER_MESSAGES_RECEIVED,
 };
+use crate::kafka::offset_tracker::OffsetTracker;
 use crate::kafka::rebalance_handler::RebalanceHandler;
 use crate::kafka::types::Partition;
 
@@ -45,6 +45,9 @@ pub struct BatchConsumer<T> {
     // where we send batches after consuming them
     processor: Arc<dyn BatchConsumerProcessor<T>>,
 
+    // tracks processed offsets per partition for safe commits
+    offset_tracker: Arc<OffsetTracker>,
+
     // shutdown signal from parent process which
     // we assume will be wrapping start_consumption
     // in a spawned thread
@@ -60,6 +63,7 @@ where
         config: &ClientConfig,
         rebalance_handler: Arc<dyn RebalanceHandler>,
         processor: Arc<dyn BatchConsumerProcessor<T>>,
+        offset_tracker: Arc<OffsetTracker>,
         shutdown_rx: Receiver<()>,
         topic: &str,
         batch_size: usize,
@@ -86,6 +90,7 @@ where
             batch_size,
             batch_timeout,
             processor,
+            offset_tracker,
             shutdown_rx,
         })
     }
@@ -113,9 +118,6 @@ where
                 batch_result = Self::consume_batch(&mut stream, batch_size, batch_timeout) => {
                     match batch_result {
                         Ok((batch, collection_duration)) => {
-                            // track latest offsets with rdkafka consumer
-                            Self::store_offsets(&consumer, &batch);
-
                             // Record batch collection duration
                             metrics::histogram!(BATCH_CONSUMER_BATCH_COLLECTION_DURATION_MS)
                                 .record(collection_duration.as_millis() as f64);
@@ -151,15 +153,11 @@ where
                     }
                 }
 
-                // Commit offsets periodically that we store after each batch
-                // NOTE: this replicates stateful consumer direct commit handling
-                // since I assume we will initially share a ClientConfig used by
-                // stateful now when we transition. However, we can configure
-                // rdkafka internal client to *autocommit but manually store* offsets
-                // and keep the store-after-batch-created logic, and remove this manual
-                // commit operation entirely once we transition to batch consumer
+                // Commit offsets periodically from the offset tracker
+                // The offset tracker contains offsets that have been successfully processed
+                // by partition workers, ensuring we only commit what's been processed
                 _ = commit_interval.tick() => {
-                    let _ = Self::commit_offsets(&consumer);
+                    Self::commit_tracked_offsets(&consumer, &self.offset_tracker);
                 }
             }
         }
@@ -300,46 +298,48 @@ where
         &self.consumer
     }
 
-    /// best-effort attempt to store latest offsets seen in the supplied Batch.
-    /// TODO: move calls to this method downstream so processors can trigger this.
-    fn store_offsets(consumer: &StreamConsumer<BatchConsumerContext>, batch: &Batch<T>) {
-        let mut offsets = HashMap::<Partition, i64>::new();
-        for kmsg in batch.get_messages() {
-            let partition = kmsg.get_topic_partition();
-
-            if let Some(current) = offsets.get(&partition) {
-                if kmsg.get_offset() + 1 > *current {
-                    offsets.insert(partition, kmsg.get_offset() + 1);
-                }
-            } else {
-                offsets.insert(partition, kmsg.get_offset() + 1);
+    /// Commit offsets from the offset tracker to Kafka
+    ///
+    /// This commits only offsets that have been successfully processed by partition
+    /// workers, ensuring we never commit offsets for messages that haven't been processed.
+    ///
+    /// Commits are skipped during rebalancing to avoid committing offsets for partitions
+    /// that may have been revoked.
+    fn commit_tracked_offsets(
+        consumer: &StreamConsumer<BatchConsumerContext>,
+        offset_tracker: &OffsetTracker,
+    ) {
+        let offsets = match offset_tracker.get_committable_offsets() {
+            Ok(offsets) => offsets,
+            Err(crate::kafka::offset_tracker::OffsetTrackerError::RebalanceInProgress) => {
+                info!("Skipping offset commit during rebalancing");
+                metrics::counter!(
+                    crate::kafka::metrics_consts::OFFSET_TRACKER_COMMITS_SKIPPED_REBALANCING
+                )
+                .increment(1);
+                return;
             }
+        };
+
+        if offsets.is_empty() {
+            return;
         }
 
         let mut list = TopicPartitionList::new();
-        for (partition, max_offset) in offsets {
+        for (partition, next_offset) in &offsets {
             let _ = list.add_partition_offset(
                 partition.topic(),
                 partition.partition_number(),
-                rdkafka::Offset::Offset(max_offset),
+                rdkafka::Offset::Offset(*next_offset),
             );
         }
 
-        let _ = consumer.store_offsets(&list);
-    }
-
-    fn commit_offsets(consumer: &StreamConsumer<BatchConsumerContext>) -> Result<()> {
-        info!("Committing offsets...");
-
-        // Commit only the safe offsets
-        match consumer.commit_consumer_state(CommitMode::Async) {
+        match consumer.commit(&list, CommitMode::Async) {
             Ok(_) => {
-                info!("Successfully committed offsets");
-                Ok(())
+                info!("Committed offsets for {} partitions", offsets.len());
             }
             Err(e) => {
-                warn!("Failed to commit safe offsets: {e}");
-                Err(e.into())
+                warn!("Failed to commit tracked offsets: {e}");
             }
         }
     }

--- a/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
+++ b/rust/kafka-deduplicator/src/kafka/metrics_consts.rs
@@ -73,3 +73,12 @@ pub const PARTITION_WORKER_BACKPRESSURE_TOTAL: &str = "kafka_partition_worker_ba
 /// Histogram for time spent waiting due to partition worker backpressure (in milliseconds)
 pub const PARTITION_WORKER_BACKPRESSURE_WAIT_MS: &str =
     "kafka_partition_worker_backpressure_wait_ms";
+
+// ==== Offset Tracker metrics ====
+/// Counter for out-of-order batch processing events
+/// Incremented when a batch completes with a batch_id lower than or equal to the last processed batch_id
+pub const OFFSET_TRACKER_OUT_OF_ORDER_BATCH: &str = "kafka_offset_tracker_out_of_order_batch_total";
+
+/// Counter for offset commits skipped during rebalancing
+pub const OFFSET_TRACKER_COMMITS_SKIPPED_REBALANCING: &str =
+    "kafka_offset_tracker_commits_skipped_rebalancing_total";

--- a/rust/kafka-deduplicator/src/kafka/mod.rs
+++ b/rust/kafka-deduplicator/src/kafka/mod.rs
@@ -4,6 +4,7 @@ pub mod batch_context;
 pub mod batch_message;
 pub mod config;
 pub mod metrics_consts;
+pub mod offset_tracker;
 pub mod partition_router;
 pub mod partition_worker;
 pub mod rebalance_handler;
@@ -15,6 +16,7 @@ pub mod test_utils;
 
 // Public API
 pub use config::ConsumerConfigBuilder;
+pub use offset_tracker::{OffsetTracker, OffsetTrackerError};
 pub use partition_router::{PartitionRouter, PartitionRouterConfig};
 pub use partition_worker::{PartitionBatch, PartitionWorker, PartitionWorkerConfig};
 pub use rebalance_handler::RebalanceHandler;

--- a/rust/kafka-deduplicator/src/kafka/offset_tracker.rs
+++ b/rust/kafka-deduplicator/src/kafka/offset_tracker.rs
@@ -1,0 +1,458 @@
+//! Offset Tracker - Tracks the latest processed offset per partition
+//!
+//! This component provides thread-safe offset tracking to ensure we only commit
+//! offsets for batches that have been successfully processed. This is in contrast
+//! to the previous approach of committing offsets immediately after receiving them.
+//!
+//! It also provides sequential batch IDs per partition to ensure ordering.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use dashmap::DashMap;
+use thiserror::Error;
+use tracing::{debug, info, warn};
+
+use crate::kafka::metrics_consts::OFFSET_TRACKER_OUT_OF_ORDER_BATCH;
+use crate::kafka::types::Partition;
+
+/// Errors that can occur when retrieving committable offsets
+#[derive(Error, Debug)]
+pub enum OffsetTrackerError {
+    /// A rebalance is currently in progress - commits should be skipped
+    #[error("Rebalance in progress - offset commits should be skipped")]
+    RebalanceInProgress,
+}
+
+/// State tracked per partition
+struct PartitionState {
+    /// The next offset to consume (highest processed + 1)
+    processed_offset: i64,
+    /// The last batch ID that was processed (for ordering verification)
+    last_processed_batch_id: u64,
+}
+
+/// Thread-safe tracker for processed offsets per partition
+///
+/// This is used to track the highest offset that has been successfully processed
+/// for each partition. The consumer periodically queries this tracker to get
+/// offsets that are safe to commit.
+///
+/// It also assigns sequential batch IDs to ensure ordering within partitions.
+pub struct OffsetTracker {
+    /// Map of partition to state (offset + last batch ID)
+    partition_state: DashMap<Partition, PartitionState>,
+    /// Global counter for assigning batch IDs (unique across all partitions)
+    next_batch_id: AtomicU64,
+    /// Flag indicating whether a rebalance is in progress
+    /// When true, offset commits should be skipped to avoid committing during rebalancing
+    rebalancing: AtomicBool,
+}
+
+impl Default for OffsetTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OffsetTracker {
+    pub fn new() -> Self {
+        Self {
+            partition_state: DashMap::new(),
+            next_batch_id: AtomicU64::new(1), // Start at 1 so 0 can mean "no batch"
+            rebalancing: AtomicBool::new(false),
+        }
+    }
+
+    /// Set the rebalancing flag to prevent offset commits during rebalancing
+    ///
+    /// This should be called at the start of a rebalance (before any partition changes)
+    /// and cleared after the rebalance is complete.
+    pub fn set_rebalancing(&self, rebalancing: bool) {
+        let was_rebalancing = self.rebalancing.swap(rebalancing, Ordering::SeqCst);
+        if was_rebalancing != rebalancing {
+            info!(
+                rebalancing = rebalancing,
+                "Offset tracker rebalancing state changed"
+            );
+        }
+    }
+
+    /// Check if a rebalance is currently in progress
+    pub fn is_rebalancing(&self) -> bool {
+        self.rebalancing.load(Ordering::SeqCst)
+    }
+
+    /// Assign a new batch ID for a partition.
+    ///
+    /// Batch IDs are globally unique and monotonically increasing. They're used
+    /// to verify ordering when marking batches as processed.
+    pub fn assign_batch_id(&self) -> u64 {
+        self.next_batch_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Mark a batch as processed.
+    ///
+    /// The offset should be `last_offset + 1` (the next offset to consume).
+    /// The batch_id must be greater than the last processed batch_id for this
+    /// partition to ensure ordering. If a batch is processed out of order,
+    /// a warning is logged and a metric is emitted, but the offset is still
+    /// updated if it advances.
+    pub fn mark_processed(&self, partition: &Partition, batch_id: u64, next_offset: i64) {
+        self.partition_state
+            .entry(partition.clone())
+            .and_modify(|state| {
+                // Verify ordering
+                if batch_id <= state.last_processed_batch_id {
+                    warn!(
+                        topic = partition.topic(),
+                        partition = partition.partition_number(),
+                        batch_id = batch_id,
+                        last_batch_id = state.last_processed_batch_id,
+                        "Batch processed out of order"
+                    );
+                    // Emit metric for out-of-order batch processing
+                    metrics::counter!(
+                        OFFSET_TRACKER_OUT_OF_ORDER_BATCH,
+                        "topic" => partition.topic().to_string(),
+                        "partition" => partition.partition_number().to_string()
+                    )
+                    .increment(1);
+                }
+
+                // Only advance offset, never go backwards
+                if next_offset > state.processed_offset {
+                    debug!(
+                        topic = partition.topic(),
+                        partition = partition.partition_number(),
+                        batch_id = batch_id,
+                        previous_offset = state.processed_offset,
+                        new_offset = next_offset,
+                        "Advancing processed offset"
+                    );
+                    state.processed_offset = next_offset;
+                }
+
+                // Always update last batch ID to track ordering
+                if batch_id > state.last_processed_batch_id {
+                    state.last_processed_batch_id = batch_id;
+                }
+            })
+            .or_insert_with(|| {
+                debug!(
+                    topic = partition.topic(),
+                    partition = partition.partition_number(),
+                    batch_id = batch_id,
+                    offset = next_offset,
+                    "Initializing partition state"
+                );
+                PartitionState {
+                    processed_offset: next_offset,
+                    last_processed_batch_id: batch_id,
+                }
+            });
+    }
+
+    /// Get all offsets ready for commit (thread-safe snapshot)
+    ///
+    /// Returns a map of partition to next offset to consume. These offsets
+    /// can be safely committed to Kafka as they represent successfully
+    /// processed batches.
+    ///
+    /// # Errors
+    ///
+    /// Returns `OffsetTrackerError::RebalanceInProgress` if a rebalance is currently
+    /// in progress. Callers should skip committing offsets in this case.
+    pub fn get_committable_offsets(&self) -> Result<HashMap<Partition, i64>, OffsetTrackerError> {
+        // Check rebalancing flag first - if true, return error to prevent commits
+        if self.rebalancing.load(Ordering::SeqCst) {
+            return Err(OffsetTrackerError::RebalanceInProgress);
+        }
+
+        Ok(self
+            .partition_state
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().processed_offset))
+            .collect())
+    }
+
+    /// Get the current offset for a specific partition
+    pub fn get_partition_offset(&self, partition: &Partition) -> Option<i64> {
+        self.partition_state
+            .get(partition)
+            .map(|r| r.value().processed_offset)
+    }
+
+    /// Clear offset tracking for a partition (during revocation)
+    ///
+    /// Called when a partition is revoked to clean up state. The offset
+    /// should have been committed before calling this.
+    pub fn clear_partition(&self, partition: &Partition) {
+        if self.partition_state.remove(partition).is_some() {
+            debug!(
+                topic = partition.topic(),
+                partition = partition.partition_number(),
+                "Cleared offset tracking for revoked partition"
+            );
+        }
+    }
+
+    /// Clear all partitions (during shutdown)
+    pub fn clear_all(&self) {
+        self.partition_state.clear();
+    }
+
+    /// Get the number of partitions being tracked
+    pub fn partition_count(&self) -> usize {
+        self.partition_state.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_partition(num: i32) -> Partition {
+        Partition::new("test-topic".to_string(), num)
+    }
+
+    #[test]
+    fn test_assign_batch_id_is_sequential() {
+        let tracker = OffsetTracker::new();
+
+        let id1 = tracker.assign_batch_id();
+        let id2 = tracker.assign_batch_id();
+        let id3 = tracker.assign_batch_id();
+
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(id3, 3);
+    }
+
+    #[test]
+    fn test_mark_processed_initializes_offset() {
+        let tracker = OffsetTracker::new();
+        let partition = test_partition(0);
+        let batch_id = tracker.assign_batch_id();
+
+        tracker.mark_processed(&partition, batch_id, 100);
+
+        assert_eq!(tracker.get_partition_offset(&partition), Some(100));
+    }
+
+    #[test]
+    fn test_mark_processed_advances_offset() {
+        let tracker = OffsetTracker::new();
+        let partition = test_partition(0);
+
+        let batch_id1 = tracker.assign_batch_id();
+        let batch_id2 = tracker.assign_batch_id();
+
+        tracker.mark_processed(&partition, batch_id1, 100);
+        tracker.mark_processed(&partition, batch_id2, 150);
+
+        assert_eq!(tracker.get_partition_offset(&partition), Some(150));
+    }
+
+    #[test]
+    fn test_mark_processed_never_goes_backwards() {
+        let tracker = OffsetTracker::new();
+        let partition = test_partition(0);
+
+        let batch_id1 = tracker.assign_batch_id();
+        let batch_id2 = tracker.assign_batch_id();
+
+        tracker.mark_processed(&partition, batch_id1, 100);
+        tracker.mark_processed(&partition, batch_id2, 50); // Try to go backwards
+
+        // Should still be at 100
+        assert_eq!(tracker.get_partition_offset(&partition), Some(100));
+    }
+
+    #[test]
+    fn test_multiple_partitions() {
+        let tracker = OffsetTracker::new();
+        let p0 = test_partition(0);
+        let p1 = test_partition(1);
+        let p2 = test_partition(2);
+
+        let batch_id1 = tracker.assign_batch_id();
+        let batch_id2 = tracker.assign_batch_id();
+        let batch_id3 = tracker.assign_batch_id();
+
+        tracker.mark_processed(&p0, batch_id1, 100);
+        tracker.mark_processed(&p1, batch_id2, 200);
+        tracker.mark_processed(&p2, batch_id3, 300);
+
+        let offsets = tracker.get_committable_offsets().unwrap();
+
+        assert_eq!(offsets.len(), 3);
+        assert_eq!(offsets.get(&p0), Some(&100));
+        assert_eq!(offsets.get(&p1), Some(&200));
+        assert_eq!(offsets.get(&p2), Some(&300));
+    }
+
+    #[test]
+    fn test_clear_partition() {
+        let tracker = OffsetTracker::new();
+        let p0 = test_partition(0);
+        let p1 = test_partition(1);
+
+        let batch_id1 = tracker.assign_batch_id();
+        let batch_id2 = tracker.assign_batch_id();
+
+        tracker.mark_processed(&p0, batch_id1, 100);
+        tracker.mark_processed(&p1, batch_id2, 200);
+
+        tracker.clear_partition(&p0);
+
+        assert_eq!(tracker.get_partition_offset(&p0), None);
+        assert_eq!(tracker.get_partition_offset(&p1), Some(200));
+        assert_eq!(tracker.partition_count(), 1);
+    }
+
+    #[test]
+    fn test_clear_all() {
+        let tracker = OffsetTracker::new();
+
+        let batch_id1 = tracker.assign_batch_id();
+        let batch_id2 = tracker.assign_batch_id();
+        let batch_id3 = tracker.assign_batch_id();
+
+        tracker.mark_processed(&test_partition(0), batch_id1, 100);
+        tracker.mark_processed(&test_partition(1), batch_id2, 200);
+        tracker.mark_processed(&test_partition(2), batch_id3, 300);
+
+        assert_eq!(tracker.partition_count(), 3);
+
+        tracker.clear_all();
+
+        assert_eq!(tracker.partition_count(), 0);
+    }
+
+    #[test]
+    fn test_concurrent_updates_same_partition() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let tracker = Arc::new(OffsetTracker::new());
+        let partition = test_partition(0);
+
+        // Pre-assign batch IDs so they're sequential
+        let batch_ids: Vec<u64> = (0..10).map(|_| tracker.assign_batch_id()).collect();
+
+        let mut handles = vec![];
+
+        // Spawn multiple threads that update the same partition
+        for (i, batch_id) in batch_ids.into_iter().enumerate() {
+            let tracker_clone = tracker.clone();
+            let partition_clone = partition.clone();
+            let offset = ((i + 1) * 100) as i64; // 100, 200, 300, ...
+
+            handles.push(thread::spawn(move || {
+                tracker_clone.mark_processed(&partition_clone, batch_id, offset);
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // The highest offset should win (1000)
+        assert_eq!(tracker.get_partition_offset(&partition), Some(1000));
+    }
+
+    #[test]
+    fn test_concurrent_different_partitions() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let tracker = Arc::new(OffsetTracker::new());
+
+        // Pre-assign batch IDs
+        let batch_ids: Vec<u64> = (0..10).map(|_| tracker.assign_batch_id()).collect();
+
+        let mut handles = vec![];
+
+        // Spawn multiple threads, each updating a different partition
+        for (i, batch_id) in batch_ids.into_iter().enumerate() {
+            let tracker_clone = tracker.clone();
+            let partition = test_partition(i as i32);
+            let offset = (i as i64 + 1) * 100;
+
+            handles.push(thread::spawn(move || {
+                tracker_clone.mark_processed(&partition, batch_id, offset);
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let offsets = tracker.get_committable_offsets().unwrap();
+        assert_eq!(offsets.len(), 10);
+
+        for i in 0..10 {
+            let partition = test_partition(i);
+            let expected = (i as i64 + 1) * 100;
+            assert_eq!(offsets.get(&partition), Some(&expected));
+        }
+    }
+
+    #[test]
+    fn test_out_of_order_batch_processing() {
+        // This tests the scenario where batches complete out of order
+        // (e.g., batch 2 finishes before batch 1)
+        let tracker = OffsetTracker::new();
+        let partition = test_partition(0);
+
+        let batch_id1 = tracker.assign_batch_id(); // 1
+        let batch_id2 = tracker.assign_batch_id(); // 2
+
+        // Batch 2 completes first with higher offset
+        tracker.mark_processed(&partition, batch_id2, 200);
+        assert_eq!(tracker.get_partition_offset(&partition), Some(200));
+
+        // Batch 1 completes later with lower offset - should not regress
+        tracker.mark_processed(&partition, batch_id1, 100);
+        assert_eq!(tracker.get_partition_offset(&partition), Some(200));
+    }
+
+    #[test]
+    fn test_rebalancing_flag() {
+        let tracker = OffsetTracker::new();
+        let partition = test_partition(0);
+        let batch_id = tracker.assign_batch_id();
+
+        // Initially not rebalancing
+        assert!(!tracker.is_rebalancing());
+
+        // Mark some offsets
+        tracker.mark_processed(&partition, batch_id, 100);
+
+        // Should be able to get offsets
+        let offsets = tracker.get_committable_offsets();
+        assert!(offsets.is_ok());
+        assert_eq!(offsets.unwrap().get(&partition), Some(&100));
+
+        // Start rebalancing
+        tracker.set_rebalancing(true);
+        assert!(tracker.is_rebalancing());
+
+        // Should get RebalanceInProgress error
+        let result = tracker.get_committable_offsets();
+        assert!(matches!(
+            result,
+            Err(OffsetTrackerError::RebalanceInProgress)
+        ));
+
+        // End rebalancing
+        tracker.set_rebalancing(false);
+        assert!(!tracker.is_rebalancing());
+
+        // Should be able to get offsets again
+        let offsets = tracker.get_committable_offsets();
+        assert!(offsets.is_ok());
+        assert_eq!(offsets.unwrap().get(&partition), Some(&100));
+    }
+}

--- a/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
@@ -1,18 +1,29 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use axum::async_trait;
 use kafka_deduplicator::kafka::{
-    batch_consumer::*, batch_message::*, test_utils::TestRebalanceHandler,
+    batch_consumer::*,
+    batch_message::*,
+    offset_tracker::OffsetTracker,
+    partition_router::{shutdown_workers, PartitionRouter, PartitionRouterConfig},
+    rebalance_handler::RebalanceHandler,
+    routing_processor::RoutingProcessor,
+    test_utils::TestRebalanceHandler,
+    types::Partition,
 };
 
 use common_types::CapturedEvent;
 
 use anyhow::Result;
 use rdkafka::{
+    admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
     config::ClientConfig,
+    consumer::{Consumer, StreamConsumer},
     producer::{FutureProducer, FutureRecord},
     util::Timeout,
+    TopicPartitionList,
 };
 use time::OffsetDateTime;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
@@ -67,11 +78,13 @@ fn create_batch_kafka_consumer(
     }
 
     let processor = Arc::new(TestProcessor { sender: chan_tx });
+    let offset_tracker = Arc::new(OffsetTracker::new());
 
     let consumer = BatchConsumer::<CapturedEvent>::new(
         &config,
         Arc::new(TestRebalanceHandler::default()),
         processor,
+        offset_tracker,
         shutdown_rx,
         topic,
         batch_size,
@@ -197,6 +210,312 @@ async fn test_simple_batch_kafka_consumer() -> Result<()> {
 
     // Wait for graceful shutdown
     let _ = consumer_handle.await;
+
+    Ok(())
+}
+
+/// Helper to create a topic with a specific number of partitions
+async fn create_topic_with_partitions(topic: &str, num_partitions: i32) -> Result<()> {
+    use rdkafka::client::DefaultClientContext;
+
+    let admin_client: AdminClient<DefaultClientContext> = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .create()?;
+
+    let new_topic = NewTopic::new(topic, num_partitions, TopicReplication::Fixed(1));
+    let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(5)));
+
+    let results = admin_client.create_topics(&[new_topic], &opts).await?;
+
+    for result in results {
+        match result {
+            Ok(_) => {}
+            Err((_, rdkafka::types::RDKafkaErrorCode::TopicAlreadyExists)) => {
+                // Topic already exists, that's fine
+            }
+            Err((topic_name, err)) => {
+                return Err(anyhow::anyhow!(
+                    "Failed to create topic {topic_name}: {err:?}"
+                ));
+            }
+        }
+    }
+
+    // Wait for topic metadata to propagate
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(())
+}
+
+/// Helper to send test messages to a specific partition
+async fn send_test_messages_to_partition(
+    topic: &str,
+    partition: i32,
+    messages: Vec<(String, String)>,
+) -> Result<()> {
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .set("message.timeout.ms", "5000")
+        .create()?;
+
+    for (key, value) in messages {
+        let record = FutureRecord::to(topic)
+            .key(&key)
+            .payload(&value)
+            .partition(partition);
+
+        producer
+            .send(record, Timeout::After(Duration::from_secs(5)))
+            .await
+            .map_err(|(e, _)| anyhow::anyhow!("Failed to send message: {e}"))?;
+    }
+
+    // Give kafka some time to process the messages
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    Ok(())
+}
+
+/// Test rebalance handler that also manages partition workers via a router
+struct RoutingRebalanceHandler {
+    inner: TestRebalanceHandler,
+    router: Arc<PartitionRouter<CapturedEvent, CountingProcessor>>,
+    offset_tracker: Arc<OffsetTracker>,
+}
+
+impl RoutingRebalanceHandler {
+    fn new(
+        router: Arc<PartitionRouter<CapturedEvent, CountingProcessor>>,
+        offset_tracker: Arc<OffsetTracker>,
+    ) -> Self {
+        Self {
+            inner: TestRebalanceHandler::default(),
+            router,
+            offset_tracker,
+        }
+    }
+}
+
+#[async_trait]
+impl RebalanceHandler for RoutingRebalanceHandler {
+    fn setup_assigned_partitions(&self, partitions: &TopicPartitionList) {
+        self.inner.setup_assigned_partitions(partitions);
+
+        // Create workers for assigned partitions
+        for elem in partitions.elements() {
+            let partition = Partition::new(elem.topic().to_string(), elem.partition());
+            self.router.add_partition(partition);
+        }
+    }
+
+    fn setup_revoked_partitions(&self, partitions: &TopicPartitionList) {
+        self.inner.setup_revoked_partitions(partitions);
+    }
+
+    async fn cleanup_assigned_partitions(&self, partitions: &TopicPartitionList) -> Result<()> {
+        self.inner.cleanup_assigned_partitions(partitions).await
+    }
+
+    async fn cleanup_revoked_partitions(&self, partitions: &TopicPartitionList) -> Result<()> {
+        // Shutdown workers for revoked partitions
+        let partitions_to_cleanup: Vec<_> = partitions
+            .elements()
+            .iter()
+            .map(|elem| Partition::new(elem.topic().to_string(), elem.partition()))
+            .collect();
+
+        let workers = self.router.remove_partitions(&partitions_to_cleanup);
+        shutdown_workers(workers).await;
+
+        // Clear offset tracker state
+        for partition in &partitions_to_cleanup {
+            self.offset_tracker.clear_partition(partition);
+        }
+
+        self.inner.cleanup_revoked_partitions(partitions).await
+    }
+
+    async fn on_pre_rebalance(&self) -> Result<()> {
+        self.offset_tracker.set_rebalancing(true);
+        self.inner.on_pre_rebalance().await
+    }
+
+    async fn on_post_rebalance(&self) -> Result<()> {
+        self.offset_tracker.set_rebalancing(false);
+        self.inner.on_post_rebalance().await
+    }
+}
+
+/// A simple processor that counts processed messages
+struct CountingProcessor {
+    count: AtomicUsize,
+}
+
+impl CountingProcessor {
+    fn new() -> Self {
+        Self {
+            count: AtomicUsize::new(0),
+        }
+    }
+
+    fn get_count(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl BatchConsumerProcessor<CapturedEvent> for CountingProcessor {
+    async fn process_batch(&self, messages: Vec<KafkaMessage<CapturedEvent>>) -> Result<()> {
+        self.count.fetch_add(messages.len(), Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+/// Integration test that verifies offset commits work correctly with the routing processor.
+///
+/// This test:
+/// 1. Creates a topic with 3 partitions and sends 100 messages to each
+/// 2. Runs the batch consumer with routing processor and partition workers
+/// 3. Waits for all messages to be processed
+/// 4. Verifies the consumer group offsets are committed at the correct positions
+#[tokio::test]
+async fn test_offset_commits_with_routing_processor() -> Result<()> {
+    let test_topic = format!("{}-offset-commit-{}", TEST_TOPIC_BASE, uuid::Uuid::now_v7());
+    let group_id = format!("test-group-offset-commit-{}", uuid::Uuid::now_v7());
+    let messages_per_partition = 100;
+    let partitions_to_use = vec![0, 1, 2];
+    let total_messages = messages_per_partition * partitions_to_use.len();
+
+    // Step 1: Create topic with the required number of partitions
+    create_topic_with_partitions(&test_topic, partitions_to_use.len() as i32).await?;
+
+    // Step 2: Send messages to specific partitions
+    for partition in &partitions_to_use {
+        let messages = generate_test_messages(messages_per_partition);
+        send_test_messages_to_partition(&test_topic, *partition, messages).await?;
+    }
+
+    // Step 3: Set up the consumer with routing processor
+    let mut config = ClientConfig::new();
+    config
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .set("group.id", &group_id)
+        .set("enable.auto.commit", "false")
+        .set("auto.offset.reset", "earliest")
+        .set("session.timeout.ms", "6000")
+        .set("heartbeat.interval.ms", "2000");
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    // Create the processor that counts messages
+    let processor = Arc::new(CountingProcessor::new());
+
+    // Create offset tracker
+    let offset_tracker = Arc::new(OffsetTracker::new());
+
+    // Create router with partition workers
+    let router = Arc::new(PartitionRouter::new(
+        processor.clone(),
+        offset_tracker.clone(),
+        PartitionRouterConfig::default(),
+    ));
+
+    // Create routing processor
+    let routing_processor = Arc::new(RoutingProcessor::new(
+        router.clone(),
+        offset_tracker.clone(),
+    ));
+
+    // Create rebalance handler that manages workers
+    let rebalance_handler = Arc::new(RoutingRebalanceHandler::new(
+        router.clone(),
+        offset_tracker.clone(),
+    ));
+
+    // Create the batch consumer
+    let consumer = BatchConsumer::<CapturedEvent>::new(
+        &config,
+        rebalance_handler,
+        routing_processor,
+        offset_tracker.clone(),
+        shutdown_rx,
+        &test_topic,
+        50, // batch size
+        Duration::from_millis(100),
+        Duration::from_millis(500), // commit interval - 500ms to ensure commits happen
+    )?;
+
+    // Step 4: Start consumption and wait for processing
+    let processor_clone = processor.clone();
+    let consumer_handle = tokio::spawn(async move { consumer.start_consumption().await });
+
+    // Wait for all messages to be processed
+    let start = std::time::Instant::now();
+    let timeout = Duration::from_secs(30);
+    while processor_clone.get_count() < total_messages {
+        if start.elapsed() > timeout {
+            panic!(
+                "Timeout waiting for messages. Got {} of {}",
+                processor_clone.get_count(),
+                total_messages
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Wait a bit longer to ensure offset commits have happened
+    // The commit interval is 500ms, so wait 1 second to be safe
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Shutdown the consumer
+    let _ = shutdown_tx.send(());
+    let _ = consumer_handle.await;
+
+    // Shutdown all workers
+    let workers = router.shutdown_all();
+    shutdown_workers(workers).await;
+
+    // Step 5: Verify committed offsets using a new consumer
+    let verification_consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .set("group.id", &group_id)
+        .set("enable.auto.commit", "false")
+        .create()?;
+
+    // Build topic partition list for the partitions we used
+    let mut tpl = TopicPartitionList::new();
+    for partition in &partitions_to_use {
+        tpl.add_partition(&test_topic, *partition);
+    }
+
+    // Fetch committed offsets
+    let committed = verification_consumer.committed_offsets(tpl, Duration::from_secs(5))?;
+
+    // Verify each partition has the correct committed offset
+    for partition in &partitions_to_use {
+        let offset = committed
+            .find_partition(&test_topic, *partition)
+            .expect("Partition should exist in committed offsets");
+
+        match offset.offset() {
+            rdkafka::Offset::Offset(o) => {
+                // The committed offset should be messages_per_partition (100)
+                // because offset represents "next offset to consume"
+                assert_eq!(
+                    o, messages_per_partition as i64,
+                    "Partition {partition} should have committed offset {messages_per_partition}, got {o}"
+                );
+            }
+            other => {
+                panic!("Partition {partition} should have a specific offset, got {other:?}");
+            }
+        }
+    }
+
+    // Verify total processed count
+    assert_eq!(
+        processor.get_count(),
+        total_messages,
+        "Should have processed all {total_messages} messages"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

The kafka-deduplicator was committing offsets immediately after receiving messages rather than after successful processing. This could lead to data loss if the service crashed between receiving and processing messages.

## Changes

- Added `OffsetTracker` that tracks processed offsets per partition with rebalancing protection
- Partition workers now call `mark_processed()` after successful batch processing
- `BatchConsumer` commits from `OffsetTracker` instead of on receive
- Rebalance handler sets rebalancing flag to prevent commits during partition changes

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
