### PR TITLE
feat(admin): Disallowing modifying user when using impersonation

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -933,6 +933,7 @@ class ImpersonationReadOnlyMiddleware:
 
 IMPERSONATION_BLOCKED_PATHS: list[str] = [
     "/api/users/",
+    "/api/personal_api_keys/",
 ]
 
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -873,10 +873,10 @@ def is_read_only_impersonation(request: HttpRequest) -> bool:
 # HTTP methods that are considered idempotent/safe and allowed during impersonation
 IMPERSONATION_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
 
-# Paths that are allowed for non-idempotent requests during impersonation.
+# Paths that are allowed for non-idempotent requests during read-only impersonation.
 # These should be paths that are safe or necessary for the impersonated session to function.
 # Supports both prefix strings and compiled regex patterns.
-IMPERSONATION_ALLOWLISTED_PATHS: list[str | re.Pattern] = [
+READ_ONLY_IMPERSONATION_ALLOWLISTED_PATHS: list[str | re.Pattern] = [
     # These endpoints use POST but are read-only
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/query/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/insights/viewed/?$"),
@@ -895,7 +895,7 @@ class ImpersonationReadOnlyMiddleware:
     to prevent unintended modifications to the impersonated user's data.
 
     Safe methods (GET, HEAD, OPTIONS, TRACE) are always allowed.
-    Specific paths can be allowlisted via IMPERSONATION_ALLOWLISTED_PATHS.
+    Specific paths can be allowlisted via READ_ONLY_IMPERSONATION_ALLOWLISTED_PATHS.
     """
 
     def __init__(self, get_response):
@@ -921,7 +921,7 @@ class ImpersonationReadOnlyMiddleware:
         )
 
     def _is_path_allowlisted(self, path: str) -> bool:
-        for allowed_path in IMPERSONATION_ALLOWLISTED_PATHS:
+        for allowed_path in READ_ONLY_IMPERSONATION_ALLOWLISTED_PATHS:
             if isinstance(allowed_path, re.Pattern):
                 if allowed_path.match(path):
                     return True

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -115,6 +115,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "posthog.middleware.AutoLogoutImpersonateMiddleware",
     "posthog.middleware.ImpersonationReadOnlyMiddleware",
+    "posthog.middleware.ImpersonationBlockedPathsMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "posthog.middleware.ActiveOrganizationMiddleware",
     "posthog.middleware.CsvNeverCacheMiddleware",

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -818,6 +818,31 @@ class TestImpersonationBlockedPathsMiddleware(APIBaseTest):
         self.user.refresh_from_db()
         assert self.user.first_name == "Updated"
 
+    def test_impersonation_allows_set_current_organization(self):
+        """Verify impersonation allows PATCH with only set_current_organization."""
+        self.login_as_other_user()
+
+        response = self.client.patch(
+            "/api/users/@me/",
+            data={"set_current_organization": str(self.organization.id)},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+
+    def test_impersonation_blocks_set_current_organization_with_other_fields(self):
+        """Verify impersonation blocks PATCH with set_current_organization plus other fields."""
+        self.login_as_other_user()
+
+        response = self.client.patch(
+            "/api/users/@me/",
+            data={"set_current_organization": str(self.organization.id), "first_name": "Hacked"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+        assert response.json()["code"] == "impersonation_path_blocked"
+
 
 @override_settings(SESSION_COOKIE_AGE=100)
 class TestSessionAgeMiddleware(APIBaseTest):


### PR DESCRIPTION
When providing support, any User modifications should be made via Admin. Users should never be modified via impersonation.

