### PR TITLE
fix(web-analytics): Connect isInitialLoad to loadPagesUrlsSuccess

### DIFF
--- a/frontend/src/scenes/web-analytics/pageReportsLogic.ts
+++ b/frontend/src/scenes/web-analytics/pageReportsLogic.ts
@@ -193,7 +193,7 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
         isInitialLoad: [
             true,
             {
-                loadPagesSuccess: () => false,
+                loadPagesUrlsSuccess: () => false,
             },
         ],
         tileVisualizations: [


### PR DESCRIPTION
## Problem
The `isInitialLoad` reducer was listening to `loadPagesSuccess` which doesn't exist. It should listen to `loadPagesUrlsSuccess` instead.

This was causing the search box to endlessly load since `isInitialLoad` was always true

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Changed `loadPagesSuccess` to `loadPagesUrlsSuccess`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
