### PR TITLE
fix(flags): Add periodic cleanup for rate limiter memory leak

### DIFF
--- a/rust/feature-flags/scripts/hammer_rate_limiter.sh
+++ b/rust/feature-flags/scripts/hammer_rate_limiter.sh
@@ -89,8 +89,8 @@ echo ""
 
 # Generate and send requests
 for i in $(seq 1 $NUM_TOKENS); do
-    # Generate unique token
-    TOKEN="phc_test_token_$(printf '%06d' $i)_$(date +%s%N | md5sum | head -c 8)"
+    # Generate unique token (using openssl for portability across Linux/macOS)
+    TOKEN="phc_test_token_$(printf '%06d' $i)_$(openssl rand -hex 4)"
 
     for j in $(seq 1 $REQUESTS_PER_TOKEN); do
         # Run in background up to CONCURRENCY limit

--- a/rust/feature-flags/scripts/hammer_rate_limiter.sh
+++ b/rust/feature-flags/scripts/hammer_rate_limiter.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+#
+# Hammer the feature flags endpoint with many unique tokens to test rate limiter cleanup.
+#
+# This script generates many unique tokens and sends requests to populate the rate
+# limiter's internal state. Use it to verify that the periodic cleanup task correctly
+# removes stale entries and prevents unbounded memory growth.
+#
+# PREREQUISITES:
+#   1. GeoIP database must exist at share/GeoLite2-City.mmdb
+#      Download test DB: curl -sL "https://github.com/maxmind/MaxMind-DB/raw/main/test-data/GeoIP2-City-Test.mmdb" -o share/GeoLite2-City.mmdb
+#
+#   2. Rate limiting must be enabled (disabled by default):
+#      FLAGS_RATE_LIMIT_ENABLED=true FLAGS_IP_RATE_LIMIT_ENABLED=true
+#
+# TESTING THE CLEANUP:
+#
+#   Terminal 1 - Start the server with a short cleanup interval for testing:
+#     FLAGS_RATE_LIMIT_ENABLED=true FLAGS_IP_RATE_LIMIT_ENABLED=true \
+#     RATE_LIMITER_CLEANUP_INTERVAL_SECS=5 \
+#     RUST_LOG=debug cargo run 2>&1 | grep -E "(cleanup|entries|Rate limiter)"
+#
+#   Terminal 2 - Run this script:
+#     ./scripts/hammer_rate_limiter.sh
+#
+#   Expected output in Terminal 1:
+#     - token_entries increases during the hammer run (e.g., 20-100+ entries)
+#     - After requests stop, token_entries drops to 0 on the next cleanup cycle
+#     - ip_entries=1 (all requests from localhost share one IP)
+#
+# OPTIONS:
+#   -n NUM_TOKENS    Number of unique tokens to generate (default: 1000)
+#   -r REQUESTS      Requests per token (default: 5)
+#   -h HOST          Target host (default: http://localhost:3001)
+#   -c CONCURRENCY   Concurrent requests (default: 50)
+
+set -e
+
+# Defaults
+NUM_TOKENS=1000
+REQUESTS_PER_TOKEN=5
+HOST="http://localhost:3001"
+CONCURRENCY=50
+
+# Parse args
+while getopts "n:r:h:c:" opt; do
+    case $opt in
+        n) NUM_TOKENS=$OPTARG ;;
+        r) REQUESTS_PER_TOKEN=$OPTARG ;;
+        h) HOST=$OPTARG ;;
+        c) CONCURRENCY=$OPTARG ;;
+        *) echo "Usage: $0 [-n num_tokens] [-r requests_per_token] [-h host] [-c concurrency]" && exit 1 ;;
+    esac
+done
+
+ENDPOINT="$HOST/flags"
+
+echo "=== Rate Limiter Hammer Test ==="
+echo "Host:              $HOST"
+echo "Endpoint:          $ENDPOINT"
+echo "Unique tokens:     $NUM_TOKENS"
+echo "Requests/token:    $REQUESTS_PER_TOKEN"
+echo "Total requests:    $((NUM_TOKENS * REQUESTS_PER_TOKEN))"
+echo "Concurrency:       $CONCURRENCY"
+echo ""
+echo "Starting in 3 seconds... (Ctrl+C to cancel)"
+sleep 3
+
+# Generate request function
+make_request() {
+    local token=$1
+    curl -s -o /dev/null -w "%{http_code}" \
+        -X POST "$ENDPOINT" \
+        -H "Content-Type: application/json" \
+        -d "{\"token\": \"$token\", \"distinct_id\": \"test-user\"}" \
+        2>/dev/null || echo "ERR"
+}
+
+export -f make_request
+export ENDPOINT
+
+# Track progress
+TOTAL=$((NUM_TOKENS * REQUESTS_PER_TOKEN))
+COUNT=0
+START_TIME=$(date +%s)
+
+echo "Sending requests..."
+echo ""
+
+# Generate and send requests
+for i in $(seq 1 $NUM_TOKENS); do
+    # Generate unique token
+    TOKEN="phc_test_token_$(printf '%06d' $i)_$(date +%s%N | md5sum | head -c 8)"
+
+    for j in $(seq 1 $REQUESTS_PER_TOKEN); do
+        # Run in background up to CONCURRENCY limit
+        while [ $(jobs -r | wc -l) -ge $CONCURRENCY ]; do
+            sleep 0.01
+        done
+
+        make_request "$TOKEN" &
+
+        COUNT=$((COUNT + 1))
+        if [ $((COUNT % 100)) -eq 0 ]; then
+            ELAPSED=$(($(date +%s) - START_TIME))
+            RATE=$((COUNT / (ELAPSED + 1)))
+            printf "\rProgress: %d/%d requests (%d req/s)" "$COUNT" "$TOTAL" "$RATE"
+        fi
+    done
+done
+
+# Wait for remaining requests
+wait
+
+END_TIME=$(date +%s)
+ELAPSED=$((END_TIME - START_TIME))
+
+echo ""
+echo ""
+echo "=== Complete ==="
+echo "Total requests:    $TOTAL"
+echo "Time elapsed:      ${ELAPSED}s"
+echo "Average rate:      $((TOTAL / (ELAPSED + 1))) req/s"
+echo ""
+echo "Now wait 60-70 seconds for cleanup to run, and check the logs for:"
+echo "  - 'Rate limiter cleanup completed'"
+echo "  - 'token_entries', 'ip_entries', 'definitions_entries'"
+echo ""
+echo "The entry counts should drop significantly after cleanup."

