### PR TITLE
fix(flags): Add `gc.collect()` and reduce memory in cache verification

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -107,11 +107,12 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     if not teams:
         return {}
 
-    # Load all flags for all teams in one query with evaluation tags pre-loaded
+    # Load all flags for all teams in one query with evaluation tags pre-loaded.
+    # Note: We intentionally don't select_related("team") here because we only need
+    # team_id (already on the model) for grouping, and the Team objects are already
+    # loaded by the caller. Avoiding the join saves memory.
     all_flags = list(
-        FeatureFlag.objects.filter(team__in=teams, active=True, deleted=False)
-        .select_related("team")
-        .annotate(
+        FeatureFlag.objects.filter(team__in=teams, active=True, deleted=False).annotate(
             evaluation_tag_names_agg=ArrayAgg(
                 "evaluation_tags__tag__name",
                 filter=Q(evaluation_tags__isnull=False),


### PR DESCRIPTION
## Problem

The `verify_and_fix_flags_cache_task` has been experiencing OOM kills. Investigation revealed that while the batch size reduction in #43961 was correct, memory can accumulate between batches because Python's GC doesn't aggressively release memory to the OS. Additionally, workers with high baseline memory from previous tasks have less headroom for this memory-intensive operation.

## Changes

- Add `gc.collect()` at the start of verification to clear accumulated garbage from previous tasks, maximizing available memory headroom
- Add `gc.collect()` after each batch to prevent memory accumulation between batches
- Remove unnecessary `select_related("team")` from the flags batch loading query since only `team_id` is needed for grouping (Team objects are already loaded by the caller)

## How did you test this code?

- Ran all 126 affected unit tests:
  - `posthog/storage/test/test_hypercache_verifier.py` (43 tests)
  - `posthog/models/feature_flag/test/test_flags_cache.py` (75 tests)
  - `posthog/tasks/test/test_hypercache_verification.py` (8 tests)
- Verified with ruff that code passes linting and formatting checks

These are conservative changes that reduce memory pressure without changing verification behavior. Worker memory recycling configuration is being investigated separately as an infrastructure change.
