### PR TITLE
fix: the logs redis was trying to connect with TLS in hobby installs causing the whole plugin server to die

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -142,6 +142,7 @@ services:
             CDP_REDIS_PORT: 6379
             LOGS_REDIS_HOST: redis7
             LOGS_REDIS_PORT: 6379
+            LOGS_REDIS_TLS: 'false'
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
             CYCLOTRON_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             PERSONS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -100,8 +100,9 @@ export class CdpApi {
                     ? {
                           url: hub.CDP_REDIS_HOST,
                           options: { port: hub.CDP_REDIS_PORT, password: hub.CDP_REDIS_PASSWORD },
+                          name: 'cdp-api-redis',
                       }
-                    : { url: hub.REDIS_URL },
+                    : { url: hub.REDIS_URL, name: 'cdp-api-redis-fallback' },
                 poolMinSize: hub.REDIS_POOL_MIN_SIZE,
                 poolMaxSize: hub.REDIS_POOL_MAX_SIZE,
             })

--- a/nodejs/src/cdp/consumers/cdp-base.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-base.consumer.ts
@@ -97,8 +97,9 @@ export abstract class CdpConsumerBase<THub extends CdpConsumerBaseHub = CdpConsu
                 ? {
                       url: hub.CDP_REDIS_HOST,
                       options: { port: hub.CDP_REDIS_PORT, password: hub.CDP_REDIS_PASSWORD },
+                      name: 'cdp-redis',
                   }
-                : { url: hub.REDIS_URL },
+                : { url: hub.REDIS_URL, name: 'cdp-redis-fallback' },
             poolMinSize: hub.REDIS_POOL_MIN_SIZE,
             poolMaxSize: hub.REDIS_POOL_MAX_SIZE,
         })

--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -142,8 +142,9 @@ export class HogTransformerService {
                 ? {
                       url: hub.CDP_REDIS_HOST,
                       options: { port: hub.CDP_REDIS_PORT, password: hub.CDP_REDIS_PASSWORD },
+                      name: 'hog-transformer-redis',
                   }
-                : { url: hub.REDIS_URL },
+                : { url: hub.REDIS_URL, name: 'hog-transformer-redis-fallback' },
             poolMinSize: hub.REDIS_POOL_MIN_SIZE,
             poolMaxSize: hub.REDIS_POOL_MAX_SIZE,
         })

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -128,8 +128,9 @@ export class LogsIngestionConsumer {
                           port: hub.LOGS_REDIS_PORT,
                           tls: hub.LOGS_REDIS_TLS ? {} : undefined,
                       },
+                      name: 'logs-redis',
                   }
-                : { url: hub.REDIS_URL },
+                : { url: hub.REDIS_URL, name: 'logs-redis-fallback' },
             poolMinSize: hub.REDIS_POOL_MIN_SIZE,
             poolMaxSize: hub.REDIS_POOL_MAX_SIZE,
         })

--- a/nodejs/src/session-recording/consumer.ts
+++ b/nodejs/src/session-recording/consumer.ts
@@ -136,8 +136,9 @@ export class SessionRecordingIngester {
                 ? {
                       url: hub.POSTHOG_SESSION_RECORDING_REDIS_HOST,
                       options: { port: hub.POSTHOG_SESSION_RECORDING_REDIS_PORT ?? 6379 },
+                      name: 'session-recording-redis',
                   }
-                : { url: hub.REDIS_URL },
+                : { url: hub.REDIS_URL, name: 'session-recording-redis-fallback' },
             poolMinSize: this.hub.REDIS_POOL_MIN_SIZE,
             poolMaxSize: this.hub.REDIS_POOL_MAX_SIZE,
         })

--- a/nodejs/src/utils/db/hub.ts
+++ b/nodejs/src/utils/db/hub.ts
@@ -67,13 +67,18 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
     logger.info('🤔', `Connecting to ingestion Redis...`)
     const redisPool = createRedisPoolFromConfig({
         connection: serverConfig.INGESTION_REDIS_HOST
-            ? { url: serverConfig.INGESTION_REDIS_HOST, options: { port: serverConfig.INGESTION_REDIS_PORT } }
+            ? {
+                  url: serverConfig.INGESTION_REDIS_HOST,
+                  options: { port: serverConfig.INGESTION_REDIS_PORT },
+                  name: 'ingestion-redis',
+              }
             : serverConfig.POSTHOG_REDIS_HOST
               ? {
                     url: serverConfig.POSTHOG_REDIS_HOST,
                     options: { port: serverConfig.POSTHOG_REDIS_PORT, password: serverConfig.POSTHOG_REDIS_PASSWORD },
+                    name: 'ingestion-redis',
                 }
-              : { url: serverConfig.REDIS_URL },
+              : { url: serverConfig.REDIS_URL, name: 'ingestion-redis' },
         poolMinSize: serverConfig.REDIS_POOL_MIN_SIZE,
         poolMaxSize: serverConfig.REDIS_POOL_MAX_SIZE,
     })
@@ -82,8 +87,12 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
     logger.info('🤔', `Connecting to cookieless Redis...`)
     const cookielessRedisPool = createRedisPoolFromConfig({
         connection: serverConfig.COOKIELESS_REDIS_HOST
-            ? { url: serverConfig.COOKIELESS_REDIS_HOST, options: { port: serverConfig.COOKIELESS_REDIS_PORT ?? 6379 } }
-            : { url: serverConfig.REDIS_URL },
+            ? {
+                  url: serverConfig.COOKIELESS_REDIS_HOST,
+                  options: { port: serverConfig.COOKIELESS_REDIS_PORT ?? 6379 },
+                  name: 'cookieless-redis',
+              }
+            : { url: serverConfig.REDIS_URL, name: 'cookieless-redis' },
         poolMinSize: serverConfig.REDIS_POOL_MIN_SIZE,
         poolMaxSize: serverConfig.REDIS_POOL_MAX_SIZE,
     })
@@ -96,8 +105,9 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
             ? {
                   url: serverConfig.POSTHOG_REDIS_HOST,
                   options: { port: serverConfig.POSTHOG_REDIS_PORT, password: serverConfig.POSTHOG_REDIS_PASSWORD },
+                  name: 'posthog-redis',
               }
-            : { url: serverConfig.REDIS_URL },
+            : { url: serverConfig.REDIS_URL, name: 'posthog-redis' },
         poolMinSize: serverConfig.REDIS_POOL_MIN_SIZE,
         poolMaxSize: serverConfig.REDIS_POOL_MAX_SIZE,
     })


### PR DESCRIPTION
hobby install pluginserver was dying with a redis timed out error

but we have _lots_ of redis connections so this was a pain to track down

1) added a name to all redis connections so that when they log an error we can see if it is one specific redis having an issue (as it was in this case)

and

2) told logs redis not to connect with TLS in hobby, i believe it was that which is killing hobbby plugin 

ran hobby locally-ish using docker compose and saw that this fix stopped the error message