### PR TITLE
chore(experiments): Refactor stats_config -> scheduling_config

### DIFF
--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -65,12 +65,5 @@ procs:
         shell: 'bin/check_postgres_up && cd hedgebox-dummy && pnpm install && pnpm run dev'
         autostart: false
 
-    dagster:
-        shell: |-
-            bin/check_postgres_up && \
-            bin/check_kafka_clickhouse_up && \
-            bin/check_ducklake_up && \
-            dagster dev --workspace $DAGSTER_HOME/workspace.yaml -p $DAGSTER_UI_PORT
-
 mouse_scroll_speed: 1
 scrollback: 10000

--- a/bin/mprocs-minimal.yaml
+++ b/bin/mprocs-minimal.yaml
@@ -65,5 +65,12 @@ procs:
         shell: 'bin/check_postgres_up && cd hedgebox-dummy && pnpm install && pnpm run dev'
         autostart: false
 
+    dagster:
+        shell: |-
+            bin/check_postgres_up && \
+            bin/check_kafka_clickhouse_up && \
+            bin/check_ducklake_up && \
+            dagster dev --workspace $DAGSTER_HOME/workspace.yaml -p $DAGSTER_UI_PORT
+
 mouse_scroll_speed: 1
 scrollback: 10000

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -87,6 +87,7 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
             "metrics",
             "metrics_secondary",
             "stats_config",
+            "scheduling_config",
             "_create_in_folder",
             "conclusion",
             "conclusion_comment",
@@ -447,6 +448,7 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
             "metrics",
             "metrics_secondary",
             "stats_config",
+            "scheduling_config",
             "conclusion",
             "conclusion_comment",
             "primary_metrics_ordered_uuids",
