### PR TITLE
feat: Added CI output summary for docker builds

### DIFF
--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -40,6 +40,9 @@ outputs:
     digest:
         description: The digest of the image that was built
         value: ${{ steps.build.outputs.digest }}
+    image-url:
+        description: The full image URL with registry and digest
+        value: ${{ steps.emit.outputs.image-url }}
 
 runs:
     using: 'composite'
@@ -84,13 +87,16 @@ runs:
               PR_NUMBER: ${{ inputs.pr-number }}
           run: |
               TAGS="posthog/posthog:$COMMIT_SHA"
+              IMAGE_URL=""
               if [[ -n "$REGISTRY" ]]; then
                 TAGS="$TAGS,$REGISTRY/posthog-cloud:$COMMIT_SHA"
+                IMAGE_URL="$REGISTRY/posthog-cloud:$COMMIT_SHA"
               fi
               if [[ "$PR_NUMBER" != "" ]]; then
                 TAGS="$TAGS,$REGISTRY/posthog-cloud:pr-$PR_NUMBER"
               fi
               echo "tag=$TAGS" >> $GITHUB_OUTPUT
+              echo "image-url=$IMAGE_URL" >> $GITHUB_OUTPUT
 
         - name: Build image
           id: build

--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -40,9 +40,9 @@ outputs:
     digest:
         description: The digest of the image that was built
         value: ${{ steps.build.outputs.digest }}
-    image-url:
-        description: The full image URL with registry and digest
-        value: ${{ steps.emit.outputs.image-url }}
+    registry:
+        description: The ECR registry URL
+        value: ${{ steps.aws-ecr.outputs.registry }}
 
 runs:
     using: 'composite'
@@ -87,16 +87,13 @@ runs:
               PR_NUMBER: ${{ inputs.pr-number }}
           run: |
               TAGS="posthog/posthog:$COMMIT_SHA"
-              IMAGE_URL=""
               if [[ -n "$REGISTRY" ]]; then
                 TAGS="$TAGS,$REGISTRY/posthog-cloud:$COMMIT_SHA"
-                IMAGE_URL="$REGISTRY/posthog-cloud:$COMMIT_SHA"
               fi
               if [[ "$PR_NUMBER" != "" ]]; then
                 TAGS="$TAGS,$REGISTRY/posthog-cloud:pr-$PR_NUMBER"
               fi
               echo "tag=$TAGS" >> $GITHUB_OUTPUT
-              echo "image-url=$IMAGE_URL" >> $GITHUB_OUTPUT
 
         - name: Build image
           id: build

--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -37,6 +37,9 @@ outputs:
     build-id:
         description: The ID of the build
         value: ${{ steps.build.outputs.build-id }}
+    digest:
+        description: The digest of the image that was built
+        value: ${{ steps.build.outputs.digest }}
 
 runs:
     using: 'composite'

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -39,11 +39,15 @@ jobs:
         # Only on PostHog/posthog, as there's no docker login on forks
         if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name  == github.repository && needs.changes.outputs.docker_files == 'true') || github.event_name == 'merge_group' }}
 
+        outputs:
+            digest: ${{ steps.build.outputs.digest }}
+
         steps:
             - name: Check out
               uses: actions/checkout@v4
 
             - name: Build and cache Docker image in Depot
+              id: build
               uses: ./.github/actions/build-n-cache-image
               with:
                   actions-id-token-request-url: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
@@ -53,6 +57,16 @@ jobs:
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
                   pr-number: ${{ github.event.number }}
                   no-cache: ${{ contains(github.event.pull_request.labels.*.name, 'no-depot-docker-cache') }}
+
+            - name: Container image digest
+              run: |
+                  echo "Image digest: ${{ steps.build.outputs.digest }}"
+                  echo "## Container image built :rocket:" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image SHA:** \`${{ github.sha }}@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "- Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- Digest: \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
 
     deploy_preview:
         name: Deploy preview environment

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -63,6 +63,8 @@ jobs:
                   echo "Image digest: ${{ steps.build.outputs.digest }}"
                   echo "## Container image built :rocket:" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image reference:** \`$${{ steps.aws-ecr.outputs.registry }}/posthog:${{ github.sha }}@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
                   echo "**Image SHA:** \`${{ github.sha }}@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "- Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -63,7 +63,7 @@ jobs:
                   echo "Image digest: ${{ steps.build.outputs.digest }}"
                   echo "## Container image built :rocket:" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image reference:** \`${{ steps.build.outputs.image-url }}@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image reference:** \`${{ steps.build.outputs.registry }}/posthog-cloud@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "**Image SHA:** \`${{ github.sha }}@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -63,7 +63,7 @@ jobs:
                   echo "Image digest: ${{ steps.build.outputs.digest }}"
                   echo "## Container image built :rocket:" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image reference:** \`$${{ steps.aws-ecr.outputs.registry }}/posthog:${{ github.sha }}@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image reference:** \`${{ steps.build.outputs.image-url }}@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "**Image SHA:** \`${{ github.sha }}@${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Problem

Often using the CI built image for manual test deploys for sensitive changes.


## Changes

<img width="1571" height="370" alt="Screenshot 2025-12-24 at 17 59 15" src="https://github.com/user-attachments/assets/b2e3325c-43e4-4e81-a439-63c92d364818" />

* Output this at the summary level now
* Annoyingly the `posthog` term gets redacted i think because it is a username somewhere. but still better than nothing

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
