### PR TITLE
fix(llma): `parameter is not a number` on ingestion

### DIFF
--- a/nodejs/src/ingestion/ai-costs/process-ai-event.test.ts
+++ b/nodejs/src/ingestion/ai-costs/process-ai-event.test.ts
@@ -558,6 +558,21 @@ describe('processAiEvent()', () => {
             expect(result.properties!.$ai_cost_model_provider).toBeUndefined()
         })
 
+        it('treats object cost values as unset and falls through to model calculation', () => {
+            event.properties!.$ai_model = 'gpt-4'
+            event.properties!.$ai_input_tokens = 100
+            event.properties!.$ai_output_tokens = 50
+            event.properties!.$ai_input_cost_usd = { value: 5.5 } as any
+            event.properties!.$ai_output_cost_usd = { value: 3.5 } as any
+
+            const result = processAiEvent(event)
+
+            // Should fall through to model-based calculation, not crash or use 0
+            expect(result.properties!.$ai_cost_model_source).toBe(CostModelSource.OpenRouter)
+            expect(result.properties!.$ai_input_cost_usd).toBeGreaterThan(0)
+            expect(result.properties!.$ai_output_cost_usd).toBeGreaterThan(0)
+        })
+
         it('handles custom pricing with cache read tokens for OpenAI', () => {
             event.properties!.$ai_provider = 'openai'
             event.properties!.$ai_input_token_price = 0.001


### PR DESCRIPTION
Defensive fix for [an error when calculating costs](https://grafana.prod-us.posthog.dev/explore?schemaVersion=1&panes=%7B%22ecx%22:%7B%22datasource%22:%22P44D702D3E93867EC%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bapp%3D%5C%22ingestion-events%5C%22,%20level%3D%5C%22error%5C%22%7D%20%7C%3D%20%60Parameter%20is%20not%20a%20number%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P44D702D3E93867EC%22%7D,%22editorMode%22:%22builder%22,%22direction%22:%22backward%22%7D%5D,%22range%22:%7B%22from%22:%221765313004056%22,%22to%22:%221766258271383%22%7D,%22panelsState%22:%7B%22logs%22:%7B%22visualisationType%22:%22logs%22%7D%7D%7D%7D&orgId=1) for LLMA events, [original thread](https://posthog.slack.com/archives/C08JQTX5RRP/p1766258311098159).