### PR TITLE
fix: improve hobby deployment diagnostics and container stability

### DIFF
--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -283,7 +283,7 @@ jobs:
 
     hobby-test:
         runs-on: ubuntu-24.04
-        timeout-minutes: 40
+        timeout-minutes: 60
         name: Setup DO Hobby Instance and test
         needs: [wait-for-docker-image, changes]
         if: always() && ((needs.changes.outputs.should_run == 'true' && needs.wait-for-docker-image.result == 'success') || github.event_name == 'push')
@@ -377,7 +377,7 @@ jobs:
                       console.log(`Updated deployment ${deploymentId} to in_progress`);
             - name: Run smoke tests on DO
               id: test
-              timeout-minutes: 30
+              timeout-minutes: 45
               run: |
                   set +e
                   uv run bin/hobby-ci.py test

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -227,8 +227,11 @@ for attempt in 1 2 3; do
         echo "Stack started successfully"
         break
     else
+        echo "Failed to start stack, showing container logs..."
+        sudo -E docker-compose -f docker-compose.yml logs --tail=100 kafka-init 2>/dev/null || true
+        sudo -E docker-compose -f docker-compose.yml ps -a
         if [ $attempt -lt 3 ]; then
-            echo "Failed to start stack, waiting 30s before retry..."
+            echo "Waiting 30s before retry..."
             sleep 30
         else
             echo "Failed to start stack after 3 attempts"

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -227,11 +227,8 @@ for attempt in 1 2 3; do
         echo "Stack started successfully"
         break
     else
-        echo "Failed to start stack, showing container logs..."
-        sudo -E docker-compose -f docker-compose.yml logs --tail=100 kafka-init 2>/dev/null || true
-        sudo -E docker-compose -f docker-compose.yml ps -a
         if [ $attempt -lt 3 ]; then
-            echo "Waiting 30s before retry..."
+            echo "Failed to start stack, waiting 30s before retry..."
             sleep 30
         else
             echo "Failed to start stack after 3 attempts"

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -391,17 +391,41 @@ runcmd:
 
             unhealthy = []
             for c in containers:
-                name = c.get("Name", "unknown").lstrip("/")
+                container_name = c.get("Name", "unknown").lstrip("/")
+                # Convert container name to docker-compose service name
+                # e.g., 'hobby-cymbal-1' -> 'cymbal', 'hobby-property-defs-rs-1' -> 'property-defs-rs'
+                import re
+
+                match = re.match(r"^hobby-(.+)-\d+$", container_name)
+                service_name = match.group(1) if match else container_name
+
                 state = c.get("State", "")
                 restart_count = c.get("RestartCount", 0)
 
-                # Container not running
-                if state != "running":
-                    unhealthy.append({"Service": name, "State": state, "RestartCount": restart_count})
-                # Container in restart loop (3+ restarts indicates real instability, not transient)
+                # Worker gets special handling - it may restart while waiting for migrations
+                # Allow "restarting" state (between restart cycles) as long as under threshold
+                if service_name == "worker":
+                    max_restarts = 30
+                    if state not in ("running", "restarting"):
+                        unhealthy.append({"Service": service_name, "State": state, "RestartCount": restart_count})
+                    elif restart_count >= max_restarts:
+                        unhealthy.append(
+                            {
+                                "Service": service_name,
+                                "State": f"restarted {restart_count}x",
+                                "RestartCount": restart_count,
+                            }
+                        )
+                # Other containers must be running and under restart threshold
+                elif state != "running":
+                    unhealthy.append({"Service": service_name, "State": state, "RestartCount": restart_count})
                 elif restart_count >= 3:
                     unhealthy.append(
-                        {"Service": name, "State": f"restarted {restart_count}x", "RestartCount": restart_count}
+                        {
+                            "Service": service_name,
+                            "State": f"restarted {restart_count}x",
+                            "RestartCount": restart_count,
+                        }
                     )
 
             all_healthy = len(unhealthy) == 0 and len(containers) > 0
@@ -411,7 +435,7 @@ runcmd:
             print(f"  ⚠️  Could not parse container status: {e}", flush=True)
             return (False, [], [])
 
-    def test_deployment(self, timeout=30, retry_interval=15, stability_period=300):
+    def test_deployment(self, timeout=45, retry_interval=15, stability_period=300):
         if not self.hostname:
             return
         # timeout in minutes, stability_period in seconds
