### PR TITLE
chore(exports): Fix a bug where single exports incorrectly mis-report failed exports (leading to uncaught exceptions in our monitoring)

### DIFF
--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -18,7 +18,7 @@ from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.subscription import Subscription
 from posthog.sync import database_sync_to_async
 from posthog.tasks import exporter
-from posthog.tasks.exporter import EXCEPTIONS_TO_RETRY, USER_QUERY_ERRORS
+from posthog.tasks.exporter import EXCEPTIONS_TO_RETRY, USER_QUERY_ERRORS, record_export_failure
 from posthog.utils import wait_for_parallel_celery_group
 
 logger = structlog.get_logger(__name__)
@@ -247,9 +247,7 @@ async def generate_assets_async(
                         team_id=resource.team_id,
                     )
 
-                asset.exception = str(e)
-                asset.exception_type = type(e).__name__
-                await database_sync_to_async(asset.save, thread_sensitive=False)()
+                await database_sync_to_async(record_export_failure, thread_sensitive=False)(asset, e)
 
         # Reserve buffer time for email/Slack delivery after exports
         buffer_seconds = 120  # 2 minutes

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -99,7 +99,7 @@ def is_user_query_error_type(exception_type: str | None) -> bool:
 def record_export_failure(exported_asset: ExportedAsset, e: Exception) -> None:
     exported_asset.exception = str(e)
     exported_asset.exception_type = type(e).__name__
-    exported_asset.save(update_fields=["exception", "exception_type"])
+    exported_asset.save()
 
 
 def _is_final_export_attempt(exception: Exception, current_retries: int, max_retries: int) -> bool:

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -5,7 +5,7 @@ from django.db import OperationalError, transaction
 
 import structlog
 import posthoganalytics
-from celery import current_task, shared_task
+from celery import Task, current_task, shared_task
 from prometheus_client import Counter, Histogram
 from urllib3.exceptions import MaxRetryError, ProtocolError
 
