### PR TITLE
chore: add frontend lint cmd - fixes "hogli lint"

### DIFF
--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -418,7 +418,7 @@ tests:
 quality:
     lint:
         cmd: ./bin/ruff.sh check . && pnpm --filter=@posthog/frontend run lint
-        description: Run code quality checks for Python and JavaScript
+        description: Run Python and JS/TS linting
     format:
         cmd: pnpm format
         description: Format both backend and frontend code

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
         "prettier": "prettier --write \"../{products,frontend/src}/**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\" --ignore-path \"../.prettierignore\"",
         "prettier:check": "prettier --check \"../{products,frontend/src}/**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\" --ignore-path \"../.prettierignore\"",
         "typescript:check": "tsc --noEmit && echo \"No errors reported by tsc.\"",
+        "lint": "cd .. && oxlint --quiet",
         "format": "cd .. && oxlint --fix --fix-suggestions --fix-dangerously --quiet && pnpm prettier -w \"./{products,frontend/src}/**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\"",
         "visualize-toolbar-bundle": "pnpm exec esbuild-visualizer --metadata ./toolbar-esbuild-meta.json --filename=toolbar-esbuild-bundle-visualization.html",
         "check-toolbar-csp-eval": "node ./bin/check-toolbar-csp-eval.mjs",


### PR DESCRIPTION
## Problem

A `lint` command does not exist in `package.json`, so when you run `hogli lint` you get:
```
🚀 ./bin/ruff.sh check . && pnpm --filter=@posthog/frontend run lint
All checks passed!
None of the selected packages has a "lint" script
```

## Changes

Add a `lint` command to `package.json`.

## How did you test this code?

Running `hogli lint` now yields:
```
🚀 ./bin/ruff.sh check . && pnpm --filter=@posthog/frontend run lint
All checks passed!

> @posthog/frontend@0.0.0 lint /Users/andehen/dev/posthog/frontend
> cd .. && oxlint --quiet


Found 601 warnings and 0 errors.
Finished in 145ms on 4171 files using 16 threads.
```