### PR TITLE
fix(llm-analytics): fix type mismatch in support trace filter

### DIFF
--- a/posthog/hogql_queries/ai/traces_query_runner.py
+++ b/posthog/hogql_queries/ai/traces_query_runner.py
@@ -479,7 +479,7 @@ class TracesQueryRunner(AnalyticsQueryRunner[TracesQueryResponse]):
                         ast.CompareOperation(
                             op=ast.CompareOperationOp.NotEq,
                             left=ast.Field(chain=["properties", "ai_support_impersonated"]),
-                            right=ast.Constant(value=True),
+                            right=ast.Constant(value="true"),
                         ),
                     ]
                 )


### PR DESCRIPTION
## Problem

The `filterSupportTraces` filter was comparing `properties.ai_support_impersonated` to a boolean `True`, which ClickHouse converts to `UInt8`. However, event properties in ClickHouse are stored as strings, so the actual value is `"true"` (a String).

This caused a ClickHouse error:
> DB::Exception: There is no supertype for types String, UInt8

## Changes

Change the comparison from `True` (boolean/UInt8) to `"true"` (string), matching the pattern used elsewhere (e.g., `$ai_is_error = 'true'` on line 264).

## How did you test this code?

locally

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
