### PR TITLE
fix(trends): histogram bins with max show correct value for 'Other'

### DIFF
--- a/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
@@ -2062,8 +2062,7 @@
                              ORDER BY day_start ASC, breakdown_value ASC)) AS breakdown_series
                        GROUP BY breakdown_series.breakdown_value) AS totals_per_breakdown) AS ranked_breakdown_totals ON equals(ranked_breakdown_totals.breakdown_value, breakdown_series.breakdown_value)) AS ranked_breakdown_values
               WHERE ifNull(greater(ranked_breakdown_values.breakdown_rank, 25), 0)
-              GROUP BY breakdown_value,
-                       ranked_breakdown_values.day_start) AS other_breakdown_values)
+              GROUP BY ranked_breakdown_values.day_start) AS other_breakdown_values)
         ORDER BY day_start ASC, value ASC) AS top_n_and_other_breakdown_values
      GROUP BY top_n_and_other_breakdown_values.breakdown_value)
   ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
@@ -2388,8 +2387,7 @@
                              ORDER BY day_start ASC, breakdown_value ASC)) AS breakdown_series
                        GROUP BY breakdown_series.breakdown_value) AS totals_per_breakdown) AS ranked_breakdown_totals ON equals(ranked_breakdown_totals.breakdown_value, breakdown_series.breakdown_value)) AS ranked_breakdown_values
               WHERE ifNull(greater(ranked_breakdown_values.breakdown_rank, 25), 0)
-              GROUP BY breakdown_value,
-                       ranked_breakdown_values.day_start) AS other_breakdown_values)
+              GROUP BY ranked_breakdown_values.day_start) AS other_breakdown_values)
         ORDER BY day_start ASC, value ASC) AS top_n_and_other_breakdown_values
      GROUP BY top_n_and_other_breakdown_values.breakdown_value)
   ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
@@ -2770,8 +2768,7 @@
                              ORDER BY day_start ASC, breakdown_value ASC)) AS breakdown_series
                        GROUP BY breakdown_series.breakdown_value) AS totals_per_breakdown) AS ranked_breakdown_totals ON equals(ranked_breakdown_totals.breakdown_value, breakdown_series.breakdown_value)) AS ranked_breakdown_values
               WHERE ifNull(greater(ranked_breakdown_values.breakdown_rank, 25), 0)
-              GROUP BY breakdown_value,
-                       ranked_breakdown_values.day_start) AS other_breakdown_values)
+              GROUP BY ranked_breakdown_values.day_start) AS other_breakdown_values)
         ORDER BY day_start ASC, value ASC) AS top_n_and_other_breakdown_values
      GROUP BY top_n_and_other_breakdown_values.breakdown_value)
   ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
@@ -3180,8 +3177,7 @@
                              ORDER BY day_start ASC, breakdown_value ASC)) AS breakdown_series
                        GROUP BY breakdown_series.breakdown_value) AS totals_per_breakdown) AS ranked_breakdown_totals ON equals(ranked_breakdown_totals.breakdown_value, breakdown_series.breakdown_value)) AS ranked_breakdown_values
               WHERE ifNull(greater(ranked_breakdown_values.breakdown_rank, 25), 0)
-              GROUP BY breakdown_value,
-                       ranked_breakdown_values.day_start) AS other_breakdown_values)
+              GROUP BY ranked_breakdown_values.day_start) AS other_breakdown_values)
         ORDER BY day_start ASC, value ASC) AS top_n_and_other_breakdown_values
      GROUP BY top_n_and_other_breakdown_values.breakdown_value)
   ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -6228,6 +6228,7 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 break
 
         self.assertIsNotNone(other_result, "Should have an 'Other' breakdown")
+        assert other_result is not None  # for mypy
 
         # The critical assertion: "Other" should take MAX of all bins that didn't make top 2
         # Bin with vcpu=5 has max=3000
@@ -6350,6 +6351,7 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 break
 
         self.assertIsNotNone(other_result, "Should have an 'Other' breakdown")
