### PR TITLE
feat(ph-ai): generic artifact manager with content handlers

### DIFF
--- a/ee/hogai/artifacts/handlers/__init__.py
+++ b/ee/hogai/artifacts/handlers/__init__.py
@@ -1,0 +1,28 @@
+from ee.hogai.artifacts.handlers.base import (
+    HANDLER_REGISTRY,
+    ArtifactHandler,
+    EnrichmentContext,
+    get_handler_for_content_class,
+    get_handler_for_content_type,
+    get_handler_for_db_type,
+)
+from ee.hogai.artifacts.handlers.notebook import NotebookArtifactManagerMixin, NotebookHandler
+
+# Import handlers to trigger registration (order matters: viz before notebook)
+from ee.hogai.artifacts.handlers.visualization import (  # noqa: I001
+    VisualizationArtifactManagerMixin,
+    VisualizationHandler,
+)
+
+__all__ = [
+    "ArtifactHandler",
+    "EnrichmentContext",
+    "HANDLER_REGISTRY",
+    "get_handler_for_content_class",
+    "get_handler_for_content_type",
+    "get_handler_for_db_type",
+    "NotebookArtifactManagerMixin",
+    "NotebookHandler",
+    "VisualizationArtifactManagerMixin",
+    "VisualizationHandler",
+]

--- a/ee/hogai/artifacts/handlers/base.py
+++ b/ee/hogai/artifacts/handlers/base.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+from pydantic import BaseModel
+
+from posthog.schema import ArtifactContentType
+
+from posthog.models import Team
+
+from ee.hogai.utils.types.base import AssistantMessageUnion
+from ee.models.assistant import AgentArtifact
+
+# Type variables for handler generics - bound to BaseModel for model_validate()
+T_Stored = TypeVar("T_Stored", bound=BaseModel)  # Stored content type (in DB)
+T_Enriched = TypeVar("T_Enriched", bound=BaseModel)  # Enriched content type (for streaming)
+# TypeVar for decorator to preserve handler class type
+T_Handler = TypeVar("T_Handler", bound="ArtifactHandler")
+
+
+@dataclass
+class EnrichmentContext:
+    """Context passed to handlers during enrichment."""
+
+    team: Team
+    state_messages: Sequence[AssistantMessageUnion] | None = None
+
+
+class ArtifactHandler(ABC, Generic[T_Stored, T_Enriched]):
+    """
+    Base class for artifact type handlers.
+
+    Each artifact type (visualization, notebook, etc.) has a handler that:
+    - Declares which sources it supports (STATE, ARTIFACT, INSIGHT)
+    - Knows how to fetch from each source
+    - Handles enrichment (e.g., resolving refs to full content)
+    """
+
+    # Type metadata - subclasses must define these
+    content_class: type[T_Stored]
+    enriched_class: type[T_Enriched]
+    db_type: AgentArtifact.Type
+    content_type: ArtifactContentType
+
+    @abstractmethod
+    async def alist(
+        self,
+        team: Team,
+        ids: list[str],
+        state_messages: Sequence[AssistantMessageUnion] | None = None,
+    ) -> list[Any]:
+        """
+        Fetch content by IDs with source tracking.
+
+        Args:
+            team: Team context for DB queries
+            ids: Artifact IDs to fetch
+            state_messages: Optional state messages for STATE source lookup
+
+        Returns:
+            Ordered list matching input IDs (None for missing artifacts).
+            Each handler returns its specific result wrapper type.
+        """
+        ...
+
+    @abstractmethod
+    async def aenrich(
+        self,
+        content: T_Stored,
+        context: EnrichmentContext,
+    ) -> T_Enriched:
+        """
+        Transform stored content to enriched content for streaming.
+
+        For types where stored == enriched (e.g., visualizations), this is a no-op.
+        For types with refs (e.g., notebooks), this resolves refs to full content.
+
+        Args:
+            content: The stored content to enrich
+            context: Enrichment context with team and state messages
+
+        Returns:
+            Enriched content ready for streaming to frontend
+        """
+        ...
+
+    def validate(self, data: dict) -> T_Stored:
+        """
+        Validate and parse raw data into content model.
+
+        Args:
+            data: Raw dict data (e.g., from DB JSON field)
+
+        Returns:
+            Validated content model instance
+        """
+        return self.content_class.model_validate(data)
+
+
+# Single registry mapping content class -> handler instance
+HANDLER_REGISTRY: dict[type, ArtifactHandler] = {}
+
+
+def register_handler(handler_class: type[T_Handler]) -> type[T_Handler]:
+    """
+    Class decorator to register a handler.
+
+    Usage:
+        @register_handler
+        class VisualizationHandler(ArtifactHandler[...]):
+            ...
+    """
+    instance = handler_class()
+    HANDLER_REGISTRY[instance.content_class] = instance
+    return handler_class
+
+
+def get_handler_for_content_class(content_class: type) -> ArtifactHandler:
+    """Get handler for a content class."""
+    handler = HANDLER_REGISTRY.get(content_class)
+    if handler is None:
+        raise ValueError(f"Unknown content type={content_class.__name__}")
+    return handler
+
+
+def get_handler_for_db_type(db_type: AgentArtifact.Type) -> ArtifactHandler | None:
+    """Get handler for a database type (iterates registry - only 2 handlers)."""
+    for handler in HANDLER_REGISTRY.values():
+        if handler.db_type == db_type:
+            return handler
+    return None
+
+
+def get_handler_for_content_type(content_type: ArtifactContentType) -> ArtifactHandler | None:
+    """Get handler for a content type enum (iterates registry - only 2 handlers)."""
+    for handler in HANDLER_REGISTRY.values():
+        if handler.content_type == content_type:
+            return handler
+    return None

