### PR TITLE
feat(funnels): expose data warehouse properties in breakdown selector

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
+++ b/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
@@ -21,8 +21,8 @@ export function Breakdown({ insightProps }: EditorFilterProps): JSX.Element {
                 updateBreakdownFilter={updateBreakdownFilter}
                 updateDisplay={updateDisplay}
                 disabledReason={
-                    !isSingleSeries && hasDataWarehouseSeries
-                        ? 'Breakdowns are not allowed for multiple series types'
+                    isTrends && !isSingleSeries && hasDataWarehouseSeries
+                        ? 'Breakdowns are not supported for multiple series types when at least one of them is a data warehouse series.'
                         : undefined
                 }
             />

--- a/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -50,7 +50,7 @@ export function PropertyGroupFilters({
 
     const showHeader = propertyGroupFilter.type && propertyGroupFilter.values.length > 1
     const disabledReason = hasDataWarehouseSeries
-        ? 'Cannot add filter groups to data warehouse series. Use individual series filters'
+        ? 'Filter groups cannot be added to insights with a data warehouse series. Please use individual series filters instead.'
         : undefined
     return (
         <div className="deprecated-space-y-2 PropertyGroupFilters">

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -366,7 +366,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                     return []
                 }
 
-                const dataWarehouseSeries = series.filter((node) => isDataWarehouseNode(node))
+                const dataWarehouseSeries = series!.filter(isDataWarehouseNode)
                 const dataWarehouseTableNames = Array.from(new Set(dataWarehouseSeries.map((node) => node.table_name)))
                 return dataWarehouseTableNames.flatMap((tableName) =>
                     Object.values(dataWarehouseTablesMap[tableName]?.fields ?? {})


### PR DESCRIPTION
## Problem

Data warehouse properties weren't accessible frontend side.

## Changes

Now they are

![Screenshot 2025-12-30 at 18.00.41.png](https://app.graphite.com/user-attachments/assets/576e27a0-e1b5-4fe2-9694-fa385a122d7c.png)

## How did you test this code?

Verified it still works for trends insights as well