### PR TITLE
feat(surveys): add virtualized response list for survey results v2

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -326,6 +326,7 @@ export const FEATURE_FLAGS = {
     SHOW_REPLAY_FILTERS_FEEDBACK_BUTTON: 'show-replay-filters-feedback-button', // owner: @ksvat #team-replay
     SSE_DASHBOARDS: 'sse-dashboards', // owner: @aspicer #team-analytics-platform
     SURVEY_ANALYSIS_MAX_TOOL: 'survey-analysis-max-tool', // owner: #team-surveys
+    SURVEY_RESULTS_V2: 'survey-results-v2', // owner: #team-surveys
     SURVEYS_ERROR_TRACKING_CROSS_SELL: 'surveys-in-error-tracking', // owner: @adboio #team-surveys
     SURVEYS_EXPERIMENTS_CROSS_SELL: 'surveys-experiments-cross-sell', // owner: @adboio #team-surveys
     SURVEYS_FF_CROSS_SELL: 'surveys-ff-cross-sell', // owner: @adboio #team-surveys

--- a/frontend/src/scenes/persons/PersonDisplay.scss
+++ b/frontend/src/scenes/persons/PersonDisplay.scss
@@ -15,4 +15,15 @@
             opacity: 0.75;
         }
     }
+
+    &--muted {
+        .Link,
+        .Link--subtle {
+            color: var(--text-secondary);
+
+            &:not(:disabled):hover {
+                color: var(--text-3000);
+            }
+        }
+    }
 }

