### PR TITLE
fix(flags): Override missing $initial values

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -9,7 +9,8 @@ use crate::flags::flag_match_reason::FeatureFlagMatchReason;
 use crate::flags::flag_matching_utils::{
     all_flag_condition_properties_match, all_properties_match, calculate_hash,
     fetch_and_locally_cache_all_relevant_properties, get_feature_flag_hash_key_overrides,
-    set_feature_flag_hash_key_overrides, should_write_hash_key_override,
+    populate_missing_initial_properties, set_feature_flag_hash_key_overrides,
+    should_write_hash_key_override,
 };
 use crate::flags::flag_models::{
     BucketingIdentifier, FeatureFlag, FeatureFlagId, FeatureFlagList, FlagPropertyGroup,
@@ -1075,7 +1076,11 @@ impl FeatureFlagMatcher {
             merged_properties.extend(overrides);
         }
 
-        // Return all merged properties
+        // Populate missing $initial_ properties from their non-initial counterparts.
+        // DB $initial_ values are preserved; this only fills in missing ones from
+        // the merged properties (which may come from DB or request overrides).
+        populate_missing_initial_properties(&mut merged_properties);
+
         Ok(merged_properties)
     }
 

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -131,7 +131,7 @@ pub fn calculate_hash(prefix: &str, hashed_identifier: &str, salt: &str) -> Resu
 /// Property name transformations:
 /// - `$browser` -> `$initial_browser`
 /// - `utm_source` -> `$initial_utm_source`
-fn populate_missing_initial_properties(properties: &mut HashMap<String, Value>) {
+pub fn populate_missing_initial_properties(properties: &mut HashMap<String, Value>) {
     let properties_to_add: Vec<(&str, Value)> = properties
         .iter()
         .filter_map(|(key, value)| {
@@ -350,8 +350,6 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     // Always add distinct_id to person properties to match Python implementation
     // This allows flags to filter on distinct_id even when no other person properties exist
     all_person_properties.insert("distinct_id".to_string(), Value::String(distinct_id));
-
-    populate_missing_initial_properties(&mut all_person_properties);
 
     flag_evaluation_state.set_person_properties(all_person_properties);
     person_processing_timer.fin();


### PR DESCRIPTION
## Problem

Feature flags which contain matching criteria based on `$initial_*` property values are subject to ingestion lag, and client SDKs do not have sufficient information for caching initial values automatically.

## Changes

This change ensures `$initial_` property values are present when evaluating flags. If a property override from [this list](https://github.com/PostHog/posthog/blob/907379f8f9c58e315c7b531729b5b2642d25bf9e/posthog/taxonomy/taxonomy.py#L24-L71) is present, but no matching `$initial_` value exists, _assume it was just set and copy the current property value as the initial value._

## How did you test this code?

Added additional unit testing