### PR TITLE
chore: sync mprocs-with-logging.yaml with mprocs.yaml

### DIFF
--- a/bin/mprocs-with-logging.yaml
+++ b/bin/mprocs-with-logging.yaml
@@ -1,15 +1,15 @@
 procs:
     backend:
-        shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/start-backend 2>&1 | tee /tmp/posthog-backend.log'
+        shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && bin/check_ducklake_up && ./bin/start-backend 2>&1 | tee /tmp/posthog-backend.log'
 
     celery-worker:
-        shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/start-celery worker 2>&1 | tee /tmp/posthog-celery-worker.log'
+        shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && bin/check_ducklake_up && ./bin/start-celery worker 2>&1 | tee /tmp/posthog-celery-worker.log'
 
     celery-beat:
-        shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/start-celery beat 2>&1 | tee /tmp/posthog-celery-beat.log'
+        shell: 'uv sync --active && bin/check_postgres_up && bin/check_kafka_clickhouse_up && bin/check_ducklake_up && ./bin/start-celery beat 2>&1 | tee /tmp/posthog-celery-beat.log'
 
     nodejs:
-        shell: 'bin/check_postgres_up && bin/check_kafka_clickhouse_up && ./bin/posthog-node 2>&1 | tee /tmp/posthog-nodejs.log'
+        shell: 'bin/check_postgres_up && bin/check_kafka_clickhouse_up && bin/check_ducklake_up && ./bin/posthog-node 2>&1 | tee /tmp/posthog-nodejs.log'
 
     frontend:
         shell: './bin/start-frontend 2>&1 | tee /tmp/posthog-frontend.log'
@@ -23,6 +23,7 @@ procs:
             bin/check_kafka_clickhouse_up && \
             bin/check_temporal_up && \
             bin/check_video_deps && \
+            bin/check_ducklake_up && \
             if [ -n "$TEMPORAL_WATCH" ]; then \
                 nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue" 2>&1 | tee /tmp/posthog-temporal-worker.log; \
             else \
@@ -33,9 +34,11 @@ procs:
         shell: |-
             bin/check_postgres_up && \
             bin/check_kafka_clickhouse_up && \
+            bin/check_ducklake_up && \
             dagster dev --workspace $DAGSTER_HOME/workspace.yaml -p $DAGSTER_UI_PORT 2>&1 | tee /tmp/posthog-dagster.log
 
     docker-compose:
+        # docker-compose makes sure the stack is up, and then follows its logs - but doesn't tear down on exit for speed
         shell: 'docker compose -f docker-compose.dev.yml up --pull always -d && docker compose -f docker-compose.dev.yml logs --tail=0 -f 2>&1 | tee /tmp/posthog-docker-compose.log'
 
     cyclotron-janitor:
@@ -78,30 +81,50 @@ procs:
             bin/check_kafka_clickhouse_up && \
             bin/start-rust-service capture-replay 2>&1 | tee /tmp/posthog-capture-replay.log
 
+    capture-ai:
+        shell: |-
+            bin/check_postgres_up && \
+            bin/check_kafka_clickhouse_up && \
+            bin/start-rust-service capture-ai 2>&1 | tee /tmp/posthog-capture-ai.log
+
     batch-import-worker:
         shell: |-
             bin/check_postgres_up && \
             bin/check_kafka_clickhouse_up && \
             bin/start-rust-service batch-import-worker 2>&1 | tee /tmp/posthog-batch-import-worker.log
 
-    migrate-postgres:
-        shell: 'bin/check_postgres_up && python manage.py migrate 2>&1 | tee /tmp/posthog-migrate-postgres.log'
+    llm-gateway:
+        shell: 'bin/check_postgres_up && bin/start-llm-gateway 2>&1 | tee /tmp/posthog-llm-gateway.log'
+        autostart: true
 
+    # This takes ~10 s
+    migrate-postgres:
+        shell: 'bin/check_postgres_up && bin/check_ducklake_up && bin/migrate --scope=postgres 2>&1 | tee /tmp/posthog-migrate-postgres.log'
+
+    # This takes ~10 s too
     migrate-clickhouse:
-        shell: 'bin/check_kafka_clickhouse_up && python manage.py migrate_clickhouse 2>&1 | tee /tmp/posthog-migrate-clickhouse.log'
+        shell: 'bin/check_kafka_clickhouse_up && bin/check_ducklake_up && bin/migrate --scope=clickhouse 2>&1 | tee /tmp/posthog-migrate-clickhouse.log'
 
     migrate-persons-db:
-        shell: 'bin/check_postgres_up posthog_persons && cd rust && DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog_persons sqlx migrate run --source persons_migrations 2>&1 | tee /tmp/posthog-migrate-persons-db.log'
+        shell: 'bin/check_postgres_up posthog_persons && bin/migrate --scope=persons 2>&1 | tee /tmp/posthog-migrate-persons-db.log'
 
     migrate-behavioral-cohorts:
-        shell: 'bin/check_postgres_up behavioral_cohorts && rust/bin/migrate-behavioral-cohorts 2>&1 | tee /tmp/posthog-migrate-behavioral-cohorts.log'
+        shell: 'bin/check_postgres_up behavioral_cohorts && bin/migrate --scope=behavioral-cohorts 2>&1 | tee /tmp/posthog-migrate-behavioral-cohorts.log'
 
     generate-demo-data:
         shell: |-
             bin/check_postgres_up && \
             bin/check_kafka_clickhouse_up && \
             bin/check_dagster_graphql_up && \
+            bin/check_ducklake_up && \
             ./manage.py generate_demo_data 2>&1 | tee /tmp/posthog-generate-demo-data.log
+        autostart: false
+
+    sync-feature-flags:
+        shell: |-
+            bin/check_postgres_up && \
+            bin/check_ducklake_up && \
+            ./manage.py sync_feature_flags 2>&1 | tee /tmp/posthog-sync-feature-flags.log
         autostart: false
 
     storybook:


### PR DESCRIPTION
## Problem

The `mprocs-with-logging.yaml` file had drifted out of sync with `mprocs.yaml`, missing several processes and configuration updates.

## Changes

- Add missing processes: `capture-ai`, `llm-gateway`, `sync-feature-flags`
- Add `bin/check_ducklake_up` checks to relevant processes
- Update migration commands to use unified `bin/migrate --scope=*` script
- Add missing comments on docker-compose and migration processes

## How did you test this code?

Compared both files to verify they are now in sync (aside from the logging redirection).

## Publish to changelog?

No