--- a/ee/hogai/artifacts/handlers/notebook.py
+++ b/ee/hogai/artifacts/handlers/notebook.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, cast
+
+from pydantic import ValidationError
+
+from posthog.schema import ArtifactContentType, ErrorBlock, NotebookArtifactContent, VisualizationBlock
+
+from posthog.models import Team
+
+from ee.hogai.artifacts.handlers.base import (
+    ArtifactHandler,
+    EnrichmentContext,
+    get_handler_for_content_type,
+    register_handler,
+)
+from ee.hogai.artifacts.types import (
+    DatabaseArtifactResult,
+    EnrichedBlock,
+    NotebookWithSourceResult,
+    StoredNotebookArtifactContent,
+    VisualizationRefBlock,
+)
+from ee.hogai.context.insight.query_executor import is_supported_query
+from ee.hogai.utils.types.base import AssistantMessageUnion
+from ee.models.assistant import AgentArtifact
+
+
+@register_handler
+class NotebookHandler(ArtifactHandler[StoredNotebookArtifactContent, NotebookArtifactContent]):
+    """
+    Handler for notebook artifacts.
+
+    Notebooks are only stored in the ARTIFACT source (AgentArtifact table).
+    They contain VisualizationRefBlock references that need to be enriched
+    to full VisualizationBlock content when streaming.
+    """
+
+    content_class = StoredNotebookArtifactContent
+    enriched_class = NotebookArtifactContent
+    db_type = AgentArtifact.Type.NOTEBOOK
+    content_type = ArtifactContentType.NOTEBOOK
+
+    async def alist(
+        self,
+        team: Team,
+        ids: list[str],
+        state_messages: Sequence[AssistantMessageUnion] | None = None,
+    ) -> list[NotebookWithSourceResult | None]:
+        """
+        Fetch notebook content by IDs from AgentArtifact table.
+
+        Returns ordered list matching input IDs (None for missing artifacts).
+        """
+        if not ids:
+            return []
+
+        artifacts = AgentArtifact.objects.filter(
+            short_id__in=ids,
+            team=team,
+            type=AgentArtifact.Type.NOTEBOOK,
+        )
+        result: dict[str, NotebookWithSourceResult] = {}
+        async for artifact in artifacts:
+            try:
+                content = StoredNotebookArtifactContent.model_validate(artifact.data)
+                result[artifact.short_id] = DatabaseArtifactResult(content=content)
+            except ValidationError:
+                # Skip invalid data
+                continue
+        return [result.get(artifact_id) for artifact_id in ids]
+
+    async def aenrich(
+        self,
+        content: StoredNotebookArtifactContent,
+        context: EnrichmentContext,
+    ) -> NotebookArtifactContent:
+        """
+        Enrich notebook by resolving VisualizationRefBlock references.
+
+        Converts VisualizationRefBlock → VisualizationBlock (with full query data)
+        or ErrorBlock (if artifact not found).
+        """
+        # Collect all artifact IDs from VisualizationRefBlock
+        viz_ids = [block.artifact_id for block in content.blocks if isinstance(block, VisualizationRefBlock)]
+
+        # Fetch visualization contents using the visualization handler
+        viz_contents = await self._list_visualization_contents(viz_ids, context.team, context.state_messages)
+
+        # Build enriched blocks
+        enriched_blocks: list[EnrichedBlock] = []
+        for block in content.blocks:
+            if isinstance(block, VisualizationRefBlock):
+                viz_content = viz_contents.get(block.artifact_id)
+                if viz_content is None:
+                    # Artifact not found - generate error block
+                    enriched_blocks.append(
+                        ErrorBlock(
+                            message=f"Visualization not found: {block.artifact_id}",
+                            artifact_id=block.artifact_id,
+                        )
+                    )
+                elif not is_supported_query(viz_content.query):
+                    # Query type not supported for rendering
+                    enriched_blocks.append(
+                        ErrorBlock(
+                            message=f"Unsupported query type: {type(viz_content.query).__name__}",
+                            artifact_id=block.artifact_id,
+                        )
+                    )
+                else:
+                    # Valid visualization - cast is safe now after runtime validation
+                    enriched_blocks.append(
+                        VisualizationBlock(
+                            query=cast(Any, viz_content.query),
+                            title=block.title or viz_content.name,
+                        )
+                    )
+            else:
+                # Pass through other block types unchanged
+                enriched_blocks.append(block)
+
+        return NotebookArtifactContent(
+            blocks=enriched_blocks,
+            title=content.title,
+        )
+
+    async def _list_visualization_contents(
+        self,
+        artifact_ids: list[str],
+        team: Team,
+        state_messages: Sequence[AssistantMessageUnion] | None = None,
+    ):
+        """
+        Fetch visualization contents for ref block artifact IDs.
+
+        Uses the VisualizationHandler (via registry) to handle fetching from all sources.
+        Returns dict mapping artifact_id -> content for easy lookup during enrichment.
+        """
+        if not artifact_ids:
+            return {}
+
+        viz_handler = get_handler_for_content_type(ArtifactContentType.VISUALIZATION)
+        if viz_handler is None:
+            return {}
+
+        # list returns result wrappers, extract content for lookup
+        results = await viz_handler.alist(team, artifact_ids, state_messages)
+        return {artifact_id: result.content for artifact_id, result in zip(artifact_ids, results) if result is not None}
+
+
+class NotebookArtifactManagerMixin:
+    """
+    Mixin providing notebook-specific artifact retrieval methods.
+
+    Mix into ArtifactManager to add type-safe notebook fetching.
+    """
+
+    # These are provided by ArtifactManager
+    _team: Team
+
+    async def aget_notebooks(
+        self,
+        state_messages: Sequence[AssistantMessageUnion],
+        artifact_ids: list[str],
+    ) -> list[NotebookWithSourceResult | None]:
+        """
+        Fetch notebooks by IDs.
+
+        Notebooks are only stored in the ARTIFACT source.
+        Returns ordered list matching input artifact_ids (None for missing IDs).
+        """
+        if not artifact_ids:
+            return []
+        handler = NotebookHandler()
+        return cast(
+            list[NotebookWithSourceResult | None],
+            await handler.alist(self._team, artifact_ids, state_messages),
+        )
+
+    async def aget_notebook(
+        self,
+        state_messages: Sequence[AssistantMessageUnion],
+        artifact_id: str,
+    ) -> NotebookWithSourceResult | None:
+        """
+        Fetch a single notebook by ID.
+        """
+        results = await self.aget_notebooks(state_messages, [artifact_id])
+        return results[0] if results else None

