### PR TITLE
fix(llma): Pass -24h timestamp start buffer from `trace.createdAt` when navigating to session view

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -64,6 +64,7 @@ import {
     formatLLMUsage,
     getEventType,
     getSessionID,
+    getSessionStartTimestamp,
     getTraceTimestamp,
     isLLMEvent,
     removeMilliseconds,
@@ -210,7 +211,7 @@ function TraceMetadata({
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SESSIONS_VIEW] ||
             featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
         ) {
-            return urls.llmAnalyticsSession(sessionId)
+            return urls.llmAnalyticsSession(sessionId, { timestamp: getSessionStartTimestamp(trace.createdAt) })
         }
         // Fallback to filtering traces by session when feature flag is off
         const filter = [

--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -4,6 +4,7 @@ import { AnthropicInputMessage, OpenAICompletionMessage } from './types'
 import {
     formatLLMEventTitle,
     getSessionID,
+    getSessionStartTimestamp,
     looksLikeXml,
     normalizeMessage,
     normalizeMessages,
@@ -11,6 +12,16 @@ import {
 } from './utils'
 
 describe('LLM Analytics utils', () => {
+    describe('getSessionStartTimestamp', () => {
+        it.each([
+            ['2024-01-15T12:00:00Z', '2024-01-14T12:00:00Z'],
+            ['2024-01-01T00:00:00Z', '2023-12-31T00:00:00Z'],
+            ['2024-03-01T06:30:00Z', '2024-02-29T06:30:00Z'],
+        ])('subtracts 24 hours from %s to get %s', (input, expected) => {
+            expect(getSessionStartTimestamp(input)).toBe(expected)
+        })
+    })
+
     it('normalizeOutputMessage: parses OpenAI message', () => {
         const message: OpenAICompletionMessage = {
             role: 'assistant',

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -724,6 +724,10 @@ export function getTraceTimestamp(timestamp: string): string {
     return dayjs(timestamp).utc().subtract(5, 'minutes').format('YYYY-MM-DDTHH:mm:ss[Z]')
 }
 
+export function getSessionStartTimestamp(timestamp: string): string {
+    return dayjs(timestamp).utc().subtract(24, 'hours').format('YYYY-MM-DDTHH:mm:ss[Z]')
+}
+
 export function formatLLMEventTitle(event: LLMTrace | LLMTraceEvent): string {
     if (isLLMEvent(event)) {
         if (event.event === '$ai_generation') {


### PR DESCRIPTION
## Problem

When clicking the session ID pill on the LLM Analytics trace view, the session page shows "No traces found" because no timestamp is passed, causing the query to use the default -1h date range which may not include the session's traces.

So this is actually a bugfix (ty @tatoalo!) since we were not passing a `timestamp` when clicking into the session view from the session pill on the trace view. 

## Changes

- Added `getSessionStartTimestamp` utility that subtracts 24h from a timestamp
- Updated `getSessionUrl` to pass this buffered timestamp when navigating to session view

This ensures the session query window captures earlier traces in the same session. Assuming that +24h is a wide enough net to case back for earlier traces that might also be in the same session - this is an assumption.

## How did you test this code?

Manual testing: Verified the session URL now includes a timestamp parameter set to 24h before the trace's createdAt.

## Publish to changelog?

no