### PR TITLE
feat(workflows): add edit functionality for templates

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -91,6 +91,7 @@ export const productScenes: Record<string, () => Promise<any>> = {
     UserInterview: () => import('../../products/user_interviews/frontend/UserInterview'),
     Workflows: () => import('../../products/workflows/frontend/WorkflowsScene'),
     Workflow: () => import('../../products/workflows/frontend/Workflows/WorkflowScene'),
+    WorkflowTemplate: () => import('../../products/workflows/frontend/Workflows/WorkflowTemplateScene'),
     WorkflowsLibraryTemplate: () => import('../../products/workflows/frontend/TemplateLibrary/MessageTemplate'),
 }
 
@@ -150,6 +151,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/workflows': ['Workflows', 'workflows'],
     '/workflows/:tab': ['Workflows', 'workflows'],
     '/workflows/:id/:tab': ['Workflow', 'workflowTab'],
+    '/workflow_templates/:templateId': ['WorkflowTemplate', 'workflowTemplate'],
     '/workflows/library/templates/:id': ['WorkflowsLibraryTemplate', 'workflowsLibraryTemplate'],
     '/workflows/library/templates/new': ['WorkflowsLibraryTemplate', 'workflowsLibraryTemplate'],
     '/workflows/library/templates/new?messageId=:messageId': [
@@ -410,6 +412,7 @@ export const productConfiguration: Record<string, any> = {
         description: 'Create and manage your workflows',
     },
     Workflow: { name: 'Workflows', iconType: 'workflows', projectBased: true },
+    WorkflowTemplate: { name: 'Workflow Template', iconType: 'workflows', projectBased: true },
     WorkflowsLibraryTemplate: { name: 'Workflows', iconType: 'workflows', projectBased: true },
 }
 
@@ -653,6 +656,7 @@ export const productUrls = {
     workflows: (tab?: WorkflowsSceneTab): string => `/workflows${tab ? `/${tab}` : ''}`,
     workflow: (id: string, tab: string): string => `/workflows/${id}/${tab}`,
     workflowNew: (): string => '/workflows/new/workflow',
+    workflowTemplate: (templateId: string): string => `/workflow_templates/${templateId}`,
     workflowsLibraryMessage: (id: string): string => `/workflows/library/messages/${id}`,
     workflowsLibraryTemplate: (id?: string): string => `/workflows/library/templates/${id}`,
     workflowsLibraryTemplateNew: (): string => '/workflows/library/templates/new',
@@ -1265,7 +1269,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconType: 'workflows',
         iconColor: ['var(--color-product-workflows-light)'] as FileSystemIconColor,
         sceneKey: 'Workflows',
-        sceneKeys: ['Workflows', 'Workflow', 'WorkflowsLibraryTemplate'],
+        sceneKeys: ['Workflows', 'Workflow', 'WorkflowTemplate', 'WorkflowsLibraryTemplate'],
     },
 ]
 

