### PR TITLE
fix: vercel local deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,10 +224,10 @@ jobs:
         steps:
             - name: Get app token
               id: app-token
-              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
+              uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
               with:
-                  app_id: ${{ secrets.GH_APP_POSTHOG_RELEASER_APP_ID }}
-                  private_key: ${{ secrets.GH_APP_POSTHOG_RELEASER_PRIVATE_KEY }}
+                  app-id: ${{ secrets.GH_APP_POSTHOG_RELEASER_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_RELEASER_PRIVATE_KEY }}
 
             - uses: actions/checkout@v4
               with:

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1521,7 +1521,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "posthog-cli"
-version = "0.5.20"
+version = "0.5.21"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.5.20"
+version = "0.5.21"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/api/releases.rs
+++ b/cli/src/api/releases.rs
@@ -73,10 +73,11 @@ impl ReleaseBuilder {
             project: info.repo_name,
         }
     }
+
     pub fn with_git(&mut self, info: GitInfo) -> &mut Self {
         if !self.has_project() {
-            if let Some(url) = &info.remote_url {
-                self.with_project(url);
+            if let Some(name) = &info.repo_name {
+                self.with_project(name);
             }
         }
         if !self.has_version() {

--- a/cli/src/utils/git.rs
+++ b/cli/src/utils/git.rs
@@ -190,7 +190,7 @@ fn get_head_commit(git_dir: &Path, branch: &str) -> Result<String> {
 }
 
 fn get_env_variable(name: &str) -> Option<String> {
-    let env_variable = std::env::var(name).ok()?;
+    let env_variable = std::env::var(name).ok()?.trim().to_string();
     match env_variable.as_ref() {
         "" => None,
         _ => Some(env_variable),

--- a/cli/src/utils/git.rs
+++ b/cli/src/utils/git.rs
@@ -38,28 +38,25 @@ pub fn get_git_info(dir: Option<PathBuf>) -> Result<Option<GitInfo>> {
 }
 
 fn get_git_info_from_vercel() -> Option<GitInfo> {
-    if std::env::var("VERCEL").ok()? != "1" {
-        return None;
-    }
+    get_env_variable("VERCEL")?;
 
-    let branch = std::env::var("VERCEL_GIT_COMMIT_REF").ok()?;
-    let commit_id = std::env::var("VERCEL_GIT_COMMIT_SHA").ok()?;
+    let branch = get_env_variable("VERCEL_GIT_COMMIT_REF")?;
+    let commit_id = get_env_variable("VERCEL_GIT_COMMIT_SHA")?;
+    let repo_slug = get_env_variable("VERCEL_GIT_REPO_SLUG")?;
 
-    let remote_url = build_vercel_remote_url();
-    let repo_name = std::env::var("VERCEL_GIT_REPO_SLUG").ok();
+    let remote_url = build_vercel_remote_url(&repo_slug);
 
     Some(GitInfo {
         remote_url,
-        repo_name,
+        repo_name: Some(repo_slug),
         branch,
         commit_id,
     })
 }
 
-fn build_vercel_remote_url() -> Option<String> {
-    let provider = std::env::var("VERCEL_GIT_PROVIDER").ok()?;
-    let owner = std::env::var("VERCEL_GIT_REPO_OWNER").ok()?;
-    let slug = std::env::var("VERCEL_GIT_REPO_SLUG").ok()?;
+fn build_vercel_remote_url(repo_slug: &String) -> Option<String> {
+    let provider = get_env_variable("VERCEL_GIT_PROVIDER")?;
+    let owner = get_env_variable("VERCEL_GIT_REPO_OWNER")?;
 
     let base_url = match provider.as_str() {
         "github" => "https://github.com",
@@ -68,7 +65,7 @@ fn build_vercel_remote_url() -> Option<String> {
         _ => return None,
     };
 
-    Some(format!("{base_url}/{owner}/{slug}.git"))
+    Some(format!("{base_url}/{owner}/{repo_slug}.git"))
 }
 
 fn find_git_dir(dir: Option<PathBuf>) -> Option<PathBuf> {
@@ -190,4 +187,12 @@ fn get_head_commit(git_dir: &Path, branch: &str) -> Result<String> {
     }
 
     anyhow::bail!("Could not determine commit ID")
+}
+
+fn get_env_variable(name: &str) -> Option<String> {
+    let env_variable = std::env::var(name).ok()?;
+    match env_variable.as_ref() {
+        "" => None,
+        _ => Some(env_variable),
+    }
 }


### PR DESCRIPTION
Related: https://posthoghelp.zendesk.com/agent/tickets/45933 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/48405)

## Problem

Vercel env variables are defined but empty when running `vercel build` locally or in github actions

## Changes

Make sure empty is treated as none
Fix repo name