### PR TITLE
feat(hogql): expose CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN errors

### DIFF
--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -459,7 +459,7 @@ CLICKHOUSE_ERROR_CODE_LOOKUP: dict[int, ErrorCodeMeta] = {
     345: ErrorCodeMeta("TABLE_DIFFERS_TOO_MUCH"),
     346: ErrorCodeMeta("CANNOT_CONVERT_CHARSET"),
     347: ErrorCodeMeta("CANNOT_LOAD_CONFIG"),
-    349: ErrorCodeMeta("CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN"),
+    349: ErrorCodeMeta("CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN", user_safe=True),
     352: ErrorCodeMeta("AMBIGUOUS_COLUMN_NAME"),
     353: ErrorCodeMeta("INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE", user_safe=True),
     354: ErrorCodeMeta("ZLIB_INFLATE_FAILED"),


### PR DESCRIPTION
## Problem

This error happens quite often in dev/prod when a potentially nullable column is passed to the funnel UDF. It seems safe to expose.

## Changes

Exposes errors like this:

![Screenshot 2025-12-30 at 12.25.15.png](https://app.graphite.com/user-attachments/assets/2eeb5c70-17df-4040-a9cd-3187f9bc8fb1.png)

## How did you test this code?

Locally