### PR TITLE
feat: Dashboard reordering in the MCP

### DIFF
--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -83,6 +83,20 @@
             "readOnlyHint": false
         }
     },
+    "dashboard-reorder-tiles": {
+        "description": "Reorder tiles (insights) on a dashboard. Provide an array of tile IDs in the desired order from top to bottom. First, use dashboard-get to retrieve the dashboard and see the current tile IDs, then provide the tile IDs in your desired order.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Reorder tiles on a dashboard.",
+        "title": "Reorder dashboard tiles",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "docs-search": {
         "description": "Use this tool to search the PostHog documentation for information that can help the user with their request. Use it as a fallback when you cannot answer the user's request using other tools in this MCP. Only use this tool for PostHog related questions.",
         "category": "Documentation",

--- a/services/mcp/typescript/src/api/client.ts
+++ b/services/mcp/typescript/src/api/client.ts
@@ -1128,14 +1128,24 @@ export class ApiClient {
                 tileOrder: number[]
             }): Promise<Result<{ success: boolean; message: string; tiles: Array<{ id: number; order: number }> }>> => {
                 // Calculate new layout positions based on the specified order
-                // Each tile gets a y position based on its index (row-based layout)
-                const tiles = tileOrder.map((tileId, index) => ({
-                    id: tileId,
-                    layouts: {
-                        sm: { x: 0, y: index * 5, w: 6, h: 5 },
-                        xs: { x: 0, y: index * 5, w: 6, h: 5 },
-                    },
-                }))
+                // Use 2-column grid for larger layouts (sm and above), single column for xs
+                const tileWidth = 6 // Half of 12-column grid
+                const tileHeight = 5
+
+                const tiles = tileOrder.map((tileId, index) => {
+                    const row = Math.floor(index / 2)
+                    const col = index % 2
+
+                    return {
+                        id: tileId,
+                        layouts: {
+                            // 2-column layout for sm and larger screens
+                            sm: { x: col * tileWidth, y: row * tileHeight, w: tileWidth, h: tileHeight },
+                            // Single column for xs (mobile)
+                            xs: { x: 0, y: index * tileHeight, w: 6, h: tileHeight },
+                        },
+                    }
+                })
 
                 const result = await this.fetchWithSchema(
                     `${this.baseUrl}/api/projects/${projectId}/dashboards/${dashboardId}/`,

--- a/services/mcp/typescript/src/schema/dashboards.ts
+++ b/services/mcp/typescript/src/schema/dashboards.ts
@@ -84,6 +84,15 @@ export const AddInsightToDashboardSchema = z.object({
     dashboardId: z.number().int().positive(),
 })
 
+// Input schema for reordering dashboard tiles
+export const ReorderDashboardTilesSchema = z.object({
+    dashboardId: z.number().int().positive().describe('The ID of the dashboard to reorder tiles on'),
+    tileOrder: z
+        .array(z.number().int().positive())
+        .min(1)
+        .describe('Array of tile IDs in the desired order from top to bottom'),
+})
+
 // Type exports
 export type PostHogDashboard = z.infer<typeof DashboardSchema>
 export type CreateDashboardInput = z.infer<typeof CreateDashboardInputSchema>
@@ -91,3 +100,4 @@ export type UpdateDashboardInput = z.infer<typeof UpdateDashboardInputSchema>
 export type ListDashboardsData = z.infer<typeof ListDashboardsSchema>
 export type AddInsightToDashboardInput = z.infer<typeof AddInsightToDashboardSchema>
 export type SimpleDashboard = z.infer<typeof SimpleDashboardSchema>
+export type ReorderDashboardTilesInput = z.infer<typeof ReorderDashboardTilesSchema>

--- a/services/mcp/typescript/src/schema/tool-inputs.ts
+++ b/services/mcp/typescript/src/schema/tool-inputs.ts
@@ -4,6 +4,7 @@ import {
     AddInsightToDashboardSchema,
     CreateDashboardInputSchema,
     ListDashboardsSchema,
+    ReorderDashboardTilesSchema,
     UpdateDashboardInputSchema,
 } from './dashboards'
 import { ErrorDetailsSchema, ListErrorsSchema } from './errors'
@@ -43,6 +44,8 @@ export const DashboardUpdateSchema = z.object({
     dashboardId: z.number(),
     data: UpdateDashboardInputSchema,
 })
+
+export const DashboardReorderTilesSchema = ReorderDashboardTilesSchema
 
 export const DocumentationSearchSchema = z.object({
     query: z.string(),

--- a/services/mcp/typescript/src/tools/dashboards/reorderTiles.ts
+++ b/services/mcp/typescript/src/tools/dashboards/reorderTiles.ts
@@ -1,0 +1,34 @@
+import type { z } from 'zod'
+
+import { DashboardReorderTilesSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = DashboardReorderTilesSchema
+
+type Params = z.infer<typeof schema>
+
+export const reorderTilesHandler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const { dashboardId, tileOrder } = params
+    const projectId = await context.stateManager.getProjectId()
+
+    const dashboardTilesResult = await context.api
+        .dashboards({ projectId })
+        .reorderTiles({ dashboardId, tileOrder })
+
+    if (!dashboardTilesResult.success) {
+        throw new Error(`Failed to reorder tiles: ${dashboardTilesResult.error.message}`)
+    }
+
+    return {
+        ...dashboardTilesResult.data,
+        url: `${context.api.getProjectBaseUrl(projectId)}/dashboard/${dashboardId}`,
+    }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'dashboard-reorder-tiles',
+    schema,
+    handler: reorderTilesHandler,
+})
+
+export default tool

--- a/services/mcp/typescript/src/tools/index.ts
+++ b/services/mcp/typescript/src/tools/index.ts
@@ -11,6 +11,7 @@ import createDashboard from './dashboards/create'
 import deleteDashboard from './dashboards/delete'
 import getDashboard from './dashboards/get'
 import getAllDashboards from './dashboards/getAll'
+import reorderDashboardTiles from './dashboards/reorderTiles'
 import updateDashboard from './dashboards/update'
 // Documentation
 import searchDocs from './documentation/searchDocs'
@@ -125,6 +126,7 @@ const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     'dashboard-create': createDashboard,
     'dashboard-update': updateDashboard,
     'dashboard-delete': deleteDashboard,
+    'dashboard-reorder-tiles': reorderDashboardTiles,
     'add-insight-to-dashboard': addInsightToDashboard,
 
     // LLM Observability

--- a/services/mcp/typescript/tests/integration/feature-routing.test.ts
+++ b/services/mcp/typescript/tests/integration/feature-routing.test.ts
@@ -36,6 +36,7 @@ describe('Feature Routing Integration', () => {
                 'dashboard-get',
                 'dashboard-update',
                 'dashboard-delete',
+                'dashboard-reorder-tiles',
                 'add-insight-to-dashboard',
             ],
         },

--- a/services/mcp/typescript/tests/tools/dashboards.integration.test.ts
+++ b/services/mcp/typescript/tests/tools/dashboards.integration.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import {
     type CreatedResources,
+    SAMPLE_HOGQL_QUERIES,
     TEST_ORG_ID,
     TEST_PROJECT_ID,
     cleanupResources,
@@ -12,11 +13,14 @@ import {
     setActiveProjectAndOrg,
     validateEnvironmentVariables,
 } from '@/shared/test-utils'
+import addInsightToDashboardTool from '@/tools/dashboards/addInsight'
 import createDashboardTool from '@/tools/dashboards/create'
 import deleteDashboardTool from '@/tools/dashboards/delete'
 import getDashboardTool from '@/tools/dashboards/get'
 import getAllDashboardsTool from '@/tools/dashboards/getAll'
+import reorderDashboardTilesTool from '@/tools/dashboards/reorderTiles'
 import updateDashboardTool from '@/tools/dashboards/update'
+import createInsightTool from '@/tools/insights/create'
 import type { Context } from '@/tools/types'
 
 describe('Dashboards', { concurrent: false }, () => {
@@ -220,6 +224,96 @@ describe('Dashboards', { concurrent: false }, () => {
             })
             const deleteResponse = parseToolResponse(deleteResult)
             expect(deleteResponse.success).toBe(true)
+        })
+    })
+
+    describe('reorder-dashboard-tiles tool', () => {
+        const createDashboard = createDashboardTool()
+        const createInsight = createInsightTool()
+        const addInsight = addInsightToDashboardTool()
+        const reorderTiles = reorderDashboardTilesTool()
+        const getDashboard = getDashboardTool()
+        const deleteDashboard = deleteDashboardTool()
+
+        it('should reorder tiles on a dashboard', async () => {
+            // Create a dashboard
+            const dashboardResult = await createDashboard.handler(context, {
+                data: {
+                    name: generateUniqueKey('Reorder Test Dashboard'),
+                    description: 'Dashboard for testing tile reordering',
+                    pinned: false,
+                },
+            })
+            const dashboard = parseToolResponse(dashboardResult)
+            createdResources.dashboards.push(dashboard.id)
+
+            // Create two insights
+            const insight1Result = await createInsight.handler(context, {
+                data: {
+                    name: generateUniqueKey('Insight 1'),
+                    description: 'First insight',
+                    query: SAMPLE_HOGQL_QUERIES.pageviews,
+                    favorited: false,
+                },
+            })
+            const insight1 = parseToolResponse(insight1Result)
+            createdResources.insights.push(insight1.id)
+
+            const insight2Result = await createInsight.handler(context, {
+                data: {
+                    name: generateUniqueKey('Insight 2'),
+                    description: 'Second insight',
+                    query: SAMPLE_HOGQL_QUERIES.topEvents,
+                    favorited: false,
+                },
+            })
+            const insight2 = parseToolResponse(insight2Result)
+            createdResources.insights.push(insight2.id)
+
+            // Add insights to dashboard
+            await addInsight.handler(context, {
+                data: {
+                    insightId: insight1.short_id,
+                    dashboardId: dashboard.id,
+                },
+            })
+            await addInsight.handler(context, {
+                data: {
+                    insightId: insight2.short_id,
+                    dashboardId: dashboard.id,
+                },
+            })
+
+            // Get the dashboard to see the tile IDs
+            const dashboardWithTilesResult = await getDashboard.handler(context, {
+                dashboardId: dashboard.id,
+            })
+            const dashboardWithTiles = parseToolResponse(dashboardWithTilesResult)
+
+            expect(dashboardWithTiles.tiles).toBeTruthy()
+            expect(dashboardWithTiles.tiles.length).toBeGreaterThanOrEqual(2)
+
+            // Get the tile IDs (filter out null tiles)
+            const tileIds = dashboardWithTiles.tiles
+                .filter((tile: any) => tile !== null && tile.id !== undefined)
+                .map((tile: any) => tile.id)
+
+            // Reorder tiles (reverse the order)
+            const reversedTileOrder = [...tileIds].reverse()
+            const reorderResult = await reorderTiles.handler(context, {
+                dashboardId: dashboard.id,
+                tileOrder: reversedTileOrder,
+            })
+            const reorderResponse = parseToolResponse(reorderResult)
+
+            expect(reorderResponse.success).toBe(true)
+            expect(reorderResponse.message).toContain('Successfully reordered')
+            expect(reorderResponse.tiles).toBeTruthy()
+            expect(reorderResponse.url).toContain('/dashboard/')
+
+            // Clean up
+            await deleteDashboard.handler(context, { dashboardId: dashboard.id })
+            createdResources.dashboards = createdResources.dashboards.filter((id) => id !== dashboard.id)
         })
     })
 })

--- a/services/mcp/typescript/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/typescript/tests/unit/tool-filtering.test.ts
@@ -126,6 +126,7 @@ describe('Tool Filtering - API Scopes', () => {
         expect(toolNames).toContain('dashboard-get')
         expect(toolNames).toContain('dashboards-get-all')
         expect(toolNames).toContain('add-insight-to-dashboard')
+        expect(toolNames).toContain('dashboard-reorder-tiles')
 
         expect(toolNames).not.toContain('create-feature-flag')
         expect(toolNames).not.toContain('organizations-get')


### PR DESCRIPTION
> Built by Cursor after some user feedback

## Problem

Users need the ability to reorder dashboard tiles programmatically via the MCP. This change introduces a new tool to facilitate this.

## Changes

Adds a new MCP tool `dashboard-reorder-tiles` that allows users to reorder tiles on a specified dashboard.

-   **`services/mcp/typescript/src/tools/dashboards/reorderTiles.ts`**: New tool handler for reordering dashboard tiles.
-   **`services/mcp/typescript/src/api/client.ts`**: Adds a `reorderTiles` API method that updates tile layouts based on the provided order.
-   **`services/mcp/typescript/src/schema/dashboards.ts` & `services/mcp/typescript/src/schema/tool-inputs.ts`**: New schema `ReorderDashboardTilesSchema` for input validation.
-   **`services/mcp/schema/tool-definitions.json`**: Adds `dashboard-reorder-tiles` tool definition.
-   **`services/mcp/typescript/src/tools/index.ts`**: Registers the new tool.
-   **`services/mcp/typescript/tests/tools/dashboards.integration.test.ts`**: Adds an integration test for the reorder tiles functionality.
-   **`services/mcp/typescript/tests/unit/tool-filtering.test.ts` & `tests/integration/feature-routing.test.ts`**: Updates to include the new tool in dashboard tool expectations.

## How did you test this code?

-   Added a dedicated integration test (`services/mcp/typescript/tests/tools/dashboards.integration.test.ts`) that creates a dashboard, adds insights, reorders them, and verifies the success of the operation.

## Publish to changelog?

Yes

---
[Slack Thread](https://posthog.slack.com/archives/C011L071P8U/p1767366539285079?thread_ts=1767366539.285079&cid=C011L071P8U)

<a href="https://cursor.com/background-agent?bcId=bc-6da949ae-80de-43e7-8739-78cc89df92cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6da949ae-80de-43e7-8739-78cc89df92cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

