### PR TITLE
feat(ux): recent items menu in navbar

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -58,6 +58,7 @@ import { navigation3000Logic } from '../navigation-3000/navigationLogic'
 import { SidePanelActivationIcon } from '../navigation-3000/sidepanel/panels/activation/SidePanelActivation'
 import { sidePanelLogic } from '../navigation-3000/sidepanel/sidePanelLogic'
 import { sidePanelStateLogic } from '../navigation-3000/sidepanel/sidePanelStateLogic'
+import { RecentItemsMenu } from './ProjectTree/menus/RecentItemsMenu'
 
 const navBarStyles = cva({
     base: 'flex flex-col max-h-screen min-h-screen bg-surface-tertiary z-[var(--z-layout-navbar)] relative border-r border-r-transparent',
@@ -342,6 +343,8 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                 }}
                                 iconOnly={isLayoutNavCollapsed}
                             />
+
+                            <RecentItemsMenu />
                         </div>
                     </div>
 

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/RecentItemsMenu.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/RecentItemsMenu.tsx
@@ -1,0 +1,112 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconClock } from '@posthog/icons'
+import { Link } from '@posthog/lemon-ui'
+
+import { keybindToKeyboardShortcutProps } from 'lib/components/AppShortcuts/AppShortcut'
+import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
+import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
+import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
+import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuTrigger,
+} from 'lib/ui/DropdownMenu/DropdownMenu'
+import { MenuSeparator } from 'lib/ui/Menus/Menus'
+
+import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+import { splitPath, unescapePath } from '~/layout/panel-layout/ProjectTree/utils'
+import { FileSystemEntry, FileSystemIconType } from '~/queries/schema/schema-general'
+
+import { recentItemsMenuLogic } from './recentItemsMenuLogic'
+
+const getItemName = (item: FileSystemEntry): string => {
+    const pathSplit = splitPath(item.path)
+    const lastPart = pathSplit.pop()
+    return unescapePath(lastPart ?? item.path)
+}
+
+export function RecentItemsMenu(): JSX.Element {
+    const { recentItems, recentItemsLoading } = useValues(recentItemsMenuLogic)
+    const { loadRecentItems } = useActions(recentItemsMenuLogic)
+    const [isOpen, setIsOpen] = useState(false)
+
+    const handleOpenChange = (open: boolean): void => {
+        setIsOpen(open)
+        if (open) {
+            loadRecentItems({})
+        }
+    }
+
+    useAppShortcut({
+        name: 'recent-items-menu',
+        keybind: [keyBinds.recentItems],
+        intent: 'Open recent items menu',
+        interaction: 'function',
+        callback: () => setIsOpen(true),
+    })
+
+    return (
+        <DropdownMenu open={isOpen} onOpenChange={handleOpenChange}>
+            <DropdownMenuTrigger asChild>
+                <ButtonPrimitive
+                    iconOnly
+                    size="sm"
+                    tooltip={
+                        <>
+                            Open recent items menu{' '}
+                            <KeyboardShortcut
+                                {...keybindToKeyboardShortcutProps(keyBinds.recentItems)}
+                                className="relative text-xs -top-px"
+                            />
+                        </>
+                    }
+                    tooltipPlacement="bottom"
+                    tooltipCloseDelayMs={0}
+                    data-attr="recent-items-menu-trigger"
+                >
+                    <IconClock className="size-4 text-tertiary" />
+                </ButtonPrimitive>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" side="bottom" className="min-w-[200px] max-w-[300px]">
+                <DropdownMenuGroup>
+                    <DropdownMenuLabel>Recent items</DropdownMenuLabel>
+                    <MenuSeparator />
+                    {recentItemsLoading ? (
+                        <DropdownMenuItem disabled>
+                            <ButtonPrimitive menuItem>
+                                <Spinner className="size-4" />
+                                <span className="ml-2">Loading...</span>
+                            </ButtonPrimitive>
+                        </DropdownMenuItem>
+                    ) : recentItems.length === 0 ? (
+                        <DropdownMenuItem disabled>
+                            <ButtonPrimitive menuItem>No recent items</ButtonPrimitive>
+                        </DropdownMenuItem>
+                    ) : (
+                        recentItems.map((item: FileSystemEntry) => (
+                            <DropdownMenuItem key={item.id} asChild>
+                                <Link
+                                    buttonProps={{
+                                        menuItem: true,
+                                    }}
+                                    to={item.href}
+                                    data-attr={`recent-item-${item.id}`}
+                                >
+                                    {iconForType(item.type as FileSystemIconType)}
+                                    <span className="ml-2 truncate">{getItemName(item)}</span>
+                                </Link>
+                            </DropdownMenuItem>
+                        ))
+                    )}
+                </DropdownMenuGroup>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+}

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/recentItemsMenuLogic.ts
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/recentItemsMenuLogic.ts
@@ -1,0 +1,33 @@
+import { afterMount, kea, path } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+
+import { FileSystemEntry } from '~/queries/schema/schema-general'
+
+import type { recentItemsMenuLogicType } from './recentItemsMenuLogicType'
+
+const RECENT_ITEMS_LIMIT = 10
+
+export const recentItemsMenuLogic = kea<recentItemsMenuLogicType>([
+    path(['layout', 'panel-layout', 'ProjectTree', 'menus', 'recentItemsMenuLogic']),
+    loaders({
+        recentItems: [
+            [] as FileSystemEntry[],
+            {
+                loadRecentItems: async (_, breakpoint) => {
+                    const response = await api.fileSystem.list({
+                        orderBy: '-last_viewed_at',
+                        notType: 'folder',
+                        limit: RECENT_ITEMS_LIMIT,
+                    })
+                    breakpoint()
+                    return response.results
+                },
+            },
+        ],
+    }),
+    afterMount(({ actions }) => {
+        actions.loadRecentItems({})
+    }),
+])

--- a/frontend/src/lib/components/AppShortcuts/AppShortcut.tsx
+++ b/frontend/src/lib/components/AppShortcuts/AppShortcut.tsx
@@ -7,7 +7,7 @@ import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardSh
 import { AppShortcutType } from './appShortcutLogic'
 import { convertPlatformKeybind, useAppShortcut } from './useAppShortcut'
 
-function keybindToKeyboardShortcutProps(keybind: string[]): Record<string, boolean> {
+export function keybindToKeyboardShortcutProps(keybind: string[]): Record<string, boolean> {
     const platformAgnosticKeybind = convertPlatformKeybind(keybind)
     return Object.fromEntries(platformAgnosticKeybind.map((key) => [key, true]))
 }

--- a/frontend/src/lib/components/AppShortcuts/shortcuts.ts
+++ b/frontend/src/lib/components/AppShortcuts/shortcuts.ts
@@ -1,6 +1,7 @@
 export const baseModifier: string[] = ['command', 'option']
 
 export const keyBinds: Record<string, string[]> = {
+    recentItems: [...baseModifier, 'y'],
     newTab: [...baseModifier, 't'],
     closeActiveTab: [...baseModifier, 'w'],
     toggleShortcutMenu: [...baseModifier, 'k'],


### PR DESCRIPTION
## Problem
Finding your last viewed items was limited to new tab page (/search)

## Changes
* Add dropdown menu "Recent" in navbar showing last 10 items, with keyboard shortcut `cmd+option+y`

![2025-12-29 23 59 37](https://github.com/user-attachments/assets/7eba2f2e-22f9-405d-a04a-bab6a1f92d5a)


## How did you test this code?
Manually

## Publish to changelog?
yes

