### PR TITLE
feat(web-analytics): show actual comparison period dates in tooltips

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -442,6 +442,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_SESSION_PROPERTY_CHARTS: 'web-analytics-session-property-charts', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_TILE_TOGGLES: 'web-analytics-tile-toggles', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_REGIONS_MAP: 'web-analytics-regions-map', // owner: @jordanm-posthog #team-web-analytics
+    WEB_ANALYTICS_TOOLTIP_COMPARISON_LABELS: 'web-analytics-tooltip-comparison-labels', // owner: @lricoy #team-web-analytics
     WORKFLOWS_BATCH_TRIGGERS: 'workflows-batch-triggers', // owner: #team-workflows
     WORKFLOWS_INTERNAL_EVENT_FILTERS: 'workflows-internal-event-filters', // owner: @haven #team-workflows
     WORKFLOWS_PERSON_TIMEZONE: 'workflows-person-timezone', // owner: #team-workflows

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -60,6 +60,7 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     dataTableRowsTransformer?: (rows: DataTableRow[]) => DataTableRow[]
     /** Compare filter for Web Analytics queries */
     compareFilter?: any
+    formatCompareLabel?: (label: string, dateLabel?: string) => string
     /** Base currency for formatting monetary values */
     baseCurrency?: CurrencyCode
     /** Limit context sent to the /query endpoint */

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -68,6 +68,7 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     customActions?: JSX.Element | JSX.Element[]
     /** Callback for drag-to-zoom on time series charts. Enables x-axis drag selection when set. */
     onDateRangeZoom?: (dateFrom: string, dateTo: string) => void
