### PR TITLE
fix(kafka-deduplicator): Storage fixes

### DIFF
--- a/rust/kafka-deduplicator/src/rocksdb/metrics_consts.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/metrics_consts.rs
@@ -44,5 +44,8 @@ pub const ROCKSDB_SST_FILES_COUNT_GAUGE: &str = "rocksdb_sst_files_count";
 /// Gauge for estimated number of keys in a column family
 pub const ROCKSDB_ESTIMATE_NUM_KEYS_GAUGE: &str = "rocksdb_estimate_num_keys";
 
+/// Gauge for age of oldest data in seconds (how far back the data goes)
+pub const ROCKSDB_OLDEST_DATA_AGE_SECONDS_GAUGE: &str = "rocksdb_oldest_data_age_seconds";
+
 /// Counter for RocksDB errors
 pub const ROCKSDB_ERRORS_COUNTER: &str = "rocksdb_errors_total";

--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -455,20 +455,40 @@ impl DeduplicationStore {
             index_end.as_ref(),
         )?;
 
-        // Calculate bytes freed
+        // Trigger async compaction to help RocksDB reclaim space from tombstones.
+        // delete_range creates tombstones but doesn't immediately free disk space.
+        // Compaction runs in the background and merges/removes tombstoned data.
+        // We trigger it for all column families that were modified.
+        info!(
+            "Store {}:{} - Triggering async compaction after cleanup",
+            self.topic, self.partition
+        );
+        self.store.compact_range(
+            Self::TIMESTAMP_CF,
+            Some(first_key_bytes.as_ref()),
+            Some(last_key_bytes.as_ref()),
+        );
+        self.store.compact_range(
+            Self::UUID_TIMESTAMP_INDEX_CF,
+            Some(index_start.as_ref()),
+            Some(index_end.as_ref()),
+        );
+        // UUID_CF doesn't have range-based keys, so compact the full range
+        self.store
+            .compact_range(Self::UUID_CF, None::<&[u8]>, None::<&[u8]>);
+
+        // Calculate bytes freed (note: this may show 0 since compaction is async,
+        // but the space will be reclaimed in the background)
         let final_size = self.get_total_size()?;
         let bytes_freed = initial_size.saturating_sub(final_size);
 
-        // Log cleanup results for this store
-        if bytes_freed > 0 {
-            info!(
-                "Store {}:{} cleanup freed {} bytes in {:?}",
-                self.topic,
-                self.partition,
-                bytes_freed,
-                start_time.elapsed()
-            );
-        }
+        info!(
+            "Store {}:{} cleanup completed in {:?} (immediate bytes freed: {}, compaction running in background)",
+            self.topic,
+            self.partition,
+            start_time.elapsed(),
+            bytes_freed
+        );
 
         Ok(bytes_freed)
     }


### PR DESCRIPTION
## Problem

The kafka-deduplicator's storage cleanup mechanism was ineffective, allowing disk usage to grow to 2x the configured limit (200GB vs 100GB max). Possible causes:

1. Cleanup triggered  only at 100% capacity, without headroom for compaction
2. `delete_range` doesn't free space immediately,  as it creates tombstones. Therefore, actual space is only eventually reclaimed by background compaction
3. No compaction trigger after cleanup could mean RocksDB wasn't prioritizing space reclamation
5. **Too many small SST files** - 64MB files resulted in ~17,000+ files across all partitions

## Changes

- Start cleanup at 80% capacity instead of 100%, giving compaction 20% headroom to reclaim space
- Trigger async compaction after `delete_range` to hint RocksDB to prioritize tombstone cleanup
- Remove cleanup cap when critical - at >90% capacity, allow up to 50% cleanup 
- Target 70% after cleanup (down from 80%) to create more buffer
- Increase SST file size to 256MB (was 64MB) to reduce file count

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
