### PR TITLE
fix: Add restriction to the UI based on role

### DIFF
--- a/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
+++ b/frontend/src/scenes/settings/organization/Approvals/ApprovalPolicies.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react'
 import { IconInfo } from '@posthog/icons'
 import { LemonButton, LemonInputSelect, LemonSelect, LemonSwitch, LemonTable, Tooltip } from '@posthog/lemon-ui'
 
+import { useRestrictedArea } from 'lib/components/RestrictedArea'
+import { OrganizationMembershipLevel } from 'lib/constants'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
@@ -22,6 +24,7 @@ export function ApprovalPolicies(): JSX.Element {
     const { loadPolicies, deletePolicy } = useActions(approvalPoliciesLogic)
     const [editingPolicy, setEditingPolicy] = useState<ApprovalPolicy | null>(null)
     const [isCreating, setIsCreating] = useState(false)
+    const restrictionReason = useRestrictedArea({ minimumAccessLevel: OrganizationMembershipLevel.Admin })
 
     useEffect(() => {
         loadPolicies()
@@ -73,6 +76,7 @@ export function ApprovalPolicies(): JSX.Element {
                                 onClick={() => {
                                     setEditingPolicy(policy)
                                 }}
+                                disabledReason={restrictionReason}
                             >
                                 Edit
                             </LemonButton>
@@ -98,6 +102,7 @@ export function ApprovalPolicies(): JSX.Element {
                                         },
                                     })
                                 }}
+                                disabledReason={restrictionReason}
                             >
                                 Delete
                             </LemonButton>
@@ -111,7 +116,7 @@ export function ApprovalPolicies(): JSX.Element {
     return (
         <div className="space-y-4">
             <div className="flex justify-end items-center">
-                <LemonButton type="primary" onClick={() => setIsCreating(true)}>
+                <LemonButton type="primary" onClick={() => setIsCreating(true)} disabledReason={restrictionReason}>
                     Add policy
                 </LemonButton>
             </div>


### PR DESCRIPTION
## Problem

- The BE is restricted so that only admins and owners can create/update approval policies, but the UI is not.

## Changes

- Restricts the UI.

<img width="987" height="319" alt="image" src="https://github.com/user-attachments/assets/e50a8ca5-913c-46e6-9f6a-60976668eb01" />

<img width="987" height="319" alt="image" src="https://github.com/user-attachments/assets/22f163fd-eb0c-4ce2-be5f-6e69e75def4f" />

