### PR TITLE
chore: remove changelog opt-in 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,8 +23,6 @@
 
 <!-- For features only -->
 
-<!-- If publishing, your PR must include a 1-3 sentence description of the feature plus a screenshot or screen recording if applicable. 🙏 -->
+<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will recieve a follow-up PR comment or notification. -->
 
-<!-- Write "no" to expicitly opt-out of posting to #changelog. Removing this section entirely will not prevent posting. -->
-
-<!-- Check #changelog in Slack for more details. -->
+<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,6 @@
 
 <!-- For features only -->
 
-<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will recieve a follow-up PR comment or notification. -->
+<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->
 
 <!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,6 @@
 
 <!-- If publishing, your PR must include a 1-3 sentence description of the feature plus a screenshot or screen recording if applicable. 🙏 -->
 
-<!-- Write "no" to expicitly opt-out of posting to #changelog -->
+<!-- Write "no" to expicitly opt-out of posting to #changelog. Removing this section entirely will not prevent posting. -->
 
 <!-- Check #changelog in Slack for more details. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,10 +21,10 @@
 
 ## Publish to changelog?
 
-<!-- For features only. Check the box if this should go in our company changelog. -->
-<!-- Removing this section or leaving it blank means this feature will probably remain unpublished. -->
+<!-- For features only -->
 
 - [ ] 🚀 Yes, publish to #changelog
+- [ ] ❌ No, not changelog worthy
 
 <!-- If publishing, your PR must include a 1-3 sentence description of the feature plus a screenshot or screen recording if applicable. 🙏 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@
 <!-- For features only -->
 
 - [ ] 🚀 Yes, publish to #changelog
-- [ ] ❌ No, not changelog worthy
+- [ ] ❌ No, it's not changelog worthy
 
 <!-- If publishing, your PR must include a 1-3 sentence description of the feature plus a screenshot or screen recording if applicable. 🙏 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,4 +25,6 @@
 
 <!-- If publishing, your PR must include a 1-3 sentence description of the feature plus a screenshot or screen recording if applicable. 🙏 -->
 
+<!-- Write "no" to expicitly opt-out of posting to #changelog -->
+
 <!-- Check #changelog in Slack for more details. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,9 +23,6 @@
 
 <!-- For features only -->
 
-- [ ] 🚀 Yes, publish to #changelog
-- [ ] ❌ No, it's not changelog worthy
-
 <!-- If publishing, your PR must include a 1-3 sentence description of the feature plus a screenshot or screen recording if applicable. 🙏 -->
 
 <!-- Check #changelog in Slack for more details. -->


### PR DESCRIPTION
## Changes

- Remove opt-in for changelog
- Will tag engineers for confirmation and publishing details instead


```markdown
## Publish to changelog?

<!-- For features only -->

<!-- If publishing, your PR must include a 1-3 sentence description of the feature plus a screenshot or screen recording if applicable. 🙏 -->

<!-- Check #changelog in Slack for more details. -->
```
