### PR TITLE
fix: Loading of attachments for legacy onevent plugins

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
@@ -198,6 +198,79 @@ describe('CdpLegacyEventsConsumer', () => {
             })
         })
 
+        it('should include attachments in inputs when provided', () => {
+            const lightweightConfig = {
+                id: pluginConfig.id,
+                team_id: team.id,
+                plugin_id: pluginConfig.plugin_id,
+                enabled: true,
+                config: {
+                    customerioSiteId: '1234567890',
+                    customerioToken: 'cio-token',
+                },
+                created_at: '2025-01-01T00:00:00.000Z',
+                updated_at: '2025-01-01T00:00:00.000Z',
+                plugin: {
+                    id: pluginConfig.plugin_id,
+                    url: 'https://github.com/PostHog/customerio-plugin',
+                },
+            }
+
+            const attachments = {
+                mappings: {
+                    event1: 'action1',
+                    event2: 'action2',
+                },
+                customField: 'value123',
+            }
+
+            const result = consumer['convertPluginConfigToHogFunction'](lightweightConfig, attachments)
+
+            expect(result).toBeTruthy()
+            expect(result?.inputs).toMatchObject({
+                customerioSiteId: { value: '1234567890' },
+                customerioToken: { value: 'cio-token' },
+                legacy_plugin_config_id: { value: pluginConfig.id },
+                mappings: {
+                    value: {
+                        event1: 'action1',
+                        event2: 'action2',
+                    },
+                },
+                customField: { value: 'value123' },
+            })
+        })
+
+        it('should not include attachments when config is empty', () => {
+            const lightweightConfig = {
+                id: pluginConfig.id,
+                team_id: team.id,
+                plugin_id: pluginConfig.plugin_id,
+                enabled: true,
+                config: {},
+                created_at: '2025-01-01T00:00:00.000Z',
+                updated_at: '2025-01-01T00:00:00.000Z',
+                plugin: {
+                    id: pluginConfig.plugin_id,
+                    url: 'https://github.com/PostHog/customerio-plugin',
+                },
+            }
+
+            const attachments = {
+                mappings: {
+                    event1: 'action1',
+                },
+            }
+
+            const result = consumer['convertPluginConfigToHogFunction'](lightweightConfig, attachments)
+
+            expect(result).toBeTruthy()
+            expect(result?.inputs).toMatchObject({
+                legacy_plugin_config_id: { value: pluginConfig.id },
+            })
+            expect(result?.inputs?.mappings).toBeUndefined()
+        })
+
         it('should handle inline plugin URLs correctly', () => {
             const lightweightConfig = {
                 id: 1,
@@ -262,6 +335,47 @@ describe('CdpLegacyEventsConsumer', () => {
 
             const invocations = await consumer['getLegacyPluginHogFunctionInvocations'](emptyInvocation)
             expect(invocations).toEqual([])
+        })
+
+        it('should load attachments and include them in hog function inputs', async () => {
+            // Insert an attachment for the plugin config
+            await hub.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `INSERT INTO posthog_pluginattachment (id, plugin_config_id, key, contents, content_type, file_size, file_name)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+                [
+                    1001,
+                    pluginConfig.id,
+                    'mappings',
+                    JSON.stringify({ event1: 'action1', event2: 'action2' }),
+                    'application/json',
+                    50,
+                    'mappings.json',
+                ],
+                'insertPluginAttachment'
+            )
+
+            // Clear cache to force reload
+            consumer['pluginConfigsLoader'].clear()
+
+            // Get invocations
+            const invocations = await consumer['getLegacyPluginHogFunctionInvocations'](invocation)
+
+            expect(invocations).toBeTruthy()
+            expect(invocations.length).toBeGreaterThan(0)
+
+            // Check that the attachment was loaded into inputs
+            const hogFunction = invocations[0].hogFunction
+            expect(hogFunction.inputs).toBeTruthy()
+            expect(hogFunction.inputs?.mappings).toBeTruthy()
+            expect(hogFunction.inputs?.mappings?.value).toEqual({
+                event1: 'action1',
+                event2: 'action2',
+            })
+
+            // Verify other inputs are still present
+            expect(hogFunction.inputs?.customerioSiteId?.value).toBe('1234567890')
+            expect(hogFunction.inputs?.customerioToken?.value).toBe('cio-token')
         })
     })
 

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -377,7 +377,7 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase {
             // Plugin configs are always static { value: any } so we can just convert to a record of strings
             const inputs = Object.entries(hogFunction.inputs || {}).reduce(
                 (acc, [key, value]) => {
-                    acc[key] = value?.value?.toString() ?? ''
+                    acc[key] = value?.value ?? ''
                     return acc
                 },
                 {} as Record<string, string>

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -289,14 +289,6 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase {
             const pluginConfigId = parseInt(result.invocation.hogFunction.id.replace('legacy-', ''))
             const error = result.error
 
-            if (error && result.invocation.hogFunction.template_id === 'plugin-pubsub-plugin') {
-                logger.error('Legacy pubsub plugin execution failed', {
-                    pluginConfigId,
-                    inputs: result.invocation.state.globals.inputs,
-                    error: error.message,
-                })
-            }
-
             legacyPluginExecutionResultCounter
                 .labels({
                     result: error ? 'error' : 'success',
@@ -377,7 +369,7 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase {
             // Plugin configs are always static { value: any } so we can just convert to a record of strings
             const inputs = Object.entries(hogFunction.inputs || {}).reduce(
                 (acc, [key, value]) => {
-                    acc[key] = value?.value ?? ''
+                    acc[key] = value?.value
                     return acc
                 },
                 {} as Record<string, string>

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -114,6 +114,43 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase {
             'loadPluginConfigHogFunctions'
         )
 
+        // Load attachments for all plugin configs with non-empty config
+        const pluginConfigIds = rows.filter((row) => Object.keys(row.config || {}).length > 0).map((row) => row.id)
+        const attachmentsMap: Record<number, Record<string, any>> = {}
+
+        if (pluginConfigIds.length > 0) {
+            const { rows: attachmentRows } = await this.hub.postgres.query(
+                PostgresUse.COMMON_READ,
+                `SELECT plugin_config_id, key, contents
+                FROM posthog_pluginattachment
+                WHERE plugin_config_id = ANY($1)`,
+                [pluginConfigIds],
+                'loadPluginConfigAttachments'
+            )
+
+            for (const attachmentRow of attachmentRows) {
+                if (!attachmentsMap[attachmentRow.plugin_config_id]) {
+                    attachmentsMap[attachmentRow.plugin_config_id] = {}
+                }
+
+                try {
+                    // Parse contents as JSON if possible
+                    const contents =
+                        typeof attachmentRow.contents === 'string'
+                            ? parseJSON(attachmentRow.contents)
+                            : attachmentRow.contents
+
+                    attachmentsMap[attachmentRow.plugin_config_id][attachmentRow.key] = contents
+                } catch (error: any) {
+                    logger.warn('Failed to parse attachment contents', {
+                        pluginConfigId: attachmentRow.plugin_config_id,
+                        key: attachmentRow.key,
+                        error: error?.message,
+                    })
+                }
+            }
+        }
+
         // Group by team_id and build hog functions directly
         const results: Record<string, PluginConfigHogFunction[]> = {}
 
@@ -124,21 +161,24 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase {
             }
 
             try {
-                const hogFunction = this.convertPluginConfigToHogFunction({
-                    id: row.id,
-                    team_id: row.team_id,
-                    plugin_id: row.plugin_id,
-                    enabled: row.enabled === 't',
-                    config: row.config,
-                    created_at: row.created_at,
-                    updated_at: row.updated_at,
-                    plugin: row.plugin__url
-                        ? {
-                              id: row.plugin__id,
-                              url: row.plugin__url,
-                          }
-                        : undefined,
-                })
+                const hogFunction = this.convertPluginConfigToHogFunction(
+                    {
+                        id: row.id,
+                        team_id: row.team_id,
+                        plugin_id: row.plugin_id,
+                        enabled: row.enabled === 't',
+                        config: row.config,
+                        created_at: row.created_at,
+                        updated_at: row.updated_at,
+                        plugin: row.plugin__url
+                            ? {
+                                  id: row.plugin__id,
+                                  url: row.plugin__url,
+                              }
+                            : undefined,
+                    },
+                    attachmentsMap[row.id]
+                )
 
                 if (hogFunction) {
                     results[teamId].push({
@@ -164,7 +204,10 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase {
         return results
     }
 
-    private convertPluginConfigToHogFunction(pluginConfig: LightweightPluginConfig): HogFunctionType | null {
+    private convertPluginConfigToHogFunction(
+        pluginConfig: LightweightPluginConfig,
+        attachments?: Record<string, any>
+    ): HogFunctionType | null {
         if (!pluginConfig.plugin?.url) {
             return null
         }
@@ -179,6 +222,15 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase {
 
         for (const [key, value] of Object.entries(pluginConfig.config)) {
             inputs[key] = { value: value?.toString() ?? '' }
+        }
+
+        // Add attachments to inputs (matching migration.py logic)
+        if (attachments && Object.keys(pluginConfig.config).length > 0) {
+            for (const [key, value] of Object.entries(attachments)) {
+                if (value) {
+                    inputs[key] = { value }
+                }
+            }
         }
 
         // Add legacy_plugin_config_id for plugins that use legacy storage

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -288,6 +288,15 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase {
         for (const result of results) {
             const pluginConfigId = parseInt(result.invocation.hogFunction.id.replace('legacy-', ''))
             const error = result.error
+
+            if (error && result.invocation.hogFunction.template_id === 'plugin-pubsub-plugin') {
+                logger.error('Legacy pubsub plugin execution failed', {
+                    pluginConfigId,
+                    inputs: result.invocation.state.globals.inputs,
+                    error: error.message,
+                })
+            }
+
             legacyPluginExecutionResultCounter
                 .labels({
                     result: error ? 'error' : 'success',

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -134,12 +134,19 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase {
                 }
 
                 try {
-                    // Parse contents as JSON if possible
-                    const contents =
-                        typeof attachmentRow.contents === 'string'
-                            ? parseJSON(attachmentRow.contents)
-                            : attachmentRow.contents
+                    // Convert Buffer to string if needed, then parse as JSON
+                    let contentsString: string
+                    if (Buffer.isBuffer(attachmentRow.contents)) {
+                        contentsString = attachmentRow.contents.toString('utf-8')
+                    } else if (typeof attachmentRow.contents === 'string') {
+                        contentsString = attachmentRow.contents
+                    } else {
+                        // If it's already an object, use it directly
+                        attachmentsMap[attachmentRow.plugin_config_id][attachmentRow.key] = attachmentRow.contents
+                        continue
+                    }
 
+                    const contents = parseJSON(contentsString)
                     attachmentsMap[attachmentRow.plugin_config_id][attachmentRow.key] = contents
                 } catch (error: any) {
                     logger.warn('Failed to parse attachment contents', {


### PR DESCRIPTION
## Problem

This element was missing which caused issues specifically for GCP related legacy plugins

## Changes

* Adds the loading of attachments

## How did you test this code?

* Test

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
