### PR TITLE
fix: reduce suffix width in series rename modal to prevent overflow

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/RenameModal.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/RenameModal.tsx
@@ -52,7 +52,7 @@ export function RenameModal({ typeKey, view }: RenameModalProps): JSX.Element {
                 onChange={(value) => setName(value)}
                 suffix={
                     <span
-                        className="text-secondary truncate max-w-[200px]"
+                        className="text-secondary truncate max-w-24"
                         title={getDisplayNameFromEntityFilter(selectedFilter, false) ?? ''}
                     >
                         {getDisplayNameFromEntityFilter(selectedFilter, false) ?? ''}


### PR DESCRIPTION
## Problem

When renaming a graph series with a long action or event name, the input text runs outside the visible area, making it difficult to edit. This is because the suffix (showing the original name) takes up 200px of horizontal space.

**Issue:** #33689

## Solution

Reduce the suffix max-width from 200px (`max-w-[200px]`) to 96px (`max-w-24`), giving approximately 100px more space for the input text.

## Changes

- `RenameModal.tsx`: Changed suffix className from `max-w-[200px]` to `max-w-24`

## Before/After

**Before:** Suffix takes 200px, leaving less room for long input values
**After:** Suffix takes 96px, input has ~100px more horizontal space

The original name is still visible (truncated with ellipsis and full text in title tooltip), but the editable input now has more room.

## Test Plan

- [ ] Open an insight with a long action/event name
- [ ] Click rename on a series
- [ ] Type a long name in the input
- [ ] Verify the text no longer overflows outside the visible input area

🤖 Generated with [Claude Code](https://claude.com/claude-code)