### PR TITLE
chore: Change expand notebook icon in sidebar

### DIFF
--- a/frontend/src/scenes/notebooks/NotebookPanel/NotebookPanel.tsx
+++ b/frontend/src/scenes/notebooks/NotebookPanel/NotebookPanel.tsx
@@ -3,6 +3,7 @@ import './NotebookPanel.scss'
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
+import { IconExpand45 } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
@@ -51,6 +52,7 @@ export function NotebookPanel(): JSX.Element | null {
                         {contentWidthHasEffect && <NotebookExpandButton size="small" />}
                         <LemonButton
                             size="small"
+                            sideIcon={<IconExpand45 />}
                             to={urls.notebook(selectedNotebook)}
                             onClick={() => closeSidePanel()}
                             targetBlank


### PR DESCRIPTION
## Problem

The button to expand notebooks has the same icon we use for links that open in a new tab. Let's change the icon it to be consistent with PostHog AI's "open as main focus" icon.

## Changes
### Before

![image.png](https://app.graphite.com/user-attachments/assets/caf7e145-72e9-430b-8986-5994976540bb.png)

### Reference (PostHog AI)

![image.png](https://app.graphite.com/user-attachments/assets/0ae67d6a-ee21-450f-bc0a-4f2e76ac74f1.png)

### After

![image.png](https://app.graphite.com/user-attachments/assets/46aedd63-8e47-42a0-8635-48c4c0726d01.png)


## How did you test this code?


## Changelog: (features only) Is this feature complete?
No, not a feature