### PR TITLE
fix(phai): compaction edge cases

### DIFF
--- a/ee/hogai/core/agent_modes/compaction_manager.py
+++ b/ee/hogai/core/agent_modes/compaction_manager.py
@@ -1,7 +1,7 @@
 import json
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 from uuid import uuid4
 
 from langchain_anthropic import ChatAnthropic
@@ -13,7 +13,7 @@ from langchain_core.messages import (
 )
 from langchain_core.tools import BaseTool
 from langchain_core.utils.function_calling import convert_to_openai_tool
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from posthog.schema import (
     AgentMode,
@@ -27,8 +27,10 @@ from posthog.schema import (
 from posthog.sync import database_sync_to_async
 
 from ee.hogai.context.prompts import CONTEXT_INITIAL_MODE_PROMPT
-from ee.hogai.core.agent_modes.prompts import ROOT_AGENT_MODE_REMINDER_PROMPT
+from ee.hogai.core.agent_modes.prompts import ROOT_AGENT_MODE_REMINDER_PROMPT, ROOT_TODO_REMINDER_PROMPT
+from ee.hogai.tools.todo_write import TodoWriteTool
 from ee.hogai.utils.helpers import find_start_message, find_start_message_idx, insert_messages_before_start
+from ee.hogai.utils.prompt import format_prompt_string
 from ee.hogai.utils.types import AssistantMessageUnion
 
 T = TypeVar("T", bound=AssistantMessageUnion)
@@ -158,6 +160,7 @@ class ConversationCompactionManager(ABC):
             start_message_copy,
             window_start_id_candidate,
             agent_mode,
+            all_messages=messages,
         )
 
     def _handle_no_window_boundary(
@@ -168,13 +171,23 @@ class ConversationCompactionManager(ABC):
         agent_mode: AgentMode,
     ) -> InsertionResult:
         """Handle case where no window boundary was found (messages too large)."""
+        # Build the new window
+        new_window_messages: Sequence[AssistantMessageUnion] = [summary_message, start_message_copy]
+
+        # Prepare result messages with summary and start
         result_messages = [*messages, summary_message, start_message_copy]
-        # Check if we need to add a mode reminder
-        if context_message := self._get_mode_message(result_messages, agent_mode):
-            # Insert mode reminder right after summary message
-            result_messages = [*messages, summary_message, context_message, start_message_copy]
+
+        # Insert todo and/or mode reminders between summary and start
+        summary_id = summary_message.id
+        if summary_id:
+            result_messages_with_reminders = self._insert_reminders_after_summary(
+                result_messages, summary_id, agent_mode, all_messages=messages, window_messages=new_window_messages
+            )
+        else:
+            result_messages_with_reminders = result_messages
+
         return InsertionResult(
-            messages=result_messages,
+            messages=result_messages_with_reminders,
             updated_start_id=start_message_copy.id,
             updated_window_start_id=summary_message.id,
         )
@@ -188,11 +201,25 @@ class ConversationCompactionManager(ABC):
         agent_mode: AgentMode,
     ) -> InsertionResult:
         """Handle case where start message is within the window boundary."""
+        # Insert summary before start message
         updated_messages = insert_messages_before_start(messages, [summary_message], start_id=start_id)
+
+        # Calculate the actual window from window_start_id_candidate onwards
+        start_message_idx = find_start_message_idx(messages, window_start_id_candidate)
+        window_messages = messages[start_message_idx:]
+
+        # Insert todo and/or mode reminders after summary
         if summary_message.id:
             updated_messages = list(
-                self._insert_mode_reminder_after_summary(updated_messages, summary_message.id, agent_mode)
+                self._insert_reminders_after_summary(
+                    updated_messages,
+                    summary_message.id,
+                    agent_mode,
+                    all_messages=messages,
+                    window_messages=window_messages,
+                )
             )
+
         return InsertionResult(
             messages=updated_messages,
             updated_start_id=start_id,
@@ -206,38 +233,82 @@ class ConversationCompactionManager(ABC):
         start_message_copy: HumanMessage,
         window_start_id_candidate: str,
         agent_mode: AgentMode,
+        all_messages: Sequence[T] | None = None,
     ) -> InsertionResult:
         """Handle case where start message is outside the window boundary."""
+        # Insert summary and start copy at the beginning of window
         updated_messages = list(
             insert_messages_before_start(
                 new_window, [summary_message, start_message_copy], start_id=window_start_id_candidate
             )
         )
+
+        # Insert todo and/or mode reminders after summary
+        # The window is the new_window (which will be checked for mode/todo presence)
         summary_id = summary_message.id
         if summary_id:
-            updated_messages = list(self._insert_mode_reminder_after_summary(updated_messages, summary_id, agent_mode))
+            updated_messages = list(
+                self._insert_reminders_after_summary(
+                    updated_messages, summary_id, agent_mode, all_messages=all_messages, window_messages=new_window
+                )
+            )
+
         return InsertionResult(
             messages=updated_messages,
             updated_start_id=start_message_copy.id,
             updated_window_start_id=window_start_id_candidate,
         )
 
-    def _insert_mode_reminder_after_summary(
+    def _insert_reminders_after_summary(
         self,
         messages: Sequence[T],
         summary_id: str,
         agent_mode: AgentMode,
+        all_messages: Sequence[T] | None = None,
+        window_messages: Sequence[T] | None = None,
     ) -> Sequence[T]:
-        """Insert mode reminder right after the summary message if needed."""
-        context_message = self._get_mode_message(messages, agent_mode)
-        if not context_message:
+        """
+        Insert both todo reminder (if needed) and mode reminder (if needed) after summary.
+        Order: summary → todo reminder → mode reminder → rest
+
+        Args:
+            messages: The messages list to insert into
+            summary_id: ID of the summary message
+            agent_mode: Current agent mode for mode reminder
+            all_messages: Full message history for finding todo (defaults to messages if None)
+            window_messages: Messages in the new window for checking presence (defaults to messages if None)
+
+        Returns:
+            Updated messages with reminders inserted
+        """
+        if all_messages is None:
+            all_messages = messages
+        if window_messages is None:
+            window_messages = messages
+
+        # Determine what needs to be inserted
+        reminders_to_insert: list[T] = []
+
+        # 1. Todo reminder (if needed)
+        if todo_reminder := self._get_todo_reminder_message(all_messages, window_messages):
+            reminders_to_insert.append(cast(T, todo_reminder))
+
+        # 2. Mode reminder (if needed)
+        if mode_reminder := self._get_mode_message_with_context(window_messages, all_messages, agent_mode):
+            reminders_to_insert.append(cast(T, mode_reminder))
+
+        # If nothing to insert, return original messages
+        if not reminders_to_insert:
             return messages
+
+        # Insert all reminders right after summary
         summary_idx = next(i for i, msg in enumerate(messages) if msg.id == summary_id)
-        return [
+        result: Sequence[T] = [
             *messages[: summary_idx + 1],
-            context_message,
+            *reminders_to_insert,
             *messages[summary_idx + 1 :],
         ]
+        return result
 
     def _get_estimated_assistant_message_tokens(self, message: AssistantMessageUnion) -> int:
         """
@@ -308,10 +379,21 @@ class ConversationCompactionManager(ABC):
     ) -> int:
         raise NotImplementedError
 
-    def _get_mode_message(
-        self, updated_messages: Sequence[AssistantMessageUnion], agent_mode: AgentMode
+    def _get_mode_message_with_context(
+        self,
+        window_messages: Sequence[AssistantMessageUnion],
+        all_messages: Sequence[AssistantMessageUnion],
+        agent_mode: AgentMode,
     ) -> ContextMessage | None:
-        if not self._should_add_mode_reminder(updated_messages):
+        """
+        Get mode reminder message with context-aware checking.
+        Checks initial mode message in all_messages, but mode evidence in window_messages.
+        """
+        # Check if initial mode message exists in full history
+        if self._has_initial_mode_message(all_messages):
+            return None
+        # Check if mode is evident in the current window
+        if self._is_mode_evident_in_window(window_messages):
             return None
         return ContextMessage(
             content=ROOT_AGENT_MODE_REMINDER_PROMPT.format(mode=agent_mode.value),
@@ -353,6 +435,81 @@ class ConversationCompactionManager(ABC):
             if isinstance(message, ContextMessage) and CONTEXT_INITIAL_MODE_PROMPT in message.content:
                 return True
         return False
+
+    def _find_last_todo_write_message(self, messages: Sequence[T]) -> AssistantMessage | None:
+        """
+        Find the last AssistantMessage with a TODO_WRITE tool call.
+        Searches backwards through ALL messages (not just window).
+
+        Returns:
+            The last AssistantMessage containing a TODO_WRITE tool call, or None.
+        """
+        for message in reversed(messages):
+            if isinstance(message, AssistantMessage) and message.tool_calls:
+                for tool_call in message.tool_calls:
+                    if tool_call.name == AssistantTool.TODO_WRITE:
+                        return message
+        return None
+
+    def _is_todo_in_window(self, todo_message: AssistantMessage, window_messages: Sequence[T]) -> bool:
+        """
+        Check if the todo message is present in the given window.
+
+        Args:
+            todo_message: The AssistantMessage containing TODO_WRITE tool call
+            window_messages: Messages in the current window
+
+        Returns:
+            True if todo_message is found in window_messages (by ID or object identity)
+        """
+        # Check by ID if available
+        if todo_message.id:
+            return any(msg.id == todo_message.id for msg in window_messages)
+
+        # Fall back to object identity check if no ID
+        return any(msg is todo_message for msg in window_messages)
+
+    def _get_todo_reminder_message(self, messages: Sequence[T], window_messages: Sequence[T]) -> HumanMessage | None:
+        """
+        Create a todo reminder message if:
+        1. A TODO_WRITE tool call exists in the conversation
+        2. That todo message is NOT in the new window
+
+        Args:
+            messages: All messages (for finding the last todo)
+            window_messages: Messages in the new window (for checking if todo is present)
+
+        Returns:
+            HumanMessage containing the todo reminder, or None if no reminder needed
+        """
+        # Find the last TODO_WRITE tool call
+        todo_message = self._find_last_todo_write_message(messages)
+        if not todo_message:
+            return None
+
+        # Check if it's already in the window
+        if self._is_todo_in_window(todo_message, window_messages):
+            return None
+
+        # Extract the todo list from the tool call
+        if not todo_message.tool_calls:
+            return None
+
+        todo_tool_call = next(
+            (tc for tc in todo_message.tool_calls if tc.name == AssistantTool.TODO_WRITE),
+            None,
+        )
+        if not todo_tool_call:
+            return None
+
+        # Format the reminder message using TodoWriteTool
+        try:
+            todo_content = TodoWriteTool.format_todo_list(todo_tool_call.args)
+        except ValidationError:
+            return None
+
+        reminder_content = format_prompt_string(ROOT_TODO_REMINDER_PROMPT, todo_content=todo_content)
+        return HumanMessage(content=reminder_content, id=str(uuid4()))
 
 
 class AnthropicConversationCompactionManager(ConversationCompactionManager):

--- a/ee/hogai/core/agent_modes/prompts.py
+++ b/ee/hogai/core/agent_modes/prompts.py
@@ -19,3 +19,9 @@ ROOT_CONVERSATION_SUMMARY_PROMPT = """
 This session continues from a prior conversation that exceeded the context window. A summary of that conversation is provided below:
 {summary}
 """.strip()
+
+ROOT_TODO_REMINDER_PROMPT = """
+{{{todo_content}}}
+
+<system_reminder>The above is your latest generated todo list. Use it to continue your work.</system_reminder>
+""".strip()

--- a/ee/hogai/core/agent_modes/test/test_compaction_manager.py
+++ b/ee/hogai/core/agent_modes/test/test_compaction_manager.py
@@ -996,3 +996,532 @@ class TestAnthropicConversationCompactionManager(BaseTest):
             assert isinstance(mode_reminder, ContextMessage)
             self.assertIn(mode.value, mode_reminder.content, f"Mode reminder should contain {mode.value}")
             self.assertNotEqual(mode_reminder.id, summary_id, "Mode reminder should have different ID from summary")
+
+    def test_mode_message_injected_when_old_messages_have_mode_indicator_but_new_window_doesnt(self):
+        """
+        Test edge case: when no window boundary is found and old messages (outside window) contain
+        mode indicators (like switch_mode tool call), the mode reminder should still be injected
+        in the NEW window because the new window doesn't have the mode indicator.
+        """
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+
+        # Old messages contain a switch_mode tool call (which will be outside the new window)
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Question", id=start_id),
+            AssistantMessage(
+                content="Switching mode",
+                tool_calls=[
+                    AssistantToolCall(
+                        id="switch-1",
+                        name=AssistantTool.SWITCH_MODE,
+                        args={"mode": "product_analytics"},
+                    )
+                ],
+            ),
+            AssistantMessage(content="x" * 10000),  # Large message to force no boundary
+        ]
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages,
+            summary_message,
+            AgentMode.PRODUCT_ANALYTICS,
+            start_id=start_id,
+        )
+
+        # The result should have: original messages + summary + mode reminder + copied start
+        # Even though old messages have switch_mode, the NEW window (summary + copied start) doesn't
+        self.assertEqual(len(result.messages), 6)
+
+        # When we filter to get messages in the new window, we should have mode reminder
+        window_messages = self.window_manager.get_messages_in_window(
+            result.messages, window_start_id=result.updated_window_start_id
+        )
+
+        # Window should contain: summary + mode reminder + copied start
+        self.assertEqual(len(window_messages), 3)
+        self.assertEqual(window_messages[0].id, summary_id)
+        self.assertIsInstance(window_messages[1], ContextMessage)
+        assert isinstance(window_messages[1], ContextMessage)
+        self.assertIn("product_analytics", window_messages[1].content)
+        self.assertIsInstance(window_messages[2], HumanMessage)
+
+        # Verify the mode reminder is NOT the switch_mode tool call
+        has_switch_mode_in_window = any(
+            isinstance(msg, AssistantMessage)
+            and msg.tool_calls
+            and any(tc.name == AssistantTool.SWITCH_MODE for tc in msg.tool_calls)
+            for msg in window_messages
+        )
+        self.assertFalse(has_switch_mode_in_window, "New window should not contain old switch_mode tool call")
+
+    def test_todo_reminder_not_injected_when_no_todo_in_conversation(self):
+        """Test that todo reminder is not injected when no TODO_WRITE tool calls exist"""
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Question", id=start_id),
+            AssistantMessage(content="Response"),
+        ]
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages, summary_message, AgentMode.PRODUCT_ANALYTICS, start_id=start_id
+        )
+
+        # Should only have summary and mode reminder, no todo reminder
+        context_messages = [msg for msg in result.messages if isinstance(msg, ContextMessage)]
+        human_messages = [msg for msg in result.messages if isinstance(msg, HumanMessage)]
+
+        # Should have 2 context messages: summary + mode reminder
+        self.assertEqual(len(context_messages), 2)
+        # Should only have 1 human message (the original)
+        self.assertEqual(len(human_messages), 1)
+        self.assertEqual(human_messages[0].id, start_id)
+
+    def test_todo_reminder_not_injected_when_todo_in_window(self):
+        """Test that todo reminder is not injected when TODO_WRITE is within the window"""
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+        todo_id = str(uuid4())
+
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Question", id=start_id),
+            AssistantMessage(
+                content="Creating todos",
+                id=todo_id,
+                tool_calls=[
+                    AssistantToolCall(
+                        id="todo-1",
+                        name=AssistantTool.TODO_WRITE,
+                        args={
+                            "todos": [
+                                {"content": "Task 1", "status": "pending", "id": "1"},
+                                {"content": "Task 2", "status": "in_progress", "id": "2"},
+                            ]
+                        },
+                    )
+                ],
+            ),
+            AssistantMessage(content="Response"),
+        ]
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages, summary_message, AgentMode.PRODUCT_ANALYTICS, start_id=start_id
+        )
+
+        # Should have the original todo message, no todo reminder
+        todo_messages = [
+            msg
+            for msg in result.messages
+            if isinstance(msg, AssistantMessage)
+            and msg.tool_calls
+            and any(tc.name == AssistantTool.TODO_WRITE for tc in msg.tool_calls)
+        ]
+        self.assertEqual(len(todo_messages), 1)
+        self.assertEqual(todo_messages[0].id, todo_id)
+
+        # Should not have a HumanMessage with "todo list" in content
+        human_messages_with_todo = [
+            msg for msg in result.messages if isinstance(msg, HumanMessage) and "todo list" in msg.content.lower()
+        ]
+        self.assertEqual(len(human_messages_with_todo), 0)
+
+    def test_todo_reminder_injected_when_todo_outside_window_no_boundary(self):
+        """Test todo reminder injection when no window boundary and todo is outside"""
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Question", id=start_id),
+            AssistantMessage(
+                content="Creating todos",
+                tool_calls=[
+                    AssistantToolCall(
+                        id="todo-1",
+                        name=AssistantTool.TODO_WRITE,
+                        args={
+                            "todos": [
+                                {"content": "Find events", "status": "pending", "id": "1"},
+                                {"content": "Create plan", "status": "in_progress", "id": "2"},
+                            ]
+                        },
+                    )
+                ],
+            ),
+            AssistantMessage(content="x" * 10000),  # Large message to force no boundary
+        ]
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages, summary_message, AgentMode.PRODUCT_ANALYTICS, start_id=start_id
+        )
+
+        # Should have a HumanMessage with todo reminder
+        todo_reminders = [
+            msg for msg in result.messages if isinstance(msg, HumanMessage) and "todo list" in msg.content.lower()
+        ]
+        self.assertEqual(len(todo_reminders), 1)
+        todo_reminder = todo_reminders[0]
+        self.assertIn("Find events", todo_reminder.content)
+        self.assertIn("Create plan", todo_reminder.content)
+        self.assertIn("system_reminder", todo_reminder.content)
+
+        # Verify order: summary → todo reminder → mode reminder → copied start
+        summary_idx = next(i for i, msg in enumerate(result.messages) if msg.id == summary_id)
+        todo_idx = next(i for i, msg in enumerate(result.messages) if msg.id == todo_reminder.id)
+        mode_idx = next(
+            i
+            for i, msg in enumerate(result.messages)
+            if isinstance(msg, ContextMessage) and "product_analytics" in msg.content
+        )
+
+        self.assertEqual(todo_idx, summary_idx + 1, "Todo reminder should be right after summary")
+        self.assertEqual(mode_idx, todo_idx + 1, "Mode reminder should be right after todo reminder")
+
+    def test_todo_reminder_injected_when_todo_outside_window_start_in_window(self):
+        """Test todo reminder injection when start is in window but todo is not"""
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Old question 1", id=str(uuid4())),
+            AssistantMessage(
+                content="Creating todos",
+                tool_calls=[
+                    AssistantToolCall(
+                        id="todo-1",
+                        name=AssistantTool.TODO_WRITE,
+                        args={"todos": [{"content": "Analyze data", "status": "pending", "id": "1"}]},
+                    )
+                ],
+            ),
+            HumanMessage(content="Old question 2", id=str(uuid4())),
+            AssistantMessage(content="Old response 2"),
+        ]
+
+        # Add many messages to push todo out of window but keep start in window
+        for i in range(10):
+            messages.append(HumanMessage(content=f"Question {i}", id=str(uuid4())))
+            messages.append(AssistantMessage(content=f"Response {i}"))
+
+        messages.append(HumanMessage(content="Recent question", id=start_id))
+        messages.append(AssistantMessage(content="Recent response"))
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages, summary_message, AgentMode.PRODUCT_ANALYTICS, start_id=start_id
+        )
+
+        # Should have a HumanMessage with todo reminder
+        todo_reminders = [
+            msg for msg in result.messages if isinstance(msg, HumanMessage) and "todo list" in msg.content.lower()
+        ]
+        self.assertEqual(len(todo_reminders), 1)
+        self.assertIn("Analyze data", todo_reminders[0].content)
+
+        # Verify order
+        summary_idx = next(i for i, msg in enumerate(result.messages) if msg.id == summary_id)
+        todo_idx = next(i for i, msg in enumerate(result.messages) if msg.id == todo_reminders[0].id)
+        start_idx = next(i for i, msg in enumerate(result.messages) if msg.id == start_id)
+
+        self.assertLess(summary_idx, todo_idx, "Summary before todo")
+        self.assertLess(todo_idx, start_idx, "Todo before start")
+
+    def test_todo_reminder_injected_when_todo_outside_window_start_outside_window(self):
+        """Test todo reminder injection when both start and todo are outside window"""
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Initial question", id=start_id),
+            AssistantMessage(
+                content="Creating todos",
+                tool_calls=[
+                    AssistantToolCall(
+                        id="todo-1",
+                        name=AssistantTool.TODO_WRITE,
+                        args={"todos": [{"content": "Build feature", "status": "in_progress", "id": "1"}]},
+                    )
+                ],
+            ),
+        ]
+
+        # Add many messages to push start and todo out of window
+        for i in range(20):
+            messages.append(HumanMessage(content=f"Question {i}", id=str(uuid4())))
+            messages.append(AssistantMessage(content=f"Response {i}" * 50))
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages, summary_message, AgentMode.PRODUCT_ANALYTICS, start_id=start_id
+        )
+
+        # Should have todo reminder
+        todo_reminders = [
+            msg for msg in result.messages if isinstance(msg, HumanMessage) and "todo list" in msg.content.lower()
+        ]
+        self.assertEqual(len(todo_reminders), 1)
+        self.assertIn("Build feature", todo_reminders[0].content)
+
+    def test_todo_reminder_formats_todos_correctly(self):
+        """Test that todo reminder formats different statuses correctly"""
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Question", id=start_id),
+            AssistantMessage(
+                content="Creating todos",
+                tool_calls=[
+                    AssistantToolCall(
+                        id="todo-1",
+                        name=AssistantTool.TODO_WRITE,
+                        args={
+                            "todos": [
+                                {"content": "Pending task", "status": "pending", "id": "1"},
+                                {"content": "In progress task", "status": "in_progress", "id": "2"},
+                                {"content": "Completed task", "status": "completed", "id": "3"},
+                            ]
+                        },
+                    )
+                ],
+            ),
+            AssistantMessage(content="x" * 10000),  # Force no boundary
+        ]
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages, summary_message, AgentMode.PRODUCT_ANALYTICS, start_id=start_id
+        )
+
+        todo_reminders = [
+            msg for msg in result.messages if isinstance(msg, HumanMessage) and "todo list" in msg.content.lower()
+        ]
+        self.assertEqual(len(todo_reminders), 1)
+        content = todo_reminders[0].content
+
+        # Check status indicators
+        self.assertIn("○ [pending] Pending task", content)
+        self.assertIn("→ [in_progress] In progress task", content)
+        self.assertIn("✓ [completed] Completed task", content)
+
+    def test_todo_reminder_uses_last_todo_when_multiple_exist(self):
+        """Test that only the last TODO_WRITE is used when multiple exist"""
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Question", id=start_id),
+            AssistantMessage(
+                content="First todo",
+                tool_calls=[
+                    AssistantToolCall(
+                        id="todo-1",
+                        name=AssistantTool.TODO_WRITE,
+                        args={"todos": [{"content": "Old task", "status": "pending", "id": "1"}]},
+                    )
+                ],
+            ),
+            AssistantMessage(
+                content="Second todo",
+                tool_calls=[
+                    AssistantToolCall(
+                        id="todo-2",
+                        name=AssistantTool.TODO_WRITE,
+                        args={"todos": [{"content": "New task", "status": "pending", "id": "2"}]},
+                    )
+                ],
+            ),
+            AssistantMessage(content="x" * 10000),
+        ]
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages, summary_message, AgentMode.PRODUCT_ANALYTICS, start_id=start_id
+        )
+
+        todo_reminders = [
+            msg for msg in result.messages if isinstance(msg, HumanMessage) and "todo list" in msg.content.lower()
+        ]
+        self.assertEqual(len(todo_reminders), 1)
+
+        # Should have the new task, not the old one
+        self.assertIn("New task", todo_reminders[0].content)
+        self.assertNotIn("Old task", todo_reminders[0].content)
+
+    def test_todo_reminder_handles_empty_todos_list(self):
+        """Test that empty todos list shows appropriate message"""
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Question", id=start_id),
+            AssistantMessage(
+                content="Empty todo",
+                tool_calls=[AssistantToolCall(id="todo-1", name=AssistantTool.TODO_WRITE, args={"todos": []})],
+            ),
+            AssistantMessage(content="x" * 10000),
+        ]
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages, summary_message, AgentMode.PRODUCT_ANALYTICS, start_id=start_id
+        )
+
+        todo_reminders = [
+            msg for msg in result.messages if isinstance(msg, HumanMessage) and "todo list" in msg.content.lower()
+        ]
+        self.assertEqual(len(todo_reminders), 1)
+        self.assertIn("empty", todo_reminders[0].content.lower())
+
+    def test_todo_and_mode_reminder_both_injected(self):
+        """Test that both todo and mode reminders are injected in correct order"""
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Question", id=start_id),
+            AssistantMessage(
+                content="Todo",
+                tool_calls=[
+                    AssistantToolCall(
+                        id="todo-1",
+                        name=AssistantTool.TODO_WRITE,
+                        args={"todos": [{"content": "Task", "status": "pending", "id": "1"}]},
+                    )
+                ],
+            ),
+            AssistantMessage(content="x" * 10000),
+        ]
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages, summary_message, AgentMode.PRODUCT_ANALYTICS, start_id=start_id
+        )
+
+        # Find all three: summary, todo reminder, mode reminder
+        summary_idx = next(i for i, msg in enumerate(result.messages) if msg.id == summary_id)
+        todo_idx = next(
+            i
+            for i, msg in enumerate(result.messages)
+            if isinstance(msg, HumanMessage) and "todo list" in msg.content.lower()
+        )
+        mode_idx = next(
+            i
+            for i, msg in enumerate(result.messages)
+            if isinstance(msg, ContextMessage) and msg.id != summary_id and "product_analytics" in msg.content
+        )
+
+        # Verify order: summary → todo → mode
+        self.assertLess(summary_idx, todo_idx)
+        self.assertLess(todo_idx, mode_idx)
+
+    def test_todo_reminder_only_no_mode_reminder(self):
+        """Test that only todo reminder is inserted when mode is evident"""
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Question", id=start_id),
+            AssistantMessage(
+                content="Todo",
+                tool_calls=[
+                    AssistantToolCall(
+                        id="todo-1",
+                        name=AssistantTool.TODO_WRITE,
+                        args={"todos": [{"content": "Task", "status": "pending", "id": "1"}]},
+                    )
+                ],
+            ),
+        ]
+
+        # Add many messages to push todo out, but keep switch_mode in window
+        for i in range(15):
+            messages.append(HumanMessage(content=f"Question {i}", id=str(uuid4())))
+            messages.append(AssistantMessage(content=f"Response {i}"))
+
+        # Add switch_mode near the end (will be in window)
+        messages.append(
+            AssistantMessage(
+                content="Switch mode",
+                tool_calls=[
+                    AssistantToolCall(id="switch-1", name=AssistantTool.SWITCH_MODE, args={"mode": "product_analytics"})
+                ],
+            )
+        )
+        messages.append(AssistantMessage(content="Response"))
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages, summary_message, AgentMode.PRODUCT_ANALYTICS, start_id=start_id
+        )
+
+        # Should have todo reminder
+        todo_reminders = [
+            msg for msg in result.messages if isinstance(msg, HumanMessage) and "todo list" in msg.content.lower()
+        ]
+        self.assertGreater(len(todo_reminders), 0)
+
+        # Should NOT have mode reminder (only summary context message)
+        context_messages = [msg for msg in result.messages if isinstance(msg, ContextMessage)]
+        mode_reminders = [msg for msg in context_messages if msg.id != summary_id]
+        self.assertEqual(len(mode_reminders), 0)
+
+    def test_mode_reminder_only_no_todo_reminder(self):
+        """Test that only mode reminder is inserted when todo is in window"""
+        start_id = str(uuid4())
+        summary_id = str(uuid4())
+
+        messages: list[AssistantMessageUnion] = [
+            HumanMessage(content="Old question", id=str(uuid4())),
+            AssistantMessage(content="Old response"),
+            HumanMessage(content="Recent question", id=start_id),
+            AssistantMessage(
+                content="Todo",
+                tool_calls=[
+                    AssistantToolCall(
+                        id="todo-1",
+                        name=AssistantTool.TODO_WRITE,
+                        args={"todos": [{"content": "Task", "status": "pending", "id": "1"}]},
+                    )
+                ],
+            ),
+            AssistantMessage(content="Response"),
+        ]
+
+        summary_message = ContextMessage(content="Summary", id=summary_id)
+
+        result = self.window_manager.update_window(
+            messages, summary_message, AgentMode.PRODUCT_ANALYTICS, start_id=start_id
+        )
+
+        # Should have mode reminder
+        mode_reminders = [
+            msg
+            for msg in result.messages
+            if isinstance(msg, ContextMessage) and msg.id != summary_id and "product_analytics" in msg.content
+        ]
+        self.assertEqual(len(mode_reminders), 1)
+
+        # Should NOT have todo reminder (todo is in window)
+        todo_reminders = [
+            msg
+            for msg in result.messages
+            if isinstance(msg, HumanMessage) and msg.id != start_id and "todo list" in msg.content.lower()
+        ]
+        self.assertEqual(len(todo_reminders), 0)

--- a/ee/hogai/tools/test/test_todo_write.py
+++ b/ee/hogai/tools/test/test_todo_write.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from posthog.test.base import BaseTest
 
 from ee.hogai.tools.todo_write import TodoItem, TodoWriteTool
@@ -11,7 +13,7 @@ class TestTodoWriteTool(BaseTest):
 
     def test_format_todo_list_empty_args(self):
         """Test formatting an empty todo list from args dict"""
-        args = {"todos": []}
+        args: dict[str, Any] = {"todos": []}
         result = TodoWriteTool.format_todo_list(args)
         self.assertEqual(result, "Your todo list is empty.")
 
@@ -19,7 +21,7 @@ class TestTodoWriteTool(BaseTest):
         """Test formatting from args with missing todos key raises validation error"""
         from pydantic import ValidationError
 
-        args = {}
+        args: dict[str, Any] = {}
         with self.assertRaises(ValidationError):
             TodoWriteTool.format_todo_list(args)
 

--- a/ee/hogai/tools/test/test_todo_write.py
+++ b/ee/hogai/tools/test/test_todo_write.py
@@ -1,0 +1,85 @@
+from posthog.test.base import BaseTest
+
+from ee.hogai.tools.todo_write import TodoItem, TodoWriteTool
+
+
+class TestTodoWriteTool(BaseTest):
+    def test_format_todo_list_empty_list(self):
+        """Test formatting an empty todo list from list"""
+        result = TodoWriteTool.format_todo_list([])
+        self.assertEqual(result, "Your todo list is empty.")
+
+    def test_format_todo_list_empty_args(self):
+        """Test formatting an empty todo list from args dict"""
+        args = {"todos": []}
+        result = TodoWriteTool.format_todo_list(args)
+        self.assertEqual(result, "Your todo list is empty.")
+
+    def test_format_todo_list_missing_todos_key(self):
+        """Test formatting from args with missing todos key raises validation error"""
+        from pydantic import ValidationError
+
+        args = {}
+        with self.assertRaises(ValidationError):
+            TodoWriteTool.format_todo_list(args)
+
+    def test_format_todo_list_single_pending_from_objects(self):
+        """Test formatting a single pending todo from TodoItem objects"""
+        todos = [TodoItem(content="Task 1", status="pending", id="1")]
+        result = TodoWriteTool.format_todo_list(todos)
+        expected = "Your current todo list:\n○ [pending] Task 1"
+        self.assertEqual(result, expected)
+
+    def test_format_todo_list_single_pending_from_args(self):
+        """Test formatting a single pending todo from args dict"""
+        args = {"todos": [{"content": "Task 1", "status": "pending", "id": "1"}]}
+        result = TodoWriteTool.format_todo_list(args)
+        expected = "Your current todo list:\n○ [pending] Task 1"
+        self.assertEqual(result, expected)
+
+    def test_format_todo_list_single_in_progress(self):
+        """Test formatting a single in-progress todo"""
+        todos = [TodoItem(content="Task 2", status="in_progress", id="2")]
+        result = TodoWriteTool.format_todo_list(todos)
+        expected = "Your current todo list:\n→ [in_progress] Task 2"
+        self.assertEqual(result, expected)
+
+    def test_format_todo_list_single_completed(self):
+        """Test formatting a single completed todo"""
+        todos = [TodoItem(content="Task 3", status="completed", id="3")]
+        result = TodoWriteTool.format_todo_list(todos)
+        expected = "Your current todo list:\n✓ [completed] Task 3"
+        self.assertEqual(result, expected)
+
+    def test_format_todo_list_multiple_statuses_from_objects(self):
+        """Test formatting a list with multiple different statuses from objects"""
+        todos = [
+            TodoItem(content="Pending task", status="pending", id="1"),
+            TodoItem(content="In progress task", status="in_progress", id="2"),
+            TodoItem(content="Completed task", status="completed", id="3"),
+        ]
+        result = TodoWriteTool.format_todo_list(todos)
+        expected = (
+            "Your current todo list:\n"
+            "○ [pending] Pending task\n"
+            "→ [in_progress] In progress task\n"
+            "✓ [completed] Completed task"
+        )
+        self.assertEqual(result, expected)
+
+    def test_format_todo_list_multiple_statuses_from_args(self):
+        """Test formatting a list with multiple different statuses from args dict"""
+        args = {
+            "todos": [
+                {"content": "Find events", "status": "pending", "id": "1"},
+                {"content": "Create plan", "status": "in_progress", "id": "2"},
+                {"content": "Analyze data", "status": "completed", "id": "3"},
+            ]
+        }
+        result = TodoWriteTool.format_todo_list(args)
+
+        # Check all status indicators are present
+        self.assertIn("○ [pending] Find events", result)
+        self.assertIn("→ [in_progress] Create plan", result)
+        self.assertIn("✓ [completed] Analyze data", result)
+        self.assertIn("Your current todo list:", result)

--- a/ee/hogai/tools/todo_write.py
+++ b/ee/hogai/tools/todo_write.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import ClassVar, Literal, Self
+from typing import Any, ClassVar, Literal, Self
 
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
@@ -225,6 +225,42 @@ class TodoWriteTool(MaxTool):
             "The to-dos were updated successfully. Please keep using the to-do list to track your progress, and continue with any active tasks as appropriate.",
             None,
         )
+
+    @staticmethod
+    def format_todo_list(todos: list[TodoItem] | dict[str, Any]) -> str:
+        """
+        Format a todo list into human-readable content.
+
+        Args:
+            todos: Either a list of TodoItem objects or a dict with 'todos' key (tool call args)
+
+        Returns:
+            Formatted string representation of the todo list
+        """
+        # Parse args dict if needed
+        if isinstance(todos, dict):
+            parsed_args = TodoWriteToolArgs(**todos)
+            todos = parsed_args.todos
+
+        if not todos:
+            return "Your todo list is empty."
+
+        lines = ["Your current todo list:"]
+        for todo in todos:
+            status = todo.status
+            content = todo.content
+
+            # Use status emoji/indicator
+            if status == "completed":
+                indicator = "✓"
+            elif status == "in_progress":
+                indicator = "→"
+            else:  # pending
+                indicator = "○"
+
+            lines.append(f"{indicator} [{status}] {content}")
+
+        return "\n".join(lines)
 
     @classmethod
     async def create_tool_class(


### PR DESCRIPTION
## Problem

Compaction didn't correctly handle the agent mode reminder, plus todo was never appended.

## Changes

- Added todo list reminder functionality to the compaction manager
- When a conversation is compacted, the system now preserves the most recent todo list
- Improved mode reminder logic to check context more intelligently
- Ensured proper ordering of reminders: summary → todo reminder → mode reminder → rest of conversation
- Added helper method to format todo lists in a consistent, readable way
- Added comprehensive test coverage for the new functionality

## How did you test this code?

Manual & unit tests