--- a/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
@@ -192,6 +192,14 @@ where
         }
     }
 
+    /// Removes stale entries and shrinks capacity across all limiters.
+    ///
+    /// Convenience method that calls `retain_recent()` followed by `shrink_to_fit()`.
+    pub fn cleanup(&self) {
+        self.retain_recent();
+        self.shrink_to_fit();
+    }
+
     /// Returns the total number of keys currently tracked across all limiters.
     ///
     /// Note: This may return an approximate value.

--- a/rust/feature-flags/src/api/flags_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flags_rate_limiter.rs
@@ -147,6 +147,13 @@ impl KeyedRateLimiter {
     fn len(&self) -> usize {
         self.limiter.len()
     }
+
+    /// Returns true if no keys are currently tracked.
+    ///
+    /// Note: This is approximate and shares the same limitations as `len()`.
+    fn is_empty(&self) -> bool {
+        self.limiter.is_empty()
+    }
 }
 
 /// Token bucket rate limiter for feature flag requests.
@@ -256,10 +263,9 @@ impl FlagsRateLimiter {
 
     /// Returns true if no keys are currently tracked.
     ///
-    /// Note: This is approximate since the underlying state store may have
-    /// concurrent modifications. Use for monitoring, not correctness.
+    /// Note: This is approximate and shares the same limitations as [`Self::len`].
     pub fn is_empty(&self) -> bool {
-        self.inner.len() == 0
+        self.inner.is_empty()
     }
 }
 
