### PR TITLE
fix(flags): Add grace period to skip fixing recently updated flags

### DIFF
--- a/posthog/management/commands/_base_hypercache_command.py
+++ b/posthog/management/commands/_base_hypercache_command.py
@@ -292,6 +292,7 @@ class BaseHyperCacheCommand(BaseCommand):
                 "error": 0,
                 "fixed": 0,
                 "fix_failed": 0,
+                "skipped_for_grace_period": 0,
             }
 
             mismatches: list[dict] = []
@@ -360,6 +361,14 @@ class BaseHyperCacheCommand(BaseCommand):
         except Exception as e:
             self.stdout.write(self.style.WARNING(f"Expiry tracking check failed, skipping: {e}"))
 
+        # Batch-check which teams should skip fixes (e.g., grace period for recently updated data)
+        team_ids_to_skip_fix: set[int] = set()
+        if fix and config.get_team_ids_to_skip_fix_fn:
+            try:
+                team_ids_to_skip_fix = config.get_team_ids_to_skip_fix_fn([t.id for t in teams])
+            except Exception as e:
+                self.stdout.write(self.style.WARNING(f"Skip-fix check failed, proceeding without skips: {e}"))
+
         for team in teams:
             stats["total"] += 1
 
@@ -379,14 +388,14 @@ class BaseHyperCacheCommand(BaseCommand):
                 identifier = config.hypercache.get_cache_identifier(team)
                 if expiry_status and not expiry_status.get(identifier, True):
                     stats["expiry_missing"] += 1
-                    self._handle_expiry_issue(team, stats, mismatches, fix, config)
+                    self._handle_expiry_issue(team, stats, mismatches, fix, config, team_ids_to_skip_fix)
 
             elif result["status"] == "miss":
                 stats["cache_miss"] += 1
-                self._handle_cache_issue(team, result, stats, mismatches, fix)
+                self._handle_cache_issue(team, result, stats, mismatches, fix, team_ids_to_skip_fix)
             elif result["status"] == "mismatch":
                 stats["cache_mismatch"] += 1
-                self._handle_cache_issue(team, result, stats, mismatches, fix)
+                self._handle_cache_issue(team, result, stats, mismatches, fix, team_ids_to_skip_fix)
 
     def _handle_cache_issue(
         self,
@@ -395,6 +404,7 @@ class BaseHyperCacheCommand(BaseCommand):
         stats: dict[str, int],
         mismatches: list[dict],
         fix: bool,
+        team_ids_to_skip_fix: set[int],
     ):
         """Handle a cache issue (miss or mismatch)."""
         issue_detail = {
@@ -408,7 +418,15 @@ class BaseHyperCacheCommand(BaseCommand):
             issue_detail["diffs"] = result["diffs"]
 
         if fix:
-            issue_detail["fixed"] = self._fix_team_cache(team, stats)
+            # Check if we should skip fixing (e.g., grace period for recently updated data)
+            if team.id in team_ids_to_skip_fix:
+                stats["skipped_for_grace_period"] += 1
+                issue_detail["skipped"] = True
+                self.stdout.write(
+                    self.style.WARNING(f"  ⏳ Skipped fix for team {team.id} ({team.name}) - within grace period")
+                )
+            else:
+                issue_detail["fixed"] = self._fix_team_cache(team, stats)
 
         mismatches.append(issue_detail)
 
@@ -450,6 +468,7 @@ class BaseHyperCacheCommand(BaseCommand):
         mismatches: list[dict],
         fix: bool,
         config: HyperCacheManagementConfig,
+        team_ids_to_skip_fix: set[int],
     ):
         """Handle a team missing from expiry tracking."""
         issue_detail: dict = {
@@ -460,7 +479,15 @@ class BaseHyperCacheCommand(BaseCommand):
         }
 
         if fix:
-            issue_detail["fixed"] = self._fix_team_cache(team, stats, "expiry tracking", config)
+            # Check if we should skip fixing (e.g., grace period for recently updated data)
+            if team.id in team_ids_to_skip_fix:
+                stats["skipped_for_grace_period"] += 1
+                issue_detail["skipped"] = True
+                self.stdout.write(
+                    self.style.WARNING(f"  ⏳ Skipped fix for team {team.id} ({team.name}) - within grace period")
+                )
+            else:
+                issue_detail["fixed"] = self._fix_team_cache(team, stats, "expiry tracking", config)
 
         mismatches.append(issue_detail)
 
