### PR TITLE
feat(navigation): add Zen mode and shortcuts

### DIFF
--- a/frontend/src/layout/GlobalShortcuts.tsx
+++ b/frontend/src/layout/GlobalShortcuts.tsx
@@ -12,12 +12,15 @@ import { sceneLogic } from 'scenes/sceneLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
+import { navigation3000Logic } from './navigation-3000/navigationLogic'
+
 export function GlobalShortcuts(): null {
     const { user } = useValues(userLogic)
     const { preflight } = useValues(preflightLogic)
     const { activeTabId } = useValues(sceneLogic)
     const { setAppShortcutMenuOpen } = useActions(appShortcutLogic)
     const { appShortcutMenuOpen } = useValues(appShortcutLogic)
+    const { toggleZenMode } = useActions(navigation3000Logic)
 
     const showDebugQueries =
         user?.is_staff || user?.is_impersonated || preflight?.is_debug || preflight?.instance_preferences?.debug_queries
@@ -55,6 +58,14 @@ export function GlobalShortcuts(): null {
         interaction: 'function',
         callback: openCHQueriesDebugModal,
         disabled: !showDebugQueries,
+    })
+
+    useAppShortcut({
+        name: 'ZenMode',
+        keybind: [keyBinds.zenMode],
+        intent: 'Toggle zen mode',
+        interaction: 'function',
+        callback: toggleZenMode,
     })
 
     return null

