### PR TITLE
fix(logs): recompute row heights when new logs are appended

### DIFF
--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -287,6 +287,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
     propsChanged(({ actions, props }, oldProps) => {
         if (props.logs !== oldProps.logs) {
             actions.setLogs(props.logs)
+            actions.recomputeRowHeights()
         }
     }),
 


### PR DESCRIPTION
## Problem

When logs are updated via props, the row heights are not being recomputed, which can lead to display issues when log content changes.

## Changes

Added a call to `recomputeRowHeights()` action when logs are updated through props to ensure the UI properly adjusts to the new content.

## How did you test this code?

Tested by changing log content through props and verifying that row heights adjust correctly to accommodate the new content.

## Publish to changelog?

No