### PR TITLE
chore(workflows): Add hint that we're still adding templates

### DIFF
--- a/products/workflows/frontend/Workflows/NewWorkflowModal.tsx
+++ b/products/workflows/frontend/Workflows/NewWorkflowModal.tsx
@@ -34,6 +34,10 @@ export function NewWorkflowModal(): JSX.Element {
                             autoFocus
                         />
                     </div>
+                    <div className="text-xs text-muted">
+                        We're still expanding our portfolio of templates. Check back soon if you can't find what you're
+                        looking for!
+                    </div>
                 </div>
             }
         >


### PR DESCRIPTION
## Problem

We don't have a lot of templates yet and we don't want users to think that these are all they're going to get

<img width="825" height="430" alt="image" src="https://github.com/user-attachments/assets/7794a8bf-cd8f-4a72-90d8-2bc56a02e418" />