### PR TITLE
fix: kafka in hobby install needs to be a plaintext connection

### DIFF
--- a/docker/livestream/configs-hobby.yml
+++ b/docker/livestream/configs-hobby.yml
@@ -3,6 +3,7 @@ kafka:
     brokers: 'kafka:9092'
     topic: 'events_plugin_ingestion'
     group_id: 'livestream'
+    security_protocol: 'PLAINTEXT'
     session_recording_enabled: true
     session_recording_security_protocol: 'PLAINTEXT'
 mmdb:

--- a/livestream/configs/configs.go
+++ b/livestream/configs/configs.go
@@ -39,6 +39,7 @@ type Config struct {
 type KafkaConfig struct {
 	Brokers                          string `mapstructure:"brokers"`
 	Topic                            string `mapstructure:"topic"`
+	SecurityProtocol                 string `mapstructure:"security_protocol"`
 	SessionRecordingEnabled          bool   `mapstructure:"session_recording_enabled"`
 	SessionRecordingTopic            string `mapstructure:"session_recording_topic"`
 	SessionRecordingBrokers          string `mapstructure:"session_recording_brokers"`
@@ -86,6 +87,13 @@ func LoadConfig() (*Config, error) {
 	}
 	if len(config.CORSAllowOrigins) == 0 {
 		config.CORSAllowOrigins = []string{"*"}
+	}
+	if config.Kafka.SecurityProtocol == "" {
+		if config.Debug {
+			config.Kafka.SecurityProtocol = "PLAINTEXT"
+		} else {
+			config.Kafka.SecurityProtocol = "SSL"
+		}
 	}
 	if config.Kafka.SessionRecordingEnabled {
 		if config.Kafka.SessionRecordingTopic == "" {

--- a/livestream/configs/configs_test.go
+++ b/livestream/configs/configs_test.go
@@ -30,6 +30,7 @@ func TestLoadConfig(t *testing.T) {
 				Kafka: KafkaConfig{
 					Brokers:                          "localhost:9092,localhost:9093",
 					Topic:                            "topic",
+					SecurityProtocol:                 "PLAINTEXT",
 					SessionRecordingEnabled:          true,
 					SessionRecordingTopic:            "session_recording_snapshot_item_events",
 					SessionRecordingBrokers:          "localhost:9092,localhost:9093",
@@ -43,7 +44,7 @@ func TestLoadConfig(t *testing.T) {
 					Secret: "token",
 				},
 				SessionRecording: SessionRecordingConfig{
-					MaxLRUEntries: 2000000,
+					MaxLRUEntries: 2_000_000_000,
 				},
 			},
 			wantErr: false,

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -67,11 +67,7 @@ func main() {
 	go stats.KeepStats(statsChan)
 	go sessionStats.KeepStats(ctx, sessionStatsChan)
 
-	kafkaSecurityProtocol := "SSL"
-	if config.Debug {
-		kafkaSecurityProtocol = "PLAINTEXT"
-	}
-	consumer, err := events.NewPostHogKafkaConsumer(config.Kafka.Brokers, kafkaSecurityProtocol, config.Kafka.GroupID, config.Kafka.Topic, geolocator, phEventChan,
+	consumer, err := events.NewPostHogKafkaConsumer(config.Kafka.Brokers, config.Kafka.SecurityProtocol, config.Kafka.GroupID, config.Kafka.Topic, geolocator, phEventChan,
 		statsChan, config.Parallelism)
 	if err != nil {
 		log.Fatalf("Failed to create Kafka consumer: %v", err)


### PR DESCRIPTION
fixes https://github.com/PostHog/posthog/issues/43827

hobby livestream is trying to connect SSL-wise and cannot

no bueno