### PR TITLE
refactor(phai): titles & descriptions of insights

### DIFF
--- a/ee/hogai/chat_agent/funnels/toolkit.py
+++ b/ee/hogai/chat_agent/funnels/toolkit.py
@@ -23,17 +23,9 @@ def generate_funnel_schema() -> dict:
             "type": "object",
             "properties": {
                 "query": dereference_schema(schema),
-                "name": {
-                    "type": "string",
-                    "description": "Short, concise name of the insight (2-7 words) that will be displayed as a header in the insight tile.",
-                },
-                "description": {
-                    "type": "string",
-                    "description": "Short, concise description of the insight (1 sentence)",
-                },
             },
             "additionalProperties": False,
-            "required": ["query", "name", "description"],
+            "required": ["query"],
         },
     }
 

--- a/ee/hogai/chat_agent/retention/toolkit.py
+++ b/ee/hogai/chat_agent/retention/toolkit.py
@@ -26,17 +26,9 @@ def generate_retention_schema() -> dict:
             "type": "object",
             "properties": {
                 "query": dereference_schema(schema),
-                "name": {
-                    "type": "string",
-                    "description": "Short, concise name of the insight (2-7 words) that will be displayed as a header in the insight tile.",
-                },
-                "description": {
-                    "type": "string",
-                    "description": "Short, concise description of the insight (1 sentence)",
-                },
             },
             "additionalProperties": False,
-            "required": ["query", "name", "description"],
+            "required": ["query"],
         },
     }
 

--- a/ee/hogai/chat_agent/schema_generator/nodes.py
+++ b/ee/hogai/chat_agent/schema_generator/nodes.py
@@ -150,8 +150,8 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
         artifact = await self.context_manager.artifacts.create(
             content=VisualizationArtifactContent(
                 query=result.query,
-                name=result.name,
-                description=result.description,
+                name=state.visualization_title,
+                description=state.visualization_description,
                 plan=generated_plan,
             ),
             name=state.visualization_title or "Visualization",

--- a/ee/hogai/chat_agent/schema_generator/test/test_nodes.py
+++ b/ee/hogai/chat_agent/schema_generator/test/test_nodes.py
@@ -92,13 +92,15 @@ class TestSchemaGeneratorNode(BaseTest):
         with patch.object(DummyGeneratorNode, "_model") as generator_model_mock:
             generator_model_mock.return_value = RunnableLambda(
                 lambda _: DummySchema(
-                    query=self.basic_trends, name="Test Query Name", description="Test Query Description"
+                    query=self.basic_trends,
                 ).model_dump()
             )
             new_state = await node(
                 AssistantState(
                     messages=[HumanMessage(content="Text", id="0")],
                     plan="Test Plan Content",
+                    visualization_title="Test Query Name",
+                    visualization_description="Test Query Description",
                     start_id="0",
                 ),
                 config,
@@ -120,13 +122,15 @@ class TestSchemaGeneratorNode(BaseTest):
         with patch.object(DummyGeneratorNode, "_model") as generator_model_mock:
             generator_model_mock.return_value = RunnableLambda(
                 lambda _: DummySchema(
-                    query=self.basic_trends, name="Query Name", description="Description"
+                    query=self.basic_trends,
                 ).model_dump()
             )
             new_state = await node(
                 AssistantState(
                     messages=[HumanMessage(content="Text", id="0")],
                     plan=None,
+                    visualization_title="Query Name",
+                    visualization_description="Description",
                     start_id="0",
                 ),
                 config,

--- a/ee/hogai/chat_agent/schema_generator/utils.py
+++ b/ee/hogai/chat_agent/schema_generator/utils.py
@@ -9,5 +9,3 @@ Q = TypeVar("Q", AssistantHogQLQuery, AssistantTrendsQuery, AssistantFunnelsQuer
 
 class SchemaGeneratorOutput(BaseModel, Generic[Q]):
     query: Q
-    name: str
-    description: str

--- a/ee/hogai/chat_agent/sql/mixins.py
+++ b/ee/hogai/chat_agent/sql/mixins.py
@@ -85,8 +85,6 @@ class HogQLGeneratorMixin(AssistantContextMixin, HogQLDatabaseMixin):
         cleaned_query = result.query.rstrip(";").strip() if result.query else ""
         return SQLSchemaGeneratorOutput(
             query=AssistantHogQLQuery(query=cleaned_query),
-            name=result.name,
-            description=result.description,
         )
 
     @database_sync_to_async(thread_sensitive=False)

--- a/ee/hogai/chat_agent/test/test_chat_agent.py
+++ b/ee/hogai/chat_agent/test/test_chat_agent.py
@@ -334,7 +334,12 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                     {
                         "id": "xyz",
                         "name": "create_insight",
-                        "args": {"insight_type": "trends", "title": "Test Insight", "query_description": "Foobar"},
+                        "args": {
+                            "insight_type": "trends",
+                            "viz_title": "Test Insight",
+                            "viz_description": "Test Description",
+                            "query_description": "Foobar",
+                        },
                     }
                 ],
             )
@@ -345,9 +350,7 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         root_mock.side_effect = cycle([res1, res2])
 
         query = AssistantTrendsQuery(series=[])
-        generator_mock.return_value = RunnableLambda(
-            lambda _: TrendsSchemaGeneratorOutput(query=query, name="Test Insight", description="Test Description")
-        )
+        generator_mock.return_value = RunnableLambda(lambda _: TrendsSchemaGeneratorOutput(query=query))
 
         # First run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
@@ -411,7 +414,12 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                     {
                         "id": "xyz",
                         "name": "create_insight",
-                        "args": {"insight_type": "funnel", "title": "Test Insight", "query_description": "Foobar"},
+                        "args": {
+                            "insight_type": "funnel",
+                            "viz_title": "Test Insight",
+                            "viz_description": "Test Description",
+                            "query_description": "Foobar",
+                        },
                     }
                 ],
             )
