### PR TITLE
feat: limit query cache size per team

### DIFF
--- a/posthog/caching/cache_size_tracker.py
+++ b/posthog/caching/cache_size_tracker.py
@@ -1,0 +1,121 @@
+import time
+from typing import Optional
+
+from django.conf import settings
+from django.core.cache import cache
+
+import structlog
+from prometheus_client import Counter
+
+from posthog import redis
+
+logger = structlog.get_logger(__name__)
+
+CACHE_EVICTION_COUNTER = Counter(
+    "posthog_cache_size_limit_evictions_total",
+    "Cache entries evicted due to per-team size limits",
+)
+
+CACHE_EVICTION_BYTES_COUNTER = Counter(
+    "posthog_cache_size_limit_evicted_bytes_total",
+    "Bytes evicted due to per-team size limits",
+)
+
+
+def get_team_cache_limit(team_id: int) -> int:
+    """Get cache limit for team, checking for per-team override in extra_settings."""
+    from posthog.models import Team
+
+    try:
+        team = Team.objects.only("extra_settings").get(pk=team_id)
+        if team.extra_settings and "cache_size_limit_bytes" in team.extra_settings:
+            return team.extra_settings["cache_size_limit_bytes"]
+    except Team.DoesNotExist:
+        pass
+    return settings.TEAM_CACHE_SIZE_LIMIT_BYTES
+
+
+class TeamCacheSizeTracker:
+    """
+    Tracks cache size per team using Redis data structures.
+
+    Redis keys used:
+    - posthog:cache_sizes:{team_id} - Sorted set: member=cache_key, score=timestamp (for LRU ordering)
+    - posthog:cache_entry_sizes:{team_id} - Hash: field=cache_key, value=size (for O(1) size lookup)
+    - posthog:cache_total:{team_id} - String counter: total bytes (for O(1) total size lookup)
+    """
+
+    def __init__(self, team_id: int):
+        self.team_id = team_id
+        self.entries_key = f"posthog:cache_sizes:{team_id}"
+        self.sizes_key = f"posthog:cache_entry_sizes:{team_id}"
+        self.total_key = f"posthog:cache_total:{team_id}"
+        self.redis_client = redis.get_client()
+
+    def track_cache_write(self, cache_key: str, size_bytes: int) -> None:
+        """Track a cache write with its size"""
+        # Check if overwriting existing key
+        old_size = self._get_key_size(cache_key)
+        if old_size:
+            self.redis_client.incrby(self.total_key, -old_size)
+
+        # Add/update entry with timestamp as score (for LRU eviction)
+        self.redis_client.zadd(self.entries_key, {cache_key: time.time()})
+        self.redis_client.hset(self.sizes_key, cache_key, size_bytes)
+        self.redis_client.incrby(self.total_key, size_bytes)
+
+        # Set TTL on tracking keys so they auto-expire for inactive teams
+        # Use cache TTL + 1 day buffer to ensure tracking outlives cached data
+        tracking_ttl = settings.CACHED_RESULTS_TTL + 86400
+        self.redis_client.expire(self.entries_key, tracking_ttl)
+        self.redis_client.expire(self.sizes_key, tracking_ttl)
+        self.redis_client.expire(self.total_key, tracking_ttl)
+
+    def get_total_size(self) -> int:
+        return int(self.redis_client.get(self.total_key) or 0)
+
+    def evict_until_under_limit(self, limit_bytes: int, new_entry_size: int) -> list[str]:
+        """
+        Evict oldest entries (LRU) until total + new_entry_size <= limit.
+        Lazy cleanup happens here - removes tracking for TTL-expired keys.
+        """
+        evicted_keys = []
+        current_size = self.get_total_size()
+
+        while current_size + new_entry_size > limit_bytes:
+            # Get oldest entry (lowest score = oldest timestamp)
+            oldest = self.redis_client.zrange(self.entries_key, 0, 0)
+            if not oldest:
+                break
+
+            cache_key = oldest[0].decode()
+            size = self._get_key_size(cache_key) or 0
+
+            # Check if key still exists (lazy cleanup for TTL-expired keys)
+            if cache.get(cache_key) is None:
+                # Already expired via TTL, just clean up tracking
+                self._remove_tracking(cache_key, size)
+                current_size -= size
+                continue
+
+            cache.delete(cache_key)
+            self._remove_tracking(cache_key, size)
+
+            current_size -= size
+            evicted_keys.append(cache_key)
+
+            # Update metrics
+            CACHE_EVICTION_COUNTER.inc()
+            CACHE_EVICTION_BYTES_COUNTER.inc(size)
+
+        return evicted_keys
+
+    def _get_key_size(self, cache_key: str) -> Optional[int]:
+        size = self.redis_client.hget(self.sizes_key, cache_key)
+        return int(size) if size else None
+
+    def _remove_tracking(self, cache_key: str, size: int) -> None:
+        """Remove all tracking data for a cache key."""
+        self.redis_client.zrem(self.entries_key, cache_key)
+        self.redis_client.hdel(self.sizes_key, cache_key)
+        self.redis_client.incrby(self.total_key, -size)

