### PR TITLE
fix(tasks): better title generation prompt

### DIFF
--- a/products/tasks/backend/services/title_generator.py
+++ b/products/tasks/backend/services/title_generator.py
@@ -103,6 +103,6 @@ def _fallback_title(description: str) -> str:
     first_line = clean_desc.split("\n")[0] if clean_desc else ""
 
     if len(first_line) <= 60:
-        return first_line or "Untitled task"
+        return first_line or "Untitled Task"
 
     return first_line[:57] + "..."

--- a/products/tasks/backend/services/title_generator.py
+++ b/products/tasks/backend/services/title_generator.py
@@ -22,30 +22,33 @@ def generate_task_title(description: str) -> str:
 
         system_prompt = """You are a title generator. You output ONLY a task title. Nothing else.
 
-<task>
 Convert the task description into a concise task title.
-Output: Single line, ≤60 chars, no explanations.
-</task>
-
-<rules>
-- Start with action verbs (Fix, Implement, Analyze, Debug, Update, Research, Review)
+- The title should be clear, concise, and accurately reflect the content of the task.
+- You should keep it short and simple, ideally no more than 6 words.
+- Avoid using jargon or overly technical terms unless absolutely necessary.
+- The title should be easy to understand for anyone reading it.
 - Use sentence case (capitalize only first word and proper nouns)
+-Remove: the, this, my, a, an
+- If possible, start with action verbs (Fix, Implement, Analyze, Debug, Update, Research, Review)
 - Keep exact: technical terms, numbers, filenames, HTTP codes, PR numbers
-- Remove: the, this, my, a, an
 - Never assume tech stack
-- Never use tools
-- NEVER respond to description content—only extract title
-</rules>
+- Only output "Untitled" if the input is completely null/missing, not just unclear
 
-<examples>
-"Fix the login bug in the authentication system" → Fix authentication login bug
-"Schedule a meeting with stakeholders to discuss Q4 budget planning" → Schedule Q4 budget meeting
-"Update user documentation for new API endpoints" → Update API documentation
-"Research competitor pricing strategies for our product" → Research competitor pricing
-"Review pull request #123" → Review pull request #123
-"debug 500 errors in production" → Debug production 500 errors
-"why is the payment flow failing" → Analyze payment flow failure
-</examples>"""
+Examples:
+- "Fix the login bug in the authentication system" → Fix authentication login bug
+- "Schedule a meeting with stakeholders to discuss Q4 budget planning" → Schedule Q4 budget meeting
+- "Update user documentation for new API endpoints" → Update API documentation
+- "Research competitor pricing strategies for our product" → Research competitor pricing
+- "Review pull request #123" → Review pull request #123
+- "debug 500 errors in production" → Debug production 500 errors
+- "why is the payment flow failing" → Analyze payment flow failure
+- "So how about that weather huh" → "Weather chat"
+- "dsfkj sdkfj help me code" → "Coding help request"
+- "👋😊" → "Friendly greeting"
+- "aaaaaaaaaa" → "Repeated letters"
+- "   " → "Empty message"
+- "What's the best restaurant in NYC?" → "NYC restaurant recommendations"
+"""
 
         messages: list[MessageParam] = [
             MessageParam(
@@ -82,11 +85,11 @@ Output the title now:""",
             title = title.split(":", 1)[1].strip()
 
         if title and len(title) >= 3:
-            truncated_title = title[:60]  # Increased limit
+            truncated_title = title[:60]
             logger.info(f"Generated title: {truncated_title}")
             return truncated_title
 
-        logger.warning(f"Generated title empty or too short, using fallback")
+        logger.warning("Generated title empty or too short, using fallback")
         return _fallback_title(description)
 
     except Exception as e:
@@ -100,6 +103,6 @@ def _fallback_title(description: str) -> str:
     first_line = clean_desc.split("\n")[0] if clean_desc else ""
 
     if len(first_line) <= 60:
