### PR TITLE
feat: table column name wrapping

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.scss
+++ b/frontend/src/queries/nodes/DataTable/DataTable.scss
@@ -48,3 +48,16 @@
         }
     }
 }
+
+.DataVisualizationTable {
+    th {
+        overflow: visible;
+        text-overflow: clip;
+        white-space: normal;
+
+        .LemonTable__header-content div {
+            word-break: break-word;
+            white-space: normal;
+        }
+    }
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -1,3 +1,5 @@
+import '../../DataTable/DataTable.scss'
+
 import { useValues } from 'kea'
 import posthog from 'posthog-js'
 
@@ -115,10 +117,12 @@ export const Table = (props: TableProps): JSX.Element => {
 
     return (
         <LemonTable
+            className="DataVisualizationTable"
             dataSource={tabularData}
             columns={tableColumns}
             loading={responseLoading}
             pagination={{ pageSize: DEFAULT_PAGE_SIZE }}
+            maxHeaderWidth="15rem"
             emptyState={
                 responseError ? (
                     <InsightErrorState


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/46109 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49873)

Labels are great for shortening long columns, but they don't work as well for non-trivial insights.

## Changes

This change adds wrapping to the column names so that they you don't need to scroll a lot for columns which have very small values, but very long names.

<img width="1345" height="528" alt="image" src="https://github.com/user-attachments/assets/e15416c9-b6c4-4369-acd9-58cfe16e4fb1" />

## How did you test this code?

Ran locally 

## Publish to changelog?

No