--- a/ee/hogai/artifacts/handlers/visualization.py
+++ b/ee/hogai/artifacts/handlers/visualization.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import cast
+
+from posthoganalytics import capture_exception
+from pydantic import ValidationError
+
+from posthog.schema import ArtifactContentType, ArtifactSource, VisualizationArtifactContent, VisualizationMessage
+
+from posthog.models import Insight, Team
+
+from ee.hogai.artifacts.handlers.base import ArtifactHandler, EnrichmentContext, register_handler
+from ee.hogai.artifacts.types import (
+    DatabaseArtifactResult,
+    ModelArtifactResult,
+    StateArtifactResult,
+    VisualizationWithSourceResult,
+)
+from ee.hogai.context.insight.context import InsightContext
+from ee.hogai.utils.types.base import AssistantMessageUnion
+from ee.models.assistant import AgentArtifact
+
+
+@register_handler
+class VisualizationHandler(ArtifactHandler[VisualizationArtifactContent, VisualizationArtifactContent]):
+    """
+    Handler for visualization artifacts.
+
+    Visualizations can come from three sources:
+    - STATE: In-memory VisualizationMessage in conversation state
+    - ARTIFACT: Saved in AgentArtifact table
+    - INSIGHT: Saved as Insight model
+
+    No enrichment needed - stored content is already in final form.
+    """
+
+    content_class = VisualizationArtifactContent
+    enriched_class = VisualizationArtifactContent  # Same, no enrichment
+    db_type = AgentArtifact.Type.VISUALIZATION
+    content_type = ArtifactContentType.VISUALIZATION
+
+    async def alist(
+        self,
+        team: Team,
+        ids: list[str],
+        state_messages: Sequence[AssistantMessageUnion] | None = None,
+    ) -> list[VisualizationWithSourceResult | None]:
+        """
+        Fetch visualizations with source tracking and Insight models.
+
+        Returns ordered list matching input IDs (None for missing IDs).
+        """
+        if not ids:
+            return []
+
+        results_map: dict[str, VisualizationWithSourceResult] = {}
+        remaining = set(ids)
+
+        # 1. Check state messages first
+        if state_messages:
+            for artifact_id in list(remaining):
+                content = self._from_state(artifact_id, state_messages)
+                if content is not None:
+                    results_map[artifact_id] = StateArtifactResult(content=content)
+                    remaining.discard(artifact_id)
+
+        # 2. Check artifact DB
+        if remaining:
+            db_contents = await self._from_db(list(remaining), team)
+            for artifact_id, content in db_contents.items():
+                results_map[artifact_id] = DatabaseArtifactResult(content=content)
+                remaining.discard(artifact_id)
+
+        # 3. Check insights table - get both content AND model in single query
+        if remaining:
+            insight_results = await self._from_insights_with_models(list(remaining), team)
+            for artifact_id, (content, model) in insight_results.items():
+                results_map[artifact_id] = ModelArtifactResult(
+                    source=ArtifactSource.INSIGHT,
+                    content=content,
+                    model=model,
+                )
+
+        # Return ordered list matching input
+        return [results_map.get(artifact_id) for artifact_id in ids]
+
+    async def aenrich(
+        self,
+        content: VisualizationArtifactContent,
+        context: EnrichmentContext,
+    ) -> VisualizationArtifactContent:
+        """No enrichment needed for visualizations."""
+        return content
+
+    def _from_state(
+        self, artifact_id: str, messages: Sequence[AssistantMessageUnion]
+    ) -> VisualizationArtifactContent | None:
+        """
+        Extract content from a VisualizationMessage in state.
+
+        Field mappings from VisualizationMessage to VisualizationArtifactContent:
+        - answer -> query: The actual query object (e.g., TrendsQuery)
+        - query -> name: The user's original query text (used as chart title)
+        - plan -> description: The agent's plan/explanation
+        """
+        for msg in messages:
+            if isinstance(msg, VisualizationMessage) and msg.id == artifact_id:
+                try:
+                    return VisualizationArtifactContent(
+                        query=msg.answer,
+                        name=msg.query,
+                        plan=msg.plan,
+                    )
+                except ValidationError as e:
+                    capture_exception(e)
+                    # Old unsupported visualization messages schemas
+                    return None
+        return None
+
+    async def _from_db(self, artifact_ids: list[str], team: Team) -> dict[str, VisualizationArtifactContent]:
+        """Fetch visualization contents from AgentArtifact table."""
+        if not artifact_ids:
+            return {}
+
+        artifacts = AgentArtifact.objects.filter(
+            short_id__in=artifact_ids,
+            team=team,
+            type=AgentArtifact.Type.VISUALIZATION,
+        )
+        result: dict[str, VisualizationArtifactContent] = {}
+        async for artifact in artifacts:
+            try:
+                result[artifact.short_id] = VisualizationArtifactContent.model_validate(artifact.data)
+            except ValidationError:
+                # Skip invalid data
+                continue
+        return result
+
+    async def _from_insights_with_models(
+        self, insight_ids: list[str], team: Team
+    ) -> dict[str, tuple[VisualizationArtifactContent, Insight]]:
+        """Fetch visualization contents along with their Insight models (single query)."""
+        if not insight_ids:
+            return {}
+
+        insights = Insight.objects.filter(
+            short_id__in=insight_ids,
+            team=team,
+            deleted=False,
+            saved=True,
+        )
+        result: dict[str, tuple[VisualizationArtifactContent, Insight]] = {}
+        async for insight in insights:
+            query_obj = InsightContext.extract_query(insight)
+            if query_obj is None:
+                continue
+            content = VisualizationArtifactContent(
+                query=query_obj,
+                name=insight.name or insight.derived_name,
+                description=insight.description,
+            )
+            result[insight.short_id] = (content, insight)
+        return result
+
+
+class VisualizationArtifactManagerMixin:
+    """
+    Mixin providing visualization-specific artifact retrieval methods.
+
+    Mix into ArtifactManager to add type-safe visualization fetching.
+    """
+
+    # These are provided by ArtifactManager
+    _team: Team
+
+    async def aget_visualizations(
+        self,
+        state_messages: Sequence[AssistantMessageUnion],
+        artifact_ids: list[str],
+    ) -> list[VisualizationWithSourceResult | None]:
+        """
+        Fetch visualizations by IDs.
+
+        Checks sources in priority order: STATE, ARTIFACT, INSIGHT.
+        Returns ordered list matching input artifact_ids (None for missing IDs).
+        """
+        if not artifact_ids:
+            return []
+        handler = VisualizationHandler()
+        return cast(
+            list[VisualizationWithSourceResult | None],
+            await handler.alist(self._team, artifact_ids, state_messages),
+        )
+
+    async def aget_visualization(
+        self,
+        state_messages: Sequence[AssistantMessageUnion],
+        artifact_id: str,
+    ) -> VisualizationWithSourceResult | None:
+        """
+        Fetch a single visualization by ID.
+
+        Checks sources in priority order: STATE, ARTIFACT, INSIGHT.
+        """
+        results = await self.aget_visualizations(state_messages, [artifact_id])
+        return results[0] if results else None

--- a/ee/hogai/artifacts/manager.py
+++ b/ee/hogai/artifacts/manager.py
@@ -1,53 +1,29 @@
 from collections.abc import Sequence
-from typing import Generic, Literal, TypeVar, cast
+from typing import Literal, cast, overload
 from uuid import UUID, uuid4
 
 from langchain_core.runnables import RunnableConfig
-from posthoganalytics import capture_exception
-from pydantic import BaseModel, ConfigDict, ValidationError
 
-from posthog.schema import (
-    ArtifactContentType,
-    ArtifactMessage,
-    ArtifactSource,
-    DocumentArtifactContent,
-    VisualizationArtifactContent,
-    VisualizationMessage,
-)
+from posthog.schema import ArtifactContentType, ArtifactMessage, ArtifactSource, VisualizationMessage
 
-from posthog.models import Insight, User
+from posthog.models import User
 from posthog.models.team import Team
 
-from ee.hogai.context.insight.context import InsightContext
+from ee.hogai.artifacts.handlers import (
+    EnrichmentContext,
+    NotebookArtifactManagerMixin,
+    VisualizationArtifactManagerMixin,
+    get_handler_for_content_class,
+    get_handler_for_content_type,
+    get_handler_for_db_type,
+)
+from ee.hogai.artifacts.types import ArtifactContent, ContentT, StoredContent
 from ee.hogai.core.mixins import AssistantContextMixin
 from ee.hogai.utils.types.base import ArtifactRefMessage, AssistantMessageUnion
 from ee.models.assistant import AgentArtifact
 
-ArtifactContentUnion = DocumentArtifactContent | VisualizationArtifactContent
 
-T = TypeVar("T", bound=ArtifactContentUnion)
-S = TypeVar("S", bound=ArtifactSource)
-M = TypeVar("M")
-
-
-class StateArtifactResult(BaseModel, Generic[T]):
-    source: Literal[ArtifactSource.STATE] = ArtifactSource.STATE
-    content: T
-
-
-class DatabaseArtifactResult(BaseModel, Generic[T]):
-    source: Literal[ArtifactSource.ARTIFACT] = ArtifactSource.ARTIFACT
-    content: T
-
-
-class ModelArtifactResult(BaseModel, Generic[T, S, M]):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-    source: S
-    content: T
-    model: M
-
-
-class ArtifactManager(AssistantContextMixin):
+class ArtifactManager(VisualizationArtifactManagerMixin, NotebookArtifactManagerMixin, AssistantContextMixin):
     """
     Manages creation and retrieval of agent artifacts.
     """
@@ -75,9 +51,9 @@ class ArtifactManager(AssistantContextMixin):
             id=str(uuid4()),
         )
 
