### PR TITLE
feat: add project secret api key API & authenticator

### DIFF
--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -1,3 +1,4 @@
+import { ProjectSecretAPIKeyAllowedScope } from '~/queries/schema/schema-general'
 import type { APIScopeAction, APIScopeObject } from '~/types'
 
 export const MAX_API_KEYS_PER_USER = 10 // Same as in posthog/api/personal_api_key.py
@@ -162,6 +163,27 @@ export const APIScopeActionLabels: Record<APIScopeAction, string> = {
     read: 'Read',
     write: 'Write',
 }
+
+export const PROJECT_SECRET_API_KEY_SCOPES: APIScope[] = Object.values(ProjectSecretAPIKeyAllowedScope)
+    .filter((scopeString) => scopeString.includes(':'))
+    .map((scopeString) => {
+        const [objectKey, action] = scopeString.split(':')
+        const scopeConfig = API_SCOPES.find((s) => s.key === objectKey)
+
+        return {
+            key: objectKey as APIScopeObject,
+            objectName: scopeConfig?.objectName ?? objectKey,
+            objectPlural: scopeConfig?.objectPlural ?? `${objectKey}s`,
+            disabledActions: action === 'read' ? (['write'] as const) : undefined,
+        }
+    })
+
+export const PROJECT_SECRET_API_KEY_SCOPE_PRESETS: {
+    value: string
+    label: string
+    scopes: string[]
+    description: string
+}[] = []
 
 export const DEFAULT_OAUTH_SCOPES = ['openid', 'email', 'profile']
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -22634,6 +22634,25 @@
             "required": ["products", "games", "metadata"],
             "type": "object"
         },
