### PR TITLE
refactor(logs): remove logs feature flags from various components

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -581,16 +581,14 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                             to: urls.llmAnalyticsDashboard(),
                             tooltipDocLink: 'https://posthog.com/docs/llm-analytics/dashboard',
                         },
-                        featureFlags[FEATURE_FLAGS.LOGS_PRE_EARLY_ACCESS]
-                            ? {
-                                  identifier: 'Logs',
-                                  label: 'Logs',
-                                  icon: <IconLive />,
-                                  to: urls.logs(),
-                                  tag: 'alpha' as const,
-                                  tooltipDocLink: 'https://posthog.com/docs/logs',
-                              }
-                            : null,
+                        {
+                            identifier: Scene.Logs,
+                            label: 'Logs',
+                            icon: <IconLive />,
+                            to: urls.logs(),
+                            tag: 'beta' as const,
+                            tooltipDocLink: 'https://posthog.com/docs/logs',
+                        },
                         {
                             identifier: Scene.ErrorTracking,
                             label: 'Error tracking',

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.stories.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.stories.tsx
@@ -27,7 +27,6 @@ const meta: Meta<(props: StoryProps) => JSX.Element> = {
             FEATURE_FLAGS.ENDPOINTS,
             FEATURE_FLAGS.LINKS,
             FEATURE_FLAGS.LIVE_DEBUGGER,
-            FEATURE_FLAGS.LOGS_PRE_EARLY_ACCESS,
             FEATURE_FLAGS.WEB_ANALYTICS_MARKETING,
             FEATURE_FLAGS.PRODUCT_TOURS,
             FEATURE_FLAGS.USER_INTERVIEWS,

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -274,8 +274,6 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_TRANSLATION: 'llm-analytics-translation', // owner: #team-llm-analytics
     LLM_ANALYTICS_PROMPTS: 'llm-analytics-prompts', // owner: #team-llm-analytics
     LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT: 'llm-observability-show-input-output', // owner: #team-llm-analytics
-    LOGS_PRE_EARLY_ACCESS: 'logs-internal', // owner: #team-logs
-    LOGS_VIRTUALIZED_LIST: 'logs-virtualized-list', // owner: #team-logs
     LOGS: 'logs', // owner: #team-logs
     MANAGE_INSIGHTS_THROUGH_TERRAFORM: 'manage-insights-through-terraform', // owner: @vasco #team-analytics-platform
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1144,7 +1144,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconType: 'logs' as FileSystemIconType,
         iconColor: ['var(--color-product-logs-light)'] as FileSystemIconColor,
         href: urls.logs(),
-        flag: FEATURE_FLAGS.LOGS_PRE_EARLY_ACCESS,
         tags: ['beta'],
         sceneKey: 'Logs',
         sceneKeys: ['Logs'],

--- a/products/logs/frontend/LogsScene.stories.tsx
+++ b/products/logs/frontend/LogsScene.stories.tsx
@@ -2,7 +2,6 @@ import { Meta } from '@storybook/react'
 import { router } from 'kea-router'
 import { useEffect } from 'react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { dateStringToDayJs, inStorybookTestRunner, sampleOne, uuid } from 'lib/utils'
 import { deterministicRandom } from 'lib/utils/random'
@@ -341,7 +340,6 @@ export default {
         options: { showPanel: false },
         viewMode: 'story',
         mockDate: '2023-02-18',
-        featureFlags: [FEATURE_FLAGS.LOGS_VIRTUALIZED_LIST],
         testOptions: {
             waitForSelector: 'text=/Logs is in beta/i',
         },

--- a/products/logs/manifest.tsx
+++ b/products/logs/manifest.tsx
@@ -1,4 +1,3 @@
-import { FEATURE_FLAGS } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
 import { FileSystemIconType, ProductKey } from '~/queries/schema/schema-general'
@@ -35,7 +34,6 @@ export const manifest: ProductManifest = {
             iconType: 'logs' as FileSystemIconType,
             iconColor: ['var(--color-product-logs-light)'] as FileSystemIconColor,
             href: urls.logs(),
-            flag: FEATURE_FLAGS.LOGS_PRE_EARLY_ACCESS,
             tags: ['beta'],
             sceneKey: 'Logs',
         },


### PR DESCRIPTION
## Problem

The Logs feature no longer needs the early access feature flag

## Changes

- Removed the `LOGS_PRE_EARLY_ACCESS` feature flag, making Logs generally available
- Removed feature flag references from ProjectTree stories and product manifest

## How did you test this code?

Verified that the Logs feature is accessible without the feature flag and displays the correct "beta" tag in the navigation.

## Publish to changelog?

No - just a tidy up