@@ -525,10 +531,9 @@ impl IpRateLimiter {
 
     /// Returns true if no keys are currently tracked.
     ///
-    /// Note: This is approximate since the underlying state store may have
-    /// concurrent modifications. Use for monitoring, not correctness.
+    /// Note: This is approximate and shares the same limitations as [`Self::len`].
     pub fn is_empty(&self) -> bool {
-        self.inner.len() == 0
+        self.inner.is_empty()
     }
 }
 

--- a/rust/feature-flags/src/api/flags_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flags_rate_limiter.rs
@@ -147,13 +147,6 @@ impl KeyedRateLimiter {
     fn len(&self) -> usize {
         self.limiter.len()
     }
-
-    /// Returns true if no keys are currently tracked.
-    ///
-    /// Note: This is approximate and shares the same limitations as `len()`.
-    fn is_empty(&self) -> bool {
-        self.limiter.is_empty()
-    }
 }
 
 /// Token bucket rate limiter for feature flag requests.
@@ -257,15 +250,9 @@ impl FlagsRateLimiter {
     }
 
     /// Returns the approximate number of keys currently tracked.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.inner.len()
-    }
-
-    /// Returns true if no keys are currently tracked.
-    ///
-    /// Note: This is approximate and shares the same limitations as [`Self::len`].
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
     }
 }
 
@@ -525,15 +512,9 @@ impl IpRateLimiter {
     }
 
     /// Returns the approximate number of keys currently tracked.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.inner.len()
-    }
-
-    /// Returns true if no keys are currently tracked.
-    ///
-    /// Note: This is approximate and shares the same limitations as [`Self::len`].
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
     }
 }
 

--- a/rust/feature-flags/src/api/flags_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flags_rate_limiter.rs
@@ -234,27 +234,13 @@ impl FlagsRateLimiter {
         self.inner.allow_request(bucket_key)
     }
 
-    /// Removes stale entries from the rate limiter to prevent unbounded memory growth.
+    /// Removes stale entries and reclaims memory.
     ///
     /// This should be called periodically (e.g., every 60 seconds) by a background task.
     /// Keys that haven't been used within the rate limit window are removed.
-    pub fn retain_recent(&self) {
-        self.inner.retain_recent();
-    }
-
-    /// Shrinks the capacity of the rate limiter's state store if possible.
-    ///
-    /// Should be called after `retain_recent()` to reclaim memory.
-    pub fn shrink_to_fit(&self) {
-        self.inner.shrink_to_fit();
-    }
-
-    /// Removes stale entries and shrinks capacity.
-    ///
-    /// Convenience method that calls `retain_recent()` followed by `shrink_to_fit()`.
     pub fn cleanup(&self) {
-        self.retain_recent();
-        self.shrink_to_fit();
+        self.inner.retain_recent();
+        self.inner.shrink_to_fit();
     }
 
     /// Returns the approximate number of keys currently tracked.
@@ -504,27 +490,13 @@ impl IpRateLimiter {
         self.inner.allow_request(ip)
     }
 
-    /// Removes stale entries from the rate limiter to prevent unbounded memory growth.
+    /// Removes stale entries and reclaims memory.
     ///
     /// This should be called periodically (e.g., every 60 seconds) by a background task.
     /// Keys that haven't been used within the rate limit window are removed.
