### PR TITLE
fix: ensure replay active ms is integer

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/segmentation.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/segmentation.test.ts
@@ -89,6 +89,19 @@ describe('segmentation', () => {
             // Should create one active segment with duration of 5000ms (from 1000 to 6000)
             expect(activeMillisecondsFromSegmentationEvents(segmentationEvents)).toBe(5000)
         })
+
+        it('should return an integer when timestamps are fractional', () => {
+            const segmentationEvents: SegmentationEvent[] = [
+                { timestamp: 1000.25, isActive: true },
+                { timestamp: 2000.75, isActive: true },
+                { timestamp: 3000.5, isActive: true },
+            ]
+
+            const result = activeMillisecondsFromSegmentationEvents(segmentationEvents)
+            // Result should be an integer, not 2000.25
+            expect(Number.isInteger(result)).toBe(true)
+            expect(result).toBe(2000)
+        })
     })
 
     describe('toSegmentationEvent', () => {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/segmentation.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/segmentation.ts
@@ -127,7 +127,7 @@ export const activeMillisecondsFromSegmentationEvents = (segmentationEvents: Seg
 }
 
 const activeMillisecondsFromSegments = (segments: RecordingSegment[]): number => {
-    return segments.reduce((acc, segment) => {
+    const total = segments.reduce((acc, segment) => {
         if (segment.isActive) {
             // if the segment is active but has no duration we count it as 1ms
             // to distinguish it from segments with no activity at all
@@ -136,4 +136,6 @@ const activeMillisecondsFromSegments = (segments: RecordingSegment[]): number =>
 
         return acc
     }, 0)
+    // timestamps can be fractional, so we floor to ensure we return an integer
+    return Math.floor(total)
 }


### PR DESCRIPTION
## Problem

We crashed CH consumer because the `active_milliseconds` field had a fractional value.

## Changes

Ensures the `active_milliseconds` is always an integer.

## How did you test this code?

- Added a new regression test