### PR TITLE
feat(billing): add logs GB ingested to billing usage page

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -2469,6 +2469,64 @@ class TestHogFunctionUsageReports(ClickhouseDestroyTablesMixin, TestCase, Clickh
         assert org_1_report["teams"]["4"]["workflow_sms_sent_in_period"] == 2
         assert org_1_report["teams"]["4"]["workflow_billable_invocations_in_period"] == 12
 
+    @patch("posthog.tasks.usage_report.get_ph_client")
+    @patch("posthog.tasks.usage_report.send_report_to_billing_service")
+    def test_logs_usage_metrics(self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock) -> None:
+        self._setup_teams()
+
+        # Create logs metrics for org 1 team 1: 1.5 GB
+        create_app_metric2(
+            team_id=self.org_1_team_1.id,
+            app_source="logs",
+            metric_name="bytes_ingested",
+            count=1_500_000_000,
+        )
+        create_app_metric2(
+            team_id=self.org_1_team_1.id,
+            app_source="logs",
+            metric_name="records_ingested",
+            count=1000,
+        )
+
+        # Create logs metrics for org 1 team 2: 2.5 GB
+        create_app_metric2(
+            team_id=self.org_1_team_2.id,
+            app_source="logs",
+            metric_name="bytes_ingested",
+            count=2_500_000_000,
+        )
+        create_app_metric2(
+            team_id=self.org_1_team_2.id,
+            app_source="logs",
+            metric_name="records_ingested",
+            count=2000,
+        )
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        period_start, period_end = period
+        all_reports = _get_all_org_reports(period_start, period_end)
+
+        org_1_report = _get_full_org_usage_report_as_dict(
+            _get_full_org_usage_report(all_reports[str(self.org_1.id)], get_instance_metadata(period))
+        )
+
+        assert org_1_report["organization_name"] == "Org 1"
+
+        # Test org-level logs metrics (sum of both teams)
+        assert org_1_report["logs_bytes_in_period"] == 4_000_000_000  # 1.5B + 2.5B
+        assert org_1_report["logs_records_in_period"] == 3000  # 1000 + 2000
+        assert org_1_report["logs_gb_in_period"] == 4.0  # 1.5 + 2.5
+
+        # Test team 1 logs metrics
+        assert org_1_report["teams"]["3"]["logs_bytes_in_period"] == 1_500_000_000
+        assert org_1_report["teams"]["3"]["logs_records_in_period"] == 1000
+        assert org_1_report["teams"]["3"]["logs_gb_in_period"] == 1.5
+
+        # Test team 2 logs metrics
+        assert org_1_report["teams"]["4"]["logs_bytes_in_period"] == 2_500_000_000
+        assert org_1_report["teams"]["4"]["logs_records_in_period"] == 2000
+        assert org_1_report["teams"]["4"]["logs_gb_in_period"] == 2.5
+
 
 @freeze_time("2022-01-10T10:00:00Z")
 class TestErrorTrackingUsageReport(ClickhouseDestroyTablesMixin, TestCase, ClickhouseTestMixin):

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -213,6 +213,7 @@ class UsageReportCounters:
     # Logs
     logs_bytes_in_period: int
     logs_records_in_period: int
+    logs_gb_in_period: float
 
 
 # Instance metadata to be included in overall report
@@ -2051,6 +2052,8 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         ),
         logs_bytes_in_period=all_data["teams_with_logs_bytes_in_period"].get(team.id, 0),
         logs_records_in_period=all_data["teams_with_logs_records_in_period"].get(team.id, 0),
+        # decimal GB (not GiB) to match pricing; billing uses logs_bytes_in_period for precision
+        logs_gb_in_period=round(all_data["teams_with_logs_bytes_in_period"].get(team.id, 0) / 1_000_000_000, 3),
     )
 
 


### PR DESCRIPTION
## Problem

We need to expose logs ingestion data in the billing UI to provide users with visibility into their logs usage.

## Changes

- Added "Logs (GB ingested)" as a new usage type in the billing UI
- Added a new field `logs_gb_in_period` to the usage report counters to track logs usage in GB
- Implemented calculation for logs usage in GB by converting bytes to GB and rounding to 3 decimal places

This should be viewable in `/organization/billing/usage`

n.b using decimal GB here, based on [this discussion](https://github.com/PostHog/posthog/pull/41888#discussion_r2549519977)

## How did you test this code?

New unit tests

## Publish to changelog?

No