### PR TITLE
chore(heatmaps): trailing slash issue

### DIFF
--- a/posthog/heatmaps/heatmaps_api.py
+++ b/posthog/heatmaps/heatmaps_api.py
@@ -241,7 +241,7 @@ class HeatmapViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             "date_to": "timestamp <= {date_to} + interval 1 day",
             "viewport_width_min": "viewport_width >= round({viewport_width_min} / 16)",
             "viewport_width_max": "viewport_width <= round({viewport_width_max} / 16)",
-            "url_exact": "current_url = {url_exact}",
+            "url_exact": "trimRight(current_url, '/') = trimRight({url_exact}, '/')",
             "url_pattern": "match(current_url, {url_pattern})",
         }
 

--- a/posthog/heatmaps/test/__snapshots__/test_heatmaps_api.ambr
+++ b/posthog/heatmaps/test/__snapshots__/test_heatmaps_api.ambr
@@ -12,7 +12,9 @@
             round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
             multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
      FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 99999), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), equals(heatmaps.current_url, 'http://example.com'), lessOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), plus('2025-03-31', toIntervalDay(1)))))
+     WHERE and(equals(heatmaps.team_id, 99999), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), equals(trim(TRAILING '/'
+                                                                                                                                                                              FROM heatmaps.current_url), trim(TRAILING '/'
+                                                                                                                                                                                                               FROM 'http://example.com')), lessOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), plus('2025-03-31', toIntervalDay(1)))))
   GROUP BY pointer_target_fixed,
            pointer_relative_x,
            client_y
@@ -42,7 +44,9 @@
             round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
             multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
      FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 99999), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), equals(heatmaps.current_url, 'http://example.com/about'), lessOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), plus('2025-03-31', toIntervalDay(1)))))
+     WHERE and(equals(heatmaps.team_id, 99999), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), equals(trim(TRAILING '/'
+                                                                                                                                                                              FROM heatmaps.current_url), trim(TRAILING '/'
+                                                                                                                                                                                                               FROM 'http://example.com/about')), lessOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), plus('2025-03-31', toIntervalDay(1)))))
   GROUP BY pointer_target_fixed,
            pointer_relative_x,
            client_y

--- a/posthog/heatmaps/test/test_heatmaps_api.py
+++ b/posthog/heatmaps/test/test_heatmaps_api.py
@@ -213,6 +213,22 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             {"date_from": "2023-03-08", "url_exact": "http://example.com/about", "type": "rageclick"}, 2
         )
 
+    @parameterized.expand(
+        [
+            ("query_no_slash_data_no_slash", "http://example.com", "http://example.com"),
+            ("query_no_slash_data_with_slash", "http://example.com", "http://example.com/"),
+            ("query_with_slash_data_no_slash", "http://example.com/", "http://example.com"),
+            ("query_with_slash_data_with_slash", "http://example.com/", "http://example.com/"),
+        ]
+    )
+    @freezegun.freeze_time("2025-03-31")
+    def test_url_exact_normalizes_trailing_slash(self, _name: str, query_url: str, data_url: str) -> None:
+        self._create_heatmap_event("session_1", "click", "2023-03-08T08:00:00", current_url=data_url)
+
+        self._assert_heatmap_single_result_count(
+            {"date_from": "2023-03-08", "url_exact": query_url, "type": "click"}, 1
+        )
+
     @freezegun.freeze_time("2025-03-31")
     @snapshot_clickhouse_queries
     def test_can_filter_by_url_pattern_where_end_is_anchored(self) -> None:


### PR DESCRIPTION
## Problem

When the URL is set to `url_exact`, we often see complaints of "no data", where in reality we have the data, but the URL differs by a trailing slash.

## Changes

Let's use ClickHouse's `trimRight` method to fix it.

### Before
`example.com` and `example.com/` - these are string-different

### After
`example.com` and `example.com/` - these are treated as the same now
