### PR TITLE
fix(nodejs): adds fresh option for setting up test databases

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -229,7 +229,6 @@ jobs:
                   BEHAVIORAL_COHORTS_DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_behavioral_cohorts'
                   PERSONS_DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_persons'
                   PERSONS_READONLY_DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_persons'
-                  PERSONS_READONLY_MIGRATION_DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_persons_migration'
                   REDIS_URL: 'redis://localhost'
                   NODE_OPTIONS: '--max_old_space_size=4096'
                   SHARD_INDEX: ${{ matrix.shard }}

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -27,7 +27,7 @@
         "prepublishOnly": "pnpm build",
         "setup:dev:clickhouse": "cd .. && DEBUG=1 python manage.py migrate_clickhouse",
         "setup:test": "cd .. && TEST=1 python manage.py setup_test_environment && cd nodejs && pnpm run setup:test:rust",
-        "setup:test:rust": "CYCLOTRON_DATABASE_NAME=test_cyclotron PERSONS_DATABASE_NAME=test_persons BEHAVIORAL_COHORTS_DATABASE_NAME=test_behavioral_cohorts ../rust/bin/migrate-entry all && PERSONS_DATABASE_NAME=test_persons_migration ../rust/bin/migrate-persons",
+        "setup:test:rust": "CYCLOTRON_DATABASE_NAME=test_cyclotron PERSONS_DATABASE_NAME=test_persons BEHAVIORAL_COHORTS_DATABASE_NAME=test_behavioral_cohorts ../rust/bin/migrate-entry all --fresh",
         "migrate:persons": "../rust/bin/migrate-persons",
         "migrate:cyclotron": "../rust/bin/migrate-cyclotron",
         "migrate:behavioral-cohorts": "../rust/bin/migrate-behavioral-cohorts",

--- a/rust/bin/migrate-entry
+++ b/rust/bin/migrate-entry
@@ -22,6 +22,17 @@ parse_args() {
     done
 }
 
+show_usage() {
+    echo "Usage: $0 <all|persons|cyclotron|behavioral-cohorts> [--fresh]"
+    echo "  all                - Run all migrations"
+    echo "  persons            - Run only persons migrations"
+    echo "  cyclotron          - Run only cyclotron migrations"
+    echo "  behavioral-cohorts - Run only behavioral cohorts migrations"
+    echo ""
+    echo "Options:"
+    echo "  --fresh            - Drop and recreate database before migrating (for test environments)"
+}
+
 parse_args "$@"
 
 log_json() {
@@ -56,14 +67,7 @@ trap handle_error ERR
 if [ -z "$MIGRATION_TYPE" ]; then
     log_json "error" "No migration type specified" "failed" "unknown"
     echo ""
-    echo "Usage: $0 <all|persons|cyclotron|behavioral-cohorts> [--fresh]"
-    echo "  all                - Run all migrations"
-    echo "  persons            - Run only persons migrations"
-    echo "  cyclotron          - Run only cyclotron migrations"
-    echo "  behavioral-cohorts - Run only behavioral cohorts migrations"
-    echo ""
-    echo "Options:"
-    echo "  --fresh            - Drop and recreate database before migrating (for test environments)"
+    show_usage
     exit 1
 fi
 
@@ -156,14 +160,7 @@ case "$MIGRATION_TYPE" in
         ;;
     *)
         log_json "error" "Invalid migration type specified" "failed" "$MIGRATION_TYPE"
-        echo "Usage: $0 <all|persons|cyclotron|behavioral-cohorts> [--fresh]"
-        echo "  all                - Run all migrations"
-        echo "  persons            - Run only persons migrations"
-        echo "  cyclotron          - Run only cyclotron migrations"
-        echo "  behavioral-cohorts - Run only behavioral cohorts migrations"
-        echo ""
-        echo "Options:"
-        echo "  --fresh            - Drop and recreate database before migrating (for test environments)"
+        show_usage
         exit 1
         ;;
 esac

