### PR TITLE
feat(kafka-deduplicator): checkpoint import on pod rebalance

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -14,10 +14,6 @@ pub struct CheckpointConfig {
     /// Base directory for local checkpoints
     pub local_checkpoint_dir: String,
 
-    /// Base temp directory for local checkpoint imports. successful
-    /// imports from remote will be copied into local store directory
-    pub local_checkpoint_import_dir: String,
-
     /// S3 bucket for checkpoint uploads
     pub s3_bucket: String,
 
@@ -68,7 +64,6 @@ impl Default for CheckpointConfig {
             checkpoint_interval: Duration::from_secs(300),
             checkpoint_full_upload_interval: 10, // create a full checkpoint every 10 attempts per partition
             local_checkpoint_dir: "./checkpoints".to_string(),
-            local_checkpoint_import_dir: "./checkpoint_imports".to_string(),
             s3_bucket: "".to_string(),
             s3_key_prefix: "deduplication-checkpoints".to_string(),
             aws_region: "us-east-1".to_string(),

--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -14,6 +14,10 @@ pub struct CheckpointConfig {
     /// Base directory for local checkpoints
     pub local_checkpoint_dir: String,
 
+    /// Base temp directory for local checkpoint imports. successful
+    /// imports from remote will be copied into local store directory
+    pub local_checkpoint_import_dir: String,
+
     /// S3 bucket for checkpoint uploads
     pub s3_bucket: String,
 
@@ -45,6 +49,12 @@ pub struct CheckpointConfig {
 
     /// Timeout for a single S3 operation attempt
     pub s3_attempt_timeout: Duration,
+
+    /// Number of recent historical checkpoint attempts to try to import,
+    /// starting from most recent, when attempting to import from remote
+    /// storage. A failed download or corrupt files will result in fallback
+    /// to the next most recent checkpoint attempt this many times
+    pub checkpoint_import_attempt_depth: usize,
 }
 
 impl Default for CheckpointConfig {
@@ -55,6 +65,7 @@ impl Default for CheckpointConfig {
             checkpoint_interval: Duration::from_secs(300),
             checkpoint_full_upload_interval: 10, // create a full checkpoint every 10 attempts per partition
             local_checkpoint_dir: "./checkpoints".to_string(),
+            local_checkpoint_import_dir: "./checkpoint_imports".to_string(),
             s3_bucket: "".to_string(),
             s3_key_prefix: "deduplication-checkpoints".to_string(),
             aws_region: "us-east-1".to_string(),
@@ -64,6 +75,7 @@ impl Default for CheckpointConfig {
             checkpoint_import_window_hours: 24,
             s3_operation_timeout: Duration::from_secs(120),
             s3_attempt_timeout: Duration::from_secs(20),
+            checkpoint_import_attempt_depth: 10,
         }
     }
 }

--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -55,6 +55,9 @@ pub struct CheckpointConfig {
     /// storage. A failed download or corrupt files will result in fallback
     /// to the next most recent checkpoint attempt this many times
     pub checkpoint_import_attempt_depth: usize,
+
+    /// Test-only: S3 endpoint URL for MinIO/localstack (not used in production)
+    pub test_s3_endpoint: Option<String>,
 }
 
 impl Default for CheckpointConfig {
@@ -76,6 +79,7 @@ impl Default for CheckpointConfig {
             s3_operation_timeout: Duration::from_secs(120),
             s3_attempt_timeout: Duration::from_secs(20),
             checkpoint_import_attempt_depth: 10,
+            test_s3_endpoint: None,
         }
     }
 }

--- a/rust/kafka-deduplicator/src/checkpoint/import.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/import.rs
@@ -11,7 +11,7 @@ pub struct CheckpointImporter {
     downloader: Box<dyn CheckpointDownloader>,
     // temporary local base path for checkpoint import attempts.
     // NOTE: if successful, caller will copy the files from here
-    // into the RocksDB store mamager's expected path structure
+    // into the RocksDB store manager's expected path structure
     local_base_import_path: PathBuf,
     // number of historical checkpoint attempts to import as fallbacks
     import_attempt_depth: usize,

--- a/rust/kafka-deduplicator/src/checkpoint/import.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/import.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use super::config::CheckpointConfig;
 use super::{CheckpointDownloader, CheckpointMetadata};
 
 use anyhow::{Context, Result};
@@ -17,15 +18,11 @@ pub struct CheckpointImporter {
 }
 
 impl CheckpointImporter {
-    pub fn new(
-        downloader: Box<dyn CheckpointDownloader>,
-        local_base_import_path: PathBuf,
-        import_attempt_depth: usize,
-    ) -> Self {
+    pub fn new(downloader: Box<dyn CheckpointDownloader>, config: &CheckpointConfig) -> Self {
         Self {
             downloader,
-            local_base_import_path,
-            import_attempt_depth,
+            local_base_import_path: PathBuf::from(&config.local_checkpoint_import_dir),
+            import_attempt_depth: config.checkpoint_import_attempt_depth,
         }
     }
 

--- a/rust/kafka-deduplicator/src/checkpoint/metadata.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/metadata.rs
@@ -456,10 +456,9 @@ mod tests {
         let base_path = Path::new("/data/stores");
         let store_path = metadata.get_store_path(base_path);
 
-        // Store path should be <base>/<topic>/<partition>/<timestamp_millis>
+        // Store path should be <base>/<topic>_<partition>/<timestamp_millis>
         let expected = base_path
-            .join(topic)
-            .join(partition.to_string())
+            .join(format!("{topic}_{partition}"))
             .join(timestamp_millis.to_string());
         assert_eq!(store_path, expected);
 
@@ -467,8 +466,7 @@ mod tests {
         let tmp_base = Path::new("/tmp/deduplication-store");
         let tmp_store_path = metadata.get_store_path(tmp_base);
         let tmp_expected = tmp_base
-            .join(topic)
-            .join(partition.to_string())
+            .join(format!("{topic}_{partition}"))
             .join(timestamp_millis.to_string());
         assert_eq!(tmp_store_path, tmp_expected);
     }

--- a/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
@@ -55,6 +55,52 @@ impl S3Downloader {
             checkpoint_import_window_hours: config.checkpoint_import_window_hours,
         })
     }
+
+    /// Test-only constructor that connects to MinIO/localstack via config.test_s3_endpoint
+    pub async fn new_for_testing(config: &CheckpointConfig) -> Result<Self> {
+        let endpoint_url = config
+            .test_s3_endpoint
+            .as_ref()
+            .context("test_s3_endpoint must be set for new_for_testing")?;
+
+        let region = Region::new(config.aws_region.clone());
+
+        let timeout_config = TimeoutConfig::builder()
+            .operation_timeout(config.s3_operation_timeout)
+            .operation_attempt_timeout(config.s3_attempt_timeout)
+            .build();
+
+        let aws_config = aws_config::defaults(BehaviorVersion::latest())
+            .region(region.clone())
+            .endpoint_url(endpoint_url)
+            .timeout_config(timeout_config)
+            .retry_config(RetryConfig::adaptive())
+            .load()
+            .await;
+
+        // force_path_style required for MinIO
+        let s3_config = Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Some(region))
+            .credentials_provider(
+                aws_config
+                    .credentials_provider()
+                    .context("No credentials provider found")?,
+            )
+            .endpoint_url(endpoint_url)
+            .force_path_style(true)
+            .build();
+
+        let client = Client::from_conf(s3_config);
+
+        Ok(Self {
+            client,
+            aws_region: config.aws_region.clone(),
+            s3_bucket: config.s3_bucket.clone(),
+            s3_key_prefix: config.s3_key_prefix.clone(),
+            checkpoint_import_window_hours: config.checkpoint_import_window_hours,
+        })
+    }
 }
 
 #[async_trait]

--- a/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
@@ -21,11 +21,14 @@ use tracing::{error, info};
 #[derive(Debug, Clone)]
 pub struct S3Downloader {
     client: Client,
-    config: CheckpointConfig,
+    aws_region: String,
+    s3_bucket: String,
+    s3_key_prefix: String,
+    checkpoint_import_window_hours: u32,
 }
 
 impl S3Downloader {
-    pub async fn new(config: CheckpointConfig) -> Result<Self> {
+    pub async fn new(config: &CheckpointConfig) -> Result<Self> {
         let region_provider =
             RegionProviderChain::default_provider().or_else(Region::new(config.aws_region.clone()));
 
@@ -44,7 +47,13 @@ impl S3Downloader {
         let s3_config = Config::from(&aws_config);
         let client = Client::from_conf(s3_config);
 
-        Ok(Self { client, config })
+        Ok(Self {
+            client,
+            aws_region: config.aws_region.clone(),
+            s3_bucket: config.s3_bucket.clone(),
+            s3_key_prefix: config.s3_key_prefix.clone(),
+            checkpoint_import_window_hours: config.checkpoint_import_window_hours,
+        })
     }
 }
 
@@ -55,7 +64,7 @@ impl CheckpointDownloader for S3Downloader {
         let get_object = match self
             .client
             .get_object()
-            .bucket(&self.config.s3_bucket)
+            .bucket(&self.s3_bucket)
             .key(remote_key)
             .send()
             .await
@@ -70,7 +79,7 @@ impl CheckpointDownloader for S3Downloader {
                     .increment(1);
                 return Err(anyhow::anyhow!(format!(
                     "Failed to get object from S3 bucket: s3://{0}/{remote_key}: {e}",
-                    self.config.s3_bucket
+                    self.s3_bucket
                 )));
             }
         };
@@ -78,7 +87,7 @@ impl CheckpointDownloader for S3Downloader {
         let body = get_object.body.collect().await.with_context(|| {
             format!(
                 "Failed to read body data from S3 object s3://{0}/{remote_key}",
-                self.config.s3_bucket,
+                self.s3_bucket,
             )
         })?;
 
@@ -95,7 +104,7 @@ impl CheckpointDownloader for S3Downloader {
         let get_object = match self
             .client
             .get_object()
-            .bucket(&self.config.s3_bucket)
+            .bucket(&self.s3_bucket)
             .key(remote_key)
             .send()
             .await
@@ -106,7 +115,7 @@ impl CheckpointDownloader for S3Downloader {
                     .increment(1);
                 return Err(anyhow::anyhow!(format!(
                     "Failed to get object from S3 bucket: s3://{0}/{remote_key}: {e}",
-                    self.config.s3_bucket
+                    self.s3_bucket
                 )));
             }
         };
@@ -179,9 +188,8 @@ impl CheckpointDownloader for S3Downloader {
         partition_number: i32,
     ) -> Result<Vec<String>> {
         let start_time = Instant::now();
-        let import_window_hours =
-            Duration::hours(self.config.checkpoint_import_window_hours as i64);
-        let remote_key_prefix = format!("{}/{topic}/{partition_number}", self.config.s3_key_prefix);
+        let import_window_hours = Duration::hours(self.checkpoint_import_window_hours as i64);
+        let remote_key_prefix = format!("{}/{topic}/{partition_number}", self.s3_key_prefix);
         let yesterday_remote_key = format!(
             "{}/{}",
             remote_key_prefix,
@@ -190,7 +198,7 @@ impl CheckpointDownloader for S3Downloader {
 
         info!(
             "Listing checkpoint files newer than {} from S3 bucket: {}",
-            yesterday_remote_key, self.config.s3_bucket
+            yesterday_remote_key, self.s3_bucket
         );
 
         // list_objects_v2 returns results in *lexicographic sort order*
@@ -202,7 +210,7 @@ impl CheckpointDownloader for S3Downloader {
         let base_request = self
             .client
             .list_objects_v2()
-            .bucket(&self.config.s3_bucket)
+            .bucket(&self.s3_bucket)
             .prefix(remote_key_prefix)
             .start_after(&yesterday_remote_key);
 
@@ -215,7 +223,7 @@ impl CheckpointDownloader for S3Downloader {
             let response = req.send().await.with_context(|| {
                 format!(
                     "Failed to list remote objects after s3://{}/{yesterday_remote_key}",
-                    self.config.s3_bucket
+                    self.s3_bucket
                 )
             })?;
 
@@ -261,6 +269,6 @@ impl CheckpointDownloader for S3Downloader {
     }
 
     async fn is_available(&self) -> bool {
-        !self.config.s3_bucket.is_empty()
+        !self.s3_bucket.is_empty() && !self.aws_region.is_empty()
     }
 }

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -135,14 +135,32 @@ pub struct Config {
     #[envconfig(from = "BIND_PORT", default = "8000")]
     pub port: u16,
 
+    //// Checkpoint configuration ////
+
+    // Checkpoint S3 remote storage bucket. If set, this also
+    // enables local successful checkpoints to be exported to S3
+    pub s3_bucket: Option<String>,
+
+    // Checkpoint S3 remote storage key prefix
+    #[envconfig(default = "deduplication-checkpoints")]
+    pub s3_key_prefix: String,
+
+    #[envconfig(default = "us-east-1")]
+    pub aws_region: String,
+
+    #[envconfig(default = "120")] // 2 minutes
+    pub s3_operation_timeout_secs: u64,
+
+    #[envconfig(default = "20")] // 20 seconds
+    pub s3_attempt_timeout_secs: u64,
+
     // Checkpoint configuration - integrated from checkpoint::config
     #[envconfig(default = "1800")] // 30 minutes in seconds
     pub checkpoint_interval_secs: u64,
 
-    #[envconfig(default = "1")] // delete local checkpoints older than this
-    pub max_checkpoint_retention_hours: u32,
-
-    #[envconfig(default = "8")] // max concurrent checkpoints to perform on single node
+    // max checkpoint attempts to perform on a single pod at once. each
+    // concurrent attempt is against a different locally assigned partition
+    #[envconfig(default = "8")]
     pub max_concurrent_checkpoints: usize,
 
     #[envconfig(default = "200")]
@@ -154,33 +172,37 @@ pub struct Config {
     #[envconfig(default = "1")]
     pub checkpoints_per_partition: usize,
 
-    #[envconfig(default = "/tmp/checkpoints")]
+    // Base directory where local checkpoints are created.
+    // cleaned up on success or failure
+    #[envconfig(default = "/tmp/local_checkpoints")]
     pub local_checkpoint_dir: String,
-
-    pub s3_bucket: Option<String>,
-
-    #[envconfig(default = "deduplication-checkpoints")]
-    pub s3_key_prefix: String,
 
     // how often to perform a full checkpoint vs. incremental
     // if 0, then we will always do full uploads
     #[envconfig(default = "0")]
     pub checkpoint_full_upload_interval: u32,
 
+    // Whether to enable checkpoint import from S3 on rebalance and/or DR scenario
+    #[envconfig(default = "false")]
+    pub checkpoint_import_enabled: bool,
+
+    // Number of historical recent checkpoints to attempt to import
+    // as fallbacks when most recent download fails or files are corrupted
+    #[envconfig(default = "10")]
+    pub checkpoint_import_attempt_depth: usize,
+
+    // Base temporary directory base for importing checkpoints from
+    // remote storage (S3) before copying into RocksDB store directory.
+    // cleaned up on success or failure
+    #[envconfig(default = "/tmp/checkpoint_imports")]
+    pub checkpoint_import_local_temp_base_path: String,
+
     // number of hours prior to "now" that the checkpoint import mechanism
     // will search for valid checkpoint attempts in a DR recovery scenario
     #[envconfig(default = "24")]
     pub checkpoint_import_window_hours: u32,
 
-    #[envconfig(default = "us-east-1")]
-    pub aws_region: String,
-
-    #[envconfig(default = "120")] // 2 minutes
-    pub s3_operation_timeout_secs: u64,
-
-    #[envconfig(default = "20")] // 20 seconds
-    pub s3_attempt_timeout_secs: u64,
-
+    //// End checkpoint config ////
     #[envconfig(default = "true")]
     pub export_prometheus: bool,
 
@@ -320,6 +342,14 @@ impl Config {
         // Try as raw integer
         s.parse::<u64>()
             .with_context(|| format!("Failed to parse storage capacity: '{s}'. Expected format: raw bytes, scientific notation, or units (1Gi, 1GB)"))
+    }
+
+    pub fn checkpoint_export_enabled(&self) -> bool {
+        !self.aws_region.is_empty() && self.s3_bucket.is_some()
+    }
+
+    pub fn checkpoint_import_enabled(&self) -> bool {
+        self.checkpoint_export_enabled() && self.checkpoint_import_enabled
     }
 
     /// Get checkpoint interval as Duration

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -196,12 +196,6 @@ pub struct Config {
     #[envconfig(default = "10")]
     pub checkpoint_import_attempt_depth: usize,
 
-    // Base temporary directory base for importing checkpoints from
-    // remote storage (S3) before copying into RocksDB store directory.
-    // cleaned up on success or failure
-    #[envconfig(default = "/tmp/checkpoint_imports")]
-    pub checkpoint_import_local_temp_base_path: String,
-
     // number of hours prior to "now" that the checkpoint import mechanism
     // will search for valid checkpoint attempts in a DR recovery scenario
     #[envconfig(default = "24")]

--- a/rust/kafka-deduplicator/src/kafka/batch_context.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_context.rs
@@ -88,7 +88,7 @@ impl BatchConsumerContext {
 
                     // Call cleanup handler (downloads checkpoints, etc.)
                     // Note: setup_assigned_partitions was already called synchronously
-                    if let Err(e) = handler.cleanup_assigned_partitions(&tpl).await {
+                    if let Err(e) = handler.async_setup_assigned_partitions(&tpl).await {
                         error!("Partition assignment cleanup failed: {}", e);
                     }
                 }

--- a/rust/kafka-deduplicator/src/kafka/test_utils.rs
+++ b/rust/kafka-deduplicator/src/kafka/test_utils.rs
@@ -40,7 +40,10 @@ impl RebalanceHandler for TestRebalanceHandler {
         }
     }
 
-    async fn cleanup_assigned_partitions(&self, _partitions: &TopicPartitionList) -> Result<()> {
+    async fn async_setup_assigned_partitions(
+        &self,
+        _partitions: &TopicPartitionList,
+    ) -> Result<()> {
         Ok(())
     }
 

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -127,6 +127,10 @@ pub const CHECKPOINT_FILE_FETCH_STORE_HISTOGRAM: &str = "checkpoint_file_fetch_a
 /// Histogram for checkpoint metadata file list duration; only measured on success
 pub const CHECKPOINT_LIST_METADATA_HISTOGRAM: &str = "checkpoint_list_metadata_seconds";
 
+/// Record outcomes for attempts to restore checkpoints
+/// when local store is missing after Kafka rebalances
+pub const REBALANCE_CHECKPOINT_IMPORT_COUNTER: &str = "rebalance_checkpoint_import_total";
+
 // ==== Store Manager Diagnostics ====
 /// Histogram for store creation duration (in milliseconds)
 pub const STORE_CREATION_DURATION_MS: &str = "store_creation_duration_ms";

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -13,6 +13,7 @@ use crate::kafka::offset_tracker::OffsetTracker;
 use crate::kafka::partition_router::{shutdown_workers, PartitionRouter};
 use crate::kafka::rebalance_handler::RebalanceHandler;
 use crate::kafka::types::Partition;
+use crate::metrics_const::REBALANCE_CHECKPOINT_IMPORT_COUNTER;
 use crate::store_manager::StoreManager;
 
 /// Rebalance handler that coordinates store cleanup and partition workers
@@ -71,6 +72,12 @@ where
         store_base_path: &Path,
     ) -> Result<Option<PathBuf>> {
         if self.checkpoint_importer.is_none() {
+            metrics::counter!(
+                REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                "result" => "skipped",
+                "reason" => "disabled",
+            )
+            .increment(1);
             return Ok(None);
         }
 
@@ -83,7 +90,13 @@ where
         {
             Ok(path) => path,
             Err(e) => {
-                // instrumented internally
+                metrics::counter!(
+                    REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                    "result" => "failed",
+                    "reason" => "import",
+                )
+                .increment(1);
+
                 return Err(e);
             }
         };
@@ -92,11 +105,19 @@ where
             .join(topic)
             .join(partition_number.to_string());
         if let Err(e) = std::fs::create_dir_all(&store_full_path) {
+            metrics::counter!(
+                REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                "result" => "failed",
+                "reason" => "create_store_dir",
+            )
+            .increment(1);
+
             error!(
                 store_full_path = %store_full_path.display()    ,
                 error = e.to_string(),
                 "Failed to create store directory for checkpoint import"
             );
+
             return Err(anyhow::anyhow!(
                 "Failed to create store directory for checkpoint import: {e}"
             ));
@@ -106,13 +127,22 @@ where
         let mut entries = match tokio::fs::read_dir(&tmp_path).await {
             Ok(entries) => entries,
             Err(e) => {
+                metrics::counter!(
+                    REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                    "result" => "failed",
+                    "reason" => "read_local_dir",
+                )
+                .increment(1);
+
                 error!(
                     tmp_path = %tmp_path.display(),
                     error = %e,
                     "Failed to read checkpoint temp directory"
                 );
+
                 let _ = tokio::fs::remove_dir_all(&tmp_path).await;
                 let _ = tokio::fs::remove_dir_all(&store_full_path).await;
+
                 return Err(anyhow::anyhow!(
                     "Failed to read checkpoint temp directory: {e}"
                 ));
@@ -124,6 +154,12 @@ where
             let entry = match entry {
                 Ok(e) => e,
                 Err(e) => {
+                    metrics::counter!(
+                        REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                        "result" => "failed",
+                        "reason" => "read_local_file",
+                    )
+                    .increment(1);
                     error!(
                         tmp_path = %tmp_path.display(),
                         store_full_path = %store_full_path.display(),
@@ -131,8 +167,10 @@ where
                         error = %e,
                         "Failed to read directory entry during checkpoint import"
                     );
+
                     let _ = tokio::fs::remove_dir_all(&tmp_path).await;
                     let _ = tokio::fs::remove_dir_all(&store_full_path).await;
+
                     return Err(anyhow::anyhow!(
                         "Failed to read directory entry during checkpoint import: {e}"
                     ));
@@ -143,6 +181,12 @@ where
             let dest = store_full_path.join(&file_name);
 
             if let Err(e) = tokio::fs::copy(entry.path(), &dest).await {
+                metrics::counter!(
+                    REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                    "result" => "failed",
+                    "reason" => "copy_local_file",
+                )
+                .increment(1);
                 error!(
                     src = %entry.path().display(),
                     dest = %dest.display(),
@@ -150,8 +194,10 @@ where
                     error = %e,
                     "Failed to copy checkpoint file"
                 );
+
                 let _ = tokio::fs::remove_dir_all(&tmp_path).await;
                 let _ = tokio::fs::remove_dir_all(&store_full_path).await;
+
                 return Err(anyhow::anyhow!("Failed to copy checkpoint file: {e}"));
             }
             files_copied += 1;
@@ -159,6 +205,13 @@ where
 
         // Clean up temp directory on success
         if let Err(e) = tokio::fs::remove_dir_all(&tmp_path).await {
+            metrics::counter!(
+                REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                "result" => "failed",
+                "reason" => "cleanup_tmp_dir",
+            )
+            .increment(1);
+
             error!(
                 tmp_path = %tmp_path.display(),
                 error = %e,
@@ -166,6 +219,12 @@ where
             );
             // Non-fatal - files are already copied
         }
+
+        metrics::counter!(
+            REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+            "result" => "success",
+        )
+        .increment(1);
 
         info!(
             topic,
@@ -285,35 +344,48 @@ where
         // If messages arrive before this completes, get_or_create in the processor
         // will handle it and emit a warning (indicating pre-creation didn't complete in time)
         for partition in &partition_infos {
-            // TODO(eli): finish wiring this up and handle errors/observability
-            match self
-                .import_checkpoint_for_topic_partition(
-                    partition.topic(),
-                    partition.partition_number(),
-                    self.store_manager.base_path(),
-                )
-                .await
+            if self
+                .store_manager
+                .get(partition.topic(), partition.partition_number())
+                .is_none()
             {
-                Ok(Some(path)) => {
-                    info!(
-                        topic = partition.topic(),
-                        partition = partition.partition_number(),
-                        path = %path.display(),
-                        "Imported checkpoint for partition"
-                    );
+                match self
+                    .import_checkpoint_for_topic_partition(
+                        partition.topic(),
+                        partition.partition_number(),
+                        self.store_manager.base_path(),
+                    )
+                    .await
+                {
+                    Ok(Some(path)) => {
+                        // import successful, replaced old checkpoint store directory and files
+                        info!(
+                            topic = partition.topic(),
+                            partition = partition.partition_number(),
+                            path = %path.display(),
+                            "Imported checkpoint for partition"
+                        );
+                    }
+                    Ok(None) => {
+                        // No checkpoint importer configured, skip
+                    }
+                    Err(e) => {
+                        warn!(
+                            topic = partition.topic(),
+                            partition = partition.partition_number(),
+                            error = %e,
+                            "Failed to import checkpoint for partition"
+                        );
+                        // Non-fatal - store will be created fresh
+                    }
                 }
-                Ok(None) => {
-                    // No checkpoint importer configured, skip
-                }
-                Err(e) => {
-                    warn!(
-                        topic = partition.topic(),
-                        partition = partition.partition_number(),
-                        error = %e,
-                        "Failed to import checkpoint for partition"
-                    );
-                    // Non-fatal - store will be created fresh
-                }
+            } else {
+                metrics::counter!(
+                    REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                    "result" => "skipped",
+                    "reason" => "store_exists",
+                )
+                .increment(1);
             }
 
             match self

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -324,7 +324,7 @@ where
     // For slow operations like I/O, draining queues, etc.
     // ============================================
 
-    async fn cleanup_assigned_partitions(&self, partitions: &TopicPartitionList) -> Result<()> {
+    async fn async_setup_assigned_partitions(&self, partitions: &TopicPartitionList) -> Result<()> {
         let partition_infos: Vec<Partition> = partitions
             .elements()
             .into_iter()

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -268,6 +268,7 @@ impl KafkaDeduplicatorService {
             self.store_manager.clone(),
             router,
             offset_tracker.clone(),
+            None, // TODO(eli): bootstrap importer if cfg enabled
         ));
 
         // Create consumer config using the kafka module's builder

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -116,6 +116,7 @@ impl KafkaDeduplicatorService {
             s3_operation_timeout: config.s3_operation_timeout(),
             s3_attempt_timeout: config.s3_attempt_timeout(),
             checkpoint_import_attempt_depth: config.checkpoint_import_attempt_depth,
+            test_s3_endpoint: None,
         };
 
         // Reset local checkpoint directory on startup (it's temporary storage)

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -124,7 +124,11 @@ impl KafkaDeduplicatorService {
 
         // create exporter conditionally if S3 config is populated
         let exporter = if config.checkpoint_export_enabled() {
-            let uploader = Box::new(S3Uploader::new(checkpoint_config.clone()).await.unwrap());
+            let uploader = Box::new(
+                S3Uploader::new(checkpoint_config.clone())
+                    .await
+                    .context("Failed to create S3 uploader")?,
+            );
             Some(Arc::new(CheckpointExporter::new(uploader)))
         } else {
             None
@@ -132,7 +136,11 @@ impl KafkaDeduplicatorService {
 
         // if checkpoint import is enabled, create and configure the importer
         let importer = if config.checkpoint_import_enabled() {
-            let downloader = Box::new(S3Downloader::new(&checkpoint_config).await.unwrap());
+            let downloader = Box::new(
+                S3Downloader::new(&checkpoint_config)
+                    .await
+                    .context("Failed to create S3 downloader")?,
+            );
             Some(Arc::new(CheckpointImporter::new(
                 downloader,
                 &checkpoint_config,

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -150,7 +150,7 @@ impl StoreManager {
 
     /// Get or create a deduplication store during rebalancing (pre-creation)
     ///
-    /// This should be called during `cleanup_assigned_partitions` to pre-create stores
+    /// This should be called during `async_setup_assigned_partitions` to pre-create stores
     /// before messages start flowing. Unlike `get_or_create`, this won't emit a warning
     /// when creating a new store.
     pub async fn get_or_create_for_rebalance(
@@ -1172,7 +1172,7 @@ mod tests {
 
         let manager = StoreManager::new(config);
 
-        // Step 1: Pre-create during rebalance (cleanup_assigned_partitions)
+        // Step 1: Pre-create during rebalance (async_setup_assigned_partitions)
         let _store = manager
             .get_or_create_for_rebalance("test-topic", 0)
             .await

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use dashmap::DashMap;
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -388,6 +388,11 @@ impl StoreManager {
 
     pub fn get_active_store_count(&self) -> usize {
         self.stores.len()
+    }
+
+    /// Get the base path where stores are created
+    pub fn base_path(&self) -> &Path {
+        &self.store_config.path
     }
 
     /// Cleanup old entries across all stores to maintain global capacity

--- a/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
@@ -310,8 +310,8 @@ impl RebalanceHandler for RoutingRebalanceHandler {
         self.inner.setup_revoked_partitions(partitions);
     }
 
-    async fn cleanup_assigned_partitions(&self, partitions: &TopicPartitionList) -> Result<()> {
-        self.inner.cleanup_assigned_partitions(partitions).await
+    async fn async_setup_assigned_partitions(&self, partitions: &TopicPartitionList) -> Result<()> {
+        self.inner.async_setup_assigned_partitions(partitions).await
     }
 
     async fn cleanup_revoked_partitions(&self, partitions: &TopicPartitionList) -> Result<()> {

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -349,6 +349,9 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
     // Open a new store from the imported checkpoint to verify it's a valid RocksDB
     info!(path = ?import_result, "Opening store from imported checkpoint");
     let restored_store_config = DeduplicationStoreConfig {
+        // for simplicity, we supply the temp import dir directly for store verification.
+        // in production, the kafka rebalance handler copies successful imports into the
+        // production store directory tree.
         path: import_result.clone(),
         max_capacity: 1_000_000,
     };
@@ -387,9 +390,6 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
 
     // Cleanup S3 bucket
     cleanup_bucket(&minio_client, &test_prefix).await;
-
-    // Note: TempDirs (tmp_store_dir, tmp_checkpoint_dir, tmp_import_dir) are
-    // automatically cleaned up when dropped at end of test
 
     Ok(())
 }

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -333,11 +333,8 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
         tmp_import_dir.path()
     );
 
-    // Verify store directory structure: <store_base>/<topic>/<partition>/
-    let expected_store_path = tmp_import_dir
-        .path()
-        .join(test_topic)
-        .join(test_partition.to_string());
+    // Verify store directory structure: <store_base>/<topic>_<partition>/<timestamp_millis>
+    let expected_store_path = downloaded_metadata.get_store_path(tmp_import_dir.path());
     assert!(
         expected_store_path.exists(),
         "Store directory structure should exist: {expected_store_path:?}"

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -310,8 +310,7 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
 
         assert!(
             imported_files.contains(&filename.to_string()),
-            "Expected file '{}' from metadata not found in imported files. \
-             Imported: {:?}",
+            "Expected file '{}' from metadata not found in imported files. Imported: {:?}",
             filename,
             imported_files
         );
@@ -321,8 +320,7 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
     assert_eq!(
         imported_files.len(),
         downloaded_metadata.files.len(),
-        "Imported file count should match metadata. \
-         Imported: {:?}, Expected: {:?}",
+        "Imported file count should match metadata. Imported: {:?}, Expected: {:?}",
         imported_files,
         downloaded_metadata
             .files

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -310,9 +310,7 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
 
         assert!(
             imported_files.contains(&filename.to_string()),
-            "Expected file '{}' from metadata not found in imported files. Imported: {:?}",
-            filename,
-            imported_files
+            "Expected file '{filename}' from metadata not found in imported files. Imported: {imported_files:?}",
         );
         info!(filename, "  - verified");
     }
@@ -320,8 +318,7 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
     assert_eq!(
         imported_files.len(),
         downloaded_metadata.files.len(),
-        "Imported file count should match metadata. Imported: {:?}, Expected: {:?}",
-        imported_files,
+        "Imported file count should match metadata. Imported: {imported_files:?}, Expected: {:?}",
         downloaded_metadata
             .files
             .iter()
@@ -332,8 +329,7 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
     // Verify import result is within the configured import directory
     assert!(
         import_result.starts_with(tmp_import_dir.path()),
-        "Imported checkpoint should be within tmp_import_dir: {:?} not in {:?}",
-        import_result,
+        "Imported checkpoint should be within tmp_import_dir: {import_result:?} not in {:?}",
         tmp_import_dir.path()
     );
 

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -1,0 +1,419 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::config::Region;
+use aws_sdk_s3::Client as AwsS3Client;
+use chrono::Utc;
+
+use kafka_deduplicator::checkpoint::{
+    CheckpointConfig, CheckpointDownloader, CheckpointExporter, CheckpointImporter,
+    CheckpointMetadata, CheckpointWorker, S3Downloader, S3Uploader,
+};
+use kafka_deduplicator::kafka::types::Partition;
+use kafka_deduplicator::store::{
+    DeduplicationStore, DeduplicationStoreConfig, TimestampKey, TimestampMetadata,
+};
+
+use common_types::RawEvent;
+
+use anyhow::Result;
+use tempfile::TempDir;
+
+// MinIO configuration matching docker-compose.dev.yml
+const MINIO_ENDPOINT: &str = "http://localhost:19000";
+const MINIO_ACCESS_KEY: &str = "object_storage_root_user";
+const MINIO_SECRET_KEY: &str = "object_storage_root_password";
+const TEST_BUCKET: &str = "test-kafka-deduplicator-checkpoints";
+
+fn create_test_checkpoint_config(
+    tmp_checkpoint_dir: &TempDir,
+    tmp_import_dir: &TempDir,
+) -> CheckpointConfig {
+    CheckpointConfig {
+        checkpoint_interval: Duration::from_secs(60),
+        local_checkpoint_dir: tmp_checkpoint_dir.path().to_string_lossy().to_string(),
+        local_checkpoint_import_dir: tmp_import_dir.path().to_string_lossy().to_string(),
+        s3_bucket: TEST_BUCKET.to_string(),
+        s3_key_prefix: "checkpoints".to_string(),
+        aws_region: "us-east-1".to_string(),
+        test_s3_endpoint: Some(MINIO_ENDPOINT.to_string()),
+        // Use a wide import window so our just-uploaded checkpoint is found
+        checkpoint_import_window_hours: 24,
+        ..Default::default()
+    }
+}
+
+fn create_test_dedup_store(tmp_dir: &TempDir, topic: &str, partition: i32) -> DeduplicationStore {
+    let config = DeduplicationStoreConfig {
+        path: tmp_dir.path().to_path_buf(),
+        max_capacity: 1_000_000,
+    };
+
+    DeduplicationStore::new(config, topic.to_string(), partition).unwrap()
+}
+
+fn create_test_raw_event(distinct_id: &str, token: &str, event_name: &str) -> RawEvent {
+    RawEvent {
+        uuid: None,
+        event: event_name.to_string(),
+        distinct_id: Some(serde_json::Value::String(distinct_id.to_string())),
+        token: Some(token.to_string()),
+        properties: std::collections::HashMap::new(),
+        timestamp: Some(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                .to_string(),
+        ),
+        ..Default::default()
+    }
+}
+
+async fn create_minio_client() -> AwsS3Client {
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .endpoint_url(MINIO_ENDPOINT)
+        .region(Region::new("us-east-1"))
+        .credentials_provider(aws_sdk_s3::config::Credentials::new(
+            MINIO_ACCESS_KEY,
+            MINIO_SECRET_KEY,
+            None,
+            None,
+            "test",
+        ))
+        .load()
+        .await;
+
+    let s3_config = aws_sdk_s3::config::Builder::from(&config)
+        .force_path_style(true)
+        .build();
+
+    AwsS3Client::from_conf(s3_config)
+}
+
+async fn ensure_bucket_exists(client: &AwsS3Client) {
+    // Try to create bucket, ignore if it already exists
+    let _ = client.create_bucket().bucket(TEST_BUCKET).send().await;
+}
+
+async fn cleanup_bucket(client: &AwsS3Client, prefix: &str) {
+    // List and delete all objects with the given prefix
+    let list_result = client
+        .list_objects_v2()
+        .bucket(TEST_BUCKET)
+        .prefix(prefix)
+        .send()
+        .await;
+
+    if let Ok(response) = list_result {
+        for object in response.contents() {
+            if let Some(key) = object.key() {
+                let _ = client
+                    .delete_object()
+                    .bucket(TEST_BUCKET)
+                    .key(key)
+                    .send()
+                    .await;
+            }
+        }
+    }
+}
+
+/// Integration test for checkpoint export and import via MinIO
+#[tokio::test]
+async fn test_checkpoint_export_import_via_minio() -> Result<()> {
+    // Set up AWS credentials for MinIO
+    std::env::set_var("AWS_ACCESS_KEY_ID", MINIO_ACCESS_KEY);
+    std::env::set_var("AWS_SECRET_ACCESS_KEY", MINIO_SECRET_KEY);
+
+    let test_topic = "test_checkpoint_integration";
+    let test_partition = 0;
+
+    // Create MinIO client and ensure bucket exists
+    let minio_client = create_minio_client().await;
+    ensure_bucket_exists(&minio_client).await;
+
+    // Clean up any previous test data
+    let test_prefix = format!("checkpoints/{test_topic}/{test_partition}");
+    cleanup_bucket(&minio_client, &test_prefix).await;
+
+    // Create temp directories
+    let tmp_store_dir = TempDir::new()?;
+    let tmp_checkpoint_dir = TempDir::new()?;
+    let tmp_import_dir = TempDir::new()?;
+
+    // Create dedup store and populate with test data
+    let store = create_test_dedup_store(&tmp_store_dir, test_topic, test_partition);
+    let events = vec![
+        create_test_raw_event("user1", "token1", "event1"),
+        create_test_raw_event("user2", "token1", "event2"),
+        create_test_raw_event("user3", "token1", "event3"),
+    ];
+    for event in &events {
+        let key = event.into();
+        let metadata = TimestampMetadata::new(event);
+        store.put_timestamp_record(&key, &metadata)?;
+    }
+
+    // Create checkpoint config
+    let config = create_test_checkpoint_config(&tmp_checkpoint_dir, &tmp_import_dir);
+
+    // Create S3Uploader for MinIO and wrap in exporter
+    let uploader = S3Uploader::new_for_testing(config.clone()).await?;
+    let exporter = Some(Arc::new(CheckpointExporter::new(Box::new(uploader))));
+
+    // Create checkpoint worker and perform checkpoint
+    let partition = Partition::new(test_topic.to_string(), test_partition);
+    let attempt_timestamp = Utc::now();
+
+    let worker = CheckpointWorker::new_for_testing(
+        1,
+        Path::new(&config.local_checkpoint_dir),
+        &config.s3_key_prefix,
+        partition.clone(),
+        attempt_timestamp,
+        exporter.clone(),
+    );
+
+    // Execute checkpoint - this creates local checkpoint and uploads to MinIO
+    let checkpoint_result = worker.checkpoint_partition(&store, None).await?;
+    assert!(
+        checkpoint_result.is_some(),
+        "Checkpoint should return CheckpointInfo"
+    );
+    let uploaded_info = checkpoint_result.unwrap();
+
+    println!(
+        "Uploaded checkpoint to: {}",
+        uploaded_info.get_remote_attempt_path()
+    );
+    println!(
+        "Checkpoint metadata has {} files",
+        uploaded_info.metadata.files.len()
+    );
+
+    // Verify checkpoint was uploaded by listing objects
+    let list_result = minio_client
+        .list_objects_v2()
+        .bucket(TEST_BUCKET)
+        .prefix(&test_prefix)
+        .send()
+        .await?;
+
+    let uploaded_keys: Vec<String> = list_result
+        .contents()
+        .iter()
+        .filter_map(|obj| obj.key().map(String::from))
+        .collect();
+
+    println!("Found {} objects in MinIO:", uploaded_keys.len());
+    for key in &uploaded_keys {
+        println!("  - {key}");
+    }
+
+    assert!(
+        !uploaded_keys.is_empty(),
+        "Should have uploaded files to MinIO"
+    );
+    assert!(
+        uploaded_keys.iter().any(|k| k.ends_with("metadata.json")),
+        "Should have uploaded metadata.json"
+    );
+    assert!(
+        uploaded_keys.iter().any(|k| k.ends_with(".sst")),
+        "Should have uploaded .sst files"
+    );
+    assert!(
+        uploaded_keys.iter().any(|k| k.ends_with("CURRENT")),
+        "Should have uploaded CURRENT file"
+    );
+
+    // Verify local checkpoint export directory has files (test_mode=true skips cleanup)
+    let local_checkpoint_path = tmp_checkpoint_dir
+        .path()
+        .join(test_topic)
+        .join(test_partition.to_string());
+    assert!(
+        local_checkpoint_path.exists(),
+        "Local checkpoint directory should exist after export: {local_checkpoint_path:?}"
+    );
+    let local_export_files: Vec<_> = std::fs::read_dir(&local_checkpoint_path)?
+        .filter_map(|e| e.ok())
+        .flat_map(|e| std::fs::read_dir(e.path()).ok())
+        .flatten()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    println!(
+        "Local export directory has {} files:",
+        local_export_files.len()
+    );
+    for f in &local_export_files {
+        println!("  - {f}");
+    }
+    assert!(
+        !local_export_files.is_empty(),
+        "Local export directory should have checkpoint files"
+    );
+
+    // Now test the import side - create S3Downloader and CheckpointImporter
+    let downloader = S3Downloader::new_for_testing(&config).await?;
+
+    // Test list_recent_checkpoints
+    let recent_checkpoints = downloader
+        .list_recent_checkpoints(test_topic, test_partition)
+        .await?;
+
+    println!(
+        "Found {} recent checkpoint metadata files",
+        recent_checkpoints.len()
+    );
+    for cp in &recent_checkpoints {
+        println!("  - {cp}");
+    }
+
+    assert!(
+        !recent_checkpoints.is_empty(),
+        "Should find at least one checkpoint metadata file"
+    );
+
+    // Download and verify metadata
+    let metadata_key = &recent_checkpoints[0];
+    let metadata_bytes = downloader.download_file(metadata_key).await?;
+    let downloaded_metadata = CheckpointMetadata::from_json_bytes(&metadata_bytes)?;
+
+    println!("Downloaded metadata:");
+    println!("  - id: {}", downloaded_metadata.id);
+    println!("  - topic: {}", downloaded_metadata.topic);
+    println!("  - partition: {}", downloaded_metadata.partition);
+    println!("  - sequence: {}", downloaded_metadata.sequence);
+    println!("  - files: {}", downloaded_metadata.files.len());
+
+    // Verify metadata matches what we uploaded
+    assert_eq!(downloaded_metadata.id, uploaded_info.metadata.id);
+    assert_eq!(downloaded_metadata.topic, test_topic);
+    assert_eq!(downloaded_metadata.partition, test_partition);
+    assert_eq!(
+        downloaded_metadata.files.len(),
+        uploaded_info.metadata.files.len()
+    );
+
+    // Test full import via CheckpointImporter
+    let importer = CheckpointImporter::new(Box::new(downloader), &config);
+    assert!(
+        importer.is_available().await,
+        "Importer should be available"
+    );
+
+    let import_result = importer
+        .import_checkpoint_for_topic_partition(test_topic, test_partition)
+        .await?;
+
+    println!("Imported checkpoint to: {import_result:?}");
+    assert!(
+        import_result.exists(),
+        "Imported checkpoint directory should exist"
+    );
+
+    // Verify imported files
+    let imported_files: Vec<_> = std::fs::read_dir(&import_result)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+
+    println!("Imported {} files:", imported_files.len());
+    for f in &imported_files {
+        println!("  - {f}");
+    }
+
+    assert!(
+        imported_files.iter().any(|f| f.ends_with(".sst")),
+        "Should have imported .sst files"
+    );
+    assert!(
+        imported_files.iter().any(|f| f == "CURRENT"),
+        "Should have imported CURRENT file"
+    );
+    assert!(
+        imported_files.iter().any(|f| f.starts_with("MANIFEST-")),
+        "Should have imported MANIFEST file"
+    );
+    assert!(
+        imported_files.iter().any(|f| f.starts_with("OPTIONS-")),
+        "Should have imported OPTIONS file"
+    );
+
+    // Verify file count matches metadata
+    assert_eq!(
+        imported_files.len(),
+        downloaded_metadata.files.len(),
+        "Imported file count should match metadata file count"
+    );
+
+    // Verify import result is within the configured import directory
+    assert!(
+        import_result.starts_with(tmp_import_dir.path()),
+        "Imported checkpoint should be within tmp_import_dir: {:?} not in {:?}",
+        import_result,
+        tmp_import_dir.path()
+    );
+
+    // Verify import directory structure: <import_dir>/<topic>/<partition>/<checkpoint_id>/
+    let expected_import_parent = tmp_import_dir
+        .path()
+        .join(test_topic)
+        .join(test_partition.to_string());
+    assert!(
+        expected_import_parent.exists(),
+        "Import directory structure should exist: {expected_import_parent:?}"
+    );
+
+    // Drop the original store to release RocksDB locks
+    drop(store);
+
+    // Open a new store from the imported checkpoint to verify it's a valid RocksDB
+    println!("Opening store from imported checkpoint: {import_result:?}");
+    let restored_store_config = DeduplicationStoreConfig {
+        path: import_result.clone(),
+        max_capacity: 1_000_000,
+    };
+    let restored_store =
+        DeduplicationStore::new(restored_store_config, test_topic.to_string(), test_partition)?;
+
+    // Verify we can read the data we originally stored
+    println!("Verifying restored store contains original data...");
+    for event in &events {
+        let key: TimestampKey = event.into();
+        let record = restored_store.get_timestamp_record(&key)?;
+        assert!(
+            record.is_some(),
+            "Restored store should contain record for event: {:?}",
+            event.distinct_id
+        );
+        let metadata = record.unwrap();
+        let stored_event = metadata.get_original_event().unwrap();
+        assert_eq!(
+            stored_event.distinct_id, event.distinct_id,
+            "Restored event should match original"
+        );
+        assert_eq!(
+            stored_event.event, event.event,
+            "Restored event name should match original"
+        );
+        println!(
+            "  - Verified event for distinct_id: {:?}",
+            event.distinct_id
+        );
+    }
+    println!("All {} events verified in restored store!", events.len());
+
+    // Cleanup S3 bucket
+    cleanup_bucket(&minio_client, &test_prefix).await;
+
+    // Note: TempDirs (tmp_store_dir, tmp_checkpoint_dir, tmp_import_dir) are
+    // automatically cleaned up when dropped at end of test
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem
We need to wire up checkpoint import on rebalance for pods (stores) that don't have a local copy of the checkpoint they are assigned to.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Inject checkpoint import module into process rebalance handler
* Implement checkpoint import and move into store directory on success
* Implement end to end integration test:
    * Creates local RocksDB store
    * Creates local checkpoint
    * Exports to S3 (MinIO)
    * Imports from S3 (MinIO)
    * Restores checkpoint successfully in RocksDB
 * Instrumentation for store bootstrap on partition reassignment
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Further smoke testing on enablement after merge 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
