### PR TITLE
fix(scim): verify user's org membership

### DIFF
--- a/ee/api/scim/test/test_users_api.py
+++ b/ee/api/scim/test/test_users_api.py
@@ -620,6 +620,13 @@ class TestSCIMUsersAPI(APILicensedTest):
         user = User.objects.create_user(
             email="testuser@example.com", password=None, first_name="", last_name="", is_email_verified=True
         )
+        SCIMProvisionedUser.objects.create(
+            user=user,
+            organization_domain=self.domain,
+            username="testuser@example.com",
+            identity_provider=SCIMProvisionedUser.IdentityProvider.OTHER,
+            active=False,
+        )
 
         patch_data = {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
@@ -671,6 +678,13 @@ class TestSCIMUsersAPI(APILicensedTest):
     def test_patch_add_active_user_with_simple_path(self):
         user = User.objects.create_user(
             email="reactivate@example.com", password=None, first_name="Test", is_email_verified=True
+        )
+        SCIMProvisionedUser.objects.create(
+            user=user,
+            organization_domain=self.domain,
+            username="reactivate@example.com",
+            identity_provider=SCIMProvisionedUser.IdentityProvider.OTHER,
+            active=False,
         )
         assert not OrganizationMembership.objects.filter(user=user, organization=self.organization).exists()
 

--- a/ee/api/scim/views.py
+++ b/ee/api/scim/views.py
@@ -184,7 +184,10 @@ class SCIMUsersView(SCIMBaseView):
 class SCIMUserDetailView(SCIMBaseView):
     def get_object(self, user_id: int) -> PostHogSCIMUser:
         organization_domain = cast(OrganizationDomain, self.request.auth)
-        user = User.objects.filter(id=user_id).first()
+        user = User.objects.filter(
+            id=user_id,
+            organization_membership__organization=organization_domain.organization,
+        ).first()
         if not user:
             raise User.DoesNotExist()
         return PostHogSCIMUser(user, organization_domain)

--- a/ee/api/scim/views.py
+++ b/ee/api/scim/views.py
@@ -1,6 +1,6 @@
 from typing import cast
 
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 
 from django_scim import constants
 from django_scim.filters import GroupFilterQuery, UserFilterQuery
@@ -185,8 +185,9 @@ class SCIMUserDetailView(SCIMBaseView):
     def get_object(self, user_id: int) -> PostHogSCIMUser:
         organization_domain = cast(OrganizationDomain, self.request.auth)
         user = User.objects.filter(
+            Q(organization_membership__organization=organization_domain.organization)
+            | Q(scim_provisions__organization_domain=organization_domain),
             id=user_id,
-            organization_membership__organization=organization_domain.organization,
         ).first()
         if not user:
             raise User.DoesNotExist()


### PR DESCRIPTION
When managing a user via SCIM, we must ensure that the user belongs to the org.