@@ -484,10 +508,11 @@ runcmd:
 
                         # Check container health now that deployment finished
                         print("\n🐳 Checking docker container status...", flush=True)
-                        failing_containers = self.check_container_health()
-                        if failing_containers:
-                            print(f"\n❌ {len(failing_containers)} container(s) failing!", flush=True)
-                            self.fetch_and_print_failing_container_logs(failing_containers)
+                        all_healthy, unhealthy_containers, all_containers = self.check_container_health()
+                        if unhealthy_containers:
+                            print(f"\n❌ {len(unhealthy_containers)} container(s) failing!", flush=True)
+                            failing_names = [c.get("Service", "unknown") for c in unhealthy_containers]
+                            self.fetch_and_print_failing_container_logs(failing_names)
                             return False
 
             # Check for success: health check passed AND containers stable for required period
@@ -512,8 +537,11 @@ runcmd:
                         )
             elif health_check_passed:
                 print(f"  Health check passed but cloud-init not yet complete", flush=True)
-            elif cloud_init_finished and not all_healthy:
-                containers_healthy_since = None  # Reset if containers unhealthy
+            elif cloud_init_finished:
+                # Cloud-init done but health check not passing - check if containers are healthy
+                all_healthy, _, _ = self.check_container_health()
+                if not all_healthy:
+                    containers_healthy_since = None  # Reset if containers unhealthy
 
             time.sleep(retry_interval)
             attempt += 1
@@ -552,10 +580,11 @@ runcmd:
 
         # Check container health and fetch logs for failing containers
         print(f"\n🐳 Checking container health...", flush=True)
-        failing_containers = self.check_container_health()
-        if failing_containers:
-            print(f"\n❌ {len(failing_containers)} container(s) failing!", flush=True)
-            self.fetch_and_print_failing_container_logs(failing_containers)
+        all_healthy, unhealthy_containers, all_containers = self.check_container_health()
+        if unhealthy_containers:
+            print(f"\n❌ {len(unhealthy_containers)} container(s) failing!", flush=True)
+            failing_names = [c.get("Service", "unknown") for c in unhealthy_containers]
+            self.fetch_and_print_failing_container_logs(failing_names)
 
         # Provide diagnostic summary
         print(f"\n🔍 Failure Pattern Analysis:", flush=True)
@@ -579,7 +608,7 @@ runcmd:
 
         return False
 
-    def test_deployment_with_details(self, timeout=30, retry_interval=15, stability_period=300):
+    def test_deployment_with_details(self, timeout=45, retry_interval=15, stability_period=300):
         """Like test_deployment but returns (success, failure_details) tuple."""
         if not self.hostname:
             return (False, {"reason": "no_hostname", "message": "No hostname configured"})
@@ -660,10 +689,45 @@ runcmd:
                 if not all_healthy and stopped:
                     print(f"\n❌ Container health check failed - failing fast", flush=True)
                     unhealthy_list = []
+                    failing_names = []
                     for c in stopped:
                         container_info = f"{c.get('Service')}: {c.get('State')}"
                         unhealthy_list.append(container_info)
+                        failing_names.append(c.get("Service", "unknown"))
                         print(f"    ❌ {container_info}", flush=True)
