### PR TITLE
chore(workflows): Track workflow-template usage

### DIFF
--- a/products/workflows/frontend/Workflows/workflowTemplateLogic.test.ts
+++ b/products/workflows/frontend/Workflows/workflowTemplateLogic.test.ts
@@ -456,8 +456,8 @@ describe('workflowTemplateLogic', () => {
 
             // Verify API call with correct data
             expect(mockApi.updateHogFlowTemplate).toHaveBeenCalledWith(
+                'template-id',
                 expect.objectContaining({
-                    id: 'template-id',
                     name: 'Updated Workflow',
                     description: 'Updated Description',
                     actions: expect.any(Array),


### PR DESCRIPTION
## Problem

We want to know how much people usage workflow templates

## Changes

Requests to create a workflow now send the template-id along, if they're created from a template. Then we add that to the hog_flow_created event

## How did you test this code?

Manually