### PR TITLE
feat(experiments): add summary to shared metrics popup

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -31,8 +31,10 @@ function MetricSummary({ metric }: { metric: SharedMetric }): JSX.Element {
                 </Link>
             </div>
             {metric.description && <p className="mt-2">{metric.description}</p>}
-            {metric.query.kind === 'ExperimentTrendsQuery' && <MetricDisplayTrends query={metric.query.count_query} />}
-            {metric.query.kind === 'ExperimentFunnelsQuery' && (
+            {metric.query.kind === NodeKind.ExperimentTrendsQuery && (
+                <MetricDisplayTrends query={metric.query.count_query} />
+            )}
+            {metric.query.kind === NodeKind.ExperimentFunnelsQuery && (
                 <MetricDisplayFunnels query={metric.query.funnels_query} />
             )}
         </div>

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -12,7 +12,6 @@ import { userLogic } from 'scenes/userLogic'
 import { ExperimentMetric, NodeKind } from '~/queries/schema/schema-general'
 import { AvailableFeature, Experiment } from '~/types'
 
-import { MetricDisplayFunnels, MetricDisplayTrends } from '../ExperimentView/components'
 import { getDefaultMetricTitle } from '../MetricsView/shared/utils'
 import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
 import { MetricContext } from './experimentMetricModalLogic'
@@ -32,12 +31,6 @@ function MetricSummary({ metric }: { metric: SharedMetric }): JSX.Element {
                 </Link>
             </div>
             {metric.description && <p className="mt-2">{metric.description}</p>}
-            {metric.query.kind === NodeKind.ExperimentTrendsQuery && (
-                <MetricDisplayTrends query={metric.query.count_query} />
-            )}
-            {metric.query.kind === NodeKind.ExperimentFunnelsQuery && (
-                <MetricDisplayFunnels query={metric.query.funnels_query} />
-            )}
             <div className="text-xs text-muted">
                 <p>Type: {metric.query.metric_type}</p>
                 <p>Metric: {getDefaultMetricTitle(metric.query as ExperimentMetric)}</p>
@@ -260,14 +253,7 @@ export function SharedMetricModal({
             {isEditMode &&
                 (() => {
                     const metric = compatibleSharedMetrics.find((m) => m.id === sharedMetricId)
-                    if (!metric) {
-                        return null
-                    }
-                    return (
-                        <div>
-                            <MetricSummary metric={metric} />
-                        </div>
-                    )
+                    return metric ? <MetricSummary metric={metric} /> : null
                 })()}
         </LemonModal>
     )

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -9,10 +9,11 @@ import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { NodeKind } from '~/queries/schema/schema-general'
+import { ExperimentMetric, NodeKind } from '~/queries/schema/schema-general'
 import { AvailableFeature, Experiment } from '~/types'
 
 import { MetricDisplayFunnels, MetricDisplayTrends } from '../ExperimentView/components'
+import { getDefaultMetricTitle } from '../MetricsView/shared/utils'
 import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
 import { MetricContext } from './experimentMetricModalLogic'
 import { sharedMetricModalLogic } from './sharedMetricModalLogic'
@@ -37,6 +38,11 @@ function MetricSummary({ metric }: { metric: SharedMetric }): JSX.Element {
             {metric.query.kind === NodeKind.ExperimentFunnelsQuery && (
                 <MetricDisplayFunnels query={metric.query.funnels_query} />
             )}
+            <div className="text-xs text-muted">
+                <p>Type: {metric.query.metric_type}</p>
+                <p>Metric: {getDefaultMetricTitle(metric.query as ExperimentMetric)}</p>
+                <p>Goal: {metric.query.goal}</p>
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -17,6 +17,28 @@ import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
 import { MetricContext } from './experimentMetricModalLogic'
 import { sharedMetricModalLogic } from './sharedMetricModalLogic'
 
+function MetricSummary({ metric }: { metric: SharedMetric }): JSX.Element {
+    return (
+        <div className="deprecated-space-y-2">
+            <div className="flex items-center gap-2">
+                <h3 className="font-semibold m-0 flex items-center">{metric.name}</h3>
+                <Link
+                    target="_blank"
+                    className="font-semibold flex items-center"
+                    to={urls.experimentsSharedMetric(metric.id)}
+                >
+                    <IconOpenInNew fontSize="18" />
+                </Link>
+            </div>
+            {metric.description && <p className="mt-2">{metric.description}</p>}
+            {metric.query.kind === 'ExperimentTrendsQuery' && <MetricDisplayTrends query={metric.query.count_query} />}
+            {metric.query.kind === 'ExperimentFunnelsQuery' && (
+                <MetricDisplayFunnels query={metric.query.funnels_query} />
+            )}
+        </div>
+    )
+}
+
 export function SharedMetricModal({
     experiment,
     onSave,
@@ -227,38 +249,18 @@ export function SharedMetricModal({
                 </div>
             )}
 
-            {isEditMode && (
-                <div>
-                    {(() => {
-                        const metric = compatibleSharedMetrics.find((m: SharedMetric) => m.id === sharedMetricId)
-                        if (!metric) {
-                            return null
-                        }
-
-                        return (
-                            <div className="deprecated-space-y-2">
-                                <div className="flex items-center gap-2">
-                                    <h3 className="font-semibold m-0 flex items-center">{metric.name}</h3>
-                                    <Link
-                                        target="_blank"
-                                        className="font-semibold flex items-center"
-                                        to={urls.experimentsSharedMetric(metric.id)}
-                                    >
-                                        <IconOpenInNew fontSize="18" />
-                                    </Link>
-                                </div>
-                                {metric.description && <p className="mt-2">{metric.description}</p>}
-                                {metric.query.kind === 'ExperimentTrendsQuery' && (
-                                    <MetricDisplayTrends query={metric.query.count_query} />
-                                )}
-                                {metric.query.kind === 'ExperimentFunnelsQuery' && (
-                                    <MetricDisplayFunnels query={metric.query.funnels_query} />
-                                )}
-                            </div>
-                        )
-                    })()}
-                </div>
-            )}
+            {isEditMode &&
+                (() => {
+                    const metric = compatibleSharedMetrics.find((m) => m.id === sharedMetricId)
+                    if (!metric) {
+                        return null
+                    }
+                    return (
+                        <div>
+                            <MetricSummary metric={metric} />
+                        </div>
+                    )
+                })()}
         </LemonModal>
     )
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
When clicking on the edit icon for shared metrics, a popup opens showing the name and description of the metric. If the user wants further information they need to click on the new tab icon to get to the metrics form. WIth this PR we show further details right in the popup.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
e.g. for funnel
<img width="1237" height="420" alt="pr-pic-1" src="https://github.com/user-attachments/assets/00efe0d6-6d89-40a6-b5d5-a3892f4d2d6c" />

e.g. for ratio
<img width="1241" height="369" alt="pr-pic-2" src="https://github.com/user-attachments/assets/f55fc4ef-cb6f-4585-9e56-77d5c7e7b8a5" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->

Only manually in this case as discussed with Juraj


## Publish to changelog?

<!-- For features only -->

do not publish to changelog