### PR TITLE
feat: Disallow modifying unused sensitive fields from Admin

### DIFF
--- a/posthog/admin/admins/organization_domain_admin.py
+++ b/posthog/admin/admins/organization_domain_admin.py
@@ -20,6 +20,8 @@ class OrganizationDomainAdmin(admin.ModelAdmin):
     search_fields = ("domain", "organization__name")
     readonly_fields = (
         "id",
+        "domain",
+        "verified_at",
         "verification_challenge",
         "last_verification_retry",
     )

--- a/posthog/admin/admins/user_admin.py
+++ b/posthog/admin/admins/user_admin.py
@@ -88,8 +88,11 @@ class UserAdmin(DjangoUserAdmin):
     search_fields = ("email", "first_name", "last_name")
     readonly_fields = [
         "id",
+        "email",
+        "pending_email",
         "current_team",
         "current_organization",
+        "is_email_verified",
         "email_verification_status",
         "revoke_sessions_link",
         "allow_impersonation",

--- a/posthog/admin/admins/user_admin.py
+++ b/posthog/admin/admins/user_admin.py
@@ -96,6 +96,8 @@ class UserAdmin(DjangoUserAdmin):
         "email_verification_status",
         "revoke_sessions_link",
         "allow_impersonation",
+        "last_login",
+        "date_joined",
     ]
     ordering = ("email",)
 

--- a/posthog/admin/inlines/organization_domain_inline.py
+++ b/posthog/admin/inlines/organization_domain_inline.py
@@ -18,6 +18,10 @@ class OrganizationDomainInline(TabularInlinePaginated):
         "verification_challenge",
     )
 
-    readonly_fields = ("verification_challenge", "verified_at")
+    readonly_fields = ("id", "domain", "verification_challenge", "verified_at")
 
     ordering = ("domain",)
+
+    def has_add_permission(self, request, obj=None):
+        # Prevent adding Domains through the admin (they should be created via API)
+        return False

--- a/posthog/admin/inlines/organization_member_inline.py
+++ b/posthog/admin/inlines/organization_member_inline.py
@@ -9,6 +9,6 @@ class OrganizationMemberInline(TabularInlinePaginated):
     per_page = 20
     pagination_key = "page-member"
     show_change_link = True
-    readonly_fields = ("user", "joined_at", "updated_at")
+    readonly_fields = ("organization", "user", "joined_at", "updated_at")
     autocomplete_fields = ("organization",)
     ordering = ("-level",)  # Order by level descending (Owner -> Admin -> Member)

--- a/posthog/admin/inlines/totp_device_inline.py
+++ b/posthog/admin/inlines/totp_device_inline.py
@@ -8,3 +8,18 @@ class TOTPDeviceInline(admin.TabularInline):
     extra = 0
     # only include non-sensitive fields
     fields = ("name", "confirmed", "throttling_failure_timestamp", "throttling_failure_count", "last_used_at")
+    readonly_fields = ("name", "confirmed", "throttling_failure_timestamp", "throttling_failure_count", "last_used_at")
+    can_delete = False
+    show_change_link = True
+
+    def has_add_permission(self, request, obj=None):
+        # Prevent adding TOTP devices through the admin (they should be created via API)
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        # Make the inline completely read-only to prevent formset validation issues
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        # Ensure the inline is still visible even though change permission is False
+        return True

--- a/posthog/admin/inlines/totp_device_inline.py
+++ b/posthog/admin/inlines/totp_device_inline.py
@@ -10,7 +10,7 @@ class TOTPDeviceInline(admin.TabularInline):
     fields = ("name", "confirmed", "throttling_failure_timestamp", "throttling_failure_count", "last_used_at")
     readonly_fields = ("name", "confirmed", "throttling_failure_timestamp", "throttling_failure_count", "last_used_at")
     can_delete = False
-    show_change_link = True
+    show_change_link = False
 
     def has_add_permission(self, request, obj=None):
         # Prevent adding TOTP devices through the admin (they should be created via API)


### PR DESCRIPTION
## Problem

Django's admin models take the approach of allowing staff to modify all fields by default. But there are sensitive fields that shouldn't be modified outside of the standard user flow.

## Changes

Staff can no longer perform the following sensitive actions:

- Modify a user's email, pending email, or email verification status
- Modify a domain's domain or verification status
- Add a new domain to an organization
- Modify a member's organization (i.e. move a member between organizations)
- Modify a user's existing TOTP MFA device, or add a new one