### PR TITLE
fix(insights): Show lifecycle stage names in legend instead of action name

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegendRow.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegendRow.tsx
@@ -92,6 +92,7 @@ export function InsightLegendRow({ item }: InsightLegendRowProps): JSX.Element {
                                     compareValue={isPrevious ? formatCompareLabel(item) : undefined}
                                     hideIcon
                                     showSingleName
+                                    seriesStatus={item.status}
                                 />
                                 {parseAliasToReadable(formattedBreakdownValue)}
                             </div>
@@ -107,6 +108,7 @@ export function InsightLegendRow({ item }: InsightLegendRowProps): JSX.Element {
                                 pillMidEllipsis={breakdownFilter?.breakdown === '$current_url'} // TODO: define set of breakdown values that would benefit from mid ellipsis truncation
                                 hideIcon
                                 showSingleName
+                                seriesStatus={item.status}
                             />
                         )
                     }


### PR DESCRIPTION
## Summary
Fixes #31157

When using an **action** (not event) in a lifecycle insight, the legend incorrectly shows the action name repeated for each color instead of the lifecycle stage names (New, Returning, Resurrecting, Dormant).

**Root cause:** The `InsightLabel` component already has a `seriesStatus` prop specifically for displaying lifecycle stage names, but `InsightLegendRow` wasn't passing `item.status` to it.

**Fix:** Pass `seriesStatus={item.status}` to both `InsightLabel` components in `InsightLegendRow`.

## AI disclosure
- This fix was researched and implemented with assistance from Claude Code (Anthropic's CLI tool)
- All code was reviewed manually

## Test plan
1. Create a new Lifecycle insight
2. Select an **action** (not event) for series A
3. Enable the legend on the visualization
4. ✅ Legend should now show "New", "Returning", "Resurrecting", "Dormant" instead of the action name repeated

🤖 Generated with [Claude Code](https://claude.com/claude-code)