### PR TITLE
fix(ph-ai): tell the agent created insights don't have URLs

### DIFF
--- a/ee/hogai/chat_agent/query_executor/test/test_nodes.py
+++ b/ee/hogai/chat_agent/query_executor/test/test_nodes.py
@@ -87,9 +87,7 @@ class TestQueryExecutorNode(ClickhouseTestMixin, NonAtomicBaseTest):
         new_state = cast(PartialAssistantState, new_state)
         mock_process_query_dict.assert_called_once()  # Query processing started
         msg = cast(AssistantToolCallMessage, new_state.messages[0])
-        self.assertIn(
-            "Here is the results table of the TrendsQuery created to answer your latest question:", msg.content
-        )
+        self.assertIn("Here is the results table of the TrendsQuery insight:", msg.content)
         self.assertEqual(msg.type, "tool")
         self.assertEqual(msg.tool_call_id, "tool1")
         self.assertIsNotNone(msg.id)
@@ -143,9 +141,7 @@ class TestQueryExecutorNode(ClickhouseTestMixin, NonAtomicBaseTest):
         new_state = cast(PartialAssistantState, new_state)
         mock_process_query_dict.assert_called_once()  # Query processing started
         msg = cast(AssistantToolCallMessage, new_state.messages[0])
-        self.assertIn(
-            "Here is the results table of the TrendsQuery created to answer your latest question:", msg.content
-        )
+        self.assertIn("Here is the results table of the TrendsQuery insight:", msg.content)
         self.assertIn(f"Insight ID: {insight.short_id}", msg.content)
         self.assertIn("Name: test insight", msg.content)
         self.assertIn("Description: test description", msg.content)
@@ -307,9 +303,7 @@ class TestQueryExecutorNode(ClickhouseTestMixin, NonAtomicBaseTest):
             new_state = cast(PartialAssistantState, new_state)
             mock_process_query_dict.assert_called_once()  # Query processing started
             msg = cast(AssistantMessage, new_state.messages[0])
-            self.assertIn(
-                "Here is the results table of the TrendsQuery created to answer your latest question:", msg.content
-            )
+            self.assertIn("Here is the results table of the TrendsQuery insight:", msg.content)
             self.assertEqual(msg.type, "tool")
             self.assertIsNotNone(msg.id)
 

--- a/ee/hogai/context/dashboard/context.py
+++ b/ee/hogai/context/dashboard/context.py
@@ -128,6 +128,7 @@ class DashboardContext:
             description=data.description,
             insight_id=data.short_id,
             insight_model_id=data.db_id,
+            insight_short_id=data.short_id,
             dashboard_filters=self.dashboard_filters,
             filters_override=data.filters_override,
             variables_override=data.variables_override,

--- a/ee/hogai/context/insight/context.py
+++ b/ee/hogai/context/insight/context.py
@@ -7,6 +7,7 @@ from posthog.sync import database_sync_to_async
 
 from ee.hogai.context.insight.query_executor import execute_and_format_query
 from ee.hogai.tool_errors import MaxToolRetryableError
+from ee.hogai.utils.helpers import build_insight_url
 from ee.hogai.utils.prompt import format_prompt_string
 from ee.hogai.utils.query import validate_assistant_query
 from ee.hogai.utils.types.base import AnyAssistantGeneratedQuery, AnyPydanticModelQuery
@@ -30,6 +31,7 @@ class InsightContext:
         description: str | None = None,
         insight_id: str | None = None,
         insight_model_id: int | None = None,
+        insight_short_id: str | None = None,
         # Optional dashboard filter handling
         dashboard_filters: dict | None = None,
         filters_override: dict | None = None,
@@ -41,9 +43,17 @@ class InsightContext:
         self.description = description
         self.insight_id = insight_id
         self.insight_model_id = insight_model_id
+        self.insight_short_id = insight_short_id
         self.dashboard_filters = dashboard_filters
         self.filters_override = filters_override
         self.variables_override = variables_override
+
+    @property
+    def insight_url(self) -> str | None:
+        """Generate insight URL from insight_short_id if available."""
+        if self.insight_short_id:
+            return build_insight_url(self.team, self.insight_short_id)
+        return None
 
     @classmethod
     def extract_query(cls, insight: Insight):
@@ -89,6 +99,7 @@ class InsightContext:
             query_schema=query_schema,
             results=results,
             include_url_reminder=self.insight_id is None,
+            insight_url=self.insight_url,
         )
 
     async def format_schema(self, prompt_template: str = INSIGHT_RESULT_TEMPLATE) -> str:
@@ -102,6 +113,7 @@ class InsightContext:
             insight_description=self.description,
             query_schema=query_schema,
             include_url_reminder=self.insight_id is None,
+            insight_url=self.insight_url,
         )
 
     async def _get_effective_query(self):

--- a/ee/hogai/context/insight/prompts.py
+++ b/ee/hogai/context/insight/prompts.py
@@ -6,6 +6,12 @@ Insight ID: {{{insight_id}}}
 {{#insight_description}}
 Description: {{{insight_description}}}
 {{/insight_description}}
+{{#insight_url}}
+Insight URL: {{{insight_url}}}
+{{/insight_url}}
+{{^insight_url}}
+This insight cannot be accessed via a URL.
+{{/insight_url}}
 {{#query_schema}}
 
 Query schema:
@@ -21,14 +27,14 @@ Query schema:
 
 
 QUERY_RESULTS_PROMPT = """
-Here is the results table of the {{{query_kind}}} created to answer your latest question:
+Here is the results table of the {{{query_kind}}} insight:
 
 ```
 {{{results}}}
 ```
 
 {{#insight_schema}}
-Here is the generated insight schema used to retrieve the results above:
+Here is the insight schema used to retrieve the results above:
 ```json
 {{{insight_schema}}}
 ```
@@ -41,7 +47,6 @@ Assume currency values are in {{currency}} and ALWAYS include the proper prefix 
 {{/currency}}
 It's expected that the data point for the current period may show a drop in value, as data collection for it is still ongoing. Do not point this out.
 Do not copy the results table as the user sees it in the UI.{{#include_url_reminder}}
-This insight cannot be accessed via a URL.
 {{/include_url_reminder}}
 </system_reminder>
 """.strip()

--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -209,6 +209,7 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
             description=result.content.description,
             insight_id=artifact_or_insight_id,
             insight_model_id=result.model.id if isinstance(result, ModelArtifactResult) else None,
+            insight_short_id=result.model.short_id if isinstance(result, ModelArtifactResult) else None,
         )
 
         # The agent wants to read the schema, just return it


### PR DESCRIPTION
## Problem

The agent thinks generated insights are accessible via URLs. We also had old prompts in the query executor that were only meant for the old flow, and don't work with the new shared context formatting.

## Changes

- Updated query results prompt.
- `insight_url` parameter in `InsightContext` adds the url to the formatted insight
- `insight_url` has to be passed when `insight_model_id` is in the context args
- `insight_url` is passed in the `read_data` tool (if insight exists), but not during insight/sql creation

## How did you test this code?

Added tests

## Publish to changelog?

No