--- a/posthog/caching/cache_size_tracker.py
+++ b/posthog/caching/cache_size_tracker.py
@@ -12,12 +12,12 @@ from posthog import redis
 logger = structlog.get_logger(__name__)
 
 CACHE_EVICTION_COUNTER = Counter(
-    "posthog_cache_size_limit_evictions_total",
+    "query_cache_size_limit_evictions_total",
     "Cache entries evicted due to per-team size limits",
 )
 
 CACHE_EVICTION_BYTES_COUNTER = Counter(
-    "posthog_cache_size_limit_evicted_bytes_total",
+    "query_cache_size_limit_evicted_bytes_total",
     "Bytes evicted due to per-team size limits",
 )
 

--- a/posthog/caching/cache_size_tracker.py
+++ b/posthog/caching/cache_size_tracker.py
@@ -1,13 +1,15 @@
 import time
+from datetime import timedelta
 from typing import Optional
 
 from django.conf import settings
 from django.core.cache import cache
 
 import structlog
-from prometheus_client import Counter
+from prometheus_client import Counter, Histogram
 
 from posthog import redis
+from posthog.cache_utils import cache_for
 
 logger = structlog.get_logger(__name__)
 
@@ -21,7 +23,71 @@ CACHE_EVICTION_BYTES_COUNTER = Counter(
     "Bytes evicted due to per-team size limits",
 )
 
+CACHE_SIZE_HISTOGRAM = Histogram(
+    "query_cache_team_size_bytes",
+    "Distribution of per-team cache sizes in bytes",
+    buckets=[
+        1_000_000,  # 1MB
+        10_000_000,  # 10MB
+        50_000_000,  # 50MB
+        100_000_000,  # 100MB
+        250_000_000,  # 250MB
+        500_000_000,  # 500MB
+        1_000_000_000,  # 1GB
+        float("inf"),
+    ],
+)
 
+# Lua script for atomic cache write tracking
+# Handles overwrite detection and counter updates in a single atomic operation
+TRACK_CACHE_WRITE_SCRIPT = """
+local entries_key = KEYS[1]
+local sizes_key = KEYS[2]
+local total_key = KEYS[3]
+
+local cache_key = ARGV[1]
+local size_bytes = tonumber(ARGV[2])
+local timestamp = tonumber(ARGV[3])
+local tracking_ttl = tonumber(ARGV[4])
+
+-- Atomically handle overwrite: only decrement if key exists
+local old_size = redis.call('HGET', sizes_key, cache_key)
+if old_size then
+    redis.call('INCRBY', total_key, -tonumber(old_size))
+end
+
+-- Update tracking
+redis.call('ZADD', entries_key, timestamp, cache_key)
+redis.call('HSET', sizes_key, cache_key, size_bytes)
+redis.call('INCRBY', total_key, size_bytes)
+
+-- Refresh TTLs
+redis.call('EXPIRE', entries_key, tracking_ttl)
+redis.call('EXPIRE', sizes_key, tracking_ttl)
+redis.call('EXPIRE', total_key, tracking_ttl)
+
+return redis.call('GET', total_key)
+"""
+
+# Lua script for atomic and idempotent tracking removal
+# Only decrements if key exists in hash, preventing double-decrement races
+REMOVE_TRACKING_SCRIPT = """
+local sizes_key = KEYS[1]
+local total_key = KEYS[2]
+local cache_key = ARGV[1]
+
+-- Only decrement if key exists in hash (idempotent)
+local size = redis.call('HGET', sizes_key, cache_key)
+if size then
+    redis.call('HDEL', sizes_key, cache_key)
+    redis.call('INCRBY', total_key, -tonumber(size))
+    return tonumber(size)
+end
+return 0
+"""
+
+
+@cache_for(timedelta(seconds=60))
 def get_team_cache_limit(team_id: int) -> int:
     """Get cache limit for team, checking for per-team override in extra_settings."""
     from posthog.models import Team
@@ -29,7 +95,7 @@ def get_team_cache_limit(team_id: int) -> int:
     try:
         team = Team.objects.only("extra_settings").get(pk=team_id)
         if team.extra_settings and "cache_size_limit_bytes" in team.extra_settings:
-            return team.extra_settings["cache_size_limit_bytes"]
+            return int(team.extra_settings["cache_size_limit_bytes"])
     except Team.DoesNotExist:
         pass
     return settings.TEAM_CACHE_SIZE_LIMIT_BYTES
