### PR TITLE
fix(workflows): fix indefinite TTL not being respected

### DIFF
--- a/plugin-server/src/cdp/services/monitoring/hog-masker.service.test.ts
+++ b/plugin-server/src/cdp/services/monitoring/hog-masker.service.test.ts
@@ -253,6 +253,88 @@ describe('HogMasker', () => {
                 ).toHaveLength(1)
             })
 
+            describe('ttl constraints', () => {
+                const getRedisKeyTtl = async (): Promise<number> => {
+                    const keys = await redis.useClient({ name: 'test-keys' }, async (client) => {
+                        return await client.keys(`${BASE_REDIS_KEY}/mask/*`)
+                    })
+                    expect(keys?.length).toBe(1)
+                    const ttl = await redis.useClient({ name: 'test-ttl' }, async (client) => {
+                        return await client.ttl(keys![0])
+                    })
+                    return ttl!
+                }
+
+                const expectTtlNear = (ttl: number, expected: number) => {
+                    expect(ttl).toBeLessThanOrEqual(expected)
+                    expect(ttl).toBeGreaterThan(expected - 10)
+                }
+
+                const oneDaySeconds = 60 * 60 * 24
+                const threeYearsSeconds = 60 * 60 * 24 * 365 * 3
+
+                describe('hog functions', () => {
+                    it('should default to 1 day when ttl is null', async () => {
+                        const hogFunction = createHogFunction({
+                            masking: {
+                                ...HOG_MASK_EXAMPLES.all.masking!,
+                                ttl: null,
+                            },
+                        })
+
+                        await masker.filterByMasking([createExampleInvocation(hogFunction)])
+                        expectTtlNear(await getRedisKeyTtl(), oneDaySeconds)
+                    })
+
+                    it('should cap at 1 day max', async () => {
+                        const hogFunction = createHogFunction({
+                            masking: {
+                                ...HOG_MASK_EXAMPLES.all.masking!,
+                                ttl: 60 * 60 * 24 * 365, // 1 year
+                            },
+                        })
+
+                        await masker.filterByMasking([createExampleInvocation(hogFunction)])
+                        expectTtlNear(await getRedisKeyTtl(), oneDaySeconds)
+                    })
+                })
+
+                describe('hog flows', () => {
+                    const createFlowWithTtl = (ttl: number | null): HogFlow => ({
+                        id: `flow_${ttl}`,
+                        team_id: 1,
+                        name: 'Test Flow',
+                        version: 1,
+                        actions: [],
+                        status: 'active',
+                        trigger: {
+                            type: 'event',
+                            filters: {
+                                events: [],
+                            },
+                        },
+                        trigger_masking: {
+                            ...HOG_FLOW_MASK_EXAMPLES.onceEver.trigger_masking!,
+                            ttl,
+                        },
+                        exit_condition: 'exit_only_at_end',
+                        edges: [],
+                    })
+
+                    it('should default to 3 years when ttl is null', async () => {
+                        const hogFlow = createFlowWithTtl(null)
+                        await masker.filterByMasking([createExampleHogFlowInvocation(hogFlow)])
+                        expectTtlNear(await getRedisKeyTtl(), threeYearsSeconds)
+                    })
+
+                    it('should cap at 3 years when set to a higher value', async () => {
+                        const hogFlow = createFlowWithTtl(60 * 60 * 24 * 365 * 10) // 10 years
+                        await masker.filterByMasking([createExampleHogFlowInvocation(hogFlow)])
+                        expectTtlNear(await getRedisKeyTtl(), threeYearsSeconds)
+                    })
+                })
+            })
+
             describe('hog flow trigger masking', () => {
                 let hogFlowEvery: HogFlow
                 let hogFlowOncePer: HogFlow

--- a/plugin-server/src/cdp/services/monitoring/hog-masker.service.ts
+++ b/plugin-server/src/cdp/services/monitoring/hog-masker.service.ts
@@ -14,8 +14,8 @@ export const BASE_REDIS_KEY = process.env.NODE_ENV == 'test' ? '@posthog-test/ho
 const REDIS_KEY_TOKENS = `${BASE_REDIS_KEY}/mask`
 
 // NOTE: These are controlled via the api so are more of a sanity fallback
-const MASKER_MAX_TTL = 60 * 60 * 24
-const MASKER_MAX_TTL_FLOW = 60 * 60 * 24 * 365 * 3 // 3 years
+const MASKER_MAX_TTL_HOG_FUNCTION = 60 * 60 * 24
+const MASKER_MAX_TTL_HOG_FLOW = 60 * 60 * 24 * 365 * 3 // 3 years
 const MASKER_MIN_TTL = 1
 
 type MaskContext = {
@@ -79,7 +79,7 @@ function getEntityId(invocation: CyclotronJobInvocation): string {
 }
 
 function getTtl(invocation: CyclotronJobInvocation, maskingConfig: HogFunctionMasking): number {
-    const maxTtl = isHogFlowInvocation(invocation) ? MASKER_MAX_TTL_FLOW : MASKER_MAX_TTL
+    const maxTtl = isHogFlowInvocation(invocation) ? MASKER_MAX_TTL_HOG_FLOW : MASKER_MAX_TTL_HOG_FUNCTION
     return Math.max(MASKER_MIN_TTL, Math.min(maxTtl, maskingConfig.ttl ?? maxTtl))
 }
 

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -150,7 +150,7 @@ class HogFlowVariableSerializer(serializers.ListSerializer):
 
 
 class HogFlowMaskingSerializer(serializers.Serializer):
-    ttl = serializers.IntegerField(required=False, min_value=60, max_value=60 * 60 * 24 * 365, allow_null=True)
+    ttl = serializers.IntegerField(required=False, min_value=60, max_value=60 * 60 * 24 * 365 * 3, allow_null=True)
     threshold = serializers.IntegerField(required=False, allow_null=True)
     hash = serializers.CharField(required=True)
     bytecode = serializers.JSONField(required=False, allow_null=True)


### PR DESCRIPTION
## Problem

A max TTL setting was overriding indefinite TTLs for workflows, causing problems like this: https://posthog.slack.com/archives/C06GG249PR6/p1766781649204749

## Changes

Apply different max TTL logic for hog functions vs. hog flows

We'll also likely need to increase memory for our redis instance, but I will monitor that here https://grafana.prod-us.posthog.dev/d/cdp/cdp?var-partition=$__all&from=now-1h&to=now&timezone=utc&var-database=posthog-cyclotron-shard0-prod-us-east-1&var-queue=$__all&var-service=$__all&refresh=10s&orgId=1

## How did you test this code?

Added test coverage for all masking TTLs cases