### PR TITLE
fix(data-modeling): add data modeling back to dwh q

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -130,8 +130,8 @@ _task_queue_specs = [
     ),
     (
         settings.DATA_WAREHOUSE_TASK_QUEUE,
-        DATA_SYNC_WORKFLOWS,
-        DATA_SYNC_ACTIVITIES,
+        DATA_SYNC_WORKFLOWS + DATA_MODELING_WORKFLOWS,
+        DATA_SYNC_ACTIVITIES + DATA_MODELING_ACTIVITIES,
     ),
     (
         settings.DATA_MODELING_TASK_QUEUE,


### PR DESCRIPTION
## Problem

"data-modeling-run" temporal class not registered for some users with materialization syncs. started on Dec 19 which corresponds to [this PR](https://github.com/PostHog/posthog/pull/42359) from me.

## Changes

Undoing the spicy part of that change.

## How did you test this code?

I haven't but this is a partial revert.

## Publish to changelog?

no