### PR TITLE
fix: livestream needs to be exposed for self-hosted

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -7,12 +7,13 @@ services:
         image: caddy
         entrypoint: sh
         restart: always
-        command: -c 'set -x && echo "$$CADDYFILE" > /etc/caddy/Caddyfile && exec caddy run -c /etc/caddy/Caddyfile'
+        command: -c 'set -x && echo "$$CADDYFILE" > /etc/caddy/Caddyfile && echo "$$CADDY_EXTRA_CONFIG" >> /etc/caddy/Caddyfile && exec caddy run -c /etc/caddy/Caddyfile'
         volumes:
             - /root/.caddy
         environment:
             CADDY_TLS_BLOCK: ''
             CADDY_HOST: 'http://localhost:8000'
+            CADDY_EXTRA_CONFIG: ''
             CADDYFILE: |
                 {
                 ${CADDY_TLS_BLOCK:-}
@@ -57,6 +58,19 @@ services:
                         path /public/webhooks/*
                         path /public/m/
                         path /public/m/*
+                    }
+
+                    @livestream {
+                        path /livestream
+                        path /livestream/
+                        path /livestream/*
+                    }
+
+                    handle @livestream {
+                        uri strip_prefix /livestream
+                        reverse_proxy livestream:8080 {
+                            flush_interval -1
+                        }
                     }
 
                     handle @capture-ai {

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -112,7 +112,7 @@ services:
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
         environment:
             SITE_URL: https://$DOMAIN
-            LIVESTREAM_HOST: 'https://${DOMAIN}:8666'
+            LIVESTREAM_HOST: 'https://${DOMAIN}/livestream'
             SECRET_KEY: $POSTHOG_SECRET
             OBJECT_STORAGE_ACCESS_KEY_ID: 'object_storage_root_user'
             OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password'
@@ -185,6 +185,7 @@ services:
             CADDY_HOST: '$DOMAIN, http://, https://'
         depends_on:
             - web
+            - livestream
     objectstorage:
         extends:
             file: docker-compose.base.yml
@@ -326,8 +327,6 @@ services:
             service: livestream
         environment:
             - LIVESTREAM_JWT_SECRET=${POSTHOG_SECRET}
-        ports:
-            - '8666:8080'
         volumes:
             - ./posthog/docker/livestream/configs-hobby.yml:/configs/configs.yml
 

--- a/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
+++ b/frontend/src/lib/components/LiveUserCount/LiveUserCount.tsx
@@ -6,8 +6,6 @@ import { useEffect } from 'react'
 import { IconPerson, IconVideoCamera } from '@posthog/icons'
 import { Tooltip } from '@posthog/lemon-ui'
 
-import { FlaggedFeature } from 'lib/components/FlaggedFeature'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { humanFriendlyLargeNumber, humanFriendlyNumber, pluralize } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
@@ -139,31 +137,29 @@ export function LiveRecordingsCount({ pollIntervalMs = 30000 }: LiveCountProps):
     }
 
     return (
-        <FlaggedFeature flag={FEATURE_FLAGS.LIVE_EVENTS_ACTIVE_RECORDINGS}>
-            <Tooltip
-                title={
-                    activeRecordings == null
-                        ? 'Unable to retrieve active recordings count.'
-                        : 'Session recordings currently in progress.'
-                }
-                placement="right"
+        <Tooltip
+            title={
+                activeRecordings == null
+                    ? 'Unable to retrieve active recordings count.'
+                    : 'Session recordings currently in progress.'
+            }
+            placement="right"
+        >
+            <div
+                className={cn(
+                    'flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors',
+                    hasRecordings ? 'bg-success-highlight' : 'bg-border-light'
+                )}
             >
-                <div
-                    className={cn(
-                        'flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors',
-                        hasRecordings ? 'bg-success-highlight' : 'bg-border-light'
-                    )}
-                >
-                    <div className={cn('live-user-indicator', hasRecordings ? 'online' : 'offline')} />
-                    <IconVideoCamera className="size-4 shrink-0 min-[660px]:hidden" />
-                    <span className="text-xs font-medium whitespace-nowrap" data-attr="live-recordings-count">
-                        <strong>{humanFriendlyLargeNumber(activeRecordings)}</strong>
-                    </span>
-                    <span className="hidden min-[660px]:inline">
-                        recently active {pluralize(activeRecordings, 'recording', undefined, false)}
-                    </span>
-                </div>
-            </Tooltip>
-        </FlaggedFeature>
+                <div className={cn('live-user-indicator', hasRecordings ? 'online' : 'offline')} />
+                <IconVideoCamera className="size-4 shrink-0 min-[660px]:hidden" />
+                <span className="text-xs font-medium whitespace-nowrap" data-attr="live-recordings-count">
+                    <strong>{humanFriendlyLargeNumber(activeRecordings)}</strong>
+                </span>
+                <span className="hidden min-[660px]:inline">
+                    recently active {pluralize(activeRecordings, 'recording', undefined, false)}
+                </span>
+            </div>
+        </Tooltip>
     )
 }

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -357,7 +357,6 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_HEALTH_TAB: 'web_analytics_health_tab', // owner: @jordanm-posthog #team-web-analytics
     AVERAGE_PAGE_VIEW_COLUMN: 'average-page-view-column', // owner: @jordanm-posthog #team-web-analytics
     NEW_TAB_PROJECT_EXPLORER: 'new-tab-project-explorer', // owner: #team-platform-ux
-    LIVE_EVENTS_ACTIVE_RECORDINGS: 'live-events-active-recordings', // owner: @pauldambra #team-replay
     EXPERIMENTS_SAMPLE_RATIO_MISMATCH: 'experiments-sample-ratio-mismatch', // owner: @jurajmajerik #team-experiments
     // PLEASE KEEP THIS ALPHABETICALLY ORDERED
 } as const

--- a/frontend/src/scenes/session-recordings/SessionsRecordings-player-failure.stories.tsx
+++ b/frontend/src/scenes/session-recordings/SessionsRecordings-player-failure.stories.tsx
@@ -5,7 +5,6 @@ import recordingEventsJson from 'scenes/session-recordings/__mocks__/recording_e
 import { snapshotsAsJSONLines } from 'scenes/session-recordings/__mocks__/recording_snapshots'
 import { urls } from 'scenes/urls'
 
-import { FEATURE_FLAGS } from '~/lib/constants'
 import { mswDecorator } from '~/mocks/browser'
 
 import { recordingPlaylists } from './__mocks__/recording_playlists'
@@ -18,7 +17,6 @@ const meta: Meta = {
         layout: 'fullscreen',
         viewMode: 'story',
         mockDate: '2023-02-01',
-        featureFlags: [FEATURE_FLAGS.LIVE_EVENTS_ACTIVE_RECORDINGS],
         pageUrl: urls.replay(),
     },
     decorators: [

--- a/frontend/src/scenes/session-recordings/SessionsRecordings-player-success.stories.tsx
+++ b/frontend/src/scenes/session-recordings/SessionsRecordings-player-success.stories.tsx
@@ -12,7 +12,6 @@ import { snapshotsAsJSONLines } from 'scenes/session-recordings/__mocks__/record
 import { playerSettingsLogic } from 'scenes/session-recordings/player/playerSettingsLogic'
 import { urls } from 'scenes/urls'
 
-import { FEATURE_FLAGS } from '~/lib/constants'
 import { mswDecorator, useStorybookMocks } from '~/mocks/browser'
 import { getAvailableProductFeatures } from '~/mocks/features'
 import { MockSignature } from '~/mocks/utils'
@@ -99,7 +98,6 @@ const meta: Meta = {
         layout: 'fullscreen',
         viewMode: 'story',
         mockDate: '2023-02-01',
-        featureFlags: [FEATURE_FLAGS.LIVE_EVENTS_ACTIVE_RECORDINGS],
         waitForSelector: '.PlayerFrame__content .replayer-wrapper iframe',
         pageUrl: urls.replay(),
     },

--- a/frontend/src/scenes/session-recordings/SessionsRecordings-playlist-listing.stories.tsx
+++ b/frontend/src/scenes/session-recordings/SessionsRecordings-playlist-listing.stories.tsx
@@ -5,7 +5,6 @@ import recordingEventsJson from 'scenes/session-recordings/__mocks__/recording_e
 import { recordings } from 'scenes/session-recordings/__mocks__/recordings'
 import { urls } from 'scenes/urls'
 
-import { FEATURE_FLAGS } from '~/lib/constants'
 import { mswDecorator } from '~/mocks/browser'
 import { ReplayTabs } from '~/types'
 
@@ -18,7 +17,6 @@ const meta: Meta = {
         layout: 'fullscreen',
         viewMode: 'story',
         mockDate: '2023-02-01',
-        featureFlags: [FEATURE_FLAGS.LIVE_EVENTS_ACTIVE_RECORDINGS],
         pageUrl: urls.replay(ReplayTabs.Playlists),
     },
     decorators: [

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.stories.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.stories.tsx
@@ -7,7 +7,6 @@ import { recordingMetaJson } from 'scenes/session-recordings/__mocks__/recording
 import { snapshotsAsJSONLines } from 'scenes/session-recordings/__mocks__/recording_snapshots'
 import { urls } from 'scenes/urls'
 
-import { FEATURE_FLAGS } from '~/lib/constants'
 import { mswDecorator } from '~/mocks/browser'
 import { PropertyFilterType, PropertyOperator, SessionRecordingPlaylistType } from '~/types'
 
@@ -83,7 +82,6 @@ const meta: Meta = {
         layout: 'fullscreen',
         viewMode: 'story',
         mockDate: '2023-07-04',
-        featureFlags: [FEATURE_FLAGS.LIVE_EVENTS_ACTIVE_RECORDINGS],
         testOptions: {
             loaderTimeout: 15000,
             waitForSelector: '.PlayerFrame__content .replayer-wrapper iframe',


### PR DESCRIPTION
livestream doesn't work in hobby
we're not exposing the port it uses...

we could expose the port - but my hetzner box has a firewall, so we'd need instructions for a gajillion platforms

instead, let's expose livestream on port 80/443

validated by manually editing my self-hosted box

(fly-by remove the flag on live recordings count)

![CleanShot 2026-01-04 at 20.33.46@2x.png](https://app.graphite.com/user-attachments/assets/27fb8749-37d5-4931-bd33-d61303f829fc.png)

<img width="1728" height="694" alt="CleanShot 2026-01-04 at 22 13 15@2x" src="https://github.com/user-attachments/assets/3d339f86-c737-476b-a1d2-7d9c0e71156d" />

