### PR TITLE
fix(funnels): Add labels to clarify conversion percentage basis

### DIFF
--- a/frontend/src/scenes/experiments/charts/funnel/StepLegend.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepLegend.tsx
@@ -41,13 +41,13 @@ export function StepLegend({ step, stepIndex, showTime }: StepLegendProps): JSX.
     const convertedCountPresentationWithPercentage = (
         <>
             {convertedCountPresentation}{' '}
-            <span className="text-secondary">({percentage(step.conversionRates.fromBasisStep, 2)})</span>
+            <span className="text-secondary">({percentage(step.conversionRates.fromBasisStep, 2)} of first)</span>
         </>
     )
     const droppedOffCountPresentationWithPercentage = (
         <>
             {droppedOffCountPresentation}{' '}
-            <span className="text-secondary">({percentage(1 - step.conversionRates.fromPrevious, 2)})</span>
+            <span className="text-secondary">({percentage(1 - step.conversionRates.fromPrevious, 2)} of prev)</span>
         </>
     )
 

--- a/frontend/src/scenes/funnels/FunnelBarVertical/StepLegend.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarVertical/StepLegend.tsx
@@ -45,16 +45,20 @@ export function StepLegend({ step, stepIndex, showTime, showPersonsModal }: Step
         aggregationTargetLabel.plural
     )
 
+    const conversionBasisLabel =
+        funnelsFilter?.funnelStepReference === FunnelStepReference.previous ? 'of prev' : 'of first'
     const convertedCountPresentationWithPercentage = (
         <>
             {convertedCountPresentation}{' '}
-            <span className="text-secondary">({percentage(step.conversionRates.fromBasisStep, 2)})</span>
+            <span className="text-secondary">
+                ({percentage(step.conversionRates.fromBasisStep, 2)} {conversionBasisLabel})
+            </span>
         </>
     )
     const droppedOffCountPresentationWithPercentage = (
         <>
             {droppedOffCountPresentation}{' '}
-            <span className="text-secondary">({percentage(1 - step.conversionRates.fromPrevious, 2)})</span>
+            <span className="text-secondary">({percentage(1 - step.conversionRates.fromPrevious, 2)} of prev)</span>
         </>
     )
 


### PR DESCRIPTION
## Summary
Fixes #25881

Added inline labels to funnel step percentages to clarify what each percentage represents without needing to hover for tooltips.

**Changes:**
- Conversion rate percentage now shows "of first" or "of prev" depending on the funnel step reference setting
- Drop-off rate percentage now shows "of prev" (always relative to previous step)

**Before:** `2 users (50%)`  
**After:** `2 users (50% of first)` or `2 users (50% of prev)`

## AI disclosure
- This fix was researched and implemented with assistance from Claude Code (Anthropic's CLI tool)
- All code was reviewed manually

## Test plan
1. Create a funnel insight with multiple steps
2. Toggle between "Overall conversion" and "Relative to previous step" modes
3. ✅ Verify grey percentage text now includes "of first" or "of prev" label
4. ✅ Labels correctly reflect which step the percentage is relative to

🤖 Generated with [Claude Code](https://claude.com/claude-code)