### PR TITLE
fix(phai): improve recursion handling

### DIFF
--- a/ee/hogai/chat_agent/test/test_chat_agent.py
+++ b/ee/hogai/chat_agent/test/test_chat_agent.py
@@ -249,12 +249,7 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         class TestNode(AssistantNode):
             async def arun(self, state, config):
                 call_count[0] += 1
-                # First call returns a message, then we'll hit recursion limit
-                if call_count[0] == 1:
-                    return PartialAssistantState(
-                        messages=[AssistantMessage(content="Working on it...", id=str(uuid4()))]
-                    )
-                # After resume, return completion message
+                # Always return completion message
                 return PartialAssistantState(
                     messages=[AssistantMessage(content="Completed successfully!", id=str(uuid4()))]
                 )

--- a/ee/hogai/chat_agent/test/test_chat_agent.py
+++ b/ee/hogai/chat_agent/test/test_chat_agent.py
@@ -227,11 +227,73 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                 raise GraphRecursionError()
 
         with patch("langgraph.pregel.Pregel.astream", side_effect=FakeStream):
-            output, _ = await self._run_assistant_graph(conversation=self.conversation)
+            output, assistant = await self._run_assistant_graph(conversation=self.conversation)
             self.assertEqual(output[0][0], "message")
-            self.assertEqual(cast(AssistantMessage, output[0][1]).content, "Hello")
+            self.assertEqual(cast(HumanMessage, output[0][1]).content, "Hello")
             self.assertEqual(output[1][0], "message")
-            self.assertIsInstance(output[1][1], FailureMessage)
+            self.assertIsInstance(output[1][1], AssistantMessage)
+            self.assertEqual(
+                cast(AssistantMessage, output[1][1]).content,
+                "I've reached the maximum number of steps. Would you like me to continue?",
+            )
+
+            # Verify state is marked as interrupted
+            config = assistant._get_config()
+            snapshot = await assistant._graph.aget_state(config)
+            self.assertTrue(snapshot.next)  # Should have next nodes to execute
+
+    async def test_recursion_error_can_resume_after_user_response(self):
+        """Test that after hitting recursion limit, the assistant can resume when user responds."""
+        call_count = [0]
+
+        class TestNode(AssistantNode):
+            async def arun(self, state, config):
+                call_count[0] += 1
+                # First call returns a message, then we'll hit recursion limit
+                if call_count[0] == 1:
+                    return PartialAssistantState(
+                        messages=[AssistantMessage(content="Working on it...", id=str(uuid4()))]
+                    )
+                # After resume, return completion message
+                return PartialAssistantState(
+                    messages=[AssistantMessage(content="Completed successfully!", id=str(uuid4()))]
+                )
+
+        graph = (
+            AssistantGraph(self.team, self.user)
+            .add_node(AssistantNodeName.ROOT, TestNode(self.team, self.user))
+            .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
+            .add_edge(AssistantNodeName.ROOT, AssistantNodeName.END)
+            .compile()
+        )
+
+        # First run - hit recursion limit
+        class FakeStream:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise GraphRecursionError()
+
+        with patch("langgraph.pregel.Pregel.astream", side_effect=FakeStream):
+            output, _ = await self._run_assistant_graph(graph, conversation=self.conversation, message="Start task")
+
+            # Should get the recursion limit message
+            self.assertEqual(len(output), 2)
+            self.assertIsInstance(output[1][1], AssistantMessage)
+            self.assertIn("maximum number of steps", cast(AssistantMessage, output[1][1]).content)
+
+        # Second run - user says "continue"
+        output, _ = await self._run_assistant_graph(graph, conversation=self.conversation, message="yes, continue")
+
+        # Should resume and complete
+        self.assertGreater(len(output), 0)
+        # Find the completion message
+        assistant_messages = [msg for _, msg in output if isinstance(msg, AssistantMessage)]
+        self.assertTrue(any("Completed successfully!" in msg.content for msg in assistant_messages))
 
     async def test_new_conversation_handles_serialized_conversation(self):
         class TestNode(AssistantNode):

--- a/ee/hogai/core/runner.py
+++ b/ee/hogai/core/runner.py
@@ -290,13 +290,18 @@ class BaseAgentRunner(ABC):
                         ),
                     )
             except GraphRecursionError:
-                yield (
-                    AssistantEventType.MESSAGE,
-                    FailureMessage(
-                        content="The assistant has reached the maximum number of steps. You can explicitly ask to continue.",
-                        id=str(uuid4()),
-                    ),
+                recursion_limit_message = AssistantMessage(
+                    content="I've reached the maximum number of steps. Would you like me to continue?",
+                    id=str(uuid4()),
                 )
+                yield AssistantEventType.MESSAGE, recursion_limit_message
+
+                if self._use_checkpointer:
+                    # Update state to mark as interrupted so the conversation can be resumed
+                    await self._graph.aupdate_state(
+                        config,
+                        self._partial_state_type(messages=[recursion_limit_message]),
+                    )
             except LLM_API_EXCEPTIONS as e:
                 # Reset the state for LLM provider errors
                 if self._use_checkpointer:
@@ -340,7 +345,7 @@ class BaseAgentRunner(ABC):
 
     def _get_config(self) -> RunnableConfig:
         config: RunnableConfig = {
-            "recursion_limit": 48,
+            "recursion_limit": 96,
             "callbacks": self._callback_handlers,
             "configurable": {
                 "thread_id": self._conversation.id,

--- a/ee/hogai/core/runner.py
+++ b/ee/hogai/core/runner.py
@@ -297,7 +297,6 @@ class BaseAgentRunner(ABC):
                 yield AssistantEventType.MESSAGE, recursion_limit_message
 
                 if self._use_checkpointer:
-                    # Update state to mark as interrupted so the conversation can be resumed
                     await self._graph.aupdate_state(
                         config,
                         self._partial_state_type(messages=[recursion_limit_message]),


### PR DESCRIPTION
## Problem

The agent has a hardcoded execution limit of 48 steps. If the limit is reached, execution fails, which is not ideal behavior. This becomes more annoying during dashboard creation because the limit is often insufficient.

## Changes

- Bumped the limit to 96 steps.
- Refactored the hard limit, so it doesn't fail but outputs a CTA message.

## How did you test this code?

Unit tests & manual testing