### PR TITLE
fix(workflows): Stop requiring changes to save workflow if created from template

### DIFF
--- a/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
@@ -23,11 +23,13 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
         useActions(logic)
     const { searchParams } = useValues(router)
     const editTemplateId = searchParams.editTemplateId as string | undefined
+    const templateId = searchParams.templateId as string | undefined
     const templateLogic = workflowTemplateLogic({ ...props, editTemplateId })
     const { showSaveAsTemplateModal } = useActions(templateLogic)
     const canCreateTemplates = useFeatureFlag('WORKFLOWS_TEMPLATE_CREATION')
 
     const isSavedWorkflow = props.id && props.id !== 'new'
+    const isCreatedFromTemplate = props.id === 'new' && !!templateId
     const isManualWorkflow = ['manual', 'schedule', 'batch'].includes(workflow?.trigger?.type || '')
     const [displayStatus, setDisplayStatus] = useState(workflow?.status)
     const [isTransitioning, setIsTransitioning] = useState(false)
@@ -134,9 +136,11 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
                                 disabledReason={
                                     workflowHasErrors
                                         ? 'Some fields still need work'
-                                        : workflowChanged
+                                        : isCreatedFromTemplate
                                           ? undefined
-                                          : 'No changes to save'
+                                          : workflowChanged
+                                            ? undefined
+                                            : 'No changes to save'
                                 }
                             >
                                 {props.id === 'new' ? 'Create as draft' : 'Save'}


### PR DESCRIPTION
## Problem

We require changes to a workflow to enable saving it, but our official templates provide a ready-to-use workflow that should be save-able immediately

## Changes

If you're creating from a template, you no longer need changes to save

## How did you test this code?

Manually
