### PR TITLE
chore(workflows): save test person across tab switches

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorNotificationPanelTest.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorNotificationPanelTest.tsx
@@ -303,7 +303,7 @@ export function EmailActionTestContent(): JSX.Element | null {
                             <LemonButton
                                 type="secondary"
                                 onClick={() => setPersonSelectorOpen(!personSelectorOpen)}
-                                tooltip="Select a person to load test data"
+                                tooltip="Select a person to load test data (selection is saved across tab switches)"
                                 size="small"
                                 loading={sampleGlobalsLoading}
                                 className="mt-1"

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorNotificationPanelTest.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorNotificationPanelTest.tsx
@@ -303,7 +303,7 @@ export function EmailActionTestContent(): JSX.Element | null {
                             <LemonButton
                                 type="secondary"
                                 onClick={() => setPersonSelectorOpen(!personSelectorOpen)}
-                                tooltip="Select a person to load test data (selection is saved across tab switches)"
+                                tooltip="Select a person to load test data (selection is saved)"
                                 size="small"
                                 loading={sampleGlobalsLoading}
                                 className="mt-1"

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorNotificationPanelTest.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/HogFlowEditorNotificationPanelTest.tsx
@@ -303,7 +303,7 @@ export function EmailActionTestContent(): JSX.Element | null {
                             <LemonButton
                                 type="secondary"
                                 onClick={() => setPersonSelectorOpen(!personSelectorOpen)}
-                                tooltip="Select a person to load test data (selection is saved)"
+                                tooltip="Select a person to load test data"
                                 size="small"
                                 loading={sampleGlobalsLoading}
                                 className="mt-1"

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorNotificationTestLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorNotificationTestLogic.test.ts
@@ -181,6 +181,25 @@ describe('hogFlowEditorNotificationTestLogic', () => {
         })
     })
 
+    describe('person persistence', () => {
+        it('should save and restore person distinct ID across mounts', async () => {
+            // Save a person
+            await expectLogic(logic, () => {
+                logic.actions.loadSamplePersonByDistinctId({ distinctId: 'test-person-123' })
+            }).toMatchValues({
+                savedPersonDistinctId: 'test-person-123',
+            })
+
+            // Unmount and remount to simulate tab switch
+            logic.unmount()
+            logic = hogFlowEditorNotificationTestLogic({ id: 'test-workflow-id' })
+            logic.mount()
+
+            // Verify the saved person persists
+            expect(logic.values.savedPersonDistinctId).toBe('test-person-123')
+        })
+    })
+
     describe('loadSamplePersonByDistinctIdSuccess listener', () => {
         it('should reorder globals with person first', async () => {
             const globals: CyclotronJobInvocationGlobals = {


### PR DESCRIPTION
## Problem

Currently when selecting a person in the email testing and switching tabs the selection is gone. This is due to the component getting completely unmounted during switching of tabs. Same goes for manually setting the email field

## Changes

![2026-01-05 10 40 09](https://github.com/user-attachments/assets/2410adfe-5b33-416b-812e-955e8b699050)


- selection is persisted
- email is persisted if overwritten

## How did you test this code?

- local dev
- added test