### PR TITLE
feat(kafka-deduplicator): temp: debug logging for race condition

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
+            - 'eli.r/kdedup-dbg-race'
 
 jobs:
     build:

--- a/rust/kafka-deduplicator/src/checkpoint/worker.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/worker.rs
@@ -192,6 +192,18 @@ impl CheckpointWorker {
         let start_time = Instant::now();
         let local_attempt_path = self.get_local_attempt_path();
 
+        info!(
+            checkpoint_debug = true,
+            hypothesis = "A",
+            step = "worker_entry",
+            worker_id = self.worker_id,
+            partition = %self.partition,
+            db_path = %store.get_db_path().display(),
+            db_exists = store.get_db_path().exists(),
+            local_attempt_path = %local_attempt_path.display(),
+            "Checkpoint debug: starting local checkpoint"
+        );
+
         // TODO: this should accept CheckpointMode argument to implement incremental local checkpoint step
         match store.create_checkpoint_with_metadata(&local_attempt_path) {
             Ok(rocks_metadata) => {

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -258,9 +258,27 @@ impl CheckpointManager {
                                 // best efort to bail if the partition is no longer owned by the
                                 // store manager when the worker thread has started executing
                                 let target_store = match worker_store_manager.get(partition.topic(), partition.partition_number()) {
-                                    Some(store) => store,
+                                    Some(store) => {
+                                        info!(
+                                            checkpoint_debug = true,
+                                            hypothesis = "A",
+                                            step = "worker_store_found",
+                                            partition = partition_tag,
+                                            db_path = %store.get_db_path().display(),
+                                            db_exists = store.get_db_path().exists(),
+                                            "Checkpoint debug: store found for checkpoint"
+                                        );
+                                        store
+                                    }
 
                                     _ => {
+                                        info!(
+                                            checkpoint_debug = true,
+                                            hypothesis = "A",
+                                            step = "worker_store_not_found",
+                                            partition = partition_tag,
+                                            "Checkpoint debug: store NOT found for checkpoint"
+                                        );
                                         metrics::counter!(CHECKPOINT_STORE_NOT_FOUND_COUNTER).increment(1);
                                         warn!(partition = partition_tag, "Checkpoint worker thread: partition no longer owned by store manager, skipping");
                                         // free the slot up since we're skipping this round and/or shutting down the process

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -171,6 +171,18 @@ impl CheckpointManager {
                             debug!("No stores to flush");
                             continue;
                         }
+
+                        // Log all partition candidates for debugging
+                        let candidate_partitions: Vec<String> = candidates.iter().map(|p| format!("{}:{}", p.topic(), p.partition_number())).collect();
+                        info!(
+                            checkpoint_debug = true,
+                            hypothesis = "C",
+                            step = "checkpoint_candidates",
+                            store_count = store_count,
+                            candidates = ?candidate_partitions,
+                            "Checkpoint debug: stores in DashMap for checkpoint"
+                        );
+
                         info!("Checkpoint manager: attempting checkpoint submission for {} stores", store_count);
 
                         // Attempt to checkpoint each partitions' backing store in

--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -595,8 +595,32 @@ impl DeduplicationStore {
         &self,
         checkpoint_path: P,
     ) -> Result<LocalCheckpointInfo> {
+        let db_path = self.store.get_path();
+
+        tracing::info!(
+            checkpoint_debug = true,
+            hypothesis = "A",
+            step = "checkpoint_step1_wal",
+            topic = %self.topic,
+            partition = self.partition,
+            db_path = %db_path.display(),
+            db_exists = db_path.exists(),
+            "Checkpoint debug: flushing WAL"
+        );
+
         // Step 1: Flush WAL to ensure durability
         self.store.flush_wal(true)?;
+
+        tracing::info!(
+            checkpoint_debug = true,
+            hypothesis = "A",
+            step = "checkpoint_step2_flush",
+            topic = %self.topic,
+            partition = self.partition,
+            db_path = %db_path.display(),
+            db_exists = db_path.exists(),
+            "Checkpoint debug: flushing column families"
+        );
 
         // Step 2: Flush all column families to ensure data is in SST files
         self.flush()?;

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -794,6 +794,7 @@ impl StoreManager {
 
         // Build a set of currently assigned partition directories
         let mut assigned_dirs = std::collections::HashSet::new();
+        let mut stores_count = 0;
         for entry in self.stores.iter() {
             let partition = entry.key();
             let dir_name = format!(
@@ -802,6 +803,7 @@ impl StoreManager {
                 partition.partition_number()
             );
             assigned_dirs.insert(dir_name);
+            stores_count += 1;
         }
 
         info!(
@@ -809,6 +811,7 @@ impl StoreManager {
             hypothesis = "B",
             step = "cleanup_orphaned_start",
             assigned_count = assigned_dirs.len(),
+            stores_in_dashmap = stores_count,
             assigned_dirs = ?assigned_dirs,
             "Checkpoint debug: checking for orphaned directories"
         );

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -322,6 +322,15 @@ impl StoreManager {
     pub fn unregister_store(&self, topic: &str, partition: i32) {
         let partition_key = Partition::new(topic.to_string(), partition);
 
+        info!(
+            checkpoint_debug = true,
+            hypothesis = "A",
+            step = "unregister_store",
+            topic = topic,
+            partition = partition,
+            "Checkpoint debug: unregistering store from DashMap"
+        );
+
         if let Some((_, store)) = self.stores.remove(&partition_key) {
             info!(
                 topic = topic,
@@ -348,6 +357,18 @@ impl StoreManager {
         );
 
         let partition_path = PathBuf::from(&partition_dir);
+
+        info!(
+            checkpoint_debug = true,
+            hypothesis = "A",
+            step = "cleanup_store_files",
+            topic = topic,
+            partition = partition,
+            partition_dir = %partition_dir,
+            dir_exists = partition_path.exists(),
+            "Checkpoint debug: cleaning up store files"
+        );
+
         if partition_path.exists() {
             match std::fs::remove_dir_all(&partition_path) {
                 Ok(_) => {
@@ -784,6 +805,15 @@ impl StoreManager {
         }
 
         info!(
+            checkpoint_debug = true,
+            hypothesis = "B",
+            step = "cleanup_orphaned_start",
+            assigned_count = assigned_dirs.len(),
+            assigned_dirs = ?assigned_dirs,
+            "Checkpoint debug: checking for orphaned directories"
+        );
+
+        info!(
             "Checking for orphaned directories. Currently assigned: {:?}",
             assigned_dirs
         );
@@ -801,6 +831,16 @@ impl StoreManager {
                             // This is an orphaned directory
                             let dir_path = entry.path();
                             let dir_size = Self::get_directory_size(&dir_path).unwrap_or(0);
+
+                            info!(
+                                checkpoint_debug = true,
+                                hypothesis = "B",
+                                step = "cleanup_orphaned_deleting",
+                                dir_name = %dir_name,
+                                dir_path = %dir_path.display(),
+                                dir_size_bytes = dir_size,
+                                "Checkpoint debug: deleting orphaned directory"
+                            );
 
                             match std::fs::remove_dir_all(&dir_path) {
                                 Ok(_) => {


### PR DESCRIPTION
## Problem
We need more signal to sus out a potential race condition between store snapshots at the start of a checkpoint run and store manager admin ops / kafka rebalance and reassignment.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Temporarily add some tagged logs to the potentially racy interactions across both modules
* Temporarily add feature branch to build

_Note: this PR will be deployed to collect debug signal but will not be merged_

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, CI, PoC deploy env
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
