### PR TITLE
fix(temporal): disable local variable dumping in exception logs

### DIFF
--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -546,7 +546,7 @@ def configure_logger(
             )
 
         base_processors += [
-            # show_locals=False prevents sensitive data from being logged in exception tracebacks. 
+            # show_locals=False prevents sensitive data from being logged in exception tracebacks.
             # The default (True) dumps all local variables at each stack frame.
             structlog.processors.ExceptionRenderer(structlog.tracebacks.ExceptionDictTransformer(show_locals=False)),
             EventRenamer("msg"),

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -546,6 +546,8 @@ def configure_logger(
             )
 
         base_processors += [
+            # show_locals=False prevents sensitive data from being logged in exception tracebacks. 
+            # The default (True) dumps all local variables at each stack frame.
             structlog.processors.ExceptionRenderer(structlog.tracebacks.ExceptionDictTransformer(show_locals=False)),
             EventRenamer("msg"),
             LogMessagesRenderer(event_key="msg"),

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -546,7 +546,9 @@ def configure_logger(
             )
 
         base_processors += [
-            structlog.processors.dict_tracebacks,
+            structlog.processors.ExceptionRenderer(
+                structlog.tracebacks.ExceptionDictTransformer(show_locals=False)
+            ),
             EventRenamer("msg"),
             LogMessagesRenderer(event_key="msg"),
         ]

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -546,9 +546,7 @@ def configure_logger(
             )
 
         base_processors += [
-            structlog.processors.ExceptionRenderer(
-                structlog.tracebacks.ExceptionDictTransformer(show_locals=False)
-            ),
+            structlog.processors.ExceptionRenderer(structlog.tracebacks.ExceptionDictTransformer(show_locals=False)),
             EventRenamer("msg"),
             LogMessagesRenderer(event_key="msg"),
         ]


### PR DESCRIPTION
## Problem

Temporal worker exception logs can dump local variables via structlog's `ExceptionRenderer`, which by default has `show_locals=True`. This causes:

1. **Security concerns**: locals will be logged in plaintext when exceptions occur
2. **Log bloat**: Exception stack traces are already ~16KB per line, contributing to promtail OOMs on temporal worker nodes. this should help reduce these events

## Changes

- Replace `structlog.processors.dict_tracebacks` with explicit `ExceptionRenderer(ExceptionDictTransformer(show_locals=False))`
- Preserves JSON-formatted exception tracebacks (type, value, file, line, function)
- Stops dumping local variables at each stack frame

## How did you test this code?

Local test comparing output with `show_locals=True` vs `show_locals=False`:

Existing test passes:
```
pytest posthog/temporal/tests/common/test_logger.py::test_logger_renders_tracebacks -v
# PASSED
```

## Publish to changelog?

no
