### PR TITLE
feat(surveys): add last-seen property to surveys internal targeting flag

### DIFF
--- a/posthog/models/surveys/util.py
+++ b/posthog/models/surveys/util.py
@@ -19,6 +19,7 @@ class SurveyEventProperties(StrEnum):
     SURVEY_RESPONDED = "$survey_responded"
     SURVEY_DISMISSED = "$survey_dismissed"
     SURVEY_COMPLETED = "$survey_completed"
+    SURVEY_LAST_SEEN_DATE = "$last_seen_survey_date"
 
 
 def get_survey_response_clickhouse_query(


### PR DESCRIPTION
## Problem

we only track the 'last seen survey date' in local storage. this means users might see surveys too frequently across different devices, browsers, etc

closes https://github.com/PostHog/posthog/issues/44150

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

this adds a new person property check to the survey internal targeting flag, so we don't show surveys if the last seen date is within the wait period.

sdk pr to set this property: https://github.com/PostHog/posthog-js/pull/2835

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->