### PR TITLE
feat(ph-ai): search error tracking tool

### DIFF
--- a/ee/hogai/core/agent_modes/presets/error_tracking.py
+++ b/ee/hogai/core/agent_modes/presets/error_tracking.py
@@ -1,0 +1,47 @@
+from typing import TYPE_CHECKING
+
+from posthog.schema import AgentMode
+
+from ee.hogai.core.agent_modes.factory import AgentModeDefinition
+from ee.hogai.core.agent_modes.toolkit import AgentToolkit
+from ee.hogai.tools.todo_write import TodoWriteExample
+
+if TYPE_CHECKING:
+    from ee.hogai.tool import MaxTool
+
+
+POSITIVE_EXAMPLE_SEARCH_ERRORS = """
+User: Show me the most frequent errors from the last week
+Assistant: I'll search for the most frequent error tracking issues from the past week.
+*Uses search_error_tracking_issues with orderBy: "occurrences" and dateRange: { date_from: "-7d" }*
+""".strip()
+
+POSITIVE_EXAMPLE_SEARCH_ERRORS_REASONING = """
+The assistant used the search tool because:
+1. The user wants to find errors based on frequency criteria
+2. The search_error_tracking_issues tool can filter by date range and order by occurrences
+3. This is a straightforward search that doesn't require multiple steps
+""".strip()
+
+
+class ErrorTrackingAgentToolkit(AgentToolkit):
+    POSITIVE_TODO_EXAMPLES = [
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_SEARCH_ERRORS,
+            reasoning=POSITIVE_EXAMPLE_SEARCH_ERRORS_REASONING,
+        ),
+    ]
+
+    @property
+    def tools(self) -> list[type["MaxTool"]]:
+        from products.error_tracking.backend.tools.search_issues import SearchErrorTrackingIssuesTool
+
+        tools: list[type[MaxTool]] = [SearchErrorTrackingIssuesTool]
+        return tools
+
+
+error_tracking_agent = AgentModeDefinition(
+    mode=AgentMode.ERROR_TRACKING,
+    mode_description="Specialized mode for analyzing error tracking issues. This mode allows you to search and filter error tracking issues by status, date range, frequency, and other criteria.",
+    toolkit_class=ErrorTrackingAgentToolkit,
+)

--- a/ee/hogai/test/test_tool.py
+++ b/ee/hogai/test/test_tool.py
@@ -356,6 +356,7 @@ class TestToolAccessControlDeclarations(BaseTest):
         "generate_hogql_query",
         "fix_hogql_query",
         "analyze_user_interviews",
+        "search_error_tracking_issues",
     }
 
     def test_all_tools_have_access_control_or_are_exempt(self):

--- a/ee/hogai/tools/task.py
+++ b/ee/hogai/tools/task.py
@@ -213,9 +213,9 @@ class TaskTool(MaxTool):
         config: RunnableConfig | None = None,
         context_manager: AssistantContextManager | None = None,
     ) -> Self:
-        from ee.hogai.chat_agent.mode_manager import CHAT_AGENT_MODE_REGISTRY
+        from ee.hogai.chat_agent.mode_manager import DEFAULT_CHAT_AGENT_MODE_REGISTRY
 
-        modes_list = list(CHAT_AGENT_MODE_REGISTRY.keys())
+        modes_list = list(DEFAULT_CHAT_AGENT_MODE_REGISTRY.keys())
         # Fix the mode types to the chat agent modes, as there might be other unsupported modes in the AgentMode enum
         SubAgentArgsWithModes = create_model(
             "SubAgentArgsWithModes",
@@ -227,7 +227,7 @@ class TaskTool(MaxTool):
         )
 
         modes_prompt = ""
-        for mode_definition in CHAT_AGENT_MODE_REGISTRY.values():
+        for mode_definition in DEFAULT_CHAT_AGENT_MODE_REGISTRY.values():
             modes_prompt += f"- {mode_definition.mode.value}: {mode_definition.mode_description}\n"
 
         description = format_prompt_string(TASK_TOOL_PROMPT, available_modes=modes_prompt)

--- a/ee/hogai/utils/feature_flags.py
+++ b/ee/hogai/utils/feature_flags.py
@@ -64,3 +64,13 @@ def has_upsert_dashboard_feature_flag(team: Team, user: User) -> bool:
         group_properties={"organization": {"id": str(team.organization_id)}},
         send_feature_flag_events=False,
     )
+
+
+def has_error_tracking_mode_feature_flag(team: Team, user: User) -> bool:
+    return posthoganalytics.feature_enabled(
+        "posthog-ai-error-tracking-mode",
+        str(user.distinct_id),
+        groups={"organization": str(team.organization_id)},
+        group_properties={"organization": {"id": str(team.organization_id)}},
+        send_feature_flag_events=False,
+    )

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -287,6 +287,7 @@ export const FEATURE_FLAGS = {
     MESSAGING_SES: 'messaging-ses', // owner #team-workflows
     NOTEBOOKS_COLLAPSIBLE_SECTIONS: 'notebooks-collapsible-sections', // owner: @daibhin @benjackwhite
     PAGE_REPORTS_AVERAGE_PAGE_VIEW: 'page-reports-average-page-view', // owner: @jordanm-posthog #team-web-analytics
+    PHAI_ERROR_TRACKING_MODE: 'posthog-ai-error-tracking-mode', // owner: #team-posthog-ai
     PHAI_TASKS: 'phai-tasks', // owner: #team-array
     PHAI_WEB_SEARCH: 'phai-web-search', // owner: @Twixes #team-posthog-ai
     PRODUCT_ANALYTICS_DASHBOARD_COLORS: 'dashboard-colors', // owner: @thmsobrmlr #team-product-analytics

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -353,7 +353,7 @@
             "type": "object"
         },
         "AgentMode": {
-            "enum": ["product_analytics", "sql", "session_replay"],
+            "enum": ["product_analytics", "sql", "session_replay", "error_tracking"],
             "type": "string"
         },
         "AggregationAxisFormat": {
@@ -1895,6 +1895,7 @@
                 "create_hog_function_inputs",
                 "create_message_template",
                 "filter_error_tracking_issues",
+                "search_error_tracking_issues",
                 "find_error_tracking_impactful_issue_event_list",
                 "error_tracking_explain_issue",
                 "experiment_results_summary",
@@ -11729,8 +11730,7 @@
                     "type": "object"
                 },
                 "status": {
-                    "enum": ["archived", "active", "resolved", "pending_release", "suppressed"],
-                    "type": "string"
+                    "$ref": "#/definitions/ErrorTrackingIssueStatus"
                 }
             },
             "required": [
@@ -11886,8 +11886,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "enum": ["archived", "active", "resolved", "pending_release", "suppressed"],
-                    "type": "string"
+                    "$ref": "#/definitions/ErrorTrackingIssueStatus"
                 }
             },
             "required": ["assignee", "description", "first_seen", "id", "last_seen", "library", "name", "status"],
