### PR TITLE
fix(data-warehouse): use str_to_optional_int for optional NUMBER fields in config generator

### DIFF
--- a/posthog/management/commands/generate_source_configs.py
+++ b/posthog/management/commands/generate_source_configs.py
@@ -129,7 +129,7 @@ class SourceConfigGenerator:
 
         field_parts = []
 
-        converter = self._get_input_converter(field.type)
+        converter = self._get_input_converter(field.type, is_optional=is_optional)
         if converter:
             field_parts.append(f"converter={converter}")
 
@@ -339,12 +339,12 @@ class SourceConfigGenerator:
 
         return type_mapping.get(field_type, "str")
 
-    def _get_input_converter(self, field_type: SourceFieldInputConfigType) -> Optional[str]:
-        converter_mapping = {
-            SourceFieldInputConfigType.NUMBER: "int",
-        }
+    def _get_input_converter(self, field_type: SourceFieldInputConfigType, is_optional: bool = False) -> Optional[str]:
+        if field_type == SourceFieldInputConfigType.NUMBER:
+            # Use str_to_optional_int for optional NUMBER fields to handle empty strings from the frontend
+            return "config.str_to_optional_int" if is_optional else "int"
 
-        return converter_mapping.get(field_type)
+        return None
 
     def _get_select_literal_type(self, field: SourceFieldSelectConfig) -> str:
         if not field.converter:

--- a/posthog/temporal/data_imports/sources/common/test/test_source_config_generator.py
+++ b/posthog/temporal/data_imports/sources/common/test/test_source_config_generator.py
@@ -418,6 +418,31 @@ class TestSourceConfigGenerator(ClickhouseTestMixin):
         output = self._run({ExternalDataSourceType.STRIPE: config})
         assert "int_value: int = config.value(converter=int)" in output
 
+    def test_source_config_optional_number_uses_str_to_optional_int(self):
+        """Optional NUMBER fields should use str_to_optional_int to handle empty strings from frontend."""
+        config = SourceConfig(
+            name=SchemaExternalDataSourceType.STRIPE,
+            iconPath="",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="optional_int_value",
+                        label="optional int",
+                        type=SourceFieldInputConfigType.NUMBER,
+                        required=False,
+                        placeholder="90",
+                    ),
+                ],
+            ),
+        )
+
+        output = self._run({ExternalDataSourceType.STRIPE: config})
+        assert (
+            "optional_int_value: int | None = config.value(converter=config.str_to_optional_int, default_factory=lambda: None)"
+            in output
+        )
+
     def test_source_config_nested_class(self):
         config = SourceConfig(
             name=SchemaExternalDataSourceType.STRIPE,

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -158,7 +158,7 @@ class MailjetSourceConfig(config.Config):
 class MetaAdsSourceConfig(config.Config):
     account_id: str
     meta_ads_integration_id: int = config.value(converter=config.str_to_int)
-    sync_lookback_days: int | None = config.value(converter=int, default_factory=lambda: None)
+    sync_lookback_days: int | None = config.value(converter=config.str_to_optional_int, default_factory=lambda: None)
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/tests/test_generated_configs.py
+++ b/posthog/temporal/data_imports/sources/tests/test_generated_configs.py
@@ -124,6 +124,12 @@ def test_meta_ads_config():
     assert config.account_id == "123"
     assert config.meta_ads_integration_id == 1
 
+    # Empty string for optional sync_lookback_days should be handled (not raise ValueError)
+    config_with_empty = MetaAdsSourceConfig.from_dict(
+        {"account_id": "123", "meta_ads_integration_id": 1, "sync_lookback_days": ""}
+    )
+    assert config_with_empty.sync_lookback_days is None
+
 
 def test_mongo_config():
     config = MongoDBSourceConfig.from_dict({"connection_string": "connection_string"})


### PR DESCRIPTION
## Problem

Users were getting "Non-ok response error" when adding Meta Ads source with empty "Sync history for insights" field. The frontend sends empty string "" which caused `int("")` to raise ValueError.

## Changes

- Update config generator to use `config.str_to_optional_int` for optional NUMBER fields (handles empty strings safely)
- Regenerate configs
- Add tests for optional NUMBER field handling

## How did you test this code?

Unit tests

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
