### PR TITLE
feat: support creating cohorts from queries with distinct_id

### DIFF
--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -546,7 +546,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
 
         cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True)
         cohort.insert_users_by_list(["1", "123"])
-        cohort = Cohort.objects.get()
+        cohort.refresh_from_db()
         results = get_person_ids_by_cohort_id(self.team.pk, cohort.id)
         self.assertEqual(len(results), 2)
         self.assertEqual(cohort.is_calculating, False)
@@ -569,6 +569,33 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         cohort.insert_users_by_list(["123"])
         results = get_person_ids_by_cohort_id(self.team.pk, cohort.id)
         self.assertEqual(len(results), 3)
+
+    def test_insert_cohort_hogql_query_with_distinct_id(self):
+        from posthog.api.cohort import insert_cohort_query_actors_into_ch
+
+        p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["user1"])
+        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["user2"])
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["user3"])
+
+        # Create a cohort with a HogQL query that returns distinct_id
+        cohort = Cohort.objects.create(
+            team=self.team,
+            is_static=True,
+            query={
+                "kind": "HogQLQuery",
+                "query": "SELECT distinct_id FROM raw_person_distinct_ids WHERE distinct_id IN ['user1', 'user2']",
+            },
+        )
+
+        insert_cohort_query_actors_into_ch(cohort, team=self.team)
+        cohort.refresh_from_db()
+
+        results = get_person_ids_by_cohort_id(self.team.pk, cohort.id)
+        self.assertEqual(len(results), 2)
+        result_ids = {str(r) for r in results}
+        self.assertIn(str(p1.uuid), result_ids)
+        self.assertIn(str(p2.uuid), result_ids)
+        self.assertEqual(cohort.is_calculating, False)
 
     @snapshot_clickhouse_insert_cohortpeople_queries
     def test_cohortpeople_basic(self):

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -413,11 +413,16 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                     LemonDialog.openForm({
                                         title: 'Save as static cohort',
                                         description: (
-                                            <div className="mt-2">
-                                                Your query must export a <code>person_id</code>, <code>actor_id</code>{' '}
-                                                or <code>id</code> column, which must match the <code>id</code> of the{' '}
-                                                <code>persons</code> table
-                                            </div>
+                                            <>
+                                                <div className="mt-2">
+                                                    Your query must export a <code>person_id</code>,{' '}
+                                                    <code>actor_id</code>, <code>id</code>, or <code>distinct_id</code>{' '}
+                                                    column. The <code>person_id</code>, <code>actor_id</code>, and{' '}
+                                                    <code>id</code> columns must match the <code>id</code> of the{' '}
+                                                    <code>persons</code> table, while <code>distinct_id</code> will be
+                                                    automatically resolved to the corresponding person.
+                                                </div>
+                                            </>
                                         ),
                                         initialValues: {
                                             name: '',


### PR DESCRIPTION
## Problem

When creating a static cohort from a HogQL query that returns a `distinct_id` column instead of `person_id`, `actor_id`, or `id`, the cohort creation would fail with an error: "ValueError: Could not find a person_id, actor_id, or id column in the query"

This was particularly problematic for queries like `SELECT * FROM <view>` where the view contains `distinct_id` but not `person_id`.

## Changes

- Modified `print_cohort_hogql_query` to detect `distinct_id` columns and automatically wrap queries with a lookup to `person_distinct_id2` table
- Updated modal descriptions to inform users that `distinct_id` is now supported and will be automatically resolved to person_id
- Added debug logging to show which ID column is being used

## How did you test this code?

1. Added test in `test_cohort.py` for queries with `distinct_id` column
2. Verified existing functionality (queries with `person_id`, `actor_id`, `id`) still works
3. Tested fallback logic for `SELECT *` and `FROM events/persons` queries

## Publish to changelog?

No.