@@ -427,9 +435,7 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                 AssistantFunnelsEventsNode(event="$pageleave"),
             ]
         )
-        generator_mock.return_value = RunnableLambda(
-            lambda _: FunnelsSchemaGeneratorOutput(query=query, name="Test Insight", description="Test Description")
-        )
+        generator_mock.return_value = RunnableLambda(lambda _: FunnelsSchemaGeneratorOutput(query=query))
 
         # First run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
@@ -495,7 +501,12 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                     {
                         "id": "xyz",
                         "name": "create_insight",
-                        "args": {"insight_type": "retention", "title": "Test Insight", "query_description": "Foobar"},
+                        "args": {
+                            "insight_type": "retention",
+                            "viz_title": "Test Insight",
+                            "viz_description": "Test Description",
+                            "query_description": "Foobar",
+                        },
                     }
                 ],
             )
@@ -511,9 +522,7 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                 returningEntity=AssistantRetentionActionsNode(name=action.name, id=action.id),
             )
         )
-        generator_mock.return_value = RunnableLambda(
-            lambda _: RetentionSchemaGeneratorOutput(query=query, name="Test Insight", description="Test Description")
-        )
+        generator_mock.return_value = RunnableLambda(lambda _: RetentionSchemaGeneratorOutput(query=query))
 
         # First run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
@@ -578,8 +587,8 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                         "name": "execute_sql",
                         "args": {
                             "query": "SELECT 1",
-                            "name": "Test Insight",
-                            "description": "Test Description",
+                            "viz_title": "Test Insight",
+                            "viz_description": "Test Description",
                         },
                     }
                 ],
@@ -871,9 +880,7 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
             )
         )
         query = AssistantTrendsQuery(series=[])
-        generator_mock.return_value = RunnableLambda(
-            lambda _: TrendsSchemaGeneratorOutput(query=query, name="Test Insight", description="Test Description")
-        )
+        generator_mock.return_value = RunnableLambda(lambda _: TrendsSchemaGeneratorOutput(query=query))
 
         # Create a graph that only uses the root node
         graph = AssistantGraph(self.team, self.user).compile_full_graph()
@@ -933,7 +940,12 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                         {
                             "id": "1",
                             "name": "create_insight",
-                            "args": {"title": "Foobar", "query_description": "Foobar", "insight_type": "trends"},
+                            "args": {
+                                "viz_title": "Foobar",
+                                "viz_description": "Test Description",
+                                "query_description": "Foobar",
+                                "insight_type": "trends",
+                            },
                         }
                     ],
                 )
