### PR TITLE
feat: Add MRR filtering to error tracking

### DIFF
--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -14,6 +14,7 @@ from posthog.schema import (
     ErrorTrackingQueryResponse,
     HogQLFilters,
     RevenueEntity,
+    RevenuePeriod,
 )
 
 from posthog.hogql import ast
@@ -273,7 +274,7 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
                         expr=ast.Call(
                             name="argMax",
                             args=[
-                                ast.Field(chain=[self.revenue_entity, "revenue_analytics", "revenue"]),
+                                ast.Field(chain=[self.revenue_entity, "revenue_analytics", self.revenue_field]),
                                 ast.Field(chain=["timestamp"]),
                             ],
                         ),
@@ -756,6 +757,10 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
     @cached_property
     def revenue_entity(self):
         return self.query.revenueEntity or RevenueEntity.PERSON
+
+    @cached_property
+    def revenue_field(self):
+        return "mrr" if self.query.revenuePeriod == RevenuePeriod.MRR else "revenue"
 
 
 def search_tokenizer(query: str) -> list[str]:

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -1028,6 +1028,262 @@
                     use_hive_partitioning=0
   '''
 # ---
+# name: TestErrorTrackingQueryRunner.test_sorting_by_mrr
+  '''
+  SELECT per_issue_per_revenue_entity.id AS id,
+         max(per_issue_per_revenue_entity.last_seen) AS last_seen,
+         min(per_issue_per_revenue_entity.first_seen) AS first_seen,
+         max(per_issue_per_revenue_entity.function) AS function,
+         max(per_issue_per_revenue_entity.source) AS source,
+         sum(per_issue_per_revenue_entity.latest_revenue) AS revenue,
+         argMax(per_issue_per_revenue_entity.library, per_issue_per_revenue_entity.last_seen) AS library
+  FROM
+    (SELECT if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID')) AS id,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen,
+            min(toTimeZone(e.timestamp, 'UTC')) AS first_seen,
+            argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function,
+            argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source,
+            argMax(e__person__revenue_analytics.mrr, toTimeZone(e.timestamp, 'UTC')) AS latest_revenue,
+            argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library
+     FROM events AS e
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     LEFT JOIN
+       (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS e__person___id,
+               person.id AS id
+        FROM person
+        WHERE equals(person.team_id, 99999)
+        GROUP BY person.id
+        HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.e__person___id)
+     LEFT JOIN
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer.id AS person_id,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+        FROM
+          (SELECT toString(persons.id) AS id,
+                  'revenue_analytics.events.purchase' AS source_label,
+                  persons.created_at AS timestamp,
+                  persons.properties___name AS name,
+                  persons.properties___email AS email,
+                  persons.properties___phone AS phone,
+                  persons.properties___address AS address,
+                  persons.properties___metadata AS metadata,
+                  persons.`properties___$geoip_country_name` AS country,
+                  formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
+                  NULL AS initial_coupon,
+                  NULL AS initial_coupon_id
+           FROM
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
+                     toTimeZone(person.created_at, 'UTC') AS created_at
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))
+                                                             ORDER BY argMax(toTimeZone(person.created_at, 'UTC'), person.version) DESC))) SETTINGS optimize_aggregation_in_order=1) AS persons
+           INNER JOIN
+             (SELECT DISTINCT events__person.id AS person_id
+              FROM events
+              LEFT OUTER JOIN
+                (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id
+                 FROM person
+                 WHERE equals(person.team_id, 99999)
+                 GROUP BY person.id
+                 HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+              WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
+           ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT toString(events.uuid) AS id,
+                     toString(events.uuid) AS invoice_item_id,
+                     'revenue_analytics.events.purchase' AS source_label,
+                     toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                     timestamp AS created_at,
+                     isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
+                     NULL AS product_id,
+                     toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                     events.`$group_0` AS group_0_key,
+                     events.`$group_1` AS group_1_key,
+                     events.`$group_2` AS group_2_key,
+                     events.`$group_3` AS group_3_key,
+                     events.`$group_4` AS group_4_key,
+                     NULL AS invoice_id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                     toString(events.`$session_id`) AS session_id,
+                     events.event AS event_name,
+                     NULL AS coupon,
+                     coupon AS coupon_id,
+                     'USD' AS original_currency,
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                     1 AS enable_currency_aware_divider,
+                     if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                     divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                     'USD' AS currency,
+                     if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+              FROM events
+              LEFT OUTER JOIN
+                (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+              WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+              ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                  sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT toString(events.uuid) AS id,
+                           toString(events.uuid) AS invoice_item_id,
+                           'revenue_analytics.events.purchase' AS source_label,
+                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                           timestamp AS created_at,
+                           isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
+                           NULL AS product_id,
+                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                           events.`$group_0` AS group_0_key,
+                           events.`$group_1` AS group_1_key,
+                           events.`$group_2` AS group_2_key,
+                           events.`$group_3` AS group_3_key,
+                           events.`$group_4` AS group_4_key,
+                           NULL AS invoice_id,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                           toString(events.`$session_id`) AS session_id,
+                           events.event AS event_name,
+                           NULL AS coupon,
+                           coupon AS coupon_id,
+                           'USD' AS original_currency,
+                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                           1 AS enable_currency_aware_divider,
+                           if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                           divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                           'USD' AS currency,
+                           if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                    FROM events
+                    LEFT OUTER JOIN
+                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                              person_distinct_id_overrides.distinct_id AS distinct_id
+                       FROM person_distinct_id_overrides
+                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                       GROUP BY person_distinct_id_overrides.distinct_id
+                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                    ORDER BY timestamp DESC) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT subscription_id AS id,
+                           'revenue_analytics.events.purchase' AS source_label,
+                           NULL AS plan_id,
+                           product_id AS product_id,
+                           toString(person_id) AS customer_id,
+                           NULL AS status,
+                           min_timestamp AS started_at,
+                           if(ifNull(greater(max_timestamp_plus_dropoff_days, today()), 0), NULL, max_timestamp_plus_dropoff_days) AS ended_at,
+                           NULL AS metadata
+                    FROM
+                      (SELECT events__person.id AS person_id,
+                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                              NULL AS product_id,
+                              min(toTimeZone(events.timestamp, 'UTC')) AS min_timestamp,
+                              max(toTimeZone(events.timestamp, 'UTC')) AS max_timestamp,
+                              addDays(max_timestamp, 45.0) AS max_timestamp_plus_dropoff_days
+                       FROM events
+                       LEFT OUTER JOIN
+                         (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                       LEFT JOIN
+                         (SELECT person.id AS id
+                          FROM person
+                          WHERE equals(person.team_id, 99999)
+                          GROUP BY person.id
+                          HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+                       WHERE and(equals(events.team_id, 99999), and(1, isNotNull(subscription_id)))
+                       GROUP BY subscription_id,
+                                person_id)
+                    ORDER BY started_at DESC) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+                 WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC, subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(error_tracking_issue_fingerprint_overrides.issue_id), error_tracking_issue_fingerprint_overrides.version), 1) AS issue_id,
+               error_tracking_issue_fingerprint_overrides.fingerprint AS fingerprint
+        FROM error_tracking_issue_fingerprint_overrides
+        WHERE equals(error_tracking_issue_fingerprint_overrides.team_id, 99999)
+        GROUP BY error_tracking_issue_fingerprint_overrides.fingerprint
+        HAVING ifNull(equals(tupleElement(argMax(tuple(error_tracking_issue_fingerprint_overrides.is_deleted), error_tracking_issue_fingerprint_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__exception_issue_override ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', ''), e__exception_issue_override.fingerprint)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID'))), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     GROUP BY id,
+              e__person.id) AS per_issue_per_revenue_entity
+  GROUP BY per_issue_per_revenue_entity.id
+  ORDER BY revenue DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
 # name: TestErrorTrackingQueryRunner.test_sorting_by_revenue
   '''
   SELECT per_issue_per_revenue_entity.id AS id,


### PR DESCRIPTION
The UI already allows this but we were always filtering by revenue in the backend, let's implement this for real