### PR TITLE
fix(destinations): log correct status and body on mailchimp PUT error

### DIFF
--- a/posthog/cdp/templates/mailchimp/template_mailchimp.py
+++ b/posthog/cdp/templates/mailchimp/template_mailchimp.py
@@ -58,7 +58,7 @@ if (userStatus.status == 404 or userStatus.status == 200) {
         }
     })
     if (res.status >= 400) {
-        throw Error(f'Error from api.mailchimp.com (status {userStatus.status}): {userStatus.body}')
+        throw Error(f'Error from api.mailchimp.com (status {res.status}): {res.body}')
     }
 } else if (userStatus.status >= 400) {
     throw Error(f'Error from api.mailchimp.com (status {userStatus.status}): {userStatus.body}')


### PR DESCRIPTION
## Problem

We used to log the wrong status and body, thereby masking the real error cause
We also generally have a problem where our mailchimp destination logs 404 errors for several users (eg. https://posthoghelp.zendesk.com/agent/tickets/45680, (moved to PostHog: https://us.posthog.com/project/2/support/tickets/47417) but also confirmed to affect other users, eg. [this one](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjozOCwidHlwZSI6InF1ZXJ5IiwicXVlcnkiOnsic291cmNlLXRhYmxlIjo0MzQ2LCJsaW1pdCI6NTAwMCwiZmlsdGVyIjpbIj0iLFsiZmllbGQiLDE1NjU5Nyx7ImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9XSwiMDE5OWExZjAtYjU5OS0wMDAwLWYzMWMtODAwMzg1NTc0ZmE1Il19fSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319))

## Changes

Logging the correct error now to help users and ourselves discover the real issue