--- a/products/workflows/frontend/Workflows/SaveAsTemplateModal.tsx
+++ b/products/workflows/frontend/Workflows/SaveAsTemplateModal.tsx
@@ -10,18 +10,23 @@ import { WorkflowTemplateLogicProps, workflowTemplateLogic } from './workflowTem
 
 export function SaveAsTemplateModal(props: WorkflowTemplateLogicProps = {}): JSX.Element {
     const { user } = useValues(userLogic)
-    const logic = workflowTemplateLogic(props)
-    const { saveAsTemplateModalVisible, isTemplateFormSubmitting, templateForm } = useValues(logic)
-    const { hideSaveAsTemplateModal, submitTemplateForm } = useActions(logic)
+    const isEditingTemplate = !!props.templateId
+    
+    const logic = workflowTemplateLogic({ ...props, id: props.id || 'new' })
+    const { saveAsTemplateModalVisible, updateTemplateModalVisible, isTemplateFormSubmitting, templateForm } = useValues(logic)
+    const { hideSaveAsTemplateModal, hideUpdateTemplateModal, submitTemplateForm } = useActions(logic)
+    
+    const isOpen = isEditingTemplate ? updateTemplateModalVisible : saveAsTemplateModalVisible
+    const onClose = isEditingTemplate ? hideUpdateTemplateModal : hideSaveAsTemplateModal
 
     return (
         <LemonModal
-            onClose={hideSaveAsTemplateModal}
-            isOpen={saveAsTemplateModalVisible}
-            title="Save as template"
+            onClose={onClose}
+            isOpen={isOpen}
+            title={isEditingTemplate ? "Update template" : "Save as template"}
             footer={
                 <>
-                    <LemonButton type="secondary" onClick={hideSaveAsTemplateModal}>
+                    <LemonButton type="secondary" onClick={onClose}>
                         Cancel
                     </LemonButton>
                     <LemonButton
@@ -30,7 +35,7 @@ export function SaveAsTemplateModal(props: WorkflowTemplateLogicProps = {}): JSX
                         loading={isTemplateFormSubmitting}
                         disabledReason={!templateForm.name ? 'Name is required' : undefined}
                     >
-                        Save template
+                        {isEditingTemplate ? 'Update template' : 'Save template'}
                     </LemonButton>
                 </>
             }

--- a/products/workflows/frontend/Workflows/WorkflowTemplateScene.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowTemplateScene.tsx
@@ -1,0 +1,215 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import { useEffect } from 'react'
+
+import { IconCopy, IconTrash } from '@posthog/icons'
+import { LemonDialog, LemonDivider, SpinnerOverlay } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { NotFound } from 'lib/components/NotFound'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+import { SaveAsTemplateModal } from './SaveAsTemplateModal'
+import { HogFlowEditor } from './hogflows/HogFlowEditor'
+import { workflowLogic } from './workflowLogic'
+import { workflowTemplateLogic } from './workflowTemplateLogic'
+
+export interface WorkflowTemplateSceneProps {
+    templateId: string
+}
+
+export const scene: SceneExport<WorkflowTemplateSceneProps> = {
+    component: WorkflowTemplateScene,
+    paramsToProps: ({ params: { templateId } }) => ({
+        templateId,
+    }),
+}
+
+export function WorkflowTemplateScene({ templateId }: WorkflowTemplateSceneProps): JSX.Element {
+    // Force remount when templateId changes by using it as a key
+    return <WorkflowTemplateSceneInner key={templateId} templateId={templateId} />
+}
+
+function WorkflowTemplateSceneInner({ templateId }: WorkflowTemplateSceneProps): JSX.Element {
+    const canEditTemplates = useFeatureFlag('WORKFLOWS_TEMPLATE_CREATION')
+    
+    // Initialize the workflow logic with the template - keep id as 'new' but use templateId for loading
+    const logic = workflowLogic({ id: 'new', templateId, isEditingTemplate: true })
+    const { workflow, workflowLoading, originalWorkflow, workflowChanged } = useValues(logic)
+    const { setWorkflowValue, loadWorkflow } = useActions(logic)
+    
+    const templateLogic = workflowTemplateLogic({ id: 'new', templateId })
+    const { showUpdateTemplateModal, setEditingTemplateId } = useActions(templateLogic)
+    
+    // Reload workflow when templateId changes
+    useEffect(() => {
+        loadWorkflow()
+    }, [templateId])
+    
+    if (!originalWorkflow && workflowLoading) {
+        return <SpinnerOverlay sceneLevel />
+    }
+
+    if (!originalWorkflow) {
+        return <NotFound object="workflow template" />
+    }
+    
+    if (!canEditTemplates) {
+        return <NotFound object="workflow template" />
+    }
+
+    const handleUpdateTemplate = async (): Promise<void> => {
+        if (!workflow) {
+            lemonToast.error('Workflow not loaded')
+            return
+        }
+
+        try {
+            const template = await api.hogFlowTemplates.getHogFlowTemplate(templateId)
+            templateLogic.actions.setTemplateFormValues({
+                name: workflow.name || template.name || '',
+                description: workflow.description || template.description || '',
+                image_url: template.image_url || null,
+                scope: template.scope || 'team',
+            })
+            setEditingTemplateId(templateId)
+            showUpdateTemplateModal()
+        } catch (error) {
+            templateLogic.actions.setTemplateFormValues({
+                name: workflow.name || '',
+                description: workflow.description || '',
+                image_url: null,
+                scope: 'team',
+            })
+            setEditingTemplateId(templateId)
+            showUpdateTemplateModal()
+        }
+    }
+
+    const handleDeleteTemplate = (): void => {
+        LemonDialog.open({
+            title: 'Delete template?',
+            description: (
+                <>
+                    Are you sure you want to delete "{workflow?.name}"?
+                    <br />
+                    This action cannot be undone.
+                </>
+            ),
+            primaryButton: {
+                children: 'Delete',
+                status: 'danger',
+                onClick: async () => {
+                    try {
+                        await api.hogFlowTemplates.deleteHogFlowTemplate(templateId)
+                        lemonToast.success('Template deleted successfully')
+                        router.actions.push(urls.workflows())
+                    } catch (error: any) {
+                        lemonToast.error(
+                            `Failed to delete template: ${error.detail || error.message || 'Unknown error'}`
+                        )
+                    }
+                },
+            },
+            secondaryButton: { children: 'Cancel' },
+        })
+    }
+
+    const handleDuplicateTemplate = async (): Promise<void> => {
+        if (!workflow) {
+            lemonToast.error('Workflow not loaded')
+            return
+        }
+
+        try {
+            const newTemplate = await api.hogFlowTemplates.createHogFlowTemplate({
+                ...workflow,
+                name: `${workflow.name} (copy)`,
+                description: workflow.description || '',
+            })
+            
+            if (newTemplate?.id) {
+                lemonToast.success('Template duplicated successfully')
+                // Navigate to the new template
+                router.actions.push(urls.workflowTemplate(newTemplate.id))
+            } else {
+                throw new Error('Template created but no ID returned')
+            }
+        } catch (error: any) {
+            lemonToast.error(
+                `Failed to duplicate template: ${error.detail || error.message || 'Unknown error'}`
+            )
+        }
+    }
+
+    return (
+        <SceneContent className="flex flex-col">
+            <SaveAsTemplateModal id="new" templateId={templateId} />
+            <SceneTitleSection
+                name={workflow?.name}
+                description={workflow?.description}
+                resourceType={{ type: 'workflows' }}
+                canEdit
+                onNameChange={(name) => setWorkflowValue('name', name)}
+                onDescriptionChange={(description) => setWorkflowValue('description', description)}
+                isLoading={workflowLoading && !workflow}
+                renameDebounceMs={200}
+                actions={
+                    <>
+                        <More
+                            size="small"
+                            overlay={
+                                <>
+                                    <LemonButton
+                                        fullWidth
+                                        onClick={handleDuplicateTemplate}
+                                        icon={<IconCopy />}
+                                    >
+                                        Duplicate
+                                    </LemonButton>
+                                    <LemonDivider />
+                                    <LemonButton
+                                        status="danger"
+                                        fullWidth
+                                        onClick={handleDeleteTemplate}
+                                        icon={<IconTrash />}
+                                    >
+                                        Delete
+                                    </LemonButton>
+                                </>
+                            }
+                        />
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            onClick={() => router.actions.push(urls.workflows())}
+                        >
+                            Cancel
+                        </LemonButton>
+                        <LemonButton
+                            type="primary"
+                            size="small"
+                            onClick={handleUpdateTemplate}
+                            disabledReason={!workflowChanged ? 'No changes to save' : undefined}
+                        >
+                            Update template
+                        </LemonButton>
+                    </>
+                }
+            />
+            <div className="relative border rounded-md h-[calc(100vh-280px)]">
+                <BindLogic logic={workflowLogic} props={{ id: 'new', templateId, isEditingTemplate: true }}>
+                    <HogFlowEditor />
+                </BindLogic>
+            </div>
+        </SceneContent>
+    )
+}

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -27,6 +27,7 @@ import { workflowSceneLogic } from './workflowSceneLogic'
 export interface WorkflowLogicProps {
     id?: string
     templateId?: string
+    isEditingTemplate?: boolean
 }
 
 export const TRIGGER_NODE_ID = 'trigger_node'
@@ -149,7 +150,8 @@ export const workflowLogic = kea<workflowLogicType>([
 
                             const newWorkflow = {
                                 ...templateWorkflow,
-                                name: `${templateWorkflow.name} (copy)`,
+                                // Don't add "(copy)" if we're editing the template
+                                name: props.isEditingTemplate ? templateWorkflow.name : `${templateWorkflow.name} (copy)`,
                                 status: 'draft' as const,
                                 version: 1,
                             }

--- a/products/workflows/manifest.tsx
+++ b/products/workflows/manifest.tsx
@@ -22,6 +22,12 @@ export const manifest: ProductManifest = {
             iconType: 'workflows',
             projectBased: true,
         },
+        WorkflowTemplate: {
+            import: () => import('./frontend/Workflows/WorkflowTemplateScene'),
+            name: 'Workflow Template',
+            iconType: 'workflows',
+            projectBased: true,
+        },
         WorkflowsLibraryTemplate: {
             import: () => import('./frontend/TemplateLibrary/MessageTemplate'),
             name: 'Workflows',
@@ -34,6 +40,7 @@ export const manifest: ProductManifest = {
         '/workflows': ['Workflows', 'workflows'],
         '/workflows/:tab': ['Workflows', 'workflows'],
         '/workflows/:id/:tab': ['Workflow', 'workflowTab'],
+        '/workflow_templates/:templateId': ['WorkflowTemplate', 'workflowTemplate'],
         '/workflows/library/templates/:id': ['WorkflowsLibraryTemplate', 'workflowsLibraryTemplate'],
         '/workflows/library/templates/new': ['WorkflowsLibraryTemplate', 'workflowsLibraryTemplate'],
         '/workflows/library/templates/new?messageId=:messageId': [
@@ -45,6 +52,7 @@ export const manifest: ProductManifest = {
         workflows: (tab?: WorkflowsSceneTab): string => `/workflows${tab ? `/${tab}` : ''}`,
         workflow: (id: string, tab: string): string => `/workflows/${id}/${tab}`,
         workflowNew: (): string => '/workflows/new/workflow',
+        workflowTemplate: (templateId: string): string => `/workflow_templates/${templateId}`,
         workflowsLibraryMessage: (id: string): string => `/workflows/library/messages/${id}`,
         workflowsLibraryTemplate: (id?: string): string => `/workflows/library/templates/${id}`,
         workflowsLibraryTemplateNew: (): string => '/workflows/library/templates/new',


### PR DESCRIPTION
## Problem

We have no possibility to edit templates so folks need to either delete templates and build them new from scratch or adjust the templates and create a completely new template and then delete the old one. Pretty cumbersome. We also did not have any possibility to just duplicate templates.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

![2025-12-30 10 39 57](https://github.com/user-attachments/assets/ab2befb8-821e-4c0e-9790-3b4b588bcd63)

- added edit functionality for templates 
- added duplication for templates 

## How did you test this code?

- local dev