--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -56,8 +56,8 @@ export function Navigation({
         return (
             // eslint-disable-next-line react/forbid-dom-props
             <div className="Navigation3000 flex-col" style={theme?.mainStyle}>
-                {mode === 'minimal' ? <MinimalNavigation /> : null}
-                <main>{children}</main>
+                {(mode === 'minimal' || mode === 'zen') && <MinimalNavigation />}
+                <main className={mode === 'zen' ? 'p-4' : undefined}>{children}</main>
             </div>
         )
     }

--- a/frontend/src/layout/navigation-3000/components/MinimalNavigation.tsx
+++ b/frontend/src/layout/navigation-3000/components/MinimalNavigation.tsx
@@ -10,6 +10,8 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
+import { ZenModeButton } from './ZenModeButton'
+
 export function MinimalNavigation(): JSX.Element {
     const { user } = useValues(userLogic)
     const { currentOrganization } = useValues(organizationLogic)
@@ -22,6 +24,7 @@ export function MinimalNavigation(): JSX.Element {
         <nav className="flex items-center gap-2 p-2 border-b">
             <LemonButton noPadding icon={<IconLogomark className="text-3xl mx-2" />} to={logoUrl} />
             <div className="flex items-center justify-end gap-2 flex-1">
+                <ZenModeButton />
                 {(currentOrganization?.teams?.length ?? 0 > 1) ? (
                     <ProjectMenu
                         buttonProps={{

--- a/frontend/src/layout/navigation-3000/components/ZenModeButton.tsx
+++ b/frontend/src/layout/navigation-3000/components/ZenModeButton.tsx
@@ -1,0 +1,27 @@
+import { useActions, useValues } from 'kea'
+
+import { IconX } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { navigation3000Logic } from '../navigationLogic'
+
+export function ZenModeButton(): JSX.Element | null {
+    const { zenMode } = useValues(navigation3000Logic)
+    const { setZenMode } = useActions(navigation3000Logic)
+
+    if (!zenMode) {
+        return null
+    }
+
+    return (
+        <LemonButton
+            type="secondary"
+            size="small"
+            icon={<IconX />}
+            onClick={() => setZenMode(false)}
+            tooltip="Exit zen mode"
+        >
+            Exit zen mode
+        </LemonButton>
+    )
+}

--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -55,7 +55,7 @@ import { BasicListItem, ExtendedListItem, NavbarItem, SidebarNavbarItem } from '
 /** Multi-segment item keys are joined using this separator for easy comparisons. */
 export const ITEM_KEY_PART_SEPARATOR = '::'
 
-export type Navigation3000Mode = 'none' | 'minimal' | 'full'
+export type Navigation3000Mode = 'none' | 'minimal' | 'zen' | 'full'
 
 const MINIMUM_SIDEBAR_WIDTH_PX: number = 192
 const DEFAULT_SIDEBAR_WIDTH_PX: number = 288
@@ -107,6 +107,8 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
         focusPreviousItem: true,
         toggleAccordion: (key: string) => ({ key }),
         toggleListItemAccordion: (key: string) => ({ key }),
+        setZenMode: (zenMode: boolean) => ({ zenMode }),
+        toggleZenMode: true,
     }),
     reducers({
         isSidebarShown: [
@@ -233,6 +235,13 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                 saveNewItemComplete: () => false,
             },
         ],
+        zenMode: [
+            false,
+            {
+                setZenMode: (_, { zenMode }) => zenMode,
+                toggleZenMode: (state) => !state,
+            },
+        ],
     }),
     listeners(({ actions, values }) => ({
         initiateNewItemInCategory: ({ category: categoryKey }) => {
@@ -338,8 +347,11 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
     })),
     selectors({
         mode: [
-            (s) => [s.sceneConfig, s.isCurrentOrganizationUnavailable],
-            (sceneConfig, isCurrentOrganizationUnavailable): Navigation3000Mode => {
+            (s) => [s.sceneConfig, s.isCurrentOrganizationUnavailable, s.zenMode],
+            (sceneConfig, isCurrentOrganizationUnavailable, zenMode): Navigation3000Mode => {
+                if (zenMode) {
+                    return 'zen'
+                }
                 if (isCurrentOrganizationUnavailable) {
                     return 'minimal'
                 }

--- a/frontend/src/lib/components/Account/AccountMenu.tsx
+++ b/frontend/src/lib/components/Account/AccountMenu.tsx
@@ -7,6 +7,7 @@ import {
     IconCopy,
     IconDatabase,
     IconDay,
+    IconExpand45,
     IconFeatures,
     IconGear,
     IconLaptop,
@@ -51,6 +52,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
+import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { AccessLevelIndicator } from '~/layout/navigation/AccessLevelIndicator'
@@ -149,6 +151,7 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
     const { mobileLayout } = useValues(navigationLogic)
     const { openSidePanel } = useActions(sidePanelStateLogic)
     const { setAppShortcutMenuOpen } = useActions(appShortcutLogic)
+    const { toggleZenMode } = useActions(navigation3000Logic)
 
     return (
         <DropdownMenu>
@@ -311,6 +314,19 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                     )}
 
                     <ThemeMenu />
+
+                    <DropdownMenuItem asChild>
+                        <ButtonPrimitive
+                            tooltip="Hide navigation and focus on content"
+                            tooltipPlacement="right"
+                            onClick={toggleZenMode}
+                            menuItem
+                        >
+                            <IconExpand45 />
+                            Zen mode
+                            <KeyboardShortcut command option z className="ml-auto" />
+                        </ButtonPrimitive>
+                    </DropdownMenuItem>
 
                     <DropdownMenuItem asChild>
                         <ButtonPrimitive

--- a/frontend/src/lib/components/AppShortcuts/shortcuts.ts
+++ b/frontend/src/lib/components/AppShortcuts/shortcuts.ts
@@ -25,4 +25,5 @@ export const keyBinds: Record<string, string[]> = {
     tab7: [...baseModifier, '7'],
     tab8: [...baseModifier, '8'],
     tab9: [...baseModifier, '9'],
+    zenMode: [...baseModifier, 'z'],
 }


### PR DESCRIPTION
## Problem

Sometimes the surrounding UI chrome can be a little noisy & distracting.

A "zen mode" would allow users to hide navigation and focus solely on the content they're working with.

## Changes

(This is available across the whole platform)

![2026-01-05 13 22 17](https://github.com/user-attachments/assets/e8665353-64ad-4e61-84ef-b390c80cae80)
![2026-01-05 13 27 51](https://github.com/user-attachments/assets/e12ba6a6-d1d7-4af4-99dc-5f0f73c90e3b)
![2026-01-05 13 29 11](https://github.com/user-attachments/assets/d3e68cd5-0df7-430f-9e3a-7582a56011e9)

- Added a new "zen mode" to the navigation system that hides most UI elements (similar to `minimal`)
- Implemented a keyboard shortcut (`⌘⌥Z`) to toggle zen mode
- Added a zen mode toggle button in the account menu
- Added an exit button when in zen mode
- Modified the navigation layout to support the zen mode view

## How did you test this code?

- Tested toggling zen mode via keyboard shortcut and UI buttons
- Verified that navigation elements are properly hidden in zen mode
- Confirmed that the exit button appears correctly when in zen mode
- Tested that the main content area displays properly with appropriate padding
- Verified that zen mode state persists correctly during navigation

## Publish to changelog?

Yes