### PR TITLE
refactor(LogsViewer): improve cursor handling and add kea-subscriptions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2062,6 +2062,9 @@ importers:
       kea-router:
         specifier: ^3.4.1
         version: 3.4.1(kea@3.1.7(react@18.2.0))
+      kea-subscriptions:
+        specifier: ^3.0.1
+        version: 3.0.1(kea@3.1.7(react@18.2.0))
       papaparse:
         specifier: '*'
         version: 5.4.1
@@ -28327,7 +28330,7 @@ snapshots:
       commander: 9.4.1
       expect-playwright: 0.8.0
       glob: 10.4.5
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -34965,7 +34968,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -35245,7 +35248,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.4.1
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import { TZLabelProps } from 'lib/components/TZLabel'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
-import { cn } from 'lib/utils/css-classes'
 
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { DateRange } from '~/queries/schema/schema-general'
@@ -102,26 +101,21 @@ function LogsViewerContent({
         pinnedLogsArray,
         isFocused,
         cursorLogId,
-        linkToLogId,
         logs,
-        logsCount,
         timezone,
         isSelectionActive,
     } = useValues(logsViewerLogic)
     const {
-        setFocused,
         moveCursorDown,
         moveCursorUp,
         toggleExpandLog,
         resetCursor,
-        setCursorToLogId,
         toggleSelectLog,
         clearSelection,
         togglePrettifyLog,
     } = useActions(logsViewerLogic)
     const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ tabId }))
     const { setCellScrollLeft } = useActions(virtualizedLogsListLogic({ tabId }))
-    const containerRef = useRef<HTMLDivElement>(null)
     const messageScrollLeft = cellScrollLefts['message'] ?? 0
     const scrollLeftRef = useRef(messageScrollLeft)
     scrollLeftRef.current = messageScrollLeft
@@ -194,14 +188,6 @@ function LogsViewerContent({
             stopScrolling()
         }
     }, [isFocused, wrapBody, startScrolling, stopScrolling])
-
-    // Position cursor at linked log when deep linking (URL -> cursor)
-    useEffect(() => {
-        if (linkToLogId && logsCount > 0) {
-            setCursorToLogId(linkToLogId)
-            containerRef.current?.focus()
-        }
-    }, [linkToLogId, logsCount, setCursorToLogId])
 
     const tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime' | 'displayTimezone'> = {
         formatDate: 'YYYY-MM-DD',