@@ -124,7 +124,7 @@ def _is_final_export_attempt(exception: Exception, current_retries: int, max_ret
     max_retries=3,
 )
 def export_asset(
-    self,
+    self: Task,
     exported_asset_id: int,
     limit: Optional[int] = None,  # For CSV/XLSX: max row count
     max_height_pixels: Optional[int] = None,  # For images: max screenshot height in pixels

--- a/posthog/tasks/test/test_exporter.py
+++ b/posthog/tasks/test/test_exporter.py
@@ -14,12 +14,7 @@ from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.models.dashboard import Dashboard
 from posthog.models.exported_asset import ExportedAsset
 from posthog.tasks import exporter
-from posthog.tasks.exporter import (
-    EXCEPTIONS_TO_RETRY,
-    _is_final_export_attempt,
-    export_asset_direct,
-    is_user_query_error_type,
-)
+from posthog.tasks.exporter import EXCEPTIONS_TO_RETRY, _is_final_export_attempt, is_user_query_error_type
 from posthog.tasks.exports.image_exporter import get_driver
 
 
@@ -107,7 +102,7 @@ class TestExporterTask(APIBaseTest):
         mock_export.side_effect = QueryError("Unknown table 'foo'")
 
         asset = ExportedAsset.objects.create(team=self.team, dashboard=None, export_format="image/png")
-        export_asset_direct(asset)
+        exporter.export_asset(asset.id)
 
         asset.refresh_from_db()
         assert asset.exception == "Unknown table 'foo'"

--- a/posthog/tasks/test/test_exporter.py
+++ b/posthog/tasks/test/test_exporter.py
@@ -8,10 +8,18 @@ from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
+from posthog.hogql.errors import QueryError
+
+from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.models.dashboard import Dashboard
 from posthog.models.exported_asset import ExportedAsset
 from posthog.tasks import exporter
-from posthog.tasks.exporter import export_asset_direct, is_user_query_error_type
+from posthog.tasks.exporter import (
+    EXCEPTIONS_TO_RETRY,
+    _is_final_export_attempt,
+    export_asset_direct,
+    is_user_query_error_type,
+)
 from posthog.tasks.exports.image_exporter import get_driver
 
 
@@ -96,8 +104,6 @@ class TestExporterTask(APIBaseTest):
 
     @patch("posthog.tasks.exports.image_exporter.export_image")
     def test_export_stores_exception_type_on_failure(self, mock_export: MagicMock, mock_uuid: MagicMock) -> None:
-        from posthog.hogql.errors import QueryError
-
         mock_export.side_effect = QueryError("Unknown table 'foo'")
 
         asset = ExportedAsset.objects.create(team=self.team, dashboard=None, export_format="image/png")
@@ -106,3 +112,100 @@ class TestExporterTask(APIBaseTest):
         asset.refresh_from_db()
         assert asset.exception == "Unknown table 'foo'"
         assert asset.exception_type == "QueryError"
+
+
+class TestIsFinalExportAttempt(TestCase):
+    @parameterized.expand(
+        [
+            # Non-retriable exceptions are always final (regardless of retry count)
+            (QueryError("test"), 0, 3, True),
+            (QueryError("test"), 1, 3, True),
+            (QueryError("test"), 3, 3, True),
+            # Retriable exceptions: not final when retries < max_retries
+            (CHQueryErrorTooManySimultaneousQueries("test"), 0, 3, False),
+            (CHQueryErrorTooManySimultaneousQueries("test"), 1, 3, False),
+            (CHQueryErrorTooManySimultaneousQueries("test"), 2, 3, False),
+            # Retriable exceptions: final when retries >= max_retries
+            (CHQueryErrorTooManySimultaneousQueries("test"), 3, 3, True),
+            (CHQueryErrorTooManySimultaneousQueries("test"), 4, 3, True),
+        ]
+    )
+    def test_is_final_export_attempt(
+        self, exception: Exception, current_retries: int, max_retries: int, expected: bool
+    ) -> None:
+        assert _is_final_export_attempt(exception, current_retries, max_retries) == expected
+
+
+class TestExportAssetFailureRecording(APIBaseTest):
+    """Tests for failure recording behavior in export_asset task."""
+
+    @patch("posthog.tasks.exports.image_exporter.export_image")
+    def test_non_retriable_error_records_failure_and_does_not_raise(self, mock_export_direct: MagicMock) -> None:
+        """
+        Test that non-retriable errors (like QueryError) record failure info
+        and do NOT re-raise the exception (swallowed to align with previous behavior).
+        """
+        mock_export_direct.side_effect = QueryError("Invalid query syntax")
+
+        asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+        )
+        # Should NOT raise - non-retriable errors are swallowed
+        exporter.export_asset(asset.id)
+
+        asset.refresh_from_db()
+        assert asset.exception == "Invalid query syntax"
+        assert asset.exception_type == "QueryError"
+
+    @patch("posthog.tasks.exporter._is_final_export_attempt", return_value=False)
+    @patch("posthog.tasks.exports.image_exporter.export_image")
+    def test_retriable_error_raises_and_does_not_record_on_non_final_attempt(
+        self, mock_export_direct: MagicMock, mock_is_final: MagicMock
+    ) -> None:
+        """
+        Test that retriable errors re-raise for Celery retry and do NOT record
+        failure info on non-final attempts.
+        """
+        e = CHQueryErrorTooManySimultaneousQueries("Too many queries")
+        assert isinstance(e, EXCEPTIONS_TO_RETRY)
+        mock_export_direct.side_effect = e
+
+        asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+        )
+
+        # Should raise - retriable errors are re-raised for Celery retry
+        with pytest.raises(CHQueryErrorTooManySimultaneousQueries):
+            exporter.export_asset(asset.id)
+
+        asset.refresh_from_db()
+        # On non-final attempts, failure should NOT be recorded yet
+        assert asset.exception is None
+        assert asset.exception_type is None
+
+    @patch("posthog.tasks.exporter._is_final_export_attempt", return_value=True)
+    @patch("posthog.tasks.exports.image_exporter.export_image")
+    def test_retriable_error_records_failure_on_final_attempt(
+        self, mock_export_direct: MagicMock, mock_is_final: MagicMock
+    ) -> None:
+        """
+        Test that retriable errors re-raise for Celery retry and do record
+        failure info on final attempts.
+        """
+        e = CHQueryErrorTooManySimultaneousQueries("Too many queries")
+        assert isinstance(e, EXCEPTIONS_TO_RETRY)
+        mock_export_direct.side_effect = e
+
+        asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+        )
+
+        with pytest.raises(CHQueryErrorTooManySimultaneousQueries):
+            exporter.export_asset(asset.id)
+
+        asset.refresh_from_db()
+        assert asset.exception == "Code: None.\nToo many queries"
+        assert asset.exception_type == "CHQueryErrorTooManySimultaneousQueries"