+        "ProjectSecretAPIKeyAllowedScope": {
+            "enum": ["feature_flag:read", "PLACEHOLDER"],
+            "type": "string"
+        },
+        "ProjectSecretAPIKeyRequest": {
+            "additionalProperties": false,
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "items": {
+                        "$ref": "#/definitions/ProjectSecretAPIKeyAllowedScope"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "PropertyFilterBaseValue": {
             "type": ["string", "number", "boolean"]
         },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -5387,3 +5387,13 @@ export interface ReplayInactivityPeriod {
     ts_to_s?: integer
     active: boolean
 }
+export interface ProjectSecretAPIKeyRequest {
+    label?: string
+    scopes?: ProjectSecretAPIKeyAllowedScope[]
+}
+
+export enum ProjectSecretAPIKeyAllowedScope {
+    FeatureFlagRead = 'feature_flag:read',
+    // Placeholder to keep this as an enum (remove once a second real scope is added)
+    _Placeholder = 'PLACEHOLDER',
+}

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -113,6 +113,7 @@ from . import (
     personal_api_key,
     plugin,
     plugin_log_entry,
+    project_secret_api_key,
     proxy_record,
     query,
     quick_filters,
@@ -440,7 +441,12 @@ projects_router.register(
 )
 
 projects_router.register(r"uploaded_media", uploaded_media.MediaViewSet, "project_media", ["project_id"])
-
+projects_router.register(
+    r"project_secret_api_keys",
+    project_secret_api_key.ProjectSecretAPIKeyViewSet,
+    "project_secret_api_keys",
+    ["project_id"],
+)
 projects_router.register(r"tags", tagged_item.TaggedItemViewSet, "project_tags", ["project_id"])
 projects_router.register(
     r"web_analytics",

--- a/posthog/api/project_secret_api_key.py
+++ b/posthog/api/project_secret_api_key.py
@@ -1,0 +1,217 @@
+from typing import cast
+
+from django.db import IntegrityError
+from django.db.models import QuerySet
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
+from django.utils import timezone
+
+from rest_framework import status, viewsets
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.schema import ProjectSecretAPIKeyAllowedScope, ProjectSecretAPIKeyRequest
+
+from posthog.api.documentation import extend_schema
+from posthog.api.mixins import PydanticModelMixin
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.api.shared import UserBasicSerializer
+from posthog.api.utils import action
+from posthog.auth import PersonalAPIKeyAuthentication, SessionAuthentication
+from posthog.exceptions_capture import capture_exception
+from posthog.models.activity_logging.activity_log import changes_between
+from posthog.models.activity_logging.model_activity import get_current_user, get_was_impersonated
+from posthog.models.activity_logging.project_secret_api_key_utils import log_project_secret_api_key_activity
+from posthog.models.personal_api_key import hash_key_value
+from posthog.models.project_secret_api_key import ProjectSecretAPIKey
+from posthog.models.signals import model_activity_signal, mutable_receiver
+from posthog.models.user import User
+from posthog.models.utils import generate_random_token_secret, mask_key_value
+from posthog.permissions import TeamMemberStrictManagementPermission, TimeSensitiveActionPermission
+from posthog.scopes import API_SCOPE_ACTIONS
+
+MAX_PROJECT_API_KEYS_PER_PROJECT = 10
+
+PROJECT_SECRET_API_KEY_ALLOWED_SCOPES: tuple[str, ...] = tuple(
+    scope.value for scope in ProjectSecretAPIKeyAllowedScope if scope.value != "PLACEHOLDER"
+)
+
+
+@extend_schema(exclude=True)
+class ProjectSecretAPIKeyViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ModelViewSet):
+    scope_object = "project"
+    lookup_field = "id"
+    permission_classes = [TimeSensitiveActionPermission, TeamMemberStrictManagementPermission]
+    authentication_classes = [PersonalAPIKeyAuthentication, SessionAuthentication]
+
+    queryset = ProjectSecretAPIKey.objects.all()
+
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        return queryset.select_related("created_by")
+
+    def get_serializer_class(self):
+        return None  # We use Pydantic models instead
+
+    def _serialize_project_secret_api_key(
+        self, instance: ProjectSecretAPIKey, include_value: str | None = None
+    ) -> dict:
+        """Serialize a ProjectSecretAPIKey instance to a dictionary.
+
+        Args:
+            instance: The ProjectSecretAPIKey to serialize.
+            include_value: If provided, includes the raw API key value in the response.
+                          Used only for create and roll operations.
+        """
+        data = {
+            "id": str(instance.id),
+            "label": instance.label,
+            "mask_value": instance.mask_value,
+            "last_rolled_at": instance.last_rolled_at,
+            "last_used_at": instance.last_used_at,
+            "scopes": instance.scopes,
+            "created_at": instance.created_at,
+            "created_by": UserBasicSerializer(instance.created_by).data,
+        }
+        if include_value is not None:
+            data["value"] = include_value
+        return data
+
+    @extend_schema(request=ProjectSecretAPIKeyRequest, description="Create a new project secret API key")
+    def create(self, request: Request, *args, **kwargs) -> Response:
+        data = self.get_model(request.data, ProjectSecretAPIKeyRequest)
+
+        if not data.label or not data.label.strip():
+            raise ValidationError({"label": "This field is required."})
+        if not data.scopes:
+            raise ValidationError({"scopes": "This field is required."})
+
+        self.validate_scopes(data.scopes)
+        team = self.team
+        key_count = ProjectSecretAPIKey.objects.filter(team=team).count()
+        if key_count >= MAX_PROJECT_API_KEYS_PER_PROJECT:
+            raise ValidationError(
+                f"A team can have at most {MAX_PROJECT_API_KEYS_PER_PROJECT} secret API keys. Remove an existing key before creating a new one."
+            )
+
+        key_value = generate_random_token_secret()
+        masked_key_value = mask_key_value(key_value)
+        secure_key_value = hash_key_value(key_value)
+
+        try:
+            project_secret_api_key = ProjectSecretAPIKey.objects.create(
+                team=self.team,
+                label=data.label,
+                scopes=data.scopes,
+                secure_value=secure_key_value,
+                mask_value=masked_key_value,
+                created_by=cast(User, request.user),
+            )
+            return Response(
+                {
+                    "id": str(project_secret_api_key.id),
+                    "value": key_value,
+                    "label": project_secret_api_key.label,
+                    "created_at": project_secret_api_key.created_at,
+                    "scopes": project_secret_api_key.scopes,
+                },
+                status=status.HTTP_201_CREATED,
+            )
+        except IntegrityError as e:
+            if "unique_team_label" in str(e):
+                raise ValidationError(
+                    f"A secret API key with the label '{data.label}' already exists for this project."
+                )
+            capture_exception(e)
+            raise ValidationError("Failed to create project secret API key.")
+        except Exception as e:
+            capture_exception(e)
+            raise ValidationError("Failed to create project secret API key.")
+
+    def validate_scopes(self, scopes):
+        for scope in scopes:
+            if scope == "*":
+                raise ValidationError(
+                    "Wildcard scope '*' is not allowed for project API keys. Please specify explicit scopes."
+                )
+
+            scope_parts = scope.split(":")
+            if len(scope_parts) != 2 or scope_parts[1] not in API_SCOPE_ACTIONS:
+                raise ValidationError(f"Invalid scope: {scope}")
+
+            if scope not in PROJECT_SECRET_API_KEY_ALLOWED_SCOPES:
+                raise ValidationError(
+                    f"Scope '{scope}' is not available for project secret API keys. "
+                    f"Allowed scopes: {', '.join(PROJECT_SECRET_API_KEY_ALLOWED_SCOPES)}"
+                )
+        return scopes
+
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        queryset = self.filter_queryset(self.get_queryset())
+        keys_data = [self._serialize_project_secret_api_key(instance) for instance in queryset]
+        return Response(keys_data, status=status.HTTP_200_OK)
+
+    def retrieve(self, request: Request, *args, **kwargs) -> Response:
+        instance = self.get_object()
+        return Response(self._serialize_project_secret_api_key(instance), status=status.HTTP_200_OK)
+
+    @extend_schema(request=ProjectSecretAPIKeyRequest, description="Update project secret API key")
+    def update(self, request: Request, *args, **kwargs) -> Response:
+        instance = self.get_object()
+        data = self.get_model(request.data, ProjectSecretAPIKeyRequest)
+        if data.scopes:
+            self.validate_scopes(data.scopes)
+            instance.scopes = data.scopes
+        if data.label is not None:
+            stripped_label = data.label.strip()
+            if not stripped_label:
+                raise ValidationError({"label": "Label cannot be empty."})
+            instance.label = stripped_label
+
+        try:
+            instance.save()
+        except IntegrityError as e:
+            if "unique_team_label" in str(e):
+                raise ValidationError(
+                    f"A secret API key with the label '{instance.label}' already exists for this project."
+                )
+            capture_exception(e)
+            raise ValidationError("Failed to update project secret API key.")
+
+        return Response(self._serialize_project_secret_api_key(instance), status=status.HTTP_200_OK)
+
+    @extend_schema(description="Roll a project secret API key")
+    @action(methods=["POST"], detail=True, url_path="roll")
+    def roll(self, request: Request, *args, **kwargs) -> Response:
+        instance = self.get_object()
+
+        key_value = generate_random_token_secret()
+        masked_key_value = mask_key_value(key_value)
+        secure_key_value = hash_key_value(key_value)
+
+        instance.secure_value = secure_key_value
+        instance.mask_value = masked_key_value
+        instance.last_rolled_at = timezone.now()
+        instance.save()
+
+        return Response(
+            self._serialize_project_secret_api_key(instance, include_value=key_value), status=status.HTTP_200_OK
+        )
+
+    def destroy(self, request: Request, *args, **kwargs) -> Response:
+        instance = self.get_object()
+        instance.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@mutable_receiver(model_activity_signal, sender=ProjectSecretAPIKey)
+def handle_project_secret_api_key_change(
+    sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
+):
+    changes = changes_between(scope, previous=before_update, current=after_update)
+    log_project_secret_api_key_activity(after_update, activity, user, was_impersonated, changes)
+
+
+@receiver(pre_delete, sender=ProjectSecretAPIKey)
+def handle_project_secret_api_key_delete(sender, instance, **kwargs):
+    log_project_secret_api_key_activity(instance, "deleted", get_current_user(), get_was_impersonated())

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -33,7 +33,7 @@ from posthog.api.services.query import process_query_model
 from posthog.api.utils import action, is_insight_actors_options_query, is_insight_actors_query, is_insight_query
 from posthog.clickhouse.client.execute_async import cancel_query, get_query_status
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
-from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import AccessMethod, get_query_tag_value, get_query_tags, tag_queries
 from posthog.constants import AvailableFeature
 from posthog.errors import ExposedCHQueryError, InternalCHQueryError
 from posthog.exceptions_capture import capture_exception
@@ -147,7 +147,10 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 execution_mode=execution_mode,
                 query_id=client_query_id,
                 user=request.user,  # type: ignore[arg-type]
-                is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
+                is_query_service=(
+                    get_query_tag_value("access_method")
+                    in [AccessMethod.PERSONAL_API_KEY, AccessMethod.PROJECT_SECRET_API_KEY]
+                ),
                 limit_context=(
                     # QUERY_ASYNC provides extended max execution time for insight queries
                     LimitContext.QUERY_ASYNC
@@ -156,7 +159,8 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                         or is_insight_actors_query(query_dict)
                         or is_insight_actors_options_query(query_dict)
                     )
-                    and get_query_tag_value("access_method") != "personal_api_key"
+                    and get_query_tag_value("access_method")
+                    not in [AccessMethod.PERSONAL_API_KEY, AccessMethod.PROJECT_SECRET_API_KEY]
                     else None
                 ),
             )

--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -465,7 +465,7 @@ class TestPersonalAPIKeysWithScopeAPIAuthentication(PersonalAPIKeysBaseTest):
         self.key.save()
         response = self._do_request(f"/api/projects/{self.team.id}/search")
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert response.json()["detail"] == "This action does not support Personal API Key access"
+        assert response.json()["detail"] == "This action does not support API Key access"
 
     def test_special_handling_for_teams_still_forbids(self):
         response = self._do_request(f"/api/projects/{self.team.id}/")
@@ -512,7 +512,7 @@ class TestPersonalAPIKeysWithScopeAPIAuthentication(PersonalAPIKeysBaseTest):
     def test_errors_for_action_without_required_scopes(self):
         response = self._do_request(f"/api/projects/{self.team.id}/feature_flags/evaluation_reasons")
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert response.json()["detail"] == "This action does not support Personal API Key access"
+        assert response.json()["detail"] == "This action does not support API Key access"
 
     def test_forbids_action_with_other_scope(self):
         response = self._do_request(f"/api/projects/{self.team.id}/feature_flags/activity")

--- a/posthog/api/test/test_project_secret_api_keys.py
+++ b/posthog/api/test/test_project_secret_api_keys.py
@@ -1,0 +1,769 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models import ActivityLog
+from posthog.models.organization import Organization, OrganizationMembership
+from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+from posthog.models.project_secret_api_key import ProjectSecretAPIKey
+from posthog.models.team.team import Team
+from posthog.models.utils import generate_random_token_personal, generate_random_token_secret
+
+
+class ProjectSecretAPIKeysAdminTestBase(APIBaseTest):
+    """Base class for tests that require organization admin permissions."""
+
+    def setUp(self):
+        super().setUp()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+
+class TestProjectSecretAPIKeysAPI(ProjectSecretAPIKeysAdminTestBase):
+    def test_create_project_secret_api_key(self):
+        label = "Test project key"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": label, "scopes": ["feature_flag:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+        data = response.json()
+
+        key = ProjectSecretAPIKey.objects.get(id=data["id"])
+
+        self.assertEqual(
+            data,
+            {
+                "id": str(key.id),
+                "label": label,
+                "created_at": data["created_at"],
+                "scopes": ["feature_flag:read"],
+                "value": data["value"],
+            },
+        )
+        self.assertTrue(data["value"].startswith("phs_"))
+
+    def test_create_too_many_project_api_keys(self):
+        for i in range(0, 10):
+            self.client.post(
+                f"/api/projects/{self.team.id}/project_secret_api_keys",
+                {"label": f"key-{i}", "scopes": ["feature_flag:read"]},
+            )
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "key-11", "scopes": ["feature_flag:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("at most 10", response.json()["detail"])
+
+    def test_create_project_api_key_label_required(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys/",
+            {"label": "", "scopes": ["feature_flag:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertIn("label", str(data).lower())
+
+    def test_create_project_api_key_scopes_required(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys/",
+            {"label": "test"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertIn("scopes", str(data).lower())
+
+    @parameterized.expand(
+        [
+            (["feature_flag:read"], True),
+            (["feature_flag:write"], False),
+            (["query:read"], False),
+            (["insight:read"], False),
+            (["feature_flag:read", "query:read"], False),
+            (["feature_flag:read", "insight:read"], False),
+            (["*"], False),
+            (["invalid"], False),
+            (["feature_flag:invalid"], False),
+            (["dashboard:read"], False),
+            (["project:read"], False),
+        ]
+    )
+    def test_scope_validation(self, scopes, should_succeed):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "test", "scopes": scopes},
+        )
+        if should_succeed:
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(response.json()["scopes"], scopes)
+        else:
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertIn("scope", response.json()["detail"].lower())
+
+    def test_wildcard_scope_not_allowed(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "test", "scopes": ["*"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("validation error", response.json()["detail"].lower())
+
+    def test_update_project_api_key(self):
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="test-label",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+        response = self.client.put(
+            f"/api/projects/{self.team.id}/project_secret_api_keys/{key.id}",
+            {"label": "updated-test-label"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["id"], str(key.id))
+        self.assertEqual(data["label"], "updated-test-label")
+        self.assertEqual(data["scopes"], ["feature_flag:read"])
+
+    def test_delete_project_api_key(self):
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Test",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+        self.assertEqual(ProjectSecretAPIKey.objects.filter(team=self.team).count(), 1)
+        response = self.client.delete(f"/api/projects/{self.team.id}/project_secret_api_keys/{key.id}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(ProjectSecretAPIKey.objects.filter(team=self.team).count(), 0)
+        log = ActivityLog.objects.filter(scope="ProjectSecretAPIKey", activity="deleted", item_id=str(key.id)).first()
+        assert log is not None
+        self.assertEqual(log.team_id, self.team.id)
+
+    def test_activity_logged_on_create(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "Activity Test", "scopes": ["feature_flag:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+        key_id = response.json()["id"]
+        activity = ActivityLog.objects.filter(
+            scope="ProjectSecretAPIKey", activity="created", item_id=str(key_id)
+        ).first()
+        assert activity is not None
+        self.assertEqual(activity.team_id, self.team.id)
+        self.assertEqual(str(activity.organization_id), str(self.organization.id))
+        assert activity.detail is not None
+        self.assertEqual(activity.detail["name"], "Activity Test")
+        context = activity.detail.get("context")
+        self.assertEqual(context["project_name"], self.team.name)
+
+    def test_activity_logged_on_update(self):
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Initial",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+        response = self.client.put(
+            f"/api/projects/{self.team.id}/project_secret_api_keys/{key.id}",
+            {"label": "Updated"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        activity = (
+            ActivityLog.objects.filter(scope="ProjectSecretAPIKey", activity="updated", item_id=str(key.id))
+            .order_by("-created_at")
+            .first()
+        )
+        assert activity is not None
+        assert activity.detail is not None
+        changes = activity.detail.get("changes", [])
+        self.assertTrue(any(change["field"] == "label" for change in changes))
+
+    def test_list_only_team_project_api_keys(self):
+        my_label = "Test"
+        my_key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label=my_label,
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+        ProjectSecretAPIKey.objects.create(
+            team=other_team,
+            label="Other test",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        self.assertEqual(ProjectSecretAPIKey.objects.count(), 2)
+        response = self.client.get(f"/api/projects/{self.team.id}/project_secret_api_keys")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(len(response_data), 1)
+        key_data = response_data[0]
+
+        self.assertEqual(key_data["id"], str(my_key.id))
+        self.assertEqual(key_data["label"], my_label)
+        self.assertEqual(key_data["mask_value"], my_key.mask_value)
+        self.assertEqual(key_data["scopes"], ["feature_flag:read"])
+        self.assertEqual(key_data["created_by"]["id"], self.user.id)
+        self.assertIn("created_at", key_data)
+
+    def test_cannot_access_other_team_api_keys(self):
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+        other_key = ProjectSecretAPIKey.objects.create(
+            team=other_team,
+            label="Other test",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/project_secret_api_keys/{other_key.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        response = self.client.delete(f"/api/projects/{self.team.id}/project_secret_api_keys/{other_key.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_unique_label_per_team(self):
+        ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="duplicate-label",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "duplicate-label", "scopes": ["feature_flag:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("already exists", response.json()["detail"])
+
+    def test_same_label_different_teams(self):
+        ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="same-label",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+        other_user = self._create_user("other@test.com")
+        self.organization_membership = other_user.join(organization=other_org, level=OrganizationMembership.Level.ADMIN)
+
+        self.client.force_login(other_user)
+
+        response = self.client.post(
+            f"/api/projects/{other_team.id}/project_secret_api_keys",
+            {"label": "same-label", "scopes": ["feature_flag:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_roll_key(self):
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="same-label",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+        original_mask_value = key.mask_value
+        original_secure_value = key.secure_value
+
+        response = self.client.post(f"/api/projects/{self.team.id}/project_secret_api_keys/{key.id}/roll")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        key.refresh_from_db()
+
+        self.assertNotEqual(key.mask_value, original_mask_value)
+        self.assertNotEqual(key.secure_value, original_secure_value)
+        self.assertEqual(data["mask_value"], key.mask_value)
+        self.assertIsNotNone(key.last_rolled_at)
+        self.assertIn("value", data)
+        self.assertTrue(data["value"].startswith("phs_"))
+
+    def test_last_used_at_update_skips_cache_invalidation(self):
+        """Updating only last_used_at should not trigger cache invalidation."""
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Test Key",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        with patch("posthog.models.project_secret_api_key.invalidate_project_secret_api_key_cache") as mock_invalidate:
+            key.last_used_at = timezone.now()
+            key.save(update_fields=["last_used_at"])
+            mock_invalidate.assert_not_called()
+
+    def test_scopes_update_triggers_cache_invalidation(self):
+        """Updating scopes should trigger cache invalidation."""
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Test Key",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        with patch("posthog.models.project_secret_api_key.invalidate_project_secret_api_key_cache") as mock_invalidate:
+            key.scopes = ["feature_flag:read", "feature_flag:write"]
+            key.save(update_fields=["scopes"])
+            mock_invalidate.assert_called_once()
+
+
+class TestProjectSecretAPIKeyWithPersonalAPIKey(ProjectSecretAPIKeysAdminTestBase):
+    CONFIG_AUTO_LOGIN = False
+
+    def setUp(self):
+        super().setUp()
+        self.personal_key_value = generate_random_token_personal()
+        self.personal_key = PersonalAPIKey.objects.create(
+            label="Test Personal Key",
+            user=self.user,
+            secure_value=hash_key_value(self.personal_key_value),
+            scopes=["project:write"],
+        )
+
+    def _get_with_personal_key(self, url: str):
+        return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.personal_key_value}")
+
+    def _post_with_personal_key(self, url: str, data: dict):
+        return self.client.post(url, data, format="json", HTTP_AUTHORIZATION=f"Bearer {self.personal_key_value}")
+
+    def _delete_with_personal_key(self, url: str):
+        return self.client.delete(url, HTTP_AUTHORIZATION=f"Bearer {self.personal_key_value}")
+
+    def test_can_create_project_api_key_with_personal_key(self):
+        response = self._post_with_personal_key(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "Created via personal key", "scopes": ["feature_flag:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+        self.assertEqual(data["label"], "Created via personal key")
+        self.assertEqual(data["scopes"], ["feature_flag:read"])
+
+    def test_can_list_project_api_keys_with_personal_key(self):
+        ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Test Key",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        response = self._get_with_personal_key(f"/api/projects/{self.team.id}/project_secret_api_keys")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 1)
+
+    def test_can_delete_project_api_key_with_personal_key(self):
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Test Key",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        response = self._delete_with_personal_key(f"/api/projects/{self.team.id}/project_secret_api_keys/{key.id}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(ProjectSecretAPIKey.objects.filter(team=self.team).count(), 0)
+
+    def test_max_limit_enforced_with_personal_key(self):
+        for i in range(0, 10):
+            ProjectSecretAPIKey.objects.create(
+                team=self.team,
+                label=f"key-{i}",
+                secure_value=hash_key_value(generate_random_token_secret()),
+                scopes=["feature_flag:read"],
+                created_by=self.user,
+            )
+
+        response = self._post_with_personal_key(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "key-11", "scopes": ["feature_flag:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("at most 10", response.json()["detail"])
+
+    def test_personal_key_without_project_write_scope_fails(self):
+        self.personal_key.scopes = ["project:read"]
+        self.personal_key.save()
+
+        response = self._post_with_personal_key(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "Should fail", "scopes": ["feature_flag:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
+    CONFIG_AUTO_LOGIN = False
+
+    def setUp(self):
+        super().setUp()
+        self.key_value = generate_random_token_secret()
+        self.project_key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Test Project Key",
+            secure_value=hash_key_value(self.key_value),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+    def _get_with_project_key(self, url: str):
+        return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.key_value}")
+
+    def test_cannot_manage_project_keys_with_project_key(self):
+        response = self._get_with_project_key(f"/api/projects/{self.team.id}/project_secret_api_keys")
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_cannot_create_project_keys_with_project_key(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "Should fail", "scopes": ["feature_flag:read"]},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.key_value}",
+        )
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_cannot_delete_project_keys_with_project_key(self):
+        response = self.client.delete(
+            f"/api/projects/{self.team.id}/project_secret_api_keys/{self.project_key.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {self.key_value}",
+        )
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_can_access_local_evaluation_with_project_secret_key(self):
+        """Integration test: Project secret API key with feature_flag:read scope can access local_evaluation."""
+        from posthog.models import FeatureFlag
+
+        # Create a feature flag
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            name="Test Flag",
+            filters={"groups": [{"rollout_percentage": 100}]},
+            active=True,
+        )
+
+        # Use the project secret API key to call local_evaluation
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/feature_flags/local_evaluation",
+            HTTP_AUTHORIZATION=f"Bearer {self.key_value}",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("flags", data)
+        flag_keys = [flag["key"] for flag in data["flags"]]
+        self.assertIn("test-flag", flag_keys)
+
+    def test_local_evaluation_updates_last_used_at(self):
+        """Verify that using the key for local_evaluation updates last_used_at."""
+        from posthog.models import FeatureFlag
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            name="Test Flag",
+            filters={"groups": [{"rollout_percentage": 100}]},
+            active=True,
+        )
+
+        # Verify last_used_at is initially None
+        self.project_key.refresh_from_db()
+        self.assertIsNone(self.project_key.last_used_at)
+
+        # Call local_evaluation
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/feature_flags/local_evaluation",
+            HTTP_AUTHORIZATION=f"Bearer {self.key_value}",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Verify last_used_at is now set
+        self.project_key.refresh_from_db()
+        self.assertIsNotNone(self.project_key.last_used_at)
+
+    def test_cross_team_access_raises_not_found(self):
+        """ProjectSecretAPIKeyPermission raises NotFound for cross-team access."""
+        from unittest.mock import MagicMock
+
+        from posthog.auth import ProjectSecretAPIKeyAuthentication, ProjectSecretAPIKeyUser
+        from posthog.permissions import ProjectSecretAPIKeyPermission
+
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+
+        # Create a mock request authenticated with our project secret key
+        mock_request = MagicMock()
+        mock_request.successful_authenticator = MagicMock(spec=ProjectSecretAPIKeyAuthentication)
+        mock_request.user = MagicMock(spec=ProjectSecretAPIKeyUser)
+        mock_request.user.project_secret_api_key = self.project_key
+
+        # Create a mock view that resolves to the other team
+        mock_view = MagicMock()
+        mock_view.team_id = other_team.id
+
+        permission = ProjectSecretAPIKeyPermission()
+
+        # Should raise NotFound, not return False (which would be 403)
+        from rest_framework.exceptions import NotFound
+
+        with self.assertRaises(NotFound):
+            permission.has_permission(mock_request, mock_view)
+
+    def test_legacy_team_token_authentication_still_works(self):
+        """Team's secret_api_token should still work for local_evaluation (backward compat)."""
+        from posthog.models import FeatureFlag
+        from posthog.models.utils import generate_random_token_secret
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            name="Test Flag",
+            filters={"groups": [{"rollout_percentage": 100}]},
+            active=True,
+        )
+
+        legacy_token = generate_random_token_secret()
+        self.team.secret_api_token = legacy_token
+        self.team.save()
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/feature_flags/local_evaluation",
+            HTTP_AUTHORIZATION=f"Bearer {legacy_token}",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("flags", data)
+
+    def test_legacy_team_token_backup_authentication_still_works(self):
+        """Team's secret_api_token_backup should still work for local_evaluation (backward compat)."""
+        from posthog.models import FeatureFlag
+        from posthog.models.utils import generate_random_token_secret
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            name="Test Flag",
+            filters={"groups": [{"rollout_percentage": 100}]},
+            active=True,
+        )
+
+        # Simulate a recently rotated key
+        backup_token = generate_random_token_secret()
+        self.team.secret_api_token = generate_random_token_secret()
+        self.team.secret_api_token_backup = backup_token
+        self.team.save()
+
+        # The backup token should be cached during save, but we need to set it in cache
+        # since the save signal doesn't automatically cache the backup token
+        from posthog.models.team import set_team_in_cache
+
+        set_team_in_cache(backup_token, self.team)
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/feature_flags/local_evaluation",
+            HTTP_AUTHORIZATION=f"Bearer {backup_token}",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("flags", data)
+
+
+class TestProjectSecretAPIKeyErrorMessages(ProjectSecretAPIKeysAdminTestBase):
+    def test_invalid_scope_rejected_by_schema(self):
+        """Invalid scopes are rejected by Pydantic enum validation."""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "test", "scopes": ["invalid:scope"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # Pydantic enum validation rejects invalid scopes
+        self.assertIn("validation error", response.json()["detail"].lower())
+
+    def test_disallowed_scope_rejected_by_schema(self):
+        """Scopes not in the allowed enum are rejected by Pydantic."""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "test", "scopes": ["insight:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # Pydantic enum validation rejects scopes not in ProjectSecretAPIKeyAllowedScope
+        self.assertIn("validation error", response.json()["detail"].lower())
+
+
+class TestProjectSecretAPIKeyPermissions(APIBaseTest):
+    """Tests for organization-level permission requirements."""
+
+    def test_member_cannot_create_project_secret_api_key(self):
+        """Organization members should not be able to create project secret API keys."""
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "Test key", "scopes": ["feature_flag:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_member_cannot_update_project_secret_api_key(self):
+        """Organization members should not be able to update project secret API keys."""
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Original label",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        response = self.client.put(
+            f"/api/projects/{self.team.id}/project_secret_api_keys/{key.id}",
+            {"label": "Updated label"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_member_cannot_delete_project_secret_api_key(self):
+        """Organization members should not be able to delete project secret API keys."""
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Test key",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        response = self.client.delete(f"/api/projects/{self.team.id}/project_secret_api_keys/{key.id}/")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(ProjectSecretAPIKey.objects.filter(team=self.team).count(), 1)
+
+    def test_member_can_list_project_secret_api_keys(self):
+        """Organization members should be able to list (read) project secret API keys."""
+        ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Test key",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        response = self.client.get(f"/api/projects/{self.team.id}/project_secret_api_keys")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 1)
+
+    def test_member_can_retrieve_project_secret_api_key(self):
+        """Organization members should be able to retrieve (read) a specific project secret API key."""
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Test key",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        response = self.client.get(f"/api/projects/{self.team.id}/project_secret_api_keys/{key.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["label"], "Test key")
+
+    @parameterized.expand(
+        [
+            (OrganizationMembership.Level.ADMIN,),
+            (OrganizationMembership.Level.OWNER,),
+        ]
+    )
+    def test_admin_and_owner_can_create_project_secret_api_key(self, level):
+        """Organization admins and owners should be able to create project secret API keys."""
+        self.organization_membership.level = level
+        self.organization_membership.save()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "Test key", "scopes": ["feature_flag:read"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @parameterized.expand(
+        [
+            (OrganizationMembership.Level.ADMIN,),
+            (OrganizationMembership.Level.OWNER,),
+        ]
+    )
+    def test_admin_and_owner_can_update_project_secret_api_key(self, level):
+        """Organization admins and owners should be able to update project secret API keys."""
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Original label",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        self.organization_membership.level = level
+        self.organization_membership.save()
+
+        response = self.client.put(
+            f"/api/projects/{self.team.id}/project_secret_api_keys/{key.id}",
+            {"label": "Updated label"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["label"], "Updated label")
+
+    @parameterized.expand(
+        [
+            (OrganizationMembership.Level.ADMIN,),
+            (OrganizationMembership.Level.OWNER,),
+        ]
+    )
+    def test_admin_and_owner_can_delete_project_secret_api_key(self, level):
+        """Organization admins and owners should be able to delete project secret API keys."""
+        key = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Test key",
+            secure_value=hash_key_value(generate_random_token_secret()),
+            scopes=["feature_flag:read"],
+            created_by=self.user,
+        )
+
+        self.organization_membership.level = level
+        self.organization_membership.save()
+
+        response = self.client.delete(f"/api/projects/{self.team.id}/project_secret_api_keys/{key.id}/")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(ProjectSecretAPIKey.objects.filter(team=self.team).count(), 0)

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -22,11 +22,12 @@ from rest_framework.request import Request
 from webauthn.helpers import base64url_to_bytes
 from zxcvbn import zxcvbn
 
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import AccessMethod, tag_queries
 from posthog.helpers.two_factor_session import enforce_two_factor
 from posthog.jwt import PosthogJwtAudience, decode_jwt
 from posthog.models.oauth import OAuthAccessToken
 from posthog.models.personal_api_key import PERSONAL_API_KEY_MODES_TO_TRY, PersonalAPIKey, hash_key_value
+from posthog.models.project_secret_api_key import ProjectSecretAPIKey
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.user import User
 from posthog.models.webauthn_credential import WebauthnCredential
@@ -103,7 +104,18 @@ class SessionAuthentication(authentication.SessionAuthentication):
         return "Session"
 
 
-class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
+class APIKeyAuthentication:
+    def update_key_last_used_at(self, key_instance):
+        now = timezone.now()
+        key_last_used_at = key_instance.last_used_at
+        # Only updating last_used_at if the hour's changed
+        # This is to avoid excessive UPDATE queries, while still presenting accurate (down to the hour) info in the UI
+        if key_last_used_at is None or (now - key_last_used_at > timedelta(hours=1)):
+            key_instance.last_used_at = now
+            key_instance.save(update_fields=["last_used_at"])
+
+
+class PersonalAPIKeyAuthentication(authentication.BaseAuthentication, APIKeyAuthentication):
     """A way of authenticating with personal API keys.
     Only the first key candidate found in the request is tried, and the order is:
     1. Request Authorization header of type Bearer.
@@ -133,6 +145,12 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
                     "pha_"
                 ):  # TRICKY: This returns None to allow the next authentication method to have a go. This should be `if not token.startswith("phx_")`, but we need to support legacy personal api keys that may not have been prefixed with phx_.
                     return None
+                if token.startswith("phs_"):
+                    # Order of Authenticators matters.
+                    # If the ProjectSecretAPIKeyAuthentication was set on the view/method that one would fail before we get here if unsuccessful.
+                    # If not, we know that this API key shouldn't work on this endpoint.
+                    raise AuthenticationFailed("This endpoint does not support project secret API keys.")
+
                 return token, "Authorization header"
         data = request.data if request_data is None and isinstance(request, Request) else request_data
 
@@ -197,20 +215,14 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
 
         personal_api_key_object = self.validate_key(personal_api_key_with_source)
 
-        now = timezone.now()
-        key_last_used_at = personal_api_key_object.last_used_at
-        # Only updating last_used_at if the hour's changed
-        # This is to avoid excessive UPDATE queries, while still presenting accurate (down to the hour) info in the UI
-        if key_last_used_at is None or (now - key_last_used_at > timedelta(hours=1)):
-            personal_api_key_object.last_used_at = now
-            personal_api_key_object.save(update_fields=["last_used_at"])
+        self.update_key_last_used_at(personal_api_key_object)
         assert personal_api_key_object.user is not None
 
         # :KLUDGE: CHMiddleware does not receive the correct user when authenticating by api key.
         tag_queries(
             user_id=personal_api_key_object.user.pk,
             team_id=personal_api_key_object.user.current_team_id,
-            access_method="personal_api_key",
+            access_method=AccessMethod.PERSONAL_API_KEY,
             api_key_mask=personal_api_key_object.mask_value,
             api_key_label=personal_api_key_object.label,
         )
@@ -224,7 +236,7 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
         return cls.keyword
 
 
-class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
+class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication, APIKeyAuthentication):
     """
     Authenticates using a project secret API key. Unlike a personal API key, this is not associated with a
     user and should only be used for local_evaluation and flags remote_config (not to be confused with the
@@ -238,6 +250,7 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
     """
 
     keyword = "Bearer"
+    project_secret_api_key: Optional["ProjectSecretAPIKey"] = None
 
     @classmethod
     def find_secret_api_token(
@@ -258,6 +271,8 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
 
         if data and "secret_api_key" in data:
             return data["secret_api_key"]
+        elif data and "project_secret_api_key" in data:
+            return data["project_secret_api_key"]
 
         return None
 
@@ -267,35 +282,68 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
         if not secret_api_token:
             return None
 
-        # get the team from the secret api key
+        project_secret_api_key_result = ProjectSecretAPIKey.find_project_secret_api_key(secret_api_token)
+
+        if project_secret_api_key_result:
+            project_secret_api_key, _ = project_secret_api_key_result
+            self.project_secret_api_key = project_secret_api_key
+
+            self.update_key_last_used_at(project_secret_api_key)
+
+            tag_queries(
+                team_id=project_secret_api_key.team_id,
+                access_method=AccessMethod.PROJECT_SECRET_API_KEY,
+                api_key_mask=project_secret_api_key.mask_value,
+                api_key_label=project_secret_api_key.label,
+            )
+
+            return (ProjectSecretAPIKeyUser(project_secret_api_key.team, project_secret_api_key), None)
+
+        # For backwards compat with feature flags - fallback to team secret_api_token
         try:
             Team = apps.get_model(app_label="posthog", model_name="Team")
             team = Team.objects.get_team_from_cache_or_secret_api_token(secret_api_token)
 
             if team is None:
-                return None
+                raise AuthenticationFailed(detail="Project secret API key is invalid.")
 
-            # Secret api keys are not associated with a user, so we create a ProjectSecretAPIKeyUser
-            # and attach the team. The team is the important part here.
-            return (ProjectSecretAPIKeyUser(team), None)
+            # Team secret token = full access, no project_secret_api_key object
+            return (ProjectSecretAPIKeyUser(team, None), None)
         except Team.DoesNotExist:
-            return None
+            raise AuthenticationFailed(detail="Project secret API key is invalid.")
 
     @classmethod
     def authenticate_header(cls, request) -> str:
         return cls.keyword
 
 
-class ProjectSecretAPIKeyUser:
+class ProjectSecretAPIKeyUser(AnonymousUser):
     """
     A "synthetic" user object returned by the ProjectSecretAPIKeyAuthentication when authenticating with a project secret API key.
     """
 
-    def __init__(self, team):
+    pk: int  # type: ignore[assignment]
+    id: int  # type: ignore[assignment]
+
+    def __init__(self, team, project_secret_api_key: Optional["ProjectSecretAPIKey"] = None):
+        self.pk = -1
+        self.id = -1
         self.team = team
         self.current_team_id = team.id
-        self.is_authenticated = True
-        self.pk = -1
+        self.project_secret_api_key = project_secret_api_key
+        self.distinct_id = (
+            f"ph_secret_project_key:{self.project_secret_api_key.id}"
+            if self.project_secret_api_key
+            else "team_secret_api_token"
+        )
+        self.email = None
+
+    def __str__(self):
+        return f"ProjectSecretAPIKeyUser in project {self.current_team_id}"
+
+    @property
+    def is_authenticated(self):
+        return True
 
     def has_perm(self, perm, obj=None):
         return False
@@ -485,7 +533,7 @@ class OAuthAccessTokenAuthentication(authentication.BaseAuthentication):
             tag_queries(
                 user_id=access_token.user.pk,
                 team_id=access_token.user.current_team_id,
-                access_method="oauth",
+                access_method=AccessMethod.OAUTH,
             )
 
             return access_token.user, None

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -182,8 +182,9 @@ def sync_execute(
             pass
     tags = get_query_tags()
     is_personal_api_key = tags.access_method == AccessMethod.PERSONAL_API_KEY
+    is_api_key = tags.access_method in [AccessMethod.PERSONAL_API_KEY, AccessMethod.PROJECT_SECRET_API_KEY]
 
-    # When someone uses an API key, always put their query to the offline cluster
+    # When someone uses a personal API key, always put their query to the offline cluster
     # Execute all celery tasks not directly set to be online on the offline cluster
     if workload == Workload.DEFAULT and (is_personal_api_key or tags.kind == "celery"):
         workload = Workload.OFFLINE
@@ -192,7 +193,7 @@ def sync_execute(
     tags_id: str = tags.id or ""
     if tags_id == "posthog.tasks.tasks.process_query_task":
         workload = Workload.ONLINE
-        ch_user = ClickHouseUser.API if is_personal_api_key else ClickHouseUser.APP
+        ch_user = ClickHouseUser.API if is_api_key else ClickHouseUser.APP
 
     if tags.workload == Workload.ENDPOINTS:
         workload = Workload.ENDPOINTS
@@ -215,7 +216,7 @@ def sync_execute(
     tags.query_settings = core_settings
     query_type = tags.query_type or "Other"
     if ch_user == ClickHouseUser.DEFAULT:
-        if is_personal_api_key:
+        if is_api_key:
             ch_user = ClickHouseUser.API
         elif tags.kind == "request" and "api/" in tags_id and "capture" not in tags_id:
             # process requests made to API from the PH app

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -16,6 +16,7 @@ from posthog.schema import ProductKey
 
 class AccessMethod(StrEnum):
     PERSONAL_API_KEY = "personal_api_key"
+    PROJECT_SECRET_API_KEY = "project_secret_api_key"
     OAUTH = "oauth"
 
 

--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -29,14 +29,18 @@ def create_default_modifiers_for_user(
     else:
         modifiers = modifiers.model_copy()
 
-    modifiers.useMaterializedViews = posthoganalytics.feature_enabled(
-        "data-modeling",
-        str(user.distinct_id),
-        person_properties={
-            "email": user.email,
-        },
-        only_evaluate_locally=True,
-        send_feature_flag_events=False,
+    modifiers.useMaterializedViews = (
+        posthoganalytics.feature_enabled(
+            "data-modeling",
+            str(user.distinct_id),
+            person_properties={
+                "email": user.email,
+            },
+            only_evaluate_locally=True,
+            send_feature_flag_events=False,
+        )
+        if user.email
+        else True
     )
 
     return create_default_modifiers_for_team(team, modifiers)

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -87,7 +87,7 @@ from posthog.clickhouse.client.limit import (
     get_materialized_endpoints_rate_limiter,
     get_org_app_concurrency_limit,
 )
-from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
+from posthog.clickhouse.query_tagging import AccessMethod, get_query_tag_value, tag_queries
 from posthog.event_usage import groups
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_cache import count_query_cache_hit
@@ -1096,7 +1096,10 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         """
         concurrency_limit = self.get_api_queries_concurrency_limit()
         is_materialized_endpoint = get_query_tag_value("workload") == Workload.ENDPOINTS
-        is_api_key_access = get_query_tag_value("access_method") == "personal_api_key"
+        is_api_key_access = get_query_tag_value("access_method") in [
+            AccessMethod.PERSONAL_API_KEY,
+            AccessMethod.PROJECT_SECRET_API_KEY,
+        ]
 
         if self.is_query_service:
             tag_queries(chargeable=1)

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -66,6 +66,7 @@ ActivityScope = Literal[
     "TaggedItem",
     "Subscription",
     "PersonalAPIKey",
+    "ProjectSecretAPIKey",
     "User",
     "Action",
     "AlertConfiguration",
@@ -284,6 +285,9 @@ signal_exclusions: dict[ActivityScope, list[str]] = {
         "current_organization_id",
         "current_team_id",
     ],
+    "ProjectSecretAPIKey": [
+        "last_used_at",
+    ],
 }
 
 # Activity visibility restrictions - controls which users can see certain activity logs
@@ -460,6 +464,11 @@ field_exclusions: dict[ActivityScope, list[str]] = {
     ],
     "PersonalAPIKey": [
         "value",
+        "secure_value",
+        "last_used_at",
+        "last_rolled_at",
+    ],
+    "ProjectSecretAPIKey": [
         "secure_value",
         "last_used_at",
         "last_rolled_at",

--- a/posthog/models/activity_logging/project_secret_api_key_utils.py
+++ b/posthog/models/activity_logging/project_secret_api_key_utils.py
@@ -1,0 +1,90 @@
+import uuid
+import dataclasses
+from collections import namedtuple
+from typing import Optional
+
+from posthog.models.activity_logging.activity_log import (
+    ActivityContextBase,
+    Detail,
+    LogActivityEntry,
+    bulk_log_activity,
+)
+from posthog.models.activity_logging.personal_api_key_utils import get_organization_name, get_team_name
+from posthog.models.project_secret_api_key import ProjectSecretAPIKey
+from posthog.models.team.team import Team
+
+LogScope = namedtuple("LogScope", ["org_id", "team_id"])
+
+
+@dataclasses.dataclass(frozen=True)
+class ProjectSecretAPIKeyContext(ActivityContextBase):
+    organization_name: Optional[str] = None
+    project_name: Optional[str] = None
+    scopes: Optional[list[str]] = None
+    created_by_email: Optional[str] = None
+    created_by_name: Optional[str] = None
+
+
+def _get_team(api_key: ProjectSecretAPIKey) -> Optional[Team]:
+    """Return the team for the given API key, fetching it if needed."""
+    team = getattr(api_key, "team", None)
+    team_id = getattr(api_key, "team_id", None)
+
+    if team is not None and (team_id is None or team.id == team_id):
+        return team
+
+    if team_id is None:
+        return None
+
+    return Team.objects.select_related("organization").filter(id=team_id).first()
+
+
+def _get_access_location(api_key: ProjectSecretAPIKey) -> tuple[LogScope, Optional[Team]]:
+    team = _get_team(api_key)
+    org_id = str(team.organization_id) if team and team.organization_id else None
+    return LogScope(org_id, team.id if team else getattr(api_key, "team_id", None)), team
+
+
+def log_project_secret_api_key_activity(
+    api_key: ProjectSecretAPIKey, activity: str, user, was_impersonated: bool, changes=None
+) -> None:
+    """Create activity logs for ProjectSecretAPIKey operations scoped to the owning team."""
+    location, team = _get_access_location(api_key)
+
+    organization_name: Optional[str] = None
+    if team and team.organization:
+        organization_name = team.organization.name
+    elif location.org_id:
+        organization_name = get_organization_name(location.org_id)
+
+    project_name = getattr(team, "name", None) or get_team_name(location.team_id)
+
+    log_entries: list[LogActivityEntry] = []
+    context = ProjectSecretAPIKeyContext(
+        organization_name=organization_name,
+        project_name=project_name,
+        scopes=list(api_key.scopes or []),
+        created_by_email=getattr(api_key.created_by, "email", None),
+        created_by_name=api_key.created_by.get_full_name()
+        if api_key.created_by and api_key.created_by.get_full_name()
+        else getattr(api_key.created_by, "email", None),
+    )
+
+    log_entries.append(
+        {
+            "organization_id": uuid.UUID(location.org_id) if location.org_id else None,
+            "team_id": location.team_id,
+            "user": user,
+            "was_impersonated": was_impersonated,
+            "item_id": api_key.id,
+            "scope": "ProjectSecretAPIKey",
+            "activity": activity,
+            "detail": Detail(
+                changes=changes,
+                name=api_key.label,
+                context=context,
+            ),
+        }
+    )
+
+    bulk_log_activity(log_entries)

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -16,6 +16,7 @@ from posthog.auth import (
     OAuthAccessTokenAuthentication,
     PersonalAPIKeyAuthentication,
     ProjectSecretAPIKeyAuthentication,
+    ProjectSecretAPIKeyUser,
     SessionAuthentication,
     SharingAccessTokenAuthentication,
     SharingPasswordProtectedAuthentication,
@@ -423,6 +424,20 @@ class ScopeBasePermission(BasePermission):
 
         return None
 
+    def _check_required_scope_satisfied(self, key_scopes, required_scopes):
+        for required_scope in required_scopes:
+            valid_scopes = [required_scope]
+
+            # For all valid scopes with :read we also add :write
+            if required_scope.endswith(":read"):
+                valid_scopes.append(required_scope.replace(":read", ":write"))
+
+            if not any(scope in key_scopes for scope in valid_scopes):
+                self.message = f"API key missing required scope '{required_scope}'"
+                return False
+
+        return True
+
 
 class APIScopePermission(ScopeBasePermission):
     """
@@ -440,12 +455,21 @@ class APIScopePermission(ScopeBasePermission):
         # Helps devs remember to add it.
         self._get_scope_object(request, view)
 
-        # API Scopes apply to PersonalAPIKeyAuthentication and OAuthAccessTokenAuthentication
+        # API Scopes apply to PersonalAPIKeyAuthentication, ProjectSecretAPIKeyAuthentication and OAuthAccessTokenAuthentication
 
         if isinstance(request.successful_authenticator, PersonalAPIKeyAuthentication):
             key_scopes = request.successful_authenticator.personal_api_key.scopes
             # TRICKY: Legacy Personal API keys have no scopes and are allowed to do anything
             if not key_scopes:
+                return True
+        elif isinstance(request.successful_authenticator, ProjectSecretAPIKeyAuthentication):
+            key_scopes = []
+            if request.successful_authenticator.project_secret_api_key:
+                key_scopes = request.successful_authenticator.project_secret_api_key.scopes
+                if not key_scopes:
+                    self.message = "Project secret API key has no scopes and cannot access this resource"
+                    return False
+            else:
                 return True
         elif isinstance(request.successful_authenticator, OAuthAccessTokenAuthentication):
             # OAuth tokens store scopes as space-separated string
@@ -461,7 +485,7 @@ class APIScopePermission(ScopeBasePermission):
         required_scopes = self._get_required_scopes(request, view)
 
         if not required_scopes:
-            self.message = f"This action does not support Personal API Key access"
+            self.message = f"This action does not support API Key access"
             return False
 
         self.check_team_and_org_permissions(request, view)
@@ -469,18 +493,7 @@ class APIScopePermission(ScopeBasePermission):
         if "*" in key_scopes:
             return True
 
-        for required_scope in required_scopes:
-            valid_scopes = [required_scope]
-
-            # For all valid scopes with :read we also add :write
-            if required_scope.endswith(":read"):
-                valid_scopes.append(required_scope.replace(":read", ":write"))
-
-            if not any(scope in key_scopes for scope in valid_scopes):
-                self.message = f"API key missing required scope '{required_scope}'"
-                return False
-
-        return True
+        return self._check_required_scope_satisfied(key_scopes, required_scopes)
 
     def check_team_and_org_permissions(self, request, view) -> None:
         scope_object = self._get_scope_object(request, view)
@@ -495,6 +508,9 @@ class APIScopePermission(ScopeBasePermission):
         elif isinstance(request.successful_authenticator, PersonalAPIKeyAuthentication):
             scoped_organizations = request.successful_authenticator.personal_api_key.scoped_organizations
             scoped_teams = request.successful_authenticator.personal_api_key.scoped_teams
+        elif isinstance(request.successful_authenticator, ProjectSecretAPIKeyAuthentication):
+            scoped_teams = [request.user.team.id]
+            scoped_organizations = []
         else:
             raise ValueError("Unexpected authentication type")
 
@@ -729,6 +745,67 @@ class ProjectSecretAPITokenPermission(BasePermission):
             return True
 
         return authenticated_team.id == resolved_team.id
+
+
+class ProjectSecretAPIKeyPermission(ScopeBasePermission):
+    """
+    Permission class for project secret API key authentication.
+
+    Validates:
+    1. Request is authenticated with ProjectSecretAPIKeyAuthentication
+    2. If authenticated with a managed ProjectSecretAPIKey (not team token), validate scopes
+    3. Key's project matches the resolved project
+    """
+
+    message = "Project secret API key does not have required permissions"
+
+    def has_permission(self, request: Request, view) -> bool:
+        if not isinstance(request.successful_authenticator, ProjectSecretAPIKeyAuthentication):
+            return True
+
+        # If not using ProjectSecretAPIKeyUser, pass through
+        if not isinstance(request.user, ProjectSecretAPIKeyUser):
+            return True
+
+        # Legacy team secret_api_token: no scopes to check. Endpoint restriction
+        # is enforced by ProjectSecretAPITokenPermission, not here.
+        if request.user.project_secret_api_key is None:
+            return True
+
+        project_secret_api_key = request.user.project_secret_api_key
+
+        try:
+            view_team_id = view.team_id
+            if project_secret_api_key.team_id != view_team_id:
+                raise NotFound()
+        except AttributeError:
+            # not a team view
+            return False
+
+        key_scopes = set(project_secret_api_key.scopes or [])
+        required_scopes = self._get_required_scopes(request, view)
+
+        if not required_scopes:
+            self.message = "This action does not support Project Secret API Key access"
+            return False
+
+        return self._check_required_scope_satisfied(key_scopes, required_scopes)
+
+    def has_object_permission(self, request: Request, view, obj) -> bool:
+        if not isinstance(request.successful_authenticator, ProjectSecretAPIKeyAuthentication):
+            return True
+
+        if not isinstance(request.user, ProjectSecretAPIKeyUser):
+            return True
+
+        # Validate key's project matches the object's project
+        team = request.user.team
+        if hasattr(obj, "team") and obj.team is not None:
+            return obj.team.id == team.id
+        elif hasattr(obj, "team_id") and obj.team_id is not None:
+            return obj.team_id == team.id
+
+        return False
 
 
 class UserCanInvitePermission(BasePermission):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2955,6 +2955,19 @@ class ProductKey(StrEnum):
     WORKFLOWS = "workflows"
 
 
+class ProjectSecretAPIKeyAllowedScope(StrEnum):
+    FEATURE_FLAG_READ = "feature_flag:read"
+    PLACEHOLDER = "PLACEHOLDER"
+
+
+class ProjectSecretAPIKeyRequest(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    label: str | None = None
+    scopes: list[ProjectSecretAPIKeyAllowedScope] | None = None
+
+
 class PropertyFilterType(StrEnum):
     META = "meta"
     EVENT = "event"

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -34,7 +34,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.batch_exports.models import BatchExport, BatchExportDestination, BatchExportRun
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import AccessMethod, tag_queries
 from posthog.cloud_utils import TEST_clear_instance_license_cache
 from posthog.hogql_queries.events_query_runner import EventsQueryRunner
 from posthog.models import Organization, Plugin, Team
@@ -1150,7 +1150,7 @@ class TestHogQLUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTa
         flush_persons_and_events()
         sync_execute("SYSTEM FLUSH LOGS")
         sync_execute("TRUNCATE TABLE system.query_log")
-        tag_queries(kind="request", id="1", access_method="personal_api_key", chargeable=1)
+        tag_queries(kind="request", id="1", access_method=AccessMethod.PERSONAL_API_KEY, chargeable=1)
 
         execute_hogql_query(
             query="select * from events limit 400",

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -28,7 +28,7 @@ from posthog import version_requirement
 from posthog.batch_exports.models import BatchExportDestination, BatchExportRun
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import AccessMethod, Product, tags_context
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.constants import FlagRequestType
 from posthog.exceptions_capture import capture_exception
@@ -1853,19 +1853,19 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
             period_start,
             period_end,
             metric="read_bytes",
-            access_method="personal_api_key",
+            access_method=AccessMethod.PERSONAL_API_KEY,
         ),
         "teams_with_query_api_rows_read": get_teams_with_query_metric(
             period_start,
             period_end,
             metric="read_rows",
-            access_method="personal_api_key",
+            access_method=AccessMethod.PERSONAL_API_KEY,
         ),
         "teams_with_query_api_duration_ms": get_teams_with_query_metric(
             period_start,
             period_end,
             metric="query_duration_ms",
-            access_method="personal_api_key",
+            access_method=AccessMethod.PERSONAL_API_KEY,
         ),
         "teams_with_api_queries_count": api_queries_usage["count"],
         "teams_with_api_queries_read_bytes": api_queries_usage["read_bytes"],
@@ -1895,21 +1895,21 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
             period_end,
             metric="read_bytes",
             query_types=["EventsQuery"],
-            access_method="personal_api_key",
+            access_method=AccessMethod.PERSONAL_API_KEY,
         ),
         "teams_with_event_explorer_api_rows_read": get_teams_with_query_metric(
             period_start,
             period_end,
             metric="read_rows",
             query_types=["EventsQuery"],
-            access_method="personal_api_key",
+            access_method=AccessMethod.PERSONAL_API_KEY,
         ),
         "teams_with_event_explorer_api_duration_ms": get_teams_with_query_metric(
             period_start,
             period_end,
             metric="query_duration_ms",
             query_types=["EventsQuery"],
-            access_method="personal_api_key",
+            access_method=AccessMethod.PERSONAL_API_KEY,
         ),
         "teams_with_survey_responses_count_in_period": get_teams_with_survey_responses_count_in_period(
             period_start, period_end

--- a/posthog/test/test_permissions.py
+++ b/posthog/test/test_permissions.py
@@ -602,7 +602,7 @@ class TestOAuthAccessTokenAPIScopePermission(BaseTest):
         self.access_token.save()
         response = self._do_request(f"/api/projects/{self.team.id}/search")
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()["detail"], "This action does not support Personal API Key access")
+        self.assertEqual(response.json()["detail"], "This action does not support API Key access")
 
     def test_allows_derived_scope_for_read(self):
         """OAuth token with feature_flag:read can read feature flags"""


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Splits #39865 - second part. API and authenticator changes.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- adds an authenticator class for ProjectSecretAPIKey
- adjusts the permissions
- adds the API for project secret API key (pretty much the same thing as personal api key)

## How did you test this code?
- locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no