### PR TITLE
chore(product tours): move URL targeting to auto-show conditions

### DIFF
--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -1,38 +1,22 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
-import { useEffect, useMemo } from 'react'
 
 import { IconInfo } from '@posthog/icons'
-import {
-    LemonButton,
-    LemonDivider,
-    LemonInput,
-    LemonInputSelect,
-    LemonSelect,
-    LemonSwitch,
-    Tooltip,
-} from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonInput, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { FeatureFlagReleaseConditions } from 'scenes/feature-flags/FeatureFlagReleaseConditions'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
-import { SurveyMatchTypeLabels } from 'scenes/surveys/constants'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { PropertyDefinitionType, SurveyMatchType } from '~/types'
 
 import { AutoShowSection } from './components/AutoShowSection'
 import { EditInToolbarButton } from './components/EditInToolbarButton'
 import { ProductTourCustomization } from './components/ProductTourCustomization'
 import { ProductTourEditTab, productTourLogic } from './productTourLogic'
-
-function InlineCode({ text }: { text: string }): JSX.Element {
-    return <code className="border border-1 border-primary rounded-xs px-1 py-0.5 text-xs">{text}</code>
-}
 
 export function ProductTourEdit({ id }: { id: string }): JSX.Element {
     const {
@@ -46,31 +30,6 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
     const { editingProductTour, setProductTourFormValue, submitProductTourForm, setEditTab } = useActions(
         productTourLogic({ id })
     )
-
-    // Load recent URLs from property definitions
-    const { options } = useValues(propertyDefinitionsModel)
-    const { loadPropertyValues } = useActions(propertyDefinitionsModel)
-    const urlOptions = options['$current_url']
-
-    useEffect(() => {
-        if (urlOptions?.status !== 'loading' && urlOptions?.status !== 'loaded') {
-            loadPropertyValues({
-                endpoint: undefined,
-                type: PropertyDefinitionType.Event,
-                propertyKey: '$current_url',
-                newInput: '',
-                eventNames: [],
-                properties: [],
-            })
-        }
-    }, [urlOptions?.status, loadPropertyValues])
-
-    const urlMatchTypeOptions = useMemo(() => {
-        return Object.entries(SurveyMatchTypeLabels).map(([key, label]) => ({
-            label,
-            value: key as SurveyMatchType,
-        }))
-    }, [])
 
     if (!productTour) {
         return <LemonSkeleton />
@@ -130,77 +89,6 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                                 onChange={(value) => setProductTourFormValue('description', value)}
                             />
                         </LemonField>
-
-                        <LemonDivider />
-
-                        <div>
-                            <h3 className="font-semibold mb-4">
-                                Tour URLs&nbsp;
-                                <Tooltip title="Tour will only display on URLs matching these conditions.">
-                                    <IconInfo />
-                                </Tooltip>
-                            </h3>
-                            <div className="flex gap-2">
-                                <LemonSelect
-                                    value={conditions.urlMatchType || SurveyMatchType.Contains}
-                                    onChange={(value) => {
-                                        setProductTourFormValue('content', {
-                                            ...productTourForm.content,
-                                            conditions: {
-                                                ...conditions,
-                                                urlMatchType: value,
-                                            },
-                                        })
-                                    }}
-                                    options={urlMatchTypeOptions}
-                                />
-                                <LemonInputSelect
-                                    className="flex-1"
-                                    mode="single"
-                                    value={conditions.url ? [conditions.url] : []}
-                                    onChange={(val) => {
-                                        setProductTourFormValue('content', {
-                                            ...productTourForm.content,
-                                            conditions: {
-                                                ...conditions,
-                                                url: val[0] || undefined,
-                                            },
-                                        })
-                                    }}
-                                    onInputChange={(newInput) => {
-                                        loadPropertyValues({
-                                            type: PropertyDefinitionType.Event,
-                                            endpoint: undefined,
-                                            propertyKey: '$current_url',
-                                            newInput: newInput.trim(),
-                                            eventNames: [],
-                                            properties: [],
-                                        })
-                                    }}
-                                    placeholder="e.g. /dashboard or https://example.com/app"
-                                    allowCustomValues
-                                    loading={urlOptions?.status === 'loading'}
-                                    options={(urlOptions?.values || []).map(({ name }) => ({
-                                        key: String(name),
-                                        label: String(name),
-                                        value: String(name),
-                                    }))}
-                                    data-attr="product-tour-url-input"
-                                />
-                            </div>
-                            {conditions.urlMatchType === SurveyMatchType.Exact && (
-                                <div className="flex flex-col gap-2 mt-2 text-secondary text-sm">
-                                    <p className="m-0">
-                                        When using <InlineCode text="= equals" />, trailing slashes will be removed
-                                        before URL comparison.
-                                    </p>
-                                    <p className="m-0">
-                                        Example: <InlineCode text="https://posthog.com/" /> will also match{' '}
-                                        <InlineCode text="https://posthog.com" />, and vice versa.
-                                    </p>
-                                </div>
-                            )}
-                        </div>
 
                         <LemonDivider />
 
@@ -266,8 +154,6 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                                                     />
                                                 </BindLogic>
                                             </div>
-
-                                            <LemonDivider />
 
                                             <AutoShowSection
                                                 conditions={conditions}

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -23,7 +23,7 @@ import {
 } from '~/types'
 
 import type { productToursLogicType } from './productToursLogicType'
-import { captureScreenshot, getElementMetadata, getSmartUrlDefaults } from './utils'
+import { captureScreenshot, getElementMetadata } from './utils'
 
 const RECENT_GOALS_KEY = 'posthog-product-tours-recent-goals'
 
@@ -336,9 +336,6 @@ export const productToursLogic = kea<productToursLogicType>([
                 // Update history if step order changed (or create initial version for new tours)
                 const stepOrderHistory = getUpdatedStepOrderHistory(stepsForApi, existingHistory)
 
-                // For new tours, set smart URL defaults based on current page
-                const urlDefaults = !isUpdate ? getSmartUrlDefaults() : null
-
                 const payload = {
                     name,
                     content: {
@@ -346,15 +343,6 @@ export const productToursLogic = kea<productToursLogicType>([
                         ...existingTour?.content,
                         steps: stepsForApi,
                         step_order_history: stepOrderHistory,
-                        // Set smart URL defaults for new tours (don't override existing conditions)
-                        ...(!isUpdate && !existingTour?.content?.conditions
-                            ? {
-                                  conditions: {
-                                      url: urlDefaults?.url,
-                                      urlMatchType: urlDefaults?.urlMatchType,
-                                  },
-                              }
-                            : {}),
                     },
                 }
                 const url = isUpdate

--- a/frontend/src/toolbar/product-tours/utils.ts
+++ b/frontend/src/toolbar/product-tours/utils.ts
@@ -2,7 +2,6 @@ import { domToJpeg } from 'modern-screenshot'
 
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { TOOLBAR_ID, elementToQuery } from '~/toolbar/utils'
-import { SurveyMatchType } from '~/types'
 
 export interface ElementInfo {
     selector: string
@@ -139,32 +138,5 @@ export function getPageContext(): { url: string; title: string } {
     return {
         url: window.location.href,
         title: document.title,
-    }
-}
-
-/**
- * Get smart URL defaults for a new product tour based on the current page URL.
- *
- * Logic:
- * - If on root domain (path is "/" or empty), use "exact" match with the full URL
- * - If on a path, use "contains" match with just the pathname
- */
-export function getSmartUrlDefaults(): { url: string; urlMatchType: SurveyMatchType } {
-    const { pathname, origin } = window.location
-
-    // Check if we're on the root path
-    const isRootPath = pathname === '/' || pathname === ''
-
-    if (isRootPath) {
-        // For root domain, use exact match with full URL (without trailing slash for consistency)
-        return {
-            url: origin,
-            urlMatchType: SurveyMatchType.Exact,
-        }
-    }
-    // For paths, use contains match with the pathname
-    return {
-        url: pathname,
-        urlMatchType: SurveyMatchType.Contains,
     }
 }


### PR DESCRIPTION
## Problem

the current UX for URL targeting in product tours is confusing

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

moves URL targeting to the auto-show display conditions. there is no need for URL targeting at the top-level (element presence + tour trigger is the implicit "tour can be shown here" logic)

...also manual trigger(s) bypassed this check anyways, so it's extra confusing.

i don't think we need any changes in the SDK for this, but will follow-up if so

![Screenshot 2026-01-05 at 11.33.11 AM.png](https://app.graphite.com/user-attachments/assets/3f4b3337-a4f3-4d6f-a0a3-9b635d6c7750.png)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no