@@ -12110,8 +12109,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "enum": ["archived", "active", "resolved", "pending_release", "suppressed", "all"],
-                    "type": "string"
+                    "$ref": "#/definitions/ErrorTrackingQueryStatus"
                 }
             },
             "required": ["orderBy"],
@@ -12129,6 +12127,11 @@
             },
             "required": ["events"],
             "type": "object"
+        },
+        "ErrorTrackingIssueStatus": {
+            "enum": ["archived", "active", "resolved", "pending_release", "suppressed"],
+            "title": "ErrorTrackingIssueStatus",
+            "type": "string"
         },
         "ErrorTrackingQuery": {
             "additionalProperties": false,
@@ -12201,8 +12204,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "enum": ["archived", "active", "resolved", "pending_release", "suppressed", "all"],
-                    "type": "string"
+                    "$ref": "#/definitions/ErrorTrackingQueryStatus"
                 },
                 "tags": {
                     "$ref": "#/definitions/QueryLogTags"
@@ -12282,6 +12284,18 @@
             "required": ["results"],
             "type": "object"
         },
+        "ErrorTrackingQueryStatus": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/ErrorTrackingIssueStatus"
+                },
+                {
+                    "const": "all",
+                    "type": "string"
+                }
+            ],
+            "title": "ErrorTrackingQueryStatus"
+        },
         "ErrorTrackingRelationalIssue": {
             "additionalProperties": false,
             "properties": {
@@ -12318,8 +12332,7 @@
                     "type": ["string", "null"]
                 },
                 "status": {
-                    "enum": ["archived", "active", "resolved", "pending_release", "suppressed"],
-                    "type": "string"
+                    "$ref": "#/definitions/ErrorTrackingIssueStatus"
                 }
             },
             "required": ["id", "name", "description", "assignee", "status", "first_seen"],

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -364,6 +364,7 @@ export type AssistantTool =
     | 'create_hog_function_inputs'
     | 'create_message_template'
     | 'filter_error_tracking_issues'
+    | 'search_error_tracking_issues'
     | 'find_error_tracking_impactful_issue_event_list'
     | 'error_tracking_explain_issue'
     | 'experiment_results_summary'
