### PR TITLE
fix: paywall modal no longer blocks disabling premium features

### DIFF
--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -329,8 +329,8 @@ export function SharingModalContent({
                                                                 )}
                                                             </div>
                                                         }
-                                                        onChange={() => {
-                                                            const newWhitelabelValue = !value
+                                                        onChange={(showBranding: boolean) => {
+                                                            const newWhitelabelValue = !showBranding
                                                             if (newWhitelabelValue) {
                                                                 guardAvailableFeature(
                                                                     AvailableFeature.WHITE_LABELLING,

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -237,11 +237,16 @@ export function SharingModalContent({
                                                         )}
                                                     </div>
                                                 }
-                                                onChange={(passwordRequired: boolean) =>
-                                                    guardAvailableFeature(AvailableFeature.ADVANCED_PERMISSIONS, () =>
+                                                onChange={(passwordRequired: boolean) => {
+                                                    if (passwordRequired) {
+                                                        guardAvailableFeature(
+                                                            AvailableFeature.ADVANCED_PERMISSIONS,
+                                                            () => setPasswordRequired(passwordRequired)
+                                                        )
+                                                    } else {
                                                         setPasswordRequired(passwordRequired)
-                                                    )
-                                                }
+                                                    }
+                                                }}
                                                 checked={sharingConfiguration.password_required}
                                             />
                                             {sharingConfiguration.password_required && (
@@ -324,15 +329,24 @@ export function SharingModalContent({
                                                                 )}
                                                             </div>
                                                         }
-                                                        onChange={() =>
-                                                            guardAvailableFeature(
-                                                                AvailableFeature.WHITE_LABELLING,
-                                                                () => {
-                                                                    // setSharingSettingsValue is used to update the form state and report the event
-                                                                    setSharingSettingsValue('whitelabel', !value)
-                                                                }
-                                                            )
-                                                        }
+                                                        onChange={() => {
+                                                            const newWhitelabelValue = !value
+                                                            if (newWhitelabelValue) {
+                                                                guardAvailableFeature(
+                                                                    AvailableFeature.WHITE_LABELLING,
+                                                                    () =>
+                                                                        setSharingSettingsValue(
+                                                                            'whitelabel',
+                                                                            newWhitelabelValue
+                                                                        )
+                                                                )
+                                                            } else {
+                                                                setSharingSettingsValue(
+                                                                    'whitelabel',
+                                                                    newWhitelabelValue
+                                                                )
+                                                            }
+                                                        }}
                                                         checked={!value}
                                                     />
                                                 )}

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.tsx
@@ -76,11 +76,15 @@ export function Customization({
                                 <span>Hide PostHog branding</span>
                             </div>
                         }
-                        onChange={(checked) =>
-                            guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () =>
+                        onChange={(checked) => {
+                            if (checked) {
+                                guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () =>
+                                    onAppearanceChange({ whiteLabel: checked })
+                                )
+                            } else {
                                 onAppearanceChange({ whiteLabel: checked })
-                            )
-                        }
+                            }
+                        }}
                         checked={survey.appearance?.whiteLabel}
                     />
                     <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
Paywall modal was showing when trying to **disable** premium features like white labeling or password protection - now it only shows when enabling them.

Re: https://posthoghelp.zendesk.com/agent/tickets/46091 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/48226)

## Test plan
Manually tested all affected toggles (surveys + sharing modal) with features removed from org.