@@ -506,6 +533,12 @@ class BaseHyperCacheCommand(BaseCommand):
                         f"Cache fixes failed:   {stats['fix_failed']} ({self.format_percentage(stats['fix_failed'], stats['total'])})"
                     )
                 )
+            if stats.get("skipped_for_grace_period", 0) > 0:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Skipped (grace period): {stats['skipped_for_grace_period']} ({self.format_percentage(stats['skipped_for_grace_period'], stats['total'])})"
+                    )
+                )
 
         if mismatches:
             self.stdout.write("\n" + "=" * 70)
@@ -515,11 +548,16 @@ class BaseHyperCacheCommand(BaseCommand):
             for mismatch in mismatches:
                 issue_prefix = f"[{mismatch['issue']}] Team {mismatch['team_id']} ({mismatch['team_name']})"
 
-                if fix and "fixed" in mismatch:
-                    if mismatch["fixed"]:
-                        self.stdout.write(self.style.SUCCESS(f"\n{issue_prefix} - FIXED"))
+                if fix:
+                    if mismatch.get("skipped"):
+                        self.stdout.write(self.style.WARNING(f"\n{issue_prefix} - SKIPPED (grace period)"))
+                    elif "fixed" in mismatch:
+                        if mismatch["fixed"]:
+                            self.stdout.write(self.style.SUCCESS(f"\n{issue_prefix} - FIXED"))
+                        else:
+                            self.stdout.write(self.style.ERROR(f"\n{issue_prefix} - FIX FAILED"))
                     else:
-                        self.stdout.write(self.style.ERROR(f"\n{issue_prefix} - FIX FAILED"))
+                        self.stdout.write(self.style.ERROR(f"\n{issue_prefix}"))
                 else:
                     self.stdout.write(self.style.ERROR(f"\n{issue_prefix}"))
 
@@ -537,17 +575,24 @@ class BaseHyperCacheCommand(BaseCommand):
             self.stdout.write(self.style.SUCCESS(f"\n✓ All {cache_name} caches verified successfully!\n"))
         else:
             if fix:
+                skipped = stats.get("skipped_for_grace_period", 0)
+                skipped_suffix = f", {skipped} skipped (grace period)" if skipped > 0 else ""
+
                 if stats["fixed"] > 0 and stats["fix_failed"] == 0:
                     self.stdout.write(
                         self.style.SUCCESS(
-                            f"\n✓ Found and fixed {stats['fixed']} issue(s) with {len(mismatches)} team(s)\n"
+                            f"\n✓ Found and fixed {stats['fixed']} issue(s) with {len(mismatches)} team(s){skipped_suffix}\n"
                         )
                     )
                 elif stats["fix_failed"] > 0:
                     self.stdout.write(
                         self.style.WARNING(
-                            f"\n⚠ Fixed {stats['fixed']} issue(s), but {stats['fix_failed']} fixes failed\n"
+                            f"\n⚠ Fixed {stats['fixed']} issue(s), but {stats['fix_failed']} fixes failed{skipped_suffix}\n"
                         )
+                    )
+                elif skipped > 0:
+                    self.stdout.write(
+                        self.style.WARNING(f"\n⚠ Found {len(mismatches)} issue(s), all skipped due to grace period\n")
                     )
             else:
                 if stats["error"] > 0:

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -27,6 +27,7 @@ Manual operations:
 
 import time
 from collections import defaultdict
+from datetime import timedelta
 from typing import Any
 
 from django.conf import settings
@@ -35,6 +36,7 @@ from django.db import transaction
 from django.db.models import Q
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
+from django.utils import timezone
 
 import structlog
 
@@ -376,6 +378,33 @@ def _get_team_ids_with_flags() -> set[int]:
     return result
 
 