@@ -400,6 +401,7 @@ export enum AgentMode {
     ProductAnalytics = 'product_analytics',
     SQL = 'sql',
     SessionReplay = 'session_replay',
+    ErrorTracking = 'error_tracking',
 }
 
 export enum SlashCommandName {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2352,7 +2352,7 @@ export interface ErrorTrackingQuery extends DataNode<ErrorTrackingQueryResponse>
     revenuePeriod?: 'all_time' | 'mrr'
     revenueEntity?: 'person' | 'group_0' | 'group_1' | 'group_2' | 'group_3' | 'group_4'
     dateRange: DateRange
-    status?: ErrorTrackingIssue['status'] | 'all'
+    status?: ErrorTrackingQueryStatus
     assignee?: ErrorTrackingIssueAssignee | null
     filterGroup?: PropertyGroupFilter
     filterTestAccounts?: boolean
@@ -2455,12 +2455,18 @@ export enum QuickFilterContext {
     LogsFilters = 'logs-filters',
 }
 
+/** @title ErrorTrackingIssueStatus */
+export type ErrorTrackingIssueStatus = 'archived' | 'active' | 'resolved' | 'pending_release' | 'suppressed'
+
+/** @title ErrorTrackingQueryStatus */
+export type ErrorTrackingQueryStatus = ErrorTrackingIssueStatus | 'all'
+
 export interface ErrorTrackingRelationalIssue {
     id: string
     name: string | null
     description: string | null
     assignee: ErrorTrackingIssueAssignee | null
-    status: 'archived' | 'active' | 'resolved' | 'pending_release' | 'suppressed'
+    status: ErrorTrackingIssueStatus
     /**  @format date-time */
     first_seen: string
     external_issues?: ErrorTrackingExternalReference[]

--- a/frontend/src/scenes/max/components/ModeSelector.tsx
+++ b/frontend/src/scenes/max/components/ModeSelector.tsx
@@ -139,7 +139,17 @@ function buildGeneralTooltip(description: string, defaultTools: ToolDefinition[]
     )
 }
 
-function getModeOptions(deepResearchEnabled: boolean, webSearchEnabled: boolean): LemonSelectSection<ModeValue>[] {
+interface GetModeOptionsParams {
+    deepResearchEnabled: boolean
+    webSearchEnabled: boolean
+    errorTrackingModeEnabled: boolean
+}
+
+function getModeOptions({
+    deepResearchEnabled,
+    webSearchEnabled,
+    errorTrackingModeEnabled,
+}: GetModeOptionsParams): LemonSelectSection<ModeValue>[] {
     const specialOptions = [
         {
             value: null as ModeValue,
@@ -158,10 +168,17 @@ function getModeOptions(deepResearchEnabled: boolean, webSearchEnabled: boolean)
         })
     }
 
+    const modeEntries = Object.entries(MODE_DEFINITIONS).filter(([mode]) => {
+        if (mode === AgentMode.ErrorTracking && !errorTrackingModeEnabled) {
+            return false
+        }
+        return true
+    })
+
     return [
         { options: specialOptions },
         {
-            options: Object.entries(MODE_DEFINITIONS).map(([mode, def]) => ({
+            options: modeEntries.map(([mode, def]) => ({
                 value: mode as AgentMode,
                 label: def.name,
                 icon: def.icon,
@@ -176,12 +193,13 @@ export function ModeSelector(): JSX.Element {
     const { setAgentMode, setDeepResearchMode } = useActions(maxThreadLogic)
     const deepResearchEnabled = useFeatureFlag('MAX_DEEP_RESEARCH')
     const webSearchEnabled = useFeatureFlag('PHAI_WEB_SEARCH')
+    const errorTrackingModeEnabled = useFeatureFlag('PHAI_ERROR_TRACKING_MODE')
 
     const currentValue: ModeValue = deepResearchMode ? 'deep_research' : agentMode
 
     const modeOptions = useMemo(
-        () => getModeOptions(deepResearchEnabled, webSearchEnabled),
-        [deepResearchEnabled, webSearchEnabled]
+        () => getModeOptions({ deepResearchEnabled, webSearchEnabled, errorTrackingModeEnabled }),
+        [deepResearchEnabled, webSearchEnabled, errorTrackingModeEnabled]
     )
 
     const handleChange = (value: ModeValue): void => {

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -563,6 +563,18 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
             return 'Filtering issues...'
         },
     },
+    search_error_tracking_issues: {
+        name: 'Search issues',
+        description: 'Search issues in error tracking',
+        product: Scene.ErrorTracking,
+        icon: iconForType('error_tracking'),
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Found issues'
+            }
+            return 'Searching issues...'
+        },
+    },
     find_error_tracking_impactful_issue_event_list: {
         name: 'Find impactful issues',
         description: 'Find impactful issues affecting your conversion, activation, or any other events',
@@ -899,6 +911,12 @@ export const MODE_DEFINITIONS: Record<AgentMode, ModeDefinition> = {
             Scene.ReplayFilePlayback,
             Scene.ReplaySettings,
         ]),
+    },
+    [AgentMode.ErrorTracking]: {
+        name: 'Error tracking',
+        description: 'Searches and analyzes error tracking issues to help you understand and fix bugs.',
+        icon: iconForType('error_tracking'),
+        scenes: new Set([Scene.ErrorTracking]),
     },
 }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -38,6 +38,7 @@ class AgentMode(StrEnum):
     PRODUCT_ANALYTICS = "product_analytics"
     SQL = "sql"
     SESSION_REPLAY = "session_replay"
+    ERROR_TRACKING = "error_tracking"
 
 
 class AggregationAxisFormat(StrEnum):
@@ -293,6 +294,7 @@ class AssistantTool(StrEnum):
     CREATE_HOG_FUNCTION_INPUTS = "create_hog_function_inputs"
     CREATE_MESSAGE_TEMPLATE = "create_message_template"
     FILTER_ERROR_TRACKING_ISSUES = "filter_error_tracking_issues"
+    SEARCH_ERROR_TRACKING_ISSUES = "search_error_tracking_issues"
     FIND_ERROR_TRACKING_IMPACTFUL_ISSUE_EVENT_LIST = "find_error_tracking_impactful_issue_event_list"
     ERROR_TRACKING_EXPLAIN_ISSUE = "error_tracking_explain_issue"
     EXPERIMENT_RESULTS_SUMMARY = "experiment_results_summary"
@@ -1192,14 +1194,6 @@ class Population(BaseModel):
     success_only: float
 
 
-class Status(StrEnum):
-    ARCHIVED = "archived"
-    ACTIVE = "active"
-    RESOLVED = "resolved"
-    PENDING_RELEASE = "pending_release"
-    SUPPRESSED = "suppressed"
-
-
 class ErrorTrackingExplainIssueToolContext(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1274,20 +1268,19 @@ class OrderDirection1(StrEnum):
     DESC = "DESC"
 
 
-class Status2(StrEnum):
-    ARCHIVED = "archived"
-    ACTIVE = "active"
-    RESOLVED = "resolved"
-    PENDING_RELEASE = "pending_release"
-    SUPPRESSED = "suppressed"
-    ALL = "all"
-
-
 class ErrorTrackingIssueImpactToolOutput(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     events: list[str]
+
+
+class ErrorTrackingIssueStatus(StrEnum):
+    ARCHIVED = "archived"
+    ACTIVE = "active"
+    RESOLVED = "resolved"
+    PENDING_RELEASE = "pending_release"
+    SUPPRESSED = "suppressed"
 
 
 class RevenueEntity(StrEnum):
@@ -1302,14 +1295,6 @@ class RevenueEntity(StrEnum):
 class RevenuePeriod(StrEnum):
     ALL_TIME = "all_time"
     MRR = "mrr"
-
-
-class Status4(StrEnum):
-    ARCHIVED = "archived"
-    ACTIVE = "active"
-    RESOLVED = "resolved"
-    PENDING_RELEASE = "pending_release"
-    SUPPRESSED = "suppressed"
 
 
 class EventDefinition(BaseModel):
@@ -1430,7 +1415,7 @@ class ExperimentMetricOutlierHandling(BaseModel):
     upper_bound_percentile: float | None = None
 
 
-class Status5(StrEnum):
+class Status(StrEnum):
     PENDING = "pending"
     COMPLETED = "completed"
     PARTIAL = "partial"
@@ -9489,7 +9474,7 @@ class ErrorTrackingIssue(BaseModel):
     name: str | None = None
     revenue: float | None = None
     source: str | None = None
-    status: Status
+    status: ErrorTrackingIssueStatus
 
 
 class ErrorTrackingIssueFilteringToolOutput(BaseModel):
@@ -9525,7 +9510,7 @@ class ErrorTrackingIssueFilteringToolOutput(BaseModel):
     orderDirection: OrderDirection1 | None = None
     removedFilterIndexes: list[int] | None = None
     searchQuery: str | None = None
-    status: Status2 | None = None
+    status: ErrorTrackingIssueStatus | str | None = Field(default=None, title="ErrorTrackingQueryStatus")
 
 
 class ErrorTrackingQueryResponse(BaseModel):
@@ -9565,7 +9550,7 @@ class ErrorTrackingRelationalIssue(BaseModel):
     first_seen: AwareDatetime
     id: str
     name: str | None = None
-    status: Status4
+    status: ErrorTrackingIssueStatus
 
 
 class ErrorTrackingSimilarIssuesQueryResponse(BaseModel):
@@ -13396,7 +13381,7 @@ class ErrorTrackingCorrelatedIssue(BaseModel):
     name: str | None = None
     odds_ratio: float
     population: Population
-    status: Status
+    status: ErrorTrackingIssueStatus
 
 
 class ErrorTrackingIssueCorrelationQueryResponse(BaseModel):
@@ -14511,7 +14496,7 @@ class ErrorTrackingQuery(BaseModel):
     revenueEntity: RevenueEntity | None = None
     revenuePeriod: RevenuePeriod | None = None
     searchQuery: str | None = None
-    status: Status2 | None = None
+    status: ErrorTrackingIssueStatus | str | None = Field(default=None, title="ErrorTrackingQueryStatus")
     tags: QueryLogTags | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
     volumeResolution: int
@@ -15578,7 +15563,7 @@ class ExperimentMetricTimeseries(BaseModel):
     metric_uuid: str
     recalculation_created_at: str | None = None
     recalculation_status: str | None = None
-    status: Status5
+    status: Status
     timeseries: dict[str, ExperimentQueryResponse] | None = None
     updated_at: str
 

--- a/products/error_tracking/backend/tools/__init__.py
+++ b/products/error_tracking/backend/tools/__init__.py
@@ -1,0 +1,3 @@
+from .search_issues import SearchErrorTrackingIssuesTool
+
+__all__ = ["SearchErrorTrackingIssuesTool"]

--- a/products/error_tracking/backend/tools/search_issues.py
+++ b/products/error_tracking/backend/tools/search_issues.py
@@ -1,0 +1,252 @@
+from datetime import UTC
+from typing import Literal
+
+from django.utils import timezone
+
+import structlog
+from posthoganalytics import capture_exception
+from pydantic import BaseModel, Field
+
+from posthog.schema import ErrorTrackingIssue, ErrorTrackingIssueStatus, ErrorTrackingQuery
+
+from ee.hogai.context.insight.query_executor import AssistantQueryExecutor
+from ee.hogai.tool import MaxTool, ToolMessagesArtifact
+from ee.hogai.tool_errors import MaxToolRetryableError
+
+logger = structlog.get_logger(__name__)
+
+
+SEARCH_QUERY_EXAMPLES = """
+# Examples
+
+## Status filtering
+- "Show me active errors" → status: "active"
+- "What resolved issues do we have?" → status: "resolved"
+- "Show suppressed errors" → status: "suppressed"
+
+## Text search
+- "TypeError errors" → searchQuery: "TypeError"
+- "Errors mentioning 'undefined'" → searchQuery: "undefined"
+- "Find null pointer exceptions" → searchQuery: "null pointer"
+
+## Date range
+- "Errors from last 7 days" → dateRange: { date_from: "-7d" }
+- "Issues since last week" → dateRange: { date_from: "-7d" }
+- "Errors from December" → dateRange: { date_from: "2024-12-01", date_to: "2024-12-31" }
+
+## Ordering
+- "Most frequent errors" → orderBy: "occurrences", orderDirection: "DESC"
+- "Newest errors first" → orderBy: "first_seen", orderDirection: "DESC"
+- "Most recent errors" → orderBy: "last_seen", orderDirection: "DESC"
+- "Errors affecting most users" → orderBy: "users", orderDirection: "DESC"
+
+## Combined queries
+- "Active TypeError errors from last week" → status: "active", searchQuery: "TypeError", dateRange: { date_from: "-7d" }
+- "Top 10 most frequent resolved issues" → status: "resolved", orderBy: "occurrences", limit: 10
+"""
+
+QUERY_FIELD_DESCRIPTION = f"""
+User's question converted into an error tracking query.
+
+# Query Structure
+
+## status (optional)
+Filter by issue status:
+- "active": Currently active issues (default if not specified)
+- "resolved": Issues marked as resolved
+- "pending_release": Issues pending a release
+- "suppressed": Suppressed/muted issues
+- "archived": Archived issues
+- "all": Show all issues regardless of status
+
+## searchQuery (optional)
+Free text search across:
+- Exception type (e.g., "TypeError", "ReferenceError")
+- Exception message
+- Function names in stack traces
+- File paths in stack traces
+
+## dateRange (REQUIRED)
+Time range for the query:
+- date_from: Start date (relative like "-7d", "-30d" or absolute "2024-12-01")
+- date_to: End date (null for "until now", or absolute date)
+
+Common relative formats:
+- "-7d" = last 7 days
+- "-30d" = last 30 days
+- "-24h" = last 24 hours
+
+Note: All dates in results are displayed in UTC timezone.
+
+## orderBy (REQUIRED)
+Sort results by:
+- "last_seen": When the issue was last seen (most recent activity)
+- "first_seen": When the issue first appeared
+- "occurrences": Total occurrence count
+- "users": Number of affected users
+- "sessions": Number of affected sessions
+- "revenue": Revenue impact (if configured)
+
+## orderDirection (optional)
+- "DESC": Descending (default, highest/newest first)
+- "ASC": Ascending (lowest/oldest first)
+
+## limit (optional)
+Number of results to return (1-100, default 25)
+
+## filterGroup (optional)
+Property filters for advanced filtering. Structure:
+{{
+    "type": "AND" | "OR",
+    "values": [
+        {{
+            "type": "AND" | "OR",
+            "values": [
+                {{
+                    "type": "event" | "person" | "session",
+                    "key": "property_name",
+                    "value": "value_or_array",
+                    "operator": "exact" | "icontains" | "is_set" | ...
+                }}
+            ]
+        }}
+    ]
+}}
+
+Common filter properties:
+- event.$browser: Browser type
+- event.$os: Operating system
+- event.$device_type: Device type (Desktop, Mobile, Tablet)
+- event.$current_url: URL where error occurred
+- event.$lib: SDK/library used (web, posthog-python, posthog-node, etc.)
+
+## filterTestAccounts (optional)
+- true: Exclude internal/test accounts
+- false: Include all accounts
+
+## volumeResolution (REQUIRED)
+Resolution for volume chart data. Use 1 for daily buckets.
+
+{SEARCH_QUERY_EXAMPLES}
+""".strip()
+
+TOOL_DESCRIPTION = """
+Search for error tracking issues based on criteria like status, search text, date range, and ordering.
+
+# When to use this tool:
+- User asks to find, search, or list error tracking issues
+- User asks about errors, exceptions, or issues in their application
+- User wants to filter errors by status, date, frequency, or other criteria
+- User asks questions like "show me recent errors" or "what are the most common issues"
+
+# What this tool returns:
+A formatted list of matching issues with their name, status, occurrence count, and other key metrics.
+All timestamps are in UTC timezone.
+""".strip()
+
+
+class SearchErrorTrackingIssuesArgs(BaseModel):
+    query: ErrorTrackingQuery = Field(description=QUERY_FIELD_DESCRIPTION)
+
+
+class SearchErrorTrackingIssuesTool(MaxTool):
+    name: Literal["search_error_tracking_issues"] = "search_error_tracking_issues"
+    args_schema: type[BaseModel] = SearchErrorTrackingIssuesArgs
+    description: str = TOOL_DESCRIPTION
+
+    async def _arun_impl(self, query: ErrorTrackingQuery) -> tuple[str, ToolMessagesArtifact | None]:
+        # Adding some sane default limits
+        if query.limit is None or query.limit <= 0:
+            query.limit = 25
+        elif query.limit > 100:
+            query.limit = 100
+
+        # Default to active issues if no status specified
+        if query.status is None:
+            query.status = ErrorTrackingIssueStatus.ACTIVE
+
+        try:
+            utc_now = timezone.now().astimezone(UTC)
+            executor = AssistantQueryExecutor(self._team, utc_now)
+            query_results = await executor.aexecute_query(query)
+        except MaxToolRetryableError:
+            raise
+        except Exception as e:
+            capture_exception(e)
+            logger.exception("Error executing error tracking query", error=str(e))
+            return f"Error searching for issues: {e}", None
+
+        return self._format_results(query_results), None
+
+    def _format_results(self, response: dict) -> str:
+        """Format query results as text output."""
+        results = response.get("results", [])
+
+        if not results:
+            return "No issues found matching your criteria."
+
+        total_count = len(results)
+        if total_count == 1:
+            content = "Found 1 issue matching your criteria:\n\n"
+        else:
+            content = f"Found {total_count} issues matching your criteria:\n\n"
+
+        # Show up to 10 issues in the response
+        for i, issue in enumerate(results[:10], 1):
+            content += self._format_issue(i, ErrorTrackingIssue.model_validate(issue))
+
+        if total_count > 10:
+            content += f"\n...and {total_count - 10} more issues"
+
+        return content
+
+    def _format_issue(self, index: int, issue: ErrorTrackingIssue) -> str:
+        """Format a single issue for display."""
+        name = issue.name or "Unnamed issue"
+        status = issue.status or "unknown"
+        first_seen = issue.first_seen
+        last_seen = issue.last_seen
+
+        aggregations = issue.aggregations
+        if aggregations:
+            occurrences = int(aggregations.occurrences or 0)
+            users = int(aggregations.users or 0)
+            sessions = int(aggregations.sessions or 0)
+        else:
+            occurrences = 0
+            users = 0
+            sessions = 0
+
+        first_seen_str = self._format_date(first_seen)
+        last_seen_str = self._format_date(last_seen)
+
+        lines = [f"{index}. {name}"]
+        lines.append(f"   Status: {status} | Occurrences: {occurrences:,} | Users: {users:,} | Sessions: {sessions:,}")
+
+        if first_seen_str or last_seen_str:
+            date_parts = []
+            if first_seen_str:
+                date_parts.append(f"First seen: {first_seen_str}")
+            if last_seen_str:
+                date_parts.append(f"Last seen: {last_seen_str}")
+            lines.append(f"   {' | '.join(date_parts)}")
+
+        # Empty line between issues for formatting
+        lines.append("")
+        return "\n".join(lines)
+
+    def _format_date(self, date_value) -> str:
+        """Format a date value for display in UTC."""
+        if not date_value:
+            return ""
+        from datetime import datetime
+
+        try:
+            if isinstance(date_value, datetime):
+                return date_value.strftime("%Y-%m-%d %H:%M UTC")
+            elif isinstance(date_value, str):
+                dt = datetime.fromisoformat(date_value.replace("Z", "+00:00"))
+                return dt.strftime("%Y-%m-%d %H:%M UTC")
+        except (ValueError, AttributeError):
+            return str(date_value) if date_value else ""
+        return ""

--- a/products/error_tracking/backend/tools/test/test_search_issues.py
+++ b/products/error_tracking/backend/tools/test/test_search_issues.py
@@ -1,0 +1,442 @@
+from freezegun import freeze_time
+from posthog.test.base import (
+    ClickhouseTestMixin,
+    NonAtomicBaseTest,
+    _create_event,
+    _create_person,
+    flush_persons_and_events,
+)
+from unittest.mock import patch
+
+from django.utils.timezone import now
+
+from dateutil.relativedelta import relativedelta
+from langchain_core.runnables import RunnableConfig
+from parameterized import parameterized
+
+from posthog.schema import (
+    DateRange,
+    ErrorTrackingIssue as ErrorTrackingIssueSchema,
+    ErrorTrackingQuery,
+)
+
+from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrackingIssueFingerprintV2
+from products.error_tracking.backend.tools.search_issues import SearchErrorTrackingIssuesTool
+
+from ee.hogai.context.context import AssistantContextManager
+from ee.hogai.utils.types import AssistantState
+from ee.hogai.utils.types.base import NodePath
+
+
+@freeze_time("2025-01-15T12:00:00Z")
+class TestSearchErrorTrackingIssuesTool(ClickhouseTestMixin, NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    distinct_id_one = "user_1"
+    distinct_id_two = "user_2"
+    issue_id_one = "01936e7f-d7ff-7314-b2d4-7627981e34f0"
+    issue_id_two = "01936e80-5e69-7e70-b837-871f5cdad28b"
+    issue_id_three = "01936e80-aa51-746f-aec4-cdf16a5c5332"
+
+    def setUp(self):
+        super().setUp()
+        self.tool_call_id = "test_tool_call_id"
+
+        _create_person(
+            team=self.team,
+            distinct_ids=[self.distinct_id_one],
+            is_identified=True,
+        )
+        _create_person(
+            team=self.team,
+            properties={"email": "email@posthog.com"},
+            distinct_ids=[self.distinct_id_two],
+            is_identified=True,
+        )
+
+        self.create_events_and_issue(
+            issue_id=self.issue_id_one,
+            issue_name="TypeError: Cannot read property 'map' of undefined",
+            fingerprint="issue_one_fingerprint",
+            distinct_ids=[self.distinct_id_one, self.distinct_id_two],
+            timestamp=now() - relativedelta(hours=3),
+        )
+        self.create_events_and_issue(
+            issue_id=self.issue_id_two,
+            issue_name="ReferenceError: foo is not defined",
+            fingerprint="issue_two_fingerprint",
+            distinct_ids=[self.distinct_id_one],
+            timestamp=now() - relativedelta(hours=2),
+        )
+        self.create_events_and_issue(
+            issue_id=self.issue_id_three,
+            issue_name="SyntaxError: Unexpected token",
+            fingerprint="issue_three_fingerprint",
+            distinct_ids=[self.distinct_id_two],
+            timestamp=now() - relativedelta(hours=1),
+            status=ErrorTrackingIssue.Status.RESOLVED,
+        )
+
+        flush_persons_and_events()
+
+    def create_issue(self, issue_id, fingerprint, name=None, status=ErrorTrackingIssue.Status.ACTIVE):
+        issue = ErrorTrackingIssue.objects.create(id=issue_id, team=self.team, status=status, name=name)
+        ErrorTrackingIssueFingerprintV2.objects.create(team=self.team, issue=issue, fingerprint=fingerprint)
+        return issue
+
+    def create_events_and_issue(
+        self,
+        issue_id,
+        fingerprint,
+        distinct_ids,
+        timestamp=None,
+        issue_name=None,
+        status=ErrorTrackingIssue.Status.ACTIVE,
+    ):
+        if timestamp:
+            with freeze_time(timestamp):
+                self.create_issue(issue_id, fingerprint, name=issue_name, status=status)
+        else:
+            self.create_issue(issue_id, fingerprint, name=issue_name, status=status)
+
+        event_properties = {"$exception_issue_id": issue_id, "$exception_fingerprint": fingerprint}
+
+        for distinct_id in distinct_ids:
+            _create_event(
+                distinct_id=distinct_id,
+                event="$exception",
+                team=self.team,
+                properties=event_properties,
+                timestamp=timestamp,
+            )
+
+    async def _create_tool(self, state: AssistantState | None = None):
+        if state is None:
+            state = AssistantState(messages=[])
+
+        config: RunnableConfig = RunnableConfig()
+        context_manager = AssistantContextManager(team=self.team, user=self.user, config=config)
+
+        tool = await SearchErrorTrackingIssuesTool.create_tool_class(
+            team=self.team,
+            user=self.user,
+            state=state,
+            config=config,
+            context_manager=context_manager,
+            node_path=(NodePath(name="test_node", tool_call_id=self.tool_call_id, message_id="test"),),
+        )
+        return tool
+
+    def _create_query(
+        self,
+        date_from="-7d",
+        date_to=None,
+        status=None,
+        search_query=None,
+        order_by="last_seen",
+        limit=25,
+    ) -> ErrorTrackingQuery:
+        return ErrorTrackingQuery(
+            kind="ErrorTrackingQuery",
+            dateRange=DateRange(date_from=date_from, date_to=date_to),
+            status=status,
+            searchQuery=search_query,
+            orderBy=order_by,
+            limit=limit,
+            volumeResolution=1,
+            withAggregations=True,
+        )
+
+    async def test_returns_no_issues_message_when_none_found(self):
+        tool = await self._create_tool()
+        query = self._create_query(search_query="nonexistent_error_xyz")
+
+        result_text, artifact = await tool._arun_impl(query=query)
+
+        self.assertIn("No issues found", result_text)
+        self.assertIsNone(artifact)
+
+    async def test_returns_active_issues_by_default(self):
+        tool = await self._create_tool()
+        query = self._create_query(status="active")
+
+        result_text, artifact = await tool._arun_impl(query=query)
+
+        self.assertIn("Found 2 issues", result_text)
+        self.assertIn("TypeError", result_text)
+        self.assertIn("ReferenceError", result_text)
+        self.assertNotIn("SyntaxError", result_text)
+        self.assertIsNone(artifact)
+
+    async def test_returns_resolved_issues_when_filtered(self):
+        tool = await self._create_tool()
+        query = self._create_query(status="resolved")
+
+        result_text, artifact = await tool._arun_impl(query=query)
+
+        self.assertIn("Found 1 issue", result_text)
+        self.assertIn("SyntaxError", result_text)
+        self.assertNotIn("TypeError", result_text)
+        self.assertIsNone(artifact)
+
+    async def test_returns_all_issues_when_status_all(self):
+        tool = await self._create_tool()
+        query = self._create_query(status="all")
+
+        result_text, artifact = await tool._arun_impl(query=query)
+
+        self.assertIn("Found 3 issues", result_text)
+        self.assertIn("TypeError", result_text)
+        self.assertIn("ReferenceError", result_text)
+        self.assertIn("SyntaxError", result_text)
+        self.assertIsNone(artifact)
+
+    @patch("ee.hogai.context.insight.query_executor.process_query_dict")
+    async def test_search_query_filters_by_text(self, mock_process_query):
+        mock_process_query.return_value = {
+            "results": [
+                {
+                    "id": "01936e7f-d7ff-7314-b2d4-7627981e34f0",
+                    "name": "TypeError: Cannot read property 'map' of undefined",
+                    "status": "active",
+                    "first_seen": "2025-01-10T10:00:00Z",
+                    "last_seen": "2025-01-15T11:00:00Z",
+                    "aggregations": {"occurrences": 1, "users": 1, "sessions": 0, "volume_buckets": []},
+                }
+            ]
+        }
+
+        tool = await self._create_tool()
+        query = self._create_query(status="all", search_query="TypeError")
+
+        result_text, artifact = await tool._arun_impl(query=query)
+
+        self.assertIn("Found 1 issue", result_text)
+        self.assertIn("TypeError", result_text)
+        self.assertIsNone(artifact)
+        # Verify search query was passed
+        call_args = mock_process_query.call_args
+        query_dict = call_args[0][1]
+        self.assertEqual(query_dict["searchQuery"], "TypeError")
+
+    @patch("ee.hogai.context.insight.query_executor.process_query_dict")
+    async def test_respects_limit(self, mock_process_query):
+        mock_process_query.return_value = {
+            "results": [
+                {
+                    "id": "01936e7f-d7ff-7314-b2d4-7627981e34f1",
+                    "name": "Error 1",
+                    "status": "active",
+                    "first_seen": "2025-01-10T10:00:00Z",
+                    "last_seen": "2025-01-15T11:00:00Z",
+                    "aggregations": {"occurrences": 1, "users": 1, "sessions": 0, "volume_buckets": []},
+                },
+                {
+                    "id": "01936e7f-d7ff-7314-b2d4-7627981e34f2",
+                    "name": "Error 2",
+                    "status": "active",
+                    "first_seen": "2025-01-10T10:00:00Z",
+                    "last_seen": "2025-01-15T11:00:00Z",
+                    "aggregations": {"occurrences": 2, "users": 1, "sessions": 0, "volume_buckets": []},
+                },
+            ]
+        }
+
+        tool = await self._create_tool()
+        query = self._create_query(status="all", limit=2)
+
+        result_text, artifact = await tool._arun_impl(query=query)
+
+        self.assertIn("Found 2 issues", result_text)
+        self.assertIsNone(artifact)
+        # Verify limit was passed to the query
+        call_args = mock_process_query.call_args
+        query_dict = call_args[0][1]
+        self.assertEqual(query_dict["limit"], 2)
+
+    async def test_formats_issue_with_aggregations(self):
+        tool = await self._create_tool()
+        query = self._create_query(status="active")
+
+        result_text, artifact = await tool._arun_impl(query=query)
+
+        self.assertIn("Status:", result_text)
+        self.assertIn("Occurrences:", result_text)
+        self.assertIn("Users:", result_text)
+        self.assertIn("Sessions:", result_text)
+        self.assertIsNone(artifact)
+
+    async def test_limits_excessive_limit_to_100(self):
+        tool = await self._create_tool()
+        query = self._create_query(status="all", limit=500)
+
+        result_text, artifact = await tool._arun_impl(query=query)
+
+        # Should cap at 100, but since we only have 3 issues, should return 3
+        self.assertIn("Found 3 issues", result_text)
+        self.assertIsNone(artifact)
+
+    async def test_defaults_to_25_when_no_limit(self):
+        tool = await self._create_tool()
+        query = self._create_query(status="all")
+        query.limit = None  # Explicitly set to None
+
+        result_text, artifact = await tool._arun_impl(query=query)
+
+        # Should default to 25, but since we only have 3 issues, should return 3
+        self.assertIn("Found 3 issues", result_text)
+        self.assertIsNone(artifact)
+
+
+class TestSearchErrorTrackingIssuesToolFormatting(NonAtomicBaseTest):
+    async def _create_tool(self):
+        config: RunnableConfig = RunnableConfig()
+        context_manager = AssistantContextManager(team=self.team, user=self.user, config=config)
+
+        return await SearchErrorTrackingIssuesTool.create_tool_class(
+            team=self.team,
+            user=self.user,
+            state=AssistantState(messages=[]),
+            config=config,
+            context_manager=context_manager,
+            node_path=(NodePath(name="test_node", tool_call_id="test", message_id="test"),),
+        )
+
+    async def test_format_issue_with_all_fields(self):
+        tool = await self._create_tool()
+        issue = ErrorTrackingIssueSchema.model_validate(
+            {
+                "id": "01936e7f-d7ff-7314-b2d4-7627981e34f0",
+                "name": "TypeError: Cannot read 'undefined'",
+                "status": "active",
+                "first_seen": "2025-01-10T10:00:00Z",
+                "last_seen": "2025-01-15T11:00:00Z",
+                "aggregations": {
+                    "occurrences": 150,
+                    "users": 25,
+                    "sessions": 30,
+                    "volume_buckets": [],
+                },
+            }
+        )
+
+        result = tool._format_issue(1, issue)
+
+        self.assertIn("1. TypeError: Cannot read 'undefined'", result)
+        self.assertIn("Status: active", result)
+        self.assertIn("Occurrences: 150", result)
+        self.assertIn("Users: 25", result)
+        self.assertIn("Sessions: 30", result)
+        self.assertIn("First seen:", result)
+        self.assertIn("Last seen:", result)
+
+    async def test_format_issue_with_minimal_fields(self):
+        tool = await self._create_tool()
+        issue = ErrorTrackingIssueSchema.model_validate(
+            {
+                "id": "01936e7f-d7ff-7314-b2d4-7627981e34f0",
+                "status": "active",
+                "first_seen": "2025-01-10T10:00:00Z",
+                "last_seen": "2025-01-15T11:00:00Z",
+            }
+        )
+
+        result = tool._format_issue(1, issue)
+
+        self.assertIn("1. Unnamed issue", result)
+        self.assertIn("Status: active", result)
+
+    async def test_format_results_empty(self):
+        tool = await self._create_tool()
+
+        result = tool._format_results({"results": []})
+
+        self.assertIn("No issues found", result)
+
+    async def test_format_results_single(self):
+        tool = await self._create_tool()
+
+        response = {
+            "results": [
+                {
+                    "id": "01936e7f-d7ff-7314-b2d4-7627981e34f0",
+                    "name": "Error",
+                    "status": "active",
+                    "first_seen": "2025-01-10T10:00:00Z",
+                    "last_seen": "2025-01-15T11:00:00Z",
+                    "aggregations": {"occurrences": 1, "users": 1, "sessions": 0, "volume_buckets": []},
+                }
+            ]
+        }
+
+        result = tool._format_results(response)
+
+        self.assertIn("Found 1 issue", result)
+
+    async def test_format_results_multiple(self):
+        tool = await self._create_tool()
+
+        response = {
+            "results": [
+                {
+                    "id": "01936e7f-d7ff-7314-b2d4-7627981e34f1",
+                    "name": "Error 1",
+                    "status": "active",
+                    "first_seen": "2025-01-10T10:00:00Z",
+                    "last_seen": "2025-01-15T11:00:00Z",
+                    "aggregations": {"occurrences": 1, "users": 1, "sessions": 0, "volume_buckets": []},
+                },
+                {
+                    "id": "01936e7f-d7ff-7314-b2d4-7627981e34f2",
+                    "name": "Error 2",
+                    "status": "active",
+                    "first_seen": "2025-01-10T10:00:00Z",
+                    "last_seen": "2025-01-15T11:00:00Z",
+                    "aggregations": {"occurrences": 2, "users": 2, "sessions": 1, "volume_buckets": []},
+                },
+            ]
+        }
+
+        result = tool._format_results(response)
+
+        self.assertIn("Found 2 issues", result)
+        self.assertIn("1. Error 1", result)
+        self.assertIn("2. Error 2", result)
+
+    async def test_format_results_limits_to_10(self):
+        tool = await self._create_tool()
+
+        response = {
+            "results": [
+                {
+                    "id": f"01936e7f-d7ff-7314-b2d4-7627981e34{i:02d}",
+                    "name": f"Error {i}",
+                    "status": "active",
+                    "first_seen": "2025-01-10T10:00:00Z",
+                    "last_seen": "2025-01-15T11:00:00Z",
+                    "aggregations": {"occurrences": i, "users": i, "sessions": 0, "volume_buckets": []},
+                }
+                for i in range(15)
+            ]
+        }
+
+        result = tool._format_results(response)
+
+        self.assertIn("Found 15 issues", result)
+        self.assertIn("...and 5 more issues", result)
+        self.assertIn("1. Error 0", result)
+        self.assertIn("10. Error 9", result)
+        self.assertNotIn("11.", result)
+
+    @parameterized.expand(
+        [
+            ("2025-01-15T10:30:00Z", "2025-01-15 10:30 UTC"),
+            ("2025-01-15T10:30:00+00:00", "2025-01-15 10:30 UTC"),
+            ("", ""),
+            (None, ""),
+        ]
+    )
+    async def test_format_date_handles_various_formats(self, date_value, expected):
+        tool = await self._create_tool()
+        result = tool._format_date(date_value)
+        self.assertEqual(result, expected)

--- a/products/error_tracking/frontend/components/IssueQueryOptions/issueQueryOptionsLogic.ts
+++ b/products/error_tracking/frontend/components/IssueQueryOptions/issueQueryOptionsLogic.ts
@@ -47,7 +47,7 @@ export const issueQueryOptionsLogic = kea<issueQueryOptionsLogicType>([
         setRevenueEntity: (revenueEntity: ErrorTrackingQueryRevenueEntity) => ({ revenueEntity }),
         setRevenuePeriod: (revenuePeriod: ErrorTrackingQueryRevenuePeriod) => ({ revenuePeriod }),
         setAssignee: (assignee: ErrorTrackingIssue['assignee']) => ({ assignee }),
-        setStatus: (status: ErrorTrackingQuery['status']) => ({ status }),
+        setStatus: (status: ErrorTrackingQueryStatus) => ({ status }),
     }),
 
     reducers({


### PR DESCRIPTION
## Problem

PostHog AI's error tracking integration was limited and lacked proper context awareness. When users asked about explaining the errors the user was visiting, we were failing. Even the `MaxTool` we had for `Explain This` was not working.

https://github.com/user-attachments/assets/bd4c7ffa-c4b1-4070-8638-06d656011faa

This meant users had to manually navigate to error tracking pages and couldn't leverage PostHog AI for error investigation workflows E2E.

## Changes

https://github.com/user-attachments/assets/9a0a0cea-34be-4d10-9ad8-670167bf82b3

(this shows the E2E work after all 3 stacked PRs are combined)

* Implements the error tracking issues search tool, so that users can correctly search and filter error tracking issues by status, date range, frequency, and text queries.
* Added `ErrorTracking` agent mode

The previous approach would have teh base `search` tool call with free-text string whilst now we are going to use a structured `ErrorTrackingQuery` schema so that we piggyback on existing Error Tracking UI work.

## How did you test this code?

- [x] unit tests
- [x] manual tests

**Note**: Work is splitted into three stacked PRs:

1. https://github.com/PostHog/posthog/pull/44050 (this one)
2. https://github.com/PostHog/posthog/pull/44055
3. https://github.com/PostHog/posthog/pull/44057