### PR TITLE
fix: non-pinned columns render weird; pinned cols don't persist; fix both

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.scss
+++ b/frontend/src/queries/nodes/DataTable/DataTable.scss
@@ -56,8 +56,23 @@
         white-space: normal;
 
         .LemonTable__header-content div {
-            word-break: break-word;
+            overflow-wrap: break-word;
             white-space: normal;
+
+            // line clamp to 3 lines of text and then ellipsis
+            > span:first-child {
+                display: -webkit-box;
+                -webkit-line-clamp: 3;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
         }
+    }
+
+    td,
+    th {
+        max-width: 20rem;
+        white-space: nowrap;
     }
 }

--- a/frontend/src/queries/nodes/DataTable/DataTable.scss
+++ b/frontend/src/queries/nodes/DataTable/DataTable.scss
@@ -51,6 +51,7 @@
 
 .DataVisualizationTable {
     th {
+        max-width: 15rem;
         overflow: visible;
         text-overflow: clip;
         white-space: normal;
@@ -70,9 +71,8 @@
         }
     }
 
-    td,
-    th {
-        max-width: 20rem;
+    td {
+        max-width: 15rem;
         white-space: nowrap;
     }
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -2,6 +2,7 @@ import '../../DataTable/DataTable.scss'
 
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
+import React from 'react'
 
 import { IconPin, IconPinFilled } from '@posthog/icons'
 import { LemonTable, LemonTableColumn, Tooltip } from '@posthog/lemon-ui'
@@ -29,6 +30,24 @@ interface TableProps {
 
 export const DEFAULT_PAGE_SIZE = 500
 
+function formatColumnTitle(title: string): React.ReactNode {
+    const parts = title.split(/([_-])/)
+    if (parts.length === 1) {
+        return title
+    }
+    // inserts <wbr> (word break opportunity tag) at dashes and unders for natural break points
+    return parts.map((part, i) =>
+        part === '_' || part === '-' ? (
+            <React.Fragment key={i}>
+                {part}
+                <wbr />
+            </React.Fragment>
+        ) : (
+            part
+        )
+    )
+}
+
 export const Table = (props: TableProps): JSX.Element => {
     const { isDarkModeOn } = useValues(themeLogic)
 
@@ -51,12 +70,14 @@ export const Table = (props: TableProps): JSX.Element => {
 
             const columnTitle = settings?.display?.label || title || column.name
 
+            const formattedTitle = typeof columnTitle === 'string' ? formatColumnTitle(columnTitle) : columnTitle
+
             return {
                 ...columnMeta,
                 key: column.name,
                 title: (
                     <div className="flex items-center gap-1">
-                        <span>{columnTitle}</span>
+                        <span>{formattedTitle}</span>
                         <Tooltip title={isColumnPinned(column.name) ? 'Unpin column' : 'Pin column'}>
                             <span
                                 className="inline-flex items-center justify-center cursor-pointer p-1 -m-1"
@@ -149,7 +170,7 @@ export const Table = (props: TableProps): JSX.Element => {
             pinnedColumns={pinnedColumns}
             loading={responseLoading}
             pagination={{ pageSize: DEFAULT_PAGE_SIZE }}
-            maxHeaderWidth="15rem"
+            maxHeaderWidth="20rem"
             emptyState={
                 responseError ? (
                     <InsightErrorState

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -61,6 +61,7 @@ export const Table = (props: TableProps): JSX.Element => {
         response,
         pinnedColumns,
         isColumnPinned,
+        isPinningEnabled,
     } = useValues(dataVisualizationLogic)
     const { toggleColumnPin } = useActions(dataVisualizationLogic)
 
@@ -78,21 +79,23 @@ export const Table = (props: TableProps): JSX.Element => {
                 title: (
                     <div className="flex items-center gap-1">
                         <span>{formattedTitle}</span>
-                        <Tooltip title={isColumnPinned(column.name) ? 'Unpin column' : 'Pin column'}>
-                            <span
-                                className="inline-flex items-center justify-center cursor-pointer p-1 -m-1"
-                                onClick={(e) => {
-                                    e.stopPropagation()
-                                    toggleColumnPin(column.name)
-                                }}
-                            >
-                                {isColumnPinned(column.name) ? (
-                                    <IconPinFilled className="text-sm" />
-                                ) : (
-                                    <IconPin className="text-sm" />
-                                )}
-                            </span>
-                        </Tooltip>
+                        {isPinningEnabled && (
+                            <Tooltip title={isColumnPinned(column.name) ? 'Unpin column' : 'Pin column'}>
+                                <span
+                                    className="inline-flex items-center justify-center cursor-pointer p-1 -m-1"
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        toggleColumnPin(column.name)
+                                    }}
+                                >
+                                    {isColumnPinned(column.name) ? (
+                                        <IconPinFilled className="text-sm" />
+                                    ) : (
+                                        <IconPin className="text-sm" />
+                                    )}
+                                </span>
+                            </Tooltip>
+                        )}
                     </div>
                 ),
                 render: (_, data, recordIndex: number, rowCount: number) => {
@@ -167,7 +170,7 @@ export const Table = (props: TableProps): JSX.Element => {
             className="DataVisualizationTable"
             dataSource={tabularData}
             columns={tableColumns}
-            pinnedColumns={pinnedColumns}
+            pinnedColumns={isPinningEnabled ? pinnedColumns : undefined}
             loading={responseLoading}
             pagination={{ pageSize: DEFAULT_PAGE_SIZE }}
             maxHeaderWidth="20rem"

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -173,7 +173,7 @@ export const Table = (props: TableProps): JSX.Element => {
             pinnedColumns={isPinningEnabled ? pinnedColumns : undefined}
             loading={responseLoading}
             pagination={{ pageSize: DEFAULT_PAGE_SIZE }}
-            maxHeaderWidth="20rem"
+            maxHeaderWidth="15rem"
             emptyState={
                 responseError ? (
                     <InsightErrorState

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -594,12 +594,16 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
         pinnedColumns: [
             [] as string[],
             {
+                persist: true,
+                storageKey: `data-visualization-pinned-columns-${props.key}`,
+            },
+            {
                 _setQuery: (state, { node }) => {
                     return node.tableSettings?.pinnedColumns ?? state
                 },
                 toggleColumnPin: (state, { columnName }) => {
                     if (state.includes(columnName)) {
-                        return state.filter((k) => k !== columnName)
+                        return state.filter((k: string) => k !== columnName)
                     }
                     return [...state, columnName]
                 },

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -595,7 +595,9 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             [] as string[],
             {
                 persist: true,
-                storageKey: `data-visualization-pinned-columns-${props.key}`,
+                // strips the dashboard suffix from the key so pinned columns persist across
+                // dashboard and insight views
+                storageKey: `data-visualization-pinned-columns-${props.key.split('/on-dashboard-')[0]}`,
             },
             {
                 _setQuery: (state, { node }) => {
@@ -884,6 +886,13 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 (columnName: string): boolean => {
                     return pinnedColumns.includes(columnName)
                 },
+        ],
+        isPinningEnabled: [
+            (s) => [s.activeSceneId],
+            (activeSceneId: Scene | null): boolean => {
+                // disable column pinning in sql editor
+                return activeSceneId !== Scene.SQLEditor
+            },
         ],
     }),
     sharedListeners(({ values, actions }) => ({

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -352,6 +352,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                 if (insightId) {
                     const insightProps: InsightLogicProps = {
                         dashboardItemId: insightId,
+                        dashboardId: values.dashboardId ?? undefined,
                         filtersOverride: values.filtersOverride,
                         variablesOverride: values.variablesOverride,
                         tileFiltersOverride: values.tileFiltersOverride,


### PR DESCRIPTION
## Problem

See title.

## Changes

1. clamps pinned column text to 3 lines followed by ellipsis
2. inserts break points at underscores and dashes in column names
3. persist pinned columns to local storage across insights and dashboards
4. disable pinned columns for editor scene

## How did you test this code?

Manually.

https://github.com/user-attachments/assets/218c8612-6ba9-4f34-beda-d476f5ecd5e4


## Publish to changelog?

no