### PR TITLE
chore: Foss sync dependabot exclusion

### DIFF
--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -54,6 +54,9 @@ jobs:
                   cd .github/workflows
                   ls | grep -v foss-release-image-publish.yml | xargs rm
 
+            - name: Remove dependabot config
+              run: rm -f .github/dependabot.yml
+
             - name: Commit "Sync and remove all non-FOSS parts"
               uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
               with:


### PR DESCRIPTION
## Problem

Dependabot should not be active on our FOSS clone, but its configuration was being copied over during the sync process.

## Changes

Adds a step to the `foss-sync.yml` GitHub Action to remove `.github/dependabot.yml` before committing changes to the FOSS repository.

## How did you test this code?

This is a workflow change; it will be tested by observing the next run of the `foss-sync.yml` action.

## Changelog: (features only) Is this feature complete?

No

---
[Slack Thread](https://posthog.slack.com/archives/C043VJ93L3B/p1766995046815339?thread_ts=1766995046.815339&cid=C043VJ93L3B)

<a href="https://cursor.com/background-agent?bcId=bc-6fbb0957-dbe6-471e-9d78-0ac9cc8f130c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6fbb0957-dbe6-471e-9d78-0ac9cc8f130c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

