### PR TITLE
feat(logs): add log comments

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4929,6 +4929,7 @@ export enum ActivityScope {
     HEATMAP = 'Heatmap',
     USER = 'User',
     LLM_TRACE = 'LLMTrace',
+    LOG = 'Log',
 }
 
 export type CommentType = {

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -73,6 +73,7 @@ ActivityScope = Literal[
     "ExternalDataSource",
     "ExternalDataSchema",
     "LLMTrace",
+    "Log",
 ]
 ChangeAction = Literal[
     "changed", "created", "deleted", "merged", "split", "exported", "revoked", "logged_in", "logged_out"

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogComments.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogComments.tsx
@@ -1,0 +1,25 @@
+import { CommentComposer } from 'scenes/comments/CommentComposer'
+import { CommentsList } from 'scenes/comments/CommentsList'
+import { CommentsLogicProps } from 'scenes/comments/commentsLogic'
+
+import { ActivityScope } from '~/types'
+
+import { ParsedLogMessage } from 'products/logs/frontend/types'
+
+export function LogComments({ log }: { log: ParsedLogMessage }): JSX.Element {
+    const commentsLogicProps: CommentsLogicProps = {
+        scope: ActivityScope.LOG,
+        item_id: log.uuid,
+        item_context: {
+            log_timestamp: log.timestamp,
+            service_name: log.resource_attributes?.service_name,
+        },
+    }
+
+    return (
+        <div className="flex flex-col gap-4">
+            <CommentsList {...commentsLogicProps} noun="log" />
+            <CommentComposer {...commentsLogicProps} />
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
@@ -8,6 +8,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { logsViewerLogic } from '../logsViewerLogic'
+import { LogComments } from './LogComments'
 import { LogExploreAI } from './Tabs/ExploreWithAI'
 import { LogDetailsTab, logDetailsModalLogic } from './logDetailsModalLogic'
 
@@ -136,6 +137,11 @@ export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element
                                         onApplyFilter={handleApplyFilter}
                                     />
                                 ),
+                            },
+                            {
+                                key: 'comments',
+                                label: 'Comments',
+                                content: <LogComments log={selectedLog} />,
                             },
                         ]}
                     />

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
@@ -4,7 +4,7 @@ import { ParsedLogMessage } from 'products/logs/frontend/types'
 
 import type { logDetailsModalLogicType } from './logDetailsModalLogicType'
 
-export type LogDetailsTab = 'details' | 'explore-ai'
+export type LogDetailsTab = 'details' | 'explore-ai' | 'comments'
 
 export const logDetailsModalLogic = kea<logDetailsModalLogicType>([
     path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'LogDetailsModal', 'logDetailsModalLogic']),


### PR DESCRIPTION
## Problem

Currently, users cannot add comments to logs in the LogsViewer, limiting collaboration and context sharing around log entries.

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/10e4e94a-56d7-47f7-af2a-15b301ded8de.png)

- Added `LOG` to the `ActivityScope` enum in frontend types
- Added `Log` to the activity logging scope list in the backend
- Created a new `LogComments` component to enable commenting on log entries
- Added a Comments tab to the LogDetailsModal
- Updated the `LogDetailsTab` type to include the new 'comments' option

## How did you test this code?

I tested this by:
- Verifying the comments component renders correctly in the LogDetailsModal
- Confirming comments can be added to log entries and are properly associated with the log UUID
- Checking that comment context includes relevant log information (timestamp and service name)
- Ensuring the comments tab navigation works as expected

## Publish to changelog?

No