### PR TITLE
fix(kafka-deduplicator): eliminate race between async store cleanup and manager bootstrap, kafka rebalancing

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
+            - 'eli.r/kdedup-dbg-race'
 
 jobs:
     build:

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -8,7 +8,6 @@ on:
             - '.github/workflows/rust-docker-build.yml'
         branches:
             - 'master'
-            - 'eli.r/kdedup-dbg-race'
 
 jobs:
     build:

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -171,6 +171,7 @@ impl CheckpointManager {
                             debug!("No stores to flush");
                             continue;
                         }
+
                         info!("Checkpoint manager: attempting checkpoint submission for {} stores", store_count);
 
                         // Attempt to checkpoint each partitions' backing store in
@@ -259,7 +260,6 @@ impl CheckpointManager {
                                 // store manager when the worker thread has started executing
                                 let target_store = match worker_store_manager.get(partition.topic(), partition.partition_number()) {
                                     Some(store) => store,
-
                                     _ => {
                                         metrics::counter!(CHECKPOINT_STORE_NOT_FOUND_COUNTER).increment(1);
                                         warn!(partition = partition_tag, "Checkpoint worker thread: partition no longer owned by store manager, skipping");

--- a/rust/kafka-deduplicator/src/utils/mod.rs
+++ b/rust/kafka-deduplicator/src/utils/mod.rs
@@ -1,1 +1,66 @@
 pub mod timestamp;
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+
+/// Format a topic/partition pair as a filesystem-safe directory name.
+/// Replaces `/` characters with `_` since `/` would create subdirectories.
+pub fn format_partition_dir(topic: &str, partition: i32) -> String {
+    format!("{}_{}", topic.replace('/', "_"), partition)
+}
+
+/// Build a complete store path with timestamp subdirectory.
+/// Used by both StoreManager and CheckpointMetadata to ensure consistent paths.
+pub fn format_store_path(
+    base_path: &Path,
+    topic: &str,
+    partition: i32,
+    timestamp: DateTime<Utc>,
+) -> PathBuf {
+    base_path
+        .join(format_partition_dir(topic, partition))
+        .join(timestamp.timestamp_millis().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn test_format_partition_dir_simple() {
+        assert_eq!(format_partition_dir("events", 0), "events_0");
+        assert_eq!(format_partition_dir("events", 42), "events_42");
+    }
+
+    #[test]
+    fn test_format_partition_dir_with_slashes() {
+        assert_eq!(format_partition_dir("org/events", 0), "org_events_0");
+        assert_eq!(format_partition_dir("a/b/c", 1), "a_b_c_1");
+    }
+
+    #[test]
+    fn test_format_partition_dir_edge_cases() {
+        assert_eq!(format_partition_dir("", 0), "_0");
+        assert_eq!(format_partition_dir("/", 0), "__0");
+        assert_eq!(format_partition_dir("events/", 0), "events__0");
+    }
+
+    #[test]
+    fn test_format_store_path() {
+        let base = Path::new("/data/stores");
+        // 2009-02-13T23:31:30.123Z
+        let ts = Utc.timestamp_millis_opt(1234567890123).unwrap();
+        let path = format_store_path(base, "events", 5, ts);
+        assert_eq!(path, PathBuf::from("/data/stores/events_5/1234567890123"));
+    }
+
+    #[test]
+    fn test_format_store_path_with_slashes() {
+        let base = Path::new("/data/stores");
+        let ts = Utc.timestamp_millis_opt(9999).unwrap();
+        let path = format_store_path(base, "org/events", 0, ts);
+        assert_eq!(path, PathBuf::from("/data/stores/org_events_0/9999"));
+    }
+}


### PR DESCRIPTION
## Problem
At rebalance or app startup, the orphaned store directory cleanup thread can race with the store manager which may have no registered stores for a moment. By skipping those runs and letting the cleaner only act when stores are up, we can avoid deleting existing stores prior to startup or rebalance.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add new `StoreManager` atomic flag to track rebalance until async task completion
* Add a check for empty store registration and rebalance flag before and during orphaned store cleaner runs
* Adds a check for rebalance flag before and during capacity cleaner runs. Empty store manager on capacity cleaner init already aborts as no-op
* Add related unit tests
* Normalize store local path builder into utility function we can use with checkpoints or new store creation, to ensure the implementations don't diverge in the future
* New store path builder tests
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; [debug log test PR](https://github.com/PostHog/posthog/pull/44119) helped validate this change does the trick in test deploy ✅ 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
