### PR TITLE
fix: cast the team id to int in sync persons task

### DIFF
--- a/posthog/temporal/sync_person_distinct_ids/activities.py
+++ b/posthog/temporal/sync_person_distinct_ids/activities.py
@@ -122,9 +122,9 @@ async def find_orphaned_persons(inputs: FindOrphanedPersonsInputs) -> FindOrphan
                     orphaned_persons.append(
                         OrphanedPerson(
                             person_id=data["person_id"],
-                            team_id=data["team_id"],
+                            team_id=int(data["team_id"]),
                             created_at=data["created_at"],
-                            version=data["version"],
+                            version=int(data["version"]),
                         )
                     )
 


### PR DESCRIPTION
## Problem

Forgot to cast team id to int in the CH query.

## Changes

Fixes the ints in the sync persons task.

## How did you test this code?

Existing integration tests for the task.