### PR TITLE
chore(flags): Add canonical log line for /flags requests

### DIFF
--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -6,7 +6,7 @@ use crate::{
         },
     },
     handler::{
-        decoding, process_request, CanonicalLogGuard, CanonicalLogLine, RequestContext,
+        decoding, process_request, FlagsCanonicalLogGuard, FlagsCanonicalLogLine, RequestContext,
     },
     router,
     utils::user_agent::UserAgentInfo,
@@ -249,7 +249,7 @@ pub async fn flags(
     // Initialize canonical log guard with all upfront request metadata.
     // The guard ensures the log is emitted even on early returns (e.g., rate limiting).
     // Fields discovered during processing (team_id, flags_evaluated, etc.) are set via log_mut().
-    let mut guard = CanonicalLogGuard::new(CanonicalLogLine {
+    let mut guard = FlagsCanonicalLogGuard::new(FlagsCanonicalLogLine {
         request_id,
         ip: ip_string.clone(),
         user_agent: user_agent.map(|s| s.to_string()),

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1447,6 +1447,7 @@ impl FeatureFlagMatcher {
                 1,
             );
             with_canonical_log(|log| log.property_cache_misses += 1);
+            with_canonical_log(|log| log.person_properties_not_cached = true);
             // Return empty HashMap instead of error - no properties is a valid state
             // TODO probably worth error modeling empty cache vs error.
             // Maybe an error is fine?  Idk.  I feel like the idea is that there's no matching properties,
@@ -1482,6 +1483,7 @@ impl FeatureFlagMatcher {
                 1,
             );
             with_canonical_log(|log| log.property_cache_misses += 1);
+            with_canonical_log(|log| log.group_properties_not_cached = true);
             // Return empty HashMap instead of error - no properties is a valid state
             Ok(HashMap::new())
         }

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -15,6 +15,7 @@ use crate::flags::flag_models::{
     BucketingIdentifier, FeatureFlag, FeatureFlagId, FeatureFlagList, FlagPropertyGroup,
 };
 use crate::flags::flag_operations::flags_require_db_preparation;
+use crate::handler::with_canonical_log;
 use crate::metrics::consts::{
     DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER, FLAG_DB_PROPERTIES_FETCH_TIME,
     FLAG_EVALUATE_ALL_CONDITIONS_TIME, FLAG_EVALUATION_ERROR_COUNTER, FLAG_EVALUATION_TIME,
@@ -391,6 +392,9 @@ impl FeatureFlagMatcher {
         target_properties: &HashMap<String, Value>,
         cohorts: Vec<Cohort>,
     ) -> Result<bool, FlagError> {
+        // Track cohort evaluations in canonical log
+        with_canonical_log(|log| log.cohorts_evaluated += cohort_property_filters.len());
+
         // Get cached static cohort results or evaluate them if not cached
         let static_cohort_matches = match self.flag_evaluation_state.get_static_cohort_matches() {
             Some(matches) => matches.clone(),
@@ -703,6 +707,9 @@ impl FeatureFlagMatcher {
                 Err(e) => {
                     errors_while_computing_flags = true;
                     let reason = parse_exception_for_prometheus_label(&e);
+
+                    // Track flag evaluation error in canonical log
+                    with_canonical_log(|log| log.flags_errored += 1);
 
                     // Handle DependencyNotFound errors differently since they indicate a deleted dependency
                     if let FlagError::DependencyNotFound(dependency_type, dependency_id) = &e {
@@ -1429,6 +1436,7 @@ impl FeatureFlagMatcher {
                 &[("type".to_string(), "person_properties".to_string())],
                 1,
             );
+            with_canonical_log(|log| log.property_cache_hits += 1);
             let mut result = HashMap::new();
             result.clone_from(properties);
             Ok(result)
@@ -1438,6 +1446,7 @@ impl FeatureFlagMatcher {
                 &[("type".to_string(), "person_properties".to_string())],
                 1,
             );
+            with_canonical_log(|log| log.property_cache_misses += 1);
             // Return empty HashMap instead of error - no properties is a valid state
             // TODO probably worth error modeling empty cache vs error.
             // Maybe an error is fine?  Idk.  I feel like the idea is that there's no matching properties,
@@ -1462,6 +1471,7 @@ impl FeatureFlagMatcher {
                 &[("type".to_string(), "group_properties".to_string())],
                 1,
             );
+            with_canonical_log(|log| log.property_cache_hits += 1);
             let mut result = HashMap::new();
             result.clone_from(properties);
             Ok(result)
@@ -1471,6 +1481,7 @@ impl FeatureFlagMatcher {
                 &[("type".to_string(), "group_properties".to_string())],
                 1,
             );
+            with_canonical_log(|log| log.property_cache_misses += 1);
             // Return empty HashMap instead of error - no properties is a valid state
             Ok(HashMap::new())
         }
@@ -1487,6 +1498,7 @@ impl FeatureFlagMatcher {
         let (hash_key_overrides, flag_hash_key_override_error) =
             if flags_have_experience_continuity_enabled {
                 common_metrics::inc(FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER, &[], 1);
+                with_canonical_log(|log| log.hash_key_override_attempted = true);
                 match hash_key_override {
                     Some(hash_key) => {
                         let target_distinct_ids = vec![self.distinct_id.clone(), hash_key.clone()];
@@ -1542,6 +1554,11 @@ impl FeatureFlagMatcher {
                 },
             )
             .fin();
+
+        // Track success in canonical log
+        if hash_key_overrides.is_some() && !flag_hash_key_override_error {
+            with_canonical_log(|log| log.hash_key_override_succeeded = true);
+        }
 
         (hash_key_overrides, flag_hash_key_override_error)
     }

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1446,8 +1446,10 @@ impl FeatureFlagMatcher {
                 &[("type".to_string(), "person_properties".to_string())],
                 1,
             );
-            with_canonical_log(|log| log.property_cache_misses += 1);
-            with_canonical_log(|log| log.person_properties_not_cached = true);
+            with_canonical_log(|log| {
+                log.property_cache_misses += 1;
+                log.person_properties_not_cached = true;
+            });
             // Return empty HashMap instead of error - no properties is a valid state
             // TODO probably worth error modeling empty cache vs error.
             // Maybe an error is fine?  Idk.  I feel like the idea is that there's no matching properties,
@@ -1482,8 +1484,10 @@ impl FeatureFlagMatcher {
                 &[("type".to_string(), "group_properties".to_string())],
                 1,
             );
-            with_canonical_log(|log| log.property_cache_misses += 1);
-            with_canonical_log(|log| log.group_properties_not_cached = true);
+            with_canonical_log(|log| {
+                log.property_cache_misses += 1;
+                log.group_properties_not_cached = true;
+            });
             // Return empty HashMap instead of error - no properties is a valid state
             Ok(HashMap::new())
         }

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -161,6 +161,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
         .map(|p| (Some(p.id), Some(p.properties)))
         .unwrap_or((None, None));
     person_query_timer.fin();
+    with_canonical_log(|log| log.person_queries += 1);
 
     let person_query_duration = person_query_start.elapsed();
 
@@ -208,6 +209,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
                 .fetch_all(&mut *conn)
                 .await?;
             cohort_timer.fin();
+            with_canonical_log(|log| log.static_cohort_queries += 1);
 
             let cohort_query_duration = cohort_query_start.elapsed();
 
@@ -298,6 +300,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             .fetch_all(&mut *conn)
             .await?;
         group_query_timer.fin();
+        with_canonical_log(|log| log.group_queries += 1);
 
         let group_query_duration = group_query_start.elapsed();
 

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -25,6 +25,7 @@ use crate::{
     api::{errors::FlagError, types::FlagValue},
     cohorts::cohort_models::CohortId,
     flags::flag_models::FeatureFlagId,
+    handler::with_canonical_log,
     metrics::consts::{
         FLAG_COHORT_PROCESSING_TIME, FLAG_COHORT_QUERY_TIME, FLAG_DATABASE_ERROR_COUNTER,
         FLAG_DEFINITION_QUERY_TIME, FLAG_GROUP_PROCESSING_TIME, FLAG_GROUP_QUERY_TIME,
@@ -91,6 +92,10 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     // Add the test-specific counter increment
     #[cfg(test)]
     increment_fetch_calls_count();
+
+    // Track database property fetch in canonical log
+    with_canonical_log(|log| log.db_property_fetches += 1);
+
     // Log pool stats before attempting connection
     if let Some(stats) = reader.as_ref().get_pool_stats() {
         info!(

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -1,0 +1,336 @@
+use crate::api::errors::FlagError;
+use std::time::Instant;
+use uuid::Uuid;
+
+/// Truncate a string to a maximum number of characters (not bytes).
+fn truncate_chars(s: &str, max_chars: usize) -> String {
+    s.chars().take(max_chars).collect()
+}
+
+/// Accumulates data throughout a /flags request lifecycle for canonical logging.
+///
+/// A canonical log line is a single comprehensive log entry emitted at request
+/// completion containing all key telemetry. This enables simple ClickHouse queries
+/// for debugging without needing to join multiple log entries.
+///
+/// Created at request start, populated during processing, emitted at request end.
+///
+/// Use [`CanonicalLogGuard`] to ensure the log is always emitted, even on early returns.
+#[derive(Debug, Clone)]
+pub struct CanonicalLogLine {
+    // Request identification
+    pub request_id: Uuid,
+    pub ip: String,
+    pub start_time: Instant,
+
+    // Request metadata (useful for SDK debugging)
+    pub user_agent: Option<String>,
+    pub lib: Option<&'static str>,
+    pub lib_version: Option<String>,
+    pub api_version: Option<String>,
+
+    // Populated during authentication
+    pub team_id: Option<i32>,
+    pub distinct_id: Option<String>,
+
+    // Populated during flag evaluation
+    pub flags_evaluated: Option<usize>,
+    pub flags_enabled: Option<usize>,
+    pub flags_disabled: bool,
+    pub quota_limited: bool,
+
+    // Rate limiting
+    pub rate_limited: bool,
+
+    // Outcome (populated at response time)
+    pub http_status: u16,
+    pub error_code: Option<String>,
+}
+
+impl Default for CanonicalLogLine {
+    fn default() -> Self {
+        Self {
+            request_id: Uuid::nil(),
+            ip: String::new(),
+            start_time: Instant::now(),
+            user_agent: None,
+            lib: None,
+            lib_version: None,
+            api_version: None,
+            team_id: None,
+            distinct_id: None,
+            flags_evaluated: None,
+            flags_enabled: None,
+            flags_disabled: false,
+            quota_limited: false,
+            rate_limited: false,
+            http_status: 200,
+            error_code: None,
+        }
+    }
+}
+
+impl CanonicalLogLine {
+    pub fn new(request_id: Uuid, ip: String) -> Self {
+        Self {
+            request_id,
+            ip,
+            ..Default::default()
+        }
+    }
+
+    /// Emit the canonical log line. Call once at request completion.
+    pub fn emit(&self) {
+        let duration_ms = self.start_time.elapsed().as_millis() as u64;
+
+        // Truncate distinct_id to prevent log line explosion from long IDs.
+        let distinct_id = self.distinct_id.as_ref().map(|d| truncate_chars(d, 64));
+
+        tracing::info!(
+            request_id = %self.request_id,
+            team_id = ?self.team_id,
+            distinct_id = ?distinct_id,
+            ip = %self.ip,
+            user_agent = ?self.user_agent,
+            lib = ?self.lib,
+            lib_version = ?self.lib_version,
+            api_version = ?self.api_version,
+            duration_ms = duration_ms,
+            http_status = self.http_status,
+            flags_evaluated = ?self.flags_evaluated,
+            flags_enabled = ?self.flags_enabled,
+            flags_disabled = self.flags_disabled,
+            quota_limited = self.quota_limited,
+            rate_limited = self.rate_limited,
+            error_code = ?self.error_code,
+            "canonical_log_line"
+        );
+    }
+
+    /// Populate error fields from a FlagError and emit the log line.
+    ///
+    /// This is a convenience method for error handling paths that reduces
+    /// repetitive code when returning errors.
+    pub fn emit_for_error(&mut self, error: &FlagError) {
+        self.http_status = error.status_code();
+        self.error_code = Some(error.error_code().to_string());
+        self.emit();
+    }
+}
+
+/// RAII guard that ensures the canonical log line is always emitted.
+///
+/// When the guard is dropped (goes out of scope), it automatically emits the log.
+/// This prevents silent data loss if new error paths are added without explicit emit() calls.
+///
+/// # Example
+/// ```ignore
+/// let guard = CanonicalLogGuard::new(CanonicalLogLine {
+///     request_id,
+///     ip: ip_string,
+///     user_agent: Some("posthog-python/3.0.0".to_string()),
+///     ..Default::default()
+/// });
+/// guard.log_mut().team_id = Some(123);  // Fields discovered during processing
+/// // Log is automatically emitted when guard goes out of scope
+/// ```
+pub struct CanonicalLogGuard {
+    log: CanonicalLogLine,
+    emitted: bool,
+}
+
+impl CanonicalLogGuard {
+    pub fn new(log: CanonicalLogLine) -> Self {
+        Self {
+            log,
+            emitted: false,
+        }
+    }
+
+    /// Get a mutable reference to the underlying log line for populating fields.
+    pub fn log_mut(&mut self) -> &mut CanonicalLogLine {
+        &mut self.log
+    }
+
+    /// Get an immutable reference to the underlying log line.
+    pub fn log(&self) -> &CanonicalLogLine {
+        &self.log
+    }
+
+    /// Consume the guard and return the inner log line without emitting.
+    /// Use this when you need to pass the log through async boundaries.
+    pub fn into_inner(mut self) -> CanonicalLogLine {
+        self.emitted = true; // Prevent double emission
+        std::mem::take(&mut self.log)
+    }
+
+    /// Explicitly emit the log and mark as emitted to prevent double emission on drop.
+    pub fn emit(mut self) {
+        self.log.emit();
+        self.emitted = true;
+    }
+}
+
+impl Drop for CanonicalLogGuard {
+    fn drop(&mut self) {
+        if !self.emitted {
+            self.log.emit();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_creates_with_defaults() {
+        let request_id = Uuid::new_v4();
+        let log = CanonicalLogLine::new(request_id, "192.168.1.1".to_string());
+
+        assert_eq!(log.request_id, request_id);
+        assert_eq!(log.ip, "192.168.1.1");
+        assert!(log.user_agent.is_none());
+        assert!(log.lib.is_none());
+        assert!(log.lib_version.is_none());
+        assert!(log.api_version.is_none());
+        assert!(log.team_id.is_none());
+        assert!(log.distinct_id.is_none());
+        assert!(log.flags_evaluated.is_none());
+        assert!(log.flags_enabled.is_none());
+        assert!(!log.flags_disabled);
+        assert!(!log.quota_limited);
+        assert!(!log.rate_limited);
+        assert_eq!(log.http_status, 200);
+        assert!(log.error_code.is_none());
+    }
+
+    #[test]
+    fn test_emit_does_not_panic() {
+        let log = CanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
+        // Should not panic
+        log.emit();
+    }
+
+    #[test]
+    fn test_emit_with_all_fields_populated() {
+        let mut log = CanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
+        log.user_agent = Some("posthog-python/1.0.0".to_string());
+        log.lib = Some("posthog-python");
+        log.lib_version = Some("1.0.0".to_string());
+        log.api_version = Some("3".to_string());
+        log.team_id = Some(123);
+        log.distinct_id = Some("user_abc".to_string());
+        log.flags_evaluated = Some(10);
+        log.flags_enabled = Some(5);
+        log.flags_disabled = false;
+        log.quota_limited = true;
+        log.rate_limited = false;
+        log.http_status = 200;
+        // Should not panic
+        log.emit();
+    }
+
+    #[test]
+    fn test_emit_with_error() {
+        let mut log = CanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
+        log.http_status = 429;
+        log.rate_limited = true;
+        log.error_code = Some("rate_limited".to_string());
+        // Should not panic
+        log.emit();
+    }
+
+    #[test]
+    fn test_long_distinct_id_is_truncated_in_emit() {
+        let mut log = CanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
+        // Create a distinct_id longer than 64 characters
+        log.distinct_id = Some("a".repeat(100));
+        // Should not panic - truncation happens in emit()
+        log.emit();
+    }
+
+    #[test]
+    fn test_multibyte_distinct_id_truncation() {
+        let mut log = CanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
+        // Create a distinct_id with multi-byte characters (emoji) longer than 64 chars
+        // Each emoji is 4 bytes but counts as 1 character
+        log.distinct_id = Some("🎉".repeat(100));
+        // Should not panic and should truncate by character count, not byte count
+        log.emit();
+    }
+
+    fn test_log() -> CanonicalLogLine {
+        CanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string())
+    }
+
+    #[test]
+    fn test_guard_emits_on_drop() {
+        // We can't easily verify the log was emitted, but we can verify no panic
+        let guard = CanonicalLogGuard::new(test_log());
+        drop(guard);
+        // If we get here, the guard emitted successfully on drop
+    }
+
+    #[test]
+    fn test_guard_log_mut_allows_modification() {
+        let mut guard = CanonicalLogGuard::new(test_log());
+        guard.log_mut().team_id = Some(123);
+        guard.log_mut().http_status = 200;
+        assert_eq!(guard.log().team_id, Some(123));
+        assert_eq!(guard.log().http_status, 200);
+    }
+
+    #[test]
+    fn test_guard_explicit_emit_prevents_double_emission() {
+        let mut guard = CanonicalLogGuard::new(test_log());
+        guard.log_mut().http_status = 200;
+        guard.emit(); // Explicit emit
+                      // Guard is consumed, so no double emission on drop
+    }
+
+    #[test]
+    fn test_guard_into_inner_prevents_emission() {
+        let mut guard = CanonicalLogGuard::new(test_log());
+        guard.log_mut().team_id = Some(456);
+        let log = guard.into_inner();
+        // Guard is consumed without emitting, log can be used elsewhere
+        assert_eq!(log.team_id, Some(456));
+    }
+
+    #[test]
+    fn test_clone_preserves_all_fields() {
+        let mut log = CanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
+        log.user_agent = Some("posthog-python/1.0.0".to_string());
+        log.lib = Some("posthog-python");
+        log.lib_version = Some("1.0.0".to_string());
+        log.api_version = Some("3".to_string());
+        log.team_id = Some(123);
+        log.distinct_id = Some("user123".to_string());
+        log.flags_evaluated = Some(5);
+        log.flags_enabled = Some(3);
+        log.flags_disabled = true;
+        log.quota_limited = true;
+        log.rate_limited = true;
+        log.http_status = 429;
+        log.error_code = Some("rate_limited".to_string());
+
+        let cloned = log.clone();
+
+        assert_eq!(cloned.request_id, log.request_id);
+        assert_eq!(cloned.ip, log.ip);
+        assert_eq!(cloned.user_agent, log.user_agent);
+        assert_eq!(cloned.lib, log.lib);
+        assert_eq!(cloned.lib_version, log.lib_version);
+        assert_eq!(cloned.api_version, log.api_version);
+        assert_eq!(cloned.team_id, log.team_id);
+        assert_eq!(cloned.distinct_id, log.distinct_id);
+        assert_eq!(cloned.flags_evaluated, log.flags_evaluated);
+        assert_eq!(cloned.flags_enabled, log.flags_enabled);
+        assert_eq!(cloned.flags_disabled, log.flags_disabled);
+        assert_eq!(cloned.quota_limited, log.quota_limited);
+        assert_eq!(cloned.rate_limited, log.rate_limited);
+        assert_eq!(cloned.http_status, log.http_status);
+        assert_eq!(cloned.error_code, log.error_code);
+    }
+}

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -106,6 +106,10 @@ pub struct FlagsCanonicalLogLine {
     pub static_cohort_queries: usize,
     pub property_cache_hits: usize,
     pub property_cache_misses: usize,
+    /// True if person properties were not found in evaluation state cache.
+    pub person_properties_not_cached: bool,
+    /// True if group properties were not found in evaluation state cache.
+    pub group_properties_not_cached: bool,
     pub cohorts_evaluated: usize,
     pub flags_errored: usize,
     pub hash_key_override_attempted: bool,
@@ -142,6 +146,8 @@ impl Default for FlagsCanonicalLogLine {
             static_cohort_queries: 0,
             property_cache_hits: 0,
             property_cache_misses: 0,
+            person_properties_not_cached: false,
+            group_properties_not_cached: false,
             cohorts_evaluated: 0,
             flags_errored: 0,
             hash_key_override_attempted: false,
@@ -191,6 +197,8 @@ impl FlagsCanonicalLogLine {
             static_cohort_queries = self.static_cohort_queries,
             property_cache_hits = self.property_cache_hits,
             property_cache_misses = self.property_cache_misses,
+            person_properties_not_cached = self.person_properties_not_cached,
+            group_properties_not_cached = self.group_properties_not_cached,
             cohorts_evaluated = self.cohorts_evaluated,
             flags_errored = self.flags_errored,
             hash_key_override_attempted = self.hash_key_override_attempted,
@@ -243,6 +251,8 @@ mod tests {
         assert_eq!(log.static_cohort_queries, 0);
         assert_eq!(log.property_cache_hits, 0);
         assert_eq!(log.property_cache_misses, 0);
+        assert!(!log.person_properties_not_cached);
+        assert!(!log.group_properties_not_cached);
         assert_eq!(log.cohorts_evaluated, 0);
         assert_eq!(log.flags_errored, 0);
         assert!(!log.hash_key_override_attempted);

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -110,13 +110,19 @@ impl CanonicalLogLine {
         );
     }
 
-    /// Populate error fields from a FlagError and emit the log line.
+    /// Populate error fields from a FlagError without emitting.
     ///
-    /// This is a convenience method for error handling paths that reduces
-    /// repetitive code when returning errors.
-    pub fn emit_for_error(&mut self, error: &FlagError) {
+    /// Use this when the guard will emit on drop (e.g., early returns).
+    pub fn set_error(&mut self, error: &FlagError) {
         self.http_status = error.status_code();
         self.error_code = Some(error.error_code().to_string());
+    }
+
+    /// Populate error fields from a FlagError and emit the log line.
+    ///
+    /// Use this when manually managing the log (after `into_inner()`).
+    pub fn emit_for_error(&mut self, error: &FlagError) {
+        self.set_error(error);
         self.emit();
     }
 }

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -109,7 +109,8 @@ pub struct FlagsCanonicalLogLine {
 
     // Outcome (populated at response time)
     pub http_status: u16,
-    pub error_code: Option<String>,
+    /// Error code from FlagError::error_code(). Uses &'static str to avoid allocation.
+    pub error_code: Option<&'static str>,
 }
 
 impl Default for FlagsCanonicalLogLine {
@@ -190,7 +191,7 @@ impl FlagsCanonicalLogLine {
     /// Populate error fields from a FlagError without emitting.
     pub fn set_error(&mut self, error: &FlagError) {
         self.http_status = error.status_code();
-        self.error_code = Some(error.error_code().to_string());
+        self.error_code = Some(error.error_code());
     }
 
     /// Populate error fields from a FlagError and emit the log line.
@@ -269,7 +270,7 @@ mod tests {
         let mut log = FlagsCanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
         log.http_status = 429;
         log.rate_limited = true;
-        log.error_code = Some("rate_limited".to_string());
+        log.error_code = Some("rate_limited");
         log.emit();
     }
 

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -34,8 +34,8 @@ pub struct FlagsCanonicalLogLine {
     pub distinct_id: Option<String>,
 
     // Populated during flag evaluation
-    pub flags_evaluated: Option<usize>,
-    pub flags_enabled: Option<usize>,
+    pub flags_evaluated: usize,
+    pub flags_experience_continuity: usize,
     pub flags_disabled: bool,
     pub quota_limited: bool,
 
@@ -59,8 +59,8 @@ impl Default for FlagsCanonicalLogLine {
             api_version: None,
             team_id: None,
             distinct_id: None,
-            flags_evaluated: None,
-            flags_enabled: None,
+            flags_evaluated: 0,
+            flags_experience_continuity: 0,
             flags_disabled: false,
             quota_limited: false,
             rate_limited: false,
@@ -98,8 +98,8 @@ impl FlagsCanonicalLogLine {
             api_version = ?self.api_version,
             duration_ms = duration_ms,
             http_status = self.http_status,
-            flags_evaluated = ?self.flags_evaluated,
-            flags_enabled = ?self.flags_enabled,
+            flags_evaluated = self.flags_evaluated,
+            flags_experience_continuity = self.flags_experience_continuity,
             flags_disabled = self.flags_disabled,
             quota_limited = self.quota_limited,
             rate_limited = self.rate_limited,
@@ -203,8 +203,8 @@ mod tests {
         assert!(log.api_version.is_none());
         assert!(log.team_id.is_none());
         assert!(log.distinct_id.is_none());
-        assert!(log.flags_evaluated.is_none());
-        assert!(log.flags_enabled.is_none());
+        assert_eq!(log.flags_evaluated, 0);
+        assert_eq!(log.flags_experience_continuity, 0);
         assert!(!log.flags_disabled);
         assert!(!log.quota_limited);
         assert!(!log.rate_limited);
@@ -228,8 +228,8 @@ mod tests {
         log.api_version = Some("3".to_string());
         log.team_id = Some(123);
         log.distinct_id = Some("user_abc".to_string());
-        log.flags_evaluated = Some(10);
-        log.flags_enabled = Some(5);
+        log.flags_evaluated = 10;
+        log.flags_experience_continuity = 2;
         log.flags_disabled = false;
         log.quota_limited = true;
         log.rate_limited = false;
@@ -295,8 +295,8 @@ mod tests {
         log.api_version = Some("3".to_string());
         log.team_id = Some(123);
         log.distinct_id = Some("user123".to_string());
-        log.flags_evaluated = Some(5);
-        log.flags_enabled = Some(3);
+        log.flags_evaluated = 5;
+        log.flags_experience_continuity = 1;
         log.flags_disabled = true;
         log.quota_limited = true;
         log.rate_limited = true;
@@ -314,7 +314,10 @@ mod tests {
         assert_eq!(cloned.team_id, log.team_id);
         assert_eq!(cloned.distinct_id, log.distinct_id);
         assert_eq!(cloned.flags_evaluated, log.flags_evaluated);
-        assert_eq!(cloned.flags_enabled, log.flags_enabled);
+        assert_eq!(
+            cloned.flags_experience_continuity,
+            log.flags_experience_continuity
+        );
         assert_eq!(cloned.flags_disabled, log.flags_disabled);
         assert_eq!(cloned.quota_limited, log.quota_limited);
         assert_eq!(cloned.rate_limited, log.rate_limited);

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -86,12 +86,15 @@ impl CanonicalLogLine {
         // Truncate distinct_id to prevent log line explosion from long IDs.
         let distinct_id = self.distinct_id.as_ref().map(|d| truncate_chars(d, 64));
 
+        // Truncate user_agent to prevent log bloat from very long headers (some bots send KB+).
+        let user_agent = self.user_agent.as_ref().map(|ua| truncate_chars(ua, 512));
+
         tracing::info!(
             request_id = %self.request_id,
             team_id = ?self.team_id,
             distinct_id = ?distinct_id,
             ip = %self.ip,
-            user_agent = ?self.user_agent,
+            user_agent = ?user_agent,
             lib = ?self.lib,
             lib_version = ?self.lib_version,
             api_version = ?self.api_version,

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -8,6 +8,7 @@ use crate::{
         flag_models::{FeatureFlag, FeatureFlagList},
         flag_service::FlagService,
     },
+    utils::user_agent::{RuntimeType, UserAgentInfo},
 };
 use axum::extract::State;
 use common_types::TeamId;
@@ -78,41 +79,14 @@ fn detect_evaluation_runtime_from_request(
         return Some(runtime);
     }
 
-    // Analyze User-Agent header
-    if let Some(user_agent) = headers.get("user-agent").and_then(|v| v.to_str().ok()) {
-        // Browser patterns - these typically indicate client-side execution
-        if user_agent.contains("Mozilla/")
-            || user_agent.contains("Chrome/")
-            || user_agent.contains("Safari/")
-            || user_agent.contains("Firefox/")
-            || user_agent.contains("Edge/")
-        {
-            return Some(EvaluationRuntime::Client);
-        }
+    // Analyze User-Agent header using shared parsing logic
+    let user_agent = headers.get("user-agent").and_then(|v| v.to_str().ok());
+    let ua_info = UserAgentInfo::parse(user_agent);
 
-        // Server SDK patterns - these indicate server-side execution
-        if user_agent.starts_with("posthog-python/")
-            || user_agent.starts_with("posthog-ruby/")
-            || user_agent.starts_with("posthog-php/")
-            || user_agent.starts_with("posthog-java/")
-            || user_agent.starts_with("posthog-go/")
-            || user_agent.starts_with("posthog-node/") // Note: server-side Node.js
-            || user_agent.starts_with("posthog-dotnet/")
-            || user_agent.starts_with("posthog-elixir/")
-            || user_agent.contains("python-requests/")
-            || user_agent.contains("curl/")
-        {
-            return Some(EvaluationRuntime::Server);
-        }
-
-        // Mobile SDK patterns - these indicate client-side mobile execution
-        if user_agent.starts_with("posthog-android/")
-            || user_agent.starts_with("posthog-ios/")
-            || user_agent.starts_with("posthog-react-native/")
-            || user_agent.starts_with("posthog-flutter/")
-        {
-            return Some(EvaluationRuntime::Client);
-        }
+    match ua_info.runtime {
+        RuntimeType::Client => return Some(EvaluationRuntime::Client),
+        RuntimeType::Server => return Some(EvaluationRuntime::Server),
+        RuntimeType::Unknown => {}
     }
 
     // Check for browser-specific headers that indicate client-side

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -1,5 +1,6 @@
 pub mod authentication;
 pub mod billing;
+pub mod canonical_log;
 pub mod config_response_builder;
 pub mod cookieless;
 pub mod decoding;
@@ -10,6 +11,7 @@ pub mod properties;
 pub mod session_recording;
 pub mod types;
 
+pub use canonical_log::{CanonicalLogGuard, CanonicalLogLine};
 pub use types::*;
 
 use crate::{
@@ -18,7 +20,7 @@ use crate::{
     metrics::consts::{FLAG_REQUESTS_COUNTER, FLAG_REQUESTS_LATENCY, FLAG_REQUEST_FAULTS_COUNTER},
 };
 use std::collections::HashMap;
-use tracing::{info, instrument, warn};
+use tracing::{instrument, warn};
 
 #[cfg(test)]
 use crate::handler::test_metrics::{histogram, inc};
@@ -32,16 +34,19 @@ use common_metrics::{histogram, inc};
 /// 2) Fetches the team and feature flags,
 /// 3) Prepares property overrides,
 /// 4) Evaluates the requested flags,
-/// 5) Returns a [`FlagsResponse`] or an error.
+/// 5) Returns a [`FlagsResponse`] or an error, along with canonical log data.
 #[instrument(skip_all, fields(request_id = %context.request_id))]
-pub async fn process_request(context: RequestContext) -> Result<FlagsResponse, FlagError> {
+pub async fn process_request(
+    context: RequestContext,
+    mut canonical_log: CanonicalLogLine,
+) -> (Result<FlagsResponse, FlagError>, CanonicalLogLine) {
     let start_time = std::time::Instant::now();
-    let (result, metrics_data) = process_request_inner(context).await;
+    let (result, metrics_data) = process_request_inner(context, &mut canonical_log).await;
     let total_duration = start_time.elapsed();
 
     record_metrics(&result, metrics_data, total_duration);
 
-    result
+    (result, canonical_log)
 }
 
 struct MetricsData {
@@ -85,6 +90,7 @@ fn record_metrics(
 
 async fn process_request_inner(
     context: RequestContext,
+    canonical_log: &mut CanonicalLogLine,
 ) -> (Result<FlagsResponse, FlagError>, MetricsData) {
     let mut metrics_data = MetricsData {
         team_id: None,
@@ -108,6 +114,9 @@ async fn process_request_inner(
             .clone()
             .unwrap_or_else(|| "disabled".to_string());
 
+        // Populate canonical log with distinct_id
+        canonical_log.distinct_id = Some(distinct_id_for_logging.clone());
+
         tracing::debug!(
             "Authentication completed for distinct_id: {}",
             distinct_id_for_logging
@@ -120,15 +129,20 @@ async fn process_request_inner(
         metrics_data.team_id = Some(team.id);
         metrics_data.flags_disabled = Some(request.is_flags_disabled());
 
+        // Populate canonical log with team_id
+        canonical_log.team_id = Some(team.id);
+
         tracing::debug!("Team fetched: team_id={}", team.id);
 
         // Early exit if flags are disabled
         let flags_response = if request.is_flags_disabled() {
+            canonical_log.flags_disabled = true;
             FlagsResponse::new(false, HashMap::new(), None, context.request_id)
         } else if let Some(quota_limited_response) =
             billing::check_limits(&context, &verified_token).await?
         {
             warn!("Request quota limited");
+            canonical_log.quota_limited = true;
             quota_limited_response
         } else {
             let distinct_id = cookieless::handle_distinct_id(
@@ -186,16 +200,12 @@ async fn process_request_inner(
         let response =
             config_response_builder::build_response(flags_response, &context, &team).await?;
 
-        // Comprehensive request summary
-        info!(
-            request_id = %context.request_id,
-            distinct_id = %distinct_id_for_logging,
-            team_id = team.id,
-            flags_count = response.flags.len(),
-            flags_disabled = request.is_flags_disabled(),
-            quota_limited = response.quota_limited.is_some(),
-            "Request completed"
-        );
+        // Populate canonical log with flag evaluation results
+        canonical_log.flags_evaluated = Some(response.flags.len());
+        canonical_log.flags_enabled = Some(response.flags.values().filter(|f| f.enabled).count());
+        if response.quota_limited.is_some() {
+            canonical_log.quota_limited = true;
+        }
 
         Ok(response)
     }

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -168,6 +168,13 @@ async fn process_request_inner(
 
             tracing::debug!("Flags filtered: {} flags found", filtered_flags.flags.len());
 
+            // Count flags with experience continuity for canonical logging
+            canonical_log.flags_experience_continuity = filtered_flags
+                .flags
+                .iter()
+                .filter(|f| f.ensure_experience_continuity.unwrap_or(false))
+                .count();
+
             let property_overrides = properties::prepare_overrides(&context, &request)?;
 
             // Evaluate flags (this will return empty if is_flags_disabled is true)
@@ -201,8 +208,7 @@ async fn process_request_inner(
             config_response_builder::build_response(flags_response, &context, &team).await?;
 
         // Populate canonical log with flag evaluation results
-        canonical_log.flags_evaluated = Some(response.flags.len());
-        canonical_log.flags_enabled = Some(response.flags.values().filter(|f| f.enabled).count());
+        canonical_log.flags_evaluated = response.flags.len();
         if response.quota_limited.is_some() {
             canonical_log.quota_limited = true;
         }

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -11,7 +11,7 @@ pub mod properties;
 pub mod session_recording;
 pub mod types;
 
-pub use canonical_log::{CanonicalLogGuard, CanonicalLogLine};
+pub use canonical_log::{FlagsCanonicalLogGuard, FlagsCanonicalLogLine};
 pub use types::*;
 
 use crate::{
@@ -38,8 +38,8 @@ use common_metrics::{histogram, inc};
 #[instrument(skip_all, fields(request_id = %context.request_id))]
 pub async fn process_request(
     context: RequestContext,
-    mut canonical_log: CanonicalLogLine,
-) -> (Result<FlagsResponse, FlagError>, CanonicalLogLine) {
+    mut canonical_log: FlagsCanonicalLogLine,
+) -> (Result<FlagsResponse, FlagError>, FlagsCanonicalLogLine) {
     let start_time = std::time::Instant::now();
     let (result, metrics_data) = process_request_inner(context, &mut canonical_log).await;
     let total_duration = start_time.elapsed();
@@ -90,7 +90,7 @@ fn record_metrics(
 
 async fn process_request_inner(
     context: RequestContext,
-    canonical_log: &mut CanonicalLogLine,
+    canonical_log: &mut FlagsCanonicalLogLine,
 ) -> (Result<FlagsResponse, FlagError>, MetricsData) {
     let mut metrics_data = MetricsData {
         team_id: None,

--- a/rust/feature-flags/src/utils/mod.rs
+++ b/rust/feature-flags/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod graph_utils;
 pub mod test_utils;
+pub mod user_agent;
 
 #[cfg(test)]
 mod test_graph_utils;

--- a/rust/feature-flags/src/utils/user_agent.rs
+++ b/rust/feature-flags/src/utils/user_agent.rs
@@ -1,0 +1,378 @@
+//! User-Agent parsing utilities for PostHog SDKs.
+//!
+//! Provides a unified way to extract SDK information from User-Agent headers,
+//! including SDK name, version, and runtime environment detection.
+
+/// Parsed information from a User-Agent header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserAgentInfo {
+    /// The SDK name if this is a PostHog SDK (e.g., "posthog-python", "posthog-js").
+    /// For browser requests without SDK header, this is None.
+    /// Uses static str since SDK names are from a known set.
+    pub sdk_name: Option<&'static str>,
+    /// The SDK version if this is a PostHog SDK.
+    pub sdk_version: Option<String>,
+    /// Whether this appears to be a browser request.
+    pub is_browser: bool,
+    /// The runtime environment: client-side, server-side, or unknown.
+    pub runtime: RuntimeType,
+}
+
+/// The runtime environment for flag evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeType {
+    /// Browser or mobile client-side execution.
+    Client,
+    /// Server-side execution.
+    Server,
+    /// Unable to determine runtime.
+    Unknown,
+}
+
+impl UserAgentInfo {
+    /// Parse a User-Agent header string into structured information.
+    pub fn parse(user_agent: Option<&str>) -> Self {
+        let Some(ua) = user_agent else {
+            return Self::unknown();
+        };
+
+        if ua.is_empty() {
+            return Self::unknown();
+        }
+
+        // Try to parse as PostHog SDK first
+        if let Some(rest) = ua.strip_prefix("posthog-") {
+            return Self::parse_posthog_sdk(rest);
+        }
+
+        // Check for browser patterns
+        if Self::is_browser_user_agent(ua) {
+            return Self {
+                sdk_name: None,
+                sdk_version: None,
+                is_browser: true,
+                runtime: RuntimeType::Client,
+            };
+        }
+
+        // Check for common HTTP clients (server-side indicators)
+        if ua.contains("python-requests/") || ua.contains("curl/") {
+            return Self {
+                sdk_name: None,
+                sdk_version: None,
+                is_browser: false,
+                runtime: RuntimeType::Server,
+            };
+        }
+
+        Self::unknown()
+    }
+
+    /// Parse a PostHog SDK User-Agent (after stripping "posthog-" prefix).
+    fn parse_posthog_sdk(rest: &str) -> Self {
+        // Pattern: <sdk-name>/<version> [optional extra info]
+        let Some(slash_idx) = rest.find('/') else {
+            return Self::unknown();
+        };
+
+        let name = &rest[..slash_idx];
+        let version_part = &rest[slash_idx + 1..];
+        // Take only the version part (stop at space or end)
+        let version = version_part
+            .split_whitespace()
+            .next()
+            .unwrap_or(version_part);
+
+        if name.is_empty() || version.is_empty() {
+            return Self::unknown();
+        }
+
+        // Match SDK name to static str and determine runtime in one step
+        let (sdk_name, runtime) = match name {
+            // Server-side SDKs
+            "python" => ("posthog-python", RuntimeType::Server),
+            "ruby" => ("posthog-ruby", RuntimeType::Server),
+            "php" => ("posthog-php", RuntimeType::Server),
+            "java" => ("posthog-java", RuntimeType::Server),
+            "go" => ("posthog-go", RuntimeType::Server),
+            "node" => ("posthog-node", RuntimeType::Server),
+            "dotnet" => ("posthog-dotnet", RuntimeType::Server),
+            "elixir" => ("posthog-elixir", RuntimeType::Server),
+            // Client-side SDKs (mobile and browser)
+            "js" => ("posthog-js", RuntimeType::Client),
+            "android" => ("posthog-android", RuntimeType::Client),
+            "ios" => ("posthog-ios", RuntimeType::Client),
+            "react-native" => ("posthog-react-native", RuntimeType::Client),
+            "flutter" => ("posthog-flutter", RuntimeType::Client),
+            // Unknown SDK - don't set sdk_name for unrecognized SDKs
+            _ => return Self::unknown(),
+        };
+
+        Self {
+            sdk_name: Some(sdk_name),
+            sdk_version: Some(version.to_string()),
+            is_browser: false,
+            runtime,
+        }
+    }
+
+    /// Check if the User-Agent indicates a browser.
+    fn is_browser_user_agent(ua: &str) -> bool {
+        ua.contains("Mozilla/")
+            || ua.contains("Chrome/")
+            || ua.contains("Safari/")
+            || ua.contains("Firefox/")
+            || ua.contains("Edge/")
+    }
+
+    fn unknown() -> Self {
+        Self {
+            sdk_name: None,
+            sdk_version: None,
+            is_browser: false,
+            runtime: RuntimeType::Unknown,
+        }
+    }
+
+    /// Get a low-cardinality client type label suitable for metrics.
+    /// Returns values like "posthog-python", "browser", or "other".
+    pub fn client_type_label(&self) -> &'static str {
+        if let Some(name) = self.sdk_name {
+            return name;
+        }
+        if self.is_browser {
+            return "browser";
+        }
+        "other"
+    }
+
+    /// Get a low-cardinality client type label suitable for metrics.
+    /// This version parses the raw user-agent and handles additional patterns
+    /// like curl and python-requests that aren't PostHog SDKs.
+    pub fn client_type_label_from_raw(user_agent: Option<&str>) -> &'static str {
+        let Some(ua) = user_agent else {
+            return "unknown";
+        };
+
+        if ua.is_empty() {
+            return "unknown";
+        }
+
+        // Check for common HTTP clients first (not PostHog SDKs)
+        if ua.contains("curl/") {
+            return "curl";
+        }
+        if ua.contains("python-requests/") {
+            return "python-requests";
+        }
+
+        // Delegate to client_type_label for SDKs, browsers, and other
+        Self::parse(Some(ua)).client_type_label()
+    }
+
+    /// Get the library name for canonical logging.
+    /// Returns the SDK name for PostHog SDKs, "web" for browsers, or None.
+    pub fn lib_for_logging(&self) -> Option<&'static str> {
+        self.sdk_name.or(self.is_browser.then_some("web"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        "posthog-python/3.0.0",
+        Some("posthog-python"),
+        Some("3.0.0"),
+        RuntimeType::Server
+    )]
+    #[case(
+        "posthog-node/1.2.3",
+        Some("posthog-node"),
+        Some("1.2.3"),
+        RuntimeType::Server
+    )]
+    #[case(
+        "posthog-ruby/2.0.0",
+        Some("posthog-ruby"),
+        Some("2.0.0"),
+        RuntimeType::Server
+    )]
+    #[case(
+        "posthog-go/1.0.0",
+        Some("posthog-go"),
+        Some("1.0.0"),
+        RuntimeType::Server
+    )]
+    #[case(
+        "posthog-php/3.1.0",
+        Some("posthog-php"),
+        Some("3.1.0"),
+        RuntimeType::Server
+    )]
+    #[case(
+        "posthog-java/1.1.0",
+        Some("posthog-java"),
+        Some("1.1.0"),
+        RuntimeType::Server
+    )]
+    #[case(
+        "posthog-dotnet/1.0.0",
+        Some("posthog-dotnet"),
+        Some("1.0.0"),
+        RuntimeType::Server
+    )]
+    #[case(
+        "posthog-elixir/0.2.0",
+        Some("posthog-elixir"),
+        Some("0.2.0"),
+        RuntimeType::Server
+    )]
+    #[case(
+        "posthog-js/1.88.0",
+        Some("posthog-js"),
+        Some("1.88.0"),
+        RuntimeType::Client
+    )]
+    #[case(
+        "posthog-android/3.0.0",
+        Some("posthog-android"),
+        Some("3.0.0"),
+        RuntimeType::Client
+    )]
+    #[case(
+        "posthog-ios/3.0.0",
+        Some("posthog-ios"),
+        Some("3.0.0"),
+        RuntimeType::Client
+    )]
+    #[case(
+        "posthog-react-native/2.5.0",
+        Some("posthog-react-native"),
+        Some("2.5.0"),
+        RuntimeType::Client
+    )]
+    #[case(
+        "posthog-flutter/4.0.0",
+        Some("posthog-flutter"),
+        Some("4.0.0"),
+        RuntimeType::Client
+    )]
+    #[case(
+        "posthog-python/3.0.0 (Linux; Python 3.11)",
+        Some("posthog-python"),
+        Some("3.0.0"),
+        RuntimeType::Server
+    )]
+    fn test_parse_posthog_sdks(
+        #[case] ua: &str,
+        #[case] expected_name: Option<&str>,
+        #[case] expected_version: Option<&str>,
+        #[case] expected_runtime: RuntimeType,
+    ) {
+        let info = UserAgentInfo::parse(Some(ua));
+        assert_eq!(info.sdk_name, expected_name);
+        assert_eq!(info.sdk_version.as_deref(), expected_version);
+        assert_eq!(info.runtime, expected_runtime);
+        assert!(!info.is_browser);
+    }
+
+    #[rstest]
+    #[case("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")]
+    #[case("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")]
+    #[case("Mozilla/5.0 (X11; Linux x86_64) Firefox/89.0")]
+    #[case("Chrome/120.0.0.0 Safari/537.36")]
+    fn test_parse_browser_user_agents(#[case] ua: &str) {
+        let info = UserAgentInfo::parse(Some(ua));
+        assert!(info.is_browser);
+        assert!(info.sdk_name.is_none());
+        assert!(info.sdk_version.is_none());
+        assert_eq!(info.runtime, RuntimeType::Client);
+    }
+
+    #[rstest]
+    #[case("curl/7.68.0", RuntimeType::Server)]
+    #[case("python-requests/2.28.0", RuntimeType::Server)]
+    fn test_parse_http_clients(#[case] ua: &str, #[case] expected_runtime: RuntimeType) {
+        let info = UserAgentInfo::parse(Some(ua));
+        assert!(!info.is_browser);
+        assert!(info.sdk_name.is_none());
+        assert_eq!(info.runtime, expected_runtime);
+    }
+
+    #[rstest]
+    #[case("posthog-python", None, None)] // No slash
+    #[case("posthog-python/", None, None)] // Empty version
+    #[case("posthog-/1.0.0", None, None)] // Empty SDK name
+    #[case("", None, None)] // Empty string
+    fn test_parse_edge_cases(
+        #[case] ua: &str,
+        #[case] expected_name: Option<&str>,
+        #[case] expected_version: Option<&str>,
+    ) {
+        let info = UserAgentInfo::parse(Some(ua));
+        assert_eq!(info.sdk_name, expected_name);
+        assert_eq!(info.sdk_version.as_deref(), expected_version);
+    }
+
+    #[test]
+    fn test_parse_none() {
+        let info = UserAgentInfo::parse(None);
+        assert!(info.sdk_name.is_none());
+        assert!(info.sdk_version.is_none());
+        assert!(!info.is_browser);
+        assert_eq!(info.runtime, RuntimeType::Unknown);
+    }
+
+    #[rstest]
+    #[case(Some("posthog-js/1.88.0"), "posthog-js")]
+    #[case(Some("posthog-android/3.1.0"), "posthog-android")]
+    #[case(Some("posthog-ios/3.0.0"), "posthog-ios")]
+    #[case(Some("posthog-react-native/2.5.0"), "posthog-react-native")]
+    #[case(Some("posthog-flutter/4.0.0"), "posthog-flutter")]
+    #[case(Some("posthog-python/1.4.0"), "posthog-python")]
+    #[case(Some("posthog-ruby/2.0.0"), "posthog-ruby")]
+    #[case(Some("posthog-php/3.0.0"), "posthog-php")]
+    #[case(Some("posthog-java/1.0.0"), "posthog-java")]
+    #[case(Some("posthog-go/0.1.0"), "posthog-go")]
+    #[case(Some("posthog-node/2.2.0"), "posthog-node")]
+    #[case(Some("posthog-dotnet/1.0.0"), "posthog-dotnet")]
+    #[case(Some("posthog-elixir/0.2.0"), "posthog-elixir")]
+    #[case(
+        Some("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"),
+        "browser"
+    )]
+    #[case(
+        Some("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/91.0.4472.124"),
+        "browser"
+    )]
+    #[case(Some("Mozilla/5.0 (X11; Linux x86_64) Firefox/89.0"), "browser")]
+    #[case(Some("curl/7.68.0"), "curl")]
+    #[case(Some("python-requests/2.28.0"), "python-requests")]
+    #[case(Some("custom-client/1.0"), "other")]
+    #[case(Some(""), "unknown")]
+    #[case(None, "unknown")]
+    fn test_client_type_label(#[case] user_agent: Option<&str>, #[case] expected: &str) {
+        assert_eq!(
+            UserAgentInfo::client_type_label_from_raw(user_agent),
+            expected
+        );
+    }
+
+    #[rstest]
+    #[case("posthog-python/3.0.0", Some("posthog-python"))]
+    #[case("posthog-node/1.2.3", Some("posthog-node"))]
+    #[case("posthog-android/3.0.0", Some("posthog-android"))]
+    #[case("Mozilla/5.0 (Windows NT 10.0; Win64; x64)", Some("web"))]
+    #[case("Chrome/120.0.0.0 Safari/537.36", Some("web"))]
+    #[case("curl/7.68.0", None)]
+    #[case("python-requests/2.28.0", None)]
+    #[case("custom-client/1.0", None)]
+    fn test_lib_for_logging(#[case] ua: &str, #[case] expected: Option<&str>) {
+        let info = UserAgentInfo::parse(Some(ua));
+        assert_eq!(info.lib_for_logging(), expected);
+    }
+}


### PR DESCRIPTION
## Problem

When debugging `/flags` request issues in production, we need to correlate multiple log entries to understand what happened during a request. This makes debugging slow and error-prone, especially when investigating SDK-specific issues or tracking down problems for specific teams.

We need a single, comprehensive log entry per request that contains all key telemetry. This is inspired by this post entitled [Fast and flexible observability with canonical log lines](https://stripe.com/blog/canonical-log-lines). @andyzzhao brought this post to our attention in [this Slack thread](https://posthog.slack.com/archives/C07Q2U4BH4L/p1766351262135789) and noted that it would enable simple ClickHouse queries for debugging without needing to join multiple log entries.

## Changes

Implement Stripe-style canonical log lines for the Rust `/flags` service:

**Core canonical log infrastructure:**

- Add `CanonicalLogLine` struct to accumulate telemetry throughout request lifecycle
- Add `CanonicalLogGuard` RAII wrapper to ensure logs are always emitted, even on early returns
- Emit a single log entry at request completion with message `"canonical_log_line"`

**Fields captured:**
| Field | Description |
|-------|-------------|
| `request_id` | UUID for distributed tracing |
| `team_id` | Team identifier |
| `distinct_id` | User identifier (truncated to 64 chars) |
| `ip` | Client IP address |
| `user_agent` | Full User-Agent string |
| `lib` | SDK name (e.g., "posthog-python", "web") |
| `lib_version` | SDK version (from query param or User-Agent) |
| `api_version` | Response format version (v=1,2,3,4) |
| `duration_ms` | Request latency |
| `http_status` | Response status code |
| `flags_evaluated` | Count of flags evaluated |
| `flags_enabled` | Count of enabled flags |
| `flags_disabled` | Whether flags were disabled via request |
| `quota_limited` | Hit quota limit |
| `rate_limited` | Hit rate limit |
| `error_code` | Error code if request failed |

**SDK detection:**
- Browser SDK: `lib_version` from `ver=` query param, `lib` = "web" from User-Agent patterns
- Server SDKs: Both `lib` and `lib_version` extracted from User-Agent (e.g., `posthog-python/3.0.0`)

## How did you test this code?

- Unit tests for all helper functions (`extract_version_from_user_agent`, `extract_lib_from_user_agent`, `extract_client_ip`, `extract_request_id`)
- Unit tests for `CanonicalLogLine` struct initialization and field population
- Unit tests for `CanonicalLogGuard` RAII behavior (emit on drop, explicit emit, into_inner)
- Manual testing with curl to verify log output format

To filter canonical logs when running locally:
```bash
RUST_LOG=info cargo run --bin feature-flags 2>&1 | grep "canonical_log_line"
```

Example output:

```
2025-12-24T00:20:20.775160Z  INFO ThreadId(09) feature_flags::handler::canonical_log: canonical_log_line request_id=41908baa-79c1-48e3-acc8-4bd541c9676f team_id=Some(2) distinct_id=Some("0198f39e-af74-7704-9e54-1d7a121a6be8") ip=127.0.0.1 user_agent=Some("posthog-python/3.0.0") lib=Some("posthog-python") lib_version=Some("3.0.0") api_version=Some("2") duration_ms=100 http_status=200 flags_evaluated=Some(6) flags_enabled=Some(5) flags_disabled=false quota_limited=false rate_limited=false error_code=None
2025-12-24T00:20:21.797560Z  INFO ThreadId(05) feature_flags::handler::canonical_log: canonical_log_line request_id=41908baa-79c1-48e3-acc8-4bd541c9676f team_id=Some(2) distinct_id=Some("0198f39e-af74-7704-9e54-1d7a121a6be8") ip=127.0.0.1 user_agent=Some("posthog-python/3.0.0") lib=Some("posthog-python") lib_version=Some("3.0.0") api_version=Some("2") duration_ms=5 http_status=200 flags_evaluated=Some(6) flags_enabled=Some(5) flags_disabled=false quota_limited=false rate_limited=false error_code=None
```

## Changelog: (features only) Is this feature complete?

No - this is internal observability infrastructure, not a user-facing feature.
