### PR TITLE
fix: Vercel SSO email mismatch handling and URL routing

### DIFF
--- a/ee/urls.py
+++ b/ee/urls.py
@@ -151,7 +151,7 @@ urlpatterns: list[Any] = [
     path("api/saml/metadata/", authentication.saml_metadata_view),
     path("api/sentry_stats/", sentry_stats.sentry_stats),
     path("max/chat/", csrf_exempt(MaxChatViewSet.as_view({"post": "create"})), name="max_chat"),
-    path("login/vercel/", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_redirect"})),
+    path("login/vercel", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_redirect"})),
     path("login/vercel/continue/", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_continue"})),
     path("webhooks/vercel", csrf_exempt(vercel_webhooks.vercel_webhook), name="vercel_webhooks"),
     path("scim/v2/<uuid:domain_id>/Users", csrf_exempt(scim_views.SCIMUsersView.as_view()), name="scim_users"),

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -152,7 +152,7 @@ urlpatterns: list[Any] = [
     path("api/sentry_stats/", sentry_stats.sentry_stats),
     path("max/chat/", csrf_exempt(MaxChatViewSet.as_view({"post": "create"})), name="max_chat"),
     path("login/vercel/", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_redirect"})),
-    path("login/vercel/continue", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_continue"})),
+    path("login/vercel/continue/", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_continue"})),
     path("webhooks/vercel", csrf_exempt(vercel_webhooks.vercel_webhook), name="vercel_webhooks"),
     path("scim/v2/<uuid:domain_id>/Users", csrf_exempt(scim_views.SCIMUsersView.as_view()), name="scim_users"),
     path(

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -152,7 +152,7 @@ urlpatterns: list[Any] = [
     path("api/sentry_stats/", sentry_stats.sentry_stats),
     path("max/chat/", csrf_exempt(MaxChatViewSet.as_view({"post": "create"})), name="max_chat"),
     path("login/vercel", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_redirect"})),
-    path("login/vercel/continue/", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_continue"})),
+    path("login/vercel/continue", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_continue"})),
     path("webhooks/vercel", csrf_exempt(vercel_webhooks.vercel_webhook), name="vercel_webhooks"),
     path("scim/v2/<uuid:domain_id>/Users", csrf_exempt(scim_views.SCIMUsersView.as_view()), name="scim_users"),
     path(

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -968,7 +968,7 @@ class VercelIntegration:
             return redirect_url
         except RequiresExistingUserLogin as e:
             # Re-cache the claims so they're available after the user logs in
-            if claims is not None:
+            if isinstance(claims, VercelUserClaims):
                 VercelIntegration._set_cached_claims(params.code, claims, timeout=300)
 
             continuation_url = f"/login/vercel/continue?{urlencode(params.to_dict_no_nulls())}"

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -808,7 +808,7 @@ class VercelIntegration:
             raise NotImplementedError("SSO is only supported for user claims, not system claims")
 
         # Cache claims for potential existing user login flow (needed because the code can only be exchanged once)
-        VercelIntegration._set_cached_claims(code, claims, timeout=300)  # 5 minutes
+        VercelIntegration.set_cached_claims(code, claims, timeout=300)  # 5 minutes
 
         return claims
 
@@ -844,7 +844,7 @@ class VercelIntegration:
                     logged_in_email=request.user.email,
                     integration="vercel",
                 )
-                VercelIntegration._set_cached_claims(params.code, claims, timeout=300)
+                VercelIntegration.set_cached_claims(params.code, claims, timeout=300)
                 error_params = {
                     "expected_email": claims.user_email,
                     "current_email": request.user.email,
@@ -934,7 +934,7 @@ class VercelIntegration:
         return claims
 
     @staticmethod
-    def _set_cached_claims(code: str, claims: VercelUserClaims, timeout: int = 300) -> None:
+    def set_cached_claims(code: str, claims: VercelUserClaims, timeout: int = 300) -> None:
         claims_key = VercelIntegration._get_cache_key(code)
         cache.set(claims_key, claims, timeout=timeout)
 
@@ -969,7 +969,7 @@ class VercelIntegration:
         except RequiresExistingUserLogin as e:
             # Re-cache the claims so they're available after the user logs in
             if isinstance(claims, VercelUserClaims):
-                VercelIntegration._set_cached_claims(params.code, claims, timeout=300)
+                VercelIntegration.set_cached_claims(params.code, claims, timeout=300)
 
             continuation_url = f"/login/vercel/continue?{urlencode(params.to_dict_no_nulls())}"
             message = f"Please log in with {e.email} to link your Vercel account"

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -946,7 +946,7 @@ class VercelIntegration:
             )
             return redirect_url
         except RequiresExistingUserLogin as e:
-            continuation_url = f"/login/vercel/continue?{urlencode(params.to_dict_no_nulls())}"
+            continuation_url = f"/login/vercel/continue/?{urlencode(params.to_dict_no_nulls())}"
             login_url = f"/login?next={quote(continuation_url)}"
 
             logger.info(

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -834,7 +834,10 @@ class VercelIntegration:
             if not isinstance(claims, VercelUserClaims):
                 raise NotImplementedError("SSO is only supported for user claims, not system claims")
 
-            if not claims.user_email or request.user.email.lower() != claims.user_email.lower():
+            if not claims.user_email:
+                raise exceptions.AuthenticationFailed("Vercel SSO claims missing user email")
+
+            if request.user.email.lower() != claims.user_email.lower():
                 logger.warning(
                     "Email mismatch in Vercel SSO",
                     expected_email=claims.user_email,
@@ -937,7 +940,7 @@ class VercelIntegration:
 
     @staticmethod
     def authenticate_sso(request, params: SSOParams) -> str:
-        claims: VercelUserClaims | None = None
+        claims: VercelClaims | None = None
         try:
             # First check for cached claims (from a previous attempt with email mismatch)
             claims = VercelIntegration._get_cached_claims(params.code)

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -106,6 +106,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.SystemStatus]: () => import('./instance/SystemStatus'),
     [Scene.ToolbarLaunch]: () => import('./toolbar-launch/ToolbarLaunch'),
     [Scene.Unsubscribe]: () => import('./Unsubscribe/Unsubscribe'),
+    [Scene.VercelLinkError]: () => import('./authentication/VercelLinkError'),
     [Scene.VerifyEmail]: () => import('./authentication/signup/verify-email/VerifyEmail'),
     [Scene.WebAnalyticsMarketing]: () => import('./web-analytics/WebAnalyticsScene'),
     [Scene.WebAnalyticsWebVitals]: () => import('./web-analytics/WebAnalyticsScene'),

--- a/frontend/src/scenes/authentication/VercelLinkError.tsx
+++ b/frontend/src/scenes/authentication/VercelLinkError.tsx
@@ -1,0 +1,57 @@
+import { useValues } from 'kea'
+import { router } from 'kea-router'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { BridgePage } from 'lib/components/BridgePage/BridgePage'
+import { IconErrorOutline } from 'lib/lemon-ui/icons'
+import { SceneExport } from 'scenes/sceneTypes'
+
+export const scene: SceneExport = {
+    component: VercelLinkError,
+}
+
+export function VercelLinkError(): JSX.Element {
+    const { searchParams } = useValues(router)
+
+    const expectedEmail = searchParams.expected_email || 'a different account'
+    const currentEmail = searchParams.current_email || 'your current account'
+    const code = searchParams.code
+    const state = searchParams.state
+
+    const nextUrl = code && state ? `/login/vercel?mode=sso&code=${code}&state=${state}` : null
+    const logoutUrl = nextUrl ? `/logout?next=${encodeURIComponent(nextUrl)}` : '/logout'
+
+    return (
+        <BridgePage view="vercel-link-error">
+            <div className="text-center mb-4">
+                <IconErrorOutline className="text-warning text-4xl" />
+            </div>
+            <h2 className="text-center">Account mismatch</h2>
+            <div className="text-center mb-6">
+                <p className="mb-2">
+                    You're currently logged in as <strong>{currentEmail}</strong>, but your Vercel account is linked to{' '}
+                    <strong>{expectedEmail}</strong>.
+                </p>
+                <p>To complete Vercel SSO, please log out and sign in with the correct account.</p>
+            </div>
+            <div className="flex flex-col gap-2">
+                <LemonButton
+                    fullWidth
+                    type="primary"
+                    center
+                    onClick={() => {
+                        window.location.href = logoutUrl
+                    }}
+                >
+                    Log out and continue with {expectedEmail}
+                </LemonButton>
+                <LemonButton fullWidth type="secondary" center to="/">
+                    Cancel
+                </LemonButton>
+            </div>
+        </BridgePage>
+    )
+}
+
+export default VercelLinkError

--- a/frontend/src/scenes/authentication/VercelLinkError.tsx
+++ b/frontend/src/scenes/authentication/VercelLinkError.tsx
@@ -14,7 +14,7 @@ export const scene: SceneExport = {
 export function VercelLinkError(): JSX.Element {
     const { searchParams } = useValues(router)
 
-    const expectedEmail = searchParams.expected_email || 'a different account'
+    const expectedEmail = searchParams.expected_email
     const currentEmail = searchParams.current_email || 'your current account'
     const code = searchParams.code
     const state = searchParams.state
@@ -34,7 +34,7 @@ export function VercelLinkError(): JSX.Element {
             <div className="text-center mb-6">
                 <p className="mb-2">
                     You're currently logged in as <strong>{currentEmail}</strong>, but your Vercel account is linked to{' '}
-                    <strong>{expectedEmail}</strong>.
+                    {expectedEmail ? <strong>{expectedEmail}</strong> : 'a different account'}.
                 </p>
                 <p>To complete Vercel SSO, please log out and sign in with the correct account.</p>
             </div>
@@ -47,7 +47,7 @@ export function VercelLinkError(): JSX.Element {
                         window.location.href = logoutUrl
                     }}
                 >
-                    Log out and continue with {expectedEmail}
+                    {expectedEmail ? `Log out and continue with ${expectedEmail}` : 'Log out and continue'}
                 </LemonButton>
                 <LemonButton fullWidth type="secondary" center to="/">
                     Cancel

--- a/frontend/src/scenes/authentication/VercelLinkError.tsx
+++ b/frontend/src/scenes/authentication/VercelLinkError.tsx
@@ -19,7 +19,10 @@ export function VercelLinkError(): JSX.Element {
     const code = searchParams.code
     const state = searchParams.state
 
-    const nextUrl = code && state ? `/login/vercel?mode=sso&code=${code}&state=${state}` : null
+    const nextUrl =
+        code && state
+            ? `/login/vercel?mode=sso&code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`
+            : null
     const logoutUrl = nextUrl ? `/logout?next=${encodeURIComponent(nextUrl)}` : '/logout'
 
     return (

--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -27,6 +27,9 @@ export interface PrecheckResponseType {
     status: 'pending' | 'completed'
 }
 
+// Routes that should be handled by Django, not the React router
+const BACKEND_ONLY_ROUTES = ['/login/vercel/continue']
+
 export function handleLoginRedirect(): void {
     let nextURL = '/'
     try {
@@ -41,6 +44,13 @@ export function handleLoginRedirect(): void {
     } catch {
         // do nothing
     }
+
+    // Check if this is a backend-only route that shouldn't go through the React router
+    if (BACKEND_ONLY_ROUTES.some((route) => nextURL.startsWith(route))) {
+        window.location.href = nextURL
+        return
+    }
+
     // A safe way to redirect to a user input URL. Calls history.replaceState() ensuring the URLs origin does not change
     router.actions.replace(nextURL)
 }

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -137,6 +137,7 @@ export enum Scene {
     Unsubscribe = 'Unsubscribe',
     UserInterview = 'UserInterview',
     UserInterviews = 'UserInterviews',
+    VercelLinkError = 'VercelLinkError',
     VerifyEmail = 'VerifyEmail',
     WebAnalytics = 'WebAnalytics',
     WebAnalyticsMarketing = 'WebAnalyticsMarketing',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -351,6 +351,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
     },
     [Scene.PasswordResetComplete]: { onlyUnauthenticated: true },
     [Scene.PasswordReset]: { onlyUnauthenticated: true },
+    [Scene.VercelLinkError]: { name: 'Vercel account mismatch' },
     [Scene.Person]: {
         projectBased: true,
         name: 'People',
@@ -766,6 +767,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.verifyEmail()]: [Scene.VerifyEmail, 'verifyEmail'],
     [urls.verifyEmail(':uuid')]: [Scene.VerifyEmail, 'verifyEmailWithUuid'],
     [urls.verifyEmail(':uuid', ':token')]: [Scene.VerifyEmail, 'verifyEmailWithToken'],
+    [urls.vercelLinkError()]: [Scene.VercelLinkError, 'vercelLinkError'],
     [urls.unsubscribe()]: [Scene.Unsubscribe, 'unsubscribe'],
     [urls.integrationsRedirect(':kind')]: [Scene.IntegrationsRedirect, 'integrationsRedirect'],
     [urls.debugQuery()]: [Scene.DebugQuery, 'debugQuery'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -110,6 +110,7 @@ export const urls = {
     signup: (): string => '/signup',
     verifyEmail: (userUuid: string = '', token: string = ''): string =>
         `/verify_email${userUuid ? `/${userUuid}` : ''}${token ? `/${token}` : ''}`,
+    vercelLinkError: (): string => '/integrations/vercel/link-error',
     inviteSignup: (id: string): string => `/signup/${id}`,
     products: (): string => '/products',
     useCaseSelection: (): string => '/onboarding/use-case',


### PR DESCRIPTION
## Problem

The Vercel SSO flow had several issues:
1. URL routing issues due to trailing slash mismatches causing 404 errors
2. When a user logged in with the wrong email (different from their Vercel account), it created an infinite redirect loop back to login
3. After login, the React router tried to handle `/login/vercel/continue` instead of Django, showing a frontend 404

## Changes

- **Remove trailing slashes** from `/login/vercel` and `/login/vercel/continue` URL patterns to match what Vercel sends
- **Add email mismatch error page** (`/integrations/vercel/link-error`) that clearly explains:
  - Which email the user is logged in as
  - Which email Vercel expects
  - Options to "Log out and continue with correct account" or "Cancel"
- **Fix SSO claims caching** - Re-cache claims when `RequiresExistingUserLogin` is raised so they're available after the user logs out and back in
- **Add backend-only route handling** - Routes like `/login/vercel/continue` now use `window.location.href` instead of React router to ensure Django handles them

## How did you test this code?


https://github.com/user-attachments/assets/13491704-34ec-4956-b096-93c9dc9b77bf



Tested locally with ngrok:
1. Connected Vercel integration
2. Clicked "Open with PostHog" from Vercel
3. Logged in with wrong email → saw error page
4. Clicked "Log out and continue" → logged in with correct email → SSO completed successfully
5. Also tested the happy path (correct email from the start)

## Changelog

- Vercel SSO: Fixed URL routing issues and added clear error page when logging in with wrong email

🤖 Generated with [Claude Code](https://claude.com/claude-code)