--- a/frontend/src/scenes/persons/PersonDisplay.tsx
+++ b/frontend/src/scenes/persons/PersonDisplay.tsx
@@ -28,6 +28,9 @@ export interface PersonDisplayProps {
     withCopyButton?: boolean
     placement?: 'top' | 'bottom' | 'left' | 'right'
     inline?: boolean
+    className?: string
+    /** Use muted/secondary text color instead of default */
+    muted?: boolean
 }
 
 export function PersonIcon({
@@ -70,6 +73,8 @@ export function PersonDisplay({
     withCopyButton,
     placement,
     inline,
+    className,
+    muted,
 }: PersonDisplayProps): JSX.Element {
     const display = displayName || asDisplay(person)
     const [visible, setVisible] = useState(false)
@@ -101,7 +106,10 @@ export function PersonDisplay({
     )
 
     content = (
-        <span className="PersonDisplay" onClick={!noPopover ? handleClick : undefined}>
+        <span
+            className={clsx('PersonDisplay', muted && 'PersonDisplay--muted', className)}
+            onClick={!noPopover ? handleClick : undefined}
+        >
             {noLink || !href || (visible && !person?.properties) ? (
                 content
             ) : (

--- a/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
@@ -26,7 +26,6 @@ interface ProcessedData {
     openEndedResponses: ChoiceQuestionResponseData[]
 }
 
-/** Convert choice responses to open question format for virtualized list */
 function toOpenQuestionFormat(responses: ChoiceQuestionResponseData[]): OpenQuestionResponseData[] {
     return responses.map((r) => ({
         distinctId: r.distinctId || '',
@@ -81,25 +80,22 @@ export function MultipleChoiceQuestionViz({ responseData, totalResponses }: Prop
         const predefinedResponses = responseData.filter((d) => d.isPredefined)
         const nonPredefinedResponses = responseData.filter((d) => !d.isPredefined)
 
-        // Chart shows predefined responses + total count for "Other" if it exists
         const chartData = [...predefinedResponses]
 
-        // If there are open-ended responses, add a summary count for the predefined "Other" option
         if (nonPredefinedResponses.length > 0) {
             const totalOpenEndedCount = nonPredefinedResponses.reduce((sum, d) => sum + d.value, 0)
             chartData.push({
                 label: 'Other (open-ended)',
                 value: totalOpenEndedCount,
-                isPredefined: true, // This represents the predefined "Other" option
+                isPredefined: true,
             })
         }
 
-        // Sort by value descending
         chartData.sort((a, b) => b.value - a.value)
 
         return {
             chartData,
-            openEndedResponses: nonPredefinedResponses, // Show all open-ended responses
+            openEndedResponses: nonPredefinedResponses,
         }
     }, [responseData])
 

--- a/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceQuestionViz.tsx
@@ -1,12 +1,14 @@
-import { BindLogic } from 'kea'
+import { BindLogic, useValues } from 'kea'
 import { useMemo } from 'react'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { LineGraph } from 'scenes/insights/views/LineGraph/LineGraph'
 import { ResponseCard, ScrollToSurveyResultsCard } from 'scenes/surveys/components/question-visualizations/ResponseCard'
+import { VirtualizedResponseList } from 'scenes/surveys/components/question-visualizations/VirtualizedResponseList'
 import { CHART_INSIGHTS_COLORS } from 'scenes/surveys/components/question-visualizations/util'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
 
-import { ChoiceQuestionResponseData, GraphType, InsightLogicProps } from '~/types'
+import { ChoiceQuestionResponseData, GraphType, InsightLogicProps, OpenQuestionResponseData } from '~/types'
 
 const insightProps: InsightLogicProps = {
     dashboardItemId: `new-survey`,
@@ -24,7 +26,57 @@ interface ProcessedData {
     openEndedResponses: ChoiceQuestionResponseData[]
 }
 
+/** Convert choice responses to open question format for virtualized list */
+function toOpenQuestionFormat(responses: ChoiceQuestionResponseData[]): OpenQuestionResponseData[] {
+    return responses.map((r) => ({
+        distinctId: r.distinctId || '',
+        response: r.label,
+        personProperties: r.personProperties,
+        timestamp: r.timestamp,
+    }))
+}
+
+function OpenEndedResponsesSection({
+    openEndedResponses,
+    useVirtualizedList,
+}: {
+    openEndedResponses: ChoiceQuestionResponseData[]
+    useVirtualizedList: boolean
+}): JSX.Element {
+    if (useVirtualizedList) {
+        return (
+            <div>
+                <h4 className="font-semibold mb-3 text-sm text-muted-foreground">Open-ended responses:</h4>
+                <VirtualizedResponseList responses={toOpenQuestionFormat(openEndedResponses)} />
+            </div>
+        )
+    }
+
+    return (
+        <div>
+            <h4 className="font-semibold mb-3 text-sm text-muted-foreground">Open-ended responses:</h4>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+                {openEndedResponses.slice(0, openEndedResponses.length > 20 ? 19 : 20).map((response, i) => (
+                    <ResponseCard
+                        key={`open-${i}`}
+                        response={response.label}
+                        distinctId={response.distinctId}
+                        personProperties={response.personProperties}
+                        timestamp={response.timestamp}
+                        count={response.value}
+                    />
+                ))}
+                {openEndedResponses.length > 20 && (
+                    <ScrollToSurveyResultsCard numOfResponses={openEndedResponses.length - 20} />
+                )}
+            </div>
+        </div>
+    )
+}
+
 export function MultipleChoiceQuestionViz({ responseData, totalResponses }: Props): JSX.Element | null {
+    const { isSurveyResultsV2Enabled } = useValues(surveyLogic)
+
     const { chartData, openEndedResponses } = useMemo((): ProcessedData => {
         const predefinedResponses = responseData.filter((d) => d.isPredefined)
         const nonPredefinedResponses = responseData.filter((d) => !d.isPredefined)
@@ -89,24 +141,10 @@ export function MultipleChoiceQuestionViz({ responseData, totalResponses }: Prop
             </div>
 
             {openEndedResponses.length > 0 && (
-                <div>
-                    <h4 className="font-semibold mb-3 text-sm text-muted-foreground">Open-ended responses:</h4>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                        {openEndedResponses.slice(0, openEndedResponses.length > 20 ? 19 : 20).map((response, i) => (
-                            <ResponseCard
-                                key={`open-${i}`}
-                                response={response.label}
-                                distinctId={response.distinctId}
-                                personProperties={response.personProperties}
-                                timestamp={response.timestamp}
-                                count={response.value}
-                            />
-                        ))}
-                        {openEndedResponses.length > 20 && (
-                            <ScrollToSurveyResultsCard numOfResponses={openEndedResponses.length - 20} />
-                        )}
-                    </div>
-                </div>
+                <OpenEndedResponsesSection
+                    openEndedResponses={openEndedResponses}
+                    useVirtualizedList={isSurveyResultsV2Enabled}
+                />
             )}
         </div>
     )

--- a/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionViz.tsx
@@ -1,14 +1,20 @@
+import { useValues } from 'kea'
+
 import { ResponseSummariesDisplay } from 'scenes/surveys/components/question-visualizations/OpenQuestionSummarizer'
 import { ResponseCard, ScrollToSurveyResultsCard } from 'scenes/surveys/components/question-visualizations/ResponseCard'
+import { VirtualizedResponseList } from 'scenes/surveys/components/question-visualizations/VirtualizedResponseList'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
 
 import { BasicSurveyQuestion, OpenQuestionResponseData } from '~/types'
 
 interface Props {
     question: BasicSurveyQuestion
+    questionIndex: number
     responseData: OpenQuestionResponseData[]
+    totalResponses: number
 }
 
-export function OpenQuestionViz({ question, responseData }: Props): JSX.Element | null {
+function OpenQuestionVizV1({ question, responseData }: Omit<Props, 'questionIndex' | 'totalResponses'>): JSX.Element {
     return (
         <div className="space-y-4">
             <ResponseSummariesDisplay />
@@ -26,4 +32,27 @@ export function OpenQuestionViz({ question, responseData }: Props): JSX.Element 
             </div>
         </div>
     )
+}
+
+function OpenQuestionVizV2({ responseData }: Pick<Props, 'responseData'>): JSX.Element {
+    return <VirtualizedResponseList responses={responseData} />
+}
+
+export function OpenQuestionViz({
+    question,
+    questionIndex: _questionIndex,
+    responseData,
+    totalResponses: _totalResponses,
+}: Props): JSX.Element | null {
+    // _questionIndex and _totalResponses are used in PR2 for AI summarization
+    void _questionIndex
+    void _totalResponses
+
+    const { isSurveyResultsV2Enabled } = useValues(surveyLogic)
+
+    if (isSurveyResultsV2Enabled) {
+        return <OpenQuestionVizV2 responseData={responseData} />
+    }
+
+    return <OpenQuestionVizV1 question={question} responseData={responseData} />
 }

--- a/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionViz.tsx
@@ -44,7 +44,6 @@ export function OpenQuestionViz({
     responseData,
     totalResponses: _totalResponses,
 }: Props): JSX.Element | null {
-    // _questionIndex and _totalResponses are used in PR2 for AI summarization
     void _questionIndex
     void _totalResponses
 

--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -181,7 +181,12 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
                             />
                         )}
                     {question.type === SurveyQuestionType.Open && demoData.type === SurveyQuestionType.Open && (
-                        <OpenQuestionViz question={question} responseData={demoData.data} />
+                        <OpenQuestionViz
+                            question={question}
+                            questionIndex={questionIndex}
+                            responseData={demoData.data}
+                            totalResponses={demoData.totalResponses}
+                        />
                     )}
                 </div>
             </div>
@@ -242,7 +247,12 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
                             />
                         )}
                     {question.type === SurveyQuestionType.Open && processedData.type === SurveyQuestionType.Open && (
-                        <OpenQuestionViz question={question} responseData={processedData.data} />
+                        <OpenQuestionViz
+                            question={question}
+                            questionIndex={questionIndex}
+                            responseData={processedData.data}
+                            totalResponses={processedData.totalResponses}
+                        />
                     )}
                 </ErrorBoundary>
             </div>

--- a/frontend/src/scenes/surveys/components/question-visualizations/VirtualizedResponseList.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/VirtualizedResponseList.tsx
@@ -1,0 +1,93 @@
+import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
+import { Grid, GridCellProps } from 'react-virtualized/dist/es/Grid'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { PersonDisplay } from 'scenes/persons/PersonDisplay'
+
+import { OpenQuestionResponseData } from '~/types'
+
+interface VirtualizedResponseListProps {
+    responses: OpenQuestionResponseData[]
+    maxHeight?: number
+}
+
+const ROW_HEIGHT = 72
+const COLUMN_COUNT = 2
+const COLUMN_GAP = 8
+
+function ResponseListItem({ response }: { response: OpenQuestionResponseData }): JSX.Element {
+    const responseText = typeof response.response !== 'string' ? JSON.stringify(response.response) : response.response
+
+    return (
+        <div className="border rounded bg-surface-primary p-2 h-full flex flex-col">
+            <div className="text-sm flex-1 line-clamp-2 mb-1">{responseText}</div>
+            <div className="flex items-center justify-between text-xs text-muted">
+                <PersonDisplay
+                    person={{
+                        distinct_id: response.distinctId,
+                        properties: response.personProperties || {},
+                    }}
+                    withIcon="xs"
+                    noEllipsis={false}
+                />
+                {response.timestamp && <TZLabel time={response.timestamp} formatDate="MMM D" formatTime="HH:mm" />}
+            </div>
+        </div>
+    )
+}
+
+export function VirtualizedResponseList({ responses, maxHeight = 400 }: VirtualizedResponseListProps): JSX.Element {
+    const rowCount = Math.ceil(responses.length / COLUMN_COUNT)
+
+    const cellRenderer = ({ columnIndex, rowIndex, key, style }: GridCellProps): JSX.Element | null => {
+        const index = rowIndex * COLUMN_COUNT + columnIndex
+        if (index >= responses.length) {
+            return null
+        }
+        const response = responses[index]
+
+        // Add gap between columns
+        const adjustedStyle = {
+            ...style,
+            left: Number(style.left) + columnIndex * COLUMN_GAP,
+            width: Number(style.width) - COLUMN_GAP,
+            paddingBottom: 8,
+        }
+
+        return (
+            <div key={key} style={adjustedStyle}>
+                <ResponseListItem response={response} />
+            </div>
+        )
+    }
+
+    // For small lists, render without virtualization
+    if (responses.length <= 8) {
+        return (
+            <div className="grid grid-cols-2 gap-2">
+                {responses.map((response, index) => (
+                    <ResponseListItem key={`${response.distinctId}-${index}`} response={response} />
+                ))}
+            </div>
+        )
+    }
+
+    return (
+        <div style={{ height: Math.min(rowCount * ROW_HEIGHT, maxHeight) }}>
+            <AutoSizer>
+                {({ height, width }) => (
+                    <Grid
+                        width={width}
+                        height={height}
+                        columnCount={COLUMN_COUNT}
+                        columnWidth={(width - COLUMN_GAP) / COLUMN_COUNT}
+                        rowCount={rowCount}
+                        rowHeight={ROW_HEIGHT}
+                        cellRenderer={cellRenderer}
+                        overscanRowCount={3}
+                    />
+                )}
+            </AutoSizer>
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/components/question-visualizations/VirtualizedResponseList.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/VirtualizedResponseList.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react'
 import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
-import { Grid, GridCellProps } from 'react-virtualized/dist/es/Grid'
+import { Grid, GridCellProps, ScrollParams } from 'react-virtualized/dist/es/Grid'
 
 import { TZLabel } from 'lib/components/TZLabel'
+import { Popover } from 'lib/lemon-ui/Popover'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 
 import { OpenQuestionResponseData } from '~/types'
@@ -17,11 +19,16 @@ const COLUMN_GAP = 8
 
 function ResponseListItem({ response }: { response: OpenQuestionResponseData }): JSX.Element {
     const responseText = typeof response.response !== 'string' ? JSON.stringify(response.response) : response.response
+    const isLongResponse = responseText.length > 100
+    const [isExpanded, setIsExpanded] = useState(false)
 
-    return (
-        <div className="border rounded bg-surface-primary p-2 h-full flex flex-col">
-            <div className="text-sm flex-1 line-clamp-2 mb-1">{responseText}</div>
-            <div className="flex items-center justify-between text-xs text-muted">
+    const cardContent = (
+        <div
+            className={`border rounded bg-surface-primary p-2 h-full flex flex-col ${isLongResponse ? 'cursor-pointer hover:border-primary' : ''}`}
+            onClick={isLongResponse ? () => setIsExpanded(!isExpanded) : undefined}
+        >
+            <div className="text-sm truncate mb-auto">{responseText}</div>
+            <div className="flex items-center justify-between text-xs text-secondary mt-1">
                 <PersonDisplay
                     person={{
                         distinct_id: response.distinctId,
@@ -29,15 +36,54 @@ function ResponseListItem({ response }: { response: OpenQuestionResponseData }):
                     }}
                     withIcon="xs"
                     noEllipsis={false}
+                    noLink={!response.distinctId}
+                    muted
                 />
                 {response.timestamp && <TZLabel time={response.timestamp} formatDate="MMM D" formatTime="HH:mm" />}
             </div>
         </div>
     )
+
+    if (!isLongResponse) {
+        return cardContent
+    }
+
+    return (
+        <Popover
+            visible={isExpanded}
+            onClickOutside={() => setIsExpanded(false)}
+            placement="bottom-start"
+            padded={false}
+            overlay={
+                <div className="max-w-sm p-3">
+                    <p className="text-sm whitespace-pre-wrap leading-relaxed">{responseText}</p>
+                    <div className="flex items-center justify-between text-xs text-secondary mt-3 pt-2 border-t">
+                        <PersonDisplay
+                            person={{
+                                distinct_id: response.distinctId,
+                                properties: response.personProperties || {},
+                            }}
+                            withIcon
+                            noEllipsis={false}
+                            noLink={!response.distinctId}
+                        />
+                        {response.timestamp && <TZLabel time={response.timestamp} />}
+                    </div>
+                </div>
+            }
+        >
+            {cardContent}
+        </Popover>
+    )
 }
 
 export function VirtualizedResponseList({ responses, maxHeight = 400 }: VirtualizedResponseListProps): JSX.Element {
     const rowCount = Math.ceil(responses.length / COLUMN_COUNT)
+    const [isAtBottom, setIsAtBottom] = useState(false)
+
+    const containerHeight = Math.min(rowCount * ROW_HEIGHT, maxHeight)
+    const totalHeight = rowCount * ROW_HEIGHT
+    const isScrollable = totalHeight > maxHeight
 
     const cellRenderer = ({ columnIndex, rowIndex, key, style }: GridCellProps): JSX.Element | null => {
         const index = rowIndex * COLUMN_COUNT + columnIndex
@@ -46,11 +92,9 @@ export function VirtualizedResponseList({ responses, maxHeight = 400 }: Virtuali
         }
         const response = responses[index]
 
-        // Add gap between columns
         const adjustedStyle = {
             ...style,
-            left: Number(style.left) + columnIndex * COLUMN_GAP,
-            width: Number(style.width) - COLUMN_GAP,
+            left: Number(style.left) + (columnIndex === 1 ? COLUMN_GAP : 0),
             paddingBottom: 8,
         }
 
@@ -61,7 +105,6 @@ export function VirtualizedResponseList({ responses, maxHeight = 400 }: Virtuali
         )
     }
 
-    // For small lists, render without virtualization
     if (responses.length <= 8) {
         return (
             <div className="grid grid-cols-2 gap-2">
@@ -72,22 +115,41 @@ export function VirtualizedResponseList({ responses, maxHeight = 400 }: Virtuali
         )
     }
 
+    const handleScroll = ({ scrollTop, clientHeight, scrollHeight }: ScrollParams): void => {
+        const atBottom = scrollTop + clientHeight >= scrollHeight - 20
+        setIsAtBottom(atBottom)
+    }
+
+    const showScrollIndicator = isScrollable && !isAtBottom
+
     return (
-        <div style={{ height: Math.min(rowCount * ROW_HEIGHT, maxHeight) }}>
-            <AutoSizer>
-                {({ height, width }) => (
-                    <Grid
-                        width={width}
-                        height={height}
-                        columnCount={COLUMN_COUNT}
-                        columnWidth={(width - COLUMN_GAP) / COLUMN_COUNT}
-                        rowCount={rowCount}
-                        rowHeight={ROW_HEIGHT}
-                        cellRenderer={cellRenderer}
-                        overscanRowCount={3}
-                    />
-                )}
-            </AutoSizer>
+        <div className="relative">
+            <div style={{ height: containerHeight }}>
+                <AutoSizer>
+                    {({ height, width }) => (
+                        <Grid
+                            width={width}
+                            height={height}
+                            columnCount={COLUMN_COUNT}
+                            columnWidth={(width - COLUMN_GAP) / COLUMN_COUNT}
+                            rowCount={rowCount}
+                            rowHeight={ROW_HEIGHT}
+                            cellRenderer={cellRenderer}
+                            overscanRowCount={3}
+                            onScroll={handleScroll}
+                        />
+                    )}
+                </AutoSizer>
+            </div>
+            <div
+                className={`absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-bg-light to-transparent pointer-events-none flex items-end justify-center pb-2 transition-all duration-300 ${
+                    showScrollIndicator ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
+                }`}
+            >
+                <span className="text-xs text-primary-alt font-medium bg-surface-primary border rounded-full px-3 py-1 shadow-sm pointer-events-auto">
+                    ↓ Scroll for more
+                </span>
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1355,6 +1355,12 @@ export const surveyLogic = kea<surveyLogicType>([
                 return !!enabledFlags[FEATURE_FLAGS.SURVEY_ANALYSIS_MAX_TOOL]
             },
         ],
+        isSurveyResultsV2Enabled: [
+            (s) => [s.enabledFlags],
+            (enabledFlags: FeatureFlagsSet): boolean => {
+                return !!enabledFlags[FEATURE_FLAGS.SURVEY_RESULTS_V2]
+            },
+        ],
         isExternalSurveyFFEnabled: [
             (s) => [s.enabledFlags],
             (enabledFlags: FeatureFlagsSet): boolean => {


### PR DESCRIPTION
## Summary

This PR introduces a new layout for survey open-ended responses behind the `SURVEY_RESULTS_V2` feature flag:

- **Virtualized two-column grid** - Shows ALL responses (not just 20) in a performant virtualized container using react-virtualized
- **Better person display** - Uses `PersonDisplay` component with popover preview for respondent identification
- **Multiple choice support** - Open-ended responses in choice questions also use the new virtualized layout

## Changes

- Add `SURVEY_RESULTS_V2` feature flag in `constants.tsx`
- Add `isSurveyResultsV2Enabled` selector in `surveyLogic.tsx`
- Create `VirtualizedResponseList` component with two-column Grid layout
- Update `OpenQuestionViz` with V1/V2 conditional rendering
- Update `MultipleChoiceQuestionViz` to use virtualized list for open-ended responses
- Update `SurveyQuestionVisualization` to pass required props

| Before | After |
| --- | --- |
| <br>![CleanShot 2026-01-05 at 11.47.49@2x.jpg](https://app.graphite.com/user-attachments/assets/f471d142-e23f-4792-ae0c-86d746d68014.jpg)<br> | ![CleanShot 2026-01-05 at 11.47.09@2x.jpg](https://app.graphite.com/user-attachments/assets/1b6fd3ae-d86b-4c32-bed7-af3a9c803277.jpg) |

## Stacked PR

This is PR 1/2. PR 2 will add AI summarization on top of this layout.