### PR TITLE
feat(logs-detail-modal): open log detail modal when linkToLogId URL param is present

### DIFF
--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -10,6 +10,7 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { AttributeColumnConfig, LogsOrderBy, ParsedLogMessage } from '../../types'
+import { logDetailsModalLogic } from './LogDetailsModal/logDetailsModalLogic'
 import type { logsViewerLogicType } from './logsViewerLogicType'
 import { logsViewerSettingsLogic } from './logsViewerSettingsLogic'
 
@@ -42,7 +43,12 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
     key((props) => props.tabId),
     connect(() => ({
         values: [logsViewerSettingsLogic, ['timezone', 'wrapBody', 'prettifyJson']],
-        actions: [logsViewerSettingsLogic, ['setTimezone', 'setWrapBody', 'setPrettifyJson']],
+        actions: [
+            logsViewerSettingsLogic,
+            ['setTimezone', 'setWrapBody', 'setPrettifyJson'],
+            logDetailsModalLogic,
+            ['openLogDetails'],
+        ],
     })),
 
     actions({
@@ -499,6 +505,10 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
             const index = values.logs.findIndex((log) => log.uuid === logId)
             if (index !== -1) {
                 actions.setCursor({ logIndex: index, attributeIndex: null })
+                // If navigating via link, also open the details modal
+                if (values.linkToLogId === logId) {
+                    actions.openLogDetails(values.logs[index])
+                }
             }
         },
         copyLinkToLog: ({ logId }) => {


### PR DESCRIPTION
## Problem

When navigating to a log via a link, the log details modal doesn't automatically open, requiring users to take an additional step to view the full log details.

## Changes

Enhanced the log navigation functionality to automatically open the log details modal when a user navigates to a specific log via a link. This creates a more seamless user experience by eliminating an unnecessary click.

Specifically:
- Connected the `logDetailsModalLogic` to the `logsViewerLogic`
- Added logic to open the log details modal when navigating to a log that matches the `linkToLogId`

## How did you test this code?

Tested by:
- Navigating to logs using direct links
- Verifying that the log details modal automatically opens when arriving via a link
- Confirming that regular log navigation without links maintains the existing behavior

## Publish to changelog?

No