### PR TITLE
feat: Add new products to the weekly digest

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -186,7 +186,7 @@ frontend/src/scenes/onboarding/ @PostHog/team-growth
 frontend/src/layout/navigation-3000/sidepanel/panels/SdkDoctor @PostHog/team-growth
 
 # Weekly digest - owned by @PostHog/team-growth
-posthog/temporal/weekly-digest
+posthog/temporal/weekly-digest @PostHog/team-growth
 
 # DevEx-adjacent files - owned by @PostHog/team-devex
 .github/dependabot.yml @PostHog/team-devex

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -183,7 +183,10 @@ ee/frontend/mobile-replay @PostHog/team-replay
 frontend/src/scenes/onboarding/ @PostHog/team-growth
 
 # SDK Doctor - owned by @PostHog/team-growth
-frontend/src/layout/navigation-3000/sidepanel/panels/_SdkDoctor_ @PostHog/team-growth
+frontend/src/layout/navigation-3000/sidepanel/panels/SdkDoctor @PostHog/team-growth
+
+# Weekly digest - owned by @PostHog/team-growth
+posthog/temporal/weekly-digest
 
 # DevEx-adjacent files - owned by @PostHog/team-devex
 .github/dependabot.yml @PostHog/team-devex

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -14,7 +14,8 @@
     "tailwindCSS.emmetCompletions": true,
     "tailwindCSS.rootFontSize": 16,
     "files.associations": {
-        "*.css": "tailwindcss"
+        "*.css": "tailwindcss",
+        "CODEOWNERS-soft": "CODEOWNERS"
     },
     "mypy-type-checker.importStrategy": "fromEnvironment",
     "mypy-type-checker.preferDaemon": true,