@@ -1175,7 +1187,12 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                     {
                         "id": "xyz",
                         "name": "create_insight",
-                        "args": {"title": "Foobar", "query_description": "Foobar", "insight_type": "trends"},
+                        "args": {
+                            "viz_title": "Foobar",
+                            "viz_description": "Test Description",
+                            "query_description": "Foobar",
+                            "insight_type": "trends",
+                        },
                     }
                 ],
             )
@@ -1183,9 +1200,7 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         root_mock.return_value = FakeAnthropicRunnableLambdaWithTokenCounter(root_side_effect)
 
         query = AssistantTrendsQuery(series=[])
-        generator_mock.return_value = RunnableLambda(
-            lambda _: TrendsSchemaGeneratorOutput(query=query, name="Test Insight", description="Test Description")
-        )
+        generator_mock.return_value = RunnableLambda(lambda _: TrendsSchemaGeneratorOutput(query=query))
 
         query_executor_mock.return_value = PartialAssistantState(
             messages=[
@@ -1280,7 +1295,12 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                             AssistantToolCall(
                                 id="tool-1",
                                 name="create_insight",
-                                args={"title": "Foobar", "query_description": "Foobar", "insight_type": "trends"},
+                                args={
+                                    "viz_title": "Foobar",
+                                    "viz_description": "Test Description",
+                                    "query_description": "Foobar",
+                                    "insight_type": "trends",
+                                },
                             )
                         ],
                     ),

--- a/ee/hogai/chat_agent/trends/toolkit.py
+++ b/ee/hogai/chat_agent/trends/toolkit.py
@@ -23,17 +23,9 @@ def generate_trends_schema() -> dict:
             "type": "object",
             "properties": {
                 "query": dereference_schema(schema),
-                "name": {
-                    "type": "string",
-                    "description": "Short, concise name of the insight (2-7 words) that will be displayed as a header in the insight tile.",
-                },
-                "description": {
-                    "type": "string",
-                    "description": "Short, concise description of the insight (1 sentence)",
-                },
             },
             "additionalProperties": False,
-            "required": ["query", "name", "description"],
+            "required": ["query"],
         },
     }
 

--- a/ee/hogai/tools/create_insight.py
+++ b/ee/hogai/tools/create_insight.py
@@ -513,9 +513,14 @@ InsightType = Literal["trends", "funnel", "retention"]
 
 
 class CreateInsightToolArgs(BaseModel):
-    title: str = Field(description="A short title for the insight.")
     query_description: str = Field(description="A plan of the query to generate based on the template.")
     insight_type: InsightType = Field(description="The type of insight to generate.")
+    viz_title: str = Field(
+        description="Short, concise name of the insight (2-7 words) that will be displayed as a header in the insight visualization."
+    )
+    viz_description: str = Field(
+        description="Short, concise summary of the insight (1 sentence) that will be displayed as a description in the insight visualization."
+    )
 
 
 class CreateInsightTool(MaxTool):
@@ -546,7 +551,7 @@ class CreateInsightTool(MaxTool):
         return cls(team=team, user=user, state=state, node_path=node_path, config=config, description=prompt)
 
     async def _arun_impl(
-        self, title: str, query_description: str, insight_type: InsightType
+        self, viz_title: str, viz_description: str, query_description: str, insight_type: InsightType
     ) -> tuple[str, ToolMessagesArtifact | None]:
         graph_builder = InsightsGraph(self._team, self._user)
         match insight_type:
@@ -568,7 +573,8 @@ class CreateInsightTool(MaxTool):
             update={
                 "root_tool_call_id": self.tool_call_id,
                 "plan": query_description,
-                "visualization_title": title,
+                "visualization_title": viz_title,
+                "visualization_description": viz_description,
             },
             deep=True,
         )

--- a/ee/hogai/tools/execute_sql/test/test_tool.py
+++ b/ee/hogai/tools/execute_sql/test/test_tool.py
@@ -46,9 +46,9 @@ class TestExecuteSQLTool(ClickhouseTestMixin, NonAtomicBaseTest):
         tool = await self._create_tool()
 
         result_text, artifact_messages = await tool._arun_impl(
-            query="SELECT event, count() as count FROM events GROUP BY event ORDER BY count DESC",
-            name="Event counts",
-            description="Count events by type",
+            "SELECT event, count() as count FROM events GROUP BY event ORDER BY count DESC",
+            "Event counts",
+            "Count events by type",
         )
 
         self.assertEqual(result_text, "")