@@ -51,25 +117,40 @@ class TeamCacheSizeTracker:
         self.sizes_key = f"posthog:cache_entry_sizes:{team_id}"
         self.total_key = f"posthog:cache_total:{team_id}"
         self.redis_client = redis.get_client()
+        self._track_write_script = self.redis_client.register_script(TRACK_CACHE_WRITE_SCRIPT)
+        self._remove_tracking_script = self.redis_client.register_script(REMOVE_TRACKING_SCRIPT)
+
+    def set(self, cache_key: str, data: bytes, data_size: int, ttl: int) -> list[str]:
+        """
+        Set cache data with size limit enforcement.
+        Handles eviction, cache write, and tracking atomically.
+        Returns list of evicted keys.
+        """
+        limit = get_team_cache_limit(self.team_id)
+        evicted: list[str] = []
+
+        if self.get_total_size() + data_size > limit:
+            evicted = self.evict_until_under_limit(limit, data_size)
+            if evicted:
+                logger.info(
+                    "cache_size_limit_eviction",
+                    team_id=self.team_id,
+                    evicted_count=len(evicted),
+                    limit_bytes=limit,
+                )
+
+        cache.set(cache_key, data, ttl)
+        self.track_cache_write(cache_key, data_size)
+        CACHE_SIZE_HISTOGRAM.observe(self.get_total_size())
+        return evicted
 
     def track_cache_write(self, cache_key: str, size_bytes: int) -> None:
-        """Track a cache write with its size"""
-        # Check if overwriting existing key
-        old_size = self._get_key_size(cache_key)
-        if old_size:
-            self.redis_client.incrby(self.total_key, -old_size)
-
-        # Add/update entry with timestamp as score (for LRU eviction)
-        self.redis_client.zadd(self.entries_key, {cache_key: time.time()})
-        self.redis_client.hset(self.sizes_key, cache_key, size_bytes)
-        self.redis_client.incrby(self.total_key, size_bytes)
-
-        # Set TTL on tracking keys so they auto-expire for inactive teams
-        # Use cache TTL + 1 day buffer to ensure tracking outlives cached data
+        """Track a cache write with its size. Atomic via Lua script."""
         tracking_ttl = settings.CACHED_RESULTS_TTL + 86400
-        self.redis_client.expire(self.entries_key, tracking_ttl)
-        self.redis_client.expire(self.sizes_key, tracking_ttl)
-        self.redis_client.expire(self.total_key, tracking_ttl)
+        self._track_write_script(
+            keys=[self.entries_key, self.sizes_key, self.total_key],
+            args=[cache_key, size_bytes, time.time(), tracking_ttl],
+        )
 
     def get_total_size(self) -> int:
         return int(self.redis_client.get(self.total_key) or 0)
@@ -77,45 +158,52 @@ class TeamCacheSizeTracker:
     def evict_until_under_limit(self, limit_bytes: int, new_entry_size: int) -> list[str]:
         """
         Evict oldest entries (LRU) until total + new_entry_size <= limit.
+        Uses ZPOPMIN for atomic dequeue - prevents double-eviction races.
         Lazy cleanup happens here - removes tracking for TTL-expired keys.
         """
-        evicted_keys = []
+        evicted_keys: list[str] = []
         current_size = self.get_total_size()
 
         while current_size + new_entry_size > limit_bytes:
-            # Get oldest entry (lowest score = oldest timestamp)
-            oldest = self.redis_client.zrange(self.entries_key, 0, 0)
-            if not oldest:
+            result = self.redis_client.zpopmin(self.entries_key, 1)
+            if not result:
                 break
 
-            cache_key = oldest[0].decode()
-            size = self._get_key_size(cache_key) or 0
+            cache_key = result[0][0]
+            if isinstance(cache_key, bytes):
+                cache_key = cache_key.decode()
 
-            # Check if key still exists (lazy cleanup for TTL-expired keys)
-            if cache.get(cache_key) is None:
+            # Check if key still exists in cache (lazy cleanup for TTL-expired keys)
+            if cache_key not in cache:
                 # Already expired via TTL, just clean up tracking
-                self._remove_tracking(cache_key, size)
-                current_size -= size
+                removed_size = self._remove_tracking(cache_key)
+                current_size -= removed_size
                 continue
 
             cache.delete(cache_key)
-            self._remove_tracking(cache_key, size)
+            removed_size = self._remove_tracking(cache_key)
 
-            current_size -= size
+            current_size -= removed_size
             evicted_keys.append(cache_key)
 
             # Update metrics
             CACHE_EVICTION_COUNTER.inc()
-            CACHE_EVICTION_BYTES_COUNTER.inc(size)
+            CACHE_EVICTION_BYTES_COUNTER.inc(removed_size)
 
         return evicted_keys
