### PR TITLE
feat(signals): Display timestamp and current URL in the recording for grounding LLMs

### DIFF
--- a/ee/hogai/videos/session_moments.py
+++ b/ee/hogai/videos/session_moments.py
@@ -158,8 +158,8 @@ class SessionMomentsLLMAnalyzer:
                     "playback_speed": SHORT_VALIDATION_VIDEO_PLAYBACK_SPEED,
                     # Keeping default values
                     "mode": "screenshot",
-                    # Display additional metadata for LLMs in the video
-                    "show_llm_metadata": True,
+                    # Display additional metadata in the video footer, like current URL (for LLM analysis and so)
+                    "show_metadata_footer": True,
                 },
                 created_by=self.user,
                 created_at=created_at,

--- a/ee/hogai/videos/session_moments.py
+++ b/ee/hogai/videos/session_moments.py
@@ -158,6 +158,8 @@ class SessionMomentsLLMAnalyzer:
                     "playback_speed": SHORT_VALIDATION_VIDEO_PLAYBACK_SPEED,
                     # Keeping default values
                     "mode": "screenshot",
+                    # Display additional metadata for LLMs in the video
+                    "show_llm_metadata": True,
                 },
                 created_by=self.user,
                 created_at=created_at,

--- a/frontend/src/scenes/session-recordings/player/PlayerFrameLLMMetaOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameLLMMetaOverlay.tsx
@@ -1,0 +1,24 @@
+import { useValues } from 'kea'
+
+import { colonDelimitedDuration } from 'lib/utils'
+
+import { sessionRecordingPlayerLogic } from './sessionRecordingPlayerLogic'
+
+export function PlayerFrameLLMMetaOverlay(): JSX.Element | null {
+    const { currentURL, currentPlayerTime } = useValues(sessionRecordingPlayerLogic)
+
+    if (!currentURL) {
+        return null
+    }
+
+    return (
+        <div className="bg-black text-white text-md px-2 pt-1 pb-2 flex justify-center gap-4 truncate">
+            <span>
+                <span className="font-bold">URL:</span> {currentURL}
+            </span>
+            <span>
+                <span className="font-bold">Timestamp:</span> {colonDelimitedDuration(currentPlayerTime / 1000, null)}
+            </span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/session-recordings/player/PlayerFrameLLMMetaOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameLLMMetaOverlay.tsx
@@ -5,11 +5,13 @@ import { colonDelimitedDuration } from 'lib/utils'
 import { sessionRecordingPlayerLogic } from './sessionRecordingPlayerLogic'
 
 export function PlayerFrameLLMMetaOverlay(): JSX.Element | null {
-    const { currentURL, currentPlayerTime } = useValues(sessionRecordingPlayerLogic)
+    const { currentURL, currentPlayerTime, currentSegment } = useValues(sessionRecordingPlayerLogic)
 
-    if (!currentURL) {
+    if (!currentURL || currentPlayerTime === undefined) {
         return null
     }
+
+    const isInactive = currentSegment?.isActive === false
 
     return (
         <div className="bg-black text-white text-md px-2 pt-1 pb-2 flex justify-center gap-4 truncate font-mono">
@@ -17,8 +19,13 @@ export function PlayerFrameLLMMetaOverlay(): JSX.Element | null {
                 <span className="font-bold">URL:</span> {currentURL}
             </span>
             <span>
-                <span className="font-bold">Timestamp:</span> {colonDelimitedDuration(currentPlayerTime / 1000, null)}
+                <span className="font-bold">TIMESTAMP:</span> {colonDelimitedDuration(currentPlayerTime / 1000, null)}
             </span>
+            {isInactive && (
+                <span>
+                    <span className="font-bold text-yellow-400">[IDLE]</span>
+                </span>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/PlayerFrameLLMMetaOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameLLMMetaOverlay.tsx
@@ -12,7 +12,7 @@ export function PlayerFrameLLMMetaOverlay(): JSX.Element | null {
     }
 
     return (
-        <div className="bg-black text-white text-md px-2 pt-1 pb-2 flex justify-center gap-4 truncate">
+        <div className="bg-black text-white text-md px-2 pt-1 pb-2 flex justify-center gap-4 truncate font-mono">
             <span>
                 <span className="font-bold">URL:</span> {currentURL}
             </span>

--- a/frontend/src/scenes/session-recordings/player/PlayerFrameMetaOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameMetaOverlay.tsx
@@ -12,8 +12,8 @@ export function PlayerFrameMetaOverlay(): JSX.Element | null {
     const isInactive = currentSegment?.isActive === false
 
     return (
-        <div className="bg-black text-white text-md px-2 pt-1 pb-2 flex justify-center gap-4 truncate font-mono">
-            <span>
+        <div className="bg-black text-white text-md px-2 pt-1 pb-2 flex justify-center gap-4 font-mono truncate">
+            <span className="truncate">
                 <span className="font-bold">URL:</span> {currentURL}
             </span>
             <span>

--- a/frontend/src/scenes/session-recordings/player/PlayerFrameMetaOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameMetaOverlay.tsx
@@ -1,10 +1,8 @@
 import { useValues } from 'kea'
 
-import { colonDelimitedDuration } from 'lib/utils'
-
 import { sessionRecordingPlayerLogic } from './sessionRecordingPlayerLogic'
 
-export function PlayerFrameLLMMetaOverlay(): JSX.Element | null {
+export function PlayerFrameMetaOverlay(): JSX.Element | null {
     const { currentURL, currentPlayerTime, currentSegment } = useValues(sessionRecordingPlayerLogic)
 
     if (!currentURL || currentPlayerTime === undefined) {
@@ -19,7 +17,7 @@ export function PlayerFrameLLMMetaOverlay(): JSX.Element | null {
                 <span className="font-bold">URL:</span> {currentURL}
             </span>
             <span>
-                <span className="font-bold">TIMESTAMP:</span> {colonDelimitedDuration(currentPlayerTime / 1000, null)}
+                <span className="font-bold">REC_T:</span> {Math.floor(currentPlayerTime / 1000)}
             </span>
             {isInactive && (
                 <span>

--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -19,7 +19,7 @@ import { PlayerFrameCommentOverlay } from 'scenes/session-recordings/player/comm
 import { urls } from 'scenes/urls'
 
 import { PlayerFrame } from './PlayerFrame'
-import { PlayerFrameLLMMetaOverlay } from './PlayerFrameLLMMetaOverlay'
+import { PlayerFrameMetaOverlay } from './PlayerFrameMetaOverlay'
 import { PlayerFrameOverlay } from './PlayerFrameOverlay'
 import { ClipOverlay } from './controller/ClipRecording'
 import { PlayerController } from './controller/PlayerController'
@@ -85,7 +85,7 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
     const { isNotFound, isRecentAndInvalid } = useValues(sessionRecordingDataCoordinatorLogic(logicProps))
     const { loadSnapshots } = useActions(sessionRecordingDataCoordinatorLogic(logicProps))
 
-    const { isCinemaMode, showLLMMetadata } = useValues(playerSettingsLogic)
+    const { isCinemaMode, showMetadataFooter } = useValues(playerSettingsLogic)
     const { setIsCinemaMode } = useActions(playerSettingsLogic)
 
     const mode = logicProps.mode ?? SessionRecordingPlayerMode.Standard
@@ -268,7 +268,7 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
                                             </>
                                         ) : null}
                                     </div>
-                                    {showLLMMetadata ? <PlayerFrameLLMMetaOverlay /> : null}
+                                    {showMetadataFooter ? <PlayerFrameMetaOverlay /> : null}
                                     {!hidePlayerElements ? <PlayerController /> : null}
                                 </div>
                             </div>

--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -19,6 +19,7 @@ import { PlayerFrameCommentOverlay } from 'scenes/session-recordings/player/comm
 import { urls } from 'scenes/urls'
 
 import { PlayerFrame } from './PlayerFrame'
+import { PlayerFrameLLMMetaOverlay } from './PlayerFrameLLMMetaOverlay'
 import { PlayerFrameOverlay } from './PlayerFrameOverlay'
 import { ClipOverlay } from './controller/ClipRecording'
 import { PlayerController } from './controller/PlayerController'
@@ -267,6 +268,7 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
                                             </>
                                         ) : null}
                                     </div>
+                                    <PlayerFrameLLMMetaOverlay />
                                     {!hidePlayerElements ? <PlayerController /> : null}
                                 </div>
                             </div>

--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -85,7 +85,7 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
     const { isNotFound, isRecentAndInvalid } = useValues(sessionRecordingDataCoordinatorLogic(logicProps))
     const { loadSnapshots } = useActions(sessionRecordingDataCoordinatorLogic(logicProps))
 
-    const { isCinemaMode } = useValues(playerSettingsLogic)
+    const { isCinemaMode, showLLMMetadata } = useValues(playerSettingsLogic)
     const { setIsCinemaMode } = useActions(playerSettingsLogic)
 
     const mode = logicProps.mode ?? SessionRecordingPlayerMode.Standard
@@ -268,7 +268,7 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
                                             </>
                                         ) : null}
                                     </div>
-                                    <PlayerFrameLLMMetaOverlay />
+                                    {showLLMMetadata ? <PlayerFrameLLMMetaOverlay /> : null}
                                     {!hidePlayerElements ? <PlayerController /> : null}
                                 </div>
                             </div>

--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -37,6 +37,7 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
         setPlaylistOpen: (open: boolean) => ({ open }),
         setURLOverrideSidebarOpen: (open: boolean) => ({ open }),
         setIsCinemaMode: (isCinemaMode: boolean) => ({ isCinemaMode }),
+        setShowLLMMetadata: (showLLMMetadata: boolean) => ({ showLLMMetadata }),
     }),
     connect(() => ({
         values: [teamLogic, ['currentTeam']],
@@ -115,6 +116,13 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
                 setIsCinemaMode: (_, { isCinemaMode }) => isCinemaMode,
             },
         ],
+        showLLMMetadata: [
+            false,
+            // Don't persist this setting as required for export only
+            {
+                setShowLLMMetadata: (_, { showLLMMetadata }) => showLLMMetadata,
+            },
+        ],
     })),
 
     selectors({
@@ -170,12 +178,6 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
     })),
 
     urlToAction(({ actions, values }) => ({
-        '*': (_, searchParams, hashParams) => {
-            const inspectorSideBarOpen = searchParams.inspectorSideBar === true || hashParams.inspectorSideBar === true
-            if (inspectorSideBarOpen && inspectorSideBarOpen !== values.sidebarOpen) {
-                actions.setSidebarOpen(inspectorSideBarOpen)
-            }
-        },
         ['**/shared/*']: (_, searchParams) => {
             // when sharing a recording, you can specify whether the inspector should be open.
             // we should obey that regardless of the preference stored here.
@@ -191,6 +193,17 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
             const playerSpeed = Number(searchParams.playerSpeed ?? 1)
             if (values.speed !== playerSpeed) {
                 actions.setSpeed(playerSpeed)
+            }
+            const showLLMMetadata = 'showLLMMetadata' in searchParams && (searchParams.showLLMMetadata ?? false)
+            if (values.showLLMMetadata !== showLLMMetadata) {
+                actions.setShowLLMMetadata(showLLMMetadata)
+            }
+        },
+        // Putting `*` last to match it only if more specific routes don't match, as the matching seems to be exclusive
+        '*': (_, searchParams, hashParams) => {
+            const inspectorSideBarOpen = searchParams.inspectorSideBar === true || hashParams.inspectorSideBar === true
+            if (inspectorSideBarOpen && inspectorSideBarOpen !== values.sidebarOpen) {
+                actions.setSidebarOpen(inspectorSideBarOpen)
             }
         },
     })),

--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -37,7 +37,7 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
         setPlaylistOpen: (open: boolean) => ({ open }),
         setURLOverrideSidebarOpen: (open: boolean) => ({ open }),
         setIsCinemaMode: (isCinemaMode: boolean) => ({ isCinemaMode }),
-        showMetadataFooter: (showMetadataFooter: boolean) => ({ showMetadataFooter }),
+        setShowMetadataFooter: (showMetadataFooter: boolean) => ({ showMetadataFooter }),
     }),
     connect(() => ({
         values: [teamLogic, ['currentTeam']],

--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -37,7 +37,7 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
         setPlaylistOpen: (open: boolean) => ({ open }),
         setURLOverrideSidebarOpen: (open: boolean) => ({ open }),
         setIsCinemaMode: (isCinemaMode: boolean) => ({ isCinemaMode }),
-        setShowLLMMetadata: (showLLMMetadata: boolean) => ({ showLLMMetadata }),
+        showMetadataFooter: (showMetadataFooter: boolean) => ({ showMetadataFooter }),
     }),
     connect(() => ({
         values: [teamLogic, ['currentTeam']],
@@ -116,11 +116,11 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
                 setIsCinemaMode: (_, { isCinemaMode }) => isCinemaMode,
             },
         ],
-        showLLMMetadata: [
+        showMetadataFooter: [
             false,
             // Don't persist this setting as required for export only
             {
-                setShowLLMMetadata: (_, { showLLMMetadata }) => showLLMMetadata,
+                setShowMetadataFooter: (_, { showMetadataFooter }) => showMetadataFooter,
             },
         ],
     })),
@@ -194,9 +194,10 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
             if (values.speed !== playerSpeed) {
                 actions.setSpeed(playerSpeed)
             }
-            const showLLMMetadata = 'showLLMMetadata' in searchParams && (searchParams.showLLMMetadata ?? false)
-            if (values.showLLMMetadata !== showLLMMetadata) {
-                actions.setShowLLMMetadata(showLLMMetadata)
+            const showMetadataFooter =
+                'showMetadataFooter' in searchParams && (searchParams.showMetadataFooter ?? false)
+            if (values.showMetadataFooter !== showMetadataFooter) {
+                actions.setShowMetadataFooter(showMetadataFooter)
             }
         },
         // Putting `*` last to match it only if more specific routes don't match, as the matching seems to be exclusive

--- a/posthog/temporal/exports_video/activities.py
+++ b/posthog/temporal/exports_video/activities.py
@@ -55,7 +55,7 @@ def build_export_context_activity(exported_asset_id: int) -> dict[str, Any]:
         height = max(300, min(2160, int(height)))
 
     # Display additional metadata for LLMs in the video
-    show_llm_metadata = asset.export_context.get("show_llm_metadata", False)
+    show_metadata_footer = asset.export_context.get("show_metadata_footer", False)
 
     # we can set playback speed to any integer between 1 and 360
     try:
@@ -72,8 +72,8 @@ def build_export_context_activity(exported_asset_id: int) -> dict[str, Any]:
     }
     if playback_speed != 1:
         url_params["playerSpeed"] = playback_speed
-    if show_llm_metadata:
-        url_params["showLLMMetadata"] = "true"
+    if show_metadata_footer:
+        url_params["showMetadataFooter"] = "true"
 
     url = absolute_uri(f"/exporter?{'&'.join(f'{key}={value}' for key, value in url_params.items())}")
 

--- a/posthog/temporal/exports_video/activities.py
+++ b/posthog/temporal/exports_video/activities.py
@@ -54,6 +54,9 @@ def build_export_context_activity(exported_asset_id: int) -> dict[str, Any]:
     if height is not None:
         height = max(300, min(2160, int(height)))
 
+    # Display additional metadata for LLMs in the video
+    show_llm_metadata = asset.export_context.get("show_llm_metadata", False)
+
     # we can set playback speed to any integer between 1 and 360
     try:
         playback_speed = max(1, min(360, int(asset.export_context.get("playback_speed", 1))))
@@ -69,6 +72,8 @@ def build_export_context_activity(exported_asset_id: int) -> dict[str, Any]:
     }
     if playback_speed != 1:
         url_params["playerSpeed"] = playback_speed
+    if show_llm_metadata:
+        url_params["showLLMMetadata"] = "true"
 
     url = absolute_uri(f"/exporter?{'&'.join(f'{key}={value}' for key, value in url_params.items())}")
 


### PR DESCRIPTION
## Problem
- Recording timestamps can be flaky (miss a couple of seconds at the start, or in the middle), so it complicates matching with actual events
- LLM doesn't see the URL of the page it visits, so instead of adding it as string context it works better if include it in the video itself
- LLM thinks too much (we pay for thinking tokens) on the idle periods (user does nothing)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

![CleanShot 2025-12-27 at 16 46 32](https://github.com/user-attachments/assets/20009a77-03c7-4b8e-aaea-7d380a69ff04)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
