### PR TITLE
feat(LogsViewer): add LogDetailsModal component for detailed log viewing

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
@@ -1,0 +1,111 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonCheckbox, LemonModal } from '@posthog/lemon-ui'
+
+import { JSONViewer } from 'lib/components/JSONViewer'
+import { TZLabel } from 'lib/components/TZLabel'
+
+import { logDetailsModalLogic } from './logDetailsModalLogic'
+
+const SEVERITY_COLORS: Record<string, string> = {
+    trace: 'bg-muted-alt',
+    debug: 'bg-muted',
+    info: 'bg-brand-blue',
+    warn: 'bg-warning',
+    error: 'bg-danger',
+    fatal: 'bg-danger-dark',
+}
+
+// Deep parse all string fields that look like JSON
+function parseJsonFields(obj: unknown): unknown {
+    if (typeof obj === 'string') {
+        try {
+            const parsed = JSON.parse(obj)
+            return parseJsonFields(parsed)
+        } catch {
+            return obj
+        }
+    }
+    if (Array.isArray(obj)) {
+        return obj.map(parseJsonFields)
+    }
+    if (obj !== null && typeof obj === 'object') {
+        const result: Record<string, unknown> = {}
+        for (const [key, value] of Object.entries(obj)) {
+            result[key] = parseJsonFields(value)
+        }
+        return result
+    }
+    return obj
+}
+
+interface LogDetailsModalProps {
+    timezone: string
+}
+
+export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element | null {
+    const { isOpen, selectedLog, jsonParseAllFields } = useValues(logDetailsModalLogic)
+    const { closeLogDetails, setJsonParseAllFields } = useActions(logDetailsModalLogic)
+
+    if (!selectedLog) {
+        return null
+    }
+
+    const severityColor = SEVERITY_COLORS[selectedLog.severity_text] ?? 'bg-muted-3000'
+    const displayData = jsonParseAllFields
+        ? (parseJsonFields(selectedLog.originalLog) as object)
+        : selectedLog.originalLog
+
+    return (
+        <LemonModal
+            title="Log details"
+            isOpen={isOpen}
+            onClose={closeLogDetails}
+            simple
+            overlayClassName="backdrop-blur-none flex items-stretch justify-end pr-16 py-4 pointer-events-none h-screen"
+            className="m-0! max-w-3xl w-[50vw] pointer-events-auto min-h-full"
+        >
+            <div className="flex flex-col h-full">
+                <LemonModal.Header className="flex flex-col gap-2">
+                    <h3>Log details</h3>
+                    <div className="flex items-center gap-6">
+                        <div className="flex items-center gap-2">
+                            <span className="text-muted text-xs font-semibold uppercase">Timestamp</span>
+                            <span className="text-xs font-mono">
+                                <TZLabel
+                                    time={selectedLog.timestamp}
+                                    formatDate="YYYY-MM-DD"
+                                    formatTime="HH:mm:ss.SSS"
+                                    displayTimezone={timezone}
+                                    timestampStyle="absolute"
+                                />
+                            </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <span className="text-muted text-xs font-semibold uppercase">Severity</span>
+                            <div className="flex items-center gap-1.5">
+                                <div className={`w-2 h-2 rounded-full ${severityColor}`} />
+                                <span className="font-mono text-xs">{selectedLog.severity_text.toUpperCase()}</span>
+                            </div>
+                        </div>
+                    </div>
+                </LemonModal.Header>
+                <LemonModal.Content>
+                    <div className="flex flex-col gap-2">
+                        <div className="flex items-center">
+                            <LemonCheckbox
+                                checked={jsonParseAllFields}
+                                onChange={setJsonParseAllFields}
+                                label="JSON parse all fields"
+                                size="small"
+                            />
+                        </div>
+                        <div className="p-2 bg-bg-light rounded overflow-auto">
+                            <JSONViewer src={displayData} collapsed={2} sortKeys />
+                        </div>
+                    </div>
+                </LemonModal.Content>
+            </div>
+        </LemonModal>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/index.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/index.ts
@@ -1,3 +1,2 @@
 export { LogDetailsModal } from './LogDetailsModal'
 export { logDetailsModalLogic } from './logDetailsModalLogic'
-export type { LogDetailsTab } from './logDetailsModalLogic'

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/index.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/index.ts
@@ -1,0 +1,3 @@
+export { LogDetailsModal } from './LogDetailsModal'
+export { logDetailsModalLogic } from './logDetailsModalLogic'
+export type { LogDetailsTab } from './logDetailsModalLogic'

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
@@ -1,0 +1,38 @@
+import { actions, kea, path, reducers } from 'kea'
+
+import { ParsedLogMessage } from 'products/logs/frontend/types'
+
+import type { logDetailsModalLogicType } from './logDetailsModalLogicType'
+
+export const logDetailsModalLogic = kea<logDetailsModalLogicType>([
+    path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'LogDetailsModal', 'logDetailsModalLogic']),
+
+    actions({
+        openLogDetails: (log: ParsedLogMessage) => ({ log }),
+        closeLogDetails: true,
+        setJsonParseAllFields: (enabled: boolean) => ({ enabled }),
+    }),
+
+    reducers({
+        selectedLog: [
+            null as ParsedLogMessage | null,
+            {
+                openLogDetails: (_, { log }) => log,
+                closeLogDetails: () => null,
+            },
+        ],
+        isOpen: [
+            false,
+            {
+                openLogDetails: () => true,
+                closeLogDetails: () => false,
+            },
+        ],
+        jsonParseAllFields: [
+            false,
+            {
+                setJsonParseAllFields: (_, { enabled }) => enabled,
+            },
+        ],
+    }),
+])