+
+    def purge(self) -> None:
+        """Delete all tracking data for this team."""
+        self.redis_client.delete(self.entries_key, self.sizes_key, self.total_key)
 
     def _get_key_size(self, cache_key: str) -> Optional[int]:
         size = self.redis_client.hget(self.sizes_key, cache_key)
         return int(size) if size else None
 
-    def _remove_tracking(self, cache_key: str, size: int) -> None:
-        """Remove all tracking data for a cache key."""
-        self.redis_client.zrem(self.entries_key, cache_key)
-        self.redis_client.hdel(self.sizes_key, cache_key)
-        self.redis_client.incrby(self.total_key, -size)
+    def _remove_tracking(self, cache_key: str) -> int:
+        """Remove tracking data. Atomic and idempotent. Returns size removed."""
+        result = self._remove_tracking_script(
+            keys=[self.sizes_key, self.total_key],
+            args=[cache_key],
+        )
+        return int(result) if result else 0

--- a/posthog/caching/test/test_cache_size_tracker.py
+++ b/posthog/caching/test/test_cache_size_tracker.py
@@ -20,6 +20,8 @@ class TestTeamCacheSizeTracker(BaseTest):
         cache.delete("test_key_3")
         cache.delete("expired_key")
         cache.delete("real_key")
+        cache.delete("test_key")
+        cache.delete("large_key")
         super().tearDown()
 
     def test_track_cache_write_increments_total(self):

--- a/posthog/caching/test/test_cache_size_tracker.py
+++ b/posthog/caching/test/test_cache_size_tracker.py
@@ -1,28 +1,20 @@
-import time
-
 from posthog.test.base import BaseTest
 
 from django.core.cache import cache
 from django.test import override_settings
 
 from posthog.caching.cache_size_tracker import TeamCacheSizeTracker, get_team_cache_limit
+from posthog.models import Team
 
 
 class TestTeamCacheSizeTracker(BaseTest):
     def setUp(self) -> None:
         super().setUp()
         self.tracker = TeamCacheSizeTracker(self.team.pk)
-        # Clean up any existing tracking data
-        self.tracker.redis_client.delete(self.tracker.entries_key)
-        self.tracker.redis_client.delete(self.tracker.sizes_key)
-        self.tracker.redis_client.delete(self.tracker.total_key)
+        self.tracker.purge()
 
     def tearDown(self) -> None:
-        # Clean up tracking data
-        self.tracker.redis_client.delete(self.tracker.entries_key)
-        self.tracker.redis_client.delete(self.tracker.sizes_key)
-        self.tracker.redis_client.delete(self.tracker.total_key)
-        # Clean up any cache keys we created
+        self.tracker.purge()
         cache.delete("test_key_1")
         cache.delete("test_key_2")
         cache.delete("test_key_3")
@@ -64,11 +56,9 @@ class TestTeamCacheSizeTracker(BaseTest):
         # Add entries with small delays to ensure different timestamps
         self.tracker.track_cache_write("test_key_1", 100)
         cache.set("test_key_1", "data1")
-        time.sleep(0.01)
 
         self.tracker.track_cache_write("test_key_2", 200)
         cache.set("test_key_2", "data2")
-        time.sleep(0.01)
 
         self.tracker.track_cache_write("test_key_3", 300)
         cache.set("test_key_3", "data3")
@@ -81,6 +71,7 @@ class TestTeamCacheSizeTracker(BaseTest):
 
         # Should have evicted oldest entries
         self.assertIn("test_key_1", evicted)
+        self.assertIn("test_key_2", evicted)
         # Total should now be under limit + new entry size
         self.assertLessEqual(self.tracker.get_total_size() + 200, 500)
         # Newest entry should still exist
@@ -117,8 +108,124 @@ class TestTeamCacheSizeTracker(BaseTest):
         self.assertEqual(evicted, [])
         self.assertEqual(self.tracker.get_total_size(), 100)
 
