### PR TITLE
chore: adding a product intent for workflows

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -21354,6 +21354,7 @@
                 "customer_analytics_usage_metric_created",
                 "nav_panel_advertisement_clicked",
                 "feature_preview_enabled",
+                "workflow_created",
                 "vercel_integration"
             ],
             "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -5132,6 +5132,9 @@ export enum ProductIntentContext {
     // Feature previews
     FEATURE_PREVIEW_ENABLED = 'feature_preview_enabled',
 
+    // Workflows
+    WORKFLOW_CREATED = 'workflow_created',
+
     // Used by the backend but defined here for type safety
     VERCEL_INTEGRATION = 'vercel_integration',
 }

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2678,6 +2678,7 @@ class ProductIntentContext(StrEnum):
     CUSTOMER_ANALYTICS_USAGE_METRIC_CREATED = "customer_analytics_usage_metric_created"
     NAV_PANEL_ADVERTISEMENT_CLICKED = "nav_panel_advertisement_clicked"
     FEATURE_PREVIEW_ENABLED = "feature_preview_enabled"
+    WORKFLOW_CREATED = "workflow_created"
     VERCEL_INTEGRATION = "vercel_integration"
 
 

--- a/products/workflows/frontend/WorkflowsScene.tsx
+++ b/products/workflows/frontend/WorkflowsScene.tsx
@@ -185,7 +185,7 @@ export function WorkflowsScene(): JSX.Element {
                             <LemonButton
                                 data-attr="new-workflow"
                                 onClick={() => {
-                                    addProductIntent({
+                                    void addProductIntent({
                                         product_type: ProductKey.WORKFLOWS,
                                         intent_context: ProductIntentContext.WORKFLOW_CREATED,
                                     })

--- a/products/workflows/frontend/WorkflowsScene.tsx
+++ b/products/workflows/frontend/WorkflowsScene.tsx
@@ -10,12 +10,14 @@ import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { IconSlack, IconTwilio } from 'lib/lemon-ui/icons'
 import { capitalizeFirstLetter } from 'lib/utils'
+import { addProductIntent } from 'lib/utils/product-intents'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import { Breadcrumb } from '~/types'
 
 import { MessageChannels } from './Channels/MessageChannels'
@@ -183,6 +185,10 @@ export function WorkflowsScene(): JSX.Element {
                             <LemonButton
                                 data-attr="new-workflow"
                                 onClick={() => {
+                                    addProductIntent({
+                                        product_type: ProductKey.WORKFLOWS,
+                                        intent_context: ProductIntentContext.WORKFLOW_CREATED,
+                                    })
                                     if (canCreateTemplates) {
                                         showNewWorkflowModal()
                                     } else {


### PR DESCRIPTION
## Problem

We like to track intents for growth purposes - essentially the top of the funnel with respect to which users may end up as workflow users.

In this pr, we are setting the intent when users click on the `new workflow` button. They do not need to save the workflow or do anything else, as it is supposed to be sufficiently wide.