@@ -300,48 +286,29 @@ function LogsViewerContent({
             <SceneDivider />
             <LogsViewerToolbar totalLogsCount={totalLogsCount} orderBy={orderBy} onChangeOrderBy={onChangeOrderBy} />
             <LogsSelectionToolbar />
-            <div
-                ref={containerRef}
-                className="flex flex-col gap-2 flex-1 min-h-0 outline-none focus:ring-1 focus:ring-border-bold focus:ring-offset-1 rounded"
-                tabIndex={0}
-                onFocus={() => {
-                    setFocused(true)
-                    containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-                }}
-                onBlur={() => setFocused(false)}
-            >
-                {pinnedLogsArray.length > 0 && (
-                    <div className="border rounded-t bg-bg-light shadow-sm">
-                        <VirtualizedLogsList
-                            dataSource={pinnedLogsArray}
-                            loading={false}
-                            wrapBody={wrapBody}
-                            prettifyJson={prettifyJson}
-                            tzLabelFormat={tzLabelFormat}
-                            showPinnedWithOpacity
-                            fixedHeight={250}
-                            disableInfiniteScroll
-                        />
-                    </div>
-                )}
-                <div
-                    className={cn(
-                        'border bg-bg-light flex-1 min-h-0',
-                        pinnedLogsArray.length > 0 ? 'rounded-b' : 'rounded'
-                    )}
-                >
-                    <VirtualizedLogsList
-                        dataSource={logs}
-                        loading={loading}
-                        wrapBody={wrapBody}
-                        prettifyJson={prettifyJson}
-                        tzLabelFormat={tzLabelFormat}
-                        showPinnedWithOpacity
-                        hasMoreLogsToLoad={hasMoreLogsToLoad}
-                        onLoadMore={onLoadMore}
-                    />
-                </div>
-            </div>
+            {pinnedLogsArray.length > 0 && (
+                <VirtualizedLogsList
+                    dataSource={pinnedLogsArray}
+                    loading={false}
+                    wrapBody={wrapBody}
+                    prettifyJson={prettifyJson}
+                    tzLabelFormat={tzLabelFormat}
+                    fixedHeight={250}
+                    disableInfiniteScroll
+                    disableCursor
+                />
+            )}
+
+            <VirtualizedLogsList
+                dataSource={logs}
+                loading={loading}
+                wrapBody={wrapBody}
+                prettifyJson={prettifyJson}
+                tzLabelFormat={tzLabelFormat}
+                showPinnedWithOpacity
+                hasMoreLogsToLoad={hasMoreLogsToLoad}
+                onLoadMore={onLoadMore}
+            />
         </div>
     )
 }

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -1,4 +1,5 @@
 import { actions, connect, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
+import { subscriptions } from 'kea-subscriptions'
 import Papa from 'papaparse'
 
 import { dayjs } from 'lib/dayjs'
@@ -59,6 +60,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         resetCursor: true,
         moveCursorDown: (shiftSelect?: boolean) => ({ shiftSelect: shiftSelect ?? false }),
         moveCursorUp: (shiftSelect?: boolean) => ({ shiftSelect: shiftSelect ?? false }),
+        requestScrollToCursor: true, // Signals React to scroll to current cursor position
 
         // Expansion
         toggleExpandLog: (logId: string) => ({ logId }),
@@ -237,6 +239,14 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
             null as { logIds?: string[]; timestamp: number } | null,
             {
                 recomputeRowHeights: (_, { logIds }) => ({ logIds, timestamp: Date.now() }),
+            },
+        ],
+
+        // Tracks requests to scroll to cursor - VirtualizedLogsList watches this timestamp
+        scrollToCursorRequest: [
+            0,
+            {
+                requestScrollToCursor: () => Date.now(),
             },
         ],
 
@@ -603,4 +613,12 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
             userSetCursorAttribute: clearLinkToLogIdFromUrl,
         }
     }),
+
+    subscriptions(({ actions }) => ({
+        cursorIndex: (cursorIndex) => {
+            if (cursorIndex !== null) {
+                actions.requestScrollToCursor()
+            }
+        },
+    })),
 ])