+    def test_purge_removes_all_tracking_data(self):
+        self.tracker.track_cache_write("test_key_1", 1000)
+        self.tracker.track_cache_write("test_key_2", 2000)
+        self.assertEqual(self.tracker.get_total_size(), 3000)
+
+        self.tracker.purge()
+
+        self.assertEqual(self.tracker.get_total_size(), 0)
+        self.assertIsNone(self.tracker._get_key_size("test_key_1"))
+        self.assertIsNone(self.tracker._get_key_size("test_key_2"))
+
+    def test_set_method_writes_cache_and_tracks(self):
+        data = b"test_data_content"
+        self.tracker.set("test_key_1", data, len(data), 300)
+
+        # Cache should be set
+        self.assertEqual(cache.get("test_key_1"), data)
+        # Tracking should be updated
+        self.assertEqual(self.tracker.get_total_size(), len(data))
+
+    @override_settings(TEAM_CACHE_SIZE_LIMIT_BYTES=500)
+    def test_set_method_triggers_eviction_when_over_limit(self):
+        # First write - under limit
+        data1 = b"x" * 200
+        cache.set("test_key_1", data1)
+        self.tracker.track_cache_write("test_key_1", len(data1))
+
+        data2 = b"y" * 200
+        cache.set("test_key_2", data2)
+        self.tracker.track_cache_write("test_key_2", len(data2))
+
+        # This should trigger eviction of test_key_1
+        data3 = b"z" * 200
+        evicted = self.tracker.set("test_key_3", data3, len(data3), 300)
+
+        self.assertIn("test_key_1", evicted)
+        self.assertIsNone(cache.get("test_key_1"))
+        self.assertIsNotNone(cache.get("test_key_3"))
+
+    def test_remove_tracking_is_idempotent(self):
+        self.tracker.track_cache_write("test_key", 1000)
+        self.assertEqual(self.tracker.get_total_size(), 1000)
+
+        # Pop it from sorted set (simulating zpopmin in eviction)
+        self.tracker.redis_client.zpopmin(self.tracker.entries_key, 1)
+
+        # Remove tracking twice - second call should be no-op
+        removed1 = self.tracker._remove_tracking("test_key")
+        removed2 = self.tracker._remove_tracking("test_key")
+
+        self.assertEqual(removed1, 1000)
+        self.assertEqual(removed2, 0)
+        self.assertEqual(self.tracker.get_total_size(), 0)
+
+    def test_stale_tracking_cleaned_during_eviction(self):
+        # Track keys but don't set them in cache (simulates TTL expiration)
+        self.tracker.track_cache_write("stale_key_1", 1000)
+        self.tracker.track_cache_write("stale_key_2", 1000)
+        # Also add a real key
+        self.tracker.track_cache_write("real_key", 500)
+        cache.set("real_key", "data")
+
+        # Total is inflated due to stale entries
+        self.assertEqual(self.tracker.get_total_size(), 2500)
+
+        # Evict to make room - stale entries are cleaned up first (not counted as evicted)
+        evicted = self.tracker.evict_until_under_limit(1000, 100)
+
+        # Stale entries cleaned up, real_key not evicted (500 + 100 <= 1000)
+        self.assertEqual(evicted, [])
+        self.assertEqual(self.tracker.get_total_size(), 500)
+        self.assertIsNotNone(cache.get("real_key"))
+
+    def test_team_isolation(self):
+        tracker_team_a = TeamCacheSizeTracker(self.team.pk)
+        tracker_team_a.purge()
+
+        team_b = Team.objects.create(organization=self.organization, name="Team B")
+        tracker_team_b = TeamCacheSizeTracker(team_b.pk)
+        tracker_team_b.purge()
+
+        tracker_team_a.track_cache_write("key_a", 1000)
+        tracker_team_b.track_cache_write("key_b", 2000)
+
+        self.assertEqual(tracker_team_a.get_total_size(), 1000)
+        self.assertEqual(tracker_team_b.get_total_size(), 2000)
+
+        tracker_team_a.purge()
+        tracker_team_b.purge()
+
+    @override_settings(TEAM_CACHE_SIZE_LIMIT_BYTES=500)
+    def test_entry_larger_than_limit_evicts_all(self):
+        cache.set("test_key_1", b"x" * 100)
+        self.tracker.track_cache_write("test_key_1", 100)
+        cache.set("test_key_2", b"y" * 100)
+        self.tracker.track_cache_write("test_key_2", 100)
+
+        self.assertEqual(self.tracker.get_total_size(), 200)
+
+        large_data = b"z" * 600
+        evicted = self.tracker.set("large_key", large_data, len(large_data), 300)
+
+        self.assertIn("test_key_1", evicted)
+        self.assertIn("test_key_2", evicted)
+        self.assertEqual(cache.get("large_key"), large_data)
+        self.assertEqual(self.tracker.get_total_size(), 600)
+
 
 class TestGetTeamCacheLimit(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        # Clear the cache_for cache to ensure fresh lookups
+        get_team_cache_limit._cache.clear()
+
+    def tearDown(self) -> None:
+        get_team_cache_limit._cache.clear()
+        super().tearDown()
+
     @override_settings(TEAM_CACHE_SIZE_LIMIT_BYTES=500_000_000)
     def test_get_team_cache_limit_uses_default(self):
         limit = get_team_cache_limit(self.team.pk)
@@ -145,3 +252,12 @@ class TestGetTeamCacheLimit(BaseTest):
 
         limit = get_team_cache_limit(self.team.pk)
         self.assertEqual(limit, 500_000_000)
+
+    @override_settings(TEAM_CACHE_SIZE_LIMIT_BYTES=500_000_000)
+    def test_get_team_cache_limit_casts_string_to_int(self):
+        # Test that string values are cast to int
+        self.team.extra_settings = {"cache_size_limit_bytes": "1000000000"}
+        self.team.save()
+
+        limit = get_team_cache_limit(self.team.pk)
+        self.assertEqual(limit, 1_000_000_000)

--- a/posthog/caching/test/test_cache_size_tracker.py
+++ b/posthog/caching/test/test_cache_size_tracker.py
@@ -1,0 +1,147 @@
+import time
+
+from posthog.test.base import BaseTest
+
+from django.core.cache import cache
+from django.test import override_settings
+
+from posthog.caching.cache_size_tracker import TeamCacheSizeTracker, get_team_cache_limit
+
+
+class TestTeamCacheSizeTracker(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.tracker = TeamCacheSizeTracker(self.team.pk)
+        # Clean up any existing tracking data
+        self.tracker.redis_client.delete(self.tracker.entries_key)
+        self.tracker.redis_client.delete(self.tracker.sizes_key)
+        self.tracker.redis_client.delete(self.tracker.total_key)
+
+    def tearDown(self) -> None:
+        # Clean up tracking data
+        self.tracker.redis_client.delete(self.tracker.entries_key)
+        self.tracker.redis_client.delete(self.tracker.sizes_key)
+        self.tracker.redis_client.delete(self.tracker.total_key)
+        # Clean up any cache keys we created
+        cache.delete("test_key_1")
+        cache.delete("test_key_2")
+        cache.delete("test_key_3")
+        cache.delete("expired_key")
+        cache.delete("real_key")
+        super().tearDown()
+
+    def test_track_cache_write_increments_total(self):
+        self.assertEqual(self.tracker.get_total_size(), 0)
+
+        self.tracker.track_cache_write("test_key_1", 1000)
+        self.assertEqual(self.tracker.get_total_size(), 1000)
+
+        self.tracker.track_cache_write("test_key_2", 500)
+        self.assertEqual(self.tracker.get_total_size(), 1500)
+
+    def test_track_cache_write_handles_overwrite(self):
+        self.tracker.track_cache_write("test_key_1", 1000)
+        self.assertEqual(self.tracker.get_total_size(), 1000)
+
+        # Overwrite with larger value
+        self.tracker.track_cache_write("test_key_1", 2000)
+        self.assertEqual(self.tracker.get_total_size(), 2000)
+
+        # Overwrite with smaller value
+        self.tracker.track_cache_write("test_key_1", 500)
+        self.assertEqual(self.tracker.get_total_size(), 500)
+
+    def test_get_total_size_returns_correct_value(self):
+        self.assertEqual(self.tracker.get_total_size(), 0)
+
+        self.tracker.track_cache_write("test_key_1", 100)
+        self.tracker.track_cache_write("test_key_2", 200)
+        self.tracker.track_cache_write("test_key_3", 300)
+
+        self.assertEqual(self.tracker.get_total_size(), 600)
+
+    def test_evict_until_under_limit_removes_oldest(self):
+        # Add entries with small delays to ensure different timestamps
+        self.tracker.track_cache_write("test_key_1", 100)
+        cache.set("test_key_1", "data1")
+        time.sleep(0.01)
+
+        self.tracker.track_cache_write("test_key_2", 200)
+        cache.set("test_key_2", "data2")
+        time.sleep(0.01)
+
+        self.tracker.track_cache_write("test_key_3", 300)
+        cache.set("test_key_3", "data3")
+
+        self.assertEqual(self.tracker.get_total_size(), 600)
+
+        # Evict to make room for 200 bytes with limit of 500
+        # Should evict test_key_1 (oldest, 100 bytes) and test_key_2 (next oldest, 200 bytes)
+        evicted = self.tracker.evict_until_under_limit(500, 200)
+
+        # Should have evicted oldest entries
+        self.assertIn("test_key_1", evicted)
+        # Total should now be under limit + new entry size
+        self.assertLessEqual(self.tracker.get_total_size() + 200, 500)
+        # Newest entry should still exist
+        self.assertIsNotNone(cache.get("test_key_3"))
+
+    def test_evict_cleans_up_expired_keys(self):
+        # Track a key but don't actually set it in cache (simulates TTL expiration)
+        self.tracker.track_cache_write("expired_key", 1000)
+        # Don't set cache.set() - simulating expired key
+
+        # Track a real key
+        self.tracker.track_cache_write("real_key", 500)
+        cache.set("real_key", "data")
+
+        # Total includes the "expired" key
+        self.assertEqual(self.tracker.get_total_size(), 1500)
+
+        # Evict should clean up expired key first
+        evicted = self.tracker.evict_until_under_limit(1000, 100)
+
+        # Expired key should be cleaned up (not in evicted list since it wasn't actually evicted)
+        self.assertNotIn("expired_key", evicted)
+        # Real key should still exist
+        self.assertIsNotNone(cache.get("real_key"))
+        # Total should now be correct (only real_key)
+        self.assertEqual(self.tracker.get_total_size(), 500)
+
+    def test_evict_returns_empty_when_under_limit(self):
+        self.tracker.track_cache_write("test_key_1", 100)
+        cache.set("test_key_1", "data1")
+
+        # Already under limit
+        evicted = self.tracker.evict_until_under_limit(1000, 100)
+        self.assertEqual(evicted, [])
+        self.assertEqual(self.tracker.get_total_size(), 100)
+
+
+class TestGetTeamCacheLimit(BaseTest):
+    @override_settings(TEAM_CACHE_SIZE_LIMIT_BYTES=500_000_000)
+    def test_get_team_cache_limit_uses_default(self):
+        limit = get_team_cache_limit(self.team.pk)
+        self.assertEqual(limit, 500_000_000)
+
+    @override_settings(TEAM_CACHE_SIZE_LIMIT_BYTES=500_000_000)
+    def test_get_team_cache_limit_uses_override(self):
+        # Set per-team override
+        self.team.extra_settings = {"cache_size_limit_bytes": 2_000_000_000}
+        self.team.save()
+
+        limit = get_team_cache_limit(self.team.pk)
+        self.assertEqual(limit, 2_000_000_000)
+
+    @override_settings(TEAM_CACHE_SIZE_LIMIT_BYTES=500_000_000)
+    def test_get_team_cache_limit_returns_default_for_nonexistent_team(self):
+        limit = get_team_cache_limit(999999)
+        self.assertEqual(limit, 500_000_000)
+
+    @override_settings(TEAM_CACHE_SIZE_LIMIT_BYTES=500_000_000)
+    def test_get_team_cache_limit_ignores_empty_extra_settings(self):
+        self.team.extra_settings = {}
+        self.team.save()
+
+        limit = get_team_cache_limit(self.team.pk)
+        self.assertEqual(limit, 500_000_000)

--- a/posthog/hogql_queries/query_cache.py
+++ b/posthog/hogql_queries/query_cache.py
@@ -6,14 +6,18 @@ from typing import NamedTuple, Optional
 from django.conf import settings
 from django.core.cache import cache
 
+import structlog
 from prometheus_client import CollectorRegistry, Counter, Histogram
 
 from posthog.cache_utils import OrjsonJsonSerializer
+from posthog.caching.cache_size_tracker import TeamCacheSizeTracker, get_team_cache_limit
 from posthog.clickhouse.query_tagging import get_query_tag_value
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
 from posthog.metrics import LABEL_TEAM_ID, pushed_metrics_registry
 from posthog.utils import get_safe_cache
+
+logger = structlog.get_logger(__name__)
 
 
 class CacheMetrics(NamedTuple):
@@ -166,7 +170,24 @@ class DjangoCacheQueryCacheManager(QueryCacheManagerBase):
         fresh_response_serialized = OrjsonJsonSerializer({}).dumps(response)
         data_size = len(fresh_response_serialized)
 
+        # Enforce per-team cache size limit
+        tracker = TeamCacheSizeTracker(self.team_id)
+        limit = get_team_cache_limit(self.team_id)
+
+        if tracker.get_total_size() + data_size > limit:
+            evicted = tracker.evict_until_under_limit(limit, data_size)
+            if evicted:
+                logger.info(
+                    "cache_size_limit_eviction",
+                    team_id=self.team_id,
+                    evicted_count=len(evicted),
+                    limit_bytes=limit,
+                )
+
         cache.set(self.cache_key, fresh_response_serialized, settings.CACHED_RESULTS_TTL)
+
+        # Track this entry for size limiting
+        tracker.track_cache_write(self.cache_key, data_size)
 
         if target_age:
             self.update_target_age(target_age)

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -38,6 +38,9 @@ COUNT_TILES_WITH_NO_FILTERS_HASH_INTERVAL_SECONDS = get_from_env(
 CACHED_RESULTS_TTL_DAYS = 7
 CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 
+# Per-team cache size limit (default 500MB, can be overridden per-team via Team.extra_settings)
+TEAM_CACHE_SIZE_LIMIT_BYTES = get_from_env("TEAM_CACHE_SIZE_LIMIT_BYTES", 500 * 1024 * 1024, type_cast=int)
+
 # Schedule to run asynchronous data deletion on. Follows crontab syntax.
 # Use empty string to prevent this
 CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON = get_from_env(


### PR DESCRIPTION
## Problem

Query cache warming is unbounded, and a single overly active team can end up using a significant amount of our Redis cache memory. See https://posthog.slack.com/archives/C0A5PTJHPST/p1767118855343279?thread_ts=1767116577.303139&cid=C0A5PTJHPST


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Adds per-team cache size limits (default 500MB) with LRU eviction to prevent any single team from consuming excessive memory 

New module: posthog/caching/cache_size_tracker.py
- TeamCacheSizeTracker class tracks cache usage per team using 3 Redis keys:
	- Sorted set for LRU ordering (member=cache_key, score=timestamp)
	- Hash for O(1) size lookups (field=cache_key, value=size)
	- String counter for O(1) total size reads
- When cache writes would exceed the limit, evicts oldest entries until under limit
- Lazy cleanup handles TTL-expired keys during eviction
- TTL on tracking keys (~8 days) ensures they auto-expire for inactive teams
- get_team_cache_limit() supports per-team overrides via Team.extra_settings["cache_size_limit_bytes"]

Note: the actual memory usage is lower because the query results are compressed before storing in Redis

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- Verified locally that tracking keys are created on query cache write and evicted when a new cache write is above the limit
<img width="597" height="336" alt="Screenshot 2025-12-30 at 10 00 54 PM" src="https://github.com/user-attachments/assets/d7306d39-4d74-4e7a-86f4-888afd6d80ae" />

Here is the script I used to test against my local instance. Make sure to change API_TOKEN and TEAM_ID.

<details>
<summary>local testing script</summary>

```
#!/usr/bin/env python
"""
E2E test: Verify cache tracking keys are created and evicted.

Usage: PYTHONPATH=. python test_cache_size_tracker_e2e.py
"""
import os

os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
import django
django.setup()

import requests
from django.core.cache import cache
from posthog.caching.cache_size_tracker import TeamCacheSizeTracker, get_team_cache_limit
from posthog.models import Insight, Team

BASE_URL = "http://localhost:8000"
API_TOKEN = ""
TEAM_ID = 4


def load_insight(insight_id: int) -> int:
    url = f"{BASE_URL}/api/environments/{TEAM_ID}/insights/{insight_id}/"
    headers = {"Authorization": f"Bearer {API_TOKEN}"}
    return requests.get(url, headers=headers, params={"refresh": "force_blocking"}, timeout=60).status_code


def get_tracked_keys(tracker: TeamCacheSizeTracker) -> set[str]:
    members = tracker.redis_client.zrange(tracker.entries_key, 0, -1)
    return {m.decode() if isinstance(m, bytes) else m for m in members}


def main():
    team = Team.objects.get(pk=TEAM_ID)
    insights = list(Insight.objects.filter(team=team, deleted=False)[:10])
    assert len(insights) >= 3, f"Need at least 3 insights, found {len(insights)}"

    tracker = TeamCacheSizeTracker(team.pk)
    original_settings = team.extra_settings.copy() if team.extra_settings else {}

    try:
        tracker.purge()

        # Load insights until we have at least 2 unique cache keys
        tracked_keys: set[str] = set()
        for insight in insights:
            load_insight(insight.pk)
            tracked_keys = get_tracked_keys(tracker)
            print(f"  Loaded insight {insight.pk}, tracked keys: {len(tracked_keys)}")
            if len(tracked_keys) >= 2:
                break

        assert len(tracked_keys) >= 2, f"Need at least 2 unique cache keys, got {len(tracked_keys)}"
        print(f"✓ {len(tracked_keys)} tracking keys created")

        # Remember the oldest key (first in sorted set)
        oldest_key = tracker.redis_client.zrange(tracker.entries_key, 0, 0)[0]
        if isinstance(oldest_key, bytes):
            oldest_key = oldest_key.decode()
        print(f"  Oldest key: {oldest_key[:40]}...")

        # Set limit to force eviction on next write
        current_size = tracker.get_total_size()
        team.extra_settings = {**original_settings, "cache_size_limit_bytes": current_size + 100}
        team.save()
        get_team_cache_limit._cache.clear()
        print(f"  Set limit to {current_size + 100} (current: {current_size})")

        # Load another insight - should evict oldest
        for insight in insights:
            keys_before = get_tracked_keys(tracker)
            if len(keys_before) >= 2:
                load_insight(insight.pk)
                keys_after = get_tracked_keys(tracker)
                if oldest_key not in keys_after:
                    break

        assert oldest_key not in get_tracked_keys(tracker), "Oldest key should have been evicted from tracking"
        assert cache.get(oldest_key) is None, "Oldest key should be removed from Django cache"
        print(f"✓ Oldest key evicted from tracking and cache")

        print(f"\nPASSED")

    finally:
        team.extra_settings = original_settings
        team.save()
        get_team_cache_limit._cache.clear()


if __name__ == "__main__":
    main()
```

</details>

	
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
