### PR TITLE
feat: increase rate limit for materialized endpoints

### DIFF
--- a/products/endpoints/backend/rate_limit.py
+++ b/products/endpoints/backend/rate_limit.py
@@ -1,0 +1,154 @@
+from django.core.cache import cache
+
+from posthog.rate_limit import PersonalApiKeyRateThrottle
+
+MATERIALIZED_ENDPOINT_CACHE_KEY = "endpoint_materialized_ready:{team_id}:{endpoint_name}"
+MATERIALIZED_ENDPOINT_CACHE_TTL = 3600  # 1 hour fallback TTL
+
+# Rate limits for inline endpoints (default)
+INLINE_BURST_RATE = "240/minute"
+INLINE_SUSTAINED_RATE = "2400/hour"
+
+# Rate limits for materialized endpoints (5x higher)
+MATERIALIZED_BURST_RATE = "1200/minute"
+MATERIALIZED_SUSTAINED_RATE = "12000/hour"
+
+
+def get_endpoint_materialization_cache_key(team_id: int, endpoint_name: str) -> str:
+    return MATERIALIZED_ENDPOINT_CACHE_KEY.format(team_id=team_id, endpoint_name=endpoint_name)
+
+
+def is_endpoint_materialization_ready(team_id: int, endpoint_name: str) -> bool | None:
+    """
+    Check if an endpoint's materialization is ready (cached).
+
+    Returns:
+        True if materialization is ready
+        False if materialization is not ready
+        None if cache miss (caller should check DB and populate cache)
+    """
+    cache_key = get_endpoint_materialization_cache_key(team_id, endpoint_name)
+    return cache.get(cache_key)
+
+
+def set_endpoint_materialization_ready(team_id: int, endpoint_name: str, is_ready: bool) -> None:
+    """
+    Set the cached materialization ready status for an endpoint.
+    Called when:
+    - Temporal workflow completes successfully (is_ready=True)
+    - Temporal workflow fails (is_ready=False)
+    - Materialization is disabled (is_ready=False)
+    """
+    cache_key = get_endpoint_materialization_cache_key(team_id, endpoint_name)
+    cache.set(cache_key, is_ready, timeout=MATERIALIZED_ENDPOINT_CACHE_TTL)
+
+
+def clear_endpoint_materialization_cache(team_id: int, endpoint_name: str) -> None:
+    """Clear the cached materialization status for an endpoint."""
+    cache_key = get_endpoint_materialization_cache_key(team_id, endpoint_name)
+    cache.delete(cache_key)
+
+
+def _get_endpoint_info_from_request(request, view) -> tuple[int | None, str | None]:
+    """Extract team_id and endpoint_name from request/view context."""
+    team_id = getattr(view, "team_id", None)
+    endpoint_name = view.kwargs.get("name") if hasattr(view, "kwargs") else None
+    return team_id, endpoint_name
+
+
+def _check_and_cache_materialization_status(team_id: int, endpoint_name: str) -> bool:
+    """
+    Check materialization status from DB and populate cache.
+    Called on cache miss for lazy loading.
+
+    Returns True if endpoint is ready for materialized execution.
+    """
+    from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+    from products.endpoints.backend.models import Endpoint
+
+    try:
+        endpoint = Endpoint.objects.select_related("saved_query").get(
+            team_id=team_id, name=endpoint_name, is_active=True
+        )
+
+        is_ready = (
+            endpoint.is_materialized
+            and endpoint.saved_query is not None
+            and endpoint.saved_query.status == DataWarehouseSavedQuery.Status.COMPLETED
+        )
+
+        set_endpoint_materialization_ready(team_id, endpoint_name, is_ready)
+        return is_ready
+    except Endpoint.DoesNotExist:
+        return False
+
+
+def _is_materialized_endpoint_request(request, view) -> bool:
+    """Check if this request is for a materialized endpoint (cached check with lazy loading)."""
+    team_id, endpoint_name = _get_endpoint_info_from_request(request, view)
+    if not team_id or not endpoint_name:
+        return False
+
+    cached_status = is_endpoint_materialization_ready(team_id, endpoint_name)
+
+    if cached_status is None:
+        return _check_and_cache_materialization_status(team_id, endpoint_name)
+
+    return cached_status is True
+
+
+class EndpointBurstThrottle(PersonalApiKeyRateThrottle):
+    """
+    Adaptive burst throttle for endpoints.
+    Uses higher rate limit for materialized endpoints.
+    """
+
+    scope = "endpoint_burst"
+    rate = INLINE_BURST_RATE
+
+    def allow_request(self, request, view):
+        if _is_materialized_endpoint_request(request, view):
+            self.rate = MATERIALIZED_BURST_RATE
+            self.scope = "materialized_endpoint_burst"
+        else:
+            self.rate = INLINE_BURST_RATE
+            self.scope = "endpoint_burst"
+
+        self.num_requests, self.duration = self.parse_rate(self.rate)
+        return super().allow_request(request, view)
+
+
+class EndpointSustainedThrottle(PersonalApiKeyRateThrottle):
+    """
+    Adaptive sustained throttle for endpoints.
+    Uses higher rate limit for materialized endpoints.
+    """
+
+    scope = "endpoint_sustained"
+    rate = INLINE_SUSTAINED_RATE
+
+    def allow_request(self, request, view):
+        if _is_materialized_endpoint_request(request, view):
+            self.rate = MATERIALIZED_SUSTAINED_RATE
+            self.scope = "materialized_endpoint_sustained"
+        else:
+            self.rate = INLINE_SUSTAINED_RATE
+            self.scope = "endpoint_sustained"
+
+        self.num_requests, self.duration = self.parse_rate(self.rate)
+        return super().allow_request(request, view)
+
+
+# Keep these for backwards compatibility and explicit use
+class MaterializedEndpointBurstThrottle(PersonalApiKeyRateThrottle):
+    """Higher burst rate limit for materialized endpoints (5x normal)."""
+
+    scope = "materialized_endpoint_burst"
+    rate = MATERIALIZED_BURST_RATE
+
+
+class MaterializedEndpointSustainedThrottle(PersonalApiKeyRateThrottle):
+    """Higher sustained rate limit for materialized endpoints (5x normal)."""
+
+    scope = "materialized_endpoint_sustained"
+    rate = MATERIALIZED_SUSTAINED_RATE

