### PR TITLE
fix: constrain funnel filter regex from overflowing

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
@@ -47,6 +47,7 @@
     flex-wrap: wrap;
     gap: 0.25rem;
     align-items: center;
+    min-width: 0;
 
     > * {
         max-width: 100%;


### PR DESCRIPTION
## Problem
<img width="720" height="571" alt="image" src="https://github.com/user-attachments/assets/36b2be05-9405-44cc-b0ad-b0c92665b39d" />

Was able to repro locally

## Changes
Add css to constrain the input to it's container, preventing massive overflow matching the regex length

![2026-01-05 23 44 57](https://github.com/user-attachments/assets/db34d6ce-b14d-4d47-bd3f-05beaa116759)


## How did you test this code?
Locally

## Publish to changelog?
No