### PR TITLE
fix: add endpoints route condition to endpoints usage

### DIFF
--- a/posthog/hogql_queries/endpoints/endpoints_usage_query_runner.py
+++ b/posthog/hogql_queries/endpoints/endpoints_usage_query_runner.py
@@ -87,6 +87,16 @@ class EndpointsUsageQueryRunner(AnalyticsQueryRunner[EAR], ABC):
             )
         )
 
+        conditions.append(
+            ast.Call(
+                name="match",
+                args=[
+                    ast.Field(chain=["query_log", "endpoint"]),
+                    ast.Constant(value=r"^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$"),
+                ],
+            )
+        )
+
         # Date range filter
         if self.query_date_range.date_from():
             conditions.append(

--- a/posthog/hogql_queries/endpoints/test/__snapshots__/test_endpoints_usage_query_runners.ambr
+++ b/posthog/hogql_queries/endpoints/test/__snapshots__/test_endpoints_usage_query_runners.ambr
@@ -10,7 +10,7 @@
          countIf(endsWith(name, '_materialized')) AS materialized_requests,
          countIf(not(endsWith(name, '_materialized'))) AS inline_requests
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   LIMIT 50000
   '''
 # ---
@@ -25,7 +25,7 @@
          countIf(endsWith(name, '_materialized')) AS materialized_requests,
          countIf(not(endsWith(name, '_materialized'))) AS inline_requests
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), or(equals(name, 'my-endpoint'), equals(name, 'my-endpoint_materialized')), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), or(equals(name, 'my-endpoint'), equals(name, 'my-endpoint_materialized')), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   LIMIT 50000
   '''
 # ---
@@ -40,7 +40,7 @@
          countIf(endsWith(name, '_materialized')) AS materialized_requests,
          countIf(not(endsWith(name, '_materialized'))) AS inline_requests
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), like(name, '%_materialized'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), like(name, '%_materialized'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   LIMIT 50000
   '''
 # ---
@@ -53,7 +53,7 @@
          avg(query_duration_ms) AS avg_query_duration_ms,
          divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY api_key_label
   ORDER BY requests DESC
   LIMIT 100
@@ -69,7 +69,7 @@
          avg(query_duration_ms) AS avg_query_duration_ms,
          divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY replaceRegexpOne(name, '_materialized$', '')
   ORDER BY requests DESC
   LIMIT 100
@@ -85,7 +85,7 @@
          avg(query_duration_ms) AS avg_query_duration_ms,
          divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY if(endsWith(name, '_materialized'), 'Materialized execution', 'Direct execution')
   ORDER BY requests DESC
   LIMIT 100
@@ -101,7 +101,7 @@
          avg(query_duration_ms) AS avg_query_duration_ms,
          divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY if(equals(exception_code, 0), 'success', 'error')
   ORDER BY requests DESC
   LIMIT 100
@@ -117,7 +117,7 @@
          avg(query_duration_ms) AS avg_query_duration_ms,
          divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')), not(like(name, '%_materialized')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')), not(like(name, '%_materialized')))
   GROUP BY replaceRegexpOne(name, '_materialized$', '')
   ORDER BY requests DESC
   LIMIT 100
@@ -133,7 +133,7 @@
          avg(query_duration_ms) AS avg_query_duration_ms,
          divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY replaceRegexpOne(name, '_materialized$', '')
   ORDER BY bytes_read ASC
   LIMIT 100
@@ -149,7 +149,7 @@
          avg(query_duration_ms) AS avg_query_duration_ms,
          divide(countIf(notEquals(exception_code, 0)), count()) AS error_rate
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY replaceRegexpOne(name, '_materialized$', '')
   ORDER BY requests DESC
   LIMIT 50
@@ -161,7 +161,7 @@
   SELECT event_date AS date,
          sum(read_bytes) AS value
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY event_date
   ORDER BY date ASC
   LIMIT 50000
@@ -172,7 +172,7 @@
   SELECT event_date AS date,
          divide(sum(cpu_microseconds), 1000000) AS value
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY event_date
   ORDER BY date ASC
   LIMIT 50000
@@ -183,7 +183,7 @@
   SELECT event_date AS date,
          divide(countIf(notEquals(exception_code, 0)), count()) AS value
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY event_date
   ORDER BY date ASC
   LIMIT 50000
@@ -194,7 +194,7 @@
   SELECT toStartOfHour(event_time) AS date,
          count() AS value
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 12:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 12:59:59.999999')))
   GROUP BY toStartOfHour(event_time)
   ORDER BY date ASC
   LIMIT 50000
@@ -205,7 +205,7 @@
   SELECT event_date AS date,
          count() AS value
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY event_date
   ORDER BY date ASC
   LIMIT 50000
@@ -216,7 +216,7 @@
   SELECT toStartOfWeek(event_date) AS date,
          count() AS value
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2023-12-16 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2023-12-16 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY toStartOfWeek(event_date)
   ORDER BY date ASC
   LIMIT 50000
@@ -228,7 +228,7 @@
          replaceRegexpOne(name, '_materialized$', '') AS breakdown,
          count() AS value
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY event_date,
            replaceRegexpOne(name, '_materialized$', '')
   ORDER BY date ASC
@@ -241,7 +241,7 @@
          if(endsWith(name, '_materialized'), 'Materialized execution', 'Direct execution') AS breakdown,
          count() AS value
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY event_date,
            if(endsWith(name, '_materialized'), 'Materialized execution', 'Direct execution')
   ORDER BY date ASC
@@ -254,7 +254,7 @@
          if(equals(exception_code, 0), 'success', 'error') AS breakdown,
          count() AS value
   FROM query_log
-  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
+  WHERE and(equals(is_personal_api_key_request, true), isNotNull(name), notEquals(name, ''), match(query_log.endpoint, '^/api/(environments|projects)/[0-9]+/endpoints/[^/]+/run/?$'), greaterOrEquals(event_date, toDateTime('2024-01-08 00:00:00.000000')), lessOrEquals(event_date, toDateTime('2024-01-15 23:59:59.999999')))
   GROUP BY event_date,
            if(equals(exception_code, 0), 'success', 'error')
   ORDER BY date ASC


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
was showing rows from query_log that just had the `name` field non-empty.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- filter on the route to be matching endpoints/XXX/run

## How did you test this code?
- locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no.
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
