### PR TITLE
feat: improve django admin redis explorer

### DIFF
--- a/ee/urls.py
+++ b/ee/urls.py
@@ -10,7 +10,7 @@ from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from posthog.middleware import impersonated_session_logout, login_as_user_read_only
-from posthog.views import api_key_search_view, redis_values_view
+from posthog.views import api_key_search_view, redis_edit_ttl_view, redis_values_view
 
 from ee.admin.oauth_views import admin_auth_check, admin_oauth_success
 from ee.api import integration
@@ -114,6 +114,7 @@ if settings.ADMIN_PORTAL_ENABLED:
         path("admin/oauth2/success", admin_oauth_success, name="admin_oauth_success"),
         path("admin/auth_check", admin_auth_check, name="admin_auth_check"),
         path("admin/redisvalues", redis_values_view, name="redis_values"),
+        path("admin/redis/edit-ttl", redis_edit_ttl_view, name="redis_edit_ttl"),
         path("admin/apikeysearch", api_key_search_view, name="api_key_search"),
         path(
             "admin/realtime-cohorts-calculation/",

--- a/posthog/templates/redis/edit_ttl.html
+++ b/posthog/templates/redis/edit_ttl.html
@@ -1,0 +1,214 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrastyle %}
+{{ block.super }}
+<link rel="stylesheet" href="{% static 'admin/css/forms.css' %}" />
+<style>
+    .ttl-form {
+        max-width: 600px;
+        margin: 20px 0;
+    }
+    .form-row {
+        margin-bottom: 15px;
+    }
+    .form-row label {
+        display: block;
+        font-weight: bold;
+        margin-bottom: 5px;
+        color: var(--body-fg);
+    }
+    .form-row input[type="text"],
+    .form-row input[type="number"] {
+        padding: 8px;
+        width: 100%;
+        max-width: 300px;
+        font-size: 14px;
+        background: var(--darkened-bg, #fff);
+        color: var(--body-fg, #333);
+        border: 2px solid var(--hairline-color, #ccc);
+        border-radius: 4px;
+    }
+    .form-row input[type="number"]:focus {
+        border-color: var(--primary, #417690);
+        outline: 2px solid var(--primary, #417690);
+        outline-offset: 2px;
+    }
+    .key-display {
+        background: var(--darkened-bg, #f8f8f8);
+        color: var(--body-fg, #333);
+        padding: 10px;
+        border: 1px solid var(--hairline-color, #ddd);
+        border-radius: 4px;
+        font-family: monospace;
+        word-break: break-all;
+    }
+    .ttl-preview {
+        margin-top: 8px;
+        padding: 8px;
+        background: #184d18;
+        border-radius: 4px;
+        color: #90ee90;
+        border: 1px solid #2d5a2d;
+    }
+    .ttl-preview.no-ttl {
+        background: #4d4018;
+        color: #ffd966;
+        border-color: #856404;
+    }
+    .button-row {
+        margin-top: 20px;
+    }
+    .button-row input[type="submit"],
+    .button-row a.cancel-button {
+        padding: 10px 20px;
+        font-size: 14px;
+        margin-right: 10px;
+        cursor: pointer;
+    }
+    .button-row a.cancel-button {
+        display: inline-block;
+        text-decoration: none;
+        background: #6c757d;
+        color: white;
+        border-radius: 4px;
+    }
+    .button-row a.cancel-button:hover {
+        background: #5a6268;
+    }
+    .current-ttl {
+        margin-bottom: 15px;
+        padding: 10px;
+        background: var(--darkened-bg, #f0f0f0);
+        color: var(--body-fg, #333);
+        border: 1px solid var(--hairline-color, #ddd);
+        border-radius: 4px;
+    }
+
+    @media (prefers-color-scheme: light) {
+        .ttl-preview {
+            background: #e8f4e8;
+            color: #2d5a2d;
+            border-color: #90ee90;
+        }
+        .ttl-preview.no-ttl {
+            background: #fff3cd;
+            color: #856404;
+            border-color: #ffd966;
+        }
+    }
+</style>
+{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    &rsaquo; <a href="/admin/redisvalues?c={{ cursor }}{% if query %}&q={{ query|urlencode }}{% endif %}">Redis values</a>
+    &rsaquo; Edit TTL
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+    <div class="ttl-form">
+        <form method="post" action="">
+            {% csrf_token %}
+            <input type="hidden" name="key" value="{{ redis_key }}" />
+            <input type="hidden" name="c" value="{{ cursor }}" />
+            <input type="hidden" name="q" value="{{ query }}" />
+
+            <div class="form-row">
+                <label>{% trans "Redis key" %}</label>
+                <div class="key-display">{{ redis_key }}</div>
+            </div>
+
+            <div class="current-ttl">
+                {% if current_ttl %}
+                    {% trans "Current TTL:" %} {{ current_ttl }} {% trans "seconds" %}
+                {% else %}
+                    {% trans "No TTL set (key does not expire)" %}
+                {% endif %}
+            </div>
+
+            <div class="form-row">
+                <label for="ttl_seconds">{% trans "New TTL (seconds)" %}</label>
+                <input type="number"
+                       name="ttl_seconds"
+                       id="ttl_seconds"
+                       min="0"
+                       placeholder="Leave empty to remove TTL"
+                       value="{{ current_ttl|default:'' }}" />
+                <div id="ttl-preview" class="ttl-preview" role="status" aria-live="polite" style="display: none;"></div>
+            </div>
+
+            <div class="button-row">
+                <input type="submit" value="{% trans 'Save' %}" class="default" />
+                <a href="/admin/redisvalues?c={{ cursor }}{% if query %}&q={{ query|urlencode }}{% endif %}" class="cancel-button">{% trans "Cancel" %}</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script nonce="{{ request.csp_nonce }}">
+(function() {
+    const input = document.getElementById('ttl_seconds');
+    const preview = document.getElementById('ttl-preview');
+
+    function formatDuration(seconds) {
+        if (seconds === 0 || seconds === '') {
+            return null;
+        }
+
+        const units = [
+            { label: 'day', seconds: 86400 },
+            { label: 'hour', seconds: 3600 },
+            { label: 'minute', seconds: 60 },
+            { label: 'second', seconds: 1 }
+        ];
+
+        const parts = [];
+        let remaining = parseInt(seconds, 10);
+
+        for (const unit of units) {
+            if (remaining >= unit.seconds) {
+                const count = Math.floor(remaining / unit.seconds);
+                remaining = remaining % unit.seconds;
+                parts.push(`${count} ${unit.label}${count !== 1 ? 's' : ''}`);
+            }
+        }
+
+        return parts.join(', ');
+    }
+
+    function updatePreview() {
+        const value = input.value.trim();
+
+        if (value === '') {
+            preview.textContent = 'Will remove TTL (key will not expire)';
+            preview.className = 'ttl-preview no-ttl';
+            preview.style.display = 'block';
+            return;
+        }
+
+        const seconds = parseInt(value, 10);
+        if (isNaN(seconds) || seconds < 0) {
+            preview.style.display = 'none';
+            return;
+        }
+
+        if (seconds === 0) {
+            preview.textContent = 'Will remove TTL (key will not expire)';
+            preview.className = 'ttl-preview no-ttl';
+        } else {
+            const formatted = formatDuration(seconds);
+            preview.textContent = `Will set ${formatted} TTL`;
+            preview.className = 'ttl-preview';
+        }
+        preview.style.display = 'block';
+    }
+
+    input.addEventListener('input', updatePreview);
+    updatePreview();
+})();
+</script>
+{% endblock %}

--- a/posthog/templates/redis/values.html
+++ b/posthog/templates/redis/values.html
@@ -49,17 +49,30 @@
                                 <div class="text"><span>{% trans "TTL" %}</span></div>
                             </th>
                             <th scope="col">
+                                <div class="text"><span>{% trans "Size" %}</span></div>
+                            </th>
+                            <th scope="col">
                                 <div class="text"><span>{% trans "Value" %}</span></div>
                             </th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for key, tuple in redis_keys.items %}
+                        {% for key_info in redis_keys %}
                         <tr>
-                            <td class="field-key">{{ key }}</td>
-                            {% for item in tuple %}
-                            <td>{{ item }}</td>
-                            {% endfor %}
+                            <td class="field-key">{{ key_info.key }}</td>
+                            <td>{{ key_info.type }}</td>
+                            <td><a href="/admin/redis/edit-ttl?key={{ key_info.key|urlencode }}&c={{ cursor }}&q={{ query|urlencode }}">{{ key_info.ttl }}</a></td>
+                            <td>{{ key_info.size }}</td>
+                            <td>
+                                {% if key_info.is_truncated %}
+                                <details>
+                                    <summary>{{ key_info.value }}</summary>
+                                    <pre style="white-space: pre-wrap; word-break: break-all; margin-top: 8px; padding: 8px; background: var(--darkened-bg, #f5f5f5); border-radius: 4px; max-height: 400px; overflow: auto;">{{ key_info.full_value }}</pre>
+                                </details>
+                                {% else %}
+                                {{ key_info.value }}
+                                {% endif %}
+                            </td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/posthog/test/test_redis_admin_views.py
+++ b/posthog/test/test_redis_admin_views.py
@@ -1,0 +1,137 @@
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.test import Client, override_settings
+
+from parameterized import parameterized
+
+from posthog.models.activity_logging.activity_log import ActivityLog
+
+
+class TestRedisEditTTLView(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.client = Client()
+        self.client.force_login(self.user)
+        self.user.is_staff = True
+        self.user.save()
+
+    @parameterized.expand(
+        [
+            ("key_with_ttl", "test:cache:key", 3600, b"3600"),
+            ("key_without_ttl", "persistent:key", -1, b"No TTL set"),
+        ]
+    )
+    @override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
+    @patch("posthog.views.get_client")
+    def test_get_request_returns_form(
+        self, _name: str, key: str, ttl_return: int, expected_content: bytes, mock_get_client: MagicMock
+    ) -> None:
+        mock_redis = MagicMock()
+        mock_redis.ttl.return_value = ttl_return
+        mock_get_client.return_value = mock_redis
+
+        response = self.client.get(f"/admin/redis/edit-ttl?key={key}")
+
+        assert response.status_code == 200
+        assert key.encode() in response.content
+        assert expected_content in response.content
+
+    @patch("posthog.views.get_client")
+    def test_nonexistent_key_returns_404(self, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_redis.ttl.return_value = -2
+        mock_get_client.return_value = mock_redis
+
+        response = self.client.get("/admin/redis/edit-ttl?key=nonexistent:key")
+
+        assert response.status_code == 404
+        assert b"Redis key not found" in response.content
+
+    def test_missing_key_redirects(self) -> None:
+        response = self.client.get("/admin/redis/edit-ttl")
+
+        assert response.status_code == 302
+        assert response["Location"] == "/admin/redisvalues"
+
+    @parameterized.expand(
+        [
+            ("set_ttl", "7200", "expire", "ttl_updated", "Set TTL to 7200s on Redis key test:cache:key"),
+            ("remove_ttl", "", "persist", "ttl_removed", "Removed TTL from Redis key test:cache:key"),
+            ("negative_ttl", "-1", "expire", "ttl_updated", "Set TTL to -1s on Redis key test:cache:key"),
+        ]
+    )
+    @patch("posthog.views.get_client")
+    def test_post_creates_activity_log(
+        self,
+        _name: str,
+        ttl_input: str,
+        expected_method: str,
+        expected_activity: str,
+        expected_detail_name: str,
+        mock_get_client: MagicMock,
+    ) -> None:
+        mock_redis = MagicMock()
+        mock_redis.ttl.return_value = 3600
+        mock_get_client.return_value = mock_redis
+
+        response = self.client.post(
+            "/admin/redis/edit-ttl",
+            data={"key": "test:cache:key", "ttl_seconds": ttl_input},
+        )
+
+        assert response.status_code == 302
+
+        if expected_method == "expire":
+            mock_redis.expire.assert_called_once_with("test:cache:key", int(ttl_input))
+        else:
+            mock_redis.persist.assert_called_once_with("test:cache:key")
+
+        log = ActivityLog.objects.filter(scope="Admin", activity=expected_activity).latest("id")
+        assert log.item_id == "test:cache:key"
+        assert log.user == self.user
+        assert log.organization_id == self.organization.id
+        detail = log.detail
+        assert detail is not None
+        assert detail["name"] == expected_detail_name
+        assert detail["type"] == "previous_ttl:3600"
+
+    @parameterized.expand(
+        [
+            ("text",),
+            ("1.5",),
+            ("abc123",),
+            ("12abc",),
+        ]
+    )
+    @patch("posthog.views.get_client")
+    def test_invalid_ttl_returns_400(self, invalid_ttl: str, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_get_client.return_value = mock_redis
+
+        response = self.client.post(
+            "/admin/redis/edit-ttl",
+            data={"key": "test:cache:key", "ttl_seconds": invalid_ttl},
+        )
+
+        assert response.status_code == 400
+        assert b"Invalid TTL value" in response.content
+        mock_redis.expire.assert_not_called()
+        mock_redis.persist.assert_not_called()
+
+    @parameterized.expand([("put",), ("patch",), ("delete",)])
+    def test_disallowed_methods_return_405(self, method: str) -> None:
+        response = getattr(self.client, method)("/admin/redis/edit-ttl?key=test:key")
+
+        assert response.status_code == 405
+
+    def test_post_without_csrf_token_returns_403(self) -> None:
+        csrf_client = Client(enforce_csrf_checks=True)
+        csrf_client.force_login(self.user)
+
+        response = csrf_client.post(
+            "/admin/redis/edit-ttl",
+            data={"key": "test:cache:key", "ttl_seconds": "3600"},
+        )
+
+        assert response.status_code == 403

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -1,6 +1,8 @@
 import os
+from dataclasses import dataclass
 from datetime import timedelta
-from functools import partial, wraps
+from functools import wraps
+from html import escape
 from typing import Union
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
@@ -27,6 +29,7 @@ from posthog.email import is_email_available
 from posthog.exceptions_capture import capture_exception
 from posthog.health import is_clickhouse_connected, is_kafka_connected
 from posthog.models import Organization, User
+from posthog.models.activity_logging.activity_log import Detail, log_activity
 from posthog.models.integration import SlackIntegration
 from posthog.models.message_category import MessageCategory
 from posthog.models.message_preferences import (
@@ -218,8 +221,40 @@ def preflight_check(request: HttpRequest) -> JsonResponse:
     return JsonResponse(response)
 
 
-def get_redis_key_type_ttl_value_tuple(key: bytes, redis_client):
-    """Get a tuple with a Redis key, type, and value from a Redis key."""
+MAX_VALUE_DISPLAY_LENGTH = 200
+
+
+@dataclass
+class RedisKeyInfo:
+    key: str
+    type: str
+    ttl: timedelta | int
+    size: str
+    value: str
+    full_value: str
+    is_truncated: bool
+
+
+def format_bytes(size_bytes: int) -> str:
+    nbsp = "\u00a0"
+    if size_bytes < 1024:
+        return f"{size_bytes}{nbsp}B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f}{nbsp}KB"
+    elif size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f}{nbsp}MB"
+    else:
+        return f"{size_bytes / (1024 * 1024 * 1024):.1f}{nbsp}GB"
+
+
+def truncate_value(value, max_length: int = MAX_VALUE_DISPLAY_LENGTH) -> str:
+    str_value = str(value)
+    if len(str_value) <= max_length:
+        return str_value
+    return str_value[:max_length] + "..."
+
+
+def get_redis_key_info(key: bytes, redis_client) -> RedisKeyInfo:
     redis_key = key.decode("utf-8")
     redis_type = redis_client.type(redis_key).decode("utf8")
     redis_ttl = redis_client.ttl(redis_key)
@@ -229,22 +264,30 @@ def get_redis_key_type_ttl_value_tuple(key: bytes, redis_client):
 
     if redis_type == "string":
         value = redis_client.get(key)
-
     elif redis_type == "hash":
         value = redis_client.hgetall(key)
-
     elif redis_type == "zset":
         value = redis_client.zrange(key, 0, -1)
-
     elif redis_type == "list":
         value = redis_client.lrange(key, 0, -1)
-
     elif redis_type == "set":
         value = redis_client.smembers(key)
     else:
         raise ValueError(f"Key {redis_key} has an unsupported type: {redis_type}")
 
-    return (redis_key, redis_type, redis_ttl, value)
+    memory_bytes = redis_client.memory_usage(redis_key) or 0
+    full_value = str(value)
+    is_truncated = len(full_value) > MAX_VALUE_DISPLAY_LENGTH
+
+    return RedisKeyInfo(
+        key=redis_key,
+        type=redis_type,
+        ttl=redis_ttl,
+        size=format_bytes(memory_bytes),
+        value=truncate_value(value),
+        full_value=full_value,
+        is_truncated=is_truncated,
+    )
 
 
 @staff_member_required
@@ -263,11 +306,7 @@ def redis_values_view(request: HttpRequest):
     redis_client = get_client()
     next_cursor, key_list = redis_client.scan(cursor=cursor, count=keys_per_page, match=query)
 
-    partial_get_redis_key = partial(get_redis_key_type_ttl_value_tuple, redis_client=redis_client)
-    redis_keys = {
-        redis_key: (redis_type, redis_ttl, value)
-        for redis_key, redis_type, redis_ttl, value in map(partial_get_redis_key, key_list)
-    }
+    redis_keys = [get_redis_key_info(key, redis_client) for key in key_list]
 
     context = {
         **admin_site.each_context(request),
@@ -282,6 +321,85 @@ def redis_values_view(request: HttpRequest):
     }
 
     return render(request, template_name="redis/values.html", context=context, status=200)
+
+
+@csrf_protect
+@staff_member_required
+def redis_edit_ttl_view(request: HttpRequest):
+    """A Django admin view to edit TTL of a Redis key."""
+    if request.method not in ("GET", "POST"):
+        return HttpResponseNotAllowed(permitted_methods=["GET", "POST"])
+
+    redis_key = request.GET.get("key") or request.POST.get("key")
+    if not redis_key:
+        return redirect("redis_values")
+
+    try:
+        cursor = int(request.GET.get("c", "0"))
+    except ValueError:
+        cursor = 0
+    query = request.GET.get("q", "")
+
+    redis_client = get_client()
+
+    if request.method == "POST":
+        ttl_seconds_str = request.POST.get("ttl_seconds", "").strip()
+        previous_ttl = redis_client.ttl(redis_key)
+
+        if ttl_seconds_str == "":
+            redis_client.persist(redis_key)
+            activity = "ttl_removed"
+            detail_name = f"Removed TTL from Redis key {redis_key}"
+        else:
+            try:
+                ttl_seconds = int(ttl_seconds_str)
+            except ValueError:
+                return HttpResponse("Invalid TTL value: must be an integer", status=400)
+
+            redis_client.expire(redis_key, ttl_seconds)
+            activity = "ttl_updated"
+            detail_name = f"Set TTL to {ttl_seconds}s on Redis key {redis_key}"
+
+        user = request.user if request.user.is_authenticated else None
+        organization_id = user.current_organization.id if user and user.current_organization else None
+
+        log_activity(
+            organization_id=organization_id,
+            team_id=None,
+            user=user,
+            was_impersonated=False,
+            item_id=redis_key,
+            scope="Admin",
+            activity=activity,
+            detail=Detail(
+                name=detail_name,
+                short_id=redis_key,
+                type=f"previous_ttl:{previous_ttl}",
+            ),
+        )
+
+        params: dict[str, str | int] = {"c": cursor}
+        if query:
+            params["q"] = query
+        return redirect(f"/admin/redisvalues?{urlencode(params)}")
+
+    current_ttl = redis_client.ttl(redis_key)
+
+    if current_ttl == -2:
+        return HttpResponse(f"Redis key not found: {escape(redis_key)}", status=404)
+
+    context = {
+        **admin_site.each_context(request),
+        **{
+            "redis_key": redis_key,
+            "current_ttl": current_ttl if current_ttl > 0 else None,
+            "cursor": cursor,
+            "query": query,
+            "title": f"Edit TTL for {redis_key}",
+        },
+    }
+
+    return render(request, template_name="redis/edit_ttl.html", context=context, status=200)
 
 
 @staff_member_required


### PR DESCRIPTION
i've wanted this a couple of times in incidents...

we have a django admin redis explorer, but it's never quite the info I want

so, no time like the present

* truncate values since they can be very long compressed strings
* show the bytes the value is taking up in redis
* allow editing the TTL
* write to the activity log when someone edits the TTL


![2025-12-30 19.39.37.gif](https://app.graphite.com/user-attachments/assets/2392074c-795f-4f99-90da-6b013a8896ea.gif)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

no