--- a/posthog/tasks/test/test_exporter.py
+++ b/posthog/tasks/test/test_exporter.py
@@ -141,10 +141,6 @@ class TestExportAssetFailureRecording(APIBaseTest):
 
     @patch("posthog.tasks.exports.image_exporter.export_image")
     def test_non_retriable_error_records_failure_and_does_not_raise(self, mock_export_direct: MagicMock) -> None:
-        """
-        Test that non-retriable errors (like QueryError) record failure info
-        and do NOT re-raise the exception (swallowed to align with previous behavior).
-        """
         mock_export_direct.side_effect = QueryError("Invalid query syntax")
 
         asset = ExportedAsset.objects.create(
@@ -163,10 +159,6 @@ class TestExportAssetFailureRecording(APIBaseTest):
     def test_retriable_error_raises_and_does_not_record_on_non_final_attempt(
         self, mock_export_direct: MagicMock, mock_is_final: MagicMock
     ) -> None:
-        """
-        Test that retriable errors re-raise for Celery retry and do NOT record
-        failure info on non-final attempts.
-        """
         e = CHQueryErrorTooManySimultaneousQueries("Too many queries")
         assert isinstance(e, EXCEPTIONS_TO_RETRY)
         mock_export_direct.side_effect = e
@@ -190,10 +182,6 @@ class TestExportAssetFailureRecording(APIBaseTest):
     def test_retriable_error_records_failure_on_final_attempt(
         self, mock_export_direct: MagicMock, mock_is_final: MagicMock
     ) -> None:
-        """
-        Test that retriable errors re-raise for Celery retry and do record
-        failure info on final attempts.
-        """
         e = CHQueryErrorTooManySimultaneousQueries("Too many queries")
         assert isinstance(e, EXCEPTIONS_TO_RETRY)
         mock_export_direct.side_effect = e


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Whilst working on improving our error tracking regarding the different possible failures around the `ExportAsset` (through both the "single" UI export and the subscription export flow), I noticed that in the first case (the single UI export), we have a code path where we do not set the `exception` and `exception_type` fields upon a retryable exception (even during the last attempt). 

This does not match with our logic inside the subscription export flow, and in the near future, when we will split the exceptions in different failure categories, it will cause us to be blindsided to retryable errors happening in this code path. 

As it's crucial that we're informed on all different failure paths (so that we can observe regressions and act upon them), we have aligned the error capture model between both flows so that we cover all different paths. This will also help in reducing the number of "uncaught exceptions" we are seeing in our dashboards, further limiting those to only contain timeouts.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

1. Effectively we now also log `exception` and `exception_type` details upon retryable failures inside the "single UI export flow".
     1.  In order to enable this, I had to move the `transaction.atomic` annotation from a decorator to a function call, as otherwise we would still not correctly set the failures during failures (as it would roll back the resource).
2. Additionally I've centralised the logic to record failures, so that we can guarantee that both flows stay in sync. 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

1. I've added a test case to cover the regression `test_retriable_error_records_failure_on_final_attempt` and confirmed it failed with the code from master. 
2. All added tests pass. 
3. Manual export still works:

<img width="3831" height="1225" alt="CleanShot 2026-01-05 at 13 10 26" src="https://github.com/user-attachments/assets/5b79fddd-c554-44ed-aecc-039ff03a6cca" />

[export-weekly-active-users-waus.csv](https://github.com/user-attachments/files/24432935/export-weekly-active-users-waus.csv)

<img width="1600" height="1018" alt="export-weekly-active-users-waus" src="https://github.com/user-attachments/assets/da084d15-48d8-440f-b405-0ae6d1fbc58f" />

4. Subscriptions still work:

<img width="987" height="424" alt="CleanShot 2026-01-05 at 13 11 22" src="https://github.com/user-attachments/assets/a91b5827-bd37-4f94-8a1b-be6c13b830a3" />

<img width="3080" height="167" alt="CleanShot 2026-01-05 at 13 11 48" src="https://github.com/user-attachments/assets/c1f9a394-85cf-476e-90d4-1f6b848373b5" />
<img width="2981" height="184" alt="CleanShot 2026-01-05 at 13 21 20" src="https://github.com/user-attachments/assets/8799f30d-429a-4f45-b0ad-9aab5a8aa150" />


<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
