### PR TITLE
fix(snowflake-batch-export): Allow duplicate JSON keys

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -944,7 +944,7 @@ class SnowflakeClient:
             SnowflakeQueryServerTimeoutError: If the COPY INTO query exceeds the timeout set in the user's account.
         """
         select_fields = ", ".join(
-            f'PARSE_JSON($1:"{field.name}")'
+            f"PARSE_JSON($1:\"{field.name}\", 'd')"
             if field.data_type == JsonType() and field.name.lower() != "elements"
             else f'$1:"{field.name}"'
             for field in table


### PR DESCRIPTION
## Problem

Duplicate JSON keys are not recommended, and multiple implementations will treat it as an error. Snowflake in particular treats it as an error as default, but we can allow duplicate keys. This is necessary as sometimes events can have duplicate keys.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Set the `'d'` parameter in Snowflake's `PARSE_JSON` function, which allows duplicate keys. Based on documentation: https://docs.snowflake.com/en/sql-reference/functions/parse_json#arguments.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran Snowflake tests, all passing.
I wasn't able to simulate a duplicate key though as we generate properties as python dictionaries, which remove duplicate keys. 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