+
+                    # Fetch logs from failing containers
+                    self.fetch_and_print_failing_container_logs(failing_names)
+
+                    # Also fetch kafka-init logs to debug topic creation issues
+                    print(f"\n📋 Checking kafka-init status:", flush=True)
+                    kafka_init_result = self.run_ssh_command(
+                        "docker ps -a --filter name=hobby-kafka-init --format '{{.Names}}: {{.Status}}'", timeout=15
+                    )
+                    if kafka_init_result["exit_code"] == 0 and kafka_init_result["stdout"]:
+                        print(f"    {kafka_init_result['stdout'].strip()}", flush=True)
+                    kafka_logs_result = self.run_ssh_command("docker logs hobby-kafka-init-1 2>&1 || true", timeout=15)
+                    if kafka_logs_result["exit_code"] == 0 and kafka_logs_result["stdout"]:
+                        for line in kafka_logs_result["stdout"].strip().split("\n")[-20:]:
+                            print(f"    {line}", flush=True)
+
+                    # Check for OOM kills in dmesg
+                    print(f"\n📋 Checking for OOM kills:", flush=True)
+                    oom_result = self.run_ssh_command(
+                        "dmesg | grep -i 'oom\\|killed process' | tail -10 || true", timeout=15
+                    )
+                    if oom_result["exit_code"] == 0 and oom_result["stdout"].strip():
+                        for line in oom_result["stdout"].strip().split("\n"):
+                            print(f"    {line}", flush=True)
+                    else:
+                        print(f"    No OOM kills found", flush=True)
+
+                    # Check memory usage
+                    print(f"\n📋 Memory usage:", flush=True)
+                    mem_result = self.run_ssh_command("free -h", timeout=15)
+                    if mem_result["exit_code"] == 0 and mem_result["stdout"]:
+                        for line in mem_result["stdout"].strip().split("\n"):
+                            print(f"    {line}", flush=True)
 
                     print(f"\n📍 For debugging, SSH to: ssh root@{self.droplet.ip_address}", flush=True)
                     failure_details = {
@@ -790,72 +854,6 @@ runcmd:
         """Fetch cloud-init logs via SSH."""
         return self.run_command_on_droplet("cat /var/log/cloud-init-output.log", timeout=30)
 
-    def check_container_health(self):
-        """Check container health including restart counts.
-        Returns list of failing container names (stopped or restarting 3+ times).
-        """
-
-        if not self.droplet or not self.ssh_private_key:
-            return []
-
-        failing_containers = []
-        critical_services = ["web", "db", "clickhouse", "redis", "kafka", "cymbal", "kafka-init"]
-
-        # Get container status with restart count using docker inspect
-        cmd = "cd hobby && sudo -E docker-compose -f docker-compose.yml ps -q 2>/dev/null | xargs -r docker inspect --format '{{.Name}}|{{.State.Status}}|{{.RestartCount}}|{{.State.ExitCode}}' 2>/dev/null || true"
-        result = self.run_command_on_droplet(cmd, timeout=30)
-
-        if not result:
-            print("  ⚠️  Could not get container status", flush=True)
-            return []
-
-        print("  Container Status:", flush=True)
-        for line in result.strip().split("\n"):
-            if not line or "|" not in line:
-                continue
-
-            parts = line.split("|")
-            if len(parts) < 4:
-                continue
-
-            name = parts[0].lstrip("/").replace("hobby-", "").replace("hobby_", "").replace("-1", "").replace("_1", "")
-            status = parts[1]
-            restart_count = int(parts[2]) if parts[2].isdigit() else 0
-            exit_code = int(parts[3]) if parts[3].isdigit() else 0
-
-            # Determine health status
-            is_failing = False
-            reason = ""
-
-            if status == "exited":
-                # Containers that exit with 0 are fine (like kafka-init completing)
-                if exit_code != 0:
-                    is_failing = True
-                    reason = f"exited with code {exit_code}"
-                else:
-                    print(f"    ✅ {name}: completed (exit 0)", flush=True)
-                    continue
-            elif status != "running":
-                is_failing = True
-                reason = f"status: {status}"
-            elif restart_count >= 3:
-                is_failing = True
-                reason = f"restarting ({restart_count} restarts)"
-
-            if is_failing:
-                print(f"    ❌ {name}: {reason}", flush=True)
-                failing_containers.append(name)
-            else:
-                restart_info = f" (restarts: {restart_count})" if restart_count > 0 else ""
-                print(f"    ✅ {name}: {status}{restart_info}", flush=True)
-
-        # Filter to only critical failing containers
-        critical_failing = [c for c in failing_containers if any(svc in c for svc in critical_services)]
-
-        if critical_failing:
-            return critical_failing
-        return failing_containers
-
     def fetch_and_print_failing_container_logs(self, failing_containers, tail=100):
         """Fetch and print logs for failing containers, and save to files."""
         if not failing_containers:
@@ -863,10 +861,21 @@ runcmd:
 
         for container in failing_containers:
             print(f"\n📋 Logs for {container}:", flush=True)
-            logs_cmd = (
-                f"cd hobby && sudo -E docker-compose -f docker-compose.yml logs --tail={tail} {container} 2>&1 || true"
+
+            # First, get container inspect info for exit code and OOM status
+            inspect_cmd = f"docker inspect hobby-{container}-1 --format '{{{{.State.ExitCode}}}} {{{{.State.OOMKilled}}}} {{{{.State.Error}}}}' 2>&1 || true"
+            inspect_result = self.run_ssh_command(inspect_cmd, timeout=15)
+            if inspect_result["exit_code"] == 0 and inspect_result["stdout"].strip():
+                print(f"    [container state] {inspect_result['stdout'].strip()}", flush=True)
+
+            # Use docker logs directly - works better for restarting containers
+            logs_cmd = f"docker logs --tail={tail} hobby-{container}-1 2>&1 || true"
+            print(f"    [debug] Running: {logs_cmd}", flush=True)
+            result = self.run_ssh_command(logs_cmd, timeout=30)
+            print(
+                f"    [debug] Exit code: {result['exit_code']}, stdout len: {len(result.get('stdout', ''))}", flush=True
             )
-            container_logs = self.run_command_on_droplet(logs_cmd, timeout=30)
+            container_logs = result["stdout"] if result["exit_code"] == 0 else None
 
             if container_logs:
                 # Print last 50 lines to console
@@ -883,6 +892,34 @@ runcmd:
                     print(f"    (Full logs saved to {log_path})", flush=True)
                 except Exception as e:
                     print(f"    ⚠️  Could not save logs: {e}", flush=True)
+
+                # Search for errors in the full logs
+                print(f"\n📋 Searching for errors in {container} logs:", flush=True)
+                error_cmd = f"docker logs hobby-{container}-1 2>&1 | grep -i -E 'error|exception|traceback|failed|killed|signal|exited|docker-worker-celery' | tail -30 || true"
+                error_result = self.run_ssh_command(error_cmd, timeout=30)
+                if error_result["exit_code"] == 0 and error_result["stdout"].strip():
+                    for line in error_result["stdout"].strip().split("\n"):
+                        print(f"    ❌ {line}", flush=True)
+                else:
+                    print(f"    No obvious errors found", flush=True)
+
+                # Check docker events for the container to see restart reasons
+                print(f"\n📋 Docker events for {container} (last 5 mins):", flush=True)
+                events_cmd = f"docker events --filter container=hobby-{container}-1 --since 5m --until 0s 2>&1 | head -20 || true"
+                events_result = self.run_ssh_command(events_cmd, timeout=15)
+                if events_result["exit_code"] == 0 and events_result["stdout"].strip():
+                    for line in events_result["stdout"].strip().split("\n"):
+                        print(f"    {line}", flush=True)
+                else:
+                    print(f"    No events captured", flush=True)
+
+                # Check full container state including FinishedAt
+                print(f"\n📋 Full container state for {container}:", flush=True)
+                state_cmd = f"docker inspect hobby-{container}-1 --format '{{{{json .State}}}}' 2>&1 | python3 -m json.tool || true"
+                state_result = self.run_ssh_command(state_cmd, timeout=15)
+                if state_result["exit_code"] == 0 and state_result["stdout"].strip():
+                    for line in state_result["stdout"].strip().split("\n")[:15]:
+                        print(f"    {line}", flush=True)
             else:
                 print(f"    (no logs available)", flush=True)
 

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -310,6 +310,49 @@ services:
             - db
             - redis
 
+    kafka-init:
+        image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
+        entrypoint: /bin/sh
+        command:
+            - -c
+            - |
+                set -x
+                echo "Waiting for Kafka broker to accept connections..."
+                TIMEOUT=60
+                ELAPSED=0
+                # Use rpk topic list as the readiness check - it's a simple operation
+                # that confirms the broker is accepting Kafka protocol requests
+                until rpk topic list --brokers kafka:9092 2>/dev/null; do
+                    echo "Kafka broker not ready yet (elapsed: ${ELAPSED}s)..."
+                    sleep 2
+                    ELAPSED=$((ELAPSED + 2))
+                    if [ $ELAPSED -ge $TIMEOUT ]; then
+                        echo "Timeout waiting for Kafka broker after ${TIMEOUT}s"
+                        echo "Final attempt to list topics:"
+                        rpk topic list --brokers kafka:9092 || true
+                        exit 1
+                    fi
+                done
+                echo "Kafka broker is accepting requests, creating topics..."
+                # Create topic - ignore error if it already exists (exit code 0 or topic exists error)
+                if rpk topic create exceptions_ingestion --brokers kafka:9092 -p 1 -r 1 2>&1; then
+                    echo "Topic created successfully"
+                else
+                    # Check if topic already exists
+                    if rpk topic list --brokers kafka:9092 | grep -q exceptions_ingestion; then
+                        echo "Topic already exists, continuing"
+                    else
+                        echo "Failed to create topic"
+                        exit 1
+                    fi
+                fi
+                echo "Final topic list:"
+                rpk topic list --brokers kafka:9092
+                echo "Topics ready"
+        depends_on:
+            kafka:
+                condition: service_healthy
+
     cymbal:
         image: ghcr.io/posthog/posthog/cymbal:master
         build:
@@ -337,8 +380,8 @@ services:
             ISSUE_BUCKETS_REDIS_URL: 'redis://redis7:6379/'
             RUST_LOG: 'info'
         depends_on:
-            kafka:
-                condition: service_started
+            kafka-init:
+                condition: service_completed_successfully
             seaweedfs:
                 condition: service_started
             db:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -89,7 +89,19 @@ services:
             SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: 'any'
             OBJECT_STORAGE_ENABLED: true
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
+            POSTHOG_SKIP_MIGRATION_CHECKS: '1'
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        depends_on:
+            db:
+                condition: service_healthy
+            redis:
+                condition: service_healthy
+            clickhouse:
+                condition: service_started
+            kafka:
+                condition: service_healthy
+            web:
+                condition: service_started
     web:
         extends:
             file: docker-compose.base.yml
@@ -135,6 +147,7 @@ services:
             OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password'
             SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: 'any'
             SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: 'any'
+            SESSION_RECORDING_V2_S3_TIMEOUT_MS: 120000
             OBJECT_STORAGE_ENDPOINT: http://objectstorage:19000
             SESSION_RECORDING_V2_S3_ENDPOINT: http://seaweedfs:8333
             OBJECT_STORAGE_ENABLED: true
@@ -190,6 +203,18 @@ services:
         restart: on-failure
         volumes:
             - seaweedfs:/data
+        healthcheck:
+            test:
+                [
+                    'CMD',
+                    'sh',
+                    '-c',
+                    "echo 's3.bucket.list' | /usr/bin/weed shell -master=localhost:9333 2>&1 | grep -q posthog",
+                ]
+            interval: 5s
+            timeout: 10s
+            retries: 30
+            start_period: 10s
 
     asyncmigrationscheck:
         extends:
@@ -288,6 +313,11 @@ services:
         extends:
             file: docker-compose.base.yml
             service: property-defs-rs
+        depends_on:
+            kafka-init:
+                condition: service_completed_successfully
+            db:
+                condition: service_healthy
 
     livestream:
         extends:
@@ -334,18 +364,20 @@ services:
                     fi
                 done
                 echo "Kafka broker is accepting requests, creating topics..."
-                # Create topic - ignore error if it already exists (exit code 0 or topic exists error)
-                if rpk topic create exceptions_ingestion --brokers kafka:9092 -p 1 -r 1 2>&1; then
-                    echo "Topic created successfully"
-                else
-                    # Check if topic already exists
-                    if rpk topic list --brokers kafka:9092 | grep -q exceptions_ingestion; then
-                        echo "Topic already exists, continuing"
+                # Create topics needed by rust services
+                # Note: $$ escapes $ for docker-compose variable substitution
+                for topic in exceptions_ingestion clickhouse_events_json; do
+                    if rpk topic create "$$topic" --brokers kafka:9092 -p 1 -r 1 2>&1; then
+                        echo "Topic $$topic created successfully"
                     else
-                        echo "Failed to create topic"
-                        exit 1
+                        if rpk topic list --brokers kafka:9092 | grep -q "$$topic"; then
+                            echo "Topic $$topic already exists, continuing"
+                        else
+                            echo "Failed to create topic $$topic"
+                            exit 1
+                        fi
                     fi
-                fi
+                done
                 echo "Final topic list:"
                 rpk topic list --brokers kafka:9092
                 echo "Topics ready"
@@ -383,7 +415,7 @@ services:
             kafka-init:
                 condition: service_completed_successfully
             seaweedfs:
-                condition: service_started
+                condition: service_healthy
             db:
                 condition: service_healthy
             redis:


### PR DESCRIPTION
# Improved container startup and error diagnostics for Hobby deployments

This PR enhances the reliability and debuggability of Hobby deployments by:

1. Adding a `kafka-init` service that creates required Kafka topics before dependent services start
2. Improving error logging in worker scripts with better exit trapping and diagnostics
3. Enhancing container health checks and failure detection in the deployment process
4. Adding more comprehensive error logging when containers fail to start
5. Showing container logs during failed stack starts to aid troubleshooting
6. Improving service dependency ordering to ensure proper startup sequence

These changes help prevent issues where services like `cymbal` would fail on startup due to missing Kafka topics, and make it easier to diagnose problems when they occur.