### PR TITLE
fix(feature-flags): Pass serializer classes instead of instances in local_evaluation decorator

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1873,9 +1873,9 @@ class FeatureFlagViewSet(
     @validated_request(
         query_serializer=LocalEvaluationQuerySerializer,
         responses={
-            200: OpenApiResponse(response=LocalEvaluationResponseSerializer()),
-            402: OpenApiResponse(response=serializers.DictField()),
-            500: OpenApiResponse(response=serializers.DictField()),
+            200: OpenApiResponse(response=LocalEvaluationResponseSerializer),
+            402: OpenApiResponse(response=serializers.DictField),
+            500: OpenApiResponse(response=serializers.DictField),
         },
     )
     @action(


### PR DESCRIPTION
## Problem
Calling `local_evaluation` in `DEBUG` mode or with `strict_response_validation` causes an internal error. 

This is because in [posthog/api/mixins.py](https://github.com/PostHog/posthog/blob/0af90bbd416b3469ee91a344626496f90d4685d4/posthog/api/mixins.py#L200C1-L200C74) we try to call `serializer_class(data=data, context=context)`, which fails because the instance is not callable.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Passes the serializer class instead of an instance to the decorator.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Ran locally and confirmed this fix worked, ran feature_flag tests locally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
