### PR TITLE
feat(llma): add daily rate limit to playground endpoint

### DIFF
--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -505,6 +505,13 @@ class LLMProxySustainedRateThrottle(UserRateThrottle):
     rate = "500/hour"
 
 
+class LLMProxyDailyRateThrottle(UserRateThrottle):
+    # Daily cap for LLM proxy (playground) endpoint
+    # Hard limit to prevent runaway costs from sustained abuse
+    scope = "llm_proxy_daily"
+    rate = "1000/day"
+
+
 class HogQLQueryThrottle(PersonalApiKeyRateThrottle):
     # Lower rate limit for HogQL queries
     scope = "query"

--- a/products/llm_analytics/backend/api/proxy.py
+++ b/products/llm_analytics/backend/api/proxy.py
@@ -25,7 +25,7 @@ from rest_framework.response import Response
 from posthog.auth import SessionAuthentication
 from posthog.event_usage import report_user_action
 from posthog.models import User
-from posthog.rate_limit import LLMProxyBurstRateThrottle, LLMProxySustainedRateThrottle
+from posthog.rate_limit import LLMProxyBurstRateThrottle, LLMProxyDailyRateThrottle, LLMProxySustainedRateThrottle
 from posthog.renderers import SafeJSONRenderer, ServerSentEventRenderer
 from posthog.settings import SERVER_GATEWAY_INTERFACE
 
@@ -84,7 +84,7 @@ class LLMProxyViewSet(viewsets.ViewSet):
     renderer_classes = [SafeJSONRenderer, ServerSentEventRenderer]
 
     def get_throttles(self):
-        return [LLMProxyBurstRateThrottle(), LLMProxySustainedRateThrottle()]
+        return [LLMProxyBurstRateThrottle(), LLMProxySustainedRateThrottle(), LLMProxyDailyRateThrottle()]
 
     def validate_messages(self, messages: list[dict[str, Any]]) -> TypeGuard[list[MessageParam]]:
         if not messages:


### PR DESCRIPTION
## Problem

The LLM analytics playground endpoint has burst (30/min) and sustained (500/hr) rate limits but no daily cap. This allows a single user to make up to 12,000 requests/day, creating potential for cost runaway from sustained abuse.

## Changes

- Add `LLMProxyDailyRateThrottle` class with 1000/day per-user limit
- Apply the new throttle to the playground proxy endpoint

## How did you test this code?

Manually verified the throttle class follows existing patterns (e.g., `LLMAnalyticsSummarizationDailyThrottle`). Linting passes.

## Publish to changelog?

No