-    async def create(
+    async def acreate(
         self,
-        content: VisualizationArtifactContent,
+        content: StoredContent,
         name: str,
     ) -> AgentArtifact:
         """Create and persist an artifact."""
@@ -89,9 +65,11 @@ class ArtifactManager(AssistantContextMixin):
         if conversation is None:
             raise ValueError("Conversation not found")
 
+        db_type = self._get_db_type_for_content(content)
+
         artifact = AgentArtifact(
             name=name[:400],
-            type=AgentArtifact.Type.VISUALIZATION,
+            type=db_type,
             data=content.model_dump(exclude_none=True),
             conversation=conversation,
             team=self._team,
@@ -100,89 +78,71 @@ class ArtifactManager(AssistantContextMixin):
 
         return artifact
 
+    async def aupdate(
+        self,
+        artifact_id: str,
+        content: StoredContent,
+    ) -> AgentArtifact:
+        """Update an existing artifact."""
+        try:
+            artifact = await AgentArtifact.objects.aget(short_id=artifact_id, team=self._team)
+        except AgentArtifact.DoesNotExist:
+            raise ValueError(f"Artifact with short_id={artifact_id} not found")
+        artifact.data = content.model_dump(exclude_none=True)
+        await artifact.asave()
+        return artifact
+
     # -------------------------------------------------------------------------
     # Content retrieval
     # -------------------------------------------------------------------------
 
-    async def aget_content_by_short_id(self, short_id: str) -> VisualizationArtifactContent:
-        """Retrieve visualization content from an artifact by short_id."""
-        contents = await self._afetch_artifact_contents([short_id])
-        content = contents.get(short_id)
-        if content is None:
-            raise AgentArtifact.DoesNotExist(f"Artifact with short_id={short_id} not found")
-        return content
+    @overload
+    async def aget(self, artifact_id: str, expected_type: type[ContentT]) -> ContentT: ...
 
-    InsightWithSourceResult = (
-        StateArtifactResult[VisualizationArtifactContent]
-        | DatabaseArtifactResult[VisualizationArtifactContent]
-        | ModelArtifactResult[VisualizationArtifactContent, Literal[ArtifactSource.INSIGHT], Insight]
-    )
+    @overload
+    async def aget(self, artifact_id: str, expected_type: None = None) -> ArtifactContent: ...
 
-    async def aget_insights_with_source(
-        self, state_messages: Sequence[AssistantMessageUnion], artifact_ids: list[str]
-    ) -> list[InsightWithSourceResult | None]:
+    async def aget(self, artifact_id: str, expected_type: type[ContentT] | None = None) -> ArtifactContent | ContentT:
+        """Retrieve artifact content by ID from the database.
+
+        Args:
+            artifact_id: The artifact's short ID.
+            expected_type: Optional content class to validate and narrow the return type.
+                          If provided, raises TypeError if the content doesn't match.
+
+        Returns:
+            The artifact content, narrowed to expected_type if provided.
+
+        Raises:
+            AgentArtifact.DoesNotExist: If artifact not found.
+            TypeError: If expected_type provided but content doesn't match.
         """
-        Retrieve artifact content for multiple IDs along with their sources.
-        Checks state first, then artifacts, then insights.
-        Returns ordered list matching input artifact_ids (None for missing IDs).
-        """
-        if not artifact_ids:
-            return []
+        stored_contents = await self._afetch_artifact_contents([artifact_id])
+        stored_content = stored_contents.get(artifact_id)
+        if stored_content is None:
+            raise AgentArtifact.DoesNotExist(f"Artifact with id={artifact_id} not found")
 
-        remaining_artifact_ids = set(artifact_ids)
-        results_map: dict[str, ArtifactManager.InsightWithSourceResult] = {}
+        # Use handler for enrichment (generic for all types)
+        handler = get_handler_for_content_class(type(stored_content))
+        context = EnrichmentContext(team=self._team)
+        content: ArtifactContent = await handler.aenrich(stored_content, context)
 
-        # Try state first if messages provided
-        for artifact_id in artifact_ids:
-            content = self._content_from_state(artifact_id, state_messages)
-            if content is None:
-                continue
-            results_map[artifact_id] = StateArtifactResult(content=content)
-            remaining_artifact_ids.remove(artifact_id)
+        if expected_type is not None and not isinstance(content, expected_type):
+            raise TypeError(
+                f"Expected content type={expected_type.__name__}, got content type={type(content).__name__}"
+            )
+        return cast(ContentT, content) if expected_type else content
 
-        # Find IDs still not resolved in state
-        if remaining_artifact_ids:
-            # Batch fetch artifacts
-            artifact_contents = await self._afetch_artifact_contents(list(remaining_artifact_ids))
-            for artifact_id, content in artifact_contents.items():
-                results_map[artifact_id] = DatabaseArtifactResult(content=content)
-                remaining_artifact_ids.remove(artifact_id)
-
-        # Find IDs still not resolved
-        if remaining_artifact_ids:
-            # Batch fetch insights
-            insight_results = await self._afetch_insights_with_models(list(remaining_artifact_ids))
-            for artifact_id, (content, insight) in insight_results.items():
-                results_map[artifact_id] = ModelArtifactResult(
-                    source=ArtifactSource.INSIGHT,
-                    content=content,
-                    model=insight,
-                )
-                remaining_artifact_ids.remove(artifact_id)
-
-        # Return ordered list matching input
-        return [results_map.get(artifact_id) for artifact_id in artifact_ids]
-
-    async def aget_insight_with_source(
-        self, state_messages: Sequence[AssistantMessageUnion], artifact_id: str
-    ) -> InsightWithSourceResult | None:
-        """
-        Retrieve artifact content by ID along with its source.
-        Checks state first, then artifacts, then insights.
-        Returns content or None if not found.
-        """
-        results = await self.aget_insights_with_source(state_messages, [artifact_id])
-        return results[0] if results else None
-
-    async def aget_enriched_message(
+    async def aenrich_message(
         self,
         message: ArtifactRefMessage,
         state_messages: Sequence[AssistantMessageUnion] | None = None,
     ) -> ArtifactMessage | None:
         """
-        Convert an artifact message to a visualization artifact message.
+        Convert an artifact ref message to an enriched artifact message with content.
         Fetches content based on source: State (from messages), Artifact (from DB), or Insight (from DB).
         """
+        # Handle visualization artifacts
         if message.source == ArtifactSource.STATE:
             if state_messages is None:
                 raise ValueError("state_messages required for State source")
@@ -190,56 +150,13 @@ class ArtifactManager(AssistantContextMixin):
         else:
             messages_for_lookup = [message]
 
-        contents = await self.aget_contents_by_message_id(messages_for_lookup)
+        contents = await self._aget_contents_by_id(messages_for_lookup, aggregate_by="message_id")
         content = contents.get(message.id or "")
 
         if content is None:
             return None
 
-        return self._to_visualization_artifact_message(message, content)
-
-    async def aget_contents_by_message_id(
-        self, messages: Sequence[AssistantMessageUnion]
-    ) -> dict[str, VisualizationArtifactContent]:
-        """
-        Get artifact content for all artifact messages, keyed by message ID.
-        """
-        result: dict[str, VisualizationArtifactContent] = {}
-
-        # Collect IDs by source
-        artifact_ids: list[str] = []
-        insight_ids: list[str] = []
-        artifact_id_to_message_id: dict[str, str] = {}
-        insight_id_to_message_id: dict[str, str] = {}
-
-        for message in messages:
-            if not isinstance(message, ArtifactRefMessage):
-                continue
-            if not message.id:
-                continue
-            if message.source == ArtifactSource.STATE:
-                content = self._content_from_state(message.artifact_id, messages)
-                if content:
-                    result[message.id] = content
-            elif message.source == ArtifactSource.ARTIFACT:
-                artifact_ids.append(message.artifact_id)
-                artifact_id_to_message_id[message.artifact_id] = message.id
-            elif message.source == ArtifactSource.INSIGHT:
-                insight_ids.append(message.artifact_id)
-                insight_id_to_message_id[message.artifact_id] = message.id
-
-        # Batch fetch from DB
-        artifact_contents = await self._afetch_artifact_contents(artifact_ids)
-        insight_contents = await self._afetch_insight_contents(insight_ids)
-
-        for artifact_id, content in artifact_contents.items():
-            if message_id := artifact_id_to_message_id.get(artifact_id):
-                result[message_id] = content
-        for insight_id, content in insight_contents.items():
-            if message_id := insight_id_to_message_id.get(insight_id):
-                result[message_id] = content
-
-        return result
+        return self._to_artifact_message(message, content)
 
     async def aenrich_messages(
         self, messages: Sequence[AssistantMessageUnion], artifacts_only: bool = False
@@ -247,65 +164,58 @@ class ArtifactManager(AssistantContextMixin):
         """
         Enrich state messages with artifact content.
         """
-        contents_by_id = await self.aget_contents_by_message_id(messages)
+        contents_by_id = await self._aget_contents_by_id(messages, aggregate_by="message_id")
 
         result: list[AssistantMessageUnion | ArtifactMessage] = []
         for message in messages:
-            if isinstance(message, ArtifactRefMessage) and message.content_type == ArtifactContentType.VISUALIZATION:
+            if isinstance(message, ArtifactRefMessage):
                 content = contents_by_id.get(message.id or "")
                 if content:
-                    result.append(self._to_visualization_artifact_message(message, content))
+                    result.append(self._to_artifact_message(message, content))
             elif not isinstance(message, VisualizationMessage) and not artifacts_only:
                 # Pass through non-artifact messages, but skip VisualizationMessage (they are already filtered in the state, just a precaution)
                 result.append(message)
 
         return result
 
-    async def aget_conversation_artifact_messages(self) -> list[ArtifactMessage]:
+    async def aget_conversation_artifacts(self) -> list[ArtifactMessage]:
         """Get all artifacts created in a conversation, by the agent and subagents."""
         conversation_id = cast(UUID, self._get_thread_id(self._config))
-        artifacts = list(AgentArtifact.objects.filter(team=self._team, conversation_id=conversation_id).all())
-        return [
-            ArtifactMessage(
-                id=artifact.short_id,
-                artifact_id=artifact.short_id,
-                source=ArtifactSource.ARTIFACT,
-                content=VisualizationArtifactContent.model_validate(artifact.data),
+        artifacts = AgentArtifact.objects.filter(team=self._team, conversation_id=conversation_id)
+
+        result: list[ArtifactMessage] = []
+        async for artifact in artifacts:
+            artifact_type = cast(AgentArtifact.Type, artifact.type)
+            handler = get_handler_for_db_type(artifact_type)
+            if handler is None:
+                continue
+
+            stored_content = handler.validate(artifact.data)
+
+            # Use handler for enrichment (generic for all types)
+            context = EnrichmentContext(team=self._team)
+            content: ArtifactContent = await handler.aenrich(stored_content, context)
+
+            result.append(
+                ArtifactMessage(
+                    id=artifact.short_id,
+                    artifact_id=artifact.short_id,
+                    source=ArtifactSource.ARTIFACT,
+                    content=content,
+                )
             )
-            for artifact in artifacts
-        ]
+        return result
 
     # -------------------------------------------------------------------------
     # Private helpers
     # -------------------------------------------------------------------------
 
-    def _content_from_state(
-        self, artifact_id: str, messages: Sequence[AssistantMessageUnion]
-    ) -> VisualizationArtifactContent | None:
-        """Extract content from a VisualizationMessage in state.
+    def _get_db_type_for_content(self, content: StoredContent) -> AgentArtifact.Type:
+        """Get the database type for a content object using handlers."""
+        handler = get_handler_for_content_class(type(content))
+        return handler.db_type
 
-        Field mappings from VisualizationMessage to VisualizationArtifactContent:
-        - answer -> query: The actual query object (e.g., TrendsQuery)
-        - query -> name: The user's original query text (used as chart title)
-        - plan -> description: The agent's plan/explanation
-        """
-        for msg in messages:
-            if isinstance(msg, VisualizationMessage) and msg.id == artifact_id:
-                try:
-                    return VisualizationArtifactContent(
-                        query=msg.answer,
-                        name=msg.query,
-                        plan=msg.plan,
-                    )
-                except ValidationError as e:
-                    capture_exception(e)
-                    # Old unsupported visualization messages schemas
-                    return None
-        return None
-
-    def _to_visualization_artifact_message(
-        self, message: ArtifactRefMessage, content: VisualizationArtifactContent
-    ) -> ArtifactMessage:
+    def _to_artifact_message(self, message: ArtifactRefMessage, content: ArtifactContent) -> ArtifactMessage:
         """Convert an ArtifactRefMessage to an ArtifactMessage."""
         return ArtifactMessage(
             id=message.id,
@@ -314,39 +224,76 @@ class ArtifactManager(AssistantContextMixin):
             content=content,
         )
 
-    async def _afetch_artifact_contents(self, artifact_ids: list[str]) -> dict[str, VisualizationArtifactContent]:
+    async def _afetch_artifact_contents(self, artifact_ids: list[str]) -> dict[str, StoredContent]:
         """Batch fetch artifact contents from the database."""
         if not artifact_ids:
             return {}
         artifacts = AgentArtifact.objects.filter(short_id__in=artifact_ids, team=self._team)
-        return {
-            artifact.short_id: VisualizationArtifactContent.model_validate(artifact.data)
-            async for artifact in artifacts
-            if artifact.type == AgentArtifact.Type.VISUALIZATION
-        }
-
-    async def _afetch_insight_contents(self, insight_ids: list[str]) -> dict[str, VisualizationArtifactContent]:
-        """Batch fetch insight contents from the database."""
-        results = await self._afetch_insights_with_models(insight_ids)
-        return {short_id: content for short_id, (content, _) in results.items()}
-
-    async def _afetch_insights_with_models(
-        self, insight_ids: list[str]
-    ) -> dict[str, tuple[VisualizationArtifactContent, Insight]]:
-        """Batch fetch insight contents and models from the database."""
-        if not insight_ids:
-            return {}
-        insights = Insight.objects.filter(short_id__in=insight_ids, team=self._team, deleted=False, saved=True)
-        result: dict[str, tuple[VisualizationArtifactContent, Insight]] = {}
-        async for insight in insights:
-            # Validate and convert dict to model
-            query_obj = InsightContext.extract_query(insight)
-            if query_obj is None:
+        result: dict[str, StoredContent] = {}
+        async for artifact in artifacts:
+            artifact_type = cast(AgentArtifact.Type, artifact.type)
+            handler = get_handler_for_db_type(artifact_type)
+            if handler is None:
                 continue
-            content = VisualizationArtifactContent(
-                query=query_obj,
-                name=insight.name or insight.derived_name,
-                description=insight.description,
-            )
-            result[insight.short_id] = (content, insight)
+            result[artifact.short_id] = handler.validate(artifact.data)
+        return result
+
+    async def _aget_contents_by_id(
+        self,
+        messages: Sequence[AssistantMessageUnion],
+        aggregate_by: Literal["message_id", "artifact_id"] = "message_id",
+        filter_by_artifact_ids: list[str] | None = None,
+    ) -> dict[str, ArtifactContent]:
+        """
+        Get artifact content for all artifact messages, keyed by aggregation ID.
+
+        Delegates to handlers which know how to fetch from their supported sources.
+        Contents are enriched via handler's enrich method.
+
+        Args:
+            messages: The messages to scan for artifact references.
+            aggregate_by: How to key results - "message_id" or "artifact_id".
+            filter_by_artifact_ids: If provided, only return contents for these artifact IDs.
+
+        Returns:
+            Dict mapping aggregation IDs to their artifact content.
+        """
+        filter_set = set(filter_by_artifact_ids) if filter_by_artifact_ids else None
+
+        # Group messages by content_type, tracking aggregation IDs
+        ids_by_content_type: dict[ArtifactContentType, list[str]] = {}
+        aggregation_map: dict[str, str] = {}  # artifact_id -> aggregation_id
+
+        for message in messages:
+            if not isinstance(message, ArtifactRefMessage) or not message.id:
+                continue
+            if filter_set and message.artifact_id not in filter_set:
+                continue
+
+            aggregation_id = message.id if aggregate_by == "message_id" else message.artifact_id
+            aggregation_map[message.artifact_id] = aggregation_id
+
+            if message.content_type not in ids_by_content_type:
+                ids_by_content_type[message.content_type] = []
+            ids_by_content_type[message.content_type].append(message.artifact_id)
+
+        # Fetch and enrich using handlers
+        result: dict[str, ArtifactContent] = {}
+        context = EnrichmentContext(team=self._team, state_messages=messages)
+
+        for content_type, artifact_ids in ids_by_content_type.items():
+            handler = get_handler_for_content_type(content_type)
+            if handler is None:
+                continue
+
+            fetch_results = await handler.alist(self._team, artifact_ids, messages)
+
+            for artifact_id, fetch_result in zip(artifact_ids, fetch_results):
+                if fetch_result is None:
+                    continue
+                enriched: ArtifactContent = await handler.aenrich(fetch_result.content, context)
+                agg_id = aggregation_map.get(artifact_id)
+                if agg_id is not None:
+                    result[agg_id] = enriched
+
         return result

--- a/ee/hogai/artifacts/types.py
+++ b/ee/hogai/artifacts/types.py
@@ -1,0 +1,87 @@
+"""Shared type definitions for artifact system."""
+
+from typing import Generic, Literal, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from posthog.schema import (
+    ArtifactSource,
+    ErrorBlock,
+    LoadingBlock,
+    MarkdownBlock,
+    NotebookArtifactContent,
+    SessionReplayBlock,
+    VisualizationArtifactContent,
+    VisualizationBlock,
+)
+
+from posthog.models import Insight
+
+
+class VisualizationRefBlock(BaseModel):
+    """Reference to a visualization artifact - stored in DB, enriched to VisualizationBlock when streaming."""
+
+    type: Literal["visualization_ref"] = "visualization_ref"
+    artifact_id: str
+    title: str | None = None
+
+
+# Type alias for blocks that can be stored in a notebook artifact
+StoredBlock = MarkdownBlock | VisualizationRefBlock | SessionReplayBlock | LoadingBlock
+
+# Type alias for enriched blocks (after resolving refs)
+EnrichedBlock = MarkdownBlock | VisualizationBlock | SessionReplayBlock | LoadingBlock | ErrorBlock
+
+
+class StoredNotebookArtifactContent(BaseModel):
+    """Notebook content as stored in the database - contains ref blocks that need enrichment."""
+
+    content_type: Literal["notebook"] = "notebook"
+    blocks: list[StoredBlock]
+    title: str | None = None
+
+
+# Content types for storage (includes StoredNotebookArtifactContent with ref blocks)
+StoredContent = VisualizationArtifactContent | StoredNotebookArtifactContent
+
+# Content types for streaming to frontend (enriched, no ref blocks)
+ArtifactContent = VisualizationArtifactContent | NotebookArtifactContent
+
+
+ContentT = TypeVar("ContentT", bound=ArtifactContent)
+
+# Generic type vars for result wrappers (using StoredContent as bound to support notebooks)
+T = TypeVar("T", bound=StoredContent)
+S = TypeVar("S", bound=ArtifactSource)
+M = TypeVar("M")
+
+
+class StateArtifactResult(BaseModel, Generic[T]):
+    source: Literal[ArtifactSource.STATE] = ArtifactSource.STATE
+    content: T
+
+
+class DatabaseArtifactResult(BaseModel, Generic[T]):
+    source: Literal[ArtifactSource.ARTIFACT] = ArtifactSource.ARTIFACT
+    content: T
+
+
+class ModelArtifactResult(BaseModel, Generic[T, S, M]):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    source: S
+    content: T
+    model: M
+
+
+# Result type for visualization artifacts (can come from state, database, or saved insights)
+VisualizationWithSourceResult = (
+    StateArtifactResult[VisualizationArtifactContent]
+    | DatabaseArtifactResult[VisualizationArtifactContent]
+    | ModelArtifactResult[VisualizationArtifactContent, Literal[ArtifactSource.INSIGHT], Insight]
+)
+
+# Result type for notebook artifacts (can only come from database)
+NotebookWithSourceResult = DatabaseArtifactResult[StoredNotebookArtifactContent]
+
+# Generic result type for any artifact
+ArtifactWithSourceResult = VisualizationWithSourceResult | NotebookWithSourceResult

--- a/ee/hogai/artifacts/utils.py
+++ b/ee/hogai/artifacts/utils.py
@@ -1,6 +1,6 @@
 from typing import Any, TypeGuard
 
-from posthog.schema import ArtifactContentType, ArtifactMessage, VisualizationArtifactContent
+from posthog.schema import ArtifactContentType, ArtifactMessage, NotebookArtifactContent, VisualizationArtifactContent
 
 from ee.hogai.utils.types.base import ArtifactRefMessage
 
@@ -17,5 +17,12 @@ def is_visualization_artifact_message(message: Any) -> TypeGuard[ArtifactMessage
 def unwrap_visualization_artifact_content(message: Any) -> VisualizationArtifactContent | None:
     """Extract VisualizationArtifactContent from an ArtifactMessage, or return None."""
     if not isinstance(message, ArtifactMessage) or message.content.content_type != "visualization":
+        return None
+    return message.content
+
+
+def unwrap_notebook_artifact_content(message: Any) -> NotebookArtifactContent | None:
+    """Extract NotebookArtifactContent from an ArtifactMessage, or return None."""
+    if not isinstance(message, ArtifactMessage) or message.content.content_type != "notebook":
         return None
     return message.content

--- a/ee/hogai/chat_agent/insights/test/test_nodes.py
+++ b/ee/hogai/chat_agent/insights/test/test_nodes.py
@@ -794,7 +794,7 @@ class TestInsightSearchNode(BaseTest):
         # Test insight1 visualization message creation
         viz_message = await self.node._create_artifact_ref_message_for_insight(self._insight_to_dict(self.insight1))
         assert isinstance(viz_message, ArtifactRefMessage), "Should create artifact ref message for insight1"
-        viz_message = await self.artifact_manager.aget_enriched_message(viz_message)
+        viz_message = await self.artifact_manager.aenrich_message(viz_message)
         assert viz_message is not None
 
         # Verify the answer contains the correct query type
@@ -817,7 +817,7 @@ class TestInsightSearchNode(BaseTest):
         # Test insight2 visualization message creation
         viz_message2 = await self.node._create_artifact_ref_message_for_insight(self._insight_to_dict(self.insight2))
         assert isinstance(viz_message2, ArtifactRefMessage), "Should create artifact ref message for insight2"
-        viz_message2 = await self.artifact_manager.aget_enriched_message(viz_message2)
+        viz_message2 = await self.artifact_manager.aenrich_message(viz_message2)
         assert viz_message2 is not None
 
         # Verify the answer contains the correct query type
@@ -867,7 +867,7 @@ class TestInsightSearchNode(BaseTest):
         # Test insight visualization message creation
         viz_message = await self.node._create_artifact_ref_message_for_insight(insight_dict)
         assert isinstance(viz_message, ArtifactRefMessage), "Should create artifact ref message for insight"
-        viz_message = await self.artifact_manager.aget_enriched_message(viz_message)
+        viz_message = await self.artifact_manager.aenrich_message(viz_message)
         assert viz_message is not None
 
         # Verify the answer contains the correct query type
@@ -905,7 +905,7 @@ class TestInsightSearchNode(BaseTest):
         # Test insight visualization message creation
         viz_message = await self.node._create_artifact_ref_message_for_insight(insight_dict)
         assert isinstance(viz_message, ArtifactRefMessage), "Should create artifact ref message for insight"
-        viz_message = await self.artifact_manager.aget_enriched_message(viz_message)
+        viz_message = await self.artifact_manager.aenrich_message(viz_message)
         assert viz_message is not None
 
         # Verify the answer contains the correct query type

--- a/ee/hogai/chat_agent/schema_generator/nodes.py
+++ b/ee/hogai/chat_agent/schema_generator/nodes.py
@@ -135,7 +135,7 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
 
         # We've got a result that either passed the quality check or we've exhausted all attempts at iterating - return
         # Create an artifact with the visualization content
-        artifact = await self.context_manager.artifacts.create(
+        artifact = await self.context_manager.artifacts.acreate(
             content=VisualizationArtifactContent(
                 query=result.query,
                 name=state.visualization_title,

--- a/ee/hogai/chat_agent/stream_processor.py
+++ b/ee/hogai/chat_agent/stream_processor.py
@@ -159,7 +159,7 @@ class ChatAgentStreamProcessor(AssistantStreamProcessorProtocol, Generic[StateTy
         # ArtifactRefMessage must always be enriched with content, regardless of nesting level
         if isinstance(message, ArtifactRefMessage):
             try:
-                enriched_message = await self._artifact_manager.aget_enriched_message(message)
+                enriched_message = await self._artifact_manager.aenrich_message(message)
             except (ValueError, KeyError) as e:
                 logger.warning("Failed to enrich ArtifactMessage", error=str(e), artifact_id=message.artifact_id)
                 enriched_message = None

--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -79,6 +79,24 @@ logger = structlog.get_logger(__name__)
 TIMING_LOG_PREFIX = "[QUERY_EXECUTOR]"
 
 
+def is_supported_query(query: AnyPydanticModelQuery | AnyAssistantGeneratedQuery) -> bool:
+    return isinstance(
+        query,
+        AssistantTrendsQuery
+        | TrendsQuery
+        | AssistantFunnelsQuery
+        | FunnelsQuery
+        | AssistantRetentionQuery
+        | RetentionQuery
+        | AssistantHogQLQuery
+        | HogQLQuery
+        | RevenueAnalyticsGrossRevenueQuery
+        | RevenueAnalyticsMetricsQuery
+        | RevenueAnalyticsMRRQuery
+        | RevenueAnalyticsTopCustomersQuery,
+    )
+
+
 class AssistantQueryExecutor:
     """
     Reusable class for executing queries and formatting results for the AI assistant.
@@ -399,6 +417,9 @@ class AssistantQueryExecutor:
         start_time = time.time()
         query_type = type(query).__name__
         formatter_name = None
+
+        if not is_supported_query(query):
+            raise NotImplementedError(f"Unsupported query type: {query_type}")
 
         try:
             # Handle assistant-specific query types with direct formatting

--- a/ee/hogai/core/test/test_artifacts.py
+++ b/ee/hogai/core/test/test_artifacts.py
@@ -61,12 +61,11 @@ class TestDocumentArtifactContent(BaseTest):
         self.assertEqual(content.blocks, [])
 
     def test_mixed_blocks(self):
-        query = AssistantTrendsQuery(series=[])
         blocks = [
-            {"type": "markdown", "content": "# Introduction"},
-            {"type": "visualization", "query": query.model_dump()},
-            {"type": "session_replay", "session_id": "sess456", "timestamp_ms": 1000, "title": "Example"},
-            {"type": "markdown", "content": "## Summary"},
+            MarkdownBlock(content="# Introduction"),
+            VisualizationBlock(query=AssistantTrendsQuery(series=[])),
+            SessionReplayBlock(session_id="sess456", timestamp_ms=1000, title="Example"),
+            MarkdownBlock(content="## Summary"),
         ]
         content = DocumentArtifactContent(blocks=blocks)
 

--- a/ee/hogai/eval/ci/conftest.py
+++ b/ee/hogai/eval/ci/conftest.py
@@ -85,7 +85,7 @@ def call_root_for_insight_generation(demo_org_team_user):
             }
 
         artifact_manager = ArtifactManager(team=demo_org_team_user[1], user=demo_org_team_user[2], config=config)
-        enriched_message = await artifact_manager.aget_enriched_message(final_state.messages[-3])
+        enriched_message = await artifact_manager.aenrich_message(final_state.messages[-3])
         content = unwrap_visualization_artifact_content(enriched_message)
         if content is None:
             return {

--- a/ee/hogai/eval/offline/eval_sql.py
+++ b/ee/hogai/eval/offline/eval_sql.py
@@ -70,7 +70,7 @@ async def call_graph(entry: DatasetInput, *args):
     maybe_viz_message = find_last_message_of_type(state["messages"], ArtifactRefMessage)
     if maybe_viz_message:
         artifact_manager = ArtifactManager(team=team, user=eval_ctx.user, config=config)
-        enriched_message = await artifact_manager.aget_enriched_message(maybe_viz_message)
+        enriched_message = await artifact_manager.aenrich_message(maybe_viz_message)
         content = unwrap_visualization_artifact_content(enriched_message)
         if content is None:
             return EvalOutput(database_schema=database_schema)

--- a/ee/hogai/tools/create_insight.py
+++ b/ee/hogai/tools/create_insight.py
@@ -3,7 +3,7 @@ from typing import Literal, Self
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
-from posthog.schema import AssistantTool, AssistantToolCallMessage
+from posthog.schema import AssistantTool, AssistantToolCallMessage, VisualizationArtifactContent
 
 from posthog.models import Team, User
 
@@ -603,8 +603,8 @@ class CreateInsightTool(MaxTool):
         if not is_visualization_artifact_message(maybe_viz_message):
             return "", ToolMessagesArtifact(messages=[tool_call_message])
 
-        visualization_content = await self._context_manager.artifacts.aget_content_by_short_id(
-            maybe_viz_message.artifact_id
+        visualization_content = await self._context_manager.artifacts.aget(
+            maybe_viz_message.artifact_id, VisualizationArtifactContent
         )
         # If the contextual tool is available, we're editing an insight.
         # Add the UI payload to the tool call message.

--- a/ee/hogai/tools/execute_sql/tool.py
+++ b/ee/hogai/tools/execute_sql/tool.py
@@ -77,7 +77,7 @@ class ExecuteSQLTool(HogQLGeneratorMixin, MaxTool):
             return format_prompt_string(EXECUTE_SQL_RECOVERABLE_ERROR_PROMPT, error=str(e)), None
 
         # Display an ephemeral visualization message to the user.
-        artifact = await self._context_manager.artifacts.create(
+        artifact = await self._context_manager.artifacts.acreate(
             VisualizationArtifactContent(query=parsed_query.query, name=viz_title, description=viz_description),
             "SQL Query",
         )

--- a/ee/hogai/tools/read_data/test/test_tool.py
+++ b/ee/hogai/tools/read_data/test/test_tool.py
@@ -17,7 +17,7 @@ from posthog.models import Dashboard, DashboardTile, Insight
 
 from products.data_warehouse.backend.models import DataWarehouseCredential, DataWarehouseSavedQuery, DataWarehouseTable
 
-from ee.hogai.artifacts.manager import StateArtifactResult
+from ee.hogai.artifacts.types import StateArtifactResult
 from ee.hogai.tool_errors import MaxToolRetryableError
 from ee.hogai.tools.read_data.tool import ReadDataTool
 from ee.hogai.utils.types import AssistantState
@@ -102,7 +102,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.artifacts = MagicMock()
-        context_manager.artifacts.aget_conversation_artifact_messages = AsyncMock(return_value=[artifact_message])
+        context_manager.artifacts.aget_conversation_artifacts = AsyncMock(return_value=[artifact_message])
 
         tool = ReadDataTool(
             team=team,
@@ -113,7 +113,7 @@ class TestReadDataTool(BaseTest):
 
         result, _ = await tool._arun_impl({"kind": "artifacts"})
 
-        context_manager.artifacts.aget_conversation_artifact_messages.assert_called_once_with()
+        context_manager.artifacts.aget_conversation_artifacts.assert_called_once_with()
         assert "artifact-123" in result
         assert "Test Chart" in result
         assert "A test visualization" in result
@@ -125,7 +125,7 @@ class TestReadDataTool(BaseTest):
         state = AssistantState(messages=[], root_tool_call_id=str(uuid4()))
         context_manager = MagicMock()
         context_manager.artifacts = MagicMock()
-        context_manager.artifacts.aget_conversation_artifact_messages = AsyncMock(return_value=[])
+        context_manager.artifacts.aget_conversation_artifacts = AsyncMock(return_value=[])
         context_manager.artifacts.check_user_has_billing_access = AsyncMock(return_value=False)
 
         tool = ReadDataTool(
@@ -206,7 +206,7 @@ class TestReadDataTool(BaseTest):
         )
 
         context_manager.artifacts = MagicMock()
-        context_manager.artifacts.aget_insight_with_source = AsyncMock(
+        context_manager.artifacts.aget_visualization = AsyncMock(
             return_value=StateArtifactResult(content=mock_content, source=ArtifactSource.STATE)
         )
 
@@ -242,7 +242,7 @@ class TestReadDataTool(BaseTest):
         )
 
         context_manager.artifacts = MagicMock()
-        context_manager.artifacts.aget_insight_with_source = AsyncMock(
+        context_manager.artifacts.aget_visualization = AsyncMock(
             return_value=StateArtifactResult(content=mock_content, source=ArtifactSource.STATE)
         )
 
@@ -285,7 +285,7 @@ class TestReadDataTool(BaseTest):
         context_manager = MagicMock()
         context_manager.check_user_has_billing_access = AsyncMock(return_value=False)
         context_manager.artifacts = MagicMock()
-        context_manager.artifacts.aget_insight_with_source = AsyncMock(return_value=None)
+        context_manager.artifacts.aget_visualization = AsyncMock(return_value=None)
 
         tool = await ReadDataTool.create_tool_class(
             team=team,
@@ -317,7 +317,7 @@ class TestReadDataTool(BaseTest):
         )
 
         context_manager.artifacts = MagicMock()
-        context_manager.artifacts.aget_insight_with_source = AsyncMock(
+        context_manager.artifacts.aget_visualization = AsyncMock(
             return_value=StateArtifactResult(content=mock_content, source=ArtifactSource.STATE)
         )
 
@@ -351,7 +351,7 @@ class TestReadDataTool(BaseTest):
         )
 
         context_manager.artifacts = MagicMock()
-        context_manager.artifacts.aget_insight_with_source = AsyncMock(
+        context_manager.artifacts.aget_visualization = AsyncMock(
             return_value=StateArtifactResult(content=mock_content, source=ArtifactSource.STATE)
         )
 

--- a/ee/hogai/tools/task.py
+++ b/ee/hogai/tools/task.py
@@ -18,7 +18,7 @@ from posthog.schema import (
 
 from posthog.models import Team, User
 
-from ee.hogai.artifacts.utils import unwrap_visualization_artifact_content
+from ee.hogai.artifacts.utils import unwrap_notebook_artifact_content, unwrap_visualization_artifact_content
 from ee.hogai.context.context import AssistantContextManager
 from ee.hogai.core.executor import AgentExecutor
 from ee.hogai.stream.redis_stream import get_subagent_stream_key
@@ -191,7 +191,13 @@ class TaskTool(MaxTool):
                 viz_content = unwrap_visualization_artifact_content(message)
                 if viz_content:
                     artifacts_list_prompt.append(
-                        f"- ID: {message.artifact_id}\nName: {viz_content.name}\nDescription: {viz_content.description}\nQuery: {viz_content.query}"
+                        f"- Insight ID: {message.artifact_id}\nName: {viz_content.name}\nDescription: {viz_content.description}\nQuery: {viz_content.query}"
+                    )
+                    continue
+                notebook_content = unwrap_notebook_artifact_content(message)
+                if notebook_content:
+                    artifacts_list_prompt.append(
+                        f"- Notebook ID: {message.artifact_id}\nTitle: {notebook_content.title}"
                     )
             artifacts_prompt = format_prompt_string(
                 TASK_ARTIFACTS_PROMPT, artifacts_list="\n\n".join(artifacts_list_prompt)

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -5,13 +5,14 @@ from django.db import transaction
 import structlog
 from pydantic import BaseModel, Field
 
-from posthog.schema import ArtifactSource, DataTableNode, HogQLQuery, InsightVizNode, QuerySchemaRoot
+from posthog.schema import DataTableNode, HogQLQuery, InsightVizNode, QuerySchemaRoot
 
 from posthog.models import Dashboard, DashboardTile, Insight
 from posthog.rbac.user_access_control import UserAccessControl, access_level_satisfied_for_resource
 from posthog.sync import database_sync_to_async
 
-from ee.hogai.artifacts.manager import ArtifactManager, DatabaseArtifactResult, ModelArtifactResult, StateArtifactResult
+from ee.hogai.artifacts.manager import ArtifactManager
+from ee.hogai.artifacts.types import ModelArtifactResult
 from ee.hogai.context.dashboard.context import DashboardContext, DashboardInsightContext
 from ee.hogai.context.insight.context import InsightContext
 from ee.hogai.tool import MaxTool, ToolMessagesArtifact
@@ -135,13 +136,13 @@ class UpsertDashboardTool(MaxTool):
 
     async def _resolve_insights(self, insight_ids: list[str]) -> tuple[list[Insight], list[str]]:
         """
-        Resolve insight_ids using ArtifactManager.aget_insights_with_source.
+        Resolve insight_ids using VisualizationHandler.
         Returns (resolved_insights, missing_ids) in same order as input.
 
         For State/Artifact sources, creates and saves new Insights before adding to dashboard.
         """
         artifact_manager = ArtifactManager(self._team, self._user, self._config)
-        results = await artifact_manager.aget_insights_with_source(self._state.messages, insight_ids)
+        results = await artifact_manager.aget_visualizations(self._state.messages, insight_ids)
 
         resolved: list[Insight] = []
         missing: list[str] = []
@@ -149,10 +150,10 @@ class UpsertDashboardTool(MaxTool):
         for insight_id, result in zip(insight_ids, results):
             if result is None:
                 missing.append(insight_id)
-            elif isinstance(result, ModelArtifactResult) and result.source == ArtifactSource.INSIGHT:
+            elif isinstance(result, ModelArtifactResult):
                 resolved.append(result.model)
-            elif isinstance(result, StateArtifactResult | DatabaseArtifactResult):
-                # Need to create and save insight from artifact content
+            else:
+                # State or Artifact source - need to create and save insight from artifact content
                 content = result.content
                 # Coerce query to the QuerySchema union
                 coerced_query = QuerySchemaRoot.model_validate(content.query.model_dump(mode="json")).root


### PR DESCRIPTION
## Problem
This PR introduces a new artifact handler system to improve how we manage different types of artifacts (visualizations, notebooks) in the AI assistant. The current implementation lacks a structured way to handle different artifact types, making it difficult to add new types or manage their lifecycle.

## Changes
- Created a new handler-based architecture for artifacts with a registry system
- Implemented handlers for visualization and notebook artifacts
- Refactored ArtifactManager to use the new handler system
- Added enrichment capabilities to resolve references in notebook artifacts
- Improved type safety with proper generics and type narrowing
- Updated tools to work with the new artifact system

## How did you test this code?
- Added comprehensive unit tests for the new handler classes
- Updated existing tests to work with the new system

## Publish to changelog?
No