### PR TITLE
feat(logs): add column reordering and consolidate attribute column config

### DIFF
--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -593,6 +593,63 @@ describe('logsViewerLogic', () => {
         })
     })
 
+    describe('attribute columns', () => {
+        beforeEach(() => {
+            logic = logsViewerLogic({ tabId: 'test-tab', logs: mockLogs, orderBy: 'latest' })
+            logic.mount()
+        })
+
+        describe('moveAttributeColumn', () => {
+            beforeEach(async () => {
+                // Set up initial columns: [A, B, C]
+                logic.actions.toggleAttributeColumn('A')
+                logic.actions.toggleAttributeColumn('B')
+                logic.actions.toggleAttributeColumn('C')
+                await expectLogic(logic).toFinishAllListeners()
+            })
+
+            it('moves column left', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.moveAttributeColumn('B', 'left')
+                }).toMatchValues({
+                    attributeColumns: ['B', 'A', 'C'],
+                })
+            })
+
+            it('moves column right', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.moveAttributeColumn('B', 'right')
+                }).toMatchValues({
+                    attributeColumns: ['A', 'C', 'B'],
+                })
+            })
+
+            it('does nothing when moving first column left', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.moveAttributeColumn('A', 'left')
+                }).toMatchValues({
+                    attributeColumns: ['A', 'B', 'C'],
+                })
+            })
+
+            it('does nothing when moving last column right', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.moveAttributeColumn('C', 'right')
+                }).toMatchValues({
+                    attributeColumns: ['A', 'B', 'C'],
+                })
+            })
+
+            it('does nothing for non-existent column', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.moveAttributeColumn('Z', 'left')
+                }).toMatchValues({
+                    attributeColumns: ['A', 'B', 'C'],
+                })
+            })
+        })
+    })
+
     describe('per-row prettification', () => {
         beforeEach(() => {
             logic = logsViewerLogic({ tabId: 'test-tab', logs: mockLogs, orderBy: 'latest' })

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -8,9 +8,15 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
-import { LogsOrderBy, ParsedLogMessage } from '../../types'
+import { AttributeColumnConfig, LogsOrderBy, ParsedLogMessage } from '../../types'
 import type { logsViewerLogicType } from './logsViewerLogicType'
 import { logsViewerSettingsLogic } from './logsViewerSettingsLogic'
+
+// Helper to get next order value for a new column
+const getNextOrder = (config: Record<string, AttributeColumnConfig>): number => {
+    const orders = Object.values(config).map((c) => c.order)
+    return orders.length > 0 ? Math.max(...orders) + 1 : 0
+}
 
 export interface VisibleLogsTimeRange {
     date_from: string
@@ -82,6 +88,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         toggleAttributeColumn: (attributeKey: string) => ({ attributeKey }),
         removeAttributeColumn: (attributeKey: string) => ({ attributeKey }),
         setAttributeColumnWidth: (attributeKey: string, width: number) => ({ attributeKey, width }),
+        moveAttributeColumn: (attributeKey: string, direction: 'left' | 'right') => ({ attributeKey, direction }),
 
         // Row height recomputation (triggered by child components when content changes)
         recomputeRowHeights: (logIds?: string[]) => ({ logIds }),
@@ -181,30 +188,46 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
             },
         ],
 
-        // Attribute columns shown in log list
-        attributeColumns: [
-            [] as string[],
+        // Attribute columns config (order, width, etc.)
+        attributeColumnsConfig: [
+            {} as Record<string, AttributeColumnConfig>,
             { persist: true },
             {
                 toggleAttributeColumn: (state, { attributeKey }) => {
-                    if (state.includes(attributeKey)) {
-                        return state.filter((k: string) => k !== attributeKey)
+                    if (attributeKey in state) {
+                        const { [attributeKey]: _, ...rest } = state
+                        return rest
                     }
-                    return [...state, attributeKey]
+                    return { ...state, [attributeKey]: { order: getNextOrder(state) } }
                 },
-                removeAttributeColumn: (state, { attributeKey }) => state.filter((k: string) => k !== attributeKey),
-            },
-        ],
-
-        // Attribute column widths (user-resizable)
-        attributeColumnWidths: [
-            {} as Record<string, number>,
-            { persist: true },
-            {
-                setAttributeColumnWidth: (state, { attributeKey, width }) => ({ ...state, [attributeKey]: width }),
                 removeAttributeColumn: (state, { attributeKey }) => {
                     const { [attributeKey]: _, ...rest } = state
                     return rest
+                },
+                setAttributeColumnWidth: (state, { attributeKey, width }) => {
+                    if (!(attributeKey in state)) {
+                        return state
+                    }
+                    return { ...state, [attributeKey]: { ...state[attributeKey], width } }
+                },
+                moveAttributeColumn: (state, { attributeKey, direction }) => {
+                    if (!(attributeKey in state)) {
+                        return state
+                    }
+                    const entries = Object.entries(state) as [string, AttributeColumnConfig][]
+                    const sorted = entries.sort(([, a], [, b]) => a.order - b.order)
+                    const index = sorted.findIndex(([key]) => key === attributeKey)
+                    const targetIndex = direction === 'left' ? index - 1 : index + 1
+                    if (targetIndex < 0 || targetIndex >= sorted.length) {
+                        return state
+                    }
+                    // Swap orders
+                    const [targetKey] = sorted[targetIndex]
+                    return {
+                        ...state,
+                        [attributeKey]: { ...state[attributeKey], order: state[targetKey].order },
+                        [targetKey]: { ...state[targetKey], order: state[attributeKey].order },
+                    }
                 },
             },
         ],
@@ -298,11 +321,31 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
 
         logsCount: [(s) => [s.logs], (logs: ParsedLogMessage[]): number => logs.length],
 
+        // Derived: ordered array of attribute column keys
+        attributeColumns: [
+            (s) => [s.attributeColumnsConfig],
+            (config: Record<string, AttributeColumnConfig>): string[] =>
+                Object.entries(config)
+                    .sort(([, a], [, b]) => a.order - b.order)
+                    .map(([key]) => key),
+        ],
+
+        // Derived: width lookup for attribute columns
+        attributeColumnWidths: [
+            (s) => [s.attributeColumnsConfig],
+            (config: Record<string, AttributeColumnConfig>): Record<string, number> =>
+                Object.fromEntries(
+                    Object.entries(config)
+                        .filter(([, c]) => c.width !== undefined)
+                        .map(([key, c]) => [key, c.width as number])
+                ),
+        ],
+
         isAttributeColumn: [
-            (s) => [s.attributeColumns],
-            (attributeColumns: string[]) =>
+            (s) => [s.attributeColumnsConfig],
+            (config: Record<string, AttributeColumnConfig>) =>
                 (attributeKey: string): boolean =>
-                    attributeColumns.includes(attributeKey),
+                    attributeKey in config,
         ],
 
         // Selection selectors

--- a/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
@@ -1,7 +1,6 @@
-import { IconBrackets, IconChevronRight, IconPin, IconPinFilled, IconX } from '@posthog/icons'
+import { IconBrackets, IconChevronRight, IconPin, IconPinFilled } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, Tooltip } from '@posthog/lemon-ui'
 
-import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
 import { TZLabel, TZLabelProps } from 'lib/components/TZLabel'
 import { cn } from 'lib/utils/css-classes'
 
@@ -15,7 +14,6 @@ import {
     ACTIONS_WIDTH,
     CHECKBOX_WIDTH,
     EXPAND_WIDTH,
-    MIN_ATTRIBUTE_COLUMN_WIDTH,
     RESIZER_HANDLE_WIDTH,
     ROW_GAP,
     SEVERITY_WIDTH,
@@ -213,106 +211,6 @@ export function LogRow({
                 </div>
             </div>
             {isExpanded && <ExpandedLogContent log={log} logIndex={logIndex} />}
-        </div>
-    )
-}
-
-export interface LogRowHeaderProps {
-    rowWidth: number
-    attributeColumns?: string[]
-    attributeColumnWidths?: Record<string, number>
-    onRemoveAttributeColumn?: (attributeKey: string) => void
-    onResizeAttributeColumn?: (attributeKey: string, width: number) => void
-    // Selection
-    selectedCount?: number
-    totalCount?: number
-    onSelectAll?: () => void
-    onClearSelection?: () => void
-}
-
-export function LogRowHeader({
-    rowWidth,
-    attributeColumns = [],
-    attributeColumnWidths = {},
-    onRemoveAttributeColumn,
-    onResizeAttributeColumn,
-    selectedCount = 0,
-    totalCount = 0,
-    onSelectAll,
-    onClearSelection,
-}: LogRowHeaderProps): JSX.Element {
-    const flexWidth =
-        rowWidth -
-        getFixedColumnsWidth(attributeColumns, attributeColumnWidths) -
-        attributeColumns.length * RESIZER_HANDLE_WIDTH
-
-    const allSelected = totalCount > 0 && selectedCount === totalCount
-    const someSelected = selectedCount > 0 && selectedCount < totalCount
-
-    return (
-        <div
-            style={{ width: rowWidth, gap: ROW_GAP }}
-            className="flex items-center h-8 border-b border-border bg-bg-3000 text-xs font-semibold text-muted sticky top-0 z-10"
-        >
-            {/* Severity + Checkbox + Expand header space */}
-            <div className="flex items-center self-stretch">
-                <div style={{ width: SEVERITY_WIDTH, flexShrink: 0 }} />
-                <div className="flex items-center justify-center shrink-0" style={{ width: CHECKBOX_WIDTH }}>
-                    <LemonCheckbox
-                        checked={someSelected ? 'indeterminate' : allSelected}
-                        onChange={() => (allSelected ? onClearSelection?.() : onSelectAll?.())}
-                        size="small"
-                    />
-                </div>
-                <div style={{ width: EXPAND_WIDTH, flexShrink: 0 }} />
-            </div>
-
-            {/* Timestamp */}
-            <div className="flex items-center pr-3" style={{ width: TIMESTAMP_WIDTH, flexShrink: 0 }}>
-                Timestamp
-            </div>
-
-            {/* Attribute columns */}
-            {attributeColumns.map((attributeKey) => {
-                const width = getAttributeColumnWidth(attributeKey, attributeColumnWidths)
-                return (
-                    <ResizableElement
-                        key={`attr-${attributeKey}`}
-                        defaultWidth={width + RESIZER_HANDLE_WIDTH}
-                        minWidth={MIN_ATTRIBUTE_COLUMN_WIDTH + RESIZER_HANDLE_WIDTH}
-                        maxWidth={Infinity}
-                        onResize={(newWidth) =>
-                            onResizeAttributeColumn?.(attributeKey, newWidth - RESIZER_HANDLE_WIDTH)
-                        }
-                        className="flex items-center h-full shrink-0 group/header"
-                        innerClassName="h-full"
-                    >
-                        <div className="flex items-center pr-3 gap-1 h-full w-full">
-                            <span className="truncate flex-1" title={attributeKey}>
-                                {attributeKey}
-                            </span>
-                            {onRemoveAttributeColumn && (
-                                <LemonButton
-                                    size="xsmall"
-                                    noPadding
-                                    icon={<IconX className="text-muted" />}
-                                    onClick={() => onRemoveAttributeColumn(attributeKey)}
-                                    tooltip="Remove column"
-                                    className="opacity-0 group-hover/header:opacity-100 shrink-0"
-                                />
-                            )}
-                        </div>
-                    </ResizableElement>
-                )
-            })}
-
-            {/* Message */}
-            <div className="flex items-center px-1" style={getMessageStyle(flexWidth)}>
-                Message
-            </div>
-
-            {/* Actions (no label) */}
-            <div className="flex items-center px-1" style={{ width: ACTIONS_WIDTH, flexShrink: 0 }} />
         </div>
     )
 }

--- a/products/logs/frontend/components/VirtualizedLogsList/LogRowHeader.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRowHeader.tsx
@@ -1,0 +1,149 @@
+import { IconArrowLeft, IconArrowRight, IconEllipsis, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonCheckbox, LemonMenu } from '@posthog/lemon-ui'
+
+import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
+
+import {
+    ACTIONS_WIDTH,
+    CHECKBOX_WIDTH,
+    EXPAND_WIDTH,
+    MIN_ATTRIBUTE_COLUMN_WIDTH,
+    RESIZER_HANDLE_WIDTH,
+    ROW_GAP,
+    SEVERITY_WIDTH,
+    TIMESTAMP_WIDTH,
+    getAttributeColumnWidth,
+    getFixedColumnsWidth,
+    getMessageStyle,
+} from 'products/logs/frontend/components/VirtualizedLogsList/layoutUtils'
+
+export interface LogRowHeaderProps {
+    rowWidth: number
+    attributeColumns?: string[]
+    attributeColumnWidths?: Record<string, number>
+    onRemoveAttributeColumn?: (attributeKey: string) => void
+    onResizeAttributeColumn?: (attributeKey: string, width: number) => void
+    onMoveAttributeColumn?: (attributeKey: string, direction: 'left' | 'right') => void
+    // Selection
+    selectedCount?: number
+    totalCount?: number
+    onSelectAll?: () => void
+    onClearSelection?: () => void
+}
+
+export function LogRowHeader({
+    rowWidth,
+    attributeColumns = [],
+    attributeColumnWidths = {},
+    onRemoveAttributeColumn,
+    onResizeAttributeColumn,
+    onMoveAttributeColumn,
+    selectedCount = 0,
+    totalCount = 0,
+    onSelectAll,
+    onClearSelection,
+}: LogRowHeaderProps): JSX.Element {
+    const flexWidth =
+        rowWidth -
+        getFixedColumnsWidth(attributeColumns, attributeColumnWidths) -
+        attributeColumns.length * RESIZER_HANDLE_WIDTH
+
+    const allSelected = totalCount > 0 && selectedCount === totalCount
+    const someSelected = selectedCount > 0 && selectedCount < totalCount
+
+    return (
+        <div
+            style={{ width: rowWidth, gap: ROW_GAP }}
+            className="flex items-center h-8 border-b border-border bg-bg-3000 text-xs font-semibold text-muted sticky top-0 z-10"
+        >
+            {/* Severity + Checkbox + Expand header space */}
+            <div className="flex items-center self-stretch">
+                <div style={{ width: SEVERITY_WIDTH, flexShrink: 0 }} />
+                <div className="flex items-center justify-center shrink-0" style={{ width: CHECKBOX_WIDTH }}>
+                    <LemonCheckbox
+                        checked={someSelected ? 'indeterminate' : allSelected}
+                        onChange={() => (allSelected ? onClearSelection?.() : onSelectAll?.())}
+                        size="small"
+                    />
+                </div>
+                <div style={{ width: EXPAND_WIDTH, flexShrink: 0 }} />
+            </div>
+
+            {/* Timestamp */}
+            <div className="flex items-center pr-3" style={{ width: TIMESTAMP_WIDTH, flexShrink: 0 }}>
+                Timestamp
+            </div>
+
+            {/* Attribute columns */}
+            {attributeColumns.map((attributeKey, index) => {
+                const width = getAttributeColumnWidth(attributeKey, attributeColumnWidths)
+                const isFirst = index === 0
+                const isLast = index === attributeColumns.length - 1
+                return (
+                    <ResizableElement
+                        key={`attr-${attributeKey}`}
+                        defaultWidth={width + RESIZER_HANDLE_WIDTH}
+                        minWidth={MIN_ATTRIBUTE_COLUMN_WIDTH + RESIZER_HANDLE_WIDTH}
+                        maxWidth={Infinity}
+                        onResize={(newWidth) =>
+                            onResizeAttributeColumn?.(attributeKey, newWidth - RESIZER_HANDLE_WIDTH)
+                        }
+                        className="flex items-center h-full shrink-0 group/header"
+                        innerClassName="h-full"
+                    >
+                        <div className="flex items-center pr-3 gap-1 h-full w-full">
+                            <span className="truncate flex-1" title={attributeKey}>
+                                {attributeKey}
+                            </span>
+                            {(onRemoveAttributeColumn || onMoveAttributeColumn) && (
+                                <LemonMenu
+                                    items={[
+                                        onMoveAttributeColumn
+                                            ? {
+                                                  label: 'Move left',
+                                                  icon: <IconArrowLeft />,
+                                                  disabledReason: isFirst ? 'Already at the start' : undefined,
+                                                  onClick: () => onMoveAttributeColumn(attributeKey, 'left'),
+                                              }
+                                            : null,
+                                        onMoveAttributeColumn
+                                            ? {
+                                                  label: 'Move right',
+                                                  icon: <IconArrowRight />,
+                                                  disabledReason: isLast ? 'Already at the end' : undefined,
+                                                  onClick: () => onMoveAttributeColumn(attributeKey, 'right'),
+                                              }
+                                            : null,
+                                        onRemoveAttributeColumn
+                                            ? {
+                                                  label: 'Remove column',
+                                                  icon: <IconTrash />,
+                                                  status: 'danger',
+                                                  onClick: () => onRemoveAttributeColumn(attributeKey),
+                                              }
+                                            : null,
+                                    ]}
+                                >
+                                    <LemonButton
+                                        size="xsmall"
+                                        noPadding
+                                        icon={<IconEllipsis className="text-muted" />}
+                                        className="opacity-0 group-hover/header:opacity-100 shrink-0"
+                                    />
+                                </LemonMenu>
+                            )}
+                        </div>
+                    </ResizableElement>
+                )
+            })}
+
+            {/* Message */}
+            <div className="flex items-center px-1" style={getMessageStyle(flexWidth)}>
+                Message
+            </div>
+
+            {/* Actions (no label) */}
+            <div className="flex items-center px-1" style={{ width: ACTIONS_WIDTH, flexShrink: 0 }} />
+        </div>
+    )
+}

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -9,7 +9,8 @@ import { List, ListRowProps } from 'react-virtualized/dist/es/List'
 import { TZLabelProps } from 'lib/components/TZLabel'
 
 import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
-import { LogRow, LogRowHeader } from 'products/logs/frontend/components/VirtualizedLogsList/LogRow'
+import { LogRow } from 'products/logs/frontend/components/VirtualizedLogsList/LogRow'
+import { LogRowHeader } from 'products/logs/frontend/components/VirtualizedLogsList/LogRowHeader'
 import {
     LOG_ROW_HEADER_HEIGHT,
     RESIZER_HANDLE_WIDTH,
@@ -61,6 +62,7 @@ export function VirtualizedLogsList({
         userSetCursorIndex,
         removeAttributeColumn,
         setAttributeColumnWidth,
+        moveAttributeColumn,
         toggleSelectLog,
         selectAll,
         clearSelection,
@@ -253,6 +255,7 @@ export function VirtualizedLogsList({
                                     attributeColumnWidths={attributeColumnWidths}
                                     onRemoveAttributeColumn={removeAttributeColumn}
                                     onResizeAttributeColumn={setAttributeColumnWidth}
+                                    onMoveAttributeColumn={moveAttributeColumn}
                                     selectedCount={selectedCount}
                                     totalCount={dataSource.length}
                                     onSelectAll={() => selectAll(dataSource)}
@@ -296,6 +299,7 @@ export function VirtualizedLogsList({
                                 attributeColumnWidths={attributeColumnWidths}
                                 onRemoveAttributeColumn={removeAttributeColumn}
                                 onResizeAttributeColumn={setAttributeColumnWidth}
+                                onMoveAttributeColumn={moveAttributeColumn}
                                 selectedCount={selectedCount}
                                 totalCount={dataSource.length}
                                 onSelectAll={() => selectAll(dataSource)}

--- a/products/logs/frontend/types.ts
+++ b/products/logs/frontend/types.ts
@@ -4,3 +4,8 @@ import { JsonType } from '~/types'
 export type ParsedLogMessage = LogMessage & { cleanBody: string; parsedBody: JsonType | null }
 
 export type LogsOrderBy = 'earliest' | 'latest' | undefined
+
+export interface AttributeColumnConfig {
+    order: number
+    width?: number
+}


### PR DESCRIPTION
## Problem

Attribute column ordering was arbitrary and could not be changed. Additionally, column configuration was split across two separate reducers (`attributeColumns: string[]` and `attributeColumnWidths: Record<string, number>`), which would make future DB persistence problematic since arrays don't guarantee ordering.

## Changes

<img width="331" height="158" alt="image" src="https://github.com/user-attachments/assets/624e9429-d123-4bca-b510-3314571cd56f" />

- Refactored attribute column storage from separate `attributeColumns` array and `attributeColumnWidths` record into a unified `attributeColumnsConfig: Record<string, AttributeColumnConfig>` where each entry has `order` and optional `width` properties
- Added `moveAttributeColumn(key, 'left' | 'right')` action to reorder columns
- Extracted `LogRowHeader` into its own file with a dropdown menu (vertical ellipsis) containing:
  - Move left (disabled when first)
  - Move right (disabled when last)
  - Remove column (danger styling)
- Derived `attributeColumns` and `attributeColumnWidths` as selectors so the consumer API remains unchanged

## How did you test this code?

- Added unit tests for `moveAttributeColumn` covering:
  - Moving column left/right
  - No-op when at boundary (first/last)
  - No-op for non-existent column
- Manual testing of column reordering via dropdown menu

## Follow-ups
- [ ] Make all columns configurable, even the default ones
- [ ] Add column expressions & column types

## Changelog: (features only) Is this feature complete?

Yes you can order attribute columns now