### PR TITLE
fix(phai): dashboard insight replacement removing all insights

### DIFF
--- a/ee/hogai/tools/upsert_dashboard/prompts.py
+++ b/ee/hogai/tools/upsert_dashboard/prompts.py
@@ -9,18 +9,11 @@ Use this tool to create or update a dashboard with provided insights.
 # When NOT to use this tool
 - The user wants to save a single insight.
 
-# Understanding replace_insights behavior
-The `replace_insights` parameter controls how new insights relate to existing ones:
+# Understanding replace_insights
+- `replace_insights=False` (default): Appends provided insights to existing ones
+- `replace_insights=True`: Dashboard will contain exactly the insights you specify in `insight_ids`
 
-- `replace_insights=False` (default): Adds the provided insights to the end of the dashboard, preserving all existing insights
-- `replace_insights=True`: Replaces the entire insight list with exactly what you provide in `insight_ids`
-
-When `replace_insights=True`, the dashboard will contain only the insights you specify. This means if you want to swap one insight while keeping others, you need to include all the insights you want to remain.
-
-Example: A dashboard currently has insights [A, B, C]. The user wants to replace insight B with insight D.
-- With `replace_insights=True` and `insight_ids=[A, D, C]`, the dashboard will have [A, D, C]
-- With `replace_insights=True` and `insight_ids=[D]`, the dashboard will have only [D] (A and C are removed)
-- With `replace_insights=False` and `insight_ids=[D]`, the dashboard will have [A, B, C, D]
+Example: Dashboard has [A, B, C]. To replace B with D, use `replace_insights=True` with `insight_ids=[A, D, C]`. Using just `insight_ids=[D]` would remove A and C.
 """.strip()
 
 

--- a/ee/hogai/tools/upsert_dashboard/prompts.py
+++ b/ee/hogai/tools/upsert_dashboard/prompts.py
@@ -8,6 +8,19 @@ Use this tool to create or update a dashboard with provided insights.
 
 # When NOT to use this tool
 - The user wants to save a single insight.
+
+# CRITICAL: Understanding replace_insights behavior
+When updating a dashboard:
+- `replace_insights=False` (default): APPENDS the provided insights to the existing insights in the dashboard
+- `replace_insights=True`: REMOVES ALL existing insights and ONLY keeps the insights you provide
+
+**IMPORTANT**: To replace a single insight while keeping all others, you MUST:
+1. Set `replace_insights=True`
+2. Provide ALL insight IDs (both existing ones to keep AND the new/replacement ones)
+
+**Example**: If a dashboard has insights [A, B, C] and the user wants to replace B with D:
+- CORRECT: `replace_insights=True`, `insight_ids=[A, D, C]`
+- WRONG: `replace_insights=True`, `insight_ids=[D]` (this REMOVES A and C!)
 """.strip()
 
 

--- a/ee/hogai/tools/upsert_dashboard/prompts.py
+++ b/ee/hogai/tools/upsert_dashboard/prompts.py
@@ -9,18 +9,18 @@ Use this tool to create or update a dashboard with provided insights.
 # When NOT to use this tool
 - The user wants to save a single insight.
 
-# CRITICAL: Understanding replace_insights behavior
-When updating a dashboard:
-- `replace_insights=False` (default): APPENDS the provided insights to the existing insights in the dashboard
-- `replace_insights=True`: REMOVES ALL existing insights and ONLY keeps the insights you provide
+# Understanding replace_insights behavior
+The `replace_insights` parameter controls how new insights relate to existing ones:
 
-**IMPORTANT**: To replace a single insight while keeping all others, you MUST:
-1. Set `replace_insights=True`
-2. Provide ALL insight IDs (both existing ones to keep AND the new/replacement ones)
+- `replace_insights=False` (default): Adds the provided insights to the end of the dashboard, preserving all existing insights
+- `replace_insights=True`: Replaces the entire insight list with exactly what you provide in `insight_ids`
 
