### PR TITLE
fix(replay): don't obscure screen with hidden canvases

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -316,7 +316,18 @@ export const CanvasReplayerPlugin = (events: eventWithTime[]): ReplayPlugin => {
                     el.setAttribute(attr.name, attr.value)
                 }
 
-                canvasElement.style.backgroundImage = PLACEHOLDER_SVG_DATA_IMAGE_URL
+                // Only show placeholder for visible canvases to avoid blocking
+                // the replay with hidden full-screen canvases
+                const style = window.getComputedStyle(canvasElement)
+                const isHidden =
+                    style.display === 'none' ||
+                    style.visibility === 'hidden' ||
+                    style.opacity === '0' ||
+                    (canvasElement.offsetWidth === 0 && canvasElement.offsetHeight === 0)
+
+                if (!isHidden) {
+                    canvasElement.style.backgroundImage = PLACEHOLDER_SVG_DATA_IMAGE_URL
+                }
 
                 // Store the image but don't replace the canvas yet
                 containers.set(id, el)


### PR DESCRIPTION
## Problem
Hidden canvases are obscuring replay recordings.

https://posthoghelp.zendesk.com/agent/tickets/46081 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/48225)

## Changes

Check whether canvases are set as display none, visibility hidden or opacity 0 and skip masking them

## How did you test this code?

Added tests to frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.test.ts 

## Publish to changelog?
no
