### PR TITLE
fix: don't mask hidden canvases and say what you're masking when you do it

### DIFF
--- a/.idea/posthog.iml
+++ b/.idea/posthog.iml
@@ -62,7 +62,7 @@
     <option name="TEMPLATE_CONFIGURATION" value="Django" />
     <option name="TEMPLATE_FOLDERS">
       <list>
-        <option value="$MODULE_DIR$/plugin-server/src/cdp/templates" />
+        <option value="$MODULE_DIR$/nodejs/src/cdp/templates" />
       </list>
     </option>
   </component>

--- a/frontend/src/scenes/session-recordings/player/rrweb/index.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/index.ts
@@ -3,8 +3,13 @@ import Hls from 'hls.js'
 import { ReplayPlugin, playerConfig } from '@posthog/rrweb'
 import { EventType, IncrementalSource, eventWithTime } from '@posthog/rrweb-types'
 
-export const PLACEHOLDER_SVG_DATA_IMAGE_URL =
+export const PLACEHOLDER_SVG_PATTERN_DATA_URL =
     'url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNOCAwSDE2TDAgMTZWOEw4IDBaIiBmaWxsPSIjMkQyRDJEIi8+CjxwYXRoIGQ9Ik0xNiA4VjE2SDhMMTYgOFoiIGZpbGw9IiMyRDJEMkQiLz4KPC9zdmc+Cg==")'
+
+export const PLACEHOLDER_SVG_TEXT_DATA_URL =
+    'url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIwIiBoZWlnaHQ9IjYwIiB2aWV3Qm94PSIwIDAgMzIwIDYwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHg9IjEwIiB5PSI1IiB3aWR0aD0iMzAwIiBoZWlnaHQ9IjUwIiByeD0iNCIgZmlsbD0iYmxhY2siIGZpbGwtb3BhY2l0eT0iMC44Ii8+PHRleHQgdGV4dC1hbmNob3I9Im1pZGRsZSIgZmlsbD0id2hpdGUiIGZvbnQtZmFtaWx5PSJzeXN0ZW0tdWksIC1hcHBsZS1zeXN0ZW0sIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTMiPjx0c3BhbiB4PSIxNjAiIHk9IjI0Ij5FbmFibGUgY2FudmFzIHJlY29yZGluZzwvdHNwYW4+PHRzcGFuIHg9IjE2MCIgeT0iNDIiPnRvIGNhcHR1cmUgdGhpcyBjYW52YXM8L3RzcGFuPjwvdGV4dD48L3N2Zz4K")'
+
+export const PLACEHOLDER_SVG_DATA_IMAGE_URL = PLACEHOLDER_SVG_PATTERN_DATA_URL
 
 const PROXY_URL = 'https://replay.ph-proxy.com' as const
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
@@ -144,7 +144,9 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
         },
 
         loadRecordingMetaSuccess: () => {
-            actions.loadSnapshotSources()
+            if (props.sessionRecordingId) {
+                actions.loadSnapshotSources()
+            }
             actions.reportUsageIfFullyLoaded()
         },
 

--- a/frontend/src/scenes/session-recordings/player/snapshotDataLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/snapshotDataLogic.tsx
@@ -211,12 +211,15 @@ export const snapshotDataLogic = kea<snapshotDataLogicType>([
                 'file-file': {
                     snapshots: snapshots,
                     source: { source: SnapshotSourceType.file },
+                    sourceLoaded: true,
                 },
             }
+            // Set sources first, then trigger the success action
+            // Otherwise processSnapshotsAsync will see null sources
+            actions.loadSnapshotSourcesSuccess([{ source: SnapshotSourceType.file }])
             actions.loadSnapshotsForSourceSuccess({
                 source: { source: SnapshotSourceType.file },
             })
-            actions.loadSnapshotSourcesSuccess([{ source: SnapshotSourceType.file }])
         },
 
         loadSnapshots: () => {


### PR DESCRIPTION
We added masking of unrecorded canvases so people would know that a canvas was there but not recorded

Then we found a customer who had a fullscreen, transparent canvas marked as aria-hidden

https://posthoghelp.zendesk.com/agent/tickets/46081 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/48225)

So, let's

1. check if a canvas is visible before masking it
2. put text on the mask so folk know what's happening
3. fix local file playback because i discovered it was broken while trying to test this

![CleanShot 2025-12-31 at 16.38.58@2x.png](https://app.graphite.com/user-attachments/assets/0a1d7d86-6072-43f6-bb1b-263ad41bd614.png)