-**Example**: If a dashboard has insights [A, B, C] and the user wants to replace B with D:
-- CORRECT: `replace_insights=True`, `insight_ids=[A, D, C]`
-- WRONG: `replace_insights=True`, `insight_ids=[D]` (this REMOVES A and C!)
+When `replace_insights=True`, the dashboard will contain only the insights you specify. This means if you want to swap one insight while keeping others, you need to include all the insights you want to remain.
+
+Example: A dashboard currently has insights [A, B, C]. The user wants to replace insight B with insight D.
+- With `replace_insights=True` and `insight_ids=[A, D, C]`, the dashboard will have [A, D, C]
+- With `replace_insights=True` and `insight_ids=[D]`, the dashboard will have only [D] (A and C are removed)
+- With `replace_insights=False` and `insight_ids=[D]`, the dashboard will have [A, B, C, D]
 """.strip()
 
 

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -51,10 +51,10 @@ class UpdateDashboardToolArgs(BaseModel):
         default=None,
     )
     replace_insights: bool | None = Field(
-        description="CRITICAL: This controls whether to REMOVE ALL existing insights or keep them. "
-        "True = REMOVE ALL existing insights and ONLY keep the insights you provide in insight_ids (use this when you want to replace/reorder insights, but remember to include ALL insights you want to keep). "
-        "False = APPEND the provided insights to the existing insights (use this when adding new insights without removing any). "
-        "WARNING: If you set this to True and only provide one insight_id, ALL other existing insights will be DELETED from the dashboard!",
+        description="Controls how the provided insights relate to existing dashboard insights. "
+        "When False (default), the provided insights are appended to the existing ones. "
+        "When True, the dashboard will contain exactly the insights specified in insight_ids—any existing insights not included will be removed. "
+        "This means to replace one insight while keeping others, include all the insight IDs you want to retain along with the new one.",
         default=False,
     )
     name: str | None = Field(

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -51,7 +51,10 @@ class UpdateDashboardToolArgs(BaseModel):
         default=None,
     )
     replace_insights: bool | None = Field(
-        description="Whether to replace the existing insights in the dashboard with the provided insights. True will replace all existing with the provided insights, keeping the provided ordering. False will append new insights to the end of the dashboard.",
+        description="CRITICAL: This controls whether to REMOVE ALL existing insights or keep them. "
+        "True = REMOVE ALL existing insights and ONLY keep the insights you provide in insight_ids (use this when you want to replace/reorder insights, but remember to include ALL insights you want to keep). "
+        "False = APPEND the provided insights to the existing insights (use this when adding new insights without removing any). "
+        "WARNING: If you set this to True and only provide one insight_id, ALL other existing insights will be DELETED from the dashboard!",
         default=False,
     )
     name: str | None = Field(

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -51,10 +51,7 @@ class UpdateDashboardToolArgs(BaseModel):
         default=None,
     )
     replace_insights: bool | None = Field(
-        description="Controls how the provided insights relate to existing dashboard insights. "
-        "When False (default), the provided insights are appended to the existing ones. "
-        "When True, the dashboard will contain exactly the insights specified in insight_ids—any existing insights not included will be removed. "
-        "This means to replace one insight while keeping others, include all the insight IDs you want to retain along with the new one.",
+        description="When False (default), appends provided insights to existing ones. When True, the dashboard will contain exactly the insights in insight_ids (others are removed).",
         default=False,
     )
     name: str | None = Field(


### PR DESCRIPTION
## Problem

Prompting around replacing insights in the `upsert_dashboard` tool is ambiguous. This PR makes it more straightforward to explain that the tool replaces all insights in a dashboard.

<img width="550" height="717" alt="Screenshot 2026-01-05 at 10 28 42" src="https://github.com/user-attachments/assets/d6cadcb6-debd-40ea-96a3-15e7ac9879c3" />

## Changes

- Fixed the prompt.
