### PR TITLE
feat(workflows): Allow editing workflow templates

### DIFF
--- a/posthog/api/hog_flow_template.py
+++ b/posthog/api/hog_flow_template.py
@@ -59,7 +59,8 @@ class OnlyStaffCanEditGlobalHogFlowTemplate(BasePermission):
         if request.method in SAFE_METHODS:
             return True
 
-        if obj.scope == HogFlowTemplate.Scope.GLOBAL:
+        # Prevent non-staff from editing global templates / updating team template to global
+        if obj.scope == HogFlowTemplate.Scope.GLOBAL or request.data.get("scope") == HogFlowTemplate.Scope.GLOBAL:
             return request.user.is_staff
 
         return True

--- a/posthog/api/hog_flow_template.py
+++ b/posthog/api/hog_flow_template.py
@@ -197,6 +197,9 @@ class HogFlowTemplateSerializer(serializers.ModelSerializer):
         data.pop("team_id", None)
         data.pop("created_at", None)
         data.pop("updated_at", None)
+        data.pop("created_by", None)
+        data.pop("status", None)
+        data.pop("version", None)
 
         return data
 

--- a/products/workflows/frontend/Workflows/SaveAsTemplateModal.tsx
+++ b/products/workflows/frontend/Workflows/SaveAsTemplateModal.tsx
@@ -11,14 +11,14 @@ import { WorkflowTemplateLogicProps, workflowTemplateLogic } from './workflowTem
 export function SaveAsTemplateModal(props: WorkflowTemplateLogicProps = {}): JSX.Element {
     const { user } = useValues(userLogic)
     const logic = workflowTemplateLogic(props)
-    const { saveAsTemplateModalVisible, isTemplateFormSubmitting, templateForm } = useValues(logic)
+    const { saveAsTemplateModalVisible, isTemplateFormSubmitting, templateForm, isEditMode } = useValues(logic)
     const { hideSaveAsTemplateModal, submitTemplateForm } = useActions(logic)
 
     return (
         <LemonModal
             onClose={hideSaveAsTemplateModal}
             isOpen={saveAsTemplateModalVisible}
-            title="Save as template"
+            title={isEditMode ? 'Update template' : 'Save as template'}
             footer={
                 <>
                     <LemonButton type="secondary" onClick={hideSaveAsTemplateModal}>
@@ -30,7 +30,7 @@ export function SaveAsTemplateModal(props: WorkflowTemplateLogicProps = {}): JSX
                         loading={isTemplateFormSubmitting}
                         disabledReason={!templateForm.name ? 'Name is required' : undefined}
                     >
-                        Save template
+                        {isEditMode ? 'Update template' : 'Save template'}
                     </LemonButton>
                 </>
             }
@@ -49,7 +49,7 @@ export function SaveAsTemplateModal(props: WorkflowTemplateLogicProps = {}): JSX
                         <LemonInput placeholder="https://example.com/image.png" />
                     </LemonField>
 
-                    {user?.is_staff && (
+                    {user?.is_staff && !isEditMode && (
                         <LemonField name="scope" label="Scope">
                             <LemonSelect
                                 value={templateForm.scope}

--- a/products/workflows/frontend/Workflows/SaveAsTemplateModal.tsx
+++ b/products/workflows/frontend/Workflows/SaveAsTemplateModal.tsx
@@ -49,7 +49,7 @@ export function SaveAsTemplateModal(props: WorkflowTemplateLogicProps = {}): JSX
                         <LemonInput placeholder="https://example.com/image.png" />
                     </LemonField>
 
-                    {user?.is_staff && !isEditMode && (
+                    {user?.is_staff && (
                         <LemonField name="scope" label="Scope">
                             <LemonSelect
                                 value={templateForm.scope}

--- a/products/workflows/frontend/Workflows/WorkflowScene.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowScene.tsx
@@ -33,8 +33,9 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
     const { currentTab } = useValues(workflowSceneLogic)
     const { searchParams } = useValues(router)
     const templateId = searchParams.templateId as string | undefined
+    const editTemplateId = searchParams.editTemplateId as string | undefined
 
-    const logic = workflowLogic({ id: props.id, templateId })
+    const logic = workflowLogic({ id: props.id, templateId, editTemplateId })
     const { workflowLoading, workflow, originalWorkflow } = useValues(logic)
 
     if (!originalWorkflow && workflowLoading) {

--- a/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
@@ -119,9 +119,6 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
                                 size="small"
                                 onClick={showSaveAsTemplateModal}
                                 loading={isTemplateEditMode && isWorkflowSubmitting}
-                                disabledReason={
-                                    isTemplateEditMode && !workflowChanged ? 'No changes to save' : undefined
-                                }
                             >
                                 {isTemplateEditMode ? 'Update template' : 'Save as template'}
                             </LemonButton>

--- a/products/workflows/frontend/Workflows/WorkflowTemplateChooser.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowTemplateChooser.tsx
@@ -2,9 +2,10 @@ import './WorkflowTemplateChooser.scss'
 
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 import { useState } from 'react'
 
-import { IconTrash } from '@posthog/icons'
+import { IconPencil, IconTrash } from '@posthog/icons'
 import { LemonDialog, LemonTag } from '@posthog/lemon-ui'
 
 import { FallbackCoverImage } from 'lib/components/FallbackCoverImage/FallbackCoverImage'
@@ -13,6 +14,8 @@ import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { Spinner } from 'lib/lemon-ui/Spinner'
+import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import BlankWorkflowHog from 'public/blank-dashboard-hog.png'
 
@@ -25,8 +28,20 @@ export function WorkflowTemplateChooser(): JSX.Element {
     const { filteredTemplates, workflowTemplatesLoading } = useValues(workflowTemplatesLogic)
     const { deleteHogflowTemplate } = useActions(workflowTemplatesLogic)
     const canCreateTemplates = useFeatureFlag('WORKFLOWS_TEMPLATE_CREATION')
+    const { user } = useValues(userLogic)
 
     const { createWorkflowFromTemplate, createEmptyWorkflow } = useActions(newWorkflowLogic)
+
+    const canEditTemplate = (template: HogFlowTemplate): boolean => {
+        if (!canCreateTemplates) {
+            return false
+        }
+        if (template.scope === 'global') {
+            return user?.is_staff ?? false
+        }
+
+        return true
+    }
 
     return (
         <div>
@@ -50,6 +65,14 @@ export function WorkflowTemplateChooser(): JSX.Element {
                             key={template.id}
                             template={template}
                             onClick={() => createWorkflowFromTemplate(template)}
+                            onEdit={
+                                canEditTemplate(template)
+                                    ? (e) => {
+                                          e.stopPropagation()
+                                          router.actions.push(urls.workflowNew(), { editTemplateId: template.id })
+                                      }
+                                    : undefined
+                            }
                             onDelete={
                                 template.scope === 'global' && !canCreateTemplates
                                     ? undefined
@@ -98,12 +121,14 @@ export function WorkflowTemplateChooser(): JSX.Element {
 function TemplateItem({
     template,
     onClick,
+    onEdit,
     onDelete,
     index,
     'data-attr': dataAttr,
 }: {
     template: Pick<HogFlowTemplate, 'name' | 'description' | 'image_url' | 'scope'>
     onClick: () => void
+    onEdit?: (e: React.MouseEvent) => void
     onDelete?: (e: React.MouseEvent) => void
     index: number
     'data-attr': string
@@ -121,7 +146,7 @@ function TemplateItem({
             onMouseLeave={() => setIsHovering(false)}
             data-attr={dataAttr}
         >
-            {onDelete && (
+            {(onEdit || onDelete) && (
                 <div className="absolute top-2 right-2 z-10" onClick={(e) => e.stopPropagation()}>
                     <More
                         size="small"
@@ -134,15 +159,31 @@ function TemplateItem({
                         overlay={
                             <LemonMenuOverlay
                                 items={[
-                                    {
-                                        label: 'Delete',
-                                        status: 'danger' as const,
-                                        icon: <IconTrash />,
-                                        onClick: (e) => {
-                                            setIsMenuOpen(false)
-                                            onDelete(e)
-                                        },
-                                    },
+                                    ...(onEdit
+                                        ? [
+                                              {
+                                                  label: 'Edit',
+                                                  icon: <IconPencil />,
+                                                  onClick: (e: any) => {
+                                                      setIsMenuOpen(false)
+                                                      onEdit(e)
+                                                  },
+                                              },
+                                          ]
+                                        : []),
+                                    ...(onDelete
+                                        ? [
+                                              {
+                                                  label: 'Delete',
+                                                  status: 'danger' as const,
+                                                  icon: <IconTrash />,
+                                                  onClick: (e: any) => {
+                                                      setIsMenuOpen(false)
+                                                      onDelete(e)
+                                                  },
+                                              },
+                                          ]
+                                        : []),
                                 ]}
                             />
                         }

--- a/products/workflows/frontend/Workflows/WorkflowTemplateChooser.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowTemplateChooser.tsx
@@ -32,7 +32,7 @@ export function WorkflowTemplateChooser(): JSX.Element {
 
     const { createWorkflowFromTemplate, createEmptyWorkflow } = useActions(newWorkflowLogic)
 
-    const canEditTemplate = (template: HogFlowTemplate): boolean => {
+    const canManageTemplate = (template: HogFlowTemplate): boolean => {
         if (!canCreateTemplates) {
             return false
         }
@@ -66,7 +66,7 @@ export function WorkflowTemplateChooser(): JSX.Element {
                             template={template}
                             onClick={() => createWorkflowFromTemplate(template)}
                             onEdit={
-                                canEditTemplate(template)
+                                canManageTemplate(template)
                                     ? (e) => {
                                           e.stopPropagation()
                                           router.actions.push(urls.workflowNew(), { editTemplateId: template.id })
@@ -74,9 +74,8 @@ export function WorkflowTemplateChooser(): JSX.Element {
                                     : undefined
                             }
                             onDelete={
-                                template.scope === 'global' && !canCreateTemplates
-                                    ? undefined
-                                    : (e) => {
+                                canManageTemplate(template)
+                                    ? (e) => {
                                           e.stopPropagation()
                                           LemonDialog.open({
                                               title: 'Delete template?',
@@ -107,6 +106,7 @@ export function WorkflowTemplateChooser(): JSX.Element {
                                               secondaryButton: { children: 'Cancel' },
                                           })
                                       }
+                                    : undefined
                             }
                             index={index + 1}
                             data-attr="create-workflow-from-template"

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -158,7 +158,7 @@ export const workflowLogic = kea<workflowLogicType>([
 
                             const newWorkflow = {
                                 ...templateWorkflow,
-                                name: `${templateWorkflow.name} (copy)`,
+                                name: templateWorkflow.name,
                                 status: 'draft' as const,
                                 version: 1,
                             }

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -23,7 +23,6 @@ import { HogFlowActionSchema, isFunctionAction, isTriggerFunction } from './hogf
 import { type HogFlow, type HogFlowAction, HogFlowActionValidationResult, type HogFlowEdge } from './hogflows/types'
 import type { workflowLogicType } from './workflowLogicType'
 import { workflowSceneLogic } from './workflowSceneLogic'
-import { workflowTemplateLogic } from './workflowTemplateLogic'
 
 export interface WorkflowLogicProps {
     id?: string
@@ -178,25 +177,6 @@ export const workflowLogic = kea<workflowLogicType>([
                 },
                 saveWorkflow: async (updates: HogFlow) => {
                     updates = sanitizeWorkflow(updates, values.hogFunctionTemplatesById)
-
-                    // If we're in template edit mode, update the template instead
-                    if (props.editTemplateId) {
-                        const updated = {
-                            ...updates,
-                            status: 'draft' as const,
-                        } as HogFlow
-                        const templateLogic = workflowTemplateLogic.findMounted({
-                            id: props.id || 'new',
-                            editTemplateId: props.editTemplateId,
-                        })
-                        if (!templateLogic) {
-                            lemonToast.error('Template logic not mounted')
-                            return updated
-                        }
-                        await templateLogic.actions.updateTemplateFromWorkflow(props.editTemplateId, updates)
-
-                        return updated
-                    }
 
                     if (!props.id || props.id === 'new') {
                         return api.hogFlows.createHogFlow(updates)

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -400,7 +400,6 @@ export const workflowLogic = kea<workflowLogicType>([
         saveWorkflowSuccess: async ({ originalWorkflow }) => {
             if (props.editTemplateId) {
                 actions.resetWorkflow(originalWorkflow)
-                lemonToast.success('Template updated')
                 return
             }
 

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -378,11 +378,6 @@ export const workflowLogic = kea<workflowLogicType>([
             actions.resetWorkflow(originalWorkflow)
         },
         saveWorkflowSuccess: async ({ originalWorkflow }) => {
-            if (props.editTemplateId) {
-                actions.resetWorkflow(originalWorkflow)
-                return
-            }
-
             lemonToast.success('Workflow saved')
             if (props.id === 'new' && originalWorkflow.id) {
                 router.actions.replace(

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -181,18 +181,21 @@ export const workflowLogic = kea<workflowLogicType>([
 
                     // If we're in template edit mode, update the template instead
                     if (props.editTemplateId) {
+                        const updated = {
+                            ...updates,
+                            status: 'draft' as const,
+                        } as HogFlow
                         const templateLogic = workflowTemplateLogic.findMounted({
                             id: props.id || 'new',
                             editTemplateId: props.editTemplateId,
                         })
-                        if (templateLogic) {
-                            await templateLogic.actions.updateTemplateFromWorkflow(props.editTemplateId, updates)
+                        if (!templateLogic) {
+                            lemonToast.error('Template logic not mounted')
+                            return updated
                         }
+                        await templateLogic.actions.updateTemplateFromWorkflow(props.editTemplateId, updates)
 
-                        return {
-                            ...updates,
-                            status: 'draft' as const,
-                        } as HogFlow
+                        return updated
                     }
 
                     if (!props.id || props.id === 'new') {

--- a/products/workflows/frontend/Workflows/workflowTemplateLogic.test.ts
+++ b/products/workflows/frontend/Workflows/workflowTemplateLogic.test.ts
@@ -12,11 +12,14 @@ import { HogFunctionTemplateType } from '~/types'
 import { HogFlow, HogFlowAction } from './hogflows/types'
 import { workflowLogic } from './workflowLogic'
 import { workflowTemplateLogic } from './workflowTemplateLogic'
+import { workflowTemplatesLogic } from './workflowTemplatesLogic'
 
 jest.mock('lib/api', () => ({
     ...jest.requireActual('lib/api'),
     hogFlowTemplates: {
         createHogFlowTemplate: jest.fn(),
+        updateHogFlowTemplate: jest.fn(),
+        getHogFlowTemplate: jest.fn(),
     },
 }))
 
@@ -127,6 +130,47 @@ describe('workflowTemplateLogic', () => {
                 .toMatchValues({
                     saveAsTemplateModalVisible: false,
                 })
+        })
+
+        it('should show error toast and hide modal when template load fails in edit mode', async () => {
+            const workflowLogicInstance = workflowLogic({ id: 'test-workflow-id', editTemplateId: 'template-id' })
+            workflowLogicInstance.mount()
+
+            const mockWorkflow: HogFlow = {
+                id: 'test-workflow-id',
+                team_id: 123,
+                name: 'Test Workflow',
+                description: 'Test Description',
+                status: 'draft',
+                version: 1,
+                created_at: '2024-01-01T00:00:00Z',
+                updated_at: '2024-01-02T00:00:00Z',
+                actions: [],
+                edges: [],
+                conversion: { window_minutes: 0, filters: [] },
+                exit_condition: 'exit_only_at_end',
+            }
+
+            await expectLogic(workflowLogicInstance, () => {
+                workflowLogicInstance.actions.loadWorkflowSuccess(mockWorkflow)
+            })
+
+            const logic = workflowTemplateLogic({ id: 'test-workflow-id', editTemplateId: 'template-id' })
+            logic.mount()
+
+            // Mock getHogFlowTemplate to fail
+            mockApi.getHogFlowTemplate.mockRejectedValue(new Error('Template not found'))
+
+            await expectLogic(logic, () => {
+                logic.actions.showSaveAsTemplateModal()
+            })
+                .toDispatchActions(['showSaveAsTemplateModal', 'hideSaveAsTemplateModal'])
+                .toMatchValues({
+                    saveAsTemplateModalVisible: false,
+                })
+
+            expect(mockApi.getHogFlowTemplate).toHaveBeenCalledWith('template-id')
+            expect(mockToast.error).toHaveBeenCalledWith('Template not found')
         })
     })
 
@@ -354,6 +398,81 @@ describe('workflowTemplateLogic', () => {
 
             const callArg = mockApi.createHogFlowTemplate.mock.calls[0][0]
             expect(callArg.scope).toBe('team')
+        })
+    })
+
+    describe('update template', () => {
+        const createWorkflow = (): HogFlow => ({
+            id: 'test-workflow-id',
+            team_id: 123,
+            name: 'Updated Workflow',
+            description: 'Updated Description',
+            status: 'draft',
+            version: 1,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-02T00:00:00Z',
+            actions: [
+                {
+                    id: 'trigger_node',
+                    type: 'trigger',
+                    name: 'Trigger',
+                    description: '',
+                    created_at: 0,
+                    updated_at: 0,
+                    config: {
+                        type: 'event',
+                        filters: {},
+                    },
+                },
+            ],
+            edges: [],
+            conversion: { window_minutes: 0, filters: [] },
+            exit_condition: 'exit_only_at_end',
+        })
+
+        it('should update template, reload workflow, and reload template list', async () => {
+            const workflow = createWorkflow()
+            const updatedTemplate = { ...workflow, id: 'template-id', scope: 'team' as const }
+            mockApi.updateHogFlowTemplate.mockResolvedValue(updatedTemplate)
+            mockApi.getHogFlowTemplate.mockResolvedValue(updatedTemplate)
+
+            // Use id: 'new' so loadWorkflow calls getHogFlowTemplate when editTemplateId is set
+            const workflowLogicInstance = workflowLogic({ id: 'new', editTemplateId: 'template-id' })
+            workflowLogicInstance.mount()
+            await expectLogic(workflowLogicInstance, () => {
+                workflowLogicInstance.actions.loadWorkflowSuccess(workflow)
+            })
+
+            const templatesLogic = workflowTemplatesLogic()
+            templatesLogic.mount()
+
+            const templateLogic = workflowTemplateLogic({ id: 'new', editTemplateId: 'template-id' })
+            templateLogic.mount()
+
+            await expectLogic(workflowLogicInstance, () => {
+                templateLogic.actions.updateTemplateFromWorkflow('template-id', workflow)
+            }).toDispatchActions(['loadWorkflow', 'loadWorkflowSuccess'])
+
+            // Verify API call with correct data
+            expect(mockApi.updateHogFlowTemplate).toHaveBeenCalledWith(
+                'template-id',
+                expect.objectContaining({
+                    name: 'Updated Workflow',
+                    description: 'Updated Description',
+                    actions: expect.any(Array),
+                    edges: expect.any(Array),
+                    conversion: expect.any(Object),
+                    exit_condition: 'exit_only_at_end',
+                })
+            )
+
+            // Verify workflow reload
+            expect(mockApi.getHogFlowTemplate).toHaveBeenCalledWith('template-id')
+
+            // Verify template list reload
+            await expectLogic(templatesLogic).toDispatchActions(['loadWorkflowTemplates'])
+
+            expect(mockToast.success).toHaveBeenCalledWith('Template updated')
         })
     })
 })

--- a/products/workflows/frontend/Workflows/workflowTemplateLogic.test.ts
+++ b/products/workflows/frontend/Workflows/workflowTemplateLogic.test.ts
@@ -449,14 +449,15 @@ describe('workflowTemplateLogic', () => {
             const templateLogic = workflowTemplateLogic({ id: 'new', editTemplateId: 'template-id' })
             templateLogic.mount()
 
+            const workflowTemplate = { ...workflow, id: 'template-id' }
             await expectLogic(workflowLogicInstance, () => {
-                templateLogic.actions.updateTemplateFromWorkflow('template-id', workflow)
+                templateLogic.actions.updateTemplate(workflowTemplate)
             }).toDispatchActions(['loadWorkflow', 'loadWorkflowSuccess'])
 
             // Verify API call with correct data
             expect(mockApi.updateHogFlowTemplate).toHaveBeenCalledWith(
-                'template-id',
                 expect.objectContaining({
+                    id: 'template-id',
                     name: 'Updated Workflow',
                     description: 'Updated Description',
                     actions: expect.any(Array),

--- a/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
@@ -58,6 +58,7 @@ export const workflowTemplateLogic = kea<workflowTemplateLogicType>([
                             name: formValues.name || workflow.name || '',
                             description: formValues.description || workflow.description || '',
                             image_url: formValues.image_url || undefined,
+                            scope: formValues.scope || undefined,
                         }
 
                         await actions.updateTemplateFromWorkflow(props.editTemplateId, updatedWorkflow)

--- a/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
@@ -124,7 +124,7 @@ export const workflowTemplateLogic = kea<workflowTemplateLogicType>([
                     try {
                         const template = await api.hogFlowTemplates.getHogFlowTemplate(props.editTemplateId)
                         actions.setTemplateFormValues({
-                            name: workflow.name || '', // Use current workflow name
+                            name: workflow.name,
                             description: workflow.description || '', // Use current workflow description
                             image_url: template.image_url || null,
                             scope: template.scope || 'team',

--- a/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
@@ -5,7 +5,7 @@ import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { userLogic } from 'scenes/userLogic'
 
-import type { HogFlow, HogFlowTemplate } from './hogflows/types'
+import type { HogFlowTemplate } from './hogflows/types'
 import { workflowLogic } from './workflowLogic'
 import type { workflowTemplateLogicType } from './workflowTemplateLogicType'
 import { workflowTemplatesLogic } from './workflowTemplatesLogic'
@@ -27,7 +27,7 @@ export const workflowTemplateLogic = kea<workflowTemplateLogicType>([
     actions({
         showSaveAsTemplateModal: true,
         hideSaveAsTemplateModal: true,
-        updateTemplateFromWorkflow: (templateId: string, workflow: HogFlow) => ({ templateId, workflow }),
+        updateTemplate: (workflowTemplate: HogFlowTemplate) => ({ workflowTemplate }),
     }),
     forms(({ actions, values, props }) => ({
         templateForm: {
@@ -55,13 +55,14 @@ export const workflowTemplateLogic = kea<workflowTemplateLogicType>([
                     try {
                         const updatedWorkflow = {
                             ...workflow,
+                            id: props.editTemplateId,
                             name: formValues.name || workflow.name || '',
                             description: formValues.description || workflow.description || '',
                             image_url: formValues.image_url || undefined,
                             scope: formValues.scope || undefined,
                         }
 
-                        await actions.updateTemplateFromWorkflow(props.editTemplateId, updatedWorkflow)
+                        await actions.updateTemplate(updatedWorkflow)
 
                         actions.hideSaveAsTemplateModal()
                     } catch (e: any) {
@@ -146,29 +147,15 @@ export const workflowTemplateLogic = kea<workflowTemplateLogicType>([
                 }
             }
         },
-        updateTemplateFromWorkflow: async ({ templateId, workflow }) => {
-            // Extract only template-relevant fields, excluding workflow-specific ones
-            const templateData: Partial<HogFlowTemplate> = {
-                name: workflow.name,
-                description: workflow.description,
-                image_url: (workflow as any).image_url,
-                trigger: workflow.trigger,
-                trigger_masking: workflow.trigger_masking,
-                conversion: workflow.conversion,
-                exit_condition: workflow.exit_condition,
-                edges: workflow.edges,
-                actions: workflow.actions,
-                abort_action: workflow.abort_action,
-                variables: workflow.variables,
-            }
+        updateTemplate: async ({ workflowTemplate }) => {
             // Remove any undefined fields
-            Object.keys(templateData).forEach((key) => {
-                if (templateData[key as keyof typeof templateData] === undefined) {
-                    delete templateData[key as keyof typeof templateData]
+            Object.keys(workflowTemplate).forEach((key) => {
+                if (workflowTemplate[key as keyof typeof workflowTemplate] === undefined) {
+                    delete workflowTemplate[key as keyof typeof workflowTemplate]
                 }
             })
 
-            await api.hogFlowTemplates.updateHogFlowTemplate(templateId, templateData)
+            await api.hogFlowTemplates.updateHogFlowTemplate(workflowTemplate.id, workflowTemplate)
             lemonToast.success('Template updated')
 
             // Update the template list in workflowTemplatesLogic

--- a/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
@@ -1,30 +1,35 @@
-import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { userLogic } from 'scenes/userLogic'
 
+import type { HogFlow, HogFlowTemplate } from './hogflows/types'
 import { workflowLogic } from './workflowLogic'
 import type { workflowTemplateLogicType } from './workflowTemplateLogicType'
+import { workflowTemplatesLogic } from './workflowTemplatesLogic'
 
 export interface WorkflowTemplateLogicProps {
     id?: string
     templateId?: string
+    editTemplateId?: string
 }
 
 export const workflowTemplateLogic = kea<workflowTemplateLogicType>([
     path(['products', 'workflows', 'frontend', 'Workflows', 'workflowTemplateLogic']),
     props({ id: 'new' } as WorkflowTemplateLogicProps),
-    key((props) => props.id || 'new'),
+    key((props) => `${props.id || 'new'}-${props.editTemplateId || ''}`),
     connect(() => ({
-        values: [workflowLogic, ['workflow'], userLogic, ['user']],
+        values: [workflowLogic, ['workflow', 'isTemplateEditMode'], userLogic, ['user']],
+        actions: [workflowTemplatesLogic, ['loadWorkflowTemplates']],
     })),
     actions({
         showSaveAsTemplateModal: true,
         hideSaveAsTemplateModal: true,
+        updateTemplateFromWorkflow: (templateId: string, workflow: HogFlow) => ({ templateId, workflow }),
     }),
-    forms(({ actions, values }) => ({
+    forms(({ actions, values, props }) => ({
         templateForm: {
             defaults: {
                 name: '',
@@ -46,6 +51,27 @@ export const workflowTemplateLogic = kea<workflowTemplateLogicType>([
                     return
                 }
 
+                if (props.editTemplateId) {
+                    try {
+                        const updatedWorkflow = {
+                            ...workflow,
+                            name: formValues.name || workflow.name || '',
+                            description: formValues.description || workflow.description || '',
+                            image_url: formValues.image_url || undefined,
+                        }
+
+                        await actions.updateTemplateFromWorkflow(props.editTemplateId, updatedWorkflow)
+
+                        actions.hideSaveAsTemplateModal()
+                    } catch (e: any) {
+                        const errorMessage = e?.detail || e?.message || 'Failed to update template'
+                        lemonToast.error(errorMessage)
+                        throw e
+                    }
+                    return
+                }
+
+                // Otherwise, create a new template
                 let scope: 'team' | 'global' = 'team'
                 if (values.user?.is_staff) {
                     scope = formValues.scope ?? 'team'
@@ -79,16 +105,84 @@ export const workflowTemplateLogic = kea<workflowTemplateLogicType>([
             },
         ],
     }),
-    listeners(({ actions, values }) => ({
+    selectors({
+        isEditMode: [
+            () => [(_, props: WorkflowTemplateLogicProps) => props],
+            (props: WorkflowTemplateLogicProps): boolean => !!props.editTemplateId,
+        ],
+        editTemplateId: [
+            () => [(_, props: WorkflowTemplateLogicProps) => props],
+            (props: WorkflowTemplateLogicProps): string | undefined => props.editTemplateId,
+        ],
+    }),
+    listeners(({ actions, values, props }) => ({
         showSaveAsTemplateModal: async () => {
             const workflow = values.workflow
             if (workflow) {
-                actions.setTemplateFormValues({
-                    name: workflow.name || '',
-                    description: workflow.description || '',
-                    image_url: null,
-                    scope: 'team',
-                })
+                if (props.editTemplateId) {
+                    // In edit mode, use workflow values for name/description, but load template for image_url and scope
+                    try {
+                        const template = await api.hogFlowTemplates.getHogFlowTemplate(props.editTemplateId)
+                        actions.setTemplateFormValues({
+                            name: workflow.name || '', // Use current workflow name
+                            description: workflow.description || '', // Use current workflow description
+                            image_url: template.image_url || null,
+                            scope: template.scope || 'team',
+                        })
+                    } catch (e: any) {
+                        const errorMessage = e?.detail || e?.message || 'Failed to load template'
+                        lemonToast.error(errorMessage)
+                        actions.hideSaveAsTemplateModal()
+                        return
+                    }
+                } else {
+                    actions.setTemplateFormValues({
+                        name: workflow.name || '',
+                        description: workflow.description || '',
+                        image_url: null,
+                        scope: 'team',
+                    })
+                }
+            }
+        },
+        updateTemplateFromWorkflow: async ({ templateId, workflow }) => {
+            // Extract only template-relevant fields, excluding workflow-specific ones
+            const templateData: Partial<HogFlowTemplate> = {
+                name: workflow.name,
+                description: workflow.description,
+                image_url: (workflow as any).image_url,
+                trigger: workflow.trigger,
+                trigger_masking: workflow.trigger_masking,
+                conversion: workflow.conversion,
+                exit_condition: workflow.exit_condition,
+                edges: workflow.edges,
+                actions: workflow.actions,
+                abort_action: workflow.abort_action,
+                variables: workflow.variables,
+            }
+            // Remove any undefined fields
+            Object.keys(templateData).forEach((key) => {
+                if (templateData[key as keyof typeof templateData] === undefined) {
+                    delete templateData[key as keyof typeof templateData]
+                }
+            })
+
+            await api.hogFlowTemplates.updateHogFlowTemplate(templateId, templateData)
+            lemonToast.success('Template updated')
+
+            // Update the template list in workflowTemplatesLogic
+            const templatesLogic = workflowTemplatesLogic.findMounted()
+            if (templatesLogic) {
+                await templatesLogic.actions.loadWorkflowTemplates()
+            }
+
+            // Reload the workflow to reflect the updated template
+            const workflowLogicInstance = workflowLogic.findMounted({
+                id: props.id || 'new',
+                editTemplateId: props.editTemplateId,
+            })
+            if (workflowLogicInstance) {
+                await workflowLogicInstance.actions.loadWorkflow()
             }
         },
     })),

--- a/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowTemplateLogic.ts
@@ -21,7 +21,7 @@ export const workflowTemplateLogic = kea<workflowTemplateLogicType>([
     props({ id: 'new' } as WorkflowTemplateLogicProps),
     key((props) => `${props.id || 'new'}-${props.editTemplateId || ''}`),
     connect(() => ({
-        values: [workflowLogic, ['workflow', 'isTemplateEditMode'], userLogic, ['user']],
+        values: [workflowLogic, ['workflow'], userLogic, ['user']],
         actions: [workflowTemplatesLogic, ['loadWorkflowTemplates']],
     })),
     actions({


### PR DESCRIPTION
## Problem

Currently the way to "edit" templates is to create a copy and delete the original, which is a bad user experience

## Changes

[template-edit.webm](https://github.com/user-attachments/assets/c16a83a3-8b75-4650-9ebb-3b4bbb265249)

You can now select "edit" in the dropdown and update an existing template

## How did you test this code?

Manually and with automated tests
