### PR TITLE
fix: try to fix realtime cohort calculation timeout

### DIFF
--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -227,7 +227,13 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                         for send_result in pending_kafka_messages:
                             try:
                                 send_result.get(timeout=0)  # Non-blocking check
-                            except Exception:
+                            except Exception as e:
+                                logger.warning(
+                                    f"Kafka send result failure for cohort {cohort.id}: {e}",
+                                    cohort_id=cohort.id,
+                                    error=str(e),
+                                    exception_type=type(e).__name__,
+                                )
                                 failed_count += 1
 
                         if failed_count > 0:

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -225,7 +225,9 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                         # Check for any Kafka produce failures
                         failed_count = 0
                         for send_result in pending_kafka_messages:
-                            if send_result.failed():
+                            try:
+                                send_result.get(timeout=0)  # Non-blocking check
+                            except Exception:
                                 failed_count += 1
 
                         if failed_count > 0:


### PR DESCRIPTION
## Problem

The realtime cohort calculation workflow was timing out for specific cohorts. 
The timeout occurred because Kafka message production was blocking the ClickHouse result stream consumption, causing the stream to be read at only ~107 KB/s. After 327 seconds, ClickHouse's server-side timeout would kill the connection.

Context: https://posthog.slack.com/archives/C076R4753Q8/p1766595266462749

## Changes

- **Non-blocking Kafka production**: Removed `asyncio.to_thread` wrapper around `kafka_producer.produce()` to allow immediate return
- **Batched flushing**: Collect all Kafka send results and flush once at the end instead of blocking per-message
- **Error resilience**: Added try-catch around Kafka produce to prevent exceptions from interrupting stream consumption
- **Proper error handling**: Check failed send results, log failures, and increment failure metric to trigger retry
- **Accurate metrics**: Only increment success metric if both query execution and Kafka delivery succeed