@@ -65,9 +65,9 @@ class TestExecuteSQLTool(ClickhouseTestMixin, NonAtomicBaseTest):
         tool = await self._create_tool()
 
         result_text, artifact_messages = await tool._arun_impl(
-            query="SELECT event, count() as count FROM events GROUP BY event",
-            name="Test query",
-            description="Test description",
+            "SELECT event, count() as count FROM events GROUP BY event",
+            "Test query",
+            "Test description",
         )
 
         self.assertEqual(result_text, "")

--- a/ee/hogai/tools/execute_sql/tool.py
+++ b/ee/hogai/tools/execute_sql/tool.py
@@ -33,10 +33,12 @@ from .prompts import (
 
 class ExecuteSQLToolArgs(BaseModel):
     query: str = Field(description="The final SQL query to be executed.")
-    name: str = Field(
-        description="Short, concise name of the query (2-5 words) that will be displayed as a header in the query tile."
+    viz_title: str = Field(
+        description="Short, concise name of the SQL query (2-5 words) that will be displayed as a header in the visualization."
     )
-    description: str = Field(description="Short, concise description of the query (1 sentence)")
+    viz_description: str = Field(
+        description="Short, concise summary of the SQL query (1 sentence) that will be displayed as a description in the visualization."
+    )
 
 
 class ExecuteSQLTool(HogQLGeneratorMixin, MaxTool):
@@ -63,8 +65,10 @@ class ExecuteSQLTool(HogQLGeneratorMixin, MaxTool):
         )
         return cls(team=team, user=user, state=state, node_path=node_path, config=config, description=prompt)
 
-    async def _arun_impl(self, query: str, name: str, description: str) -> tuple[str, ToolMessagesArtifact | None]:
-        parsed_query = self._parse_output({"query": query, "name": name, "description": description})
+    async def _arun_impl(
+        self, query: str, viz_title: str, viz_description: str
+    ) -> tuple[str, ToolMessagesArtifact | None]:
+        parsed_query = self._parse_output({"query": query})
         try:
             await self._quality_check_output(
                 output=parsed_query,
@@ -74,9 +78,7 @@ class ExecuteSQLTool(HogQLGeneratorMixin, MaxTool):
 
         # Display an ephemeral visualization message to the user.
         artifact = await self._context_manager.artifacts.create(
-            VisualizationArtifactContent(
-                query=parsed_query.query, name=parsed_query.name, description=parsed_query.description
-            ),
+            VisualizationArtifactContent(query=parsed_query.query, name=viz_title, description=viz_description),
             "SQL Query",
         )
         artifact_message = self._context_manager.artifacts.create_message(
@@ -88,8 +90,8 @@ class ExecuteSQLTool(HogQLGeneratorMixin, MaxTool):
         insight_context = InsightContext(
             team=self._team,
             query=parsed_query.query,
-            name=parsed_query.name,
-            description=parsed_query.description,
+            name=viz_title,
+            description=viz_description,
             insight_id=artifact_message.artifact_id,
         )
 

--- a/ee/hogai/tools/test/test_create_insight.py
+++ b/ee/hogai/tools/test/test_create_insight.py
@@ -88,7 +88,10 @@ class TestCreateInsightTool(ClickhouseTestMixin, NonAtomicBaseTest):
             mock_graph_builder.compile.return_value = mock_compiled_graph
 
             result_text, artifact = await tool._arun_impl(
-                title="Test Chart", query_description="test trends description", insight_type="trends"
+                viz_title="Test Chart",
+                viz_description="Test description",
+                query_description="test trends description",
+                insight_type="trends",
             )
 
         self.assertEqual(result_text, "")
@@ -132,7 +135,12 @@ class TestCreateInsightTool(ClickhouseTestMixin, NonAtomicBaseTest):
             mock_compiled_graph.ainvoke = AsyncMock(return_value=mock_state.model_dump())
             mock_graph_builder.compile.return_value = mock_compiled_graph
 
-            await tool._arun_impl(title="Test Funnel", query_description="test funnel", insight_type="funnel")
+            await tool._arun_impl(
+                viz_title="Test Funnel",
+                viz_description="Test description",
+                query_description="test funnel",
+                insight_type="funnel",
+            )
 
         mock_graph_builder.add_funnel_generator.assert_called_once()
         mock_graph_builder.add_edge.assert_called_with(AssistantNodeName.START, AssistantNodeName.FUNNEL_GENERATOR)
@@ -168,7 +176,12 @@ class TestCreateInsightTool(ClickhouseTestMixin, NonAtomicBaseTest):
             mock_compiled_graph.ainvoke = AsyncMock(return_value=mock_state.model_dump())
             mock_graph_builder.compile.return_value = mock_compiled_graph
 
-            await tool._arun_impl(title="Test Retention", query_description="test retention", insight_type="retention")
+            await tool._arun_impl(
+                viz_title="Test Retention",
+                viz_description="Test description",
+                query_description="test retention",
+                insight_type="retention",
+            )
 
         mock_graph_builder.add_retention_generator.assert_called_once()
         mock_graph_builder.add_edge.assert_called_with(AssistantNodeName.START, AssistantNodeName.RETENTION_GENERATOR)
@@ -192,7 +205,10 @@ class TestCreateInsightTool(ClickhouseTestMixin, NonAtomicBaseTest):
             mock_graph_builder.compile.return_value = mock_compiled_graph
 
             result_text, artifact = await tool._arun_impl(
-                title="Test Chart", query_description="test description", insight_type="trends"
+                viz_title="Test Chart",
+                viz_description="Test description",
+                query_description="test description",
+                insight_type="trends",
             )
 
         self.assertIsNone(artifact)
@@ -233,7 +249,10 @@ class TestCreateInsightTool(ClickhouseTestMixin, NonAtomicBaseTest):
             mock_graph_builder.compile.return_value = mock_compiled_graph
 
             result_text, artifact = await tool._arun_impl(
-                title="Test Chart", query_description="test description", insight_type="trends"
+                viz_title="Test Chart",
+                viz_description="Test description",
+                query_description="test description",
+                insight_type="trends",
             )
 
         self.assertIsNone(artifact)
@@ -259,7 +278,10 @@ class TestCreateInsightTool(ClickhouseTestMixin, NonAtomicBaseTest):
             mock_graph_builder.compile.return_value = mock_compiled_graph
 
             result_text, artifact = await tool._arun_impl(
-                title="Test Chart", query_description="test description", insight_type="funnel"
+                viz_title="Test Chart",
+                viz_description="Test description",
+                query_description="test description",
+                insight_type="funnel",
             )
 
         self.assertEqual(result_text, "")
@@ -300,7 +322,10 @@ class TestCreateInsightTool(ClickhouseTestMixin, NonAtomicBaseTest):
             mock_graph_builder.compile.return_value = mock_compiled_graph
 
             result_text, artifact = await tool._arun_impl(
-                title="Test Chart", query_description="test description", insight_type="trends"
+                viz_title="Test Chart",
+                viz_description="Test description",
+                query_description="test description",
+                insight_type="trends",
             )
 
         self.assertIsNotNone(artifact)
@@ -349,7 +374,12 @@ class TestCreateInsightTool(ClickhouseTestMixin, NonAtomicBaseTest):
             mock_compiled_graph.ainvoke = AsyncMock(side_effect=capture_invoked_state)
             mock_graph_builder.compile.return_value = mock_compiled_graph
 
-            await tool._arun_impl(title="Test Chart", query_description="my test query", insight_type="retention")
+            await tool._arun_impl(
+                viz_title="Test Chart",
+                viz_description="Test description",
+                query_description="my test query",
+                insight_type="retention",
+            )
 
         self.assertIsNotNone(invoked_state)
         validated_state = AssistantState.model_validate(invoked_state)

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -443,6 +443,10 @@ class _SharedAssistantState(BaseStateWithMessages, BaseStateWithIntermediateStep
     """
     The title of the visualization to be created.
     """
+    visualization_description: Optional[str] = Field(default=None)
+    """
+    The description of the visualization to be created.
+    """
 
 
 class AssistantState(_SharedAssistantState):


### PR DESCRIPTION
## Problem

#43767 implemented title and description generation for insights. However, it is happening in the schema generator that only has access to the plan, so context around insights is lost. It is specifically visible in dashboard generation, producing generic titles like "pageviews for 30 days", as the insight meta is not used.

## Changes

- Removed title and description from the schema.
- Added `viz_title` and `viz_description` to the `execute_sql` and `create_insight` tools.

## How did you test this code?

Unit tests and manual testing