--- a/products/logs/frontend/components/LogsViewer/LogRowFAB/LogRowFAB.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogRowFAB/LogRowFAB.tsx
@@ -1,12 +1,21 @@
 import { useActions, useValues } from 'kea'
 
-import { IconBrackets, IconChevronLeft, IconChevronRight, IconCopy, IconPin, IconPinFilled } from '@posthog/icons'
+import {
+    IconBrackets,
+    IconChevronLeft,
+    IconChevronRight,
+    IconCopy,
+    IconExpand45,
+    IconPin,
+    IconPinFilled,
+} from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { IconLink } from 'lib/lemon-ui/icons'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { cn } from 'lib/utils/css-classes'
 
+import { logDetailsModalLogic } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal'
 import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
 import { useCellScrollControls } from 'products/logs/frontend/components/VirtualizedLogsList/useCellScroll'
 import { ParsedLogMessage } from 'products/logs/frontend/types'
@@ -32,6 +41,7 @@ export function LogRowFAB({
 }: LogRowFABProps): JSX.Element {
     const { tabId } = useValues(logsViewerLogic)
     const { copyLinkToLog } = useActions(logsViewerLogic)
+    const { openLogDetails } = useActions(logDetailsModalLogic)
     const { startScrolling, stopScrolling } = useCellScrollControls({ tabId, cellKey: 'message' })
 
     return (
@@ -44,6 +54,18 @@ export function LogRowFAB({
             onMouseDown={(e) => e.stopPropagation()}
         >
             <FABGroup>
+                <LemonButton
+                    size="xsmall"
+                    noPadding
+                    icon={<IconExpand45 />}
+                    onClick={(e) => {
+                        e.preventDefault()
+                        openLogDetails(log)
+                    }}
+                    tooltip="View log details"
+                    className="text-muted"
+                    data-attr="logs-viewer-view-details"
+                />
                 <LemonButton
                     size="xsmall"
                     noPadding

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -12,6 +12,7 @@ import { VirtualizedLogsList } from 'products/logs/frontend/components/Virtualiz
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
 import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
 
+import { LogDetailsModal } from './LogDetailsModal'
 import { LogsSelectionToolbar } from './LogsSelectionToolbar'
 import { LogsSparkline, LogsSparklineData } from './LogsViewerSparkline'
 import { LogsViewerToolbar } from './LogsViewerToolbar'
@@ -309,6 +310,8 @@ function LogsViewerContent({
                 hasMoreLogsToLoad={hasMoreLogsToLoad}
                 onLoadMore={onLoadMore}
             />
+
+            <LogDetailsModal timezone={timezone} />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

Currently, users can only view logs in a list format without the ability to examine detailed information for individual log entries. This limits the ability to debug and analyze log data effectively.

## Changes

![2025-12-31 13.58.44.gif](https://app.graphite.com/user-attachments/assets/165b47c7-14f7-4079-bd70-70880988612e.gif)

Added a new Log Details Modal component that allows users to view detailed information about a specific log entry. The modal includes:

- A header displaying timestamp and severity level with appropriate color coding
- An option to JSON parse all fields for better readability
- A collapsible JSON viewer for examining the log content
- Integration with the existing logs viewer through a new "View details" button in the log row floating action button (FAB)

The implementation includes:
- New `LogDetailsModal` component with supporting logic
- Integration with the existing logs viewer
- JSON parsing functionality for better data visualization
- Severity color coding for quick visual identification

## How did you test this code?

Tested by:
- Verifying the modal opens correctly when clicking the "View details" button
- Confirming timestamp and severity information displays properly
- Testing the JSON parsing toggle functionality with various log formats
- Ensuring the modal closes correctly
- Checking that the UI is responsive and matches design specifications

## Publish to changelog?

Yes