### PR TITLE
fix(data-warehouse): fix crash when updating source without SSH tunnel

### DIFF
--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -1276,11 +1276,7 @@ class TestExternalDataSource(APIBaseTest):
         assert source.job_inputs["password"] == "new_password"
 
     def test_update_source_without_ssh_tunnel_does_not_crash(self):
-        """Regression test: updating a source that has no ssh_tunnel should not crash.
-
-        The bug was that setdefault("ssh_tunnel", {}) returns None if the key exists
-        with value None, then calling .setdefault("auth", {}) on None crashes.
-        """
+        """Regression test: updating a source that has no ssh_tunnel should not crash."""
         source = ExternalDataSource.objects.create(
             team_id=self.team.pk,
             source_id=str(uuid.uuid4()),


### PR DESCRIPTION
Fixes crash when updating a data warehouse source that doesn't have ssh_tunnel configured.

The bug was `AttributeError: 'NoneType' object has no attribute 'setdefault'` - we were calling `.setdefault()` on None when the source didn't have an ssh_tunnel.

Also fixes edge case where empty string passwords would overwrite stored credentials.