### PR TITLE
feat: add dedicated Changelog side panel tab with product filtering

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -4,7 +4,16 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useEffect, useRef } from 'react'
 
-import { IconEllipsis, IconGear, IconInfo, IconLock, IconLogomark, IconNotebook, IconSupport } from '@posthog/icons'
+import {
+    IconEllipsis,
+    IconGear,
+    IconInfo,
+    IconLock,
+    IconLogomark,
+    IconNotebook,
+    IconSparkles,
+    IconSupport,
+} from '@posthog/icons'
 import { LemonButton, LemonMenu, LemonMenuItems, LemonModal } from '@posthog/lemon-ui'
 
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
@@ -21,6 +30,7 @@ import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { SidePanelTab } from '~/types'
 
+import { SidePanelChangelog } from './panels/SidePanelChangelog'
 import { SidePanelDocs } from './panels/SidePanelDocs'
 import { SidePanelHealth, SidePanelHealthIcon } from './panels/SidePanelHealth'
 import { SidePanelMax } from './panels/SidePanelMax'
@@ -64,6 +74,12 @@ export const SIDE_PANEL_TABS: Record<
         label: 'Docs',
         Icon: IconInfo,
         Content: SidePanelDocs,
+        noModalSupport: true,
+    },
+    [SidePanelTab.Changelog]: {
+        label: 'Changelog',
+        Icon: IconSparkles,
+        Content: SidePanelChangelog,
         noModalSupport: true,
     },
 

--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -5,13 +5,13 @@ import { useActions, useValues } from 'kea'
 import { useEffect, useRef } from 'react'
 
 import {
+    IconBook,
     IconEllipsis,
     IconGear,
     IconInfo,
     IconLock,
     IconLogomark,
     IconNotebook,
-    IconSparkles,
     IconSupport,
 } from '@posthog/icons'
 import { LemonButton, LemonMenu, LemonMenuItems, LemonModal } from '@posthog/lemon-ui'
@@ -78,7 +78,7 @@ export const SIDE_PANEL_TABS: Record<
     },
     [SidePanelTab.Changelog]: {
         label: 'Changelog',
-        Icon: IconSparkles,
+        Icon: IconBook,
         Content: SidePanelChangelog,
         noModalSupport: true,
     },

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelChangelog.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelChangelog.tsx
@@ -1,0 +1,49 @@
+import clsx from 'clsx'
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { sceneLogic } from 'scenes/sceneLogic'
+
+import { SidePanelPaneHeader } from '../components/SidePanelPaneHeader'
+import { sidePanelStateLogic } from '../sidePanelStateLogic'
+import { SidePanelDocsSkeleton } from './SidePanelDocs'
+
+const CHANGELOG_BASE_URL = 'https://posthog.com/changelog'
+
+export function SidePanelChangelog(): JSX.Element {
+    const { closeSidePanel } = useActions(sidePanelStateLogic)
+    const { sceneConfig } = useValues(sceneLogic)
+    const [ready, setReady] = useState(false)
+
+    const teamSlug = sceneConfig?.changelogTeamSlug
+    const changelogUrl = teamSlug ? `${CHANGELOG_BASE_URL}?team=${encodeURIComponent(teamSlug)}` : CHANGELOG_BASE_URL
+
+    return (
+        <>
+            <SidePanelPaneHeader>
+                <div className="flex-1" />
+                <LemonButton
+                    size="small"
+                    targetBlank
+                    onClick={() => {
+                        window.open(changelogUrl, '_blank')?.focus()
+                        closeSidePanel()
+                    }}
+                >
+                    Open in new tab
+                </LemonButton>
+            </SidePanelPaneHeader>
+            <div className="relative flex-1 overflow-hidden">
+                <iframe
+                    src={changelogUrl}
+                    title="Changelog"
+                    className={clsx('w-full h-full', !ready && 'hidden')}
+                    onLoad={() => setReady(true)}
+                />
+                {!ready && <SidePanelDocsSkeleton />}
+            </div>
+        </>
+    )
+}

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelChangelog.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelChangelog.tsx
@@ -1,33 +1,15 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { useMemo, useState } from 'react'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
-import { sceneLogic } from 'scenes/sceneLogic'
-
 import { SidePanelPaneHeader } from '../components/SidePanelPaneHeader'
-import { sidePanelStateLogic } from '../sidePanelStateLogic'
 import { SidePanelDocsSkeleton } from './SidePanelDocs'
