### PR TITLE
chore: Changelog PR template update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,9 +23,9 @@
 
 <!-- For features only. Check the box if this should go in our company changelog. -->
 
-- [ ] 🚀 Yes, publish to #changelog
-
 <!-- Removing this section or leaving it blank means this feature will probably remain unpublished. -->
+
+- [ ] 🚀 Yes, publish to #changelog
 
 <!-- If publishing, please make sure your PR includes a 1-3 sentence description of the feature, plus a screenshot or screen recording if it helps 🙏 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,11 +22,10 @@
 ## Publish to changelog?
 
 <!-- For features only. Check the box if this should go in our company changelog. -->
-
 <!-- Removing this section or leaving it blank means this feature will probably remain unpublished. -->
 
 - [ ] 🚀 Yes, publish to #changelog
 
-<!-- If publishing, please make sure your PR includes a 1-3 sentence description of the feature, plus a screenshot or screen recording if it helps 🙏 -->
+<!-- If publishing, your PR must include a 1-3 sentence description of the feature plus a screenshot or screen recording if applicable. 🙏 -->
 
 <!-- Check #changelog in Slack for more details -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,4 +28,4 @@
 
 <!-- If publishing, your PR must include a 1-3 sentence description of the feature plus a screenshot or screen recording if applicable. 🙏 -->
 
-<!-- Check #changelog in Slack for more details -->
+<!-- Check #changelog in Slack for more details. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,6 @@
 
 <!-- Removing this section or leaving it blank means this feature will probably remain unpublished. -->
 
-<!-- If publishing, please make sure your PR includes a 1-3 sentence description of the feature. Screenshots or screen recordings are very encouraged! 🙏 -->
+<!-- If publishing, please make sure your PR includes a 1-3 sentence description of the feature, plus a screenshot or screen recording if it helps 🙏 -->
 
 <!-- Check #changelog in Slack for more details -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,6 @@
 
 <!-- Removing this section or leaving it blank means this feature will probably remain unpublished. -->
 
-<!-- If publishing, please make sure your PR includes a 1-3 sentence description of the feature. Screenshots and screen recordings are optional but very encouraged! 🙏 -->
+<!-- If publishing, please make sure your PR includes a 1-3 sentence description of the feature. Screenshots or screen recordings are very encouraged! 🙏 -->
 
 <!-- Check #changelog in Slack for more details -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,11 +21,10 @@
 
 ## Publish to changelog?
 
-<!-- For features only -->
-<!-- Check the box if this feature should be published to the website changelog and the #changelog Slack channel -->
+<!-- For features only. -->
 
-<!-- Removing this section or leaving it blank means this feature will probably remain unpublished -->
+- [ ] 🚀 Yes, publish to #changelog and website changelog
 
-- [ ] Yes, publish to website changelog and #changelog
+<!-- Removing this section or leaving it blank means this feature will probably remain unpublished. -->
 
-<!-- If publishing, please make sure your PR includes a 1-3 sentence description of the feature. Screenshots and screen recordings are optional but very encouraged 🙏 -->
+<!-- If publishing, please make sure your PR includes a 1-3 sentence description of the feature. Screenshots and screen recordings are optional but very encouraged! 🙏 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,10 +21,12 @@
 
 ## Publish to changelog?
 
-<!-- For features only. Check the box if this should go in our changelog. -->
+<!-- For features only. Check the box if this should go in our company changelog. -->
 
-- [ ] 🚀 Yes, publish to #changelog and website changelog
+- [ ] 🚀 Yes, publish to #changelog
 
 <!-- Removing this section or leaving it blank means this feature will probably remain unpublished. -->
 
 <!-- If publishing, please make sure your PR includes a 1-3 sentence description of the feature. Screenshots and screen recordings are optional but very encouraged! 🙏 -->
+
+<!-- Check #changelog in Slack for more details -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,13 @@
 
 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
 
-## Changelog: (features only) Is this feature complete?
+## Publish to changelog?
 
-<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
-<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
+<!-- For features only -->
+<!-- Check the box if this feature should be published to the website changelog and the #changelog Slack channel -->
+
+<!-- Removing this section or leaving it blank means this feature will probably remain unpublished -->
+
+- [ ] Yes, publish to website changelog and #changelog
+
+<!-- If publishing, please make sure your PR includes a 1-3 sentence description of the feature. Screenshots and screen recordings are optional but very encouraged 🙏 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@
 
 ## Publish to changelog?
 
-<!-- For features only. -->
+<!-- For features only. Check the box if this should go in our changelog. -->
 
 - [ ] 🚀 Yes, publish to #changelog and website changelog
 


### PR DESCRIPTION
## Problem

We've started to [publish features that aren't ready](https://posthog.slack.com/archives/C087XQ7K9K7/p1765403720146099) in the changelog. It's cool seeing all the PRs coming in, but we need to reduce the noise in the #changelog Slack channel to keep publishing running smoothly. 

## Changes

- Updated PR template to include an explicit opt-in checkbox for publishing to #changelog 
- Added more inline comments and instructions
- Next step: update the replay workflow to look for the opt-in checkbox

Here's what the new PR template section looks like below:

## Publish to changelog?

<!-- For features only. Check the box if this should go in our company changelog. -->
<!-- Removing this section or leaving it blank means this feature will probably remain unpublished. -->

- [ ] 🚀 Yes, publish to #changelog

<!-- If publishing, make sure your PR includes a 1-3 sentence description of the feature, plus a screenshot or screen recording if applicable. 🙏 -->

<!-- Check #changelog in Slack for more details -->


