### PR TITLE
feat(LemonButton): add onMouseUp to supported props

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -24,6 +24,7 @@ export interface LemonButtonPropsBase
         | 'tabIndex'
         | 'form'
         | 'onMouseDown'
+        | 'onMouseUp'
         | 'onMouseEnter'
         | 'onMouseLeave'
         | 'onKeyDown'


### PR DESCRIPTION
## Problem

The `LemonButton` component is missing the ability to handle `onMouseUp` events, which limits its functionality for certain interaction patterns.

## Changes

Added `onMouseUp` to the list of allowed props in the `LemonButtonPropsBase` interface, enabling the component to handle mouse up events.

## How did you test this code?

Verified that the `onMouseUp` event handler can now be passed to `LemonButton` components and that it correctly triggers when the mouse button is released while over the button.

## Publish to changelog?

No