### PR TITLE
feat(graphite-demo): add Express server with task search endpoint

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Problem

We need a simple Express server to handle task search functionality for the Graphite demo application.

## Changes

Created a new Express server that:
- Sets up a basic Express application listening on port 3000
- Includes sample task data with IDs and descriptions
- Implements a `/search` endpoint that:
  - Accepts a query parameter
  - Filters tasks based on the query string
  - Sorts the filtered results alphabetically by description
  - Returns the results as JSON

## How did you test this code?

Tested the server by:
- Starting the Express server locally
- Making requests to the `/search` endpoint with various query parameters
- Verifying that the filtering and sorting logic works correctly
- Checking edge cases like empty queries and case sensitivity

## Publish to changelog?

No