### PR TITLE
refactor(customers): Person profile content

### DIFF
--- a/frontend/src/scenes/persons/PersonProfileCanvas.tsx
+++ b/frontend/src/scenes/persons/PersonProfileCanvas.tsx
@@ -1,21 +1,23 @@
-import { BindLogic, useActions } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
-import { uuid } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { Notebook } from 'scenes/notebooks/Notebook/Notebook'
 import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
 
 import { AnyPropertyFilter, PersonType, PropertyFilterType, PropertyOperator } from '~/types'
 
+import { personProfileCanvasLogic } from 'products/customer_analytics/frontend/personProfileCanvasLogic'
+
 type PersonProfileCanvasProps = {
     person: PersonType
 }
 
 const PersonProfileCanvas = ({ person }: PersonProfileCanvasProps): JSX.Element => {
-    const { reportPersonProfileViewed } = useActions(eventUsageLogic)
     const id = person.id
     const distinctId = person.distinct_ids[0]
+    const { reportPersonProfileViewed } = useActions(eventUsageLogic)
+    const { content } = useValues(personProfileCanvasLogic({ personId: id, distinctId }))
     const shortId = `canvas-${id}`
     const mode = 'canvas'
 
@@ -40,52 +42,7 @@ const PersonProfileCanvas = ({ person }: PersonProfileCanvasProps): JSX.Element 
                 mode={mode}
                 initialContent={{
                     type: 'doc',
-                    content: [
-                        { type: 'ph-usage-metrics', attrs: { personId: id, nodeId: uuid() } },
-                        {
-                            type: 'ph-person-feed',
-                            attrs: {
-                                height: null,
-                                title: null,
-                                nodeId: uuid(),
-                                id,
-                                distinctId,
-                                __init: null,
-                                children: [
-                                    {
-                                        type: 'ph-person',
-                                        attrs: { id, distinctId, nodeId: uuid(), title: 'Info' },
-                                    },
-                                    // FIXME: Map bg image is broken
-                                    // ...(isCloudOrDev
-                                    //     ? [
-                                    //           {
-                                    //               type: 'ph-map',
-                                    //               attrs: { id, distinctId, nodeId: uuid() },
-                                    //           },
-                                    //       ]
-                                    //     : []),
-                                    {
-                                        type: 'ph-person-properties',
-                                        attrs: { id, distinctId, nodeId: uuid() },
-                                    },
-                                    { type: 'ph-related-groups', attrs: { id, nodeId: uuid(), type: 'group' } },
-                                ],
-                            },
-                        },
-                        {
-                            type: 'ph-llm-trace',
-                            attrs: { personId: id, nodeId: uuid() },
-                        },
-                        {
-                            type: 'ph-zendesk-tickets',
-                            attrs: { personId: id, nodeId: uuid() },
-                        },
-                        {
-                            type: 'ph-issues',
-                            attrs: { personId: id, nodeId: uuid() },
-                        },
-                    ],
+                    content,
                 }}
             />
         </BindLogic>

--- a/frontend/src/scenes/persons/PersonProfileCanvas.tsx
+++ b/frontend/src/scenes/persons/PersonProfileCanvas.tsx
@@ -8,11 +8,11 @@ import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
 
 import { AnyPropertyFilter, PersonType, PropertyFilterType, PropertyOperator } from '~/types'
 
-type PersonFeedCanvasProps = {
+type PersonProfileCanvasProps = {
     person: PersonType
 }
 
-const PersonFeedCanvas = ({ person }: PersonFeedCanvasProps): JSX.Element => {
+const PersonProfileCanvas = ({ person }: PersonProfileCanvasProps): JSX.Element => {
     const { reportPersonProfileViewed } = useActions(eventUsageLogic)
     const id = person.id
     const distinctId = person.distinct_ids[0]
@@ -92,4 +92,4 @@ const PersonFeedCanvas = ({ person }: PersonFeedCanvasProps): JSX.Element => {
     )
 }
 
-export default PersonFeedCanvas
+export default PersonProfileCanvas

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -45,7 +45,7 @@ import { FeedbackBanner } from 'products/customer_analytics/frontend/components/
 
 import { MergeSplitPerson } from './MergeSplitPerson'
 import { PersonCohorts } from './PersonCohorts'
-import PersonFeedCanvas from './PersonFeedCanvas'
+import PersonProfileCanvas from './PersonProfileCanvas'
 import { RelatedFeatureFlags } from './RelatedFeatureFlags'
 import { asDisplay } from './person-utils'
 import { PersonsLogicProps, personsLogic } from './personsLogic'
@@ -258,7 +258,7 @@ export function PersonScene(): JSX.Element | null {
                         ? {
                               key: PersonsTabType.PROFILE,
                               label: <span data-attr="persons-profile-tab">Profile</span>,
-                              content: <PersonFeedCanvas person={person} />,
+                              content: <PersonProfileCanvas person={person} />,
                           }
                         : false,
                     {

--- a/products/customer_analytics/frontend/personProfileCanvasLogic.ts
+++ b/products/customer_analytics/frontend/personProfileCanvasLogic.ts
@@ -1,0 +1,98 @@
+import { kea, key, path, props, selectors } from 'kea'
+
+import { JSONContent } from 'lib/components/RichContentEditor/types'
+import { uuid } from 'lib/utils'
+
+import type { personProfileCanvasLogicType } from './personProfileCanvasLogicType'
+
+export const DEFAULT_PERSON_PROFILE_SIDEBAR: JSONContent[] = [
+    { type: 'ph-person' },
+    // FIXME: Map bg image is broken
+    // { type: 'ph-map' },
+    { type: 'ph-person-properties' },
+    { type: 'ph-related-groups' },
+]
+
+export const DEFAULT_PERSON_PROFILE_CONTENT: JSONContent[] = [
+    { type: 'ph-usage-metrics' },
+    { type: 'ph-person-feed' },
+    { type: 'ph-llm-trace' },
+    { type: 'ph-zendesk-tickets' },
+    { type: 'ph-issues' },
+]
+
+export interface PersonProfileCanvasLogicProps {
+    personId: string | undefined
+    distinctId: string
+}
+
+export const personProfileCanvasLogic = kea<personProfileCanvasLogicType>([
+    path(['products', 'customer_analytics', 'person_profile_canvas']),
+    props({} as PersonProfileCanvasLogicProps),
+    key(({ personId, distinctId }) => personId || distinctId),
+
+    selectors({
+        content: [
+            () => [(_, props) => props.personId, (_, props) => props.distinctId],
+            (personId, distinctId): JSONContent[] => {
+                const sidebar = DEFAULT_PERSON_PROFILE_SIDEBAR.map((node) =>
+                    addPersonAttrsToNode({ node, personId, distinctId })
+                )
+                return DEFAULT_PERSON_PROFILE_CONTENT.map((node, index) => {
+                    if (index === 0) {
+                        return addPersonAttrsToNode({ node, personId, distinctId, children: sidebar })
+                    }
+                    return addPersonAttrsToNode({ node, personId, distinctId })
+                })
+            },
+        ],
+    }),
+])
+
+export interface AddPersonAttrsToNodeProps {
+    node: JSONContent
+    personId: string | undefined
+    distinctId: string
+    children?: JSONContent[]
+}
+
+export function addPersonAttrsToNode({
+    node,
+    personId,
+    distinctId,
+    children = [],
+}: AddPersonAttrsToNodeProps): JSONContent {
+    switch (node.type) {
+        case 'ph-usage-metrics':
+        case 'ph-llm-trace':
+        case 'ph-zendesk-tickets':
+        case 'ph-issues':
+            return {
+                ...node,
+                attrs: { personId, nodeId: uuid(), children },
+            }
+        case 'ph-person-feed':
+            return {
+                ...node,
+                attrs: { height: null, title: null, id: personId, distinctId, nodeId: uuid(), __init: null, children },
+            }
+        case 'ph-person':
+            return {
+                ...node,
+                attrs: { id: personId, distinctId, nodeId: uuid(), title: 'Info', children },
+            }
+        case 'ph-person':
+        case 'ph-person-properties':
+            return {
+                ...node,
+                attrs: { id: personId, distinctId, nodeId: uuid(), children },
+            }
+        case 'ph-related-groups':
+            return {
+                ...node,
+                attrs: { id: personId, nodeId: uuid(), type: 'group', children },
+            }
+        default:
+            return node
+    }
+}

--- a/products/customer_analytics/frontend/personProfileCanvasLogic.ts
+++ b/products/customer_analytics/frontend/personProfileCanvasLogic.ts
@@ -6,19 +6,19 @@ import { uuid } from 'lib/utils'
 import type { personProfileCanvasLogicType } from './personProfileCanvasLogicType'
 
 export const DEFAULT_PERSON_PROFILE_SIDEBAR: JSONContent[] = [
-    { type: 'ph-person' },
+    { type: 'ph-person', title: 'Info' },
     // FIXME: Map bg image is broken
-    // { type: 'ph-map' },
-    { type: 'ph-person-properties' },
-    { type: 'ph-related-groups' },
+    // { type: 'ph-map', title: 'Map' },
+    { type: 'ph-person-properties', title: 'Properties' },
+    { type: 'ph-related-groups', title: 'Related groups' },
 ]
 
 export const DEFAULT_PERSON_PROFILE_CONTENT: JSONContent[] = [
-    { type: 'ph-usage-metrics' },
-    { type: 'ph-person-feed' },
-    { type: 'ph-llm-trace' },
-    { type: 'ph-zendesk-tickets' },
-    { type: 'ph-issues' },
+    { type: 'ph-usage-metrics', title: 'Usage metrics' },
+    { type: 'ph-person-feed', title: 'Session feed' },
+    { type: 'ph-llm-trace', title: 'LLM traces' },
+    { type: 'ph-zendesk-tickets', title: 'Zendesk tickets' },
+    { type: 'ph-issues', title: 'Issues' },
 ]
 
 export interface PersonProfileCanvasLogicProps {
@@ -69,28 +69,31 @@ export function addPersonAttrsToNode({
         case 'ph-issues':
             return {
                 ...node,
-                attrs: { personId, nodeId: uuid(), children },
+                attrs: { personId, nodeId: uuid(), children, title: node.title },
             }
         case 'ph-person-feed':
             return {
                 ...node,
-                attrs: { height: null, title: null, id: personId, distinctId, nodeId: uuid(), __init: null, children },
-            }
-        case 'ph-person':
-            return {
-                ...node,
-                attrs: { id: personId, distinctId, nodeId: uuid(), title: 'Info', children },
+                attrs: {
+                    height: null,
+                    id: personId,
+                    distinctId,
+                    nodeId: uuid(),
+                    __init: null,
+                    children,
+                    title: node.title,
+                },
             }
         case 'ph-person':
         case 'ph-person-properties':
             return {
                 ...node,
-                attrs: { id: personId, distinctId, nodeId: uuid(), children },
+                attrs: { id: personId, distinctId, nodeId: uuid(), children, title: node.title },
             }
         case 'ph-related-groups':
             return {
                 ...node,
-                attrs: { id: personId, nodeId: uuid(), type: 'group', children },
+                attrs: { id: personId, nodeId: uuid(), type: 'group', children, title: node.title },
             }
         default:
             return node


### PR DESCRIPTION
## Problem

Customer profile nodes are currently hardcoded and the params are passed in "manually". This PR is the first step towards making it dynamic, so we can support customization.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Part of https://github.com/PostHog/posthog/issues/44005
## Changes
- Create `personProfileCanvasLogic` to handle content logic
- Create method to populate node attributes according to node type
- Rename `PersonFeedCanvas` to `PersonProfileCanvas`, aligned with the new nomenclature
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- Confirming in the UI that the people profiles are rendered with the same content as before
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
No, not a feature
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
