### PR TITLE
fix(flags): Prevent OOM in flags cache verification task

### DIFF
--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -42,3 +42,15 @@ FLAGS_CACHE_REFRESH_TTL_THRESHOLD_HOURS: int = get_from_env(
 # Based on typical flag data, 5000 teams ≈ 10-100 MB depending on flag complexity.
 # See cache_expiry_manager.py for implementation details.
 FLAGS_CACHE_REFRESH_LIMIT: int = get_from_env("FLAGS_CACHE_REFRESH_LIMIT", 5000, type_cast=int)
+
+# Batch size for flags cache verification. Each batch loads both cached data
+# (from Redis) and DB data (FeatureFlag objects) into memory simultaneously.
+# Teams with 100+ flags and large filters JSONs can use significant memory.
+# Reduced from 1000 to 250 to prevent OOM. Decrease further if OOMs persist.
+FLAGS_CACHE_VERIFICATION_CHUNK_SIZE: int = get_from_env("FLAGS_CACHE_VERIFICATION_CHUNK_SIZE", 250, type_cast=int)
+
+# Batch size for team metadata cache verification. Team metadata is much smaller
+# than flags data, so we can use larger batches without OOM risk.
+TEAM_METADATA_CACHE_VERIFICATION_CHUNK_SIZE: int = get_from_env(
+    "TEAM_METADATA_CACHE_VERIFICATION_CHUNK_SIZE", 1000, type_cast=int
+)

--- a/posthog/storage/hypercache_verifier.py
+++ b/posthog/storage/hypercache_verifier.py
@@ -5,10 +5,11 @@ Provides reusable verification logic for Celery tasks that verify cache consiste
 and automatically fix issues.
 """
 
-import os
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
+
+from django.conf import settings
 
 import structlog
 from prometheus_client import Counter
@@ -18,11 +19,10 @@ from posthog.storage.hypercache_manager import HyperCacheManagementConfig, batch
 
 logger = structlog.get_logger(__name__)
 
-# Default chunk size for batch processing, configurable via environment variable
-DEFAULT_VERIFICATION_CHUNK_SIZE = int(os.environ.get("HYPERCACHE_VERIFICATION_CHUNK_SIZE", "1000"))
-
 # Number of batches between progress logs (balance between log spam and visibility)
-PROGRESS_LOG_BATCH_INTERVAL = 10
+# With 250 teams/batch and ~238K teams, we have ~950 batches. Logging every 20
+# batches gives us ~48 progress logs total.
+PROGRESS_LOG_BATCH_INTERVAL = 20
 
 # Prometheus counter for tracking fixes during scheduled verification
 HYPERCACHE_VERIFY_FIX_COUNTER = Counter(
@@ -81,13 +81,14 @@ def verify_and_fix_all_teams(
             a dict with 'status' ("match", "miss", "mismatch") and 'issue' type
         cache_type: Name for metrics/logging (e.g., "team_metadata", "flags")
         chunk_size: Number of teams to process per batch. Defaults to
-            HYPERCACHE_VERIFICATION_CHUNK_SIZE env var or 1000.
+            settings.FLAGS_CACHE_VERIFICATION_CHUNK_SIZE (the more conservative setting).
 
     Returns:
         VerificationResult with stats and list of fixed team IDs
     """
     if chunk_size is None:
-        chunk_size = DEFAULT_VERIFICATION_CHUNK_SIZE
+        # Use the more conservative flags setting as default
+        chunk_size = settings.FLAGS_CACHE_VERIFICATION_CHUNK_SIZE
 
     result = VerificationResult()
     last_id = 0
@@ -388,6 +389,7 @@ def _run_verification_for_cache(
     config: HyperCacheManagementConfig,
     verify_team_fn: Callable[[Team, dict | None, dict | None], dict],
     cache_type: str,
+    chunk_size: int,
 ) -> VerificationResult:
     """
     Run verification for a single cache type and log results.
@@ -396,17 +398,19 @@ def _run_verification_for_cache(
         config: HyperCache management configuration
         verify_team_fn: Function to verify a single team
         cache_type: Name for metrics/logging
+        chunk_size: Number of teams to process per batch
 
     Returns:
         VerificationResult with stats
     """
     start_time = time.time()
-    logger.info(f"Starting {cache_type} cache verification")
+    logger.info(f"Starting {cache_type} cache verification", chunk_size=chunk_size)
 
     result = verify_and_fix_all_teams(
         config=config,
         verify_team_fn=verify_team_fn,
         cache_type=cache_type,
+        chunk_size=chunk_size,
     )
 
     duration = time.time() - start_time

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -25,11 +25,15 @@ logger = structlog.get_logger(__name__)
 
 CacheType = Literal["flags", "team_metadata"]
 
-# Lock timeout matches time_limit to ensure lock is released if task is killed
-LOCK_TIMEOUT_SECONDS = 60 * 60  # 1 hour
+# Lock timeout matches time_limit to ensure lock is released if task is killed.
+# Reduced from 1 hour to 25 minutes to enable faster recovery when tasks crash
+# (OOM, deploy kills) without executing their finally block. With 30-minute
+# scheduling and 25-minute lock timeout, a crashed task's lock expires before
+# the next scheduled run, so at most 1 run is skipped after a crash.
+LOCK_TIMEOUT_SECONDS = 25 * 60  # 25 minutes
 
 
-def _run_cache_verification(cache_type: CacheType) -> None:
+def _run_cache_verification(cache_type: CacheType, chunk_size: int) -> None:
     """
     Run verification for a specific cache type.
 
@@ -52,7 +56,7 @@ def _run_cache_verification(cache_type: CacheType) -> None:
         return
 
     try:
-        logger.info("Starting cache verification", cache_type=cache_type)
+        logger.info("Starting cache verification", cache_type=cache_type, chunk_size=chunk_size)
 
         from posthog.storage.hypercache_verifier import _run_verification_for_cache
 
@@ -71,7 +75,9 @@ def _run_cache_verification(cache_type: CacheType) -> None:
         start_time = time.time()
 
         try:
-            _run_verification_for_cache(config=config, verify_team_fn=verify_fn, cache_type=cache_type)
+            _run_verification_for_cache(
+                config=config, verify_team_fn=verify_fn, cache_type=cache_type, chunk_size=chunk_size
+            )
         except Exception as e:
             logger.exception("Failed cache verification", cache_type=cache_type, error=str(e))
             capture_exception(e)
@@ -86,27 +92,29 @@ def _run_cache_verification(cache_type: CacheType) -> None:
 @shared_task(
     ignore_result=True,
     queue=CeleryQueue.DEFAULT.value,
-    soft_time_limit=45 * 60,  # 45 min soft limit
-    time_limit=60 * 60,  # 1 hour hard limit
+    soft_time_limit=20 * 60,  # 20 min soft limit
+    time_limit=25 * 60,  # 25 min hard limit (matches LOCK_TIMEOUT_SECONDS)
 )
 def verify_and_fix_flags_cache_task() -> None:
     """
     Periodic task to verify the flags HyperCache and fix issues.
 
-    Runs hourly at minute 40. Verifies all teams' flags caches,
-    automatically fixing any cache misses, mismatches, or expiry tracking issues.
+    Runs every 30 minutes. Verifies all teams' flags caches, automatically
+    fixing any cache misses, mismatches, or expiry tracking issues.
     Uses a distributed lock to skip execution if a previous run is still in progress.
+
+    Expected duration: ~8-10 minutes with 250-team batch size.
 
     Metrics: posthog_hypercache_verify_fixes_total{cache_type="flags", issue_type="..."}
     """
-    _run_cache_verification("flags")
+    _run_cache_verification("flags", settings.FLAGS_CACHE_VERIFICATION_CHUNK_SIZE)
 
 
 @shared_task(
     ignore_result=True,
     queue=CeleryQueue.DEFAULT.value,
-    soft_time_limit=45 * 60,  # 45 min soft limit
-    time_limit=60 * 60,  # 1 hour hard limit
+    soft_time_limit=20 * 60,  # 20 min soft limit
+    time_limit=25 * 60,  # 25 min hard limit (matches LOCK_TIMEOUT_SECONDS)
 )
 def verify_and_fix_team_metadata_cache_task() -> None:
     """
@@ -116,6 +124,8 @@ def verify_and_fix_team_metadata_cache_task() -> None:
     automatically fixing any cache misses, mismatches, or expiry tracking issues.
     Uses a distributed lock to skip execution if a previous run is still in progress.
 
+    Expected duration: ~3-5 minutes with 1000-team batch size.
+
     Metrics: posthog_hypercache_verify_fixes_total{cache_type="team_metadata", issue_type="..."}
     """
-    _run_cache_verification("team_metadata")
+    _run_cache_verification("team_metadata", settings.TEAM_METADATA_CACHE_VERIFICATION_CHUNK_SIZE)

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -208,13 +208,14 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         expires_seconds=60 * 60,
     )
 
-    # Flags cache verification - hourly at minute 40
+    # Flags cache verification - every 30 minutes
+    # Task takes ~8-10 minutes with 250-team batch size
     add_periodic_task_with_expiry(
         sender,
-        crontab(hour="*", minute="40"),
+        crontab(minute="*/30"),
         verify_and_fix_flags_cache_task.s(),
         name="verify and fix flags cache",
-        expires_seconds=60 * 60,
+        expires_seconds=30 * 60,
     )
 
     # Update events table partitions twice a week


### PR DESCRIPTION
## Problem

The flags cache verification task was experiencing two issues causing it to fail ~50% of scheduled runs:

1. **OOM kills**: The task loads both cached data (from Redis) and DB data (FeatureFlag objects with large `filters` JSON) into memory simultaneously. With 1000 teams per batch, some batches containing "power user" teams with 100+ flags caused memory spikes of 100-200MB, triggering OOM kills.

2. **Stale locks after crashes**: When pods are killed (OOM or deploy), the `finally` block never runs, leaving a stale distributed lock for the full 1-hour timeout. This caused the next scheduled run to skip, resulting in 2 hours of lost verification after each crash.

## Changes

**Batch size reduction (flags only):**
- Reduce flags cache verification batch size from 1000 to 250 teams
- Keep team metadata verification at 1000 (lighter data, no OOM issues)
- Add separate Django settings for each cache type's chunk size

**Scheduling improvements:**
- Run flags verification every 30 min instead of hourly
- Reduce lock timeout from 60 to 25 min for faster crash recovery
- Reduce task time limits from 45/60 to 20/25 min (soft/hard)

**Expected behavior after changes:**

| Metric | Before | After |
|--------|--------|-------|
| Flags batch size | 1000 | 250 |
| Memory per batch | 100-200MB | 25-50MB |
| Task duration | ~3-5 min (but OOM'd) | ~8-10 min |
| Runs per hour | 1 | 2 |
| Recovery after crash | 2 hours | ~30 min |

## How did you test this code?

- Ran existing unit tests for hypercache verification tasks
- Analyzed production data to understand flag distribution across teams
- Verified batch size reduction prevents memory amplification from heavy teams

Query results showed oldest teams (IDs 0-999) average 27.4 flags vs 4.1 for newer teams, and the first batch with ID ordering contained 6-14x more flags than subsequent batches.

## Changelog: (features only) Is this feature complete?

No - this is a reliability fix, not a user-facing feature.
