### PR TITLE
feat(capture): change capture body read timeout response to 408 

### DIFF
--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -159,7 +159,7 @@ impl IntoResponse for CaptureError {
                 (StatusCode::TOO_MANY_REQUESTS, self.to_string())
             }
 
-            CaptureError::BodyReadTimeout => (StatusCode::GATEWAY_TIMEOUT, self.to_string()),
+            CaptureError::BodyReadTimeout => (StatusCode::REQUEST_TIMEOUT, self.to_string()),
         }
         .into_response()
     }

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -135,7 +135,8 @@ pub struct Config {
     pub http1_header_read_timeout_ms: Option<u64>,
 
     // Body chunk read timeout in milliseconds. If a client stops sending data
-    // for this duration mid-upload, the request is aborted with 504.
+    // for this duration mid-upload, the request is aborted with 408 to avoid
+    // pointless gateway retries of stalled mobile requests that can't succeed.
     // Set env var to enable; unset to disable (existing behavior).
     pub body_chunk_read_timeout_ms: Option<u64>,
 


### PR DESCRIPTION
## Problem
Returning 504 for body read timeouts is causing needless Envoy retries that cannot succeed - stalled requests from mobile submissions will not succeed on internal retry.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Change capture body read timeout error responses to 408
* Leave global request timeouts to 504 as these could succeed on retry
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Root problem already observed in production
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
