### PR TITLE
fix(web-analytics): Use the cutoff value for pageviews to force a cache miss in the Live dashboard

### DIFF
--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -270,7 +270,21 @@ const loadQueryData = async (): Promise<[HogQLQueryResponse, TrendsQueryResponse
 
     const usersPageviewsQuery: HogQLQuery = {
         kind: NodeKind.HogQLQuery,
-        query: "SELECT toStartOfMinute(timestamp) AS minute_bucket, arrayDistinct(groupArray(distinct_id)) AS distinct_users, count() as total FROM events WHERE event = '$pageview' AND timestamp >= now() - INTERVAL 30 MINUTE GROUP BY minute_bucket ORDER BY minute_bucket ASC",
+        query: `SELECT 
+                    toStartOfMinute(timestamp) AS minute_bucket, 
+                    arrayDistinct(groupArray(distinct_id)) AS distinct_users, 
+                    count() as total 
+                FROM events 
+                WHERE 
+                    event = '$pageview' AND 
+                    timestamp >= toDateTime({cutoff})
+                GROUP BY 
+                    minute_bucket 
+                ORDER BY 
+                    minute_bucket ASC`,
+        values: {
+            cutoff,
+        },
     }
 
     const deviceQuery: TrendsQuery = {


### PR DESCRIPTION
## Problem
When getting page views per minute, our query was being cached, resulting in a loss of data in the charts between views. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Use the cutoff value we use for the other queries to force the data to be fresh every time.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally tested.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
