### PR TITLE
chore(sqlx-migrations): adds structured logging to sqlx migrations

### DIFF
--- a/rust/bin/migrate-entry
+++ b/rust/bin/migrate-entry
@@ -3,7 +3,6 @@ set -eE
 
 MIGRATION_TYPE="$1"
 
-# JSON logging helper function
 log_json() {
     local level="$1"
     local message="$2"
@@ -24,14 +23,13 @@ log_json() {
     echo "$json"
 }
 
-# Error handler to log failures as JSON
 handle_error() {
     local exit_code=$?
-    local failed_command="${BASH_COMMAND}"
-    log_json "error" "Migration failed" "failed" "$MIGRATION_TYPE" "\"error\":\"Command failed: $failed_command\",\"exit_code\":$exit_code"
+    log_json "error" "Migration failed" "failed" "$MIGRATION_TYPE" "\"exit_code\":$exit_code"
     exit $exit_code
 }
 
+# Trap errors and use the error handler to log the error as JSON
 trap handle_error ERR
 
 if [ -z "$MIGRATION_TYPE" ]; then

--- a/rust/bin/migrate-entry
+++ b/rust/bin/migrate-entry
@@ -1,10 +1,41 @@
 #!/bin/bash
-set -e
+set -eE
 
 MIGRATION_TYPE="$1"
 
+# JSON logging helper function
+log_json() {
+    local level="$1"
+    local message="$2"
+    local status="$3"
+    local migration_type="${4:-$MIGRATION_TYPE}"
+    local extra="${5:-}"
+
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    local json="{\"timestamp\":\"$timestamp\",\"level\":\"$level\",\"message\":\"$message\",\"migration_type\":\"$migration_type\",\"status\":\"$status\""
+
+    if [ -n "$extra" ]; then
+        json="$json,$extra"
+    fi
+
+    json="$json}"
+    echo "$json"
+}
+
+# Error handler to log failures as JSON
+handle_error() {
+    local exit_code=$?
+    local failed_command="${BASH_COMMAND}"
+    log_json "error" "Migration failed" "failed" "$MIGRATION_TYPE" "\"error\":\"Command failed: $failed_command\",\"exit_code\":$exit_code"
+    exit $exit_code
+}
+
+trap handle_error ERR
+
 if [ -z "$MIGRATION_TYPE" ]; then
-    echo "Error: No migration type specified"
+    log_json "error" "No migration type specified" "failed" "unknown"
     echo ""
     echo "Usage: $0 <all|persons|cyclotron|behavioral-cohorts>"
     echo "  all                - Run all migrations"
@@ -24,55 +55,54 @@ else
 fi
 
 run_persons_migrations() {
-    echo "Running persons migrations..."
-
+    local db_type="persons"
     PERSONS_DATABASE_NAME=${PERSONS_DATABASE_NAME:-posthog_persons}
     PERSONS_DATABASE_URL=${PERSONS_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/$PERSONS_DATABASE_NAME}
 
-    echo "Performing persons migrations for $PERSONS_DATABASE_URL"
+    log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$PERSONS_DATABASE_NAME\""
 
     sqlx database create -D "$PERSONS_DATABASE_URL"
+    log_json "info" "Database created or already exists" "running" "$db_type"
 
     sqlx migrate run -D "$PERSONS_DATABASE_URL" --source "$MIGRATIONS_BASE/persons_migrations/"
 
-    echo "Persons migrations completed successfully"
+    log_json "info" "Migrations completed successfully" "completed" "$db_type"
 }
 
 run_cyclotron_migrations() {
-    echo "Running cyclotron migrations..."
-
+    local db_type="cyclotron"
     CYCLOTRON_DATABASE_NAME=${CYCLOTRON_DATABASE_NAME:-cyclotron}
     CYCLOTRON_DATABASE_URL=${CYCLOTRON_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/$CYCLOTRON_DATABASE_NAME}
 
-    echo "Performing cyclotron migrations for $CYCLOTRON_DATABASE_URL"
+    log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$CYCLOTRON_DATABASE_NAME\""
 
     sqlx database create -D "$CYCLOTRON_DATABASE_URL"
+    log_json "info" "Database created or already exists" "running" "$db_type"
 
     sqlx migrate run -D "$CYCLOTRON_DATABASE_URL" --source "$MIGRATIONS_BASE/cyclotron-core/migrations/"
 
-    echo "Cyclotron migrations completed successfully"
+    log_json "info" "Migrations completed successfully" "completed" "$db_type"
 }
 
 run_behavioral_cohorts_migrations() {
-    echo "Running behavioral cohorts migrations..."
-
+    local db_type="behavioral-cohorts"
     BEHAVIORAL_COHORTS_DATABASE_NAME=${BEHAVIORAL_COHORTS_DATABASE_NAME:-behavioral_cohorts}
 
     # Use environment variables with defaults
     DB_HOST="${POSTGRES_BEHAVIORAL_COHORTS_HOST:-localhost}"
     DB_USER="${POSTGRES_BEHAVIORAL_COHORTS_USER:-posthog}"
     DB_PASS="${POSTGRES_BEHAVIORAL_COHORTS_PASSWORD:-posthog}"
-    
+
     BEHAVIORAL_COHORTS_DATABASE_URL=${BEHAVIORAL_COHORTS_DATABASE_URL:-postgres://${DB_USER}:${DB_PASS}@${DB_HOST}:5432/$BEHAVIORAL_COHORTS_DATABASE_NAME}
 
-    echo "Performing behavioral cohorts migrations for $BEHAVIORAL_COHORTS_DATABASE_URL"
-    echo "Database name: ${BEHAVIORAL_COHORTS_DATABASE_NAME}"
+    log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$BEHAVIORAL_COHORTS_DATABASE_NAME\""
 
     sqlx database create -D "$BEHAVIORAL_COHORTS_DATABASE_URL"
+    log_json "info" "Database created or already exists" "running" "$db_type"
 
     sqlx migrate run -D "$BEHAVIORAL_COHORTS_DATABASE_URL" --source "$MIGRATIONS_BASE/behavioral_cohorts_migrations/"
 
-    echo "Behavioral cohorts migrations completed successfully"
+    log_json "info" "Migrations completed successfully" "completed" "$db_type"
 }
 
 case "$MIGRATION_TYPE" in
@@ -91,6 +121,7 @@ case "$MIGRATION_TYPE" in
         run_behavioral_cohorts_migrations
         ;;
     *)
+        log_json "error" "Invalid migration type specified" "failed" "$MIGRATION_TYPE"
         echo "Usage: $0 <all|persons|cyclotron|behavioral-cohorts>"
         echo "  all                - Run all migrations"
         echo "  persons            - Run only persons migrations"
@@ -100,4 +131,4 @@ case "$MIGRATION_TYPE" in
         ;;
 esac
 
-echo "All requested migrations completed successfully"
+log_json "info" "All requested migrations completed successfully" "completed"


### PR DESCRIPTION
## Problem

We'd like to get good logs from the Kubernetes Jobs responsible for running any sqlx migrations. These logs should be JSON structured logs with useful information like timestamp, error messages, context, etc.

## Changes

Adds a helper function to turn error messages from the sqlx-migrator into structured json logs. Adds more details logging to the different steps of the sqlx migrator entry script to give developers more observability into what part of their migration failed.
## How did you test this code?

I tested this code by running the migrations locally. I ran migrations with DB connection values that would purposefully fail and I ran migrations that would be successful.
An example of an error log generated:

```
{                                                                                                                                                                              
       "timestamp": "2025-12-29T19:56:21Z",
       "level": "info",
       "message": "Starting migrations",
       "migration_type": "persons",
       "status": "starting",
       "database_name": "posthog_persons"
     }
     error: error communicating with database: Connection refused (os error 61)
     {"timestamp":"2025-12-29T19:56:31Z","level":"error","message":"Migration failed","migration_type":"persons","status":"failed","error":"Command failed: sqlx database create -D
     "$PERSONS_DATABASE_URL"","exit_code":1}
```