--- a/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
@@ -45,7 +45,7 @@ export interface LogRowProps {
     tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime' | 'displayTimezone'>
     onTogglePin: (log: ParsedLogMessage) => void
     onToggleExpand: () => void
-    onSetCursor: () => void
+    onSetCursor?: () => void
     rowWidth?: number
     attributeColumns?: string[]
     attributeColumnWidths?: Record<string, number>
@@ -94,7 +94,7 @@ export function LogRow({
             e.preventDefault()
             onShiftClick(logIndex)
         } else {
-            onSetCursor()
+            onSetCursor?.()
         }
     }
 
@@ -109,8 +109,7 @@ export function LogRow({
                     'flex items-center cursor-pointer hover:bg-fill-highlight-100 group',
                     isSelected && 'bg-fill-highlight-100',
                     isAtCursor && 'bg-primary-highlight',
-                    pinned && 'bg-warning-highlight',
-                    pinned && showPinnedWithOpacity && 'opacity-50'
+                    pinned && showPinnedWithOpacity && 'bg-warning-highlight opacity-50'
                 )}
                 onMouseDown={handleMouseDown}
             >

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -26,6 +26,7 @@ interface VirtualizedLogsListProps {
     prettifyJson: boolean
     tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime' | 'displayTimezone'>
     showPinnedWithOpacity?: boolean
+    disableCursor?: boolean
     fixedHeight?: number
     disableInfiniteScroll?: boolean
     hasMoreLogsToLoad?: boolean
@@ -39,6 +40,7 @@ export function VirtualizedLogsList({
     prettifyJson,
     tzLabelFormat,
     showPinnedWithOpacity = false,
+    disableCursor = false,
     fixedHeight,
     disableInfiniteScroll = false,
     hasMoreLogsToLoad = false,
@@ -50,11 +52,14 @@ export function VirtualizedLogsList({
         expandedLogIds,
         cursorIndex,
         recomputeRowHeightsRequest,
+        scrollToCursorRequest,
         attributeColumns,
         attributeColumnWidths,
         selectedLogIds,
         selectedCount,
         prettifiedLogIds,
+        linkToLogId,
+        logsCount,
     } = useValues(logsViewerLogic)
     const {
         togglePinLog,
@@ -68,7 +73,11 @@ export function VirtualizedLogsList({
         clearSelection,
         selectLogRange,
         togglePrettifyLog,
+        setFocused,
+        setCursorToLogId,
     } = useActions(logsViewerLogic)
+
+    const containerRef = useRef<HTMLDivElement>(null)
 
     const { shouldLoadMore, containerWidth } = useValues(virtualizedLogsListLogic({ tabId }))
     const { setContainerWidth } = useActions(virtualizedLogsListLogic({ tabId }))
@@ -91,6 +100,15 @@ export function VirtualizedLogsList({
             }),
         []
     )
+
+    // Position cursor at linked log when deep linking (URL -> cursor)
+    useEffect(() => {
+        if (!disableCursor && linkToLogId && logsCount > 0) {
+            setCursorToLogId(linkToLogId)
+            containerRef.current?.focus()
+            containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        }
+    }, [disableCursor, linkToLogId, logsCount, setCursorToLogId])
 
     // Handle recompute requests from child components (via the logic)
     const lastRecomputeTimestampRef = useRef<number>(0)
@@ -128,38 +146,19 @@ export function VirtualizedLogsList({
         }
     }, [loading, dataSource.length, cache])
 
-    // Scroll to cursor when it changes (but not when data length changes from pagination)
-    const prevCursorIndexRef = useRef<number | null>(cursorIndex)
+    // Scroll to cursor when requested (subscription fires when cursorIndex changes)
     useEffect(() => {
-        const cursorChanged = cursorIndex !== prevCursorIndexRef.current
-        prevCursorIndexRef.current = cursorIndex
-
-        if (cursorChanged && cursorIndex !== null && dataSource.length > 0) {
+        if (!disableCursor && cursorIndex !== null) {
             listRef.current?.scrollToRow(cursorIndex)
-            // Double scroll after two animation frames to ensure row measurement is complete
-            let raf1: number | null = null
-            let raf2: number | null = null
-            raf1 = requestAnimationFrame(() => {
-                raf2 = requestAnimationFrame(() => {
-                    listRef.current?.scrollToRow(cursorIndex)
-                })
+            const raf = requestAnimationFrame(() => {
+                listRef.current?.scrollToRow(cursorIndex)
             })
-            return () => {
-                if (raf1 !== null) {
-                    cancelAnimationFrame(raf1)
-                }
-                if (raf2 !== null) {
-                    cancelAnimationFrame(raf2)
-                }
-            }
+            return () => cancelAnimationFrame(raf)
         }
-    }, [cursorIndex, dataSource.length])
+    }, [disableCursor, scrollToCursorRequest, cursorIndex])
 
     const handleRowsRendered = ({ stopIndex }: { stopIndex: number }): void => {
-        if (disableInfiniteScroll) {
-            return
-        }
-        if (shouldLoadMore(stopIndex, dataSource.length, hasMoreLogsToLoad, loading)) {
+        if (!disableInfiniteScroll && shouldLoadMore(stopIndex, dataSource.length, hasMoreLogsToLoad, loading)) {
             onLoadMore?.()
         }
     }
@@ -181,7 +180,7 @@ export function VirtualizedLogsList({
                                 <LogRow
                                     log={log}
                                     logIndex={index}
-                                    isAtCursor={index === cursorIndex}
+                                    isAtCursor={!disableCursor && index === cursorIndex}
                                     isExpanded={isExpanded}
                                     pinned={!!pinnedLogs[log.uuid]}
                                     showPinnedWithOpacity={showPinnedWithOpacity}
@@ -190,7 +189,7 @@ export function VirtualizedLogsList({
                                     tzLabelFormat={tzLabelFormat}
                                     onTogglePin={togglePinLog}
                                     onToggleExpand={() => toggleExpandLog(log.uuid)}
-                                    onSetCursor={() => userSetCursorIndex(index)}
+                                    onSetCursor={disableCursor ? undefined : () => userSetCursorIndex(index)}
                                     rowWidth={rowWidth}
                                     attributeColumns={attributeColumns}
                                     attributeColumnWidths={attributeColumnWidths}
@@ -216,6 +215,7 @@ export function VirtualizedLogsList({
             pinnedLogs,
             cache,
             showPinnedWithOpacity,
+            disableCursor,
             wrapBody,
             prettifyJson,
             tzLabelFormat,
@@ -239,7 +239,7 @@ export function VirtualizedLogsList({
     // Fixed height mode for pinned logs
     if (fixedHeight !== undefined) {
         return (
-            <div style={{ height: fixedHeight }} className="flex flex-col">
+            <div style={{ height: fixedHeight }} className="flex flex-col bg-bg-light border rounded overflow-hidden">
                 <AutoSizer disableHeight>
                     {({ width }) => {
                         if (width !== autosizerWidthRef.current) {
@@ -282,7 +282,13 @@ export function VirtualizedLogsList({
     }
 
     return (
-        <div className="h-full flex-1 flex flex-col">
+        <div
+            tabIndex={0}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            ref={containerRef}
+            className="gap-2 min-h-0 outline-none focus:ring-1 focus:ring-border-bold focus:ring-offset-1 h-full flex-1 flex flex-col bg-bg-light border rounded overflow-hidden"
+        >
             <AutoSizer>
                 {({ width, height }) => {
                     if (width !== autosizerWidthRef.current) {

--- a/products/logs/package.json
+++ b/products/logs/package.json
@@ -4,7 +4,8 @@
     "dependencies": {
         "kea": "^3.1.7",
         "kea-loaders": "^3.1.1",
-        "kea-router": "^3.4.1"
+        "kea-router": "^3.4.1",
+        "kea-subscriptions": "^3.0.1"
     },
     "peerDependencies": {
         "@posthog/icons": "*",


### PR DESCRIPTION
## Problem

The current logs viewer implementation has issues with cursor management and UI layout. The logs viewer needs to be more responsive and provide better user experience when navigating through logs.

## Changes

- Added `kea-subscriptions` package to improve state management
- Refactored the LogsViewer component to separate pinned logs and regular logs into distinct VirtualizedLogsList components
- Improved cursor management with a new `requestScrollToCursor` action and subscription
- Simplified container focus handling by moving it to the VirtualizedLogsList component
- Enhanced scrolling behavior to ensure cursor visibility
- Fixed styling issues with borders and containers
- Added a `disableCursor` prop to VirtualizedLogsList to prevent cursor interactions in pinned logs section
- Prevent auto page scroll-to logviewer on focus, this was poor UX

## How did you test this code?

Tested by navigating through logs with keyboard shortcuts, verifying cursor positioning and scrolling behavior works correctly. Verified that pinned logs display properly and that focus management works as expected when clicking between different log sections.

Ensured that deep linking to specific logs via URL parameters continues to work correctly with the refactored implementation.

## Publish to changelog?

No