+def _get_team_ids_with_recently_updated_flags(team_ids: list[int]) -> set[int]:
+    """
+    Batch check which teams have flags updated within the grace period.
+
+    When a flag is updated, an async task updates the cache. If verification
+    runs before the async task completes, it sees a stale cache and tries to
+    "fix" it, causing unnecessary work. This grace period lets recent async
+    updates complete before treating cache misses as genuine errors.
+
+    Args:
+        team_ids: List of team IDs to check
+
+    Returns:
+        Set of team IDs that have recently updated flags (should skip fix)
+    """
+    grace_period_minutes = settings.FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES
+    if grace_period_minutes <= 0 or not team_ids:
+        return set()
+
+    cutoff = timezone.now() - timedelta(minutes=grace_period_minutes)
+    return set(
+        FeatureFlag.objects.filter(team_id__in=team_ids, updated_at__gte=cutoff)
+        .values_list("team_id", flat=True)
+        .distinct()
+    )
+
+
 # Initialize hypercache management config after update_flags_cache is defined
 FLAGS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
     hypercache=flags_hypercache,
@@ -383,6 +412,7 @@ FLAGS_HYPERCACHE_MANAGEMENT_CONFIG = HyperCacheManagementConfig(
     cache_name="flags",
     get_team_ids_needing_full_verification_fn=_get_team_ids_with_flags,
     empty_cache_value={"flags": []},
+    get_team_ids_to_skip_fix_fn=_get_team_ids_with_recently_updated_flags,
 )
 
 

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -18,6 +18,7 @@ from posthog.models import FeatureFlag, Tag, Team
 from posthog.models.feature_flag.feature_flag import FeatureFlagEvaluationTag
 from posthog.models.feature_flag.flags_cache import (
     _get_feature_flags_for_service,
+    _get_team_ids_with_recently_updated_flags,
     clear_flags_cache,
     flags_hypercache,
     get_flags_from_cache,
@@ -1793,3 +1794,118 @@ class TestServiceFlagsGuards(BaseTest):
         clear_flags_cache(self.team)
 
         # Should complete without error (nothing to verify as it's a no-op)
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test", FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES=5)
+class TestGetTeamIdsWithRecentlyUpdatedFlags(BaseTest):
+    """Test _get_team_ids_with_recently_updated_flags batch helper for grace period logic."""
+
+    def test_returns_empty_set_for_team_with_no_flags(self):
+        """Test returns empty set for team with no flags."""
+        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        assert result == set()
+
+    def test_returns_team_id_for_recently_updated_flag(self):
+        """Test returns team ID for team with recently updated flag."""
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="recent-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        assert result == {self.team.id}
+
+    def test_returns_empty_set_for_old_flag(self):
+        """Test returns empty set for team with flag updated outside grace period."""
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="old-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        # Manually set updated_at to outside grace period
+        FeatureFlag.objects.filter(id=flag.id).update(updated_at=timezone.now() - timedelta(minutes=10))
+
+        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        assert result == set()
+
+    @override_settings(FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES=0)
+    def test_returns_empty_set_when_grace_period_is_zero(self):
+        """Test returns empty set when grace period is disabled (0 minutes)."""
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="recent-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        assert result == set()
+
+    def test_returns_empty_set_for_empty_team_ids_list(self):
+        """Test returns empty set when given empty list of team IDs."""
+        result = _get_team_ids_with_recently_updated_flags([])
+        assert result == set()
+
+    def test_returns_team_id_if_any_flag_is_recent(self):
+        """Test returns team ID if ANY flag is recent (OR logic across team flags)."""
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        # Old flag outside grace period
+        old_flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="old-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        FeatureFlag.objects.filter(id=old_flag.id).update(updated_at=timezone.now() - timedelta(minutes=10))
+
+        # Recent flag within grace period
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="recent-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Should return team ID because at least one flag is recent
+        result = _get_team_ids_with_recently_updated_flags([self.team.id])
+        assert result == {self.team.id}
+
+    def test_batch_returns_only_teams_with_recent_flags(self):
+        """Test batch query returns only team IDs that have recently updated flags."""
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        # Create second team
+        team2 = Team.objects.create(organization=self.organization, name="Team 2")
+
+        # Team 1 has a recent flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="recent-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Team 2 has an old flag
+        old_flag = FeatureFlag.objects.create(
+            team=team2,
+            key="old-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        FeatureFlag.objects.filter(id=old_flag.id).update(updated_at=timezone.now() - timedelta(minutes=10))
+
+        # Query both teams - should only return team 1
+        result = _get_team_ids_with_recently_updated_flags([self.team.id, team2.id])
+        assert result == {self.team.id}

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -62,3 +62,10 @@ FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES: int = get_from_env(
 TEAM_METADATA_CACHE_VERIFICATION_CHUNK_SIZE: int = get_from_env(
     "TEAM_METADATA_CACHE_VERIFICATION_CHUNK_SIZE", 1000, type_cast=int
 )
+
+# Grace period in minutes for skipping team metadata cache fixes during verification.
+# If a team was updated within this window, the verification task will skip
+# "fixing" it to avoid race conditions with async cache update tasks.
+TEAM_METADATA_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES: int = get_from_env(
+    "TEAM_METADATA_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES", 5, type_cast=int
+)

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -49,6 +49,14 @@ FLAGS_CACHE_REFRESH_LIMIT: int = get_from_env("FLAGS_CACHE_REFRESH_LIMIT", 5000,
 # Reduced from 1000 to 250 to prevent OOM. Decrease further if OOMs persist.
 FLAGS_CACHE_VERIFICATION_CHUNK_SIZE: int = get_from_env("FLAGS_CACHE_VERIFICATION_CHUNK_SIZE", 250, type_cast=int)
 
+# Grace period in minutes for skipping cache fixes during verification.
+# If a flag was updated within this window, the verification task will skip
+# "fixing" it to avoid race conditions with async cache update tasks.
+# The next verification run will fix it if the cache is still stale.
+FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES: int = get_from_env(
+    "FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES", 5, type_cast=int
+)
+
 # Batch size for team metadata cache verification. Team metadata is much smaller
 # than flags data, so we can use larger batches without OOM risk.
 TEAM_METADATA_CACHE_VERIFICATION_CHUNK_SIZE: int = get_from_env(

--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -192,6 +192,13 @@ class HyperCacheManagementConfig:
     # The expected cache value for teams that don't need full verification (e.g., {"flags": []})
     empty_cache_value: dict | None = None
 
+    # Optional batch function to determine which teams should skip fixes.
+    # Used to implement grace periods for recently updated data, avoiding race
+    # conditions between async cache updates and verification.
+    # Takes a list of team IDs, returns a set of team IDs that should skip fixes.
+    # Called once per batch for efficiency (avoids N+1 queries).
+    get_team_ids_to_skip_fix_fn: Callable[[list[int]], set[int]] | None = None
+
     def __post_init__(self) -> None:
         """Validate that optimization fields are set together."""
         has_team_ids_fn = self.get_team_ids_needing_full_verification_fn is not None


### PR DESCRIPTION
## Problem

When running the `verify_flags` Celery task, we're seeing cache mismatches nearly every run. However, upon investigation, these misses are due to a race condition, not signal misses.

The race condition occurs when:
1. A flag changes, queuing a task to rebuild the cache for that team
2. Before the rebuild completes, the scheduled verification task runs
3. Verification sees a mismatch between DB and cache, and "fixes" it

This is benign but problematic because it:
- Generates noisy alerts/logs that hide potential real signal misses
- Causes unnecessary cache rebuilds (double work)

## Changes

Add a configurable grace period (default: 5 minutes) to skip fixing caches for teams with recently updated flags. This allows async cache updates to complete before treating mismatches as genuine errors.

**Implementation:**
- Add `FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES` setting (default: 5, set to 0 to disable)
- Add `get_team_ids_to_skip_fix_fn` to `HyperCacheManagementConfig` for generic grace period support
- Apply grace period in both the Celery task (`hypercache_verifier.py`) and management command (`verify_flags_cache`)
- Track and report skipped teams separately from fixed teams

The implementation is generic - any HyperCache (flags, team metadata, etc.) can configure its own grace period logic via `get_team_ids_to_skip_fix_fn`.

## How did you test this code?

- Unit tests for the grace period logic in both Celery task and management command
- Local testing with `python manage.py verify_flags_cache --fix --verbose`