--- a/posthog/temporal/tests/weekly_digest/test_activities.py
+++ b/posthog/temporal/tests/weekly_digest/test_activities.py
@@ -741,11 +741,11 @@ async def test_generate_product_suggestion_lookup(mock_redis, common_input, dige
     mock_user_2.id = 101
 
     # Mock product suggestions - user 1 has multiple, but only first should be stored
-    mock_suggestions_user_1 = [
+    mock_suggestions_user_1: list[dict] = [
         {"product_path": "Error tracking", "reason": "sales_led", "reason_text": None},
         {"product_path": "Session replay", "reason": "new_product", "reason_text": "Custom text"},
     ]
-    mock_suggestions_user_2 = []  # No suggestions for user 2
+    mock_suggestions_user_2: list[dict] = []  # No suggestions for user 2
 
     mock_team_queryset = MockAsyncQuerySet([mock_team])
 

--- a/posthog/temporal/tests/weekly_digest/test_activities.py
+++ b/posthog/temporal/tests/weekly_digest/test_activities.py
@@ -17,6 +17,7 @@ from posthog.temporal.weekly_digest.activities import (
     generate_feature_flag_lookup,
     generate_filter_lookup,
     generate_organization_digest_batch,
+    generate_product_suggestion_lookup,
     generate_recording_lookup,
     generate_survey_lookup,
     generate_user_notification_lookup,
@@ -722,3 +723,168 @@ async def test_send_weekly_digest_batch_dry_run(mock_redis, common_input, digest
 
     # In dry run mode, PostHog client should not be called
     mock_ph_client.capture.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_product_suggestion_lookup(mock_redis, common_input, digest):
+    """Test generating product suggestion lookup stores only one suggestion per user."""
+    batch = (0, 1)
+    input_data = GenerateDigestDataBatchInput(batch=batch, digest=digest, common=common_input)
+
+    mock_team = MagicMock()
+    mock_team.id = 1
+
+    mock_user_1 = MagicMock()
+    mock_user_1.id = 100
+
+    mock_user_2 = MagicMock()
+    mock_user_2.id = 101
+
+    # Mock product suggestions - user 1 has multiple, but only first should be stored
+    mock_suggestions_user_1 = [
+        {"product_path": "Error tracking", "reason": "sales_led", "reason_text": None},
+        {"product_path": "Session replay", "reason": "new_product", "reason_text": "Custom text"},
+    ]
+    mock_suggestions_user_2 = []  # No suggestions for user 2
+
+    mock_team_queryset = MockAsyncQuerySet([mock_team])
+
+    # Create an async generator function for users
+    async def async_user_generator():
+        for user in [mock_user_1, mock_user_2]:
+            yield user
+
+    async def async_wrapper():
+        return async_user_generator()
+
+    # Mock queryset that returns different results based on user_id
+    def mock_query_user_product_suggestions(user_id, team_id, period_start, period_end):
+        mock_qs = MagicMock()
+        mock_qs.user_id = user_id
+        return mock_qs
+
+    async def mock_queryset_to_list(qs):
+        if hasattr(qs, "user_id"):
+            if qs.user_id == 100:
+                return mock_suggestions_user_1
+            return mock_suggestions_user_2
+        return []
+
+    with patch("posthog.temporal.weekly_digest.activities.query_teams_for_digest", return_value=mock_team_queryset):
+        with patch(
+            "posthog.temporal.weekly_digest.activities.query_user_product_suggestions",
+            side_effect=mock_query_user_product_suggestions,
+        ):
+            with patch("posthog.temporal.weekly_digest.activities.queryset_to_list", side_effect=mock_queryset_to_list):
+                with patch("posthog.temporal.weekly_digest.activities.database_sync_to_async") as mock_sync:
+                    mock_sync.return_value = async_wrapper
+                    with patch("posthog.temporal.weekly_digest.activities.redis.from_url", return_value=mock_redis):
+                        await generate_product_suggestion_lookup(input_data)
+
+    # Verify only one suggestion stored per user (user 100), none for user 101
+    assert f"{digest.key}-product-suggestion-100" in mock_redis.data
+    assert f"{digest.key}-product-suggestion-101" not in mock_redis.data
+
+    # Verify only the first suggestion was stored with team_id
+    import json
+
+    stored_data = json.loads(mock_redis.data[f"{digest.key}-product-suggestion-100"])
+    assert stored_data["team_id"] == mock_team.id
+    assert stored_data["product_path"] == "Error tracking"
+    assert stored_data["reason"] == "sales_led"
+
+
+@pytest.mark.asyncio
+async def test_send_weekly_digest_batch_with_product_suggestion(mock_redis, common_input, digest):
+    """Test sending weekly digest batch includes single product suggestion in payload."""
+    batch = (0, 1)
+    input_data = SendWeeklyDigestBatchInput(
+        batch=batch, dry_run=True, allow_already_sent=False, digest=digest, common=common_input
+    )
+
+    mock_org = MagicMock()
+    mock_org.id = UUID("12345678-1234-1234-1234-123456789abc")
+    mock_org.name = "Test Organization"
+
+    mock_member = MagicMock()
+    mock_user = MagicMock()
+    mock_user.id = 100
+    mock_user.distinct_id = "user-100"
+    mock_user.email = "test@example.com"
+    mock_member.user = mock_user
+
+    # Pre-populate Redis with organization digest
+    org_digest_json = """{
+        "id": "12345678-1234-1234-1234-123456789abc",
+        "name": "Test Organization",
+        "created_at": "2024-01-01T00:00:00Z",
+        "team_digests": [
+            {
+                "id": 1,
+                "name": "Test Team",
+                "dashboards": [{"name": "Test Dashboard", "id": 1}],
+                "event_definitions": [],
+                "experiments_launched": [
+                    {"name": "Experiment A", "id": 1, "start_date": "2024-01-01T00:00:00Z"},
+                    {"name": "Experiment B", "id": 2, "start_date": "2024-01-01T00:00:00Z"}
+                ],
+                "experiments_completed": [],
+                "external_data_sources": [
+                    {"source_type": "stripe", "id": "12345678-1234-1234-1234-123456789abc"}
+                ],
+                "feature_flags": [],
+                "filters": [],
+                "expiring_recordings": {"recording_count": 0},
+                "surveys_launched": []
+            }
+        ]
+    }"""
+    await mock_redis.setex(f"{digest.key}-{mock_org.id}", 3600, org_digest_json)
+
+    # Add user notification
+    await mock_redis.sadd(f"{digest.key}-user-notify-100", "1")
+
+    # Add single product suggestion for user 100 (team_id matches the team in the digest)
+    suggestion_json = '{"team_id": 1, "product_path": "Error tracking", "reason": "sales_led", "reason_text": null}'
+    await mock_redis.setex(f"{digest.key}-product-suggestion-100", 3600, suggestion_json)
+
+    mock_org_queryset = MockAsyncQuerySet([mock_org])
+    mock_member_queryset = MockAsyncQuerySet([mock_member])
+
+    mock_ph_client = MagicMock()
+    mock_ph_client.capture = MagicMock()
+
+    mock_messaging_record = MagicMock()
+    mock_messaging_record.sent_at = None
+
+    mock_messaging_objects = MagicMock()
+    mock_messaging_objects.aget_or_create = AsyncMock(return_value=(mock_messaging_record, True))
+
+    captured_payload = {}
+
+    # Capture the logged payload in dry run mode
+    with patch("posthog.temporal.weekly_digest.activities.query_orgs_for_digest", return_value=mock_org_queryset):
+        with patch("posthog.temporal.weekly_digest.activities.query_org_members", return_value=mock_member_queryset):
+            with patch("posthog.temporal.weekly_digest.activities.get_ph_client", return_value=mock_ph_client):
+                with patch("posthog.temporal.weekly_digest.activities.MessagingRecord.objects", mock_messaging_objects):
+                    with patch("posthog.temporal.weekly_digest.activities.redis.from_url", return_value=mock_redis):
+                        with patch("posthog.temporal.weekly_digest.activities.LOGGER") as mock_logger:
+                            mock_bound_logger = MagicMock()
+                            mock_logger.bind.return_value = mock_bound_logger
+
+                            def capture_info(*args, **kwargs):
+                                if "digest" in kwargs:
+                                    captured_payload.update(kwargs["digest"])
+
+                            mock_bound_logger.info = capture_info
+                            await send_weekly_digest_batch(input_data)
+
+    # Verify single product suggestion was included in the team's report
+    assert "teams" in captured_payload
+    teams = captured_payload["teams"]
+    assert len(teams) == 1
+    team_report = teams[0]["report"]
+    assert "new_product_suggestion" in team_report
+    suggestion = team_report["new_product_suggestion"]
+    assert suggestion["product_path"] == "Error tracking"
+    assert suggestion["reason_text"] == "This product is recommended for you by our team."

--- a/posthog/temporal/tests/weekly_digest/test_types.py
+++ b/posthog/temporal/tests/weekly_digest/test_types.py
@@ -563,8 +563,14 @@ def test_organization_digest_render_payload_with_custom_reason_text():
     payload = org.render_payload(digest, product_suggestion=suggestion)
 
     teams = payload["teams"]
+    assert isinstance(teams, list)
+
     team_report = teams[0]["report"]
-    assert team_report["new_product_suggestion"]["reason_text"] == "Custom reason text for this user"
+    assert isinstance(team_report, dict)
+
+    suggestion_payload = team_report["new_product_suggestion"]
+    assert isinstance(suggestion_payload, dict)
+    assert suggestion_payload["reason_text"] == "Custom reason text for this user"
 
 
 def test_organization_digest_render_payload_suggestion_wrong_team():
@@ -601,8 +607,11 @@ def test_organization_digest_render_payload_suggestion_wrong_team():
     payload = org.render_payload(digest, product_suggestion=suggestion)
 
     teams = payload["teams"]
+    assert isinstance(teams, list)
     assert len(teams) == 1
+
     team_report = teams[0]["report"]
+    assert isinstance(team_report, dict)
     assert "new_product_suggestion" not in team_report
 
 
@@ -632,5 +641,8 @@ def test_organization_digest_render_payload_without_product_suggestion():
     payload = org.render_payload(digest)
 
     teams = payload["teams"]
+    assert isinstance(teams, list)
+
     team_report = teams[0]["report"]
+    assert isinstance(team_report, dict)
     assert "new_product_suggestion" not in team_report

--- a/posthog/temporal/tests/weekly_digest/test_workflows.py
+++ b/posthog/temporal/tests/weekly_digest/test_workflows.py
@@ -119,6 +119,7 @@ async def test_generate_digest_data_workflow():
         "user_notification": 0,
         "filter": 0,
         "recording": 0,
+        "product_suggestion": 0,
         "org_digest": 0,
     }
 
@@ -172,6 +173,10 @@ async def test_generate_digest_data_workflow():
     async def generate_recording_lookup_mocked(input) -> None:
         activity_calls["recording"] += 1
 
+    @activity.defn(name="generate-product-suggestion-lookup")
+    async def generate_product_suggestion_lookup_mocked(input) -> None:
+        activity_calls["product_suggestion"] += 1
+
     @activity.defn(name="generate-organization-digest-batch")
     async def generate_organization_digest_batch_mocked(input) -> None:
         activity_calls["org_digest"] += 1
@@ -195,6 +200,7 @@ async def test_generate_digest_data_workflow():
                 generate_user_notification_lookup_mocked,
                 generate_filter_lookup_mocked,
                 generate_recording_lookup_mocked,
+                generate_product_suggestion_lookup_mocked,
                 generate_organization_digest_batch_mocked,
             ],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
@@ -230,6 +236,7 @@ async def test_generate_digest_data_workflow():
     assert activity_calls["user_notification"] == expected_team_batches
     assert activity_calls["filter"] == expected_team_batches
     assert activity_calls["recording"] == expected_team_batches
+    assert activity_calls["product_suggestion"] == expected_team_batches
 
     # Calculate expected batches for organizations
     expected_org_batches = (TEST_ORG_COUNT + TEST_BATCH_SIZE - 1) // TEST_BATCH_SIZE

--- a/posthog/temporal/weekly_digest/README.md
+++ b/posthog/temporal/weekly_digest/README.md
@@ -1,0 +1,217 @@
+# Weekly Digest
+
+The weekly digest is an email sent to all customers summarizing activity in their PostHog projects over the past week.
+
+## Architecture Overview
+
+The digest is generated and sent via two Temporal workflows:
+
+1. **GenerateDigestDataWorkflow** - Generates all digest data and stores it in Redis
+2. **SendWeeklyDigestWorkflow** - Reads from Redis and sends personalized emails
+
+## Redis Storage Structure
+
+Data is stored with keys prefixed by `{digest_key}` (e.g., `weekly-digest-2024-01`).
+
+**Important:** All Redis keys are generated via helper functions in `keys.py`. Never hardcode key strings - use the typed enums and generator functions instead.
+
+### Team-level data
+
+Generated via `team_data_key(digest_key, TeamDataKey.*, team_id)`:
+
+| `TeamDataKey` enum      | Key Pattern                                    | Contents                           |
+| ----------------------- | ---------------------------------------------- | ---------------------------------- |
+| `DASHBOARDS`            | `{digest_key}-dashboards-{team_id}`            | New dashboards created             |
+| `EVENT_DEFINITIONS`     | `{digest_key}-event-definitions-{team_id}`     | New event definitions              |
+| `EXPERIMENTS_LAUNCHED`  | `{digest_key}-experiments-launched-{team_id}`  | Experiments started                |
+| `EXPERIMENTS_COMPLETED` | `{digest_key}-experiments-completed-{team_id}` | Experiments finished               |
+| `EXTERNAL_DATA_SOURCES` | `{digest_key}-external-data-sources-{team_id}` | New data sources                   |
+| `FEATURE_FLAGS`         | `{digest_key}-feature-flags-{team_id}`         | New feature flags                  |
+| `SAVED_FILTERS`         | `{digest_key}-saved-filters-{team_id}`         | Interesting replay filters         |
+| `EXPIRING_RECORDINGS`   | `{digest_key}-expiring-recordings-{team_id}`   | Count of soon-to-expire recordings |
+| `SURVEYS_LAUNCHED`      | `{digest_key}-surveys-launched-{team_id}`      | Surveys launched                   |
+
+### Organization-level data
+
+Generated via `org_digest_key(digest_key, org_id)`:
+
+| Key Pattern             | Contents                                                      |
+| ----------------------- | ------------------------------------------------------------- |
+| `{digest_key}-{org_id}` | `OrganizationDigest` containing all team digests for that org |
+
+### User-level data
+
+Generated via `user_data_key(digest_key, UserDataKey.*, user_id)`:
+
+| `UserDataKey` enum   | Key Pattern                                 | Contents                                                        |
+| -------------------- | ------------------------------------------- | --------------------------------------------------------------- |
+| `NOTIFY_TEAMS`       | `{digest_key}-user-notify-{user_id}`        | Redis SET of team IDs the user should receive notifications for |
+| `PRODUCT_SUGGESTION` | `{digest_key}-product-suggestion-{user_id}` | Single `DigestProductSuggestion` for product recommendations    |
+
+## Data Flow
+
+```plaintext
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        GenerateDigestDataWorkflow                           │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  1. Count teams & orgs for batching                                         │
+│                                                                             │
+│  2. Generate team-level data (parallel per batch):                          │
+│     ├── generate_dashboard_lookup                                           │
+│     ├── generate_event_definition_lookup                                    │
+│     ├── generate_experiment_launched_lookup                                 │
+│     ├── generate_experiment_completed_lookup                                │
+│     ├── generate_external_data_source_lookup                                │
+│     ├── generate_feature_flag_lookup                                        │
+│     ├── generate_survey_lookup                                              │
+│     ├── generate_filter_lookup                                              │
+│     ├── generate_recording_lookup                                           │
+│     ├── generate_user_notification_lookup                                   │
+│     └── generate_product_suggestion_lookup                                  │
+│                                                                             │
+│  3. Aggregate into org digests:                                             │
+│     └── generate_organization_digest_batch                                  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+                              Redis Storage
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         SendWeeklyDigestWorkflow                            │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  For each organization (batched):                                           │
+│    1. Load OrganizationDigest from Redis                                    │
+│    2. For each org member:                                                  │
+│       a. Load user's notification team set                                  │
+│       b. Load user's product suggestion                                     │
+│       c. Create UserSpecificDigest via org_digest.for_user()                │
+│       d. Render payload and send via PostHog capture event                  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Key Types
+
+### OrganizationDigest
+
+The base digest containing all team data for an organization. Stored in Redis.
+
+### UserDigestContext
+
+Container for all user-specific data. This is where you add new user-specific fields:
+
+```python
+class UserDigestContext(BaseModel):
+    product_suggestion: DigestProductSuggestion | None = None
+    # Add new user-specific fields here
+```
+
+### UserSpecificDigest
+
+A personalized view created at send time by calling `OrganizationDigest.for_user(user_teams, context)`. Contains:
+
+- Filtered team digests (only teams user has notifications enabled for)
+- `context`: A `UserDigestContext` with user-specific data
+
+This is **not stored on Redis** - it's computed on-the-fly during the send phase.
+
+### DigestProductSuggestion
+
+A product recommendation for a user, containing:
+
+- `team_id`: Which project the suggestion is for
+- `product_path`: The product name (e.g., "Session replay")
+- `reason`: Why it was suggested (enum value)
+- `reason_text`: Human-readable explanation for the email
+
+## Adding New Team-Level Fields
+
+Team-level fields are data that belongs to a project/team (dashboards, feature flags, etc.). Each field type should have its own activity method to keep concerns separated and allow parallel execution.
+
+1. **Add a new enum value to `TeamDataKey`** in `keys.py`:
+
+   ```python
+   class TeamDataKey(StrEnum):
+       # ... existing keys ...
+       ALERTS = "alerts"  # new
+   ```
+
+2. **Create a Pydantic model** in `types.py` for the new data type (e.g., `DigestAlert`, `AlertList`)
+
+3. **Add a query function** in `queries.py` to fetch the data from the database
+
+4. **Create a new activity** in `activities.py`:
+
+   ```python
+   @activity.defn(name="generate-alert-lookup")
+   async def generate_alert_lookup(input: GenerateDigestDataBatchInput) -> None:
+       return await generate_digest_data_lookup(
+           input,
+           key_kind=TeamDataKey.ALERTS,
+           query_func=query_new_alerts,
+           resource_type=AlertList,
+       )
+   ```
+
+5. **Register the activity** in `workflows.py` by adding it to the `generators` list in `GenerateDigestDataWorkflow`
+
+6. **Add the field to `TeamDigest`** in `types.py` and update `generate_organization_digest_batch` to load it from Redis (the key order in `all_team_data_keys` matches `TeamDataKey` enum order)
+
+7. **Update `TeamDigest.render_payload()`** to include the new field in the email payload
+
+## Adding New User-Specific Fields
+
+User-specific fields are data personalized per user (product suggestions, notification preferences, etc.). Each field type should have its own activity method for loading data during the generate phase.
+
+1. **Add a new enum value to `UserDataKey`** in `keys.py`:
+
+   ```python
+   class UserDataKey(StrEnum):
+       # ... existing keys ...
+       RECOMMENDATIONS = "recommendations"  # new
+   ```
+
+2. **Create a Pydantic model** in `types.py` for the new data type
+
+3. **Add a query function** in `queries.py` to fetch the data
+
+4. **Create a new activity** in `activities.py` to generate and store the data in Redis:
+
+   ```python
+   @activity.defn(name="generate-user-recommendations-lookup")
+   async def generate_user_recommendations_lookup(input: GenerateDigestDataBatchInput) -> None:
+       # Iterate through teams/users, query data, store in Redis using:
+       key = user_data_key(input.digest.key, UserDataKey.RECOMMENDATIONS, user.id)
+   ```
+
+5. **Register the activity** in `workflows.py` by adding it to the `generators` list
+
+6. **Add the field to `UserDigestContext`** in `types.py`:
+
+   ```python
+   class UserDigestContext(BaseModel):
+       product_suggestion: DigestProductSuggestion | None = None
+       recommendations: UserRecommendations | None = None  # new field
+   ```
+
+7. **Load the data in `send_weekly_digest_batch`** and set it on the context:
+
+   ```python
+   raw_recommendations = await r.get(
+       user_data_key(input.digest.key, UserDataKey.RECOMMENDATIONS, user.id)
+   )
+   recommendations = UserRecommendations.model_validate_json(raw_recommendations) if raw_recommendations else None
+
+   user_context = UserDigestContext(
+       product_suggestion=product_suggestion,
+       recommendations=recommendations,
+   )
+   ```
+
+8. **Use it in `UserSpecificDigest.render_payload()`** to include in the email payload
+
+The `for_user()` signature never changes - all user-specific data flows through `UserDigestContext`.

--- a/posthog/temporal/weekly_digest/activities.py
+++ b/posthog/temporal/weekly_digest/activities.py
@@ -603,7 +603,13 @@ async def send_weekly_digest_batch(input: SendWeeklyDigestBatchInput) -> None:
                         product_suggestion: DigestProductSuggestion | None = None
                         raw_suggestion: str | None = await r.get(f"{input.digest.key}-product-suggestion-{user.id}")
                         if raw_suggestion:
-                            product_suggestion = DigestProductSuggestion.model_validate_json(raw_suggestion)
+                            try:
+                                product_suggestion = DigestProductSuggestion.model_validate_json(raw_suggestion)
+                            except ValidationError:
+                                logger.warning(
+                                    "Failed to parse product suggestion, skipping...",
+                                    user_id=user.id,
+                                )
 
                         payload = user_specific_digest.render_payload(
                             input.digest,

--- a/posthog/temporal/weekly_digest/activities.py
+++ b/posthog/temporal/weekly_digest/activities.py
@@ -22,6 +22,7 @@ from posthog.tasks.email import NotificationSetting, should_send_notification
 from posthog.temporal.common.clickhouse import get_client as get_ch_client
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
+from posthog.temporal.weekly_digest.keys import TeamDataKey, UserDataKey, org_digest_key, team_data_key, user_data_key
 from posthog.temporal.weekly_digest.queries import (
     query_experiments_completed,
     query_experiments_launched,
@@ -57,6 +58,7 @@ from posthog.temporal.weekly_digest.types import (
     SendWeeklyDigestBatchInput,
     SurveyList,
     TeamDigest,
+    UserDigestContext,
 )
 
 
@@ -90,7 +92,7 @@ LOGGER = get_write_only_logger()
 
 async def generate_digest_data_lookup(
     input: GenerateDigestDataBatchInput,
-    resource_key: str,
+    key_kind: TeamDataKey,
     query_func: Callable[[datetime, datetime], QuerySet],
     resource_type: DigestResourceType,
 ) -> None:
@@ -103,7 +105,7 @@ async def generate_digest_data_lookup(
             batch_end=input.batch[1],
         )
         logger = LOGGER.bind()
-        logger.info(f"Generating digest data batch", resource_key=resource_key)
+        logger.info("Generating digest data batch", key_kind=key_kind)
 
         resource_count = 0
         team_count = 0
@@ -116,7 +118,7 @@ async def generate_digest_data_lookup(
                 try:
                     digest_data = resource_type(await queryset_to_list(db_query.filter(team_id=team.id)))
 
-                    key: str = f"{input.digest.key}-{resource_key}-{team.id}"
+                    key = team_data_key(input.digest.key, key_kind, team.id)
                     await r.setex(key, input.common.redis_ttl, digest_data.model_dump_json())
 
                     team_count += 1
@@ -128,8 +130,8 @@ async def generate_digest_data_lookup(
                     continue
 
         logger.info(
-            f"Finished generating digest data batch",
-            resource_key=resource_key,
+            "Finished generating digest data batch",
+            key_kind=key_kind,
             resource_count=resource_count,
             team_count=team_count,
         )
@@ -139,7 +141,7 @@ async def generate_digest_data_lookup(
 async def generate_dashboard_lookup(input: GenerateDigestDataBatchInput) -> None:
     return await generate_digest_data_lookup(
         input,
-        resource_key="dashboards",
+        key_kind=TeamDataKey.DASHBOARDS,
         query_func=query_new_dashboards,
         resource_type=DashboardList,
     )
@@ -149,7 +151,7 @@ async def generate_dashboard_lookup(input: GenerateDigestDataBatchInput) -> None
 async def generate_event_definition_lookup(input: GenerateDigestDataBatchInput) -> None:
     return await generate_digest_data_lookup(
         input,
-        resource_key="event-definitions",
+        key_kind=TeamDataKey.EVENT_DEFINITIONS,
         query_func=query_new_event_definitions,
         resource_type=EventDefinitionList,
     )
@@ -159,7 +161,7 @@ async def generate_event_definition_lookup(input: GenerateDigestDataBatchInput) 
 async def generate_experiment_completed_lookup(input: GenerateDigestDataBatchInput) -> None:
     await generate_digest_data_lookup(
         input,
-        resource_key="experiments-completed",
+        key_kind=TeamDataKey.EXPERIMENTS_COMPLETED,
         query_func=query_experiments_completed,
         resource_type=ExperimentList,
     )
@@ -169,7 +171,7 @@ async def generate_experiment_completed_lookup(input: GenerateDigestDataBatchInp
 async def generate_experiment_launched_lookup(input: GenerateDigestDataBatchInput) -> None:
     return await generate_digest_data_lookup(
         input,
-        resource_key="experiments-launched",
+        key_kind=TeamDataKey.EXPERIMENTS_LAUNCHED,
         query_func=query_experiments_launched,
         resource_type=ExperimentList,
     )
@@ -179,7 +181,7 @@ async def generate_experiment_launched_lookup(input: GenerateDigestDataBatchInpu
 async def generate_external_data_source_lookup(input: GenerateDigestDataBatchInput) -> None:
     return await generate_digest_data_lookup(
         input,
-        resource_key="external-data-sources",
+        key_kind=TeamDataKey.EXTERNAL_DATA_SOURCES,
         query_func=query_new_external_data_sources,
         resource_type=ExternalDataSourceList,
     )
@@ -189,7 +191,7 @@ async def generate_external_data_source_lookup(input: GenerateDigestDataBatchInp
 async def generate_feature_flag_lookup(input: GenerateDigestDataBatchInput) -> None:
     return await generate_digest_data_lookup(
         input,
-        resource_key="feature-flags",
+        key_kind=TeamDataKey.FEATURE_FLAGS,
         query_func=query_new_feature_flags,
         resource_type=FeatureFlagList,
     )
@@ -199,7 +201,7 @@ async def generate_feature_flag_lookup(input: GenerateDigestDataBatchInput) -> N
 async def generate_survey_lookup(input: GenerateDigestDataBatchInput) -> None:
     return await generate_digest_data_lookup(
         input,
-        resource_key="surveys-launched",
+        key_kind=TeamDataKey.SURVEYS_LAUNCHED,
         query_func=query_surveys_launched,
         resource_type=SurveyList,
     )
@@ -244,7 +246,7 @@ async def generate_filter_lookup(input: GenerateDigestDataBatchInput) -> None:
 
                     ordered_filters = filters.order_by_recording_count()
 
-                    key: str = f"{input.digest.key}-saved-filters-{team.id}"
+                    key = team_data_key(input.digest.key, TeamDataKey.SAVED_FILTERS, team.id)
                     await r.setex(key, input.common.redis_ttl, ordered_filters.model_dump_json())
 
                     team_count += 1
@@ -306,7 +308,7 @@ async def generate_recording_lookup(input: GenerateDigestDataBatchInput) -> None
                     response = ClickHouseResponse.model_validate_json(raw_response)
                     expiring_recordings = RecordingCount.model_validate(response.data[0])
 
-                    key: str = f"{input.digest.key}-expiring-recordings-{team.id}"
+                    key = team_data_key(input.digest.key, TeamDataKey.EXPIRING_RECORDINGS, team.id)
                     await r.setex(key, input.common.redis_ttl, expiring_recordings.model_dump_json())
 
                     team_count += 1
@@ -342,7 +344,7 @@ async def generate_user_notification_lookup(input: GenerateDigestDataBatchInput)
                 try:
                     async for user in await database_sync_to_async(team.all_users_with_access)():
                         if should_send_notification(user, NotificationSetting.WEEKLY_PROJECT_DIGEST.value, team.id):
-                            key: str = f"{input.digest.key}-user-notify-{user.id}"
+                            key = user_data_key(input.digest.key, UserDataKey.NOTIFY_TEAMS, user.id)
                             await r.sadd(key, team.id)
                             await r.expire(key, input.common.redis_ttl)
 
@@ -398,7 +400,7 @@ async def generate_product_suggestion_lookup(input: GenerateDigestDataBatchInput
 
                         if suggestions:
                             suggestion = DigestProductSuggestion(team_id=team.id, **suggestions[0])
-                            key: str = f"{input.digest.key}-product-suggestion-{user.id}"
+                            key = user_data_key(input.digest.key, UserDataKey.PRODUCT_SUGGESTION, user.id)
                             await r.setex(key, input.common.redis_ttl, suggestion.model_dump_json())
                             users_with_suggestion.add(user.id)
                             suggestion_count += 1
@@ -452,15 +454,15 @@ async def generate_organization_digest_batch(input: GenerateOrganizationDigestIn
                     async for team in query_org_teams(organization):
                         results: list[str | None] = await r.mget(
                             [
-                                f"{input.digest.key}-dashboards-{team.id}",
-                                f"{input.digest.key}-event-definitions-{team.id}",
-                                f"{input.digest.key}-experiments-launched-{team.id}",
-                                f"{input.digest.key}-experiments-completed-{team.id}",
-                                f"{input.digest.key}-external-data-sources-{team.id}",
-                                f"{input.digest.key}-feature-flags-{team.id}",
-                                f"{input.digest.key}-saved-filters-{team.id}",
-                                f"{input.digest.key}-expiring-recordings-{team.id}",
-                                f"{input.digest.key}-surveys-launched-{team.id}",
+                                team_data_key(input.digest.key, TeamDataKey.DASHBOARDS, team.id),
+                                team_data_key(input.digest.key, TeamDataKey.EVENT_DEFINITIONS, team.id),
+                                team_data_key(input.digest.key, TeamDataKey.EXPERIMENTS_LAUNCHED, team.id),
+                                team_data_key(input.digest.key, TeamDataKey.EXPERIMENTS_COMPLETED, team.id),
+                                team_data_key(input.digest.key, TeamDataKey.EXTERNAL_DATA_SOURCES, team.id),
+                                team_data_key(input.digest.key, TeamDataKey.FEATURE_FLAGS, team.id),
+                                team_data_key(input.digest.key, TeamDataKey.SAVED_FILTERS, team.id),
+                                team_data_key(input.digest.key, TeamDataKey.EXPIRING_RECORDINGS, team.id),
+                                team_data_key(input.digest.key, TeamDataKey.SURVEYS_LAUNCHED, team.id),
                             ]
                         )
 
@@ -505,7 +507,7 @@ async def generate_organization_digest_batch(input: GenerateOrganizationDigestIn
                         team_digests=team_digests,
                     )
 
-                    key: str = f"{input.digest.key}-{organization.id}"
+                    key = org_digest_key(input.digest.key, organization.id)
                     await r.setex(key, input.common.redis_ttl, org_digest.model_dump_json())
 
                     organization_count += 1
@@ -553,7 +555,7 @@ async def send_weekly_digest_batch(input: SendWeeklyDigestBatchInput) -> None:
             async for organization in query_orgs_for_digest()[batch_start:batch_end]:
                 partial = False
                 try:
-                    raw_digest: Optional[str] = await r.get(f"{input.digest.key}-{organization.id}")
+                    raw_digest: Optional[str] = await r.get(org_digest_key(input.digest.key, organization.id))
 
                     if not raw_digest:
                         logger.warning(
@@ -583,25 +585,17 @@ async def send_weekly_digest_batch(input: SendWeeklyDigestBatchInput) -> None:
                     async for member in query_org_members(organization):
                         user = member.user
                         user_notify_teams: set[int] = set(
-                            map(int, await r.smembers(f"{input.digest.key}-user-notify-{user.id}"))
-                        )
-                        user_specific_digest: OrganizationDigest = org_digest.filter_for_user(user_notify_teams)
-
-                        if (
-                            user_specific_digest.is_empty()
-                            or user_specific_digest.count_items() < DIGEST_ITEM_COUNT_THRESHOLD
-                        ):
-                            logger.warning(
-                                "Got empty digest for user, skipping...",
-                                organization_id=organization.id,
-                                user_id=user.id,
+                            map(
+                                int,
+                                await r.smembers(user_data_key(input.digest.key, UserDataKey.NOTIFY_TEAMS, user.id)),
                             )
-                            empty_user_digest_count += 1
-                            continue
+                        )
 
-                        # Load product suggestion for the user (at most one)
+                        # Load user-specific context
                         product_suggestion: DigestProductSuggestion | None = None
-                        raw_suggestion: str | None = await r.get(f"{input.digest.key}-product-suggestion-{user.id}")
+                        raw_suggestion: str | None = await r.get(
+                            user_data_key(input.digest.key, UserDataKey.PRODUCT_SUGGESTION, user.id)
+                        )
                         if raw_suggestion:
                             try:
                                 product_suggestion = DigestProductSuggestion.model_validate_json(raw_suggestion)
@@ -611,10 +605,19 @@ async def send_weekly_digest_batch(input: SendWeeklyDigestBatchInput) -> None:
                                     user_id=user.id,
                                 )
 
-                        payload = user_specific_digest.render_payload(
-                            input.digest,
-                            product_suggestion=product_suggestion,
-                        )
+                        user_context = UserDigestContext(product_suggestion=product_suggestion)
+                        digest_for_user = org_digest.for_user(user_notify_teams, user_context)
+
+                        if digest_for_user.is_empty() or digest_for_user.count_items() < DIGEST_ITEM_COUNT_THRESHOLD:
+                            logger.warning(
+                                "Got empty digest for user, skipping...",
+                                organization_id=organization.id,
+                                user_id=user.id,
+                            )
+                            empty_user_digest_count += 1
+                            continue
+
+                        payload = digest_for_user.render_payload(input.digest)
 
                         if input.dry_run:
                             logger.info(

--- a/posthog/temporal/weekly_digest/keys.py
+++ b/posthog/temporal/weekly_digest/keys.py
@@ -1,0 +1,31 @@
+from enum import StrEnum
+from uuid import UUID
+
+
+class TeamDataKey(StrEnum):
+    DASHBOARDS = "dashboards"
+    EVENT_DEFINITIONS = "event-definitions"
+    EXPERIMENTS_LAUNCHED = "experiments-launched"
+    EXPERIMENTS_COMPLETED = "experiments-completed"
+    EXTERNAL_DATA_SOURCES = "external-data-sources"
+    FEATURE_FLAGS = "feature-flags"
+    SAVED_FILTERS = "saved-filters"
+    EXPIRING_RECORDINGS = "expiring-recordings"
+    SURVEYS_LAUNCHED = "surveys-launched"
+
+
+class UserDataKey(StrEnum):
+    NOTIFY_TEAMS = "user-notify"
+    PRODUCT_SUGGESTION = "product-suggestion"
+
+
+def team_data_key(digest_key: str, kind: TeamDataKey, team_id: int) -> str:
+    return f"{digest_key}-{kind}-{team_id}"
+
+
+def org_digest_key(digest_key: str, org_id: UUID) -> str:
+    return f"{digest_key}-{org_id}"
+
+
+def user_data_key(digest_key: str, kind: UserDataKey, user_id: int) -> str:
+    return f"{digest_key}-{kind}-{user_id}"

--- a/posthog/temporal/weekly_digest/queries.py
+++ b/posthog/temporal/weekly_digest/queries.py
@@ -8,6 +8,7 @@ from posthog.models.dashboard import Dashboard
 from posthog.models.event_definition import EventDefinition
 from posthog.models.experiment import Experiment
 from posthog.models.feature_flag import FeatureFlag
+from posthog.models.file_system.user_product_list import UserProductList
 from posthog.models.organization import OrganizationMembership
 from posthog.models.surveys.survey import Survey
 from posthog.models.team import Team
@@ -135,6 +136,19 @@ def query_saved_filters(period_start: datetime, period_end: datetime) -> QuerySe
         .values("name", "short_id", "view_count")
         .order_by("-view_count")
     )
+
+
+def query_user_product_suggestions(
+    user_id: int, team_id: int, period_start: datetime, period_end: datetime
+) -> QuerySet:
+    return UserProductList.objects.filter(
+        user_id=user_id,
+        team_id=team_id,
+        enabled=True,
+        reason__in=[UserProductList.Reason.SALES_LED, UserProductList.Reason.NEW_PRODUCT],
+        created_at__gt=period_start,
+        created_at__lte=period_end,
+    ).values("product_path", "reason", "reason_text")
 
 
 @database_sync_to_async

--- a/posthog/temporal/weekly_digest/types.py
+++ b/posthog/temporal/weekly_digest/types.py
@@ -154,6 +154,27 @@ class SurveyList(RootModel):
     root: list[DigestSurvey]
 
 
+PRODUCT_SUGGESTION_REASON_DEFAULTS: dict[str, str] = {
+    "new_product": "This is a brand new product. Give it a try!",
+    "sales_led": "This product is recommended for you by our team.",
+}
+
+
+class DigestProductSuggestion(BaseModel):
+    team_id: int
+    product_path: str  # This is the product name (e.g., "Product analytics")
+    reason: str | None
+    reason_text: str | None
+
+    def get_readable_reason_text(self) -> str | None:
+        """Returns human-readable reason text for email interpolation."""
+        if self.reason_text:
+            return self.reason_text
+        if self.reason:
+            return PRODUCT_SUGGESTION_REASON_DEFAULTS.get(self.reason)
+        return None
+
+
 # mypy and ruff do not agree about TypeAlias
 # ruff: noqa: UP040
 
@@ -199,21 +220,31 @@ class TeamDigest(BaseModel):
     def count_items(self) -> int:
         return sum(len(f.root) for f in self._fields())
 
-    def render_payload(self) -> dict[str, str | int | dict[str, list | dict]]:
+    def render_payload(
+        self, product_suggestion: "DigestProductSuggestion | None" = None
+    ) -> dict[str, str | int | dict[str, list | dict]]:
+        report: dict[str, list | dict] = {
+            "new_dashboards": self.dashboards.model_dump(),
+            "new_event_definitions": self.event_definitions.model_dump(),
+            "new_experiments_launched": self.experiments_launched.model_dump(),
+            "new_experiments_completed": self.experiments_completed.model_dump(),
+            "new_external_data_sources": self.external_data_sources.model_dump(),
+            "new_feature_flags": self.feature_flags.model_dump(),
+            "interesting_saved_filters": [f.render_payload() for f in self.filters.root],
+            "expiring_recordings": self.expiring_recordings.model_dump(),
+            "new_surveys_launched": self.surveys_launched.model_dump(),
+        }
+
+        if product_suggestion:
+            report["new_product_suggestion"] = {
+                "product_path": product_suggestion.product_path,
+                "reason_text": product_suggestion.get_readable_reason_text(),
+            }
+
         return {
             "team_name": self.name,
             "team_id": self.id,
-            "report": {
-                "new_dashboards": self.dashboards.model_dump(),
-                "new_event_definitions": self.event_definitions.model_dump(),
-                "new_experiments_launched": self.experiments_launched.model_dump(),
-                "new_experiments_completed": self.experiments_completed.model_dump(),
-                "new_external_data_sources": self.external_data_sources.model_dump(),
-                "new_feature_flags": self.feature_flags.model_dump(),
-                "interesting_saved_filters": [f.render_payload() for f in self.filters.root],
-                "expiring_recordings": self.expiring_recordings.model_dump(),
-                "new_surveys_launched": self.surveys_launched.model_dump(),
-            },
+            "report": report,
         }
 
 
@@ -240,11 +271,24 @@ class OrganizationDigest(BaseModel):
     def count_items(self) -> int:
         return sum(td.count_items() for td in self.team_digests)
 
-    def render_payload(self, digest: Digest) -> dict[str, str | list | dict[str, str] | int | None]:
+    def render_payload(
+        self,
+        digest: Digest,
+        product_suggestion: "DigestProductSuggestion | None" = None,
+    ) -> dict[str, str | list | dict[str, str] | int | None]:
+        teams = []
+        for td in self.team_digests:
+            if td.is_empty():
+                continue
+            suggestion_for_team = (
+                product_suggestion if product_suggestion and product_suggestion.team_id == td.id else None
+            )
+            teams.append(td.render_payload(product_suggestion=suggestion_for_team))
+
         return {
             "organization_name": self.name,
             "organization_id": str(self.id),
-            "teams": [td.render_payload() for td in self.team_digests if not td.is_empty()],
+            "teams": teams,
             "scope": "user",
             "template_name": "weekly_digest_report",
             "period": digest.render_payload(),

--- a/posthog/temporal/weekly_digest/workflows.py
+++ b/posthog/temporal/weekly_digest/workflows.py
@@ -19,6 +19,7 @@ from posthog.temporal.weekly_digest.activities import (
     generate_feature_flag_lookup,
     generate_filter_lookup,
     generate_organization_digest_batch,
+    generate_product_suggestion_lookup,
     generate_recording_lookup,
     generate_survey_lookup,
     generate_user_notification_lookup,
@@ -131,6 +132,7 @@ class GenerateDigestDataWorkflow(PostHogWorkflow):
             generate_user_notification_lookup,
             generate_filter_lookup,
             generate_recording_lookup,
+            generate_product_suggestion_lookup,
         ]
 
         await asyncio.gather(


### PR DESCRIPTION
Let's add a new entry to the weekly digest to include one new product we added to the user's sidebar on the digest. This is only adding it to the code, I'll add it to the email at a later time - once I've confirmed this is working as expected.