### PR TITLE
chore(capture): add chunk size extractor param for capture-ai

### DIFF
--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -123,6 +123,7 @@ pub async fn ai_handler(
         body,
         body_limit,
         state.body_chunk_read_timeout,
+        state.body_read_chunk_size_kb,
         path.as_str(),
     )
     .await?;


### PR DESCRIPTION
## Problem
Capture AI extractor enablement PR was merged out of order with new chunk size param PR, and CI didn't catch the error prior to merge. Luckily, `master` merge CI sequence did catch it. This fix will enable the original change to land.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add missing param to `capture-ai` body extractor in endpoint handler
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, CI, prod deploy (for other capture endpoints)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?
N/A
<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
