### PR TITLE
fix(err): fix $exception duplicated properties

### DIFF
--- a/rust/cymbal/src/fingerprinting/grouping_rules.rs
+++ b/rust/cymbal/src/fingerprinting/grouping_rules.rs
@@ -254,6 +254,7 @@ mod test {
             fingerprint: None,
             issue_name: None,
             issue_description: None,
+            handled: None,
             other: HashMap::new(),
         }
     }

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -148,7 +148,7 @@ pub struct RawErrProps {
     pub issue_name: Option<String>, // Clients can send us custom issue names, which we'll use if present
     #[serde(rename = "$issue_description", skip_serializing_if = "Option::is_none")]
     pub issue_description: Option<String>, // Clients can send us custom issue descriptions, which we'll use if present
-    #[serde(rename = "$exception_handled")]
+    #[serde(rename = "$exception_handled", skip_serializing_if = "Option::is_none")]
     pub handled: Option<bool>, // Clients can send us handled status, which we'll use if present
     #[serde(flatten)]
     // A catch-all for all the properties we don't "care" about, so when we send back to kafka we don't lose any info

--- a/rust/cymbal/tests/assignment_rules.rs
+++ b/rust/cymbal/tests/assignment_rules.rs
@@ -59,6 +59,7 @@ fn test_props(fingerprint: Fingerprint) -> FingerprintedErrProps {
         proposed_issue_name: None,
         proposed_issue_description: None,
         proposed_fingerprint: String::new(),
+        handled: None,
         other: HashMap::new(),
     }
 }


### PR DESCRIPTION
## Changes

- Allow overriding $exception_handled
- Make sure properties are not duplicated (context: https://posthog.slack.com/archives/C02E3BKC78F/p1767358087236889)