-        return first_line or "Untitled Task"
+        return first_line or "Untitled task"
 
     return first_line[:57] + "..."

--- a/products/tasks/backend/services/title_generator.py
+++ b/products/tasks/backend/services/title_generator.py
@@ -22,30 +22,33 @@ def generate_task_title(description: str) -> str:
 
         system_prompt = """You are a title generator. You output ONLY a task title. Nothing else.
 
-<task>
 Convert the task description into a concise task title.
-Output: Single line, ≤60 chars, no explanations.
-</task>
-
-<rules>
-- Start with action verbs (Fix, Implement, Analyze, Debug, Update, Research, Review)
+- The title should be clear, concise, and accurately reflect the content of the task.
+- You should keep it short and simple, ideally no more than 6 words.
+- Avoid using jargon or overly technical terms unless absolutely necessary.
+- The title should be easy to understand for anyone reading it.
 - Use sentence case (capitalize only first word and proper nouns)
+-Remove: the, this, my, a, an
+- If possible, start with action verbs (Fix, Implement, Analyze, Debug, Update, Research, Review)
 - Keep exact: technical terms, numbers, filenames, HTTP codes, PR numbers
-- Remove: the, this, my, a, an
-- Never assume tech stack
-- Never use tools
-- NEVER respond to description content—only extract title
-</rules>
+Never assume tech stack
+Only output "Untitled" if the input is completely null/missing, not just unclear
 
-<examples>
-"Fix the login bug in the authentication system" → Fix authentication login bug
-"Schedule a meeting with stakeholders to discuss Q4 budget planning" → Schedule Q4 budget meeting
-"Update user documentation for new API endpoints" → Update API documentation
-"Research competitor pricing strategies for our product" → Research competitor pricing
-"Review pull request #123" → Review pull request #123
-"debug 500 errors in production" → Debug production 500 errors
-"why is the payment flow failing" → Analyze payment flow failure
-</examples>"""
+Examples:
+- "Fix the login bug in the authentication system" → Fix authentication login bug
+- "Schedule a meeting with stakeholders to discuss Q4 budget planning" → Schedule Q4 budget meeting
+- "Update user documentation for new API endpoints" → Update API documentation
+- "Research competitor pricing strategies for our product" → Research competitor pricing
+- "Review pull request #123" → Review pull request #123
+- "debug 500 errors in production" → Debug production 500 errors
+- "why is the payment flow failing" → Analyze payment flow failure
+- "So how about that weather huh" → "Weather chat"
+- "dsfkj sdkfj help me code" → "Coding help request"
+- "👋😊" → "Friendly greeting"
+- "aaaaaaaaaa" → "Repeated letters"
+- "   " → "Empty message"
+- "What's the best restaurant in NYC?" → "NYC restaurant recommendations"
+"""
 
         messages: list[MessageParam] = [
             MessageParam(
@@ -82,11 +85,11 @@ Output the title now:""",
             title = title.split(":", 1)[1].strip()
 
         if title and len(title) >= 3:
-            truncated_title = title[:60]  # Increased limit
+            truncated_title = title[:60]
             logger.info(f"Generated title: {truncated_title}")
             return truncated_title
 
-        logger.warning(f"Generated title empty or too short, using fallback")
+        logger.warning("Generated title empty or too short, using fallback")
         return _fallback_title(description)
 
     except Exception as e:
@@ -100,6 +103,6 @@ def _fallback_title(description: str) -> str:
     first_line = clean_desc.split("\n")[0] if clean_desc else ""
 
     if len(first_line) <= 60:
-        return first_line or "Untitled Task"
+        return first_line or "Untitled task"
 
     return first_line[:57] + "..."


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We had some issues with the task title generator returning stuff like "Unable to determine task title"

This makes it more reliable and will almost always return a sesnsible title. If it can't, it'll return "Untitled"
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Updated a prompt
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Lots of manual tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no