### PR TITLE
fix: show unrecorded canvases during playback

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.test.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { PLACEHOLDER_SVG_DATA_IMAGE_URL } from '../index'
 import { CanvasReplayerPlugin } from './canvas-plugin'
 
 // Mock rrweb canvasMutation function
@@ -331,6 +332,16 @@ describe('CanvasReplayerPlugin', () => {
             expect(plugin.handler).toBeTruthy()
             expect(typeof plugin.onBuild).toBe('function')
             expect(typeof plugin.handler).toBe('function')
+        })
+
+        it('applies placeholder background to canvas elements on build', () => {
+            const plugin = CanvasReplayerPlugin([])
+
+            plugin.onBuild?.(mockCanvas, { id: 1, replayer: mockReplayer })
+
+            // jsdom normalizes CSS by removing optional quotes from data URLs
+            const base64Data = PLACEHOLDER_SVG_DATA_IMAGE_URL.match(/base64,([^"]+)/)?.[1]
+            expect(mockCanvas.style.backgroundImage).toContain(`base64,${base64Data}`)
         })
     })
 })

--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -13,6 +13,7 @@ import {
 
 import { debounce } from 'lib/utils'
 
+import { PLACEHOLDER_SVG_DATA_IMAGE_URL } from '../index'
 import { deserializeCanvasArg } from './deserialize-canvas-args'
 
 type CanvasEventWithTime = eventWithTime & {
@@ -314,6 +315,8 @@ export const CanvasReplayerPlugin = (events: eventWithTime[]): ReplayPlugin => {
                     const attr = canvasElement.attributes[i]
                     el.setAttribute(attr.name, attr.value)
                 }
+
+                canvasElement.style.backgroundImage = PLACEHOLDER_SVG_DATA_IMAGE_URL
 
                 // Store the image but don't replace the canvas yet
                 containers.set(id, el)

--- a/frontend/src/scenes/session-recordings/player/rrweb/index.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/index.ts
@@ -4,7 +4,7 @@ import { ReplayPlugin, playerConfig } from '@posthog/rrweb'
 import { EventType, IncrementalSource, eventWithTime } from '@posthog/rrweb-types'
 
 export const PLACEHOLDER_SVG_DATA_IMAGE_URL =
-    'url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNOCAwSDE2TDAgMTZWOEw4IDBaIiBmaWxsPSIjMkQyRDJEIi8+CjxwYXRoIGQ9Ik0xNiA4VjE2SDhMMTYgOFoiIGZpbGw9IiMyRDJEMkQiLz4KPC9zdmc+Cg==");'
+    'url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNOCAwSDE2TDAgMTZWOEw4IDBaIiBmaWxsPSIjMkQyRDJEIi8+CjxwYXRoIGQ9Ik0xNiA4VjE2SDhMMTYgOFoiIGZpbGw9IiMyRDJEMkQiLz4KPC9zdmc+Cg==")'
 
 const PROXY_URL = 'https://replay.ph-proxy.com' as const
 
@@ -161,7 +161,7 @@ export const HLSPlayerPlugin: ReplayPlugin = {
     },
 }
 
-const defaultStyleRules = `.ph-no-capture { background-image: ${PLACEHOLDER_SVG_DATA_IMAGE_URL} }`
+const defaultStyleRules = `.ph-no-capture { background-image: ${PLACEHOLDER_SVG_DATA_IMAGE_URL}; }`
 // replaces a common rule in Shopify templates removed during capture
 // fix tracked in https://github.com/rrweb-io/rrweb/pull/1322
 const shopifyShorthandCSSFix =


### PR DESCRIPTION
this had bothered me for ages and i was just testing local recording with my own build of posthog-js and couldn't see it it was broken

if there is a canvas element but canvas recording wasn't on, then we keep the space in the page so the page overall displays correctly

but we show nothing where the unrecorded canvas is

now we set the blocked image background so you can see there's an element there

|before|after|
|-|-|
|![Screenshot 2025-12-29 at 17.48.50.png](https://app.graphite.com/user-attachments/assets/147f2692-41aa-4720-aefe-824b1bd1191f.png)|![Screenshot 2025-12-29 at 17.35.59.png](https://app.graphite.com/user-attachments/assets/f9afb7e3-0afe-4800-ab72-29316a5c9628.png)|

