### PR TITLE
fix(frontend): surface SDK Doctor load error

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
@@ -134,6 +134,9 @@ export const sidePanelSdkDoctorLogic = kea<sidePanelSdkDoctorLogicType>([
 
                         return response
                     } catch (error) {
+                        const message =
+                            error instanceof Error ? error.message : 'Failed to load SDK Doctor data'
+                        lemonToast.error(message)
                         console.error('Error loading SDK doctor data', error)
                         return null
                     }


### PR DESCRIPTION
Surfaces an error toast when loading SDK Doctor data fails, while keeping
existing console logging intact. This improves user feedback during
troubleshooting without changing behavior.
