### PR TITLE
feat: manage PostHog endpoints with YAML files

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.5.23
+
+- feat: add experimental commands for endpoints management
+
 # 0.5.22
 
 - feat: add `--project` and `--version` to upload command to define release

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -320,6 +320,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1196,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,6 +1483,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,26 +1566,31 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.22"
+version = "0.5.23"
 dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "colored",
  "crossterm 0.28.1",
  "dirs",
  "globset",
  "inquire",
  "magic_string",
  "miette",
+ "open",
  "posthog-rs",
  "posthog-symbol-data",
  "proguard",
  "ratatui",
  "rayon",
+ "regex",
  "reqwest 0.12.24",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
+ "similar",
  "sourcemap",
  "test-log",
  "thiserror 2.0.17",
@@ -2110,6 +2160,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +2228,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -2691,6 +2760,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.22"
+version = "0.5.23"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",
@@ -41,7 +41,10 @@ reqwest = { version = "0.12.14", features = [
     "rustls-tls",
 ], default-features = false }
 anyhow = "1.0.97"
-serde = "1.0.219"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_yaml = "0.9"
+colored = "3.0"
+regex = "1.12"
 tracing = "0.1.41"
 uuid = { version = "1.16.0", features = ["v7"] }
 thiserror = "2.0.12"
@@ -50,6 +53,8 @@ posthog-rs = { version = "0.3.5", default-features = false }
 sha2 = "0.10.9"
 urlencoding = "2.1.3"
 rayon = "1.11.0"
+similar = "2.7"
+open = "5"
 
 [dev-dependencies]
 test-log = "0.2.17"

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,6 +10,7 @@ Commands:
   login      Interactively authenticate with PostHog, storing a personal API token locally. You can also use the environment variables `POSTHOG_CLI_TOKEN`, `POSTHOG_CLI_ENV_ID` and `POSTHOG_CLI_HOST`
   query      Run a SQL query against any data you have in posthog. This is mostly for fun, and subject to change
   sourcemap  Upload a directory of bundled chunks to PostHog
+  exp        Contains a set of experimental commands
   help       Print this message or the help of the given subcommand(s)
 
 Options:
@@ -23,5 +24,18 @@ Options:
 You can authenticate with PostHog interactively for using the CLI locally, but if you'd like to use it in a CI/CD pipeline, we recommend using these environment variables:
 
 - `POSTHOG_CLI_HOST`: The PostHog host to connect to [default: https://us.posthog.com]
-- `POSTHOG_CLI_TOKEN`: [A posthog person API key.](https://posthog.com/docs/api#private-endpoint-authentication)
+- `POSTHOG_CLI_TOKEN`: [A posthog personal API key.](https://posthog.com/docs/api#private-endpoint-authentication)
 - `POSTHOG_CLI_ENV_ID`: The ID number of the project/environment to connect to. E.g. the "2" in `https://us.posthog.com/project/2`
+
+### Personal API key scopes
+
+Commands require different API scopes. Make sure to set these scopes on your personal API key:
+
+| Command                       | Required Scopes                            |
+| ----------------------------- | ------------------------------------------ |
+| `query`                       | `query:read`                               |
+| `sourcemap`                   | `error_tracking:write`                     |
+| `exp endpoints list/get/pull` | `endpoint:read`                            |
+| `exp endpoints push`          | `endpoint:write`, `insight_variable:write` |
+| `exp endpoints run`           | `query:read`                               |
+| `exp tasks`                   | `task:read`                                |

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3,7 +3,7 @@ use tracing::error;
 
 use crate::{
     error::CapturedError,
-    experimental::{query::command::QueryCommand, tasks::TaskCommand},
+    experimental::{endpoints::EndpointCommand, query::command::QueryCommand, tasks::TaskCommand},
     invocation_context::{context, init_context},
     proguard::ProguardSubcommand,
     sourcemaps::{hermes::HermesSubcommand, plain::SourcemapCommand},
@@ -67,6 +67,12 @@ pub enum ExpCommand {
     Query {
         #[command(subcommand)]
         cmd: QueryCommand,
+    },
+
+    /// Manage PostHog endpoints as YAML files. Pull endpoints from PostHog, or push changes from your YAML files.
+    Endpoints {
+        #[command(subcommand)]
+        cmd: EndpointCommand,
     },
 
     #[command(about = "Upload hermes sourcemaps to PostHog")]
@@ -157,6 +163,9 @@ impl Cli {
                 }
                 ExpCommand::Query { cmd } => {
                     crate::experimental::query::command::query_command(&cmd)?
+                }
+                ExpCommand::Endpoints { cmd } => {
+                    cmd.run()?;
                 }
                 ExpCommand::Hermes { cmd } => match cmd {
                     HermesSubcommand::Inject(args) => {

--- a/cli/src/experimental/endpoints/diff.rs
+++ b/cli/src/experimental/endpoints/diff.rs
@@ -1,0 +1,239 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+
+use crate::invocation_context::context;
+
+use super::{
+    compute_changes_for_push, fetch_all_endpoints, print_diff, Change, DiffArgs, EndpointResponse,
+    EndpointYaml,
+};
+
+pub fn diff_endpoints(args: &DiffArgs) -> Result<()> {
+    context().capture_command_invoked("endpoints_diff");
+
+    // Collect all YAML files from the provided paths
+    let yaml_files = collect_yaml_files(&args.paths)?;
+
+    if yaml_files.is_empty() {
+        println!("No endpoint YAML files found in the specified paths.");
+        return Ok(());
+    }
+
+    // Parse local endpoints
+    let local_endpoints: Vec<EndpointYaml> = yaml_files
+        .iter()
+        .filter_map(
+            |(path, content)| match serde_yaml::from_str::<EndpointYaml>(content) {
+                Ok(endpoint) => Some(endpoint),
+                Err(e) => {
+                    eprintln!("{} Failed to parse {}: {}", "⚠".yellow(), path, e);
+                    None
+                }
+            },
+        )
+        .collect();
+
+    if local_endpoints.is_empty() {
+        println!("No valid endpoint YAML files found.");
+        return Ok(());
+    }
+
+    // Fetch remote endpoints
+    let remote_list = fetch_all_endpoints(args.debug)?;
+    let remote_map: HashMap<&str, &EndpointResponse> = remote_list
+        .results
+        .iter()
+        .map(|e| (e.name.as_str(), e))
+        .collect();
+
+    println!();
+
+    let mut has_differences = false;
+    let mut new_count = 0;
+    let mut changed_count = 0;
+    let mut unchanged_count = 0;
+
+    for local in &local_endpoints {
+        if let Some(remote) = remote_map.get(local.name.as_str()) {
+            let changes = compute_changes_for_push(local, remote);
+            if changes.is_empty() {
+                unchanged_count += 1;
+                if args.verbose {
+                    println!("  {}  {}", "SAME".dimmed(), local.name);
+                }
+            } else {
+                changed_count += 1;
+                has_differences = true;
+                println!("  {}  {}", "CHANGED".yellow().bold(), local.name.bold());
+                for change in &changes {
+                    print_change_with_labels(change);
+                }
+                println!();
+            }
+        } else {
+            new_count += 1;
+            has_differences = true;
+            println!(
+                "  {}  {} (not in PostHog)",
+                "NEW".green().bold(),
+                local.name.bold()
+            );
+            if let Some(desc) = &local.description {
+                if !desc.is_empty() {
+                    let truncated: String = if desc.chars().count() > 60 {
+                        format!("{}...", desc.chars().take(57).collect::<String>())
+                    } else {
+                        desc.clone()
+                    };
+                    println!("    {}", truncated.dimmed());
+                }
+            }
+            println!();
+        }
+    }
+
+    // Summary
+    println!(
+        "{} file{} compared: {} new, {} changed, {} unchanged",
+        local_endpoints.len(),
+        if local_endpoints.len() == 1 { "" } else { "s" },
+        new_count,
+        changed_count,
+        unchanged_count
+    );
+
+    if has_differences {
+        println!();
+        println!(
+            "{}",
+            "Run 'posthog-cli exp endpoints push <path>' to apply changes.".dimmed()
+        );
+    }
+
+    Ok(())
+}
+
+/// Collect all YAML files from the provided paths (files or directories)
+fn collect_yaml_files(paths: &[String]) -> Result<Vec<(String, String)>> {
+    let mut files = Vec::new();
+
+    for path_str in paths {
+        let path = Path::new(path_str);
+
+        if path.is_file() {
+            let content = fs::read_to_string(path)
+                .with_context(|| format!("Failed to read file: {path_str:?}"))?;
+            files.push((path_str.clone(), content));
+        } else if path.is_dir() {
+            for entry in fs::read_dir(path)
+                .with_context(|| format!("Failed to read directory: {path_str:?}"))?
+            {
+                let entry = entry?;
+                let entry_path = entry.path();
+
+                if entry_path.is_file() {
+                    if let Some(ext) = entry_path.extension() {
+                        if ext == "yaml" || ext == "yml" {
+                            let content = fs::read_to_string(&entry_path).with_context(|| {
+                                format!("Failed to read: {}", entry_path.display())
+                            })?;
+                            files.push((entry_path.display().to_string(), content));
+                        }
+                    }
+                }
+            }
+        } else {
+            eprintln!("{} Path not found: {}", "⚠".yellow(), path_str);
+        }
+    }
+
+    Ok(files)
+}
+
+/// Print a change with clear local/remote labels
+fn print_change_with_labels(change: &Change) {
+    match change {
+        Change::Description { from, to } => {
+            println!("    {}:", "Description".bold());
+            println!(
+                "      {} {}",
+                "remote:".cyan(),
+                if from.is_empty() {
+                    "(empty)".dimmed().to_string()
+                } else {
+                    from.clone()
+                }
+            );
+            println!(
+                "      {}  {}",
+                "local:".green(),
+                if to.is_empty() {
+                    "(empty)".dimmed().to_string()
+                } else {
+                    to.clone()
+                }
+            );
+        }
+        Change::Query { from, to } => {
+            println!("    {}:", "Query".bold());
+            println!("      {} {}", "---".red(), "remote (PostHog)".red());
+            println!("      {} {}", "+++".green(), "local (YAML)".green());
+            print_diff(from, to, "      ");
+        }
+        Change::QueryDefinition { from, to } => {
+            println!("    {}:", "Query definition".bold());
+            println!("      {} {}", "---".red(), "remote (PostHog)".red());
+            println!("      {} {}", "+++".green(), "local (YAML)".green());
+            print_diff(from, to, "      ");
+        }
+        Change::Materialization { from, to } => {
+            println!("    {}:", "Materialization".bold());
+            println!(
+                "      {} {}",
+                "remote:".cyan(),
+                if *from { "enabled" } else { "disabled" }
+            );
+            println!(
+                "      {}  {}",
+                "local:".green(),
+                if *to { "enabled" } else { "disabled" }
+            );
+        }
+        Change::Schedule { from, to } => {
+            println!("    {}:", "Schedule".bold());
+            println!(
+                "      {} {}",
+                "remote:".cyan(),
+                if from.is_empty() {
+                    "(none)"
+                } else {
+                    from.as_str()
+                }
+            );
+            println!(
+                "      {}  {}",
+                "local:".green(),
+                if to.is_empty() { "(none)" } else { to.as_str() }
+            );
+        }
+        Change::Variables { from, to } => {
+            println!("    {}:", "Variables".bold());
+            let from_str = if from.is_empty() {
+                "(none)".to_string()
+            } else {
+                from.join(", ")
+            };
+            let to_str = if to.is_empty() {
+                "(none)".to_string()
+            } else {
+                to.join(", ")
+            };
+            println!("      {} [{}]", "remote:".cyan(), from_str);
+            println!("      {}  [{}]", "local:".green(), to_str);
+        }
+    }
+}

--- a/cli/src/experimental/endpoints/get.rs
+++ b/cli/src/experimental/endpoints/get.rs
@@ -1,0 +1,105 @@
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::invocation_context::context;
+
+use super::{fetch_endpoint, GetArgs};
+
+pub fn get_endpoint(args: &GetArgs) -> Result<()> {
+    context().capture_command_invoked("endpoints_get");
+
+    let endpoint = fetch_endpoint(&args.name, args.debug)?;
+
+    // URLs prominently at the top
+    println!();
+    if let Some(ui_url) = &endpoint.ui_url {
+        println!("  {}  {}", "View:".bold(), ui_url.cyan());
+    }
+    if let Some(url) = &endpoint.url {
+        println!("  {}  {}", "Run:".bold(), url.cyan());
+    }
+    println!();
+
+    // Name and status
+    println!("  {}  {}", "Name:".bold(), endpoint.name);
+    println!(
+        "  {}  {}",
+        "Status:".bold(),
+        if endpoint.is_active {
+            "active".green()
+        } else {
+            "inactive".red()
+        }
+    );
+
+    // Description
+    if !endpoint.description.is_empty() {
+        println!("  {}  {}", "Description:".bold(), endpoint.description);
+    }
+
+    // Version info
+    println!(
+        "  {}  {} ({} total)",
+        "Version:".bold(),
+        endpoint.current_version,
+        endpoint.versions_count
+    );
+
+    // Materialization
+    println!();
+    if endpoint.is_materialized {
+        println!("  {}", "Materialization".bold().underline());
+        if let Some(mat) = &endpoint.materialization {
+            println!(
+                "    Status: {}",
+                match mat.status.as_deref() {
+                    Some("Completed") => "completed".green(),
+                    Some("Running") => "running".yellow(),
+                    Some("Failed") => "failed".red(),
+                    Some(s) => s.normal(),
+                    None => "unknown".dimmed(),
+                }
+            );
+            if let Some(freq) = &mat.sync_frequency {
+                println!("    Sync frequency: {freq}");
+            }
+            if let Some(last) = &mat.last_materialized_at {
+                println!("    Last materialized: {last}");
+            }
+            if let Some(err) = &mat.error {
+                println!("    Error: {}", err.red());
+            }
+        }
+    } else {
+        println!("  {}  disabled", "Materialization:".bold());
+        if let Some(mat) = &endpoint.materialization {
+            if !mat.can_materialize {
+                if let Some(reason) = &mat.reason {
+                    println!("    {}", reason.dimmed());
+                }
+            }
+        }
+    }
+
+    // Query
+    println!();
+    println!("  {}", "Query".bold().underline());
+    let query_str = if let Some(query) = endpoint.query.get("query").and_then(|q| q.as_str()) {
+        query.to_string()
+    } else {
+        serde_json::to_string_pretty(&endpoint.query).unwrap_or_else(|_| "{}".to_string())
+    };
+
+    for line in query_str.lines() {
+        println!("    {}", line.dimmed());
+    }
+
+    // Timestamps
+    println!();
+    println!("  Created: {}", endpoint.created_at.dimmed());
+    println!("  Updated: {}", endpoint.updated_at.dimmed());
+
+    println!();
+
+    Ok(())
+}

--- a/cli/src/experimental/endpoints/list.rs
+++ b/cli/src/experimental/endpoints/list.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::invocation_context::context;
+
+use super::{fetch_all_endpoints, EndpointResponse, ListArgs};
+
+pub fn list_endpoints(args: &ListArgs) -> Result<()> {
+    context().capture_command_invoked("endpoints_list");
+
+    let client = &context().client;
+    let env_id = client.get_env_id();
+
+    println!();
+    println!("Fetching endpoints from PostHog...");
+    println!();
+
+    let endpoint_list = fetch_all_endpoints(args.debug)?;
+
+    if endpoint_list.results.is_empty() {
+        println!("No endpoints found in project {env_id}.");
+        println!();
+        println!("Create an endpoint by pushing a YAML file:");
+        println!("  posthog-cli exp endpoints push my-endpoint.yaml");
+        return Ok(());
+    }
+
+    println!("Endpoints in project {}:", env_id.bold());
+    println!();
+
+    for endpoint in &endpoint_list.results {
+        print_endpoint_summary(endpoint);
+    }
+
+    println!();
+    println!(
+        "{} endpoint{} total.",
+        endpoint_list.results.len(),
+        if endpoint_list.results.len() == 1 {
+            ""
+        } else {
+            "s"
+        }
+    );
+
+    Ok(())
+}
+
+fn print_endpoint_summary(endpoint: &EndpointResponse) {
+    let status = if endpoint.is_materialized {
+        let schedule = endpoint
+            .materialization
+            .as_ref()
+            .and_then(|m| m.sync_frequency.as_ref())
+            .map(|s| format_sync_frequency(s))
+            .unwrap_or_else(|| "scheduled".to_string());
+        format!("Materialized ({schedule})").green().to_string()
+    } else {
+        "On-demand".yellow().to_string()
+    };
+
+    let active_status = if endpoint.is_active {
+        ""
+    } else {
+        " [inactive]"
+    };
+
+    println!(
+        "  {:<28} {}{}",
+        endpoint.name.bold(),
+        status,
+        active_status.dimmed()
+    );
+
+    if !endpoint.description.is_empty() {
+        let desc = if endpoint.description.len() > 60 {
+            format!("{}...", &endpoint.description[..57])
+        } else {
+            endpoint.description.clone()
+        };
+        println!("    {}", desc.dimmed());
+    }
+}
+
+/// Format sync frequency for display
+fn format_sync_frequency(freq: &str) -> String {
+    match freq {
+        "5min" => "every 5 min".to_string(),
+        "15min" => "every 15 min".to_string(),
+        "30min" => "every 30 min".to_string(),
+        "1hour" => "hourly".to_string(),
+        "2hour" => "every 2 hours".to_string(),
+        "4hour" => "every 4 hours".to_string(),
+        "6hour" => "every 6 hours".to_string(),
+        "12hour" => "every 12 hours".to_string(),
+        "24hour" => "daily".to_string(),
+        "7day" => "weekly".to_string(),
+        "30day" => "monthly".to_string(),
+        _ => freq.to_string(),
+    }
+}

--- a/cli/src/experimental/endpoints/mod.rs
+++ b/cli/src/experimental/endpoints/mod.rs
@@ -1,0 +1,1137 @@
+mod diff;
+mod get;
+mod list;
+mod open;
+mod pull;
+mod push;
+mod run;
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+use colored::Colorize;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use similar::{ChangeTag, TextDiff};
+use std::collections::HashMap;
+
+pub use diff::diff_endpoints;
+pub use get::get_endpoint;
+pub use list::list_endpoints;
+pub use open::open_endpoint;
+pub use pull::pull_endpoints;
+pub use push::push_endpoints;
+pub use run::run_endpoint;
+
+use crate::invocation_context::context;
+
+// ============================================================================
+// Debug logging utilities
+// ============================================================================
+
+/// Log a debug message for API requests. Only prints if debug is true.
+#[inline]
+pub fn debug_request(debug: bool, method: &str, path: &str) {
+    if debug {
+        eprintln!("  {} {} {}", "DEBUG".cyan().bold(), method, path);
+    }
+}
+
+/// Log a debug response body. Only prints if debug is true.
+#[inline]
+pub fn debug_response_body<T: serde::Serialize>(debug: bool, body: &T) {
+    if debug {
+        if let Ok(json) = serde_json::to_string_pretty(body) {
+            eprintln!("  Response:\n{}", json.dimmed());
+        }
+    }
+}
+
+/// Log a debug error. Only prints if debug is true.
+#[inline]
+pub fn debug_error<E: std::fmt::Display>(debug: bool, error: &E) {
+    if debug {
+        eprintln!("  {} {}", "Error:".red(), error);
+    }
+}
+
+/// YAML representation of an endpoint for local file storage.
+/// This mirrors the API endpoint format but in a simpler YAML-friendly structure.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EndpointYaml {
+    /// URL-safe name for the endpoint (required)
+    pub name: String,
+
+    /// Human-readable description of what this endpoint does
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// The HogQL query to execute (for simple HogQL queries)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+
+    /// Full query object for complex queries (TrendsQuery, FunnelsQuery, etc.)
+    /// This takes precedence over the `query` field if both are specified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query_definition: Option<Value>,
+
+    /// Query variables for parameterized queries
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub variables: Option<Vec<EndpointVariable>>,
+
+    /// Materialization configuration
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub materialization: Option<MaterializationConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EndpointVariable {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub var_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<Value>,
+}
+
+/// Materialization configuration for an endpoint.
+///
+/// When enabled, PostHog will pre-compute and cache the query results
+/// according to the specified schedule.
+///
+/// Valid schedule values:
+/// - Minutes: "5min", "15min", "30min"
+/// - Hours: "1hour", "2hour", "4hour", "6hour", "12hour", "24hour"
+/// - Days: "7day", "30day"
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MaterializationConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Sync frequency. Valid values: 5min, 15min, 30min, 1hour, 2hour, 4hour, 6hour, 12hour, 24hour, 7day, 30day
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<String>,
+}
+
+/// API response for an endpoint from PostHog
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EndpointResponse {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub query: Value,
+    #[serde(default)]
+    pub parameters: HashMap<String, Value>,
+    pub is_active: bool,
+    #[serde(default)]
+    pub cache_age_seconds: Option<i64>,
+    pub endpoint_path: String,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub ui_url: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub is_materialized: bool,
+    #[serde(default)]
+    pub current_version: i32,
+    #[serde(default)]
+    pub versions_count: i32,
+    #[serde(default)]
+    pub materialization: Option<MaterializationStatus>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MaterializationStatus {
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub can_materialize: bool,
+    #[serde(default)]
+    pub last_materialized_at: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub sync_frequency: Option<String>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EndpointListResponse {
+    pub results: Vec<EndpointResponse>,
+}
+
+#[derive(Subcommand)]
+pub enum EndpointCommand {
+    /// List all PostHog endpoints
+    List(ListArgs),
+
+    /// Get details of a specific PostHog endpoint
+    Get(GetArgs),
+
+    /// Open an endpoint in the browser
+    Open(OpenArgs),
+
+    /// Run an endpoint and see the results
+    Run(RunArgs),
+
+    /// Push local endpoint YAML files to PostHog
+    Push(PushArgs),
+
+    /// Pull PostHog endpoints to local endpoint YAML files
+    Pull(PullArgs),
+
+    /// Show differences between local YAML files and remote endpoints
+    Diff(DiffArgs),
+}
+
+#[derive(Args, Clone)]
+pub struct ListArgs {
+    /// Show detailed API request/response information
+    #[arg(long)]
+    pub debug: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct OpenArgs {
+    /// Name of the endpoint to open
+    pub name: String,
+
+    /// Show detailed API request/response information
+    #[arg(long)]
+    pub debug: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct GetArgs {
+    /// Name of the endpoint to get
+    pub name: String,
+
+    /// Show detailed API request/response information
+    #[arg(long)]
+    pub debug: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct RunArgs {
+    /// Name of the endpoint to run
+    #[arg(conflicts_with = "file")]
+    pub name: Option<String>,
+
+    /// Run query from a local YAML file (without creating endpoint)
+    #[arg(long, short = 'f')]
+    pub file: Option<String>,
+
+    /// Pass a variable (can be used multiple times, format: name=value)
+    #[arg(long = "var", short = 'v')]
+    pub var: Vec<String>,
+
+    /// Output raw JSON
+    #[arg(long)]
+    pub json: bool,
+
+    /// Output format (table, json)
+    #[arg(long)]
+    pub format: Option<String>,
+
+    /// Suppress status messages
+    #[arg(long, short = 'q')]
+    pub quiet: bool,
+
+    /// Show detailed API request/response information
+    #[arg(long)]
+    pub debug: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct PushArgs {
+    /// Local PostHog YAML files or directories to push to PostHog
+    #[arg(required = true)]
+    pub paths: Vec<String>,
+
+    /// Preview changes without applying
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Skip confirmation prompt
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+
+    /// Show detailed API request/response information
+    #[arg(long)]
+    pub debug: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct PullArgs {
+    /// Endpoint name(s) to pull
+    #[arg()]
+    pub names: Vec<String>,
+
+    /// Pull all endpoints
+    #[arg(long)]
+    pub all: bool,
+
+    /// Output path (directory for multiple endpoints, or .yaml/.yml file for single endpoint)
+    #[arg(long, short = 'o', default_value = ".")]
+    pub output: String,
+
+    /// Preview changes without writing to YAML files
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Skip confirmation prompt
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+
+    /// Show detailed API request/response information
+    #[arg(long)]
+    pub debug: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct DiffArgs {
+    /// Local YAML files or directories to compare
+    #[arg(required = true)]
+    pub paths: Vec<String>,
+
+    /// Show unchanged endpoints too
+    #[arg(long, short = 'v')]
+    pub verbose: bool,
+
+    /// Show detailed API request/response information
+    #[arg(long)]
+    pub debug: bool,
+}
+
+impl EndpointCommand {
+    pub fn run(&self) -> Result<()> {
+        match self {
+            EndpointCommand::List(args) => list_endpoints(args),
+            EndpointCommand::Get(args) => get_endpoint(args),
+            EndpointCommand::Open(args) => open_endpoint(args),
+            EndpointCommand::Run(args) => run_endpoint(args),
+            EndpointCommand::Push(args) => push_endpoints(args),
+            EndpointCommand::Pull(args) => pull_endpoints(args),
+            EndpointCommand::Diff(args) => diff_endpoints(args),
+        }
+    }
+}
+
+/// Resolved variable mapping: code_name -> (variableId, InsightVariable)
+pub type ResolvedVariables = HashMap<String, (String, InsightVariable)>;
+
+impl EndpointYaml {
+    /// Convert this YAML representation to an API request body.
+    /// If resolved_variables is provided, includes the variables in the query.
+    pub fn to_api_request(&self, resolved_variables: Option<&ResolvedVariables>) -> Value {
+        let mut request = serde_json::Map::new();
+
+        request.insert("name".to_string(), Value::String(self.name.clone()));
+
+        if let Some(desc) = &self.description {
+            request.insert("description".to_string(), Value::String(desc.clone()));
+        }
+
+        // Build the query object
+        let mut query = if let Some(query_def) = &self.query_definition {
+            // Use the full query definition if provided
+            query_def.clone()
+        } else if let Some(hogql) = &self.query {
+            // Build a HogQLQuery from the simple query string
+            let mut q = serde_json::Map::new();
+            q.insert("kind".to_string(), Value::String("HogQLQuery".to_string()));
+            q.insert("query".to_string(), Value::String(hogql.clone()));
+            Value::Object(q)
+        } else {
+            // No query specified - this should be caught during validation
+            Value::Null
+        };
+
+        // Add resolved variables to the query object
+        if let (Some(resolved), Some(local_vars)) = (resolved_variables, &self.variables) {
+            if !local_vars.is_empty() {
+                let mut vars_obj = serde_json::Map::new();
+                for local_var in local_vars {
+                    if let Some((var_id, insight_var)) = resolved.get(&local_var.name) {
+                        let mut var_entry = serde_json::Map::new();
+                        var_entry.insert("variableId".to_string(), Value::String(var_id.clone()));
+                        var_entry.insert(
+                            "code_name".to_string(),
+                            Value::String(insight_var.code_name.clone()),
+                        );
+                        if let Some(default) = &local_var.default {
+                            var_entry.insert("value".to_string(), default.clone());
+                        }
+                        vars_obj.insert(var_id.clone(), Value::Object(var_entry));
+                    }
+                }
+                if !vars_obj.is_empty() {
+                    if let Value::Object(ref mut q) = query {
+                        q.insert("variables".to_string(), Value::Object(vars_obj));
+                    }
+                }
+            }
+        }
+
+        request.insert("query".to_string(), query);
+
+        // Handle materialization
+        if let Some(mat) = &self.materialization {
+            request.insert("is_materialized".to_string(), Value::Bool(mat.enabled));
+            if let Some(schedule) = &mat.schedule {
+                request.insert(
+                    "sync_frequency".to_string(),
+                    Value::String(schedule.clone()),
+                );
+            }
+        }
+
+        Value::Object(request)
+    }
+
+    /// Extract variable references from the query string.
+    /// Looks for patterns like {variables.code_name}
+    pub fn get_variable_references(&self) -> Vec<String> {
+        let query_str = self.query.as_deref().unwrap_or("");
+        extract_variable_references(query_str)
+    }
+
+    /// Create an EndpointYaml from an API response
+    pub fn from_api_response(response: &EndpointResponse) -> Self {
+        let (query, query_definition) = if let Some(kind) = response.query.get("kind") {
+            if kind == "HogQLQuery" {
+                // Simple HogQL query - extract just the query string
+                let query_str = response
+                    .query
+                    .get("query")
+                    .and_then(|q| q.as_str())
+                    .map(|s| s.to_string());
+                (query_str, None)
+            } else {
+                // Complex query - store the full definition
+                (None, Some(response.query.clone()))
+            }
+        } else {
+            (None, Some(response.query.clone()))
+        };
+
+        // Extract variables from the query object
+        let variables = response
+            .query
+            .get("variables")
+            .and_then(|v| v.as_object())
+            .map(|vars_map| {
+                vars_map
+                    .values()
+                    .filter_map(|var| {
+                        let code_name = var.get("code_name")?.as_str()?.to_string();
+                        let default = var.get("value").cloned();
+                        // Infer type from the default value
+                        let var_type = match &default {
+                            Some(Value::Number(n)) => {
+                                if n.is_i64() || n.is_u64() {
+                                    "integer"
+                                } else {
+                                    "number"
+                                }
+                            }
+                            Some(Value::Bool(_)) => "boolean",
+                            Some(Value::String(_)) => "string",
+                            Some(Value::Array(_)) => "array",
+                            Some(Value::Object(_)) => "object",
+                            Some(Value::Null) | None => "string",
+                        };
+                        Some(EndpointVariable {
+                            name: code_name,
+                            var_type: var_type.to_string(),
+                            default,
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .filter(|v: &Vec<EndpointVariable>| !v.is_empty());
+
+        let materialization = if response.is_materialized {
+            let schedule = response
+                .materialization
+                .as_ref()
+                .and_then(|m| m.sync_frequency.as_ref())
+                .cloned();
+            Some(MaterializationConfig {
+                enabled: true,
+                schedule,
+            })
+        } else {
+            None
+        };
+
+        EndpointYaml {
+            name: response.name.clone(),
+            description: if response.description.is_empty() {
+                None
+            } else {
+                Some(response.description.clone())
+            },
+            query,
+            query_definition,
+            variables,
+            materialization,
+        }
+    }
+
+    /// Validate the endpoint YAML (basic structural checks only, backend validates the rest)
+    pub fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            anyhow::bail!("Endpoint name is required");
+        }
+
+        if self.query.is_none() && self.query_definition.is_none() {
+            anyhow::bail!(
+                "Either 'query' or 'query_definition' is required for endpoint '{}'",
+                self.name
+            );
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Shared utilities for push/pull change tracking
+// ============================================================================
+
+/// Represents a change between local and remote endpoint state
+#[derive(Debug, Clone)]
+pub enum Change {
+    Description { from: String, to: String },
+    Query { from: String, to: String },
+    QueryDefinition { from: String, to: String },
+    Materialization { from: bool, to: bool },
+    Schedule { from: String, to: String },
+    Variables { from: Vec<String>, to: Vec<String> },
+}
+
+/// Format a change for human-readable display
+pub fn format_change_summary(change: &Change) -> String {
+    match change {
+        Change::Description { from, to } => {
+            format!(
+                "Description: {} → {}",
+                if from.is_empty() {
+                    "(empty)"
+                } else {
+                    from.as_str()
+                },
+                if to.is_empty() {
+                    "(empty)"
+                } else {
+                    to.as_str()
+                }
+            )
+        }
+        Change::Query { .. } => "Query".to_string(),
+        Change::QueryDefinition { .. } => "Query definition".to_string(),
+        Change::Materialization { from, to } => {
+            format!(
+                "Materialization: {} → {}",
+                if *from { "enabled" } else { "disabled" },
+                if *to { "enabled" } else { "disabled" }
+            )
+        }
+        Change::Schedule { from, to } => {
+            format!(
+                "Schedule: {} → {}",
+                if from.is_empty() {
+                    "(none)"
+                } else {
+                    from.as_str()
+                },
+                if to.is_empty() { "(none)" } else { to.as_str() }
+            )
+        }
+        Change::Variables { from, to } => {
+            let from_str = if from.is_empty() {
+                "(none)".to_string()
+            } else {
+                from.join(", ")
+            };
+            let to_str = if to.is_empty() {
+                "(none)".to_string()
+            } else {
+                to.join(", ")
+            };
+            format!("Variables: [{from_str}] → [{to_str}]")
+        }
+    }
+}
+
+/// Print a unified diff of two strings with colored output
+pub fn print_diff(from: &str, to: &str, indent: &str) {
+    let diff = TextDiff::from_lines(from, to);
+
+    for change in diff.iter_all_changes() {
+        let (sign, color_fn): (&str, fn(&str) -> colored::ColoredString) = match change.tag() {
+            ChangeTag::Delete => ("-", |s: &str| s.red()),
+            ChangeTag::Insert => ("+", |s: &str| s.green()),
+            ChangeTag::Equal => (" ", |s: &str| s.dimmed()),
+        };
+        let line = change.to_string_lossy();
+        let line_trimmed = line.trim_end_matches('\n');
+        println!("{indent}{} {}", color_fn(sign), color_fn(line_trimmed));
+    }
+}
+
+// ============================================================================
+// Shared comparison helpers
+// ============================================================================
+
+/// Extract variable code_names from a remote endpoint response
+pub fn get_remote_variable_names(remote: &EndpointResponse) -> Vec<String> {
+    remote
+        .query
+        .get("variables")
+        .and_then(|v| v.as_object())
+        .map(|vars_map| {
+            vars_map
+                .values()
+                .filter_map(|var| var.get("code_name")?.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Get the schedule from local YAML (empty string if none)
+pub fn get_local_schedule(local: &EndpointYaml) -> String {
+    local
+        .materialization
+        .as_ref()
+        .and_then(|m| m.schedule.clone())
+        .unwrap_or_default()
+}
+
+/// Get the schedule from remote endpoint (empty string if none)
+pub fn get_remote_schedule(remote: &EndpointResponse) -> String {
+    remote
+        .materialization
+        .as_ref()
+        .and_then(|m| m.sync_frequency.clone())
+        .unwrap_or_default()
+}
+
+/// Compute changes between local and remote endpoints (for push/diff direction).
+/// Returns changes where `from` is the remote state and `to` is the local state.
+pub fn compute_changes_for_push(local: &EndpointYaml, remote: &EndpointResponse) -> Vec<Change> {
+    let mut changes = Vec::new();
+
+    // Description
+    let local_desc = local.description.as_deref().unwrap_or("");
+    if local_desc != remote.description {
+        changes.push(Change::Description {
+            from: remote.description.clone(),
+            to: local_desc.to_string(),
+        });
+    }
+
+    // Query (for HogQL queries)
+    let local_query = local.query.as_deref().unwrap_or("");
+    let remote_query = remote
+        .query
+        .get("query")
+        .and_then(|q| q.as_str())
+        .unwrap_or("");
+
+    if !local_query.is_empty() && local_query != remote_query {
+        changes.push(Change::Query {
+            from: remote_query.to_string(),
+            to: local_query.to_string(),
+        });
+    } else if let Some(local_def) = &local.query_definition {
+        let local_json = serde_json::to_string_pretty(local_def).unwrap_or_default();
+        let remote_json = serde_json::to_string_pretty(&remote.query).unwrap_or_default();
+        if local_json != remote_json {
+            changes.push(Change::QueryDefinition {
+                from: remote_json,
+                to: local_json,
+            });
+        }
+    }
+
+    // Materialization enabled/disabled
+    let local_mat = local
+        .materialization
+        .as_ref()
+        .map(|m| m.enabled)
+        .unwrap_or(false);
+    if local_mat != remote.is_materialized {
+        changes.push(Change::Materialization {
+            from: remote.is_materialized,
+            to: local_mat,
+        });
+    }
+
+    // Schedule
+    let local_schedule = get_local_schedule(local);
+    let remote_schedule = get_remote_schedule(remote);
+    if local_schedule != remote_schedule {
+        changes.push(Change::Schedule {
+            from: remote_schedule,
+            to: local_schedule,
+        });
+    }
+
+    // Variables
+    let local_vars: Vec<String> = local
+        .variables
+        .as_ref()
+        .map(|vars| vars.iter().map(|v| v.name.clone()).collect())
+        .unwrap_or_default();
+    let remote_vars = get_remote_variable_names(remote);
+
+    let mut local_sorted = local_vars.clone();
+    let mut remote_sorted = remote_vars.clone();
+    local_sorted.sort();
+    remote_sorted.sort();
+
+    if local_sorted != remote_sorted {
+        changes.push(Change::Variables {
+            from: remote_vars,
+            to: local_vars,
+        });
+    }
+
+    changes
+}
+
+// ============================================================================
+// InsightVariable API types
+// ============================================================================
+
+/// PostHog InsightVariable from the API
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InsightVariable {
+    pub id: String,
+    pub name: String,
+    pub code_name: String,
+    #[serde(rename = "type")]
+    pub var_type: String,
+    #[serde(default)]
+    pub default_value: Option<Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InsightVariableListResponse {
+    pub results: Vec<InsightVariable>,
+}
+
+/// Request body for creating an InsightVariable
+#[derive(Debug, Serialize)]
+pub struct CreateInsightVariableRequest {
+    pub name: String,
+    pub code_name: String,
+    #[serde(rename = "type")]
+    pub var_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_value: Option<Value>,
+}
+
+// ============================================================================
+// Shared API helpers
+// ============================================================================
+
+/// Fetch all insight variables for the current environment
+pub fn fetch_insight_variables(debug: bool) -> Result<Vec<InsightVariable>> {
+    let client = &context().client;
+    debug_request(debug, "GET", "insight_variables/");
+
+    let result = client.send_get(client.env_url("insight_variables/")?, |req| req);
+
+    match result {
+        Ok(response) => {
+            let list: InsightVariableListResponse = response
+                .json()
+                .context("Failed to parse insight variables response")?;
+            if debug {
+                eprintln!(
+                    "  Response: {} variable{}",
+                    list.results.len(),
+                    if list.results.len() == 1 { "" } else { "s" }
+                );
+            }
+            Ok(list.results)
+        }
+        Err(e) => {
+            debug_error(debug, &e);
+            Err(e).context("Failed to fetch insight variables")
+        }
+    }
+}
+
+/// Create a new insight variable
+/// If debug is true, prints the request body and any error response
+pub fn create_insight_variable(
+    request: &CreateInsightVariableRequest,
+    debug: bool,
+) -> Result<InsightVariable> {
+    let client = &context().client;
+
+    if debug {
+        eprintln!("  {} POST insight_variables/", "DEBUG".cyan().bold());
+        if let Ok(json) = serde_json::to_string_pretty(request) {
+            eprintln!("  Request body:\n{}", json.dimmed());
+        }
+    }
+
+    let result = client.send_post(client.env_url("insight_variables/")?, |req| {
+        req.json(request)
+    });
+
+    match result {
+        Ok(response) => response.json().context("Failed to parse variable response"),
+        Err(e) => {
+            if debug {
+                eprintln!("  {} {}", "Error:".red(), e);
+            }
+            Err(e).with_context(|| format!("Failed to create variable '{}'", request.code_name))
+        }
+    }
+}
+
+/// Fetch a single endpoint by name from PostHog
+pub fn fetch_endpoint(name: &str, debug: bool) -> Result<EndpointResponse> {
+    let client = &context().client;
+    let path = format!("endpoints/{name}/");
+    debug_request(debug, "GET", &path);
+
+    let url = client.env_url(&path)?;
+    let result = client.send_get(url, |req| req);
+
+    match result {
+        Ok(response) => {
+            let endpoint: EndpointResponse = response
+                .json()
+                .context("Failed to parse endpoint response")?;
+            debug_response_body(debug, &endpoint);
+            Ok(endpoint)
+        }
+        Err(e) => {
+            debug_error(debug, &e);
+            Err(e).with_context(|| format!("Failed to fetch endpoint '{name}'"))
+        }
+    }
+}
+
+/// Fetch all endpoints from PostHog
+pub fn fetch_all_endpoints(debug: bool) -> Result<EndpointListResponse> {
+    let client = &context().client;
+    debug_request(debug, "GET", "endpoints/");
+
+    let result = client.send_get(client.env_url("endpoints/")?, |req| req);
+
+    match result {
+        Ok(response) => {
+            let list: EndpointListResponse = response
+                .json()
+                .context("Failed to parse endpoints response")?;
+            if debug {
+                eprintln!(
+                    "  Response: {} endpoint{}",
+                    list.results.len(),
+                    if list.results.len() == 1 { "" } else { "s" }
+                );
+            }
+            Ok(list)
+        }
+        Err(e) => {
+            debug_error(debug, &e);
+            Err(e).context("Failed to fetch endpoints")
+        }
+    }
+}
+
+// ============================================================================
+// Variable reference extraction
+// ============================================================================
+
+/// Extract variable references from a HogQL query string.
+/// Looks for patterns like {variables.code_name}
+pub fn extract_variable_references(query: &str) -> Vec<String> {
+    let re = regex::Regex::new(r"\{variables\.([a-zA-Z_][a-zA-Z0-9_]*)\}")
+        .expect("valid regex pattern for variable references");
+    re.captures_iter(query)
+        .filter_map(|cap| cap.get(1).map(|m| m.as_str().to_string()))
+        .collect()
+}
+
+// ============================================================================
+// Schedule/frequency conversion helpers
+// ============================================================================
+
+/// Valid sync frequency values for materialization schedules.
+///
+/// These values map directly to what the PostHog API accepts:
+/// - Minutes: "5min", "15min", "30min"
+/// - Hours: "1hour", "2hour", "4hour", "6hour", "12hour", "24hour"
+/// - Days: "7day", "30day"
+pub const VALID_SYNC_FREQUENCIES: &[&str] = &[
+    "5min", "15min", "30min", "1hour", "2hour", "4hour", "6hour", "12hour", "24hour", "7day",
+    "30day",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // YAML parsing tests
+    // =========================================================================
+
+    #[test]
+    fn test_parse_simple_endpoint_yaml() {
+        let yaml = r#"
+name: my-endpoint
+description: A test endpoint
+query: SELECT count() FROM events
+"#;
+        let endpoint: EndpointYaml = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(endpoint.name, "my-endpoint");
+        assert_eq!(endpoint.description, Some("A test endpoint".to_string()));
+        assert_eq!(
+            endpoint.query,
+            Some("SELECT count() FROM events".to_string())
+        );
+        assert!(endpoint.query_definition.is_none());
+        assert!(endpoint.variables.is_none());
+        assert!(endpoint.materialization.is_none());
+    }
+
+    #[test]
+    fn test_parse_endpoint_with_variables() {
+        let yaml = r#"
+name: events-by-type
+query: SELECT count() FROM events WHERE event = {variables.event_type}
+variables:
+  - name: event_type
+    type: string
+    default: "$pageview"
+"#;
+        let endpoint: EndpointYaml = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(endpoint.name, "events-by-type");
+        let vars = endpoint.variables.unwrap();
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].name, "event_type");
+        assert_eq!(vars[0].var_type, "string");
+    }
+
+    #[test]
+    fn test_parse_endpoint_with_materialization() {
+        let yaml = r#"
+name: materialized-endpoint
+query: SELECT count() FROM events
+materialization:
+  enabled: true
+  schedule: "1hour"
+"#;
+        let endpoint: EndpointYaml = serde_yaml::from_str(yaml).unwrap();
+        let mat = endpoint.materialization.unwrap();
+        assert!(mat.enabled);
+        assert_eq!(mat.schedule, Some("1hour".to_string()));
+    }
+
+    // =========================================================================
+    // Variable extraction tests
+    // =========================================================================
+
+    #[test]
+    fn test_extract_single_variable() {
+        let query = "SELECT * FROM events WHERE event = {variables.event_name}";
+        let vars = extract_variable_references(query);
+        assert_eq!(vars, vec!["event_name"]);
+    }
+
+    #[test]
+    fn test_extract_multiple_variables() {
+        let query = "SELECT * FROM events WHERE event = {variables.event_name} AND timestamp > {variables.start_date}";
+        let vars = extract_variable_references(query);
+        assert_eq!(vars.len(), 2);
+        assert!(vars.contains(&"event_name".to_string()));
+        assert!(vars.contains(&"start_date".to_string()));
+    }
+
+    #[test]
+    fn test_extract_no_variables() {
+        let query = "SELECT count() FROM events";
+        let vars = extract_variable_references(query);
+        assert!(vars.is_empty());
+    }
+
+    #[test]
+    fn test_extract_variable_with_underscores() {
+        let query = "SELECT * FROM events WHERE prop = {variables.my_long_var_name}";
+        let vars = extract_variable_references(query);
+        assert_eq!(vars, vec!["my_long_var_name"]);
+    }
+
+    #[test]
+    fn test_get_variable_references_from_endpoint() {
+        let endpoint = EndpointYaml {
+            name: "test".to_string(),
+            description: None,
+            query: Some("SELECT * FROM events WHERE type = {variables.event_type}".to_string()),
+            query_definition: None,
+            variables: Some(vec![
+                EndpointVariable {
+                    name: "event_type".to_string(),
+                    var_type: "string".to_string(),
+                    default: None,
+                },
+                EndpointVariable {
+                    name: "unused_var".to_string(),
+                    var_type: "string".to_string(),
+                    default: None,
+                },
+            ]),
+            materialization: None,
+        };
+
+        let refs = endpoint.get_variable_references();
+        assert_eq!(refs, vec!["event_type"]);
+
+        // This shows unused_var is NOT in query - push command will reject this
+        let defined: Vec<_> = endpoint
+            .variables
+            .unwrap()
+            .iter()
+            .map(|v| v.name.clone())
+            .collect();
+        let unused: Vec<_> = defined.iter().filter(|v| !refs.contains(v)).collect();
+        assert_eq!(unused, vec![&"unused_var".to_string()]);
+    }
+
+    // =========================================================================
+    // Schedule validation tests
+    // =========================================================================
+
+    #[test]
+    fn test_valid_sync_frequencies() {
+        // Ensure all expected frequencies are in the list
+        assert!(VALID_SYNC_FREQUENCIES.contains(&"5min"));
+        assert!(VALID_SYNC_FREQUENCIES.contains(&"1hour"));
+        assert!(VALID_SYNC_FREQUENCIES.contains(&"24hour"));
+        assert!(VALID_SYNC_FREQUENCIES.contains(&"7day"));
+    }
+
+    #[test]
+    fn test_invalid_sync_frequencies() {
+        assert!(!VALID_SYNC_FREQUENCIES.contains(&"invalid"));
+        assert!(!VALID_SYNC_FREQUENCIES.contains(&"*/5 * * * *")); // cron not supported
+        assert!(!VALID_SYNC_FREQUENCIES.contains(&"3hour")); // not a valid option
+    }
+
+    // =========================================================================
+    // API request building tests
+    // =========================================================================
+
+    #[test]
+    fn test_to_api_request_simple() {
+        let endpoint = EndpointYaml {
+            name: "test".to_string(),
+            description: Some("Test endpoint".to_string()),
+            query: Some("SELECT 1".to_string()),
+            query_definition: None,
+            variables: None,
+            materialization: None,
+        };
+        let request = endpoint.to_api_request(None);
+        assert_eq!(request["name"], "test");
+        assert_eq!(request["description"], "Test endpoint");
+        assert_eq!(request["query"]["kind"], "HogQLQuery");
+        assert_eq!(request["query"]["query"], "SELECT 1");
+    }
+
+    #[test]
+    fn test_to_api_request_with_materialization() {
+        let endpoint = EndpointYaml {
+            name: "mat-test".to_string(),
+            description: None,
+            query: Some("SELECT 1".to_string()),
+            query_definition: None,
+            variables: None,
+            materialization: Some(MaterializationConfig {
+                enabled: true,
+                schedule: Some("1hour".to_string()),
+            }),
+        };
+        let request = endpoint.to_api_request(None);
+        assert_eq!(request["is_materialized"], true);
+        assert_eq!(request["sync_frequency"], "1hour");
+    }
+
+    // =========================================================================
+    // Validation tests
+    // =========================================================================
+
+    #[test]
+    fn test_validate_requires_name() {
+        let endpoint = EndpointYaml {
+            name: "".to_string(),
+            description: None,
+            query: Some("SELECT 1".to_string()),
+            query_definition: None,
+            variables: None,
+            materialization: None,
+        };
+        assert!(endpoint.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_requires_query() {
+        let endpoint = EndpointYaml {
+            name: "test".to_string(),
+            description: None,
+            query: None,
+            query_definition: None,
+            variables: None,
+            materialization: None,
+        };
+        assert!(endpoint.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_accepts_query_definition() {
+        let endpoint = EndpointYaml {
+            name: "test".to_string(),
+            description: None,
+            query: None,
+            query_definition: Some(serde_json::json!({"kind": "TrendsQuery"})),
+            variables: None,
+            materialization: None,
+        };
+        assert!(endpoint.validate().is_ok());
+    }
+
+    // =========================================================================
+    // Change detection tests
+    // =========================================================================
+
+    #[test]
+    fn test_format_change_summary_description() {
+        let change = Change::Description {
+            from: "Old".to_string(),
+            to: "New".to_string(),
+        };
+        let summary = format_change_summary(&change);
+        assert!(summary.contains("Old"));
+        assert!(summary.contains("New"));
+    }
+
+    #[test]
+    fn test_format_change_summary_materialization() {
+        let change = Change::Materialization {
+            from: false,
+            to: true,
+        };
+        let summary = format_change_summary(&change);
+        assert!(summary.contains("disabled"));
+        assert!(summary.contains("enabled"));
+    }
+}

--- a/cli/src/experimental/endpoints/open.rs
+++ b/cli/src/experimental/endpoints/open.rs
@@ -1,0 +1,20 @@
+use anyhow::{Context, Result};
+
+use crate::invocation_context::context;
+
+use super::{fetch_endpoint, OpenArgs};
+
+pub fn open_endpoint(args: &OpenArgs) -> Result<()> {
+    context().capture_command_invoked("endpoints_open");
+
+    let endpoint = fetch_endpoint(&args.name, args.debug)?;
+
+    let ui_url = endpoint
+        .ui_url
+        .ok_or_else(|| anyhow::anyhow!("Endpoint has no UI URL"))?;
+
+    println!("Opening {ui_url}...");
+    open::that(&ui_url).context("Failed to open browser")?;
+
+    Ok(())
+}

--- a/cli/src/experimental/endpoints/pull.rs
+++ b/cli/src/experimental/endpoints/pull.rs
@@ -1,0 +1,440 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use inquire::Confirm;
+
+use crate::invocation_context::context;
+
+use super::{
+    fetch_all_endpoints, format_change_summary, get_local_schedule, get_remote_schedule,
+    get_remote_variable_names, print_diff, Change, EndpointResponse, EndpointYaml, PullArgs,
+};
+
+#[derive(Debug)]
+enum PullAction {
+    Create {
+        endpoint: EndpointResponse,
+        file_path: String,
+    },
+    Update {
+        endpoint: EndpointResponse,
+        file_path: String,
+        changes: Vec<Change>,
+    },
+    Skip {
+        name: String,
+        reason: String,
+    },
+}
+
+/// Check if a path looks like a YAML file path (ends in .yaml or .yml)
+fn is_yaml_file_path(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    lower.ends_with(".yaml") || lower.ends_with(".yml")
+}
+
+pub fn pull_endpoints(args: &PullArgs) -> Result<()> {
+    context().capture_command_invoked("endpoints_pull");
+
+    println!();
+    println!("Fetching endpoints from PostHog...");
+    println!();
+
+    // Fetch all remote endpoints
+    let remote_list = fetch_all_endpoints(args.debug)?;
+
+    if remote_list.results.is_empty() {
+        println!("No endpoints found in PostHog.");
+        return Ok(());
+    }
+
+    // Check if output is a file path (for single endpoint output)
+    let output_is_file = is_yaml_file_path(&args.output);
+
+    // Determine which endpoints to pull
+    let endpoints_to_pull: Vec<&EndpointResponse> = if args.all {
+        remote_list.results.iter().collect()
+    } else if !args.names.is_empty() {
+        let name_set: std::collections::HashSet<_> = args.names.iter().collect();
+        let found: Vec<_> = remote_list
+            .results
+            .iter()
+            .filter(|e| name_set.contains(&e.name))
+            .collect();
+
+        // Check for missing endpoints
+        for name in &args.names {
+            if !remote_list.results.iter().any(|e| &e.name == name) {
+                println!("{} Endpoint '{}' not found in PostHog", "⚠".yellow(), name);
+            }
+        }
+
+        if found.is_empty() {
+            println!("No matching endpoints found.");
+            return Ok(());
+        }
+
+        found
+    } else {
+        println!("Specify endpoint name(s) to pull, or use --all to pull all endpoints.");
+        println!();
+        println!("Usage:");
+        println!("  posthog-cli exp endpoints pull <name>...");
+        println!("  posthog-cli exp endpoints pull --all");
+        return Ok(());
+    };
+
+    // If output is a file path, only allow pulling a single endpoint
+    if output_is_file && endpoints_to_pull.len() > 1 {
+        anyhow::bail!(
+            "Cannot write {} endpoints to a single file. Use a directory path or pull one endpoint at a time.",
+            endpoints_to_pull.len()
+        );
+    }
+
+    // Read existing local files to compare (only for directory mode)
+    let output_path = Path::new(&args.output);
+    let local_files = if output_is_file {
+        // For file mode, check if the target file exists and parse it
+        if output_path.exists() {
+            let content = fs::read_to_string(output_path)?;
+            match serde_yaml::from_str::<EndpointYaml>(&content) {
+                Ok(endpoint) => {
+                    let mut map = HashMap::new();
+                    map.insert(endpoint.name.clone(), endpoint);
+                    map
+                }
+                Err(_) => HashMap::new(),
+            }
+        } else {
+            HashMap::new()
+        }
+    } else {
+        read_local_endpoints(output_path)?
+    };
+
+    // Determine actions for each endpoint
+    let actions: Vec<PullAction> = endpoints_to_pull
+        .into_iter()
+        .map(|remote| {
+            // In file mode, use the exact path; in directory mode, construct {dir}/{name}.yaml
+            let file_path = if output_is_file {
+                args.output.clone()
+            } else {
+                output_path
+                    .join(format!("{}.yaml", remote.name))
+                    .display()
+                    .to_string()
+            };
+
+            if let Some(local) = local_files.get(&remote.name) {
+                let changes = compute_changes_from_remote(remote, local);
+                if changes.is_empty() {
+                    PullAction::Skip {
+                        name: remote.name.clone(),
+                        reason: "No changes".to_string(),
+                    }
+                } else {
+                    PullAction::Update {
+                        endpoint: remote.clone(),
+                        file_path,
+                        changes,
+                    }
+                }
+            } else {
+                PullAction::Create {
+                    endpoint: remote.clone(),
+                    file_path,
+                }
+            }
+        })
+        .collect();
+
+    // Count actions
+    let creates: Vec<_> = actions
+        .iter()
+        .filter(|a| matches!(a, PullAction::Create { .. }))
+        .collect();
+    let updates: Vec<_> = actions
+        .iter()
+        .filter(|a| matches!(a, PullAction::Update { .. }))
+        .collect();
+    let skips: Vec<_> = actions
+        .iter()
+        .filter(|a| matches!(a, PullAction::Skip { .. }))
+        .collect();
+
+    if creates.is_empty() && updates.is_empty() {
+        println!("No changes to write.");
+        for skip in &skips {
+            if let PullAction::Skip { name, reason, .. } = skip {
+                println!("  {} {} ({})", "SKIP".dimmed(), name, reason.dimmed());
+            }
+        }
+        return Ok(());
+    }
+
+    // Display preview
+    println!("Files to write:");
+    println!();
+
+    for action in &actions {
+        match action {
+            PullAction::Create {
+                endpoint,
+                file_path,
+            } => {
+                println!("  {}  {}", "CREATE".green().bold(), file_path.bold());
+                println!("    New file (endpoint not in local directory)");
+                if !endpoint.description.is_empty() {
+                    let desc = if endpoint.description.chars().count() > 50 {
+                        format!(
+                            "{}...",
+                            endpoint.description.chars().take(47).collect::<String>()
+                        )
+                    } else {
+                        endpoint.description.clone()
+                    };
+                    println!("    Description: {}", desc.dimmed());
+                }
+                println!();
+            }
+            PullAction::Update {
+                file_path, changes, ..
+            } => {
+                println!("  {}  {}", "UPDATE".yellow().bold(), file_path.bold());
+                for change in changes {
+                    println!("    - {}", format_change_summary(change));
+                    if let Change::Query { from, to } = change {
+                        print_diff(from, to, "      ");
+                    }
+                }
+                println!();
+            }
+            PullAction::Skip { name, reason, .. } => {
+                println!(
+                    "  {}    {}.yaml ({})",
+                    "SKIP".dimmed(),
+                    name,
+                    reason.dimmed()
+                );
+            }
+        }
+    }
+
+    // If dry-run, stop here
+    if args.dry_run {
+        println!();
+        println!("{}", "(dry-run mode, no files written)".dimmed());
+        return Ok(());
+    }
+
+    // Confirm unless --yes
+    let change_count = creates.len() + updates.len();
+    if !args.yes {
+        let confirm = Confirm::new(&format!(
+            "Write {} file{}?",
+            change_count,
+            if change_count == 1 { "" } else { "s" }
+        ))
+        .with_default(true)
+        .prompt();
+
+        match confirm {
+            Ok(true) => {}
+            Ok(false) => {
+                println!("Cancelled.");
+                return Ok(());
+            }
+            Err(_) => {
+                println!("Cancelled.");
+                return Ok(());
+            }
+        }
+    }
+
+    println!();
+
+    // Ensure output directory exists
+    if output_is_file {
+        // For file mode, ensure the parent directory exists
+        if let Some(parent) = output_path.parent() {
+            if !parent.as_os_str().is_empty() && !parent.exists() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+            }
+        }
+    } else if !output_path.exists() {
+        fs::create_dir_all(output_path)
+            .with_context(|| format!("Failed to create directory: {}", args.output))?;
+    }
+
+    // Write files
+    let mut success_count = 0;
+
+    for action in actions {
+        match action {
+            PullAction::Create {
+                endpoint,
+                file_path,
+            } => {
+                let yaml = EndpointYaml::from_api_response(&endpoint);
+                match write_yaml_file(&file_path, &yaml) {
+                    Ok(()) => {
+                        println!("{} Created: {}", "✓".green(), file_path);
+                        success_count += 1;
+                    }
+                    Err(e) => {
+                        println!("{} Failed to write {}: {}", "✗".red(), file_path, e);
+                    }
+                }
+            }
+            PullAction::Update {
+                endpoint,
+                file_path,
+                ..
+            } => {
+                let yaml = EndpointYaml::from_api_response(&endpoint);
+                match write_yaml_file(&file_path, &yaml) {
+                    Ok(()) => {
+                        println!("{} Updated: {}", "✓".green(), file_path);
+                        success_count += 1;
+                    }
+                    Err(e) => {
+                        println!("{} Failed to write {}: {}", "✗".red(), file_path, e);
+                    }
+                }
+            }
+            PullAction::Skip { .. } => {}
+        }
+    }
+
+    println!();
+    println!(
+        "{} file{} written.",
+        success_count,
+        if success_count == 1 { "" } else { "s" }
+    );
+
+    Ok(())
+}
+
+/// Read existing local endpoint YAML files from a directory
+fn read_local_endpoints(dir: &Path) -> Result<HashMap<String, EndpointYaml>> {
+    let mut endpoints = HashMap::new();
+
+    if !dir.exists() {
+        return Ok(endpoints);
+    }
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                if ext == "yaml" || ext == "yml" {
+                    let content = fs::read_to_string(&path)?;
+                    match serde_yaml::from_str::<EndpointYaml>(&content) {
+                        Ok(endpoint) => {
+                            endpoints.insert(endpoint.name.clone(), endpoint);
+                        }
+                        Err(_) => {
+                            // Skip files that don't parse as endpoints
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(endpoints)
+}
+
+/// Compute changes between a remote endpoint and a local YAML file (pull direction).
+/// Returns changes where `from` is the local state and `to` is the remote state.
+fn compute_changes_from_remote(remote: &EndpointResponse, local: &EndpointYaml) -> Vec<Change> {
+    let mut changes = Vec::new();
+
+    // Description
+    let local_desc = local.description.as_deref().unwrap_or("");
+    if remote.description != local_desc {
+        changes.push(Change::Description {
+            from: local_desc.to_string(),
+            to: remote.description.clone(),
+        });
+    }
+
+    // Query
+    let remote_query = remote
+        .query
+        .get("query")
+        .and_then(|q| q.as_str())
+        .unwrap_or("");
+    let local_query = local.query.as_deref().unwrap_or("");
+    if !remote_query.is_empty() && remote_query != local_query {
+        changes.push(Change::Query {
+            from: local_query.to_string(),
+            to: remote_query.to_string(),
+        });
+    }
+
+    // Materialization
+    let local_mat = local
+        .materialization
+        .as_ref()
+        .map(|m| m.enabled)
+        .unwrap_or(false);
+    if remote.is_materialized != local_mat {
+        changes.push(Change::Materialization {
+            from: local_mat,
+            to: remote.is_materialized,
+        });
+    }
+
+    // Schedule
+    let local_schedule = get_local_schedule(local);
+    let remote_schedule = get_remote_schedule(remote);
+    if local_schedule != remote_schedule {
+        changes.push(Change::Schedule {
+            from: local_schedule,
+            to: remote_schedule,
+        });
+    }
+
+    // Variables
+    let local_vars: Vec<String> = local
+        .variables
+        .as_ref()
+        .map(|vars| vars.iter().map(|v| v.name.clone()).collect())
+        .unwrap_or_default();
+    let remote_vars = get_remote_variable_names(remote);
+
+    let mut local_sorted = local_vars.clone();
+    let mut remote_sorted = remote_vars.clone();
+    local_sorted.sort();
+    remote_sorted.sort();
+
+    if local_sorted != remote_sorted {
+        changes.push(Change::Variables {
+            from: local_vars,
+            to: remote_vars,
+        });
+    }
+
+    changes
+}
+
+/// Write an EndpointYaml to a file
+fn write_yaml_file(path: &str, endpoint: &EndpointYaml) -> Result<()> {
+    let yaml_content =
+        serde_yaml::to_string(endpoint).context("Failed to serialize endpoint to YAML")?;
+
+    // Add a header comment
+    let content = format!("# {}.yaml\n{}", endpoint.name, yaml_content);
+
+    fs::write(path, content).with_context(|| format!("Failed to write file: {path}"))
+}

--- a/cli/src/experimental/endpoints/push.rs
+++ b/cli/src/experimental/endpoints/push.rs
@@ -1,0 +1,685 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use inquire::Confirm;
+
+use crate::invocation_context::context;
+
+use super::{
+    compute_changes_for_push, create_insight_variable, fetch_all_endpoints,
+    fetch_insight_variables, format_change_summary, get_remote_variable_names, print_diff, Change,
+    CreateInsightVariableRequest, EndpointResponse, EndpointVariable, EndpointYaml,
+    InsightVariable, PushArgs, ResolvedVariables, VALID_SYNC_FREQUENCIES,
+};
+
+/// Represents a variable change for display in the diff
+#[derive(Debug, Clone)]
+pub enum VariableChange {
+    Create(EndpointVariable),
+    Update {
+        code_name: String,
+        from_type: String,
+        to_type: String,
+    },
+    Remove(String), // code_name being removed
+}
+
+#[derive(Debug)]
+enum PushAction {
+    Create {
+        endpoint: EndpointYaml,
+        variable_changes: Vec<VariableChange>,
+    },
+    Update {
+        local: EndpointYaml,
+        changes: Vec<Change>,
+        variable_changes: Vec<VariableChange>,
+    },
+    Skip {
+        name: String,
+        reason: String,
+    },
+}
+
+/// Push local YAML files to PostHog
+pub fn push_endpoints(args: &PushArgs) -> Result<()> {
+    context().capture_command_invoked("endpoints_push");
+
+    // 1. Collect and parse all YAML files
+    let yaml_files = collect_yaml_files(&args.paths)?;
+
+    if yaml_files.is_empty() {
+        println!("No YAML files found in the specified paths.");
+        return Ok(());
+    }
+
+    // 2. Parse YAML files into endpoint definitions
+    let mut endpoints: Vec<EndpointYaml> = Vec::new();
+    for (path, content) in &yaml_files {
+        match parse_yaml_file(path, content) {
+            Ok(endpoint) => {
+                if let Err(e) = endpoint.validate() {
+                    println!("{} Skipping {}: {}", "⚠".yellow(), path, e);
+                    continue;
+                }
+                endpoints.push(endpoint);
+            }
+            Err(e) => {
+                println!("{} Failed to parse {}: {}", "✗".red(), path, e);
+            }
+        }
+    }
+
+    if endpoints.is_empty() {
+        println!("No valid endpoints found to push.");
+        return Ok(());
+    }
+
+    println!();
+    println!("Comparing local files with PostHog...");
+    println!();
+
+    // 3. Fetch remote endpoints and insight variables
+    let remote_list = fetch_all_endpoints(args.debug)?;
+    let remote_by_name: HashMap<String, EndpointResponse> = remote_list
+        .results
+        .into_iter()
+        .map(|e| (e.name.clone(), e))
+        .collect();
+
+    let existing_variables = fetch_insight_variables(args.debug)?;
+    let vars_by_code_name: HashMap<String, InsightVariable> = existing_variables
+        .into_iter()
+        .map(|v| (v.code_name.clone(), v))
+        .collect();
+
+    // 4. Determine actions for each endpoint
+    let mut actions: Vec<PushAction> = Vec::new();
+
+    for local in endpoints {
+        // Compute variable changes
+        let remote_vars = remote_by_name
+            .get(&local.name)
+            .map(get_remote_variable_names)
+            .unwrap_or_default();
+
+        let local_vars: Vec<String> = local
+            .variables
+            .as_ref()
+            .map(|v| v.iter().map(|var| var.name.clone()).collect())
+            .unwrap_or_default();
+
+        // Check for variables being removed
+        let removed_vars: Vec<String> = remote_vars
+            .iter()
+            .filter(|v| !local_vars.contains(v))
+            .cloned()
+            .collect();
+
+        // Validate that removed variables aren't still referenced in query
+        let query_refs = local.get_variable_references();
+        let still_referenced: Vec<&String> = removed_vars
+            .iter()
+            .filter(|v| query_refs.contains(v))
+            .collect();
+
+        if !still_referenced.is_empty() {
+            actions.push(PushAction::Skip {
+                name: local.name.clone(),
+                reason: format!(
+                    "Query still references removed variable(s): {}",
+                    still_referenced
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            });
+            continue;
+        }
+
+        // Validate that all defined variables are actually used in the query
+        let unused_vars: Vec<&String> = local_vars
+            .iter()
+            .filter(|v| !query_refs.contains(v))
+            .collect();
+
+        if !unused_vars.is_empty() {
+            actions.push(PushAction::Skip {
+                name: local.name.clone(),
+                reason: format!(
+                    "Variable(s) defined but not used in query: {}. Remove from 'variables' in YAML.",
+                    unused_vars
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            });
+            continue;
+        }
+
+        // Validate schedule if materialization is enabled
+        if let Some(mat) = &local.materialization {
+            if mat.enabled {
+                if let Some(schedule) = &mat.schedule {
+                    if !VALID_SYNC_FREQUENCIES.contains(&schedule.as_str()) {
+                        actions.push(PushAction::Skip {
+                            name: local.name.clone(),
+                            reason: format!(
+                                "Invalid schedule '{}'. Valid options: {}",
+                                schedule,
+                                VALID_SYNC_FREQUENCIES.join(", ")
+                            ),
+                        });
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // Compute variable changes for display
+        let variable_changes = compute_variable_changes(&local, &remote_vars, &vars_by_code_name);
+
+        if let Some(remote) = remote_by_name.get(&local.name) {
+            let changes = compute_changes_for_push(&local, remote);
+            if changes.is_empty() && variable_changes.is_empty() {
+                actions.push(PushAction::Skip {
+                    name: local.name.clone(),
+                    reason: "No changes".to_string(),
+                });
+            } else {
+                actions.push(PushAction::Update {
+                    local,
+                    changes,
+                    variable_changes,
+                });
+            }
+        } else {
+            actions.push(PushAction::Create {
+                endpoint: local,
+                variable_changes,
+            });
+        }
+    }
+
+    // Count actions
+    let creates: Vec<_> = actions
+        .iter()
+        .filter(|a| matches!(a, PushAction::Create { .. }))
+        .collect();
+    let updates: Vec<_> = actions
+        .iter()
+        .filter(|a| matches!(a, PushAction::Update { .. }))
+        .collect();
+    let skips: Vec<_> = actions
+        .iter()
+        .filter(|a| matches!(a, PushAction::Skip { .. }))
+        .collect();
+
+    if creates.is_empty() && updates.is_empty() {
+        println!("No changes to apply.");
+        for skip in &skips {
+            if let PushAction::Skip { name, reason } = skip {
+                println!("  {} {} ({})", "SKIP".dimmed(), name, reason.dimmed());
+            }
+        }
+        return Ok(());
+    }
+
+    // 5. Display preview
+    println!("Changes to apply:");
+    println!();
+
+    for action in &actions {
+        match action {
+            PushAction::Create {
+                endpoint,
+                variable_changes,
+            } => {
+                println!("  {}  {}", "CREATE".green().bold(), endpoint.name.bold());
+                if let Some(desc) = &endpoint.description {
+                    println!("    Description: {}", desc.dimmed());
+                }
+                print_query_preview(endpoint);
+                print_variable_changes(variable_changes);
+                if let Some(mat) = &endpoint.materialization {
+                    if mat.enabled {
+                        let schedule = mat.schedule.as_deref().unwrap_or("default");
+                        println!("    Materialization: {schedule}");
+                    }
+                }
+                println!();
+            }
+            PushAction::Update {
+                local,
+                changes,
+                variable_changes,
+            } => {
+                println!("  {}  {}", "UPDATE".yellow().bold(), local.name.bold());
+                for change in changes {
+                    println!("    - {}", format_change_summary(change));
+                    match change {
+                        Change::Query { from, to } | Change::QueryDefinition { from, to } => {
+                            print_diff(from, to, "      ");
+                        }
+                        _ => {}
+                    }
+                }
+                print_variable_changes(variable_changes);
+                println!();
+            }
+            PushAction::Skip { name, reason } => {
+                println!("  {}    {} ({})", "SKIP".dimmed(), name, reason.dimmed());
+            }
+        }
+    }
+
+    // 6. If dry-run, stop here
+    if args.dry_run {
+        println!();
+        println!("{}", "(dry-run mode, no changes applied)".dimmed());
+        return Ok(());
+    }
+
+    // 7. Confirm unless --yes
+    if !args.yes {
+        let confirm = Confirm::new("Apply these changes?")
+            .with_default(true)
+            .prompt();
+
+        match confirm {
+            Ok(true) => {}
+            Ok(false) => {
+                println!("Cancelled.");
+                return Ok(());
+            }
+            Err(_) => {
+                println!("Cancelled.");
+                return Ok(());
+            }
+        }
+    }
+
+    println!();
+
+    // 8. Apply changes
+    let mut success_count = 0;
+    // Keep a mutable copy of vars_by_code_name to track newly created variables
+    let mut vars_by_code_name = vars_by_code_name;
+
+    for action in actions {
+        match action {
+            PushAction::Create {
+                endpoint,
+                variable_changes,
+            } => {
+                // Create any new variables first
+                let resolved = match resolve_variables(
+                    &endpoint,
+                    &variable_changes,
+                    &mut vars_by_code_name,
+                    args.debug,
+                ) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        println!(
+                            "{} Failed to resolve variables for {}: {}",
+                            "✗".red(),
+                            endpoint.name,
+                            e
+                        );
+                        continue;
+                    }
+                };
+
+                match create_endpoint(&endpoint, &resolved, args.debug) {
+                    Ok(created) => {
+                        println!("{} Created: {}", "✓".green(), endpoint.name.bold());
+                        if let Some(ui_url) = &created.ui_url {
+                            println!("  {ui_url}");
+                        }
+                        success_count += 1;
+                    }
+                    Err(e) => {
+                        println!("{} Failed to create {}: {}", "✗".red(), endpoint.name, e);
+                    }
+                }
+            }
+            PushAction::Update {
+                local,
+                variable_changes,
+                ..
+            } => {
+                // Create any new variables first
+                let resolved = match resolve_variables(
+                    &local,
+                    &variable_changes,
+                    &mut vars_by_code_name,
+                    args.debug,
+                ) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        println!(
+                            "{} Failed to resolve variables for {}: {}",
+                            "✗".red(),
+                            local.name,
+                            e
+                        );
+                        continue;
+                    }
+                };
+
+                match update_endpoint(&local, &resolved, args.debug) {
+                    Ok(updated) => {
+                        println!("{} Updated: {}", "✓".green(), local.name.bold());
+                        if let Some(ui_url) = &updated.ui_url {
+                            println!("  {ui_url}");
+                        }
+                        success_count += 1;
+                    }
+                    Err(e) => {
+                        println!("{} Failed to update {}: {}", "✗".red(), local.name, e);
+                    }
+                }
+            }
+            PushAction::Skip { .. } => {}
+        }
+    }
+
+    println!();
+    println!(
+        "{} endpoint{} synced.",
+        success_count,
+        if success_count == 1 { "" } else { "s" }
+    );
+
+    Ok(())
+}
+
+/// Collect YAML files from the given paths
+fn collect_yaml_files(paths: &[String]) -> Result<Vec<(String, String)>> {
+    let mut files = Vec::new();
+
+    for path_str in paths {
+        let path = Path::new(path_str);
+
+        if path.is_dir() {
+            // Collect all .yaml and .yml files from directory
+            for entry in walkdir::WalkDir::new(path)
+                .max_depth(1)
+                .into_iter()
+                .filter_map(|e| e.ok())
+            {
+                let entry_path = entry.path();
+                if entry_path.is_file() {
+                    if let Some(ext) = entry_path.extension() {
+                        if ext == "yaml" || ext == "yml" {
+                            let content = fs::read_to_string(entry_path).with_context(|| {
+                                format!("Failed to read {}", entry_path.display())
+                            })?;
+                            files.push((entry_path.display().to_string(), content));
+                        }
+                    }
+                }
+            }
+        } else if path.is_file() {
+            let content =
+                fs::read_to_string(path).with_context(|| format!("Failed to read {path_str}"))?;
+            files.push((path_str.clone(), content));
+        } else {
+            // Try glob pattern
+            let glob_pattern = globset::Glob::new(path_str)
+                .with_context(|| format!("Invalid path pattern: {path_str}"))?
+                .compile_matcher();
+
+            let current_dir = std::env::current_dir()?;
+            for entry in walkdir::WalkDir::new(&current_dir)
+                .max_depth(3)
+                .into_iter()
+                .filter_map(|e| e.ok())
+            {
+                let entry_path = entry.path();
+                if entry_path.is_file() {
+                    let relative = entry_path.strip_prefix(&current_dir).unwrap_or(entry_path);
+                    if glob_pattern.is_match(relative) {
+                        let content = fs::read_to_string(entry_path)
+                            .with_context(|| format!("Failed to read {}", entry_path.display()))?;
+                        files.push((entry_path.display().to_string(), content));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(files)
+}
+
+/// Parse a YAML file into an EndpointYaml
+fn parse_yaml_file(path: &str, content: &str) -> Result<EndpointYaml> {
+    serde_yaml::from_str(content).with_context(|| format!("Failed to parse YAML in {path}"))
+}
+
+/// Print a preview of the query
+fn print_query_preview(endpoint: &EndpointYaml) {
+    if let Some(query) = &endpoint.query {
+        let preview: String = query
+            .lines()
+            .take(3)
+            .collect::<Vec<_>>()
+            .join(" ")
+            .chars()
+            .take(60)
+            .collect();
+        println!("    Query: {}...", preview.dimmed());
+    } else if let Some(query_def) = &endpoint.query_definition {
+        if let Some(kind) = query_def.get("kind") {
+            println!("    Query type: {kind}");
+        }
+    }
+}
+
+/// Print variable changes in the diff display
+fn print_variable_changes(changes: &[VariableChange]) {
+    if changes.is_empty() {
+        return;
+    }
+
+    println!("    Variables:");
+    for change in changes {
+        match change {
+            VariableChange::Create(var) => {
+                println!(
+                    "      {} {} ({})",
+                    "+".green(),
+                    var.name.green(),
+                    var.var_type.dimmed()
+                );
+            }
+            VariableChange::Update {
+                code_name,
+                from_type,
+                to_type,
+            } => {
+                println!(
+                    "      {} {} ({} → {})",
+                    "~".yellow(),
+                    code_name.yellow(),
+                    from_type.dimmed(),
+                    to_type.dimmed()
+                );
+            }
+            VariableChange::Remove(code_name) => {
+                println!("      {} {}", "-".red(), code_name.red());
+            }
+        }
+    }
+}
+
+/// Compute variable changes between local YAML and remote state
+fn compute_variable_changes(
+    local: &EndpointYaml,
+    remote_vars: &[String],
+    existing_vars: &HashMap<String, InsightVariable>,
+) -> Vec<VariableChange> {
+    let mut changes = Vec::new();
+
+    let local_vars = local.variables.as_ref();
+
+    // Variables being added
+    if let Some(vars) = local_vars {
+        for var in vars {
+            if !remote_vars.contains(&var.name) {
+                // Variable will be added to this endpoint (may need to be created globally first)
+                changes.push(VariableChange::Create(var.clone()));
+            } else if let Some(existing) = existing_vars.get(&var.name) {
+                // Variable exists - check for type changes
+                if existing.var_type != var.var_type {
+                    changes.push(VariableChange::Update {
+                        code_name: var.name.clone(),
+                        from_type: existing.var_type.clone(),
+                        to_type: var.var_type.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    // Variables being removed
+    let local_var_names: Vec<String> = local_vars
+        .map(|v| v.iter().map(|var| var.name.clone()).collect())
+        .unwrap_or_default();
+
+    for remote_var in remote_vars {
+        if !local_var_names.contains(remote_var) {
+            changes.push(VariableChange::Remove(remote_var.clone()));
+        }
+    }
+
+    changes
+}
+
+/// Resolve variables: look up existing ones, create missing ones
+fn resolve_variables(
+    endpoint: &EndpointYaml,
+    variable_changes: &[VariableChange],
+    vars_by_code_name: &mut HashMap<String, InsightVariable>,
+    debug: bool,
+) -> Result<ResolvedVariables> {
+    let mut resolved = ResolvedVariables::new();
+
+    let local_vars = match &endpoint.variables {
+        Some(v) => v,
+        None => return Ok(resolved),
+    };
+
+    for local_var in local_vars {
+        // Check if we already have this variable
+        if let Some(existing) = vars_by_code_name.get(&local_var.name) {
+            resolved.insert(
+                local_var.name.clone(),
+                (existing.id.clone(), existing.clone()),
+            );
+        } else {
+            // Need to create the variable
+            let is_being_created = variable_changes
+                .iter()
+                .any(|c| matches!(c, VariableChange::Create(v) if v.name == local_var.name));
+
+            if is_being_created {
+                println!("  {} Creating variable '{}'...", "→".cyan(), local_var.name);
+
+                let request = CreateInsightVariableRequest {
+                    name: local_var.name.clone(), // Use code_name as display name
+                    code_name: local_var.name.clone(),
+                    var_type: local_var.var_type.clone(),
+                    default_value: local_var.default.clone(),
+                };
+
+                let created = create_insight_variable(&request, debug)?;
+
+                // Add to our cache
+                vars_by_code_name.insert(created.code_name.clone(), created.clone());
+                resolved.insert(local_var.name.clone(), (created.id.clone(), created));
+            }
+        }
+    }
+
+    Ok(resolved)
+}
+
+/// Create an endpoint via API
+fn create_endpoint(
+    endpoint: &EndpointYaml,
+    resolved: &ResolvedVariables,
+    debug: bool,
+) -> Result<EndpointResponse> {
+    let client = &context().client;
+    let resolved_opt = if resolved.is_empty() {
+        None
+    } else {
+        Some(resolved)
+    };
+    let request_body = endpoint.to_api_request(resolved_opt);
+
+    if debug {
+        eprintln!("  {} POST endpoints/", "DEBUG".cyan().bold());
+        if let Ok(json) = serde_json::to_string_pretty(&request_body) {
+            eprintln!("  Request body:\n{}", json.dimmed());
+        }
+    }
+
+    let result = client.send_post(client.env_url("endpoints/")?, |req| req.json(&request_body));
+
+    match result {
+        Ok(response) => response.json().context("Failed to parse create response"),
+        Err(e) => {
+            if debug {
+                eprintln!("  {} {}", "Error:".red(), e);
+            }
+            Err(e).context("Failed to create endpoint")
+        }
+    }
+}
+
+/// Update an endpoint via API
+fn update_endpoint(
+    endpoint: &EndpointYaml,
+    resolved: &ResolvedVariables,
+    debug: bool,
+) -> Result<EndpointResponse> {
+    let client = &context().client;
+    let resolved_opt = if resolved.is_empty() {
+        None
+    } else {
+        Some(resolved)
+    };
+    let request_body = endpoint.to_api_request(resolved_opt);
+    let url = client.env_url(&format!("endpoints/{}/", endpoint.name))?;
+
+    if debug {
+        eprintln!(
+            "  {} PATCH endpoints/{}/",
+            "DEBUG".cyan().bold(),
+            endpoint.name
+        );
+        if let Ok(json) = serde_json::to_string_pretty(&request_body) {
+            eprintln!("  Request body:\n{}", json.dimmed());
+        }
+    }
+
+    let result = client.send_request(reqwest::Method::PATCH, url, |req| req.json(&request_body));
+
+    match result {
+        Ok(response) => response.json().context("Failed to parse update response"),
+        Err(e) => {
+            if debug {
+                eprintln!("  {} {}", "Error:".red(), e);
+            }
+            Err(e).context("Failed to update endpoint")
+        }
+    }
+}

--- a/cli/src/experimental/endpoints/run.rs
+++ b/cli/src/experimental/endpoints/run.rs
@@ -1,0 +1,308 @@
+use std::collections::HashMap;
+use std::fs;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde_json::Value;
+
+use crate::invocation_context::context;
+
+use super::{
+    debug_error, debug_request, debug_response_body, fetch_endpoint, EndpointYaml, RunArgs,
+};
+
+pub fn run_endpoint(args: &RunArgs) -> Result<()> {
+    context().capture_command_invoked("endpoints_run");
+
+    let client = &context().client;
+
+    // Build the query to execute
+    let (query, name) = if let Some(file_path) = &args.file {
+        // Run from local file without creating endpoint
+        let content = fs::read_to_string(file_path)
+            .with_context(|| format!("Failed to read file: {file_path}"))?;
+        let endpoint: EndpointYaml = serde_yaml::from_str(&content)
+            .with_context(|| format!("Failed to parse YAML: {file_path}"))?;
+        endpoint.validate()?;
+
+        let query = if let Some(query_def) = endpoint.query_definition {
+            query_def
+        } else if let Some(hogql) = endpoint.query {
+            serde_json::json!({
+                "kind": "HogQLQuery",
+                "query": hogql
+            })
+        } else {
+            anyhow::bail!("No query found in YAML file");
+        };
+
+        (query, endpoint.name)
+    } else if let Some(endpoint_name) = &args.name {
+        // Run existing endpoint - fetch its query first
+        let endpoint = fetch_endpoint(endpoint_name, args.debug)?;
+
+        if !endpoint.is_active {
+            anyhow::bail!("Endpoint '{endpoint_name}' is not active");
+        }
+
+        (endpoint.query, endpoint_name.clone())
+    } else {
+        anyhow::bail!("Either --file or endpoint name is required");
+    };
+
+    // Parse variables from command line
+    let variables: HashMap<String, String> = args
+        .var
+        .iter()
+        .filter_map(|v| {
+            let parts: Vec<&str> = v.splitn(2, '=').collect();
+            if parts.len() == 2 {
+                Some((parts[0].to_string(), parts[1].to_string()))
+            } else {
+                eprintln!(
+                    "{} Invalid variable format: {v} (expected name=value)",
+                    "⚠".yellow(),
+                );
+                None
+            }
+        })
+        .collect();
+
+    // Build the run request
+    let mut request_body = serde_json::json!({});
+
+    if !variables.is_empty() {
+        request_body["variables"] = serde_json::to_value(&variables)?;
+    }
+
+    if args.file.is_some() {
+        // For file-based runs, we execute the query directly via the query endpoint
+        if !args.quiet {
+            println!("{} Running query from file...", "→".cyan());
+            println!();
+        }
+
+        let mut query_request = serde_json::json!({
+            "query": query,
+            "name": "endpoints_cli"
+        });
+
+        if !variables.is_empty() {
+            query_request["variables"] = serde_json::to_value(&variables)?;
+        }
+
+        debug_request(args.debug, "POST", "query/");
+        if args.debug {
+            if let Ok(json) = serde_json::to_string_pretty(&query_request) {
+                eprintln!("  Request body:\n{}", json.dimmed());
+            }
+        }
+
+        let api_result =
+            client.send_post(client.env_url("query/")?, |req| req.json(&query_request));
+
+        match api_result {
+            Ok(response) => {
+                let result: Value = response.json().context("Failed to parse query response")?;
+                debug_response_body(args.debug, &result);
+                print_results(&result, args)?;
+            }
+            Err(e) => {
+                debug_error(args.debug, &e);
+                return Err(e).context("Failed to execute query");
+            }
+        }
+    } else {
+        // For named endpoints, use the run endpoint
+        if !args.quiet {
+            println!("{} Running endpoint '{name}'...", "→".cyan());
+            println!();
+        }
+
+        let path = format!("endpoints/{name}/run/");
+        debug_request(args.debug, "POST", &path);
+        if args.debug && !variables.is_empty() {
+            if let Ok(json) = serde_json::to_string_pretty(&request_body) {
+                eprintln!("  Request body:\n{}", json.dimmed());
+            }
+        }
+
+        let url = client.env_url(&path)?;
+        let api_result = client.send_post(url, |req| req.json(&request_body));
+
+        match api_result {
+            Ok(response) => {
+                let result: Value = response.json().context("Failed to parse response")?;
+                debug_response_body(args.debug, &result);
+                print_results(&result, args)?;
+            }
+            Err(e) => {
+                debug_error(args.debug, &e);
+                return Err(e).context("Failed to run endpoint");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn print_results(result: &Value, args: &RunArgs) -> Result<()> {
+    if args.json {
+        // Raw JSON output
+        println!("{}", serde_json::to_string_pretty(result)?);
+        return Ok(());
+    }
+
+    // Extract results array
+    let results = result.get("results").and_then(|r| r.as_array());
+    let columns = result.get("columns").and_then(|c| c.as_array());
+
+    match (&results, &columns, &args.format) {
+        (Some(rows), Some(cols), Some(format)) if format == "table" => {
+            print_table(cols, rows)?;
+        }
+        (Some(rows), Some(cols), None) => {
+            // Default: print table if small enough, otherwise summary
+            if rows.len() <= 50 && cols.len() <= 10 {
+                print_table(cols, rows)?;
+            } else {
+                print_summary(rows, cols)?;
+            }
+        }
+        (Some(rows), None, _) => {
+            // No columns, just print results
+            println!("{}", serde_json::to_string_pretty(&rows)?);
+        }
+        _ => {
+            // Fallback to full JSON
+            println!("{}", serde_json::to_string_pretty(result)?);
+        }
+    }
+
+    Ok(())
+}
+
+fn print_table(columns: &[Value], rows: &[Value]) -> Result<()> {
+    if rows.is_empty() {
+        println!("{}", "(no results)".dimmed());
+        return Ok(());
+    }
+
+    // Get column names
+    let col_names: Vec<String> = columns
+        .iter()
+        .map(|c| c.as_str().unwrap_or("?").to_string())
+        .collect();
+
+    // Calculate column widths
+    let mut widths: Vec<usize> = col_names.iter().map(|c| c.len()).collect();
+
+    for row in rows {
+        if let Some(row_arr) = row.as_array() {
+            for (i, cell) in row_arr.iter().enumerate() {
+                if i < widths.len() {
+                    let cell_str = format_cell(cell);
+                    widths[i] = widths[i].max(cell_str.len()).min(40); // Cap at 40 chars
+                }
+            }
+        }
+    }
+
+    // Print header
+    let header: String = col_names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| format!("{name:width$}", width = widths[i]))
+        .collect::<Vec<_>>()
+        .join("  ");
+    println!("{}", header.bold());
+
+    // Print separator
+    let separator: String = widths
+        .iter()
+        .map(|w| "─".repeat(*w))
+        .collect::<Vec<_>>()
+        .join("──");
+    println!("{}", separator.dimmed());
+
+    // Print rows
+    for row in rows {
+        if let Some(row_arr) = row.as_array() {
+            let row_str: String = row_arr
+                .iter()
+                .enumerate()
+                .map(|(i, cell)| {
+                    let cell_str = format_cell(cell);
+                    let width = widths.get(i).copied().unwrap_or(10);
+                    let char_count = cell_str.chars().count();
+                    if char_count > width && width > 1 {
+                        format!("{}…", cell_str.chars().take(width - 1).collect::<String>())
+                    } else {
+                        format!("{cell_str:width$}")
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("  ");
+            println!("{row_str}");
+        }
+    }
+
+    println!();
+    println!("{} rows", rows.len().to_string().bold());
+
+    Ok(())
+}
+
+fn print_summary(rows: &[Value], columns: &[Value]) -> Result<()> {
+    println!(
+        "{} rows × {} columns",
+        rows.len().to_string().bold(),
+        columns.len().to_string().bold()
+    );
+    println!();
+
+    // Show column names
+    println!("{}", "Columns:".dimmed());
+    for col in columns {
+        println!("  {}", col.as_str().unwrap_or("?"));
+    }
+
+    // Show first few rows as preview
+    println!();
+    println!("{}", "Preview (first 5 rows):".dimmed());
+    for row in rows.iter().take(5) {
+        if let Some(row_arr) = row.as_array() {
+            let preview: String = row_arr
+                .iter()
+                .take(5)
+                .map(format_cell)
+                .collect::<Vec<_>>()
+                .join(", ");
+            println!("  {preview}");
+        }
+    }
+
+    if rows.len() > 5 {
+        let remaining = rows.len() - 5;
+        println!("  {}", format!("... and {remaining} more rows").dimmed());
+    }
+
+    println!();
+    println!(
+        "{}",
+        "Use --json for full output or --format table for tabular view".dimmed()
+    );
+
+    Ok(())
+}
+
+fn format_cell(value: &Value) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => s.clone(),
+        Value::Array(arr) => format!("[{} items]", arr.len()),
+        Value::Object(_) => "{...}".to_string(),
+    }
+}

--- a/cli/src/experimental/mod.rs
+++ b/cli/src/experimental/mod.rs
@@ -1,6 +1,7 @@
 // module for anything we put under the "experimental" subcommand.
 // Things in here should be considered unstable and possibly broken
 
+pub mod endpoints;
 pub mod query;
 pub mod schema;
 pub mod tasks;

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -95,8 +95,20 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
     # NOTE: Do we need to override the scopes for the "create"
     scope_object = "endpoint"
     # Special case for query - these are all essentially read actions
-    scope_object_read_actions = ["retrieve", "list", "run", "versions", "version_detail", "openapi_spec"]
-    scope_object_write_actions: list[str] = ["create", "destroy", "update"]
+    scope_object_read_actions = [
+        "retrieve",
+        "list",
+        "run",
+        "versions",
+        "version_detail",
+        "openapi_spec",
+    ]
+    scope_object_write_actions: list[str] = [
+        "create",
+        "destroy",
+        "update",
+        "partial_update",
+    ]
     lookup_field = "name"
     queryset = Endpoint.objects.all()
     filter_backends = [DjangoFilterBackend]
@@ -108,7 +120,14 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
     def get_throttles(self):
         return [EndpointBurstThrottle(), EndpointSustainedThrottle()]
 
-    def _serialize_endpoint(self, endpoint: Endpoint) -> dict:
+    def _serialize_endpoint(self, endpoint: Endpoint, request: Request | None = None) -> dict:
+        url = None
+        ui_url = None
+        if request:
+            url = request.build_absolute_uri(endpoint.endpoint_path)
+            ui_path = f"/project/{endpoint.team_id}/endpoints/{endpoint.name}"
+            ui_url = request.build_absolute_uri(ui_path)
+
         result = {
             "id": str(endpoint.id),
             "name": endpoint.name,
@@ -118,6 +137,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             "is_active": endpoint.is_active,
             "cache_age_seconds": endpoint.cache_age_seconds,
             "endpoint_path": endpoint.endpoint_path,
+            "url": url,
+            "ui_url": ui_url,
             "created_at": endpoint.created_at,
             "updated_at": endpoint.updated_at,
             "created_by": UserBasicSerializer(endpoint.created_by).data if hasattr(endpoint, "created_by") else None,
@@ -153,13 +174,13 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
     def list(self, request: Request, *args, **kwargs) -> Response:
         """List all endpoints for the team."""
         queryset = self.filter_queryset(self.get_queryset()).select_related("saved_query")
-        results = [self._serialize_endpoint(endpoint) for endpoint in queryset]
+        results = [self._serialize_endpoint(endpoint, request) for endpoint in queryset]
         return Response({"results": results})
 
     def retrieve(self, request: Request, name=None, *args, **kwargs) -> Response:
         """Retrieve an endpoint."""
         endpoint = get_object_or_404(Endpoint.objects.select_related("saved_query"), team=self.team, name=name)
-        return Response(self._serialize_endpoint(endpoint), status=status.HTTP_200_OK)
+        return Response(self._serialize_endpoint(endpoint, request), status=status.HTTP_200_OK)
 
     def _validate_cache_age_seconds(self, cache_age_seconds: float | None) -> None:
         """Validate cache_age_seconds is within allowed range."""
@@ -243,7 +264,10 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 team=self.team,
             )
 
-            return Response(self._serialize_endpoint(endpoint), status=status.HTTP_201_CREATED)
+            return Response(
+                self._serialize_endpoint(endpoint, request),
+                status=status.HTTP_201_CREATED,
+            )
 
         except Exception as e:
             capture_exception(
@@ -257,7 +281,10 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             raise ValidationError("Failed to create endpoint.")
 
     def validate_update_request(
-        self, data: EndpointRequest, endpoint: Endpoint | None = None, strict: bool = True
+        self,
+        data: EndpointRequest,
+        endpoint: Endpoint | None = None,
+        strict: bool = True,
     ) -> None:
         self._validate_cache_age_seconds(data.cache_age_seconds)
 
@@ -345,7 +372,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 detail=Detail(name=endpoint.name, changes=changes),
             )
 
-            return Response(self._serialize_endpoint(endpoint))
+            return Response(self._serialize_endpoint(endpoint, request))
 
         except Exception as e:
             capture_exception(
@@ -372,7 +399,9 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         saved_query = DataWarehouseSavedQuery.objects.filter(name=endpoint.name, team=self.team, deleted=False).first()
         if saved_query is None:
             saved_query = DataWarehouseSavedQuery(
-                name=endpoint.name, team=self.team, origin=DataWarehouseSavedQuery.Origin.ENDPOINT
+                name=endpoint.name,
+                team=self.team,
+                origin=DataWarehouseSavedQuery.Origin.ENDPOINT,
             )
 
         hogql_query = convert_insight_query_to_hogql(endpoint.query, self.team)
@@ -537,7 +566,11 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         return last_refresh < saved_query.last_run_at
 
     def _execute_materialized_endpoint(
-        self, endpoint: Endpoint, data: EndpointRunRequest, request: Request, debug: bool = False
+        self,
+        endpoint: Endpoint,
+        data: EndpointRunRequest,
+        request: Request,
+        debug: bool = False,
     ) -> Response:
         """Execute against a materialized table in S3."""
         try:
@@ -558,7 +591,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                     raise ValidationError("Failed to apply property filters.")
 
             materialized_hogql_query = HogQLQuery(
-                query=select_query.to_hogql(), modifiers=HogQLQueryModifiers(useMaterializedViews=True)
+                query=select_query.to_hogql(),
+                modifiers=HogQLQueryModifiers(useMaterializedViews=True),
             )
 
             refresh_type = _endpoint_refresh_mode_to_refresh_type(data.refresh)
@@ -577,13 +611,21 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             tag_queries(workload=Workload.ENDPOINTS, warehouse_query=True)
 
             result = self._execute_query_and_respond(
-                query_request_data, data.client_query_id, request, extra_result_fields=extra_fields, debug=debug
+                query_request_data,
+                data.client_query_id,
+                request,
+                extra_result_fields=extra_fields,
+                debug=debug,
             )
 
             if self._is_cache_stale(result, saved_query):
                 query_request_data["refresh"] = RefreshType.FORCE_BLOCKING
                 result = self._execute_query_and_respond(
-                    query_request_data, data.client_query_id, request, extra_result_fields=extra_fields, debug=debug
+                    query_request_data,
+                    data.client_query_id,
+                    request,
+                    extra_result_fields=extra_fields,
+                    debug=debug,
                 )
 
             return result
@@ -628,7 +670,12 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         return variables_override
 
     def _execute_inline_endpoint(
-        self, endpoint: Endpoint, data: EndpointRunRequest, request: Request, query: dict, debug: bool = False
+        self,
+        endpoint: Endpoint,
+        data: EndpointRunRequest,
+        request: Request,
+        query: dict,
+        debug: bool = False,
     ) -> Response:
         """Execute query directly against ClickHouse."""
         try:
@@ -689,7 +736,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                     version_number = int(version_param)
                 except (ValueError, TypeError):
                     return Response(
-                        {"error": f"Invalid version parameter: {version_param}"}, status=status.HTTP_400_BAD_REQUEST
+                        {"error": f"Invalid version parameter: {version_param}"},
+                        status=status.HTTP_400_BAD_REQUEST,
                     )
 
         version_obj = None
@@ -848,10 +896,16 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         try:
             version_obj = endpoint.get_version(int(version_number))
         except EndpointVersion.DoesNotExist:
-            return Response({"error": f"Version {version_number} not found"}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"error": f"Version {version_number} not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         if version_obj is None:
-            return Response({"error": f"Version {version_number} not found"}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"error": f"Version {version_number} not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         return Response(self._serialize_endpoint_version(version_obj))
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

I saw [Theo](https://www.youtube.com/live/VR4A-hB03qw?t=9120s) save his endpoint SQL in a typescript file because it's closer to code for devs to know what the endpoint does. 

We're missing a way to manage endpoints outside the UI.

## Changes

Introducing `posthog-cli exp endpoints` set of commands:

- list - list all endpoints
- get - show the state of the endpoint
- open - open the endpoint's page in PostHog
- pull - pull remote endpoint to a local YAML file
- push - push local YAML to remote endpoint
- diff - what it says on the tin, show the diff between remote and local
- run - for when you don't want to `push` yet, but you want to see the effect of your query changes on the query results

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

[posthog-cli endpoints.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/c75fe3f8-ca3c-4cee-900f-a6a262e56651.mov" />](https://app.graphite.com/user-attachments/video/c75fe3f8-ca3c-4cee-900f-a6a262e56651.mov)



## How did you test this code?

a bunch of experiments locally.

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Changelog: (features only) Is this feature complete?

hell yeah, this is cool

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->

<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->