+        assert other_result is not None  # for mypy
 
         # The critical assertion: "Other" should sum all bins that didn't make top 2
         # This should be: 4500 (vcpu=5) + 2000 (vcpu=7) = 6500

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -6012,3 +6012,365 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             response_exact.results[0]["count"],
             "With explicitDate=True, only includes events within the 7-day filter even with relative dates",
         )
+
+    def test_breakdown_other_aggregates_correctly(self):
+        """
+        Test that the "Other" breakdown correctly sums values across all breakdown values
+        that didn't make the top list, rather than taking the maximum.
+
+        Related to bug report: https://posthog.slack.com/archives/...
+        When breaking down by a property with property value sum aggregation,
+        the "Other" bucket should sum all values from breakdown values that fall into "Other",
+        not take the maximum value.
+        """
+        PropertyDefinition.objects.create(team=self.team, name="category", property_type="String")
+        PropertyDefinition.objects.create(team=self.team, name="ram_mb", property_type="Numeric")
+
+        # Create events with many distinct breakdown values to trigger "Other"
+        # We'll make sure top 3 categories by sum are A, B, C
+        # And D, E go to "Other" with varying ram_mb values to detect sum vs max bug
+
+        # Category A: 10 events with ram_mb=1000 each -> total 10000
+        for i in range(10):
+            _create_event(
+                team=self.team,
+                event="server_created",
+                distinct_id=f"person_a_{i}",
+                timestamp="2020-01-11T12:00:00Z",
+                properties={"category": "A", "ram_mb": 1000},
+            )
+
+        # Category B: 8 events with ram_mb=1000 each -> total 8000
+        for i in range(8):
+            _create_event(
+                team=self.team,
+                event="server_created",
+                distinct_id=f"person_b_{i}",
+                timestamp="2020-01-11T12:00:00Z",
+                properties={"category": "B", "ram_mb": 1000},
+            )
+
+        # Category C: 6 events with ram_mb=1000 each -> total 6000
+        for i in range(6):
+            _create_event(
+                team=self.team,
+                event="server_created",
+                distinct_id=f"person_c_{i}",
+                timestamp="2020-01-11T12:00:00Z",
+                properties={"category": "C", "ram_mb": 1000},
+            )
+
+        # Category D: 3 events -> goes to "Other"
+        # Event 1: ram_mb=500
+        # Event 2: ram_mb=1000
+        # Event 3: ram_mb=2000 <- This is the MAX value in D
+        # Sum: 3500 (correct), Max: 2000 (incorrect if bug exists)
+        _create_event(
+            team=self.team,
+            event="server_created",
+            distinct_id="person_d_1",
+            timestamp="2020-01-11T12:00:00Z",
+            properties={"category": "D", "ram_mb": 500},
+        )
+        _create_event(
+            team=self.team,
+            event="server_created",
+            distinct_id="person_d_2",
+            timestamp="2020-01-11T12:00:00Z",
+            properties={"category": "D", "ram_mb": 1000},
+        )
+        _create_event(
+            team=self.team,
+            event="server_created",
+            distinct_id="person_d_3",
+            timestamp="2020-01-11T12:00:00Z",
+            properties={"category": "D", "ram_mb": 2000},
+        )
+
+        # Category E: 2 events -> goes to "Other"
+        # Event 1: ram_mb=800
+        # Event 2: ram_mb=1200
+        # Sum: 2000
+        _create_event(
+            team=self.team,
+            event="server_created",
+            distinct_id="person_e_1",
+            timestamp="2020-01-11T12:00:00Z",
+            properties={"category": "E", "ram_mb": 800},
+        )
+        _create_event(
+            team=self.team,
+            event="server_created",
+            distinct_id="person_e_2",
+            timestamp="2020-01-11T12:00:00Z",
+            properties={"category": "E", "ram_mb": 1200},
+        )
+
+        flush_persons_and_events()
+
+        response = self._run_trends_query(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            [EventsNode(event="server_created", math=PropertyMathType.SUM, math_property="ram_mb")],
+            None,
+            BreakdownFilter(breakdown="category", breakdown_type=BreakdownType.EVENT, breakdown_limit=3),
+        )
+
+        # Should have 4 results: A, B, C, and "Other"
+        self.assertEqual(len(response.results), 4)
+
+        breakdown_to_result = {result["breakdown_value"]: result for result in response.results}
+
+        # Verify top 3 categories are correct (by sum: A=10000, B=8000, C=6000)
+        self.assertIn("A", breakdown_to_result)
+        self.assertIn("B", breakdown_to_result)
+        self.assertIn("C", breakdown_to_result)
+        self.assertIn("$$_posthog_breakdown_other_$$", breakdown_to_result)
+
+        # Check the sums for known categories
+        self.assertEqual(breakdown_to_result["A"]["data"][2], 10000.0)  # 10 * 1000
+        self.assertEqual(breakdown_to_result["B"]["data"][2], 8000.0)  # 8 * 1000
+        self.assertEqual(breakdown_to_result["C"]["data"][2], 6000.0)  # 6 * 1000
+
+        # The critical assertion: "Other" should sum D + E
+        # D sum: 500 + 1000 + 2000 = 3500
+        # E sum: 800 + 1200 = 2000
+        # Total Other sum: 5500 (correct)
+        #
+        # If the bug exists and it takes max of each category then sums:
+        # D max: 2000, E max: 1200 -> total 3200 (incorrect)
+        #
+        # Or if it takes the overall max across all "Other" values: 2000 (incorrect)
+        other_result = breakdown_to_result["$$_posthog_breakdown_other_$$"]
+        self.assertEqual(
+            other_result["data"][2],
+            5500.0,
+            "Other should sum all ram_mb values from categories D and E (3500 + 2000 = 5500), not take the max",
+        )
+
+    def test_breakdown_other_with_histogram_bins_and_max_aggregation(self):
+        """
+        Test that the "Other" breakdown with histogram bins and MAX aggregation correctly
+        takes the maximum, not sums values.
+        """
+        PropertyDefinition.objects.create(team=self.team, name="vcpu", property_type="Numeric")
+        PropertyDefinition.objects.create(team=self.team, name="ram_mb", property_type="Numeric")
+
+        # Create events with various vcpu values that will be binned
+        # We'll use MAX aggregation on ram_mb
+
+        # Bin 1: vcpu=[1,2] - should have high max to be in top 2
+        # 5 events with varying ram_mb, max=10000
+        for i, ram in enumerate([1000, 2000, 5000, 8000, 10000]):
+            _create_event(
+                team=self.team,
+                event="server_created",
+                distinct_id=f"person_vcpu1_{i}",
+                timestamp="2020-01-11T12:00:00Z",
+                properties={"vcpu": 1, "ram_mb": ram},
+            )
+
+        # Bin 2: vcpu=[3,4] - should have high max to be in top 2
+        # 5 events with varying ram_mb, max=9000
+        for i, ram in enumerate([1000, 2000, 4000, 7000, 9000]):
+            _create_event(
+                team=self.team,
+                event="server_created",
+                distinct_id=f"person_vcpu3_{i}",
+                timestamp="2020-01-11T12:00:00Z",
+                properties={"vcpu": 3, "ram_mb": ram},
+            )
+
+        # Bin 3: vcpu=[5,6] - will go to "Other"
+        # 3 events, max=3000
+        for i, ram in enumerate([500, 1500, 3000]):
+            _create_event(
+                team=self.team,
+                event="server_created",
+                distinct_id=f"person_vcpu5_{i}",
+                timestamp="2020-01-11T12:00:00Z",
+                properties={"vcpu": 5, "ram_mb": ram},
+            )
+
+        # Bin 4: vcpu=[7,8] - will also go to "Other"
+        # 2 events, max=2500
+        for i, ram in enumerate([1200, 2500]):
+            _create_event(
+                team=self.team,
+                event="server_created",
+                distinct_id=f"person_vcpu7_{i}",
+                timestamp="2020-01-11T12:00:00Z",
+                properties={"vcpu": 7, "ram_mb": ram},
+            )
+
+        flush_persons_and_events()
+
+        # Use histogram bins with MAX aggregation and limit=2
+        response = self._run_trends_query(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            [EventsNode(event="server_created", math=PropertyMathType.MAX, math_property="ram_mb")],
+            None,
+            BreakdownFilter(
+                breakdowns=[Breakdown(property="vcpu", histogram_bin_count=4)],
+                breakdown_limit=2,
+            ),
+        )
+
+        # Should have 3 results: 2 bins + "Other"
+        self.assertEqual(len(response.results), 3)
+
+        # Find the "Other" result (breakdown_value is a list when using multiple breakdowns)
+        other_result = None
+        for result in response.results:
+            bv = result["breakdown_value"]
+            if (
+                isinstance(bv, list) and "$$_posthog_breakdown_other_$$" in bv
+            ) or bv == "$$_posthog_breakdown_other_$$":
+                other_result = result
+                break
+
+        self.assertIsNotNone(other_result, "Should have an 'Other' breakdown")
+
+        # The critical assertion: "Other" should take MAX of all bins that didn't make top 2
+        # Bin with vcpu=5 has max=3000
+        # Bin with vcpu=7 has max=2500
+        # So "Other" should show max(3000, 2500) = 3000
+        #
+        # If the bug exists and it sums instead of taking max:
+        # It might show 3000 + 2500 = 5500 (incorrect - bigger than the max!)
+        #
+        # The user reported: "the Other suddenly is bigger than the previous max"
+        # which would happen if it's summing (5500) instead of maxing (3000)
+        self.assertEqual(
+            other_result["data"][2],
+            3000.0,
+            "Other with MAX aggregation should take the maximum value across bins (max of 3000 and 2500 = 3000), not sum them (which would be 5500)",
+        )
+
+    def test_breakdown_other_with_histogram_bins_aggregates_correctly(self):
+        """
+        Test that the "Other" breakdown with histogram bins correctly sums values,
+        not takes the maximum.
+
+        This is related to the follow-up bug report where "Other" during breakdown with
+        histogram bins shows incorrect (likely max) aggregation instead of sum.
+
+        The original bug was that histogram bins themselves were taking max instead of sum.
+        The follow-up bug is that "Other" also has the same issue when combined with histogram bins.
+        """
+        PropertyDefinition.objects.create(team=self.team, name="vcpu", property_type="Numeric")
+        PropertyDefinition.objects.create(team=self.team, name="ram_mb", property_type="Numeric")
+
+        # We'll create events with various vcpu values that will be binned
+        # and have different ram_mb values to aggregate
+
+        # Bin 1: vcpu=[1,2] - should have high total to be in top 2
+        # 10 events with vcpu=1, ram_mb=1000 each -> total 10000
+        for i in range(10):
+            _create_event(
+                team=self.team,
+                event="server_created",
+                distinct_id=f"person_vcpu1_{i}",
+                timestamp="2020-01-11T12:00:00Z",
+                properties={"vcpu": 1, "ram_mb": 1000},
+            )
+
+        # Bin 2: vcpu=[3,4] - should have high total to be in top 2
+        # 8 events with vcpu=3, ram_mb=1000 each -> total 8000
+        for i in range(8):
+            _create_event(
+                team=self.team,
+                event="server_created",
+                distinct_id=f"person_vcpu3_{i}",
+                timestamp="2020-01-11T12:00:00Z",
+                properties={"vcpu": 3, "ram_mb": 1000},
+            )
+
+        # Bin 3: vcpu=[5,6] - will go to "Other"
+        # 3 events with varying ram_mb values
+        _create_event(
+            team=self.team,
+            event="server_created",
+            distinct_id="person_vcpu5_1",
+            timestamp="2020-01-11T12:00:00Z",
+            properties={"vcpu": 5, "ram_mb": 500},
+        )
+        _create_event(
+            team=self.team,
+            event="server_created",
+            distinct_id="person_vcpu5_2",
+            timestamp="2020-01-11T12:00:00Z",
+            properties={"vcpu": 5, "ram_mb": 1000},
+        )
+        _create_event(
+            team=self.team,
+            event="server_created",
+            distinct_id="person_vcpu5_3",
+            timestamp="2020-01-11T12:00:00Z",
+            properties={"vcpu": 5, "ram_mb": 3000},  # <- MAX value is 3000
+        )
+        # vcpu=5 total: 500 + 1000 + 3000 = 4500
+
+        # Bin 4: vcpu=[7,8] - will also go to "Other"
+        # 2 events
+        _create_event(
+            team=self.team,
+            event="server_created",
+            distinct_id="person_vcpu7_1",
+            timestamp="2020-01-11T12:00:00Z",
+            properties={"vcpu": 7, "ram_mb": 800},
+        )
+        _create_event(
+            team=self.team,
+            event="server_created",
+            distinct_id="person_vcpu7_2",
+            timestamp="2020-01-11T12:00:00Z",
+            properties={"vcpu": 7, "ram_mb": 1200},
+        )
+        # vcpu=7 total: 800 + 1200 = 2000
+
+        flush_persons_and_events()
+
+        # Use histogram bins with limit=2, so bins for vcpu=5 and vcpu=7 should go to "Other"
+        response = self._run_trends_query(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            [EventsNode(event="server_created", math=PropertyMathType.SUM, math_property="ram_mb")],
+            None,
+            BreakdownFilter(
+                breakdowns=[Breakdown(property="vcpu", histogram_bin_count=4)],
+                breakdown_limit=2,
+            ),
+        )
+
+        # Should have 3 results: 2 bins + "Other"
+        self.assertEqual(len(response.results), 3)
+
+        # Find the "Other" result (breakdown_value is a list when using multiple breakdowns)
+        other_result = None
+        for result in response.results:
+            bv = result["breakdown_value"]
+            if (
+                isinstance(bv, list) and "$$_posthog_breakdown_other_$$" in bv
+            ) or bv == "$$_posthog_breakdown_other_$$":
+                other_result = result
+                break
+
+        self.assertIsNotNone(other_result, "Should have an 'Other' breakdown")
+
+        # The critical assertion: "Other" should sum all bins that didn't make top 2
+        # This should be: 4500 (vcpu=5) + 2000 (vcpu=7) = 6500
+        #
+        # If the bug exists, it might show:
+        # - 3000 (the max single value across all "Other" events)
+        # - 4500 (max of the bin totals if those were computed incorrectly)
+        # - Some other incorrect value
+        self.assertEqual(
+            other_result["data"][2],
+            6500.0,
+            "Other should sum all ram_mb values from bins that didn't make the top 2 (4500 + 2000 = 6500), not take the max",
+        )

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -6017,11 +6017,6 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         """
         Test that the "Other" breakdown correctly sums values across all breakdown values
         that didn't make the top list, rather than taking the maximum.
-
-        Related to bug report: https://posthog.slack.com/archives/...
-        When breaking down by a property with property value sum aggregation,
-        the "Other" bucket should sum all values from breakdown values that fall into "Other",
-        not take the maximum value.
         """
         PropertyDefinition.objects.create(team=self.team, name="category", property_type="String")
         PropertyDefinition.objects.create(team=self.team, name="ram_mb", property_type="Numeric")
@@ -6254,12 +6249,6 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         """
         Test that the "Other" breakdown with histogram bins correctly sums values,
         not takes the maximum.
-
-        This is related to the follow-up bug report where "Other" during breakdown with
-        histogram bins shows incorrect (likely max) aggregation instead of sum.
-
-        The original bug was that histogram bins themselves were taking max instead of sum.
-        The follow-up bug is that "Other" also has the same issue when combined with histogram bins.
         """
         PropertyDefinition.objects.create(team=self.team, name="vcpu", property_type="Numeric")
         PropertyDefinition.objects.create(team=self.team, name="ram_mb", property_type="Numeric")


### PR DESCRIPTION
## Problem
https://posthog.slack.com/archives/C090GAZNU1H/p1766429502961009?thread_ts=1765509708.280919&cid=C090GAZNU1H

## Changes
1. Changed GROUP BY breakdown_value, day_start to GROUP BY day_start so all excluded breakdown values are aggregated together correctly per day using the math-appropriate function (MAX/MIN/SUM).
2. Added get_array_fold_merge_operation() method to AggregationOperations that returns the correct ClickHouse operation

## How did you test this code?
Added tests + 👁️ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