+    formatCompareLabel?: (label: string) => string
 }
 
 export type QueryContextColumnTitleComponent = ComponentType<{

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -69,7 +69,6 @@ export interface QueryContext<Q extends QuerySchema = QuerySchema> {
     customActions?: JSX.Element | JSX.Element[]
     /** Callback for drag-to-zoom on time series charts. Enables x-axis drag selection when set. */
     onDateRangeZoom?: (dateFrom: string, dateTo: string) => void
-    formatCompareLabel?: (label: string) => string
 }
 
 export type QueryContextColumnTitleComponent = ComponentType<{

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -104,6 +104,7 @@ export function InsightTooltip({
     interval,
     dateRange,
     showShiftKeyHint,
+    formatCompareLabel,
 }: InsightTooltipProps): JSX.Element {
     // Display entities as columns if multiple exist (e.g., pageview + autocapture, or multiple formulas)
     // and the insight has a breakdown or compare option enabled. This gives us space for labels
@@ -134,7 +135,7 @@ export function InsightTooltip({
 
     if (itemizeEntitiesAsColumns) {
         hideColorCol = true
-        const dataSource = invertDataSource(seriesData, breakdownFilter)
+        const dataSource = invertDataSource(seriesData, breakdownFilter, formatCompareLabel)
         const columns: LemonTableColumns<InvertedSeriesDatum> = [
             {
                 key: 'datum',

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -20,6 +20,7 @@ export interface SeriesDatum {
     compare_label?: CompareLabelType
     action?: ActionFilter
     label?: string
+    date_label?: string
     order: number
     dotted?: boolean
     color?: string
@@ -52,7 +53,7 @@ export interface TooltipConfig {
     getInspectLabel?: (referenceDatum: SeriesDatum | undefined) => string
     groupTypeLabel?: string
     filter?: (s: SeriesDatum) => boolean
-    formatCompareLabel?: (label: string) => string
+    formatCompareLabel?: (label: string, dateLabel?: string) => string
 }
 
 export interface InsightTooltipProps extends Omit<TooltipConfig, 'renderSeries' | 'renderCount' | 'getInspectLabel'> {
@@ -74,7 +75,7 @@ export interface InsightTooltipProps extends Omit<TooltipConfig, 'renderSeries' 
     dateRange?: DateRange | null
     /** Show hint about holding shift to highlight individual bars in stacked charts */
     showShiftKeyHint?: boolean
-    formatCompareLabel?: (label: string) => string
+    formatCompareLabel?: (label: string, dateLabel?: string) => string
 }
 
 export interface FormattedDateOptions {
@@ -174,7 +175,7 @@ function getPillValues(
     breakdownFilter: BreakdownFilter | null | undefined,
     cohorts: any,
     formatPropertyValueForDisplay: any,
-    formatCompareLabel?: (label: string) => string
+    formatCompareLabel?: (label: string, dateLabel?: string) => string
 ): string[] {
     const pillValues = []
     if (s.breakdown_value !== undefined) {
@@ -184,7 +185,7 @@ function getPillValues(
     }
     if (s.compare_label) {
         const formattedLabel = formatCompareLabel
-            ? formatCompareLabel(String(s.compare_label))
+            ? formatCompareLabel(String(s.compare_label), s.date_label)
             : capitalizeFirstLetter(String(s.compare_label))
         pillValues.push(formattedLabel)
     }
@@ -194,7 +195,7 @@ function getPillValues(
 function getDatumTitle(
     s: SeriesDatum,
     breakdownFilter: BreakdownFilter | null | undefined,
-    formatCompareLabel?: (label: string) => string
+    formatCompareLabel?: (label: string, dateLabel?: string) => string
 ): React.ReactNode {
     // NOTE: Assuming these logics are mounted elsewhere, and we're not interested in tracking changes.
     const cohorts = cohortsModel.findMounted()?.values?.allCohorts
@@ -231,7 +232,7 @@ function getDatumTitle(
 export function invertDataSource(
     seriesData: SeriesDatum[],
     breakdownFilter: BreakdownFilter | null | undefined,
-    formatCompareLabel?: (label: string) => string
+    formatCompareLabel?: (label: string, dateLabel?: string) => string
 ): InvertedSeriesDatum[] {
     const flattenedData: Record<string, InvertedSeriesDatum> = {}
 

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -52,6 +52,7 @@ export interface TooltipConfig {
     getInspectLabel?: (referenceDatum: SeriesDatum | undefined) => string
     groupTypeLabel?: string
     filter?: (s: SeriesDatum) => boolean
+    formatCompareLabel?: (label: string) => string
 }
 
 export interface InsightTooltipProps extends Omit<TooltipConfig, 'renderSeries' | 'renderCount' | 'getInspectLabel'> {
@@ -73,6 +74,7 @@ export interface InsightTooltipProps extends Omit<TooltipConfig, 'renderSeries' 
     dateRange?: DateRange | null
     /** Show hint about holding shift to highlight individual bars in stacked charts */
     showShiftKeyHint?: boolean
+    formatCompareLabel?: (label: string) => string
 }
 
 export interface FormattedDateOptions {
@@ -171,7 +173,8 @@ function getPillValues(
     s: SeriesDatum,
     breakdownFilter: BreakdownFilter | null | undefined,
     cohorts: any,
-    formatPropertyValueForDisplay: any
+    formatPropertyValueForDisplay: any,
+    formatCompareLabel?: (label: string) => string
 ): string[] {
     const pillValues = []
     if (s.breakdown_value !== undefined) {
@@ -180,16 +183,23 @@ function getPillValues(
         )
     }
     if (s.compare_label) {
-        pillValues.push(capitalizeFirstLetter(String(s.compare_label)))
+        const formattedLabel = formatCompareLabel
+            ? formatCompareLabel(String(s.compare_label))
+            : capitalizeFirstLetter(String(s.compare_label))
+        pillValues.push(formattedLabel)
     }
     return pillValues
 }
 
-function getDatumTitle(s: SeriesDatum, breakdownFilter: BreakdownFilter | null | undefined): React.ReactNode {
+function getDatumTitle(
+    s: SeriesDatum,
+    breakdownFilter: BreakdownFilter | null | undefined,
+    formatCompareLabel?: (label: string) => string
+): React.ReactNode {
     // NOTE: Assuming these logics are mounted elsewhere, and we're not interested in tracking changes.
     const cohorts = cohortsModel.findMounted()?.values?.allCohorts
     const formatPropertyValueForDisplay = propertyDefinitionsModel.findMounted()?.values?.formatPropertyValueForDisplay
-    const pillValues = getPillValues(s, breakdownFilter, cohorts, formatPropertyValueForDisplay)
+    const pillValues = getPillValues(s, breakdownFilter, cohorts, formatPropertyValueForDisplay, formatCompareLabel)
     const showPathCleaningHighlight = breakdownFilter?.breakdown_path_cleaning
 
     if (pillValues.length > 0) {
@@ -220,7 +230,8 @@ function getDatumTitle(s: SeriesDatum, breakdownFilter: BreakdownFilter | null |
 
 export function invertDataSource(
     seriesData: SeriesDatum[],
-    breakdownFilter: BreakdownFilter | null | undefined
+    breakdownFilter: BreakdownFilter | null | undefined,
+    formatCompareLabel?: (label: string) => string
 ): InvertedSeriesDatum[] {
     const flattenedData: Record<string, InvertedSeriesDatum> = {}
 
@@ -234,7 +245,7 @@ export function invertDataSource(
                 id: datumKey,
                 datasetIndex: s.datasetIndex,
                 color: s.color,
-                datumTitle: getDatumTitle(s, breakdownFilter),
+                datumTitle: getDatumTitle(s, breakdownFilter, formatCompareLabel),
                 seriesData: [s],
             }
         }

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -770,6 +770,7 @@ export function LineGraph_({
                                         interval={interval}
                                         dateRange={insightData?.resolved_date_range}
                                         showShiftKeyHint={isBar && isStacked && !isHighlightBarMode && !inSurveyView}
+                                        formatCompareLabel={tooltipConfig?.formatCompareLabel}
                                         renderSeries={(value, datum) => {
                                             const hasBreakdown =
                                                 datum.breakdown_value !== undefined && !!datum.breakdown_value

--- a/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
@@ -27,6 +27,7 @@ export function createTooltipData(
                 compare_label: pointDataset?.compare_label ?? pointDataset?.compareLabels?.[dp.dataIndex] ?? undefined,
                 action: pointDataset?.action ?? pointDataset?.actions?.[dp.dataIndex] ?? undefined,
                 label: pointDataset?.label ?? pointDataset.labels?.[dp.dataIndex] ?? undefined,
+                date_label: pointDataset?.labels?.[dp.dataIndex] ?? undefined,
                 order: pointDataset?.order ?? 0,
                 color: Array.isArray(pointDataset.borderColor)
                     ? pointDataset.borderColor?.[dp.dataIndex]

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -198,6 +198,7 @@ export function ActionsLineGraph({
                     : {
                           groupTypeLabel: context?.groupTypeLabel,
                           filter: (s) => !s.hideTooltip,
+                          formatCompareLabel: context?.formatCompareLabel,
                       }
             }
             isInProgress={!isStickiness && incompletenessOffsetFromEnd < 0}

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -12,12 +12,19 @@ import { parseAliasToReadable } from 'lib/components/PathCleanFilters/PathCleanF
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { PropertyIcon } from 'lib/components/PropertyIcon/PropertyIcon'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { dayjs } from 'lib/dayjs'
 import { IconOpenInNew, IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { UnexpectedNeverError, humanFriendlyDuration, percentage, tryDecodeURIComponent } from 'lib/utils'
+import {
+    UnexpectedNeverError,
+    capitalizeFirstLetter,
+    humanFriendlyDuration,
+    percentage,
+    tryDecodeURIComponent,
+} from 'lib/utils'
 import {
     COUNTRY_CODE_TO_LONG_NAME,
     LANGUAGE_CODE_TO_NAME,
@@ -658,14 +665,45 @@ export const WebStatsTrendTile = ({
     )
 
     const context = useMemo((): QueryContext => {
+        const compareFilter = 'compareFilter' in query.source ? query.source.compareFilter : undefined
+        const dateRange = 'dateRange' in query.source ? query.source.dateRange : undefined
+
+        const formatComparisonDates = (isPrevious: boolean): string => {
+            if (!compareFilter?.compare || !dateRange?.date_from) {
+                return ''
+            }
+
+            const currentFrom = dayjs(dateRange.date_from)
+            const currentTo = dateRange.date_to ? dayjs(dateRange.date_to) : dayjs()
+            const diffDays = currentTo.diff(currentFrom, 'day')
+
+            if (isPrevious) {
+                const prevTo = currentFrom.subtract(1, 'day')
+                const prevFrom = prevTo.subtract(diffDays, 'day')
+                return ` (${prevFrom.format('MMM D')} - ${prevTo.format('MMM D')})`
+            }
+
+            return ` (${currentFrom.format('MMM D')} - ${currentTo.format('MMM D')})`
+        }
+
         const baseContext: QueryContext = {
             ...webAnalyticsDataTableQueryContext,
             insightProps: {
                 ...insightProps,
                 query,
             },
-            compareFilter: 'compareFilter' in query.source ? query.source.compareFilter : undefined,
+            compareFilter,
             onDateRangeZoom: isDragToZoomEnabled ? zoomIntoPeriod : undefined,
+            formatCompareLabel: (label: string) => {
+                const lowerLabel = label.toLowerCase()
+                if (lowerLabel === 'previous') {
+                    return `Previous period${formatComparisonDates(true)}`
+                }
+                if (lowerLabel === 'current') {
+                    return `Current period${formatComparisonDates(false)}`
+                }
+                return capitalizeFirstLetter(label)
+            },
         }
 
         // World maps need custom click handler for country filtering, trend lines use default persons modal

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -637,6 +637,7 @@ export const WebStatsTrendTile = ({
     const isDragToZoomEnabled = !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_DRAG_TO_ZOOM]
     const worldMapPropertyName = webStatsBreakdownToPropertyName(WebStatsBreakdown.Country)?.key
     const regionPropertyName = webStatsBreakdownToPropertyName(WebStatsBreakdown.Region)?.key
+    const showComparisonLabels = featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TOOLTIP_COMPARISON_LABELS]
 
     const onWorldMapClick = useCallback(
         (breakdownValue: string) => {
@@ -698,16 +699,20 @@ export const WebStatsTrendTile = ({
             },
             compareFilter,
             onDateRangeZoom: isDragToZoomEnabled ? zoomIntoPeriod : undefined,
-            formatCompareLabel: (label: string) => {
-                const lowerLabel = label.toLowerCase()
-                if (lowerLabel === 'previous') {
-                    return `Previous period${formatComparisonDates(true)}`
-                }
-                if (lowerLabel === 'current') {
-                    return `Current period${formatComparisonDates(false)}`
-                }
-                return capitalizeFirstLetter(label)
-            },
+            ...(showComparisonLabels
+                ? {
+                      formatCompareLabel: (label: string) => {
+                          const lowerLabel = label.toLowerCase()
+                          if (lowerLabel === 'previous') {
+                              return `Previous period${formatComparisonDates(true)}`
+                          }
+                          if (lowerLabel === 'current') {
+                              return `Current period${formatComparisonDates(false)}`
+                          }
+                          return capitalizeFirstLetter(label)
+                      },
+                  }
+                : {}),
         }
 
         // World maps need custom click handler for country filtering, trend lines use default persons modal
@@ -747,7 +752,7 @@ export const WebStatsTrendTile = ({
         }
 
         return baseContext
-    }, [onWorldMapClick, onRegionMapClick, zoomIntoPeriod, insightProps, query])
+    }, [onWorldMapClick, onRegionMapClick, zoomIntoPeriod, insightProps, query, showComparisonLabels])
 
     return (
         <div className="border rounded bg-surface-primary flex-1 flex flex-col">

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -12,7 +12,6 @@ import { parseAliasToReadable } from 'lib/components/PathCleanFilters/PathCleanF
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { PropertyIcon } from 'lib/components/PropertyIcon/PropertyIcon'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { dayjs } from 'lib/dayjs'
 import { IconOpenInNew, IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
@@ -21,7 +20,6 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import {
     UnexpectedNeverError,
     capitalizeFirstLetter,
-    dateStringToDayJs,
     humanFriendlyDuration,
     percentage,
     tryDecodeURIComponent,
@@ -637,7 +635,7 @@ export const WebStatsTrendTile = ({
     const isDragToZoomEnabled = !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_DRAG_TO_ZOOM]
     const worldMapPropertyName = webStatsBreakdownToPropertyName(WebStatsBreakdown.Country)?.key
     const regionPropertyName = webStatsBreakdownToPropertyName(WebStatsBreakdown.Region)?.key
-    const showComparisonLabels = featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TOOLTIP_COMPARISON_LABELS]
+    const showComparisonLabels = !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TOOLTIP_COMPARISON_LABELS]
 
     const onWorldMapClick = useCallback(
         (breakdownValue: string) => {
@@ -668,28 +666,6 @@ export const WebStatsTrendTile = ({
 
     const context = useMemo((): QueryContext => {
         const compareFilter = 'compareFilter' in query.source ? query.source.compareFilter : undefined
-        const dateRange = 'dateRange' in query.source ? query.source.dateRange : undefined
-
-        const formatComparisonDates = (isPrevious: boolean): string => {
-            if (!compareFilter?.compare || !dateRange?.date_from) {
-                return ''
-            }
-
-            const currentFrom = dateStringToDayJs(dateRange.date_from)
-            const currentTo = dateRange.date_to ? dateStringToDayJs(dateRange.date_to) : dayjs()
-            if (!currentFrom || !currentTo) {
-                return ''
-            }
-            const diffDays = currentTo.diff(currentFrom, 'day')
-
-            if (isPrevious) {
-                const prevTo = currentFrom.subtract(1, 'day')
-                const prevFrom = prevTo.subtract(diffDays, 'day')
-                return ` (${prevFrom.format('MMM D')} - ${prevTo.format('MMM D')})`
-            }
-
-            return ` (${currentFrom.format('MMM D')} - ${currentTo.format('MMM D')})`
-        }
 
         const baseContext: QueryContext = {
             ...webAnalyticsDataTableQueryContext,
@@ -701,13 +677,14 @@ export const WebStatsTrendTile = ({
             onDateRangeZoom: isDragToZoomEnabled ? zoomIntoPeriod : undefined,
             ...(showComparisonLabels
                 ? {
-                      formatCompareLabel: (label: string) => {
+                      formatCompareLabel: (label: string, dateLabel?: string) => {
                           const lowerLabel = label.toLowerCase()
+                          const dateSuffix = dateLabel ? ` (${dateLabel})` : ''
                           if (lowerLabel === 'previous') {
-                              return `Previous period${formatComparisonDates(true)}`
+                              return `Previous${dateSuffix}`
                           }
                           if (lowerLabel === 'current') {
-                              return `Current period${formatComparisonDates(false)}`
+                              return `Current${dateSuffix}`
                           }
                           return capitalizeFirstLetter(label)
                       },

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -21,6 +21,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import {
     UnexpectedNeverError,
     capitalizeFirstLetter,
+    dateStringToDayJs,
     humanFriendlyDuration,
     percentage,
     tryDecodeURIComponent,
@@ -673,8 +674,11 @@ export const WebStatsTrendTile = ({
                 return ''
             }
 
-            const currentFrom = dayjs(dateRange.date_from)
-            const currentTo = dateRange.date_to ? dayjs(dateRange.date_to) : dayjs()
+            const currentFrom = dateStringToDayJs(dateRange.date_from)
+            const currentTo = dateRange.date_to ? dateStringToDayJs(dateRange.date_to) : dayjs()
+            if (!currentFrom || !currentTo) {
+                return ''
+            }
             const diffDays = currentTo.diff(currentFrom, 'day')
 
             if (isPrevious) {


### PR DESCRIPTION
## Problem

When comparing periods in Web Analytics trend charts, the tooltips only show generic labels like "Current" and "Previous" which don't tell the user what dates are being compared. This is especially troublesome when people use other comparison periods like 1 month before.

| Before | After |
|--------|--------|
| <img width="236" height="108" alt="image" src="https://github.com/user-attachments/assets/d93291f3-2e3f-414a-aa1c-802195289238" /> | <img width="217" height="88" alt="image" src="https://github.com/user-attachments/assets/d767dd43-5194-4abc-a6a4-596230af87dd" /> |



## Changes

- Add `formatCompareLabel` callback to QueryContext that allows customizing comparison labels in tooltips
- In Web Analytics trend tiles, format the comparison labels to include actual date ranges:
  - "Current" → "Current period (Jan 15 - Jan 21)"
  - "Previous" → "Previous period (Jan 8 - Jan 14)"
- Thread the formatter through InsightTooltip, LineGraph, and ActionsLineGraph components

## How did you test this code?

Manual testing on Web Analytics dashboards with compare mode enabled - verified that tooltips now show the actual date ranges for both current and previous periods.