### PR TITLE
chore: delete dead caching code

### DIFF
--- a/posthog/caching/test/test_insight_cache.py
+++ b/posthog/caching/test/test_insight_cache.py
@@ -46,39 +46,6 @@ def cache_keys(cache):
     return {key.split(":", 2)[-1] for key in cache._cache.keys()}
 
 
-@pytest.mark.parametrize(
-    "params,expected_matches",
-    [
-        ({}, 1),
-        ({"limit": 0}, 0),
-        ({"last_refresh": None}, 1),
-        ({"target_cache_age": None, "last_refresh": None}, 0),
-        ({"target_cache_age": timedelta(days=1), "last_refresh": timedelta(days=2)}, 1),
-        (
-            {
-                "target_cache_age": timedelta(days=1),
-                "last_refresh": timedelta(hours=23),
-            },
-            0,
-        ),
-        (
-            {
-                "target_cache_age": timedelta(days=1),
-                "last_refresh_queued_at": timedelta(hours=23),
-            },
-            1,
-        ),
-        (
-            {
-                "target_cache_age": timedelta(days=1),
-                "last_refresh_queued_at": timedelta(minutes=5),
-            },
-            0,
-        ),
-        ({"refresh_attempt": 2}, 1),
-        ({"refresh_attempt": 3}, 0),
-    ],
-)
 @pytest.mark.django_db
 @freeze_time("2020-01-04T13:01:01Z")
 def test_update_cache(team: Team, user: User, cache):

--- a/posthog/caching/test/test_insight_cache.py
+++ b/posthog/caching/test/test_insight_cache.py
@@ -3,13 +3,13 @@ from typing import Optional
 
 import pytest
 from freezegun import freeze_time
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 from django.utils.timezone import now
 
 import orjson as json
 
-from posthog.caching.insight_cache import fetch_states_in_need_of_updating, schedule_cache_updates, update_cache
+from posthog.caching.insight_cache import update_cache
 from posthog.caching.insight_caching_state import upsert
 from posthog.caching.test.test_insight_caching_state import create_insight, filter_dict
 from posthog.models import InsightCachingState, Team, User
@@ -46,34 +46,6 @@ def cache_keys(cache):
     return {key.split(":", 2)[-1] for key in cache._cache.keys()}
 
 
-@pytest.mark.django_db
-@patch("posthog.caching.insight_cache.update_cache_task")
-def test_schedule_cache_updates(update_cache_task, team: Team, user: User):
-    caching_state1 = create_insight_caching_state(team, user, filters=filter_dict, last_refresh=None)
-    create_insight_caching_state(team, user, filters=filter_dict)
-    caching_state3 = create_insight_caching_state(
-        team,
-        user,
-        filters={
-            **filter_dict,
-            "events": [{"id": "$pageleave"}],
-        },
-    )
-
-    schedule_cache_updates()
-
-    assert update_cache_task.delay.call_args_list == [
-        call(caching_state1.pk),
-        call(caching_state3.pk),
-    ]
-
-    last_refresh_queued_at = InsightCachingState.objects.filter(team=team).values_list(
-        "last_refresh_queued_at", flat=True
-    )
-    assert len(last_refresh_queued_at) == 3
-    assert None not in last_refresh_queued_at
-
-
 @pytest.mark.parametrize(
     "params,expected_matches",
     [
@@ -107,14 +79,6 @@ def test_schedule_cache_updates(update_cache_task, team: Team, user: User):
         ({"refresh_attempt": 3}, 0),
     ],
 )
-@pytest.mark.django_db
-def test_fetch_states_in_need_of_updating(team: Team, user: User, params, expected_matches):
-    create_insight_caching_state(team, user, **params)
-
-    results = fetch_states_in_need_of_updating(params.get("limit", 10))
-    assert len(results) == expected_matches
-
-
 @pytest.mark.django_db
 @freeze_time("2020-01-04T13:01:01Z")
 def test_update_cache(team: Team, user: User, cache):

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -637,13 +637,6 @@ def sync_insight_cache_states_task() -> None:
     sync_insight_cache_states()
 
 
-@shared_task(ignore_result=True)
-def schedule_cache_updates_task() -> None:
-    from posthog.caching.insight_cache import schedule_cache_updates
-
-    schedule_cache_updates()
-
-
 @shared_task(
     ignore_result=True,
     autoretry_for=(CHQueryErrorTooManySimultaneousQueries,),

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -100,7 +100,6 @@
     'posthog.tasks.tasks.redis_heartbeat',
     'posthog.tasks.tasks.refresh_activity_log_fields_cache',
     'posthog.tasks.tasks.replay_count_metrics',
-    'posthog.tasks.tasks.schedule_cache_updates_task',
     'posthog.tasks.tasks.send_org_usage_reports',
     'posthog.tasks.tasks.start_poll_query_performance',
     'posthog.tasks.tasks.stop_surveys_reached_target',


### PR DESCRIPTION
## Problem

`schedule_cache_updates_task` isn't scheduled so it is never called. 

https://github.com/search?q=repo%3APostHog%2Fposthog%20schedule_cache_updates_task&type=code

Non hog-ql insight (i.e. legacy insights) caching (insights_api.py, insight_caching_state.py, insight_cache.py) can be entirely removed once legacy insights no longer exist, but that will be a heavier lift as we currently still allow users to create them through the API. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Delete `schedule_cache_updates_task` and it's related code

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