@@ -921,6 +923,7 @@ class EnterpriseExperimentsViewSet(
             "metrics": source_experiment.metrics,
             "metrics_secondary": source_experiment.metrics_secondary,
             "stats_config": source_experiment.stats_config,
+            "scheduling_config": source_experiment.scheduling_config,
             "exposure_criteria": source_experiment.exposure_criteria,
             "saved_metrics_ids": saved_metrics_data,
             "feature_flag_key": feature_flag_key,  # Use provided key or fall back to existing

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -392,8 +392,8 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                 const isEditMode = values.isEditMode
 
                 // Make experiment eligible for timeseries
-                const statsConfig = {
-                    ...values.experiment?.stats_config,
+                const schedulingConfig = {
+                    ...values.experiment?.scheduling_config,
                     timeseries: true,
                 }
 
@@ -414,7 +414,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
 
                 const experimentPayload: Experiment = {
                     ...values.experiment,
-                    stats_config: statsConfig,
+                    scheduling_config: schedulingConfig,
                     saved_metrics_ids: savedMetrics,
                 }
 

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -425,7 +425,7 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
                     const filteredPayload = {
                         ...filterExperimentForUpdate(experimentPayload),
                         // Ensure these are always included for update
-                        stats_config: statsConfig,
+                        scheduling_config: schedulingConfig,
                         saved_metrics_ids: savedMetrics,
                     }
                     response = (await api.update(

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -119,7 +119,7 @@ export function MetricRowGroup({
 
     const { reportExperimentTimeseriesViewed } = useActions(experimentLogic)
 
-    const timeseriesEnabled = experiment.stats_config?.timeseries
+    const timeseriesEnabled = experiment.scheduling_config?.timeseries
 
     // Calculate total rows for loading/error states
     const totalRows = isLoading || error || !result ? 1 : 1 + (result.variant_results?.length || 0)

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -969,8 +969,8 @@ export const experimentLogic = kea<experimentLogicType>([
                     }
                 } else {
                     // Make experiment eligible for timeseries
-                    const statsConfig = {
-                        ...values.experiment?.stats_config,
+                    const schedulingConfig = {
+                        ...values.experiment?.scheduling_config,
                         timeseries: true,
                     }
 
@@ -992,7 +992,7 @@ export const experimentLogic = kea<experimentLogicType>([
                                 : values.experiment?.parameters,
                         ...(!draft && { start_date: dayjs() }),
                         ...(typeof folder === 'string' ? { _create_in_folder: folder } : {}),
-                        stats_config: statsConfig,
+                        scheduling_config: schedulingConfig,
                     })
 
                     if (response) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4078,6 +4078,8 @@ export interface Experiment {
     stats_config?: {
         version?: number
         method?: ExperimentStatsMethod
+    }
+    scheduling_config?: {
         timeseries?: boolean
     }
     _create_in_folder?: string | null

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -3864,6 +3864,7 @@
          "posthog_experiment"."primary_metrics_ordered_uuids",
          "posthog_experiment"."secondary_metrics_ordered_uuids",
          "posthog_experiment"."stats_config",
+         "posthog_experiment"."scheduling_config",
          "posthog_experiment"."conclusion",
          "posthog_experiment"."conclusion_comment"
   FROM "posthog_experiment"
@@ -4157,6 +4158,7 @@
          "posthog_experiment"."primary_metrics_ordered_uuids",
          "posthog_experiment"."secondary_metrics_ordered_uuids",
          "posthog_experiment"."stats_config",
+         "posthog_experiment"."scheduling_config",
          "posthog_experiment"."conclusion",
          "posthog_experiment"."conclusion_comment"
   FROM "posthog_experiment"

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -2235,6 +2235,7 @@
          "posthog_experiment"."primary_metrics_ordered_uuids",
          "posthog_experiment"."secondary_metrics_ordered_uuids",
          "posthog_experiment"."stats_config",
+         "posthog_experiment"."scheduling_config",
          "posthog_experiment"."conclusion",
          "posthog_experiment"."conclusion_comment"
   FROM "posthog_experiment"

--- a/posthog/migrations/0954_experiment_scheduling_config.py
+++ b/posthog/migrations/0954_experiment_scheduling_config.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "0953_create_core_event"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="experiment",
+            name="scheduling_config",
+            field=models.JSONField(blank=True, default=dict, null=True),
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0953_create_core_event
+0954_experiment_scheduling_config

--- a/posthog/models/experiment.py
+++ b/posthog/models/experiment.py
@@ -63,6 +63,7 @@ class Experiment(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.
     )
 
     stats_config = models.JSONField(default=dict, null=True, blank=True)
+    scheduling_config = models.JSONField(default=dict, null=True, blank=True)
 
     conclusion = models.CharField(
         max_length=30,

--- a/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
+++ b/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
@@ -280,6 +280,7 @@
          "posthog_experiment"."primary_metrics_ordered_uuids",
          "posthog_experiment"."secondary_metrics_ordered_uuids",
          "posthog_experiment"."stats_config",
+         "posthog_experiment"."scheduling_config",
          "posthog_experiment"."conclusion",
          "posthog_experiment"."conclusion_comment"
   FROM "posthog_experiment"
@@ -1042,6 +1043,7 @@
          "posthog_experiment"."primary_metrics_ordered_uuids",
          "posthog_experiment"."secondary_metrics_ordered_uuids",
          "posthog_experiment"."stats_config",
+         "posthog_experiment"."scheduling_config",
          "posthog_experiment"."conclusion",
          "posthog_experiment"."conclusion_comment"
   FROM "posthog_experiment"

--- a/products/experiments/dags/experiment_regular_metrics_timeseries.py
+++ b/products/experiments/dags/experiment_regular_metrics_timeseries.py
@@ -251,7 +251,7 @@ def _get_experiment_regular_metrics_timeseries(
     # likely stale experiments. Users can still manually backfill those.
     experiments = Experiment.objects.filter(
         deleted=False,
-        stats_config__timeseries=True,
+        scheduling_config__timeseries=True,
         start_date__isnull=False,
         start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=90),
         end_date__isnull=True,

--- a/products/experiments/dags/experiment_saved_metrics_timeseries.py
+++ b/products/experiments/dags/experiment_saved_metrics_timeseries.py
@@ -259,7 +259,7 @@ def _get_experiment_saved_metrics_timeseries(context: dagster.SensorEvaluationCo
     # likely stale experiments. Users can still manually backfill those.
     experiments = Experiment.objects.filter(
         deleted=False,
-        stats_config__timeseries=True,
+        scheduling_config__timeseries=True,
         start_date__isnull=False,
         start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=90),
         end_date__isnull=True,

--- a/products/experiments/dags/tests/test_experiment_regular_metrics_timeseries_schedule.py
+++ b/products/experiments/dags/tests/test_experiment_regular_metrics_timeseries_schedule.py
@@ -47,7 +47,7 @@ class TestScheduleIntegration(BaseTest):
             feature_flag=flag_ended,
             start_date=datetime.datetime.now(),
             end_date=datetime.datetime.now(),  # Has end date - should be excluded
-            stats_config={"timeseries": True},
+            scheduling_config={"timeseries": True},
             metrics=[{"uuid": "metric1", "metric_type": "mean"}],
         )
 
@@ -57,7 +57,7 @@ class TestScheduleIntegration(BaseTest):
             team=team,
             feature_flag=flag_no_timeseries,
             start_date=datetime.datetime.now(),
-            stats_config={"timeseries": False},  # Timeseries disabled - should be excluded
+            scheduling_config={"timeseries": False},  # Timeseries disabled - should be excluded
             metrics=[{"uuid": "metric2", "metric_type": "mean"}],
         )
 
@@ -67,7 +67,7 @@ class TestScheduleIntegration(BaseTest):
             team=team,
             feature_flag=flag_valid,
             start_date=datetime.datetime.now(),
-            stats_config={"timeseries": True},  # This one should be included
+            scheduling_config={"timeseries": True},  # This one should be included
             metrics=[{"uuid": "metric3", "metric_type": "mean"}],
         )
 

--- a/products/experiments/dags/tests/test_experiment_saved_metrics_timeseries_schedule.py
+++ b/products/experiments/dags/tests/test_experiment_saved_metrics_timeseries_schedule.py
@@ -54,7 +54,7 @@ class TestScheduleIntegration(BaseTest):
             feature_flag=flag_ended,
             start_date=datetime.datetime.now(),
             end_date=datetime.datetime.now(),  # Has end date - should be excluded
-            stats_config={"timeseries": True},
+            scheduling_config={"timeseries": True},
         )
         ExperimentToSavedMetric.objects.create(experiment=exp_ended, saved_metric=saved_metric)
 
@@ -64,7 +64,7 @@ class TestScheduleIntegration(BaseTest):
             team=team,
             feature_flag=flag_no_timeseries,
             start_date=datetime.datetime.now(),
-            stats_config={"timeseries": False},  # Timeseries disabled - should be excluded
+            scheduling_config={"timeseries": False},  # Timeseries disabled - should be excluded
         )
         ExperimentToSavedMetric.objects.create(experiment=exp_no_timeseries, saved_metric=saved_metric)
 
@@ -74,7 +74,7 @@ class TestScheduleIntegration(BaseTest):
             team=team,
             feature_flag=flag_valid,
             start_date=datetime.datetime.now(),
-            stats_config={"timeseries": True},  # This one should be included
+            scheduling_config={"timeseries": True},  # This one should be included
         )
         ExperimentToSavedMetric.objects.create(experiment=exp_valid, saved_metric=saved_metric)
 

--- a/products/experiments/dags/utils.py
+++ b/products/experiments/dags/utils.py
@@ -87,7 +87,7 @@ def schedule_experiment_metric_partitions(
         target_experiment_ids = set(
             Experiment.objects.filter(
                 deleted=False,
-                stats_config__timeseries=True,
+                scheduling_config__timeseries=True,
                 start_date__isnull=False,
                 start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=90),
                 end_date__isnull=True,

--- a/services/mcp/typescript/src/schema/experiments.ts
+++ b/services/mcp/typescript/src/schema/experiments.ts
@@ -184,6 +184,7 @@ export const ExperimentSchema = z.object({
     holdout: z.any().nullish(),
     holdout_id: z.number().nullish(),
     stats_config: z.any().optional(),
+    scheduling_config: z.any().optional(),
     conclusion: z.enum(ExperimentConclusion).nullish(),
     conclusion_comment: z.string().nullish(),
     primary_metrics_ordered_uuids: z.array(z.string()).nullish(),
@@ -350,6 +351,9 @@ export const ExperimentCreatePayloadSchema = ToolExperimentCreateSchema.transfor
 
         // Stats config (empty, will be filled by backend)
         stats_config: {},
+
+        // Scheduling config (empty, will be filled by backend)
+        scheduling_config: {},
 
         // State fields
         start_date: input.draft === false ? new Date().toISOString() : null,
@@ -562,6 +566,7 @@ export const ExperimentUpdatePayloadSchema = z
         exposure_criteria: ExperimentExposureCriteriaSchema.optional(),
         saved_metrics_ids: z.array(z.any()).nullish(),
         stats_config: z.any().optional(),
+        scheduling_config: z.any().optional(),
     })
     .strict()
 


### PR DESCRIPTION
## Problem
`stats_config` has become a dumping ground for config that doesn't fit anywhere else. It should only contain statistics-related configuration. This will be even more important going forward as we make more stats things configurable.

## Changes
- Add new `scheduling_config` field on Experiment model
- Move `timeseries` from `stats_config` to `scheduling_config`
- Update all references

- There are two more fields to clean up (`migrated_from`/`migrated_to`) - will handle those in a follow-up PR.
- Before merging, I'll run a management command to migrate existing records.

## How did you test this code?
- Existing tests pass
- Confirmed the field is populated on newly created experiments
- Confirmed that newly added metrics trigger timeseries calculations in Dagster