--- a/rust/bin/migrate-entry
+++ b/rust/bin/migrate-entry
@@ -1,7 +1,28 @@
 #!/bin/bash
 set -eE
 
-MIGRATION_TYPE="$1"
+# Global variables set by parse_args
+MIGRATION_TYPE=""
+FRESH_MODE=false
+
+parse_args() {
+    MIGRATION_TYPE="$1"
+    shift || true
+
+    for arg in "$@"; do
+        case "$arg" in
+            --fresh)
+                FRESH_MODE=true
+                ;;
+            *)
+                echo "Unknown option: $arg"
+                exit 1
+                ;;
+        esac
+    done
+}
+
+parse_args "$@"
 
 log_json() {
     local level="$1"
@@ -35,11 +56,14 @@ trap handle_error ERR
 if [ -z "$MIGRATION_TYPE" ]; then
     log_json "error" "No migration type specified" "failed" "unknown"
     echo ""
-    echo "Usage: $0 <all|persons|cyclotron|behavioral-cohorts>"
+    echo "Usage: $0 <all|persons|cyclotron|behavioral-cohorts> [--fresh]"
     echo "  all                - Run all migrations"
     echo "  persons            - Run only persons migrations"
     echo "  cyclotron          - Run only cyclotron migrations"
     echo "  behavioral-cohorts - Run only behavioral cohorts migrations"
+    echo ""
+    echo "Options:"
+    echo "  --fresh            - Drop and recreate database before migrating (for test environments)"
     exit 1
 fi
 
@@ -57,14 +81,18 @@ run_persons_migrations() {
     PERSONS_DATABASE_NAME=${PERSONS_DATABASE_NAME:-posthog_persons}
     PERSONS_DATABASE_URL=${PERSONS_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/$PERSONS_DATABASE_NAME}
 
-    log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$PERSONS_DATABASE_NAME\""
+    log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$PERSONS_DATABASE_NAME\",\"fresh_mode\":$FRESH_MODE"
 
-    sqlx database create -D "$PERSONS_DATABASE_URL"
-    log_json "info" "Database created or already exists" "running" "$db_type"
+    if [ "$FRESH_MODE" = true ]; then
+        sqlx database reset -y -D "$PERSONS_DATABASE_URL" --source "$MIGRATIONS_BASE/persons_migrations/"
+        log_json "info" "Database reset and migrations completed" "completed" "$db_type"
+    else
+        sqlx database create -D "$PERSONS_DATABASE_URL"
+        log_json "info" "Database created or already exists" "running" "$db_type"
 
-    sqlx migrate run -D "$PERSONS_DATABASE_URL" --source "$MIGRATIONS_BASE/persons_migrations/"
-
-    log_json "info" "Migrations completed successfully" "completed" "$db_type"
+        sqlx migrate run -D "$PERSONS_DATABASE_URL" --source "$MIGRATIONS_BASE/persons_migrations/"
+        log_json "info" "Migrations completed successfully" "completed" "$db_type"
+    fi
 }
 
 run_cyclotron_migrations() {
@@ -72,14 +100,18 @@ run_cyclotron_migrations() {
     CYCLOTRON_DATABASE_NAME=${CYCLOTRON_DATABASE_NAME:-cyclotron}
     CYCLOTRON_DATABASE_URL=${CYCLOTRON_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/$CYCLOTRON_DATABASE_NAME}
 
-    log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$CYCLOTRON_DATABASE_NAME\""
+    log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$CYCLOTRON_DATABASE_NAME\",\"fresh_mode\":$FRESH_MODE"
 
-    sqlx database create -D "$CYCLOTRON_DATABASE_URL"
-    log_json "info" "Database created or already exists" "running" "$db_type"
+    if [ "$FRESH_MODE" = true ]; then
+        sqlx database reset -y -D "$CYCLOTRON_DATABASE_URL" --source "$MIGRATIONS_BASE/cyclotron-core/migrations/"
+        log_json "info" "Database reset and migrations completed" "completed" "$db_type"
+    else
+        sqlx database create -D "$CYCLOTRON_DATABASE_URL"
+        log_json "info" "Database created or already exists" "running" "$db_type"
 
-    sqlx migrate run -D "$CYCLOTRON_DATABASE_URL" --source "$MIGRATIONS_BASE/cyclotron-core/migrations/"
-
-    log_json "info" "Migrations completed successfully" "completed" "$db_type"
+        sqlx migrate run -D "$CYCLOTRON_DATABASE_URL" --source "$MIGRATIONS_BASE/cyclotron-core/migrations/"
+        log_json "info" "Migrations completed successfully" "completed" "$db_type"
+    fi
 }
 
 run_behavioral_cohorts_migrations() {
@@ -93,14 +125,18 @@ run_behavioral_cohorts_migrations() {
 
     BEHAVIORAL_COHORTS_DATABASE_URL=${BEHAVIORAL_COHORTS_DATABASE_URL:-postgres://${DB_USER}:${DB_PASS}@${DB_HOST}:5432/$BEHAVIORAL_COHORTS_DATABASE_NAME}
 
-    log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$BEHAVIORAL_COHORTS_DATABASE_NAME\""
+    log_json "info" "Starting migrations" "starting" "$db_type" "\"database_name\":\"$BEHAVIORAL_COHORTS_DATABASE_NAME\",\"fresh_mode\":$FRESH_MODE"
 
-    sqlx database create -D "$BEHAVIORAL_COHORTS_DATABASE_URL"
-    log_json "info" "Database created or already exists" "running" "$db_type"
+    if [ "$FRESH_MODE" = true ]; then
+        sqlx database reset -y -D "$BEHAVIORAL_COHORTS_DATABASE_URL" --source "$MIGRATIONS_BASE/behavioral_cohorts_migrations/"
+        log_json "info" "Database reset and migrations completed" "completed" "$db_type"
+    else
+        sqlx database create -D "$BEHAVIORAL_COHORTS_DATABASE_URL"
+        log_json "info" "Database created or already exists" "running" "$db_type"
 
-    sqlx migrate run -D "$BEHAVIORAL_COHORTS_DATABASE_URL" --source "$MIGRATIONS_BASE/behavioral_cohorts_migrations/"
-
-    log_json "info" "Migrations completed successfully" "completed" "$db_type"
+        sqlx migrate run -D "$BEHAVIORAL_COHORTS_DATABASE_URL" --source "$MIGRATIONS_BASE/behavioral_cohorts_migrations/"
+        log_json "info" "Migrations completed successfully" "completed" "$db_type"
+    fi
 }
 
 case "$MIGRATION_TYPE" in
@@ -120,11 +156,14 @@ case "$MIGRATION_TYPE" in
         ;;
     *)
         log_json "error" "Invalid migration type specified" "failed" "$MIGRATION_TYPE"
-        echo "Usage: $0 <all|persons|cyclotron|behavioral-cohorts>"
+        echo "Usage: $0 <all|persons|cyclotron|behavioral-cohorts> [--fresh]"
         echo "  all                - Run all migrations"
         echo "  persons            - Run only persons migrations"
         echo "  cyclotron          - Run only cyclotron migrations"
         echo "  behavioral-cohorts - Run only behavioral cohorts migrations"
+        echo ""
+        echo "Options:"
+        echo "  --fresh            - Drop and recreate database before migrating (for test environments)"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Problem

Test databases should be re-created each time they are setup to reduce the fragility of the setup process

## Changes

- adds a --fresh option to rust/bin/migrate-entry that drops and re-creates the database when passed in to the command
- uses the new --fresh option in the setup rust commands for test setup in nodejs
- removes dead code left over from plugin-server dual write test setup

## How did you test this code?

locally tested the new migrate option --fresh

unit tests in nodejs use the setup:test command that uses the new --fresh option

locally tested the migrate-entry script without --fresh option
