### PR TITLE
feat(LogsViewer): implement AI-powered log analysis tab in LogDetailsModal

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -196,6 +196,7 @@ import {
     ErrorTrackingRuleType,
 } from 'products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/types'
 import { SymbolSetOrder } from 'products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/symbol_sets/symbolSetLogic'
+import { LogExplanation } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/types'
 import type {
     SessionGroupSummaryListItemType,
     SessionGroupSummaryType,
@@ -679,7 +680,7 @@ export class ApiRequest {
     }
 
     public logsExplainWithAI(projectId?: ProjectType['id']): ApiRequest {
-        return this.environmentsDetail(projectId).addPathComponent('logs').addPathComponent('explainLogWithAI')
+        return this.logs(projectId).addPathComponent('explainLogWithAI')
     }
 
     // # Data management
@@ -2309,23 +2310,7 @@ const api = {
                 .get()
                 .then((response) => Boolean(response.hasLogs))
         },
-        async explain(
-            uuid: string,
-            timestamp: string
-        ): Promise<{
-            headline: string
-            severity_assessment: 'ok' | 'warning' | 'error' | 'critical'
-            impact_summary: string
-            probable_causes: Array<{ hypothesis: string; confidence: 'high' | 'medium' | 'low'; reasoning: string }>
-            immediate_actions: Array<{ action: string; priority: 'now' | 'soon' | 'later'; why: string }>
-            technical_explanation: string
-            key_fields: Array<{
-                field: string
-                value: string
-                significance: string
-                attribute_type: 'log' | 'resource'
-            }>
-        }> {
+        async explain(uuid: string, timestamp: string): Promise<LogExplanation> {
             return new ApiRequest().logsExplainWithAI().create({ data: { uuid, timestamp } })
         },
     },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -678,6 +678,10 @@ export class ApiRequest {
         return this.logs(projectId).addPathComponent('has_logs')
     }
 
+    public logsExplainWithAI(projectId?: ProjectType['id']): ApiRequest {
+        return this.environmentsDetail(projectId).addPathComponent('logs').addPathComponent('explainLogWithAI')
+    }
+
     // # Data management
     public eventDefinitions(projectId?: ProjectType['id']): ApiRequest {
         return this.projectsDetail(projectId).addPathComponent('event_definitions')
@@ -2304,6 +2308,25 @@ const api = {
                 .logsHasLogs()
                 .get()
                 .then((response) => Boolean(response.hasLogs))
+        },
+        async explain(
+            uuid: string,
+            timestamp: string
+        ): Promise<{
+            headline: string
+            severity_assessment: 'ok' | 'warning' | 'error' | 'critical'
+            impact_summary: string
+            probable_causes: Array<{ hypothesis: string; confidence: 'high' | 'medium' | 'low'; reasoning: string }>
+            immediate_actions: Array<{ action: string; priority: 'now' | 'soon' | 'later'; why: string }>
+            technical_explanation: string
+            key_fields: Array<{
+                field: string
+                value: string
+                significance: string
+                attribute_type: 'log' | 'resource'
+            }>
+        }> {
+            return new ApiRequest().logsExplainWithAI().create({ data: { uuid, timestamp } })
         },
     },
 

--- a/frontend/src/scenes/comments/CommentsList.tsx
+++ b/frontend/src/scenes/comments/CommentsList.tsx
@@ -8,7 +8,11 @@ import { PhonePairHogs } from 'lib/components/hedgehogs'
 import { CommentWithReplies } from './Comment'
 import { CommentsLogicProps, commentsLogic } from './commentsLogic'
 
-export const CommentsList = (props: CommentsLogicProps): JSX.Element => {
+export interface CommentsListProps extends CommentsLogicProps {
+    noun?: string
+}
+
+export const CommentsList = ({ noun = 'page', ...props }: CommentsListProps): JSX.Element => {
     const { key, commentsWithReplies, commentsLoading } = useValues(commentsLogic(props))
     const { loadComments } = useActions(commentsLogic(props))
 
@@ -31,8 +35,8 @@ export const CommentsList = (props: CommentsLogicProps): JSX.Element => {
                         </div>
                         <h2>Start the discussion!</h2>
                         <p>
-                            You can add comments about this page for your team members to see. Great for sharing context
-                            or ideas without getting in the way of the thing you are commenting on
+                            You can add comments about this {noun} for your team members to see. Great for sharing
+                            context or ideas without getting in the way of the thing you are commenting on
                         </p>
                     </div>
                 ) : null}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
@@ -1,11 +1,15 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonCheckbox, LemonModal } from '@posthog/lemon-ui'
+import { LemonCheckbox, LemonModal, LemonTabs } from '@posthog/lemon-ui'
 
 import { JSONViewer } from 'lib/components/JSONViewer'
 import { TZLabel } from 'lib/components/TZLabel'
 
-import { logDetailsModalLogic } from './logDetailsModalLogic'
+import { PropertyFilterType, PropertyOperator } from '~/types'
+
+import { logsViewerLogic } from '../logsViewerLogic'
+import { LogExploreAI } from './Tabs/ExploreWithAI'
+import { LogDetailsTab, logDetailsModalLogic } from './logDetailsModalLogic'
 
 const SEVERITY_COLORS: Record<string, string> = {
     trace: 'bg-muted-alt',
@@ -44,8 +48,16 @@ interface LogDetailsModalProps {
 }
 
 export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element | null {
-    const { isOpen, selectedLog, jsonParseAllFields } = useValues(logDetailsModalLogic)
-    const { closeLogDetails, setJsonParseAllFields } = useActions(logDetailsModalLogic)
+    const { isOpen, selectedLog, jsonParseAllFields, activeTab } = useValues(logDetailsModalLogic)
+    const { closeLogDetails, setJsonParseAllFields, setActiveTab } = useActions(logDetailsModalLogic)
+    const { addFilter } = useActions(logsViewerLogic)
+
+    const handleApplyFilter = (key: string, value: string, attributeType: 'log' | 'resource'): void => {
+        const filterType =
+            attributeType === 'resource' ? PropertyFilterType.LogResourceAttribute : PropertyFilterType.LogAttribute
+        addFilter(key, value, PropertyOperator.Exact, filterType)
+        closeLogDetails()
+    }
 
     if (!selectedLog) {
         return null
@@ -91,19 +103,42 @@ export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element
                     </div>
                 </LemonModal.Header>
                 <LemonModal.Content>
-                    <div className="flex flex-col gap-2">
-                        <div className="flex items-center">
-                            <LemonCheckbox
-                                checked={jsonParseAllFields}
-                                onChange={setJsonParseAllFields}
-                                label="JSON parse all fields"
-                                size="small"
-                            />
-                        </div>
-                        <div className="p-2 bg-bg-light rounded overflow-auto">
-                            <JSONViewer src={displayData} collapsed={2} sortKeys />
-                        </div>
-                    </div>
+                    <LemonTabs
+                        activeKey={activeTab}
+                        onChange={(key) => setActiveTab(key as LogDetailsTab)}
+                        tabs={[
+                            {
+                                key: 'details',
+                                label: 'Details',
+                                content: (
+                                    <div className="flex flex-col gap-2">
+                                        <div className="flex items-center">
+                                            <LemonCheckbox
+                                                checked={jsonParseAllFields}
+                                                onChange={setJsonParseAllFields}
+                                                label="JSON parse all fields"
+                                                size="small"
+                                            />
+                                        </div>
+                                        <div className="p-2 bg-bg-light rounded overflow-auto">
+                                            <JSONViewer src={displayData} collapsed={2} sortKeys />
+                                        </div>
+                                    </div>
+                                ),
+                            },
+                            {
+                                key: 'explore-ai',
+                                label: 'Explore with AI',
+                                content: (
+                                    <LogExploreAI
+                                        logUuid={selectedLog.uuid}
+                                        logTimestamp={selectedLog.timestamp}
+                                        onApplyFilter={handleApplyFilter}
+                                    />
+                                ),
+                            },
+                        ]}
+                    />
                 </LemonModal.Content>
             </div>
         </LemonModal>

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/EmptyState.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/EmptyState.tsx
@@ -1,0 +1,34 @@
+import { IconAIText } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
+
+export interface EmptyStateProps {
+    onGenerate: () => void
+    dataProcessingAccepted: boolean
+    loading: boolean
+}
+
+export function EmptyState({ onGenerate, dataProcessingAccepted, loading }: EmptyStateProps): JSX.Element {
+    return (
+        <div className="flex flex-col items-center justify-center gap-4 p-8">
+            <IconAIText className="text-4xl text-muted" />
+            <div className="text-center">
+                <h4 className="font-semibold m-0">AI-powered incident analysis</h4>
+                <p className="text-muted text-sm mt-1 mb-0">Get log analysis & prioritized actions.</p>
+            </div>
+            <AIConsentPopoverWrapper showArrow onApprove={onGenerate} hidden={loading}>
+                <LemonButton
+                    type="primary"
+                    onClick={dataProcessingAccepted ? onGenerate : undefined}
+                    loading={loading}
+                    disabledReason={
+                        !dataProcessingAccepted ? 'AI data processing must be approved to generate analysis' : undefined
+                    }
+                >
+                    Analyze this log
+                </LemonButton>
+            </AIConsentPopoverWrapper>
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/ExplanationContent.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/ExplanationContent.tsx
@@ -1,0 +1,80 @@
+import { LemonCollapse } from '@posthog/lemon-ui'
+
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+
+import { ImmediateActionsSection } from './ImmediateActionsSection'
+import { KeyFieldsSection } from './KeyFieldsSection'
+import { ProbableCausesSection } from './ProbableCausesSection'
+import { SeverityBanner } from './SeverityBanner'
+import { SEVERITY_CONFIG } from './constants'
+import { LogExplanation } from './types'
+
+export interface ExplanationContentProps {
+    explanation: LogExplanation
+    onApplyFilter?: (filterKey: string, filterValue: string, attributeType: 'log' | 'resource') => void
+}
+
+export function ExplanationContent({ explanation, onApplyFilter }: ExplanationContentProps): JSX.Element {
+    // Handle both new and potentially cached old schema responses
+    const headline = explanation.headline ?? 'Log Analysis'
+    const impactSummary = explanation.impact_summary ?? ''
+    const technicalExplanation = explanation.technical_explanation ?? ''
+    const severityAssessment = explanation.severity_assessment ?? 'ok'
+
+    const config = SEVERITY_CONFIG[severityAssessment] ?? SEVERITY_CONFIG.ok
+    const isCriticalOrError = severityAssessment === 'critical' || severityAssessment === 'error'
+
+    const probableCauses = explanation.probable_causes ?? []
+    const immediateActions = explanation.immediate_actions ?? []
+    const keyFields = explanation.key_fields ?? []
+
+    const collapsePanels = [
+        probableCauses.length > 0 && {
+            key: 'causes',
+            header: `AI hypotheses (${probableCauses.length})`,
+            content: <ProbableCausesSection causes={probableCauses} />,
+        },
+        immediateActions.length > 0 && {
+            key: 'actions',
+            header: `Suggested actions (${immediateActions.filter((a) => a.priority === 'now').length} urgent)`,
+            content: <ImmediateActionsSection actions={immediateActions} />,
+        },
+        keyFields.length > 0 && {
+            key: 'fields',
+            header: `Key fields (${keyFields.length})`,
+            content: <KeyFieldsSection fields={keyFields} onApplyFilter={onApplyFilter} />,
+        },
+    ].filter(Boolean)
+
+    return (
+        <div className="flex flex-col gap-3">
+            {/* Severity Banner */}
+            <SeverityBanner
+                type={config.banner}
+                headline={headline}
+                impact={impactSummary}
+                severityLabel={config.label}
+            />
+
+            {/* Technical Explanation */}
+            {technicalExplanation && (
+                <div className="bg-bg-light rounded p-3 text-sm">
+                    <LemonMarkdown>{technicalExplanation}</LemonMarkdown>
+                </div>
+            )}
+
+            {/* Collapsible Sections */}
+            <LemonCollapse
+                panels={collapsePanels}
+                multiple
+                defaultActiveKeys={isCriticalOrError ? ['causes', 'actions', 'fields'] : ['actions']}
+                size="small"
+            />
+
+            {/* AI Disclaimer */}
+            <p className="text-xs text-muted text-center mt-2 mb-0">
+                This analysis is AI-generated and may be inaccurate. Always verify with your own investigation.
+            </p>
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/ExplanationContent.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/ExplanationContent.tsx
@@ -15,34 +15,34 @@ export interface ExplanationContentProps {
 }
 
 export function ExplanationContent({ explanation, onApplyFilter }: ExplanationContentProps): JSX.Element {
-    // Handle both new and potentially cached old schema responses
-    const headline = explanation.headline ?? 'Log Analysis'
-    const impactSummary = explanation.impact_summary ?? ''
-    const technicalExplanation = explanation.technical_explanation ?? ''
-    const severityAssessment = explanation.severity_assessment ?? 'ok'
+    const {
+        headline,
+        impact_summary,
+        technical_explanation,
+        severity_assessment,
+        probable_causes,
+        immediate_actions,
+        key_fields,
+    } = explanation
 
-    const config = SEVERITY_CONFIG[severityAssessment] ?? SEVERITY_CONFIG.ok
-    const isCriticalOrError = severityAssessment === 'critical' || severityAssessment === 'error'
-
-    const probableCauses = explanation.probable_causes ?? []
-    const immediateActions = explanation.immediate_actions ?? []
-    const keyFields = explanation.key_fields ?? []
+    const config = SEVERITY_CONFIG[severity_assessment]
+    const isCriticalOrError = severity_assessment === 'critical' || severity_assessment === 'error'
 
     const collapsePanels = [
-        probableCauses.length > 0 && {
+        probable_causes.length > 0 && {
             key: 'causes',
-            header: `AI hypotheses (${probableCauses.length})`,
-            content: <ProbableCausesSection causes={probableCauses} />,
+            header: `AI hypotheses (${probable_causes.length})`,
+            content: <ProbableCausesSection causes={probable_causes} />,
         },
-        immediateActions.length > 0 && {
+        immediate_actions.length > 0 && {
             key: 'actions',
-            header: `Suggested actions (${immediateActions.filter((a) => a.priority === 'now').length} urgent)`,
-            content: <ImmediateActionsSection actions={immediateActions} />,
+            header: `Suggested actions (${immediate_actions.filter((a) => a.priority === 'now').length} urgent)`,
+            content: <ImmediateActionsSection actions={immediate_actions} />,
         },
-        keyFields.length > 0 && {
+        key_fields.length > 0 && {
             key: 'fields',
-            header: `Key fields (${keyFields.length})`,
-            content: <KeyFieldsSection fields={keyFields} onApplyFilter={onApplyFilter} />,
+            header: `Key fields (${key_fields.length})`,
+            content: <KeyFieldsSection fields={key_fields} onApplyFilter={onApplyFilter} />,
         },
     ].filter(Boolean)
 
@@ -52,14 +52,14 @@ export function ExplanationContent({ explanation, onApplyFilter }: ExplanationCo
             <SeverityBanner
                 type={config.banner}
                 headline={headline}
-                impact={impactSummary}
+                impact={impact_summary}
                 severityLabel={config.label}
             />
 
             {/* Technical Explanation */}
-            {technicalExplanation && (
+            {technical_explanation && (
                 <div className="bg-bg-light rounded p-3 text-sm">
-                    <LemonMarkdown>{technicalExplanation}</LemonMarkdown>
+                    <LemonMarkdown>{technical_explanation}</LemonMarkdown>
                 </div>
             )}
 

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/ImmediateActionsSection.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/ImmediateActionsSection.tsx
@@ -1,0 +1,33 @@
+import { LemonTag, Tooltip } from '@posthog/lemon-ui'
+
+import { PRIORITY_TAG_TYPE, PRIORITY_TOOLTIP } from './constants'
+import { ImmediateAction } from './types'
+
+export interface ImmediateActionsSectionProps {
+    actions: ImmediateAction[]
+}
+
+export function ImmediateActionsSection({ actions }: ImmediateActionsSectionProps): JSX.Element {
+    const sortedActions = [...actions].sort((a, b) => {
+        const order: Record<string, number> = { now: 0, soon: 1, later: 2 }
+        return (order[a.priority] ?? 2) - (order[b.priority] ?? 2)
+    })
+
+    return (
+        <div className="flex flex-col gap-2 p-2">
+            {sortedActions.map((action, index) => (
+                <div key={index} className="flex items-start gap-2 p-2 bg-bg-light rounded">
+                    <Tooltip title={PRIORITY_TOOLTIP[action.priority]}>
+                        <LemonTag type={PRIORITY_TAG_TYPE[action.priority] ?? 'muted'} size="small">
+                            {action.priority.toUpperCase()}
+                        </LemonTag>
+                    </Tooltip>
+                    <div className="flex flex-col gap-0.5">
+                        <span className="text-sm font-medium">{action.action}</span>
+                        <span className="text-xs text-muted">{action.why}</span>
+                    </div>
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/KeyFieldsSection.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/KeyFieldsSection.tsx
@@ -1,0 +1,44 @@
+import { IconSearch } from '@posthog/icons'
+import { LemonButton, Tooltip } from '@posthog/lemon-ui'
+
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+
+import { KeyField } from './types'
+
+export interface KeyFieldsSectionProps {
+    fields: KeyField[]
+    onApplyFilter?: (filterKey: string, filterValue: string, attributeType: 'log' | 'resource') => void
+}
+
+export function KeyFieldsSection({ fields, onApplyFilter }: KeyFieldsSectionProps): JSX.Element {
+    return (
+        <div className="flex flex-col gap-1 p-2">
+            {fields.map((field, index) => (
+                <div key={index} className="flex items-center gap-2 p-2 bg-bg-light rounded text-sm">
+                    <span className="font-mono text-muted shrink-0">{field.field}:</span>
+                    <CopyToClipboardInline explicitValue={field.value} className="font-mono truncate">
+                        {field.value.length > 40 ? `${field.value.slice(0, 40)}...` : field.value}
+                    </CopyToClipboardInline>
+                    {onApplyFilter && (
+                        <Tooltip title="Filter logs by this value">
+                            <LemonButton
+                                size="xsmall"
+                                icon={<IconSearch />}
+                                onClick={() =>
+                                    onApplyFilter(
+                                        field.field,
+                                        field.value,
+                                        field.attribute_type === 'resource' ? 'resource' : 'log'
+                                    )
+                                }
+                            />
+                        </Tooltip>
+                    )}
+                    <Tooltip title={field.significance}>
+                        <span className="text-warning text-xs">⚠️</span>
+                    </Tooltip>
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/KeyFieldsSection.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/KeyFieldsSection.tsx
@@ -1,4 +1,4 @@
-import { IconSearch } from '@posthog/icons'
+import { IconInfo, IconSearch } from '@posthog/icons'
 import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
@@ -35,7 +35,7 @@ export function KeyFieldsSection({ fields, onApplyFilter }: KeyFieldsSectionProp
                         </Tooltip>
                     )}
                     <Tooltip title={field.significance}>
-                        <span className="text-warning text-xs">⚠️</span>
+                        <IconInfo className="text-muted-alt shrink-0" />
                     </Tooltip>
                 </div>
             ))}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/LoadingState.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/LoadingState.tsx
@@ -1,0 +1,23 @@
+import { IconAIText } from '@posthog/icons'
+import { LemonSkeleton } from '@posthog/lemon-ui'
+
+export function LoadingState(): JSX.Element {
+    return (
+        <div className="flex flex-col gap-4 p-4">
+            <div className="flex items-center gap-2 text-muted">
+                <IconAIText className="text-lg animate-pulse" />
+                <span>Analyzing log... Hold on tight!</span>
+            </div>
+            <LemonSkeleton className="h-12 w-full" />
+            <LemonSkeleton className="h-6 w-3/4" />
+            <LemonSkeleton className="h-4 w-full" />
+            <LemonSkeleton className="h-4 w-full" />
+            <LemonSkeleton className="h-4 w-2/3" />
+            <div className="flex gap-2 mt-2">
+                <LemonSkeleton className="h-8 w-24" />
+                <LemonSkeleton className="h-8 w-32" />
+                <LemonSkeleton className="h-8 w-28" />
+            </div>
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/LogExploreAITab.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/LogExploreAITab.tsx
@@ -1,0 +1,58 @@
+import { useActions, useValues } from 'kea'
+import { BindLogic } from 'kea'
+
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { EmptyState } from './EmptyState'
+import { ExplanationContent } from './ExplanationContent'
+import { LoadingState } from './LoadingState'
+import { LogExploreAILogicProps, logExploreAILogic } from './logExploreAILogic'
+
+export interface LogExploreAITabProps {
+    logUuid: string
+    logTimestamp: string
+    onApplyFilter?: (filterKey: string, filterValue: string, attributeType: 'log' | 'resource') => void
+}
+
+export function LogExploreAITab({ logUuid, logTimestamp, onApplyFilter }: LogExploreAITabProps): JSX.Element {
+    const logicProps: LogExploreAILogicProps = { logUuid, logTimestamp }
+
+    return (
+        <BindLogic logic={logExploreAILogic} props={logicProps}>
+            <LogExploreAITabContent onApplyFilter={onApplyFilter} />
+        </BindLogic>
+    )
+}
+
+function LogExploreAITabContent({
+    onApplyFilter,
+}: {
+    onApplyFilter?: (filterKey: string, filterValue: string, attributeType: 'log' | 'resource') => void
+}): JSX.Element {
+    const { explanation, explanationLoading, explanationError, dataProcessingAccepted } = useValues(logExploreAILogic)
+    const { loadExplanation } = useActions(logExploreAILogic)
+
+    if (explanationLoading) {
+        return <LoadingState />
+    }
+
+    if (explanationError) {
+        return (
+            <LemonBanner type="error" className="m-4">
+                {explanationError}
+            </LemonBanner>
+        )
+    }
+
+    if (!explanation) {
+        return (
+            <EmptyState
+                onGenerate={loadExplanation}
+                dataProcessingAccepted={dataProcessingAccepted}
+                loading={explanationLoading}
+            />
+        )
+    }
+
+    return <ExplanationContent explanation={explanation} onApplyFilter={onApplyFilter} />
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/ProbableCausesSection.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/ProbableCausesSection.tsx
@@ -1,0 +1,29 @@
+import { LemonTag, Tooltip } from '@posthog/lemon-ui'
+
+import { CONFIDENCE_CONFIG } from './constants'
+import { ProbableCause } from './types'
+
+export interface ProbableCausesSectionProps {
+    causes: ProbableCause[]
+}
+
+export function ProbableCausesSection({ causes }: ProbableCausesSectionProps): JSX.Element {
+    return (
+        <div className="flex flex-col gap-2 p-2">
+            {causes.map((cause, index) => (
+                <div key={index} className="flex flex-col gap-1 p-2 bg-bg-light rounded">
+                    <div className="flex items-center gap-2">
+                        <span className="text-muted text-xs font-mono">{index + 1}.</span>
+                        <Tooltip title="AI's confidence in this hypothesis">
+                            <LemonTag type={CONFIDENCE_CONFIG[cause.confidence]?.type ?? 'muted'} size="small">
+                                {CONFIDENCE_CONFIG[cause.confidence]?.label ?? cause.confidence}
+                            </LemonTag>
+                        </Tooltip>
+                        <span className="font-medium text-sm">{cause.hypothesis}</span>
+                    </div>
+                    <p className="m-0 text-xs text-muted pl-6">{cause.reasoning}</p>
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/SeverityBanner.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/SeverityBanner.tsx
@@ -1,0 +1,34 @@
+import { IconAIText } from '@posthog/icons'
+import { LemonBanner, LemonTag, LemonTagType, Tooltip } from '@posthog/lemon-ui'
+
+const BANNER_TO_TAG_TYPE: Record<SeverityBannerProps['type'], LemonTagType> = {
+    error: 'danger',
+    warning: 'warning',
+    success: 'success',
+    info: 'default',
+}
+
+export interface SeverityBannerProps {
+    type: 'info' | 'warning' | 'error' | 'success'
+    headline: string
+    impact: string
+    severityLabel: string
+}
+
+export function SeverityBanner({ type, headline, impact, severityLabel }: SeverityBannerProps): JSX.Element {
+    return (
+        <LemonBanner type={type} hideIcon={false} icon={<IconAIText className="text-lg" />}>
+            <div className="flex flex-col gap-0.5">
+                <div className="flex items-center gap-2">
+                    <Tooltip title="AI's assessment of this log's severity">
+                        <LemonTag type={BANNER_TO_TAG_TYPE[type]} size="small">
+                            {severityLabel}
+                        </LemonTag>
+                    </Tooltip>
+                    <span className="font-semibold">{headline}</span>
+                </div>
+                <span className="text-sm opacity-80">{impact}</span>
+            </div>
+        </LemonBanner>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/constants.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/constants.ts
@@ -1,0 +1,29 @@
+import { ActionPriority, ConfidenceLevel, SeverityAssessment } from './types'
+
+export const SEVERITY_CONFIG: Record<
+    SeverityAssessment,
+    { banner: 'info' | 'warning' | 'error' | 'success'; label: string }
+> = {
+    ok: { banner: 'success', label: 'Likely not an issue' },
+    warning: { banner: 'warning', label: 'May need attention' },
+    error: { banner: 'error', label: 'Likely an issue' },
+    critical: { banner: 'error', label: 'Likely critical' },
+}
+
+export const CONFIDENCE_CONFIG: Record<ConfidenceLevel, { type: 'danger' | 'warning' | 'success'; label: string }> = {
+    high: { type: 'danger', label: 'High confidence' },
+    medium: { type: 'warning', label: 'Medium confidence' },
+    low: { type: 'success', label: 'Low confidence' },
+}
+
+export const PRIORITY_TAG_TYPE: Record<ActionPriority, 'highlight' | 'option' | 'muted'> = {
+    now: 'highlight',
+    soon: 'option',
+    later: 'muted',
+}
+
+export const PRIORITY_TOOLTIP: Record<ActionPriority, string> = {
+    now: 'AI suggests: do immediately',
+    soon: 'AI suggests: do within 15 minutes',
+    later: 'AI suggests: can wait',
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/constants.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/constants.ts
@@ -11,9 +11,9 @@ export const SEVERITY_CONFIG: Record<
 }
 
 export const CONFIDENCE_CONFIG: Record<ConfidenceLevel, { type: 'danger' | 'warning' | 'success'; label: string }> = {
-    high: { type: 'danger', label: 'High confidence' },
+    high: { type: 'success', label: 'High confidence' },
     medium: { type: 'warning', label: 'Medium confidence' },
-    low: { type: 'success', label: 'Low confidence' },
+    low: { type: 'danger', label: 'Low confidence' },
 }
 
 export const PRIORITY_TAG_TYPE: Record<ActionPriority, 'highlight' | 'option' | 'muted'> = {
@@ -24,6 +24,6 @@ export const PRIORITY_TAG_TYPE: Record<ActionPriority, 'highlight' | 'option' | 
 
 export const PRIORITY_TOOLTIP: Record<ActionPriority, string> = {
     now: 'AI suggests: do immediately',
-    soon: 'AI suggests: do within 15 minutes',
+    soon: 'AI suggests: address soon',
     later: 'AI suggests: can wait',
 }

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/index.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/index.ts
@@ -1,0 +1,2 @@
+export { LogExploreAITab as LogExploreAI } from './LogExploreAITab'
+export type { LogExploreAITabProps as LogExploreAIProps } from './LogExploreAITab'

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/logExploreAILogic.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/logExploreAILogic.ts
@@ -1,0 +1,57 @@
+import { kea, key, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { organizationLogic } from 'scenes/organizationLogic'
+
+import type { logExploreAILogicType } from './logExploreAILogicType'
+import { LogExplanation } from './types'
+
+export interface LogExploreAILogicProps {
+    logUuid: string
+    logTimestamp: string
+}
+
+export const logExploreAILogic = kea<logExploreAILogicType>([
+    props({} as LogExploreAILogicProps),
+    key((props) => props.logUuid),
+    path((key) => [
+        'products',
+        'logs',
+        'frontend',
+        'components',
+        'LogsViewer',
+        'LogDetailsModal',
+        'logExploreAILogic',
+        key,
+    ]),
+
+    selectors({
+        dataProcessingAccepted: [
+            () => [organizationLogic.selectors.currentOrganization],
+            (currentOrganization): boolean => !!currentOrganization?.is_ai_data_processing_approved,
+        ],
+    }),
+
+    reducers({
+        explanationError: [
+            null as string | null,
+            {
+                loadExplanation: () => null,
+                loadExplanationFailure: (_, { error }) => error || 'Failed to generate explanation',
+            },
+        ],
+    }),
+
+    loaders(({ props, values }) => ({
+        explanation: {
+            __default: null as LogExplanation | null,
+            loadExplanation: async (): Promise<LogExplanation> => {
+                if (!values.dataProcessingAccepted) {
+                    throw new Error('AI data processing must be approved before generating explanations')
+                }
+                return await api.logs.explain(props.logUuid, props.logTimestamp)
+            },
+        },
+    })),
+])

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/types.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/types.ts
@@ -1,0 +1,32 @@
+export type SeverityAssessment = 'ok' | 'warning' | 'error' | 'critical'
+export type ConfidenceLevel = 'high' | 'medium' | 'low'
+export type ActionPriority = 'now' | 'soon' | 'later'
+
+export interface ProbableCause {
+    hypothesis: string
+    confidence: ConfidenceLevel
+    reasoning: string
+}
+
+export interface ImmediateAction {
+    action: string
+    priority: ActionPriority
+    why: string
+}
+
+export interface KeyField {
+    field: string
+    value: string
+    significance: string
+    attribute_type: 'log' | 'resource'
+}
+
+export interface LogExplanation {
+    headline: string
+    severity_assessment: SeverityAssessment
+    impact_summary: string
+    probable_causes: ProbableCause[]
+    immediate_actions: ImmediateAction[]
+    technical_explanation: string
+    key_fields: KeyField[]
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
@@ -4,6 +4,8 @@ import { ParsedLogMessage } from 'products/logs/frontend/types'
 
 import type { logDetailsModalLogicType } from './logDetailsModalLogicType'
 
+export type LogDetailsTab = 'details' | 'explore-ai'
+
 export const logDetailsModalLogic = kea<logDetailsModalLogicType>([
     path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'LogDetailsModal', 'logDetailsModalLogic']),
 
@@ -11,6 +13,7 @@ export const logDetailsModalLogic = kea<logDetailsModalLogicType>([
         openLogDetails: (log: ParsedLogMessage) => ({ log }),
         closeLogDetails: true,
         setJsonParseAllFields: (enabled: boolean) => ({ enabled }),
+        setActiveTab: (tab: LogDetailsTab) => ({ tab }),
     }),
 
     reducers({
@@ -32,6 +35,13 @@ export const logDetailsModalLogic = kea<logDetailsModalLogicType>([
             false,
             {
                 setJsonParseAllFields: (_, { enabled }) => enabled,
+            },
+        ],
+        activeTab: [
+            'details' as LogDetailsTab,
+            {
+                setActiveTab: (_, { tab }) => tab,
+                closeLogDetails: () => 'details',
             },
         ],
     }),

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
@@ -41,6 +41,7 @@ export const logDetailsModalLogic = kea<logDetailsModalLogicType>([
             'details' as LogDetailsTab,
             {
                 setActiveTab: (_, { tab }) => tab,
+                openLogDetails: () => 'details',
                 closeLogDetails: () => 'details',
             },
         ],


### PR DESCRIPTION
## Problem

Users need better tools to understand and troubleshoot log entries. Currently, they can only view raw log data, which requires manual analysis and interpretation.

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/7c10d756-9a6b-401f-94e0-5c49e2b3fdcb.png)

Added an "Explore with AI" tab to the log details modal that provides AI-powered analysis of log entries:

- Utilises new API endpoint for log analysis with AI
- Added a new tab in the log details modal with AI-powered insights
- Implemented components to display:
  - Severity assessment with visual indicators
  - Impact summary and technical explanation
  - Probable causes with confidence levels
  - Prioritized immediate actions
  - Key fields with significance explanations
- Included proper AI consent handling

## How did you test this code?

- Tested the UI components with various log types and severity levels
- Verified AI consent flow works correctly
- Confirmed filtering functionality works when clicking on key fields
- Tested loading states and error handling
- Verified responsive design in different viewport sizes

## Publish to changelog?

Yes - this is a user-facing feature that provides significant value for log analysis.