-    pub fn retain_recent(&self) {
-        self.inner.retain_recent();
-    }
-
-    /// Shrinks the capacity of the rate limiter's state store if possible.
-    ///
-    /// Should be called after `retain_recent()` to reclaim memory.
-    pub fn shrink_to_fit(&self) {
-        self.inner.shrink_to_fit();
-    }
-
-    /// Removes stale entries and shrinks capacity.
-    ///
-    /// Convenience method that calls `retain_recent()` followed by `shrink_to_fit()`.
     pub fn cleanup(&self) {
-        self.retain_recent();
-        self.shrink_to_fit();
+        self.inner.retain_recent();
+        self.inner.shrink_to_fit();
     }
 
     /// Returns the approximate number of keys currently tracked.

--- a/rust/feature-flags/src/api/flags_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flags_rate_limiter.rs
@@ -249,6 +249,14 @@ impl FlagsRateLimiter {
         self.inner.shrink_to_fit();
     }
 
+    /// Removes stale entries and shrinks capacity.
+    ///
+    /// Convenience method that calls `retain_recent()` followed by `shrink_to_fit()`.
+    pub fn cleanup(&self) {
+        self.retain_recent();
+        self.shrink_to_fit();
+    }
+
     /// Returns the approximate number of keys currently tracked.
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
@@ -509,6 +517,14 @@ impl IpRateLimiter {
     /// Should be called after `retain_recent()` to reclaim memory.
     pub fn shrink_to_fit(&self) {
         self.inner.shrink_to_fit();
+    }
+
+    /// Removes stale entries and shrinks capacity.
+    ///
+    /// Convenience method that calls `retain_recent()` followed by `shrink_to_fit()`.
+    pub fn cleanup(&self) {
+        self.retain_recent();
+        self.shrink_to_fit();
     }
 
     /// Returns the approximate number of keys currently tracked.

--- a/rust/feature-flags/src/api/flags_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flags_rate_limiter.rs
@@ -255,6 +255,9 @@ impl FlagsRateLimiter {
     }
 
     /// Returns true if no keys are currently tracked.
+    ///
+    /// Note: This is approximate since the underlying state store may have
+    /// concurrent modifications. Use for monitoring, not correctness.
     pub fn is_empty(&self) -> bool {
         self.inner.len() == 0
     }
@@ -521,6 +524,9 @@ impl IpRateLimiter {
     }
 
     /// Returns true if no keys are currently tracked.
+    ///
+    /// Note: This is approximate since the underlying state store may have
+    /// concurrent modifications. Use for monitoring, not correctness.
     pub fn is_empty(&self) -> bool {
         self.inner.len() == 0
     }

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -475,6 +475,13 @@ pub struct Config {
     #[envconfig(from = "FLAGS_IP_RATE_LIMIT_LOG_ONLY", default = "true")]
     pub flags_ip_rate_limit_log_only: FlexBool,
 
+    // How often to clean up stale rate limiter entries (seconds)
+    // The governor crate's keyed rate limiters accumulate entries for every unique key.
+    // Without periodic cleanup, this leads to unbounded memory growth.
+    // This interval controls how often retain_recent() is called to remove stale entries.
+    #[envconfig(from = "RATE_LIMITER_CLEANUP_INTERVAL_SECS", default = "60")]
+    pub rate_limiter_cleanup_interval_secs: u64,
+
     // Redis compression configuration
     // When enabled, uses zstd compression for Redis values above threshold
     // The `default_test_config()` sets this to true for test/development scenarios.
@@ -603,6 +610,7 @@ impl Config {
             flags_ip_replenish_rate: 100.0,
             flags_rate_limit_log_only: FlexBool(true),
             flags_ip_rate_limit_log_only: FlexBool(true),
+            rate_limiter_cleanup_interval_secs: 60,
             redis_compression_enabled: FlexBool(true),
             redis_client_retry_count: 3,
         }

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -1,4 +1,4 @@
-use std::{future::ready, sync::Arc};
+use std::{future::ready, sync::Arc, time::Duration};
 
 use crate::billing_limiters::{FeatureFlagsLimiter, SessionReplayLimiter};
 use crate::database_pools::DatabasePools;
@@ -12,6 +12,7 @@ use common_geoip::GeoIpClient;
 use common_metrics::{setup_metrics_recorder, track_metrics};
 use common_redis::Client as RedisClient;
 use health::HealthRegistry;
+use metrics::gauge;
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::{
     cors::{AllowHeaders, AllowOrigin, CorsLayer},
@@ -107,6 +108,13 @@ pub fn router(
     // Clone database_pools for readiness check before moving into State
     let db_pools_for_readiness = database_pools.clone();
 
+    spawn_rate_limiter_cleanup_task(
+        flags_rate_limiter.clone(),
+        ip_rate_limiter.clone(),
+        flag_definitions_limiter.clone(),
+        config.rate_limiter_cleanup_interval_secs,
+    );
+
     let state = State {
         redis_client,
         dedicated_redis_client,
@@ -175,6 +183,47 @@ pub fn router(
     } else {
         router
     }
+}
+
+/// Spawns a background task to periodically clean up stale rate limiter entries.
+/// Without this, the rate limiters would accumulate entries for every unique
+/// token/IP that makes a request, leading to unbounded memory growth.
+/// See: https://docs.rs/governor/latest/governor/struct.RateLimiter.html#method.retain_recent
+fn spawn_rate_limiter_cleanup_task(
+    flags_rate_limiter: FlagsRateLimiter,
+    ip_rate_limiter: IpRateLimiter,
+    flag_definitions_limiter: FlagDefinitionsRateLimiter,
+    cleanup_interval_secs: u64,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(cleanup_interval_secs));
+        loop {
+            interval.tick().await;
+
+            // Remove stale entries (keys that haven't been used within the rate limit window)
+            flags_rate_limiter.retain_recent();
+            flags_rate_limiter.shrink_to_fit();
+
+            ip_rate_limiter.retain_recent();
+            ip_rate_limiter.shrink_to_fit();
+
+            flag_definitions_limiter.retain_recent();
+            flag_definitions_limiter.shrink_to_fit();
+
+            // Report metrics for monitoring
+            gauge!("flags_rate_limiter_token_entries").set(flags_rate_limiter.len() as f64);
+            gauge!("flags_rate_limiter_ip_entries").set(ip_rate_limiter.len() as f64);
+            gauge!("flags_rate_limiter_definitions_entries")
+                .set(flag_definitions_limiter.len() as f64);
+
+            tracing::debug!(
+                token_entries = flags_rate_limiter.len(),
+                ip_entries = ip_rate_limiter.len(),
+                definitions_entries = flag_definitions_limiter.len(),
+                "Rate limiter cleanup completed"
+            );
+        }
+    });
 }
 
 pub async fn readiness(

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -206,15 +206,10 @@ fn spawn_rate_limiter_cleanup_task(
             interval.tick().await;
 
             let result = catch_unwind(AssertUnwindSafe(|| {
-                // Remove stale entries (keys that haven't been used within the rate limit window)
-                flags_rate_limiter.retain_recent();
-                flags_rate_limiter.shrink_to_fit();
-
-                ip_rate_limiter.retain_recent();
-                ip_rate_limiter.shrink_to_fit();
-
-                flag_definitions_limiter.retain_recent();
-                flag_definitions_limiter.shrink_to_fit();
+                // Remove stale entries and reclaim memory
+                flags_rate_limiter.cleanup();
+                ip_rate_limiter.cleanup();
+                flag_definitions_limiter.cleanup();
 
                 // Report metrics for monitoring
                 gauge!("flags_rate_limiter_token_entries").set(flags_rate_limiter.len() as f64);

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -5,8 +5,6 @@ use std::{
     time::Duration,
 };
 
-use rand::Rng;
-
 use crate::billing_limiters::{FeatureFlagsLimiter, SessionReplayLimiter};
 use crate::database_pools::DatabasePools;
 use axum::{
@@ -203,10 +201,7 @@ fn spawn_rate_limiter_cleanup_task(
     cleanup_interval_secs: u64,
 ) {
     tokio::spawn(async move {
-        // Add jitter to avoid synchronized cleanup across replicas
-        let jitter_secs = rand::thread_rng().gen_range(0..10);
-        let mut interval =
-            tokio::time::interval(Duration::from_secs(cleanup_interval_secs + jitter_secs));
+        let mut interval = tokio::time::interval(Duration::from_secs(cleanup_interval_secs));
         loop {
             interval.tick().await;
 


### PR DESCRIPTION
## Problem

The `governor` crate uses a `DashMap` (like a `HashMap` but thread safe) to store tokens used for rate limiting. But it doesn't automatically clean them up, leading to potential memory leaks.

<img width="480" height="463" alt="image" src="https://github.com/user-attachments/assets/df63fd07-3e1c-4f16-83a0-9a12810975ae" />
<img width="1905" height="1510" alt="image" src="https://github.com/user-attachments/assets/122c7cbb-1eeb-46ac-bf0a-0e169cdb9f4b" />


## Changes

- Add `retain_recent()`, `shrink_to_fit()`, `len()`, and `is_empty()` methods to `FlagsRateLimiter`, `IpRateLimiter`, and `FlagDefinitionsRateLimiter`
- Add `spawn_rate_limiter_cleanup_task()` background task that periodically:
  - Calls `retain_recent()` to remove stale entries (keys that haven't been used within the rate limit window)
  - Calls `shrink_to_fit()` to reclaim memory
  - Emits Prometheus gauges (`flags_rate_limiter_token_entries`, `flags_rate_limiter_ip_entries`, `flags_rate_limiter_definitions_entries`) for monitoring
- Add `RATE_LIMITER_CLEANUP_INTERVAL_SECS` config option (default: 60 seconds)
- Add `hammer_rate_limiter.sh` test script

## How did you test this code?

Added a `hammer_rate_limiter.sh` script to hammer the endpoint for testing:

Make sure you're in the `rust/feature-flags` directory:

Terminal 1 - Start the server with a short cleanup interval for testing:

```bash
FLAGS_RATE_LIMIT_ENABLED=true FLAGS_IP_RATE_LIMIT_ENABLED=true \
RATE_LIMITER_CLEANUP_INTERVAL_SECS=5 \
RUST_LOG=debug cargo run 2>&1 | grep -E "(cleanup|entries|Rate limiter)"
```

Terminal 2 - Run this script:

```bash
./scripts/hammer_rate_limiter.sh
```

Expected output in Terminal 1:
- token_entries increases during the hammer run (e.g., 20-100+ entries)
- After requests stop, token_entries drops to 0 on the next cleanup cycle
- ip_entries=1 (all requests from localhost share one IP)

Example output:

```
2025-12-23T18:33:25.390214Z DEBUG feature_flags::router: Rate limiter cleanup completed token_entries=0 ip_entries=0 definitions_entries=0
2025-12-23T18:33:32.389444Z DEBUG feature_flags::router: Rate limiter cleanup completed token_entries=31 ip_entries=1 definitions_entries=0
2025-12-23T18:33:39.389600Z DEBUG feature_flags::router: Rate limiter cleanup completed token_entries=28 ip_entries=1 definitions_entries=0
2025-12-23T18:33:46.389849Z DEBUG feature_flags::router: Rate limiter cleanup completed token_entries=24 ip_entries=1 definitions_entries=0
2025-12-23T18:33:53.391285Z DEBUG feature_flags::router: Rate limiter cleanup completed token_entries=0 ip_entries=1 definitions_entries=0
```

Another test run where we let more tokens accumulate:

```bash
FLAGS_RATE_LIMIT_ENABLED=true FLAGS_IP_RATE_LIMIT_ENABLED=true \
FLAGS_BUCKET_REPLENISH_RATE=0.1 \
RATE_LIMITER_CLEANUP_INTERVAL_SECS=5 \
RUST_LOG=debug cargo run 2>&1 | grep -E "(cleanup|entries|Rate limiter)"
2025-12-23T18:41:43.287050Z DEBUG ThreadId(06) feature_flags::cohorts::cohort_cache_manager: Cohort cache metrics - size: 0 bytes, entries: 0
2025-12-23T18:41:43.289550Z DEBUG ThreadId(13) feature_flags::router: Rate limiter cleanup completed token_entries=0 ip_entries=0 definitions_entries=0
2025-12-23T18:41:49.289221Z DEBUG ThreadId(04) feature_flags::router: Rate limiter cleanup completed token_entries=143 ip_entries=1 definitions_entries=0
2025-12-23T18:41:55.289510Z DEBUG ThreadId(04) feature_flags::router: Rate limiter cleanup completed token_entries=424 ip_entries=1 definitions_entries=0
2025-12-23T18:42:01.290758Z DEBUG ThreadId(08) feature_flags::router: Rate limiter cleanup completed token_entries=684 ip_entries=1 definitions_entries=0
2025-12-23T18:42:07.290153Z DEBUG ThreadId(04) feature_flags::router: Rate limiter cleanup completed token_entries=936 ip_entries=1 definitions_entries=0
2025-12-23T18:42:13.287858Z DEBUG ThreadId(06) feature_flags::cohorts::cohort_cache_manager: Cohort cache metrics - size: 0 bytes, entries: 0
2025-12-23T18:42:13.290411Z DEBUG ThreadId(08) feature_flags::router: Rate limiter cleanup completed token_entries=1000 ip_entries=1 definitions_entries=0
2025-12-23T18:42:19.290096Z DEBUG ThreadId(08) feature_flags::router: Rate limiter cleanup completed token_entries=1000 ip_entries=1 definitions_entries=0
2025-12-23T18:42:25.291065Z DEBUG ThreadId(04) feature_flags::router: Rate limiter cleanup completed token_entries=1000 ip_entries=1 definitions_entries=0
2025-12-23T18:42:31.290810Z DEBUG ThreadId(04) feature_flags::router: Rate limiter cleanup completed token_entries=1000 ip_entries=0 definitions_entries=0
2025-12-23T18:42:37.291136Z DEBUG ThreadId(08) feature_flags::router: Rate limiter cleanup completed token_entries=1000 ip_entries=0 definitions_entries=0
2025-12-23T18:42:43.287673Z DEBUG ThreadId(05) feature_flags::cohorts::cohort_cache_manager: Cohort cache metrics - size: 0 bytes, entries: 0
2025-12-23T18:42:43.290186Z DEBUG ThreadId(06) feature_flags::router: Rate limiter cleanup completed token_entries=1000 ip_entries=0 definitions_entries=0
2025-12-23T18:42:49.291748Z DEBUG ThreadId(04) feature_flags::router: Rate limiter cleanup completed token_entries=904 ip_entries=0 definitions_entries=0
2025-12-23T18:42:55.291010Z DEBUG ThreadId(08) feature_flags::router: Rate limiter cleanup completed token_entries=620 ip_entries=0 definitions_entries=0
2025-12-23T18:43:01.290960Z DEBUG ThreadId(08) feature_flags::router: Rate limiter cleanup completed token_entries=357 ip_entries=0 definitions_entries=0
2025-12-23T18:43:07.290838Z DEBUG ThreadId(08) feature_flags::router: Rate limiter cleanup completed token_entries=105 ip_entries=0 definitions_entries=0
2025-12-23T18:43:13.288481Z DEBUG ThreadId(04) feature_flags::cohorts::cohort_cache_manager: Cohort cache metrics - size: 0 bytes, entries: 0
2025-12-23T18:43:13.289916Z DEBUG ThreadId(04) feature_flags::router: Rate limiter cleanup completed token_entries=0 ip_entries=0 definitions_entries=0
```


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog

No - infrastructure fix, not user-facing.
