### PR TITLE
chore(cdp): switch to new geoip hogfunction creation for projects

### DIFF
--- a/nodejs/src/cdp/legacy-plugins/_transformations/posthog-plugin-geoip/template.ts
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/posthog-plugin-geoip/template.ts
@@ -7,7 +7,7 @@ export const posthogPluginGeoip: LegacyTransformationPlugin = {
     processEvent,
     template: {
         free: true,
-        status: 'stable',
+        status: 'hidden',
         type: 'transformation',
         id: 'plugin-posthog-plugin-geoip',
         name: 'GeoIP',

--- a/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
@@ -42,6 +42,7 @@ if (ip == '127.0.0.1' or
     print('spoofing private ip for local development', ip)
     ip := '89.160.20.129'
 }
+let response := geoipLookup(ip)
 if (not response) {
     print('geoip lookup failed for ip', ip)
     return event

--- a/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
@@ -2,7 +2,7 @@ import { HogFunctionTemplate } from '~/cdp/types'
 
 export const template: HogFunctionTemplate = {
     free: true,
-    status: 'alpha', // TODO: change to beta once we want to enable it by default for every project.
+    status: 'stable',
     type: 'transformation',
     id: 'template-geoip',
     name: 'GeoIP',
@@ -35,10 +35,11 @@ if (event.properties?.$geoip_disable or empty(event.properties?.$ip)) {
     return event
 }
 let ip := event.properties.$ip
-if (ip == '127.0.0.1') {
-    print('spoofing ip for local development', ip)
-    ip := '89.160.20.129'
-}
+if (ip == '127.0.0.1' or 
+    match(ip, '^192\\.168\\.') or 
+    match(ip, '^10\\.') or 
+    match(ip, '^172\\.(1[6-9]|2[0-9]|3[01])\\.')) {
+    print('spoofing private ip for local development', ip)
 let response := geoipLookup(ip)
 if (not response) {
     print('geoip lookup failed for ip', ip)

--- a/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
@@ -35,10 +35,7 @@ if (event.properties?.$geoip_disable or empty(event.properties?.$ip)) {
     return event
 }
 let ip := event.properties.$ip
-if (ip == '127.0.0.1' or 
-    match(ip, '^192\\.168\\.') or 
-    match(ip, '^10\\.') or 
-    match(ip, '^172\\.(1[6-9]|2[0-9]|3[01])\\.')) {
+if (ip == '127.0.0.1') {
     print('spoofing private ip for local development', ip)
     ip := '89.160.20.129'
 }

--- a/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
@@ -35,7 +35,7 @@ if (event.properties?.$geoip_disable or empty(event.properties?.$ip)) {
     return event
 }
 let ip := event.properties.$ip
-if (ip == '127.0.0.1' or match(ip, '^192\\.168\\.') or match(ip, '^10\\.') or match(ip, '^172\\.(1[6-9]|2[0-9]|3[01])\\.')) {
+if (ip == '127.0.0.1') {
     print('spoofing ip for local development', ip)
     ip := '89.160.20.129'
 }

--- a/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
@@ -35,7 +35,8 @@ if (event.properties?.$geoip_disable or empty(event.properties?.$ip)) {
     return event
 }
 let ip := event.properties.$ip
-if (ip == '127.0.0.1') {
+// Check for localhost and common private network IPs
+if (ip == '127.0.0.1' or substring(ip, 1, 8) == '192.168.') {
     print('spoofing ip for local development', ip)
     ip := '89.160.20.129'
 }

--- a/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
@@ -40,7 +40,8 @@ if (ip == '127.0.0.1' or
     match(ip, '^10\\.') or 
     match(ip, '^172\\.(1[6-9]|2[0-9]|3[01])\\.')) {
     print('spoofing private ip for local development', ip)
-let response := geoipLookup(ip)
+    ip := '89.160.20.129'
+}
 if (not response) {
     print('geoip lookup failed for ip', ip)
     return event

--- a/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/geoip/geoip.template.ts
@@ -35,8 +35,8 @@ if (event.properties?.$geoip_disable or empty(event.properties?.$ip)) {
     return event
 }
 let ip := event.properties.$ip
-if (ip == '127.0.0.1') {
-    print('spoofing private ip for local development', ip)
+if (ip == '127.0.0.1' or match(ip, '^192\\.168\\.') or match(ip, '^10\\.') or match(ip, '^172\\.(1[6-9]|2[0-9]|3[01])\\.')) {
+    print('spoofing ip for local development', ip)
     ip := '89.160.20.129'
 }
 let response := geoipLookup(ip)

--- a/posthog/models/hog_functions/hog_function.py
+++ b/posthog/models/hog_functions/hog_function.py
@@ -305,11 +305,6 @@ def _create_geoip_transformation_fallback(team: Team, initiating_user=None) -> O
             enabled=True,
             execution_order=1,
         )
-        logger.info(
-            "Successfully created GeoIP transformation using fallback method",
-            team_id=team.id,
-            hog_function_id=hog_function.id,
-        )
         GEOIP_CREATION_COUNTER.labels(creation_method="plugin_fallback").inc()
         return hog_function
     except Exception as e:

--- a/posthog/models/test/test_hog_function.py
+++ b/posthog/models/test/test_hog_function.py
@@ -327,6 +327,87 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
         transformations = HogFunction.objects.filter(team=team, type="transformation")
         assert transformations.count() == 0
 
+    @patch("posthog.plugins.plugin_server_api.get_hog_function_templates")
+    def test_geoip_transformation_fallback_when_sync_fails(self, mock_get_templates):
+        # Mock sync failure
+        mock_get_templates.side_effect = Exception("Network error")
+
+        with self.settings(DISABLE_MMDB=False):
+            team = Team.objects.create_with_data(
+                organization=self.org, name="Test Team Fallback", initiating_user=self.user
+            )
+
+        # Should have created using fallback method
+        transformations = HogFunction.objects.filter(team=team, type="transformation")
+        assert transformations.count() == 1
+        geoip = transformations.first()
+        assert geoip
+        assert geoip.name == "GeoIP"
+        assert geoip.description == "Enrich events with GeoIP data"
+        assert geoip.icon_url == "/static/transformations/geoip.png"
+        assert geoip.enabled
+        assert geoip.execution_order == 1
+        assert geoip.template_id == "plugin-posthog-plugin-geoip"  # Old plugin template ID
+        assert geoip.hog == "return event"  # Simple hog code for fallback
+
+    @patch("posthog.plugins.plugin_server_api.get_hog_function_templates")
+    def test_geoip_transformation_fallback_when_template_not_found(self, mock_get_templates):
+        # Mock empty response (no templates)
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get_templates.return_value = mock_response
+
+        with self.settings(DISABLE_MMDB=False):
+            team = Team.objects.create_with_data(
+                organization=self.org, name="Test Team No Template", initiating_user=self.user
+            )
+
+        # Should have created using fallback method
+        transformations = HogFunction.objects.filter(team=team, type="transformation")
+        assert transformations.count() == 1
+        geoip = transformations.first()
+        assert geoip
+        assert geoip.name == "GeoIP"
+        assert geoip.description == "Enrich events with GeoIP data"
+        assert geoip.template_id == "plugin-posthog-plugin-geoip"
+
+    @patch("posthog.plugins.plugin_server_api.get_hog_function_templates")
+    def test_geoip_transformation_fallback_when_hog_code_invalid(self, mock_get_templates):
+        # Mock template with invalid Hog code that will fail validation
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                "id": "template-geoip",
+                "name": "GeoIP",
+                "description": "Adds geoip data to the event",
+                "type": "transformation",
+                "code": "invalid {{ hog code that will fail",  # Invalid code
+                "inputs_schema": [],
+                "status": "stable",
+                "free": True,
+                "category": ["Custom"],
+                "code_language": "hog",
+                "icon_url": "/static/transformations/geoip.png",
+            }
+        ]
+        mock_get_templates.return_value = mock_response
+
+        with self.settings(DISABLE_MMDB=False):
+            team = Team.objects.create_with_data(
+                organization=self.org, name="Test Team Invalid Code", initiating_user=self.user
+            )
+
+        # Should have created using fallback method due to validation failure
+        transformations = HogFunction.objects.filter(team=team, type="transformation")
+        assert transformations.count() == 1
+        geoip = transformations.first()
+        assert geoip
+        assert geoip.name == "GeoIP"
+        assert geoip.template_id == "plugin-posthog-plugin-geoip"  # Fallback template
+        assert geoip.hog == "return event"  # Simple valid code
+
     def test_hog_function_file_system(self):
         hog_function_3 = HogFunction.objects.create(
             name="func 3",

--- a/posthog/models/test/test_hog_function.py
+++ b/posthog/models/test/test_hog_function.py
@@ -1,7 +1,9 @@
 import json
 
 from posthog.test.base import QueryMatchingTest
+from unittest.mock import Mock, patch
 
+from django.core.management import call_command
 from django.test import TestCase
 
 from posthog.models.action.action import Action
@@ -284,7 +286,30 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
 
         assert json.dumps(hog_function_3.filters["bytecode"]) == f'["_H", {HOGQL_BYTECODE_VERSION}, 29]'
 
-    def test_geoip_transformation_created_when_enabled(self):
+    @patch("posthog.plugins.plugin_server_api.get_hog_function_templates")
+    def test_geoip_transformation_created_when_enabled(self, mock_get_templates):
+        # Mock the response from plugin server
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                "id": "template-geoip",
+                "name": "GeoIP",
+                "description": "Adds geoip data to the event",
+                "type": "transformation",
+                "code": "return event",
+                "inputs_schema": [],
+                "status": "stable",
+                "free": True,
+                "category": ["Custom"],
+                "code_language": "hog",
+                "icon_url": "/static/transformations/geoip.png",
+            }
+        ]
+        mock_get_templates.return_value = mock_response
+        # Run the command to sync templates
+        call_command("sync_hog_function_templates")
+
         with self.settings(DISABLE_MMDB=False):
             team = Team.objects.create_with_data(organization=self.org, name="Test Team", initiating_user=self.user)
 
@@ -293,11 +318,11 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
         geoip = transformations.first()
         assert geoip
         assert geoip.name == "GeoIP"
-        assert geoip.description == "Enrich events with GeoIP data"
+        assert geoip.description == "Adds geoip data to the event"
         assert geoip.icon_url == "/static/transformations/geoip.png"
         assert geoip.enabled
         assert geoip.execution_order == 1
-        assert geoip.template_id == "plugin-posthog-plugin-geoip"
+        assert geoip.template_id == "template-geoip"
 
     def test_geoip_transformation_not_created_when_disabled(self):
         with self.settings(DISABLE_MMDB=True):

--- a/posthog/models/test/test_hog_function.py
+++ b/posthog/models/test/test_hog_function.py
@@ -3,7 +3,6 @@ import json
 from posthog.test.base import QueryMatchingTest
 from unittest.mock import Mock, patch
 
-from django.core.management import call_command
 from django.test import TestCase
 
 from posthog.models.action.action import Action
@@ -307,8 +306,6 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
             }
         ]
         mock_get_templates.return_value = mock_response
-        # Run the command to sync templates
-        call_command("sync_hog_function_templates")
 
         with self.settings(DISABLE_MMDB=False):
             team = Team.objects.create_with_data(organization=self.org, name="Test Team", initiating_user=self.user)


### PR DESCRIPTION
## Problem

Currently we show both the plugin-geoip (legacy) transformation and the new hog one. We also still create the plugin-geoip transformation whenever a new team is created. As this is legacy and should be deprecated we want to swap that out for hog.

## Changes

![2026-01-07 11 25 10](https://github.com/user-attachments/assets/a35e1242-7899-4622-8df7-0c6fb6e9be85)

- creates hog function when a team is created from template-geoip instead of the plugin
- if creating hog function fails we fallback to creating the plugin version as last resort
- hides the old geoip transformation
- marks the new geoip transformation as stable
- on local dev transformations were failing because the spoofing for local dev did not contain certain ip addresses

## How did you test this code?

- adjusted tests
- local dev 