### PR TITLE
fix: change persistence prefix for replayer resizers

### DIFF
--- a/frontend/src/lib/components/Resizer/resizerLogic.ts
+++ b/frontend/src/lib/components/Resizer/resizerLogic.ts
@@ -10,6 +10,8 @@ export type ResizerEvent = {
 export type ResizerLogicProps = {
     logicKey: string
     persistent?: boolean
+    /** Optional prefix for localStorage key - change this to invalidate cached values */
+    persistPrefix?: string
     placement: 'left' | 'right' | 'top' | 'bottom'
     containerRef: React.RefObject<HTMLDivElement>
     /** At what size, should this rather be considered a "close" event */
@@ -41,7 +43,7 @@ export const resizerLogic = kea<resizerLogicType>([
         ],
         size: [
             null as number | null,
-            { persist: props.persistent },
+            { persist: props.persistent, prefix: props.persistPrefix },
             {
                 setDesiredSize: (_, { size }) => size,
                 resetDesiredSize: () => null,

--- a/frontend/src/scenes/session-recordings/player/PlayerSidebar.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSidebar.tsx
@@ -32,7 +32,7 @@ export function PlayerSidebar(): JSX.Element {
         logicKey,
         containerRef: ref,
         persistent: true,
-        persistPrefix: '2024-12-29',
+        persistPrefix: '2025-12-29',
         closeThreshold: 100,
         placement: isVerticallyStacked ? 'top' : 'left',
         onToggleClosed: (shouldBeClosed) => setSidebarOpen(!shouldBeClosed),

--- a/frontend/src/scenes/session-recordings/player/PlayerSidebar.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSidebar.tsx
@@ -32,6 +32,7 @@ export function PlayerSidebar(): JSX.Element {
         logicKey,
         containerRef: ref,
         persistent: true,
+        persistPrefix: '2024-12-29',
         closeThreshold: 100,
         placement: isVerticallyStacked ? 'top' : 'left',
         onToggleClosed: (shouldBeClosed) => setSidebarOpen(!shouldBeClosed),

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -64,7 +64,7 @@ function HorizontalLayout({
         logicKey: 'playlist-resizer-horizontal',
         containerRef: playlistRef,
         persistent: true,
-        persistPrefix: '2024-12-29',
+        persistPrefix: '2025-12-29',
         placement: 'right',
     }
 
@@ -106,7 +106,7 @@ function VerticalLayout({
         logicKey: 'playlist-resizer-vertical',
         containerRef: playerRef,
         persistent: true,
-        persistPrefix: '2024-12-29',
+        persistPrefix: '2025-12-29',
         placement: 'bottom',
     }
 

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -64,6 +64,7 @@ function HorizontalLayout({
         logicKey: 'playlist-resizer-horizontal',
         containerRef: playlistRef,
         persistent: true,
+        persistPrefix: '2024-12-29',
         placement: 'right',
     }
 
@@ -105,6 +106,7 @@ function VerticalLayout({
         logicKey: 'playlist-resizer-vertical',
         containerRef: playerRef,
         persistent: true,
+        persistPrefix: '2024-12-29',
         placement: 'bottom',
     }
 


### PR DESCRIPTION
i helped a user on reddit https://www.reddit.com/r/posthog/comments/1pv0q2z/comment/nwb0e14/?context=1

after the recent player changes their player was squashed between the tabs and the playlist

clearing local storage fixed this for them

their HTML was different to mine so i think this was a cached asset problem

but it is safe to force all resizer positions back to default to rule that out

so, let's do that



tested locally that i can still resize the player scene and the sizes persist