-
-const CHANGELOG_BASE_URL = 'https://posthog.com/changelog'
+import { sidePanelChangelogLogic } from './sidePanelChangelogLogic'
 
 export function SidePanelChangelog(): JSX.Element {
-    const { closeSidePanel } = useActions(sidePanelStateLogic)
-    const { sceneConfig } = useValues(sceneLogic)
-    const [ready, setReady] = useState(false)
-
-    const changelogUrl = useMemo(() => {
-        const params = new URLSearchParams()
-        if (sceneConfig?.changelogTeamSlug) {
-            params.set('team', sceneConfig.changelogTeamSlug)
-        }
-        if (sceneConfig?.changelogCategory) {
-            params.set('category', sceneConfig.changelogCategory)
-        }
-        const queryString = params.toString()
-        return queryString ? `${CHANGELOG_BASE_URL}?${queryString}` : CHANGELOG_BASE_URL
-    }, [sceneConfig?.changelogTeamSlug, sceneConfig?.changelogCategory])
+    const { changelogUrl, iframeReady } = useValues(sidePanelChangelogLogic)
+    const { closeSidePanel, setIframeReady } = useActions(sidePanelChangelogLogic)
 
     return (
         <>
@@ -48,10 +30,10 @@ export function SidePanelChangelog(): JSX.Element {
                 <iframe
                     src={changelogUrl}
                     title="Changelog"
-                    className={clsx('w-full h-full', !ready && 'hidden')}
-                    onLoad={() => setReady(true)}
+                    className={clsx('w-full h-full', !iframeReady && 'hidden')}
+                    onLoad={() => setIframeReady(true)}
                 />
-                {!ready && <SidePanelDocsSkeleton />}
+                {!iframeReady && <SidePanelDocsSkeleton />}
             </div>
         </>
     )

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelChangelog.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelChangelog.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
@@ -17,8 +17,17 @@ export function SidePanelChangelog(): JSX.Element {
     const { sceneConfig } = useValues(sceneLogic)
     const [ready, setReady] = useState(false)
 
-    const teamSlug = sceneConfig?.changelogTeamSlug
-    const changelogUrl = teamSlug ? `${CHANGELOG_BASE_URL}?team=${encodeURIComponent(teamSlug)}` : CHANGELOG_BASE_URL
+    const changelogUrl = useMemo(() => {
+        const params = new URLSearchParams()
+        if (sceneConfig?.changelogTeamSlug) {
+            params.set('team', sceneConfig.changelogTeamSlug)
+        }
+        if (sceneConfig?.changelogCategory) {
+            params.set('category', sceneConfig.changelogCategory)
+        }
+        const queryString = params.toString()
+        return queryString ? `${CHANGELOG_BASE_URL}?${queryString}` : CHANGELOG_BASE_URL
+    }, [sceneConfig?.changelogTeamSlug, sceneConfig?.changelogCategory])
 
     return (
         <>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelChangelogLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelChangelogLogic.ts
@@ -1,0 +1,47 @@
+import { actions, connect, kea, path, reducers, selectors } from 'kea'
+
+import { sceneLogic } from 'scenes/sceneLogic'
+import { SceneConfig } from 'scenes/sceneTypes'
+
+import { sidePanelStateLogic } from '../sidePanelStateLogic'
+import type { sidePanelChangelogLogicType } from './sidePanelChangelogLogicType'
+
+const CHANGELOG_BASE_URL = 'https://posthog.com/changelog'
+
+export const sidePanelChangelogLogic = kea<sidePanelChangelogLogicType>([
+    path(['scenes', 'navigation', 'sidepanel', 'sidePanelChangelogLogic']),
+    connect(() => ({
+        actions: [sidePanelStateLogic, ['closeSidePanel']],
+        values: [sceneLogic, ['sceneConfig']],
+    })),
+
+    actions({
+        setIframeReady: (ready: boolean) => ({ ready }),
+    }),
+
+    reducers(() => ({
+        iframeReady: [
+            false as boolean,
+            {
+                setIframeReady: (_, { ready }) => ready,
+            },
+        ],
+    })),
+
+    selectors({
+        changelogUrl: [
+            (s) => [s.sceneConfig],
+            (sceneConfig: SceneConfig) => {
+                const params = new URLSearchParams()
+                if (sceneConfig?.changelogTeamSlug) {
+                    params.set('team', sceneConfig.changelogTeamSlug)
+                }
+                if (sceneConfig?.changelogCategory) {
+                    params.set('category', sceneConfig.changelogCategory)
+                }
+                const queryString = params.toString()
+                return queryString ? `${CHANGELOG_BASE_URL}?${queryString}` : CHANGELOG_BASE_URL
+            },
+        ],
+    }),
+])

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -26,6 +26,7 @@ const ALWAYS_EXTRA_TABS = [
     SidePanelTab.Exports,
     SidePanelTab.SdkDoctor,
     SidePanelTab.Health,
+    SidePanelTab.Changelog,
 ]
 
 const TABS_REQUIRING_A_TEAM = [

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -112,6 +112,7 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                 tabs.push(SidePanelTab.Settings)
                 tabs.push(SidePanelTab.SdkDoctor)
                 tabs.push(SidePanelTab.Health)
+                tabs.push(SidePanelTab.Changelog)
 
                 if (!currentTeam) {
                     return tabs.filter((tab) => !TABS_REQUIRING_A_TEAM.includes(tab))

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -363,6 +363,7 @@ export const productConfiguration: Record<string, any> = {
         iconType: 'logs',
         description: 'Monitor and analyze your logs to understand and fix issues.',
         defaultDocsPath: '/docs/logs',
+        changelogTeamSlug: 'Logs',
     },
     ManagedMigration: { name: 'Managed migrations', projectBased: true },
     ManagedMigrationNew: { name: 'Managed migrations', projectBased: true },

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -259,6 +259,8 @@ export interface SceneConfig {
     defaultDocsPath?: string | (() => string) | (() => Promise<string>)
     /** Team slug for changelog - appended as ?team= to the changelog URL in the side panel */
     changelogTeamSlug?: string
+    /** Category for changelog - appended as ?category= to the changelog URL in the side panel */
+    changelogCategory?: string
     /** Component import, used only in manifests */
     import?: () => Promise<any>
     /** Custom icon for the tabs */

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -257,6 +257,8 @@ export interface SceneConfig {
     activityScope?: ActivityScope | string
     /** Default docs path - what the docs side panel will open by default when this scene is active  */
     defaultDocsPath?: string | (() => string) | (() => Promise<string>)
+    /** Team slug for changelog - appended as ?team= to the changelog URL in the side panel */
+    changelogTeamSlug?: string
     /** Component import, used only in manifests */
     import?: () => Promise<any>
     /** Custom icon for the tabs */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5530,6 +5530,7 @@ export enum SidePanelTab {
     Notebooks = 'notebook',
     Support = 'support',
     Docs = 'docs',
+    Changelog = 'changelog',
     Activation = 'activation',
     Settings = 'settings',
     Activity = 'activity',

--- a/products/logs/manifest.tsx
+++ b/products/logs/manifest.tsx
@@ -17,6 +17,7 @@ export const manifest: ProductManifest = {
             iconType: 'logs',
             description: 'Monitor and analyze your logs to understand and fix issues.',
             defaultDocsPath: '/docs/logs',
+            changelogTeamSlug: 'Logs',
         },
     },
     routes: {


### PR DESCRIPTION
## Problem

When I'm using a product (like Logs), I want to see what's shipped recently without leaving the app to go dig through the website changelog. The current "What's new?" in the Account Menu dumps you into the generic changelog with no context about the product you're actually using.

## Changes

<img width="344" height="660" alt="image" src="https://github.com/user-attachments/assets/6daf28c7-1b65-4998-8db1-01f38c47e53a" />
<img width="1707" height="694" alt="image" src="https://github.com/user-attachments/assets/cc81f823-e840-45a9-9f24-e4e0280bd3e0" />

- New `SidePanelTab.Changelog` in the side panel ellipsis menu 🎉
- Embeds `posthog.com/changelog` in an iframe, stays in-app
- Added `changelogTeamSlug` and `changelogCategory` to scene config - products can specify their team slug and/or category for filtered changelogs relevant to what they're using
- Proper URL param building via `URLSearchParams` - supports `?team=` and `?category=` params (or both)
- Logs gets it first (`changelogTeamSlug: 'Logs'`)

## How to?

- Find your product category team slug or category on https://posthog.com/changelog   
![image.png](https://app.graphite.com/user-attachments/assets/a903ae14-24ad-4a87-ab00-497daade33ab.png)
- Use the URL Param e.g. `?team=Logs` to update your product's `manifest.tsx` with either `changelogTeamSlug` or `changelogCategory`

## Follow-ups

I would like to integrate directly with the [posthog.com](http://posthog.com) changelog endpoint so we can pull new changes in dynamically & check for updates since the user last visited, providing a badge/modal popup to help orient users. Elevenlabs does this nicely as an example.

- [ ] Badge/notification dot when there are unread changelog entries for the current product
- [ ] Optional modal or popover highlighting new features (similar to Max AI's "What's new" popover)
- [ ] Roll out `changelogTeamSlug`/`changelogCategory` to other products

## How did you test this code?

Clicked around, opened the changelog tab, verified iframe loads with correct `?team=` param on Logs scene, works without team slug on other scenes.

## Changelog: (features only) Is this feature complete?

Yes! Future products to follow.