### PR TITLE
fix(insights): Use immutable update for goal line changes

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/goalLinesLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/goalLinesLogic.ts
@@ -42,15 +42,9 @@ export const goalLinesLogic = kea<goalLinesLogicType>([
             {
                 addGoalLine: (state) => [...state, { label: 'Q4 Goal', value: 0, displayLabel: true }],
                 updateGoalLine: (state, { goalLineIndex, key, value }) => {
-                    const goalLines = [...state]
-                    if (key === 'value') {
-                        goalLines[goalLineIndex][key] = value as number
-                    } else {
-                        // @ts-expect-error not sure why it thinks this is an error but it clearly isn't
-                        goalLines[goalLineIndex][key] = value
-                    }
-
-                    return goalLines
+                    return state.map((goalLine, index) =>
+                        index === goalLineIndex ? { ...goalLine, [key]: value } : goalLine
+                    )
                 },
                 removeGoalLine: (state, { goalLineIndex }) => {
                     const goalLines = [...state]

--- a/frontend/src/scenes/insights/EditorFilters/goalLinesLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/goalLinesLogic.ts
@@ -46,8 +46,7 @@ export const goalLinesLogic = kea<goalLinesLogicType>([
                         index === goalLineIndex ? { ...goalLine, [key]: value } : goalLine
                     )
                 },
-                removeGoalLine: (state, { goalLineIndex }) =>
-                    state.filter((_, index) => index !== goalLineIndex),
+                removeGoalLine: (state, { goalLineIndex }) => state.filter((_, index) => index !== goalLineIndex),
                 setGoalLines: (_, { goalLines }) => goalLines,
             },
         ],

--- a/frontend/src/scenes/insights/EditorFilters/goalLinesLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/goalLinesLogic.ts
@@ -46,11 +46,8 @@ export const goalLinesLogic = kea<goalLinesLogicType>([
                         index === goalLineIndex ? { ...goalLine, [key]: value } : goalLine
                     )
                 },
-                removeGoalLine: (state, { goalLineIndex }) => {
-                    const goalLines = [...state]
-                    goalLines.splice(goalLineIndex, 1)
-                    return goalLines
-                },
+                removeGoalLine: (state, { goalLineIndex }) =>
+                    state.filter((_, index) => index !== goalLineIndex),
                 setGoalLines: (_, { goalLines }) => goalLines,
             },
         ],


### PR DESCRIPTION
## Summary
- Fixes goal line changes not being detected as modifications (UI shows "no changes to be saved")

## Root Cause
The `updateGoalLine` reducer was mutating the goal line object in place:
```js
const goalLines = [...state]
goalLines[goalLineIndex][key] = value  // ← mutation
```

This creates a shallow copy of the array but still references the same object, causing change detection to fail.

## Fix
Use `.map()` to create both a new array and a new object for the updated goal line:
```js
return state.map((goalLine, index) =>
    index === goalLineIndex ? { ...goalLine, [key]: value } : goalLine
)
```

This ensures proper immutable state updates that React/Kea can detect.

## Test Plan
1. Open an insight with an existing goal line
2. Edit the goal line's label or value
3. Verify the changes are recognized and can be saved

Closes #30324

🤖 Generated with [Claude Code](https://claude.com/claude-code)