### PR TITLE
fix(trends): fix decimal point not changing the visualization inside trends

### DIFF
--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -47,10 +47,10 @@ export const formatAggregationAxisValue = (
                 formattedValue = humanFriendlyDuration(value / 1000, { secondsFixed: 1 })
                 break
             case 'percentage':
-                formattedValue = percentage(value / 100)
+                formattedValue = percentage(value / 100, maxDecimalPlaces)
                 break
             case 'percentage_scaled':
-                formattedValue = percentage(value)
+                formattedValue = percentage(value, maxDecimalPlaces)
                 break
             case 'currency':
                 formattedValue = humanFriendlyCurrency(value)

--- a/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
@@ -10,6 +10,7 @@ describe('formatAggregationAxisValue', () => {
         { candidate: 3.944, filters: { aggregation_axis_format: 'percentage' }, expected: '3.94%' },
         { candidate: 3.956, filters: { aggregation_axis_format: 'percentage' }, expected: '3.96%' },
         { candidate: 3940, filters: { aggregation_axis_format: 'percentage' }, expected: '3,940%' },
+        { candidate: 2.5341, filters: { aggregation_axis_format: 'percentage', decimalPlaces: 3 }, expected: '2.534%' },
         { candidate: 34, filters: { aggregation_axis_format: 'numeric' }, expected: '34' },
         { candidate: 394, filters: { aggregation_axis_format: 'numeric' }, expected: '394' },
         { candidate: 3940, filters: { aggregation_axis_format: 'numeric' }, expected: '3,940' },


### PR DESCRIPTION
## Problem

When selecting a percent unit for trends visualization and trying to modify the decimal places it would always default to 2. 

Closes: https://github.com/PostHog/posthog/issues/40309

## Changes

Pass down the `maxDecimalPlaces` that we get from the filters to the `percent` function given that If we don't do this we always default to 2 decimal place.

https://github.com/user-attachments/assets/359ef83b-a5c4-42af-9c17-897e0f793158


## How did you test this code?

Manual testing and added a new test case for when we choose percent and a decimal place that is not 2.
