### PR TITLE
fix: realtime cohort calculation timeout and Kafka format

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -833,6 +833,7 @@ async def get_client(
             team_id, settings.CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT
         )
     max_block_size = kwargs.pop("max_block_size", None) or default_max_block_size
+    http_send_timeout = kwargs.pop("http_send_timeout", 0)
 
     if clickhouse_url is None:
         url = settings.CLICKHOUSE_OFFLINE_HTTP_URL
@@ -851,7 +852,7 @@ async def get_client(
         max_block_size=max_block_size,
         cancel_http_readonly_queries_on_client_close=1,
         output_format_arrow_string_as_string="true",
-        http_send_timeout=0,
+        http_send_timeout=http_send_timeout,
         **kwargs,
     ) as client:
         yield client

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -175,14 +175,16 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                         product=Product.MESSAGING,
                         query_type="realtime_cohort_calculation",
                     ):
-                        async with get_client(team_id=cohort.team_id) as client:
+                        status_counts = {"entered": 0, "left": 0}
+                        async with get_client(team_id=cohort.team_id, http_send_timeout=300) as client:
                             async for row in client.stream_query_as_jsonl(final_query, query_parameters=query_params):
                                 status = row["status"]
+                                status_counts[status] += 1
                                 payload = {
                                     "team_id": cohort.team_id,
                                     "cohort_id": cohort.id,
                                     "person_id": str(row["person_id"]),
-                                    "last_updated": dt.datetime.now(dt.UTC).isoformat(),
+                                    "last_updated": dt.datetime.now(dt.UTC).strftime("%Y-%m-%d %H:%M:%S.%f"),
                                     "status": status,
                                 }
                                 await asyncio.to_thread(
@@ -192,7 +194,10 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                                     data=payload,
                                 )
 
-                                get_membership_changed_metric(status).add(1)
+                        if status_counts["entered"] > 0:
+                            get_membership_changed_metric("entered").add(status_counts["entered"])
+                        if status_counts["left"] > 0:
+                            get_membership_changed_metric("left").add(status_counts["left"])
 
                     get_cohort_calculation_success_metric().add(1)
                     cohorts_count += 1


### PR DESCRIPTION
## Problem

The realtime cohort calculation workflow was experiencing query timeouts and Kafka parsing errors when writing to the `cohort_membership` table.

## Changes

1. **Allow workflow-specific `http_send_timeout` override**
- Modified `get_client()` to extract `http_send_timeout` from kwargs
- Set `http_send_timeout=300` for cohort calculation queries to prevent connection timeouts

2. **Fix DateTime64 format for Kafka JSONEachRow parsing**
- Changed `last_updated` from `.isoformat()` to `.strftime("%Y-%m-%d %H:%M:%S.%f")`
- Matches DateTime64(6) format used in other parts of the codebase

3. **Batch metric updates**
- Count status changes during streaming and update metrics once at the end

## How did you test this code?

Testing in progress - monitoring workflow execution and Kafka message consumption.

## Changelog: (features only) Is this feature complete?

No - this is a bug fix.
