### PR TITLE
fix: error on string frames

### DIFF
--- a/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
+++ b/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
@@ -41,23 +41,25 @@ export function ExceptionRenderer({
 }: ExceptionRendererProps): JSX.Element {
     const knownException = useMemo(() => KnownExceptionRegistry.match(exception), [exception])
 
-    const hasProperStackTrace = (
-        stackTrace: ErrorTrackingRawStackTrace | ErrorTrackingResolvedStackTrace | undefined
-    ): boolean => {
-        if (stackTrace === null || stackTrace === undefined) {
-            return false
-        }
+    const hasProperStackTrace = useMemo(
+        () =>
+            (stackTrace: ErrorTrackingRawStackTrace | ErrorTrackingResolvedStackTrace | undefined): boolean => {
+                if (stackTrace === null || stackTrace === undefined) {
+                    return false
+                }
 
-        if (!stackTrace.frames || stackTrace.frames.length === 0) {
-            return false
-        }
+                if (!stackTrace.frames || stackTrace.frames.length === 0) {
+                    return false
+                }
 
-        if (stackTrace.frames.some((frame) => typeof frame !== 'object')) {
-            return false
-        }
+                if (stackTrace.frames.some((frame) => typeof frame !== 'object')) {
+                    return false
+                }
 
-        return true
-    }
+                return true
+            },
+        [exception]
+    )
 
     return (
         <div className={className}>

--- a/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
+++ b/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
@@ -1,12 +1,7 @@
 import { useMemo } from 'react'
 import { match } from 'ts-pattern'
 
-import {
-    ErrorTrackingException,
-    ErrorTrackingRawStackTrace,
-    ErrorTrackingResolvedStackTrace,
-    ErrorTrackingStackFrame,
-} from '../types'
+import { ErrorTrackingException, ErrorTrackingStackFrame } from '../types'
 import { KnownException, KnownExceptionRegistry } from './known-exceptions'
 
 type StackTraceRenderer = (
@@ -41,25 +36,22 @@ export function ExceptionRenderer({
 }: ExceptionRendererProps): JSX.Element {
     const knownException = useMemo(() => KnownExceptionRegistry.match(exception), [exception])
 
-    const hasProperStackTrace = useMemo(
-        () =>
-            (stackTrace: ErrorTrackingRawStackTrace | ErrorTrackingResolvedStackTrace | undefined): boolean => {
-                if (stackTrace === null || stackTrace === undefined) {
-                    return false
-                }
+    const hasProperStackTrace = useMemo(() => {
+        const stackTrace = exception.stacktrace
+        if (stackTrace === null || stackTrace === undefined) {
+            return false
+        }
 
-                if (!stackTrace.frames || stackTrace.frames.length === 0) {
-                    return false
-                }
+        if (!stackTrace.frames || stackTrace.frames.length === 0) {
+            return false
+        }
 
-                if (stackTrace.frames.some((frame) => typeof frame !== 'object' || frame === null)) {
-                    return false
-                }
+        if (stackTrace.frames.some((frame) => typeof frame !== 'object' || frame === null)) {
+            return false
+        }
 
-                return true
-            },
-        [exception]
-    )
+        return true
+    }, [exception])
 
     return (
         <div className={className}>
@@ -67,7 +59,7 @@ export function ExceptionRenderer({
             <div>
                 {match(exception.stacktrace)
                     .when(
-                        (stack) => !hasProperStackTrace(stack),
+                        () => !hasProperStackTrace,
                         () => renderUndefinedTrace(exception, knownException)
                     )
                     .when(

--- a/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
+++ b/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
@@ -52,7 +52,7 @@ export function ExceptionRenderer({
                     return false
                 }
 
-                if (stackTrace.frames.some((frame) => typeof frame !== 'object')) {
+                if (stackTrace.frames.some((frame) => typeof frame !== 'object' || frame === null)) {
                     return false
                 }
 

--- a/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
+++ b/frontend/src/lib/components/Errors/Exception/ExceptionRenderer.tsx
@@ -46,7 +46,7 @@ export function ExceptionRenderer({
             return false
         }
 
-        if (stackTrace.frames.some((frame) => typeof frame !== 'object' || frame === null)) {
+        if (stackTrace.frames.some((frame) => frame === null || typeof frame !== 'object')) {
             return false
         }
 


### PR DESCRIPTION
Display a nicer message when frames are malformed
