### PR TITLE
fix(flags): Reset schedule form date after creating scheduled change

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -1258,6 +1258,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
         createScheduledChangeSuccess: ({ scheduledChange }) => {
             if (scheduledChange) {
                 lemonToast.success('Change scheduled successfully')
+                actions.setScheduleDateMarker(null)
                 actions.setSchedulePayload(NEW_FLAG.filters, NEW_FLAG.active, {}, null, null)
                 actions.setIsRecurring(false)
                 actions.setRecurrenceInterval(null)


### PR DESCRIPTION
## Summary
Fixes #31914

After successfully creating a scheduled change, the form wasn't fully resetting - the date picker retained its value, causing confusion when scheduling another change.

**Root cause:** `createScheduledChangeSuccess` was resetting `schedulePayload`, `isRecurring`, `recurrenceInterval`, and `endDate`, but not `scheduleDateMarker`.

**Fix:** Added `actions.setScheduleDateMarker(null)` to reset the date picker.

## AI disclosure
- This fix was researched and implemented with assistance from Claude Code
- Traced the issue through the Kea logic to find the missing reset

## Test plan
1. Navigate to a feature flag → Schedule tab
2. Select a date/time and configure a scheduled change
3. Click "Schedule"
4. ✅ Date picker should reset to empty
5. ✅ User can immediately schedule another change without confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)