### PR TITLE
feat(logs): add original log reference to log entries in logsLogic

### DIFF
--- a/products/logs/frontend/components/LogsViewer/ExpandedLogContent.tsx
+++ b/products/logs/frontend/components/LogsViewer/ExpandedLogContent.tsx
@@ -48,8 +48,8 @@ export function ExpandedLogContent({ log, logIndex }: ExpandedLogContentProps): 
 
     const expandedBreakdownsForThisLog = expandedAttributeBreakdowns[log.uuid] || []
 
-    const rows = [
-        ...Object.entries(log.resource_attributes).map(([key, value], index) => ({
+    const rows: { key: string; value: string; type: PropertyFilterType; index: number }[] = [
+        ...Object.entries(log.resource_attributes as Record<string, string>).map(([key, value], index) => ({
             key,
             value,
             type: PropertyFilterType.LogResourceAttribute,

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -6,23 +6,29 @@ import { ParsedLogMessage } from 'products/logs/frontend/types'
 
 import { logsViewerLogic } from './logsViewerLogic'
 
-const createMockParsedLog = (uuid: string): ParsedLogMessage => ({
-    uuid,
-    trace_id: 'trace-1',
-    span_id: 'span-1',
-    body: `Log ${uuid}`,
-    attributes: {},
-    timestamp: '2024-01-01T00:00:00Z',
-    observed_timestamp: '2024-01-01T00:00:00Z',
-    severity_text: 'info',
-    severity_number: 9,
-    level: 'info',
-    resource_attributes: {},
-    instrumentation_scope: 'test',
-    event_name: 'log',
-    cleanBody: `Log ${uuid}`,
-    parsedBody: null,
-})
+const createMockParsedLog = (uuid: string): ParsedLogMessage => {
+    const baseLog = {
+        uuid,
+        trace_id: 'trace-1',
+        span_id: 'span-1',
+        body: `Log ${uuid}`,
+        attributes: {},
+        timestamp: '2024-01-01T00:00:00Z',
+        observed_timestamp: '2024-01-01T00:00:00Z',
+        severity_text: 'info' as const,
+        severity_number: 9,
+        level: 'info' as const,
+        resource_attributes: {},
+        instrumentation_scope: 'test',
+        event_name: 'log',
+    }
+    return {
+        ...baseLog,
+        cleanBody: `Log ${uuid}`,
+        parsedBody: null,
+        originalLog: baseLog,
+    }
+}
 
 const mockLogs = [createMockParsedLog('log-1'), createMockParsedLog('log-2'), createMockParsedLog('log-3')]
 

--- a/products/logs/frontend/logsLogic.tsx
+++ b/products/logs/frontend/logsLogic.tsx
@@ -588,6 +588,7 @@ export const logsLogic = kea<logsLogicType>([
                         attributes: stringifyLogAttributes(log.attributes),
                         cleanBody,
                         parsedBody,
+                        originalLog: log,
                     })
                 }
 
@@ -610,6 +611,7 @@ export const logsLogic = kea<logsLogicType>([
                         attributes: stringifyLogAttributes(log.attributes),
                         cleanBody,
                         parsedBody,
+                        originalLog: log,
                     }
                 })
             },

--- a/products/logs/frontend/types.ts
+++ b/products/logs/frontend/types.ts
@@ -1,7 +1,8 @@
 import { LogMessage } from '~/queries/schema/schema-general'
 import { JsonType } from '~/types'
 
-export type ParsedLogMessage = LogMessage & {
+export type ParsedLogMessage = Omit<LogMessage, 'attributes'> & {
+    attributes: Record<string, string>
     cleanBody: string
     parsedBody: JsonType | null
     originalLog: LogMessage

--- a/products/logs/frontend/types.ts
+++ b/products/logs/frontend/types.ts
@@ -1,7 +1,11 @@
 import { LogMessage } from '~/queries/schema/schema-general'
 import { JsonType } from '~/types'
 
-export type ParsedLogMessage = LogMessage & { cleanBody: string; parsedBody: JsonType | null }
+export type ParsedLogMessage = LogMessage & {
+    cleanBody: string
+    parsedBody: JsonType | null
+    originalLog: LogMessage
+}
 
 export type LogsOrderBy = 'earliest' | 'latest' | undefined
 


### PR DESCRIPTION
## Problem

The current logs logic doesn't preserve the original log object when processing logs for display, which limits access to the complete log data in downstream components.

## Changes

Added the `originalLog` property to the processed log objects in the `logsLogic.tsx` file. This change ensures that the complete original log object is available alongside the processed data in two locations:
- When processing a single log entry
- When processing multiple log entries in a batch

## How did you test this code?

Verified that the original log object is correctly passed through the processing pipeline and available in components that consume the processed log data.

## Publish to changelog?

No