### PR TITLE
add user search

### DIFF
--- a/graphite-demo/frontend.jsx
+++ b/graphite-demo/frontend.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 
-const TaskSearch = () => {
+const TaskAndUserSearch = () => {
   const [tasks, setTasks] = useState([]);
+  const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -16,14 +17,15 @@ const TaskSearch = () => {
         return response.json();
       })
       .then(data => {
-        setTasks(data);
+        setTasks(data.tasks);
+        setUsers(data.users);
         setLoading(false);
       })
       .catch(error => {
         setError(error.message);
         setLoading(false);
       });
-  }, [searchQuery]); // Depend on searchQuery
+  }, [searchQuery]);
 
   if (loading) {
     return <div>Loading...</div>;
@@ -35,13 +37,14 @@ const TaskSearch = () => {
 
   return (
     <div>
-      <h2>Task Search</h2>
+      <h2>Search Tasks and Users</h2>
       <input
         type="text"
-        placeholder="Search tasks..."
+        placeholder="Search tasks and users..."
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
       />
+      <h3>Tasks</h3>
       <ul>
         {tasks.map(task => (
           <li key={task.id}>
@@ -49,8 +52,16 @@ const TaskSearch = () => {
           </li>
         ))}
       </ul>
+      <h3>Users</h3>
+      <ul>
+        {users.map(user => (
+          <li key={user.id}>
+            <p>{user.name}</p>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };
 
-export default TaskSearch;
+export default TaskAndUserSearch;

--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -18,17 +18,38 @@ const tasks = [
   }
 ];
 
+// Fake data for users
+const users = [
+  {
+    id: 101,
+    name: 'Alice Smith'
+  },
+  {
+    id: 102,
+    name: 'Bob Johnson'
+  },
+  {
+    id: 103,
+    name: 'Charlie Brown'
+  }
+];
+
 app.get('/search', (req, res) => {
   // Retrieve the query parameter
   const query = req.query.query?.toLowerCase() || '';
 
   // Filter tasks based on the query
-  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+  const filteredTasks = tasks.filter(task =>
+    task.description.toLowerCase().includes(query)
+  ).sort((a, b) => a.description.localeCompare(b.description));
 
-  // Sort the filtered tasks alphabetically by description
-  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+  // Filter users based on the query
+  const filteredUsers = users.filter(user =>
+    user.name.toLowerCase().includes(query)
+  ).sort((a, b) => a.name.localeCompare(b.name));
 
-  res.json(sortedTasks);
+  // Return both sets of results
+  res.json({ tasks: filteredTasks, users: filteredUsers });
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Problem

The current search functionality only allows users to search for tasks. We need to expand this to include user search capabilities as well, providing a more comprehensive search experience.

## Changes

- Renamed `TaskSearch` component to `TaskAndUserSearch` to reflect its expanded functionality
- Added state management for users with a new `users` state variable
- Updated the API response handling to process both tasks and users data
- Modified the UI to display both task and user search results in separate sections
- Updated placeholder text and heading to indicate the dual search capability
- Enhanced the backend to include user data in search results
- Added sorting for both tasks and users in alphabetical order

## How did you test this code?

Tested the search functionality by:
1. Verifying that both tasks and users appear in the search results
2. Confirming that the search filters both tasks and users correctly based on the query
3. Checking that results are properly sorted alphabetically
4. Testing edge cases with empty search queries and no matching results

## Publish to changelog?

No