### PR TITLE
fix(external): skip tests requiring OIDC token for external PRs

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -9,6 +9,7 @@ from products.tasks.backend.temporal.process_task.activities.update_task_run_sta
 )
 
 
+@pytest.mark.requires_secrets
 class TestUpdateTaskRunStatusActivity:
     @pytest.mark.django_db
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

External contributor PRs are failing due to missing OIDC token:
https://github.com/PostHog/posthog/actions/runs/20568544631/job/59071138650?pr=44020

## Changes

We have `@pytest.mark.requires_secrets` for this.

## How did you test this code?

n/a