--- a/products/endpoints/backend/rate_limit.py
+++ b/products/endpoints/backend/rate_limit.py
@@ -101,9 +101,10 @@ class EndpointBurstThrottle(PersonalApiKeyRateThrottle):
     """
     Adaptive burst throttle for endpoints.
     Uses higher rate limit for materialized endpoints.
+    Non-materialized endpoints share the api_queries_burst bucket.
     """
 
-    scope = "endpoint_burst"
+    scope = "api_queries_burst"
     rate = INLINE_BURST_RATE
 
     def allow_request(self, request, view):
@@ -112,7 +113,7 @@ class EndpointBurstThrottle(PersonalApiKeyRateThrottle):
             self.scope = "materialized_endpoint_burst"
         else:
             self.rate = INLINE_BURST_RATE
-            self.scope = "endpoint_burst"
+            self.scope = "api_queries_burst"
 
         self.num_requests, self.duration = self.parse_rate(self.rate)
         return super().allow_request(request, view)
@@ -122,9 +123,10 @@ class EndpointSustainedThrottle(PersonalApiKeyRateThrottle):
     """
     Adaptive sustained throttle for endpoints.
     Uses higher rate limit for materialized endpoints.
+    Non-materialized endpoints share the api_queries_sustained bucket.
     """
 
-    scope = "endpoint_sustained"
+    scope = "api_queries_sustained"
     rate = INLINE_SUSTAINED_RATE
 
     def allow_request(self, request, view):
@@ -133,22 +135,7 @@ class EndpointSustainedThrottle(PersonalApiKeyRateThrottle):
             self.scope = "materialized_endpoint_sustained"
         else:
             self.rate = INLINE_SUSTAINED_RATE
-            self.scope = "endpoint_sustained"
+            self.scope = "api_queries_sustained"
 
         self.num_requests, self.duration = self.parse_rate(self.rate)
         return super().allow_request(request, view)
-
-
-# Keep these for backwards compatibility and explicit use
-class MaterializedEndpointBurstThrottle(PersonalApiKeyRateThrottle):
-    """Higher burst rate limit for materialized endpoints (5x normal)."""
-
-    scope = "materialized_endpoint_burst"
-    rate = MATERIALIZED_BURST_RATE
-
-
-class MaterializedEndpointSustainedThrottle(PersonalApiKeyRateThrottle):
-    """Higher sustained rate limit for materialized endpoints (5x normal)."""
-
-    scope = "materialized_endpoint_sustained"
-    rate = MATERIALIZED_SUSTAINED_RATE

--- a/products/endpoints/backend/tests/test_rate_limit.py
+++ b/products/endpoints/backend/tests/test_rate_limit.py
@@ -9,8 +9,6 @@ from parameterized import parameterized
 from products.data_warehouse.backend.models import DataWarehouseSavedQuery
 from products.endpoints.backend.models import Endpoint
 from products.endpoints.backend.rate_limit import (
-    MATERIALIZED_BURST_RATE,
-    MATERIALIZED_SUSTAINED_RATE,
     EndpointBurstThrottle,
     EndpointSustainedThrottle,
     _check_and_cache_materialization_status,
@@ -180,12 +178,12 @@ class TestEndpointThrottles(APIBaseTest):
 
         self.assertEqual(throttle.scope, "api_queries_burst")
 
-    def test_uses_materialized_scope_and_higher_rate_when_materialized(self):
+    def test_uses_materialized_scope_when_materialized(self):
         set_endpoint_materialization_ready(self.team.id, "mat_endpoint", True)
 
-        for throttle_class, expected_rate, expected_scope in [
-            (EndpointBurstThrottle, MATERIALIZED_BURST_RATE, "materialized_endpoint_burst"),
-            (EndpointSustainedThrottle, MATERIALIZED_SUSTAINED_RATE, "materialized_endpoint_sustained"),
+        for throttle_class, expected_scope in [
+            (EndpointBurstThrottle, "materialized_endpoint_burst"),
+            (EndpointSustainedThrottle, "materialized_endpoint_sustained"),
         ]:
             throttle = throttle_class()
             request = MagicMock()
@@ -196,5 +194,4 @@ class TestEndpointThrottles(APIBaseTest):
             with patch.object(throttle_class, "allow_request", return_value=True):
                 throttle.allow_request(request, view)
 
-            self.assertEqual(throttle.rate, expected_rate)
             self.assertEqual(throttle.scope, expected_scope)

--- a/products/endpoints/backend/tests/test_rate_limit.py
+++ b/products/endpoints/backend/tests/test_rate_limit.py
@@ -1,0 +1,273 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from products.data_warehouse.backend.models import DataWarehouseSavedQuery
+from products.endpoints.backend.models import Endpoint
+from products.endpoints.backend.rate_limit import (
+    INLINE_BURST_RATE,
+    INLINE_SUSTAINED_RATE,
+    MATERIALIZED_BURST_RATE,
+    MATERIALIZED_SUSTAINED_RATE,
+    EndpointBurstThrottle,
+    EndpointSustainedThrottle,
+    _check_and_cache_materialization_status,
+    _is_materialized_endpoint_request,
+    clear_endpoint_materialization_cache,
+    get_endpoint_materialization_cache_key,
+    is_endpoint_materialization_ready,
+    set_endpoint_materialization_ready,
+)
+
+
+class TestMaterializationCacheHelpers(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_get_cache_key_format(self):
+        cache_key = get_endpoint_materialization_cache_key(123, "my_endpoint")
+        self.assertEqual(cache_key, "endpoint_materialized_ready:123:my_endpoint")
+
+    def test_is_endpoint_materialization_ready_returns_none_on_miss(self):
+        result = is_endpoint_materialization_ready(123, "nonexistent")
+        self.assertIsNone(result)
+
+    def test_set_and_get_materialization_ready_true(self):
+        set_endpoint_materialization_ready(123, "test_endpoint", True)
+        result = is_endpoint_materialization_ready(123, "test_endpoint")
+        self.assertTrue(result)
+
+    def test_set_and_get_materialization_ready_false(self):
+        set_endpoint_materialization_ready(123, "test_endpoint", False)
+        result = is_endpoint_materialization_ready(123, "test_endpoint")
+        self.assertFalse(result)
+
+    def test_clear_cache(self):
+        set_endpoint_materialization_ready(123, "test_endpoint", True)
+        self.assertTrue(is_endpoint_materialization_ready(123, "test_endpoint"))
+
+        clear_endpoint_materialization_cache(123, "test_endpoint")
+        self.assertIsNone(is_endpoint_materialization_ready(123, "test_endpoint"))
+
+
+class TestCheckAndCacheMaterializationStatus(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    def test_returns_false_for_nonexistent_endpoint(self):
+        result = _check_and_cache_materialization_status(self.team.id, "nonexistent")
+        self.assertFalse(result)
+
+    def test_returns_false_for_non_materialized_endpoint(self):
+        endpoint = Endpoint.objects.create(
+            name="inline_endpoint",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            created_by=self.user,
+            is_active=True,
+        )
+
+        result = _check_and_cache_materialization_status(self.team.id, endpoint.name)
+        self.assertFalse(result)
+        self.assertFalse(is_endpoint_materialization_ready(self.team.id, endpoint.name))
+
+    def test_returns_false_for_materialized_but_not_completed(self):
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            name="test_query",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            is_materialized=True,
+            status=DataWarehouseSavedQuery.Status.RUNNING,
+            origin=DataWarehouseSavedQuery.Origin.ENDPOINT,
+        )
+        endpoint = Endpoint.objects.create(
+            name="running_endpoint",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            created_by=self.user,
+            is_active=True,
+            saved_query=saved_query,
+        )
+
+        result = _check_and_cache_materialization_status(self.team.id, endpoint.name)
+        self.assertFalse(result)
+        self.assertFalse(is_endpoint_materialization_ready(self.team.id, endpoint.name))
+
+    def test_returns_true_for_completed_materialized_endpoint(self):
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            name="completed_query",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            is_materialized=True,
+            status=DataWarehouseSavedQuery.Status.COMPLETED,
+            origin=DataWarehouseSavedQuery.Origin.ENDPOINT,
+        )
+        endpoint = Endpoint.objects.create(
+            name="materialized_endpoint",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            created_by=self.user,
+            is_active=True,
+            saved_query=saved_query,
+        )
+
+        result = _check_and_cache_materialization_status(self.team.id, endpoint.name)
+        self.assertTrue(result)
+        self.assertTrue(is_endpoint_materialization_ready(self.team.id, endpoint.name))
+
+
+class TestIsMaterializedEndpointRequest(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    def test_returns_false_when_no_team_id(self):
+        request = MagicMock()
+        view = MagicMock()
+        view.team_id = None
+        view.kwargs = {"name": "test"}
+
+        result = _is_materialized_endpoint_request(request, view)
+        self.assertFalse(result)
+
+    def test_returns_false_when_no_endpoint_name(self):
+        request = MagicMock()
+        view = MagicMock()
+        view.team_id = 123
+        view.kwargs = {}
+
+        result = _is_materialized_endpoint_request(request, view)
+        self.assertFalse(result)
+
+    def test_returns_cached_true_value(self):
+        set_endpoint_materialization_ready(123, "test", True)
+
+        request = MagicMock()
+        view = MagicMock()
+        view.team_id = 123
+        view.kwargs = {"name": "test"}
+
+        result = _is_materialized_endpoint_request(request, view)
+        self.assertTrue(result)
+
+    def test_returns_cached_false_value(self):
+        set_endpoint_materialization_ready(123, "test", False)
+
+        request = MagicMock()
+        view = MagicMock()
+        view.team_id = 123
+        view.kwargs = {"name": "test"}
+
+        result = _is_materialized_endpoint_request(request, view)
+        self.assertFalse(result)
+
+    def test_lazy_loads_on_cache_miss(self):
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            name="lazy_load_query",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            is_materialized=True,
+            status=DataWarehouseSavedQuery.Status.COMPLETED,
+            origin=DataWarehouseSavedQuery.Origin.ENDPOINT,
+        )
+        endpoint = Endpoint.objects.create(
+            name="lazy_load_endpoint",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            created_by=self.user,
+            is_active=True,
+            saved_query=saved_query,
+        )
+
+        self.assertIsNone(is_endpoint_materialization_ready(self.team.id, endpoint.name))
+
+        request = MagicMock()
+        view = MagicMock()
+        view.team_id = self.team.id
+        view.kwargs = {"name": endpoint.name}
+
+        result = _is_materialized_endpoint_request(request, view)
+        self.assertTrue(result)
+        self.assertTrue(is_endpoint_materialization_ready(self.team.id, endpoint.name))
+
+
+class TestEndpointThrottles(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    def test_burst_throttle_uses_inline_rate_by_default(self):
+        throttle = EndpointBurstThrottle()
+
+        request = MagicMock()
+        view = MagicMock()
+        view.team_id = 999
+        view.kwargs = {"name": "nonexistent"}
+
+        with patch.object(throttle, "allow_request", wraps=throttle.allow_request):
+            throttle.allow_request(request, view)
+
+        self.assertEqual(throttle.rate, INLINE_BURST_RATE)
+        self.assertEqual(throttle.scope, "endpoint_burst")
+
+    def test_burst_throttle_uses_materialized_rate_when_cached_true(self):
+        set_endpoint_materialization_ready(self.team.id, "mat_endpoint", True)
+        throttle = EndpointBurstThrottle()
+
+        request = MagicMock()
+        view = MagicMock()
+        view.team_id = self.team.id
+        view.kwargs = {"name": "mat_endpoint"}
+
+        with patch.object(EndpointBurstThrottle, "allow_request", return_value=True):
+            throttle.allow_request(request, view)
+
+        self.assertEqual(throttle.rate, MATERIALIZED_BURST_RATE)
+        self.assertEqual(throttle.scope, "materialized_endpoint_burst")
+
+    def test_sustained_throttle_uses_inline_rate_by_default(self):
+        throttle = EndpointSustainedThrottle()
+
+        request = MagicMock()
+        view = MagicMock()
+        view.team_id = 999
+        view.kwargs = {"name": "nonexistent"}
+
+        with patch.object(throttle, "allow_request", wraps=throttle.allow_request):
+            throttle.allow_request(request, view)
+
+        self.assertEqual(throttle.rate, INLINE_SUSTAINED_RATE)
+        self.assertEqual(throttle.scope, "endpoint_sustained")
+
+    def test_sustained_throttle_uses_materialized_rate_when_cached_true(self):
+        set_endpoint_materialization_ready(self.team.id, "mat_endpoint", True)
+        throttle = EndpointSustainedThrottle()
+
+        request = MagicMock()
+        view = MagicMock()
+        view.team_id = self.team.id
+        view.kwargs = {"name": "mat_endpoint"}
+
+        with patch.object(EndpointSustainedThrottle, "allow_request", return_value=True):
+            throttle.allow_request(request, view)
+
+        self.assertEqual(throttle.rate, MATERIALIZED_SUSTAINED_RATE)
+        self.assertEqual(throttle.scope, "materialized_endpoint_sustained")

--- a/products/endpoints/backend/tests/test_rate_limit.py
+++ b/products/endpoints/backend/tests/test_rate_limit.py
@@ -191,7 +191,6 @@ class TestEndpointThrottles(APIBaseTest):
             view.team_id = self.team.id
             view.kwargs = {"name": "mat_endpoint"}
 
-            with patch.object(throttle_class, "allow_request", return_value=True):
-                throttle.allow_request(request, view)
+            throttle.allow_request(request, view)
 
             self.assertEqual(throttle.scope, expected_scope)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

we have higher concurrency limits. we now need to raise rate limits on materialized endpoint execution.

## Changes

- Add rate_limit.py with caching helpers and throttle classes
- Cache materialization status in Redis (1hr TTL with write-through)
- Set cache on Temporal workflow completion (success/failure)
- Clear cache when materialization is disabled
- Lazy load cache on first request for existing materializations

Rate limits:

- Inline: 240/min burst, 2400/hr sustained (unchanged)
- Materialized: 1200/min burst, 12000/hr sustained (5x higher)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

locally, but not super confident yet

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

yeah buddy

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->