### PR TITLE
perf(flags): Optimize experience continuity lookups for flags that don't need them

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -482,6 +482,15 @@ pub struct Config {
     #[envconfig(from = "RATE_LIMITER_CLEANUP_INTERVAL_SECS", default = "60")]
     pub rate_limiter_cleanup_interval_secs: u64,
 
+    // Experience continuity optimization
+    // When enabled, skip hash key override lookups for flags that don't need them:
+    // - Flags at 100% rollout with no multivariate variants
+    // - Multivariate flags where any variant is at 100% (that variant wins for everyone)
+    // These flags return the same value regardless of user bucketing, so the lookup is wasted work.
+    // Disabled by default for safe rollout - enable after validation.
+    #[envconfig(from = "OPTIMIZE_EXPERIENCE_CONTINUITY_LOOKUPS", default = "false")]
+    pub optimize_experience_continuity_lookups: FlexBool,
+
     // Redis compression configuration
     // When enabled, uses zstd compression for Redis values above threshold
     // The `default_test_config()` sets this to true for test/development scenarios.
@@ -613,6 +622,7 @@ impl Config {
             rate_limiter_cleanup_interval_secs: 60,
             redis_compression_enabled: FlexBool(true),
             redis_client_retry_count: 3,
+            optimize_experience_continuity_lookups: FlexBool(false),
         }
     }
 

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -484,8 +484,7 @@ pub struct Config {
 
     // Experience continuity optimization
     // When enabled, skip hash key override lookups for flags that don't need them:
-    // - Flags at 100% rollout with no multivariate variants
-    // - Multivariate flags where any variant is at 100% (that variant wins for everyone)
+    // - Flags at 100% rollout with no multivariate variants OR where a single variant is at 100%
     // These flags return the same value regardless of user bucketing, so the lookup is wasted work.
     // Disabled by default for safe rollout - enable after validation.
     #[envconfig(from = "OPTIMIZE_EXPERIENCE_CONTINUITY_LOOKUPS", default = "false")]

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -26,8 +26,8 @@ use crate::metrics::consts::{
 use crate::metrics::utils::parse_exception_for_prometheus_label;
 use crate::properties::property_models::PropertyFilter;
 use crate::utils::graph_utils::{
-    build_dependency_graph, filter_graph_by_keys, log_dependency_graph_construction_errors,
-    log_dependency_graph_operation_error, DependencyGraph,
+    build_dependency_graph, filter_graph_by_keys, log_dependency_graph_operation_error,
+    DependencyGraph,
 };
 use anyhow::Result;
 use common_metrics::{inc, timing_guard};
@@ -254,11 +254,8 @@ impl FeatureFlagMatcher {
             global_dependency_graph
         };
 
-        // Track graph construction errors for the response
+        // Track graph construction errors for the response (errors already logged in build_dependency_graph)
         let has_graph_errors = !graph_errors.is_empty();
-        if has_graph_errors {
-            log_dependency_graph_construction_errors(&graph_errors, self.team_id);
-        }
 
         // Compute experience continuity stats from the filtered graph.
         // This considers all flags that will actually be evaluated (including dependencies).

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -12,17 +12,16 @@ use crate::flags::flag_matching_utils::{
     populate_missing_initial_properties, set_feature_flag_hash_key_overrides,
     should_write_hash_key_override,
 };
-use crate::flags::flag_models::{
-    BucketingIdentifier, FeatureFlag, FeatureFlagId, FeatureFlagList, FlagPropertyGroup,
-};
+use crate::flags::flag_models::{FeatureFlag, FeatureFlagId, FeatureFlagList, FlagPropertyGroup};
 use crate::flags::flag_operations::flags_require_db_preparation;
 use crate::handler::with_canonical_log;
 use crate::metrics::consts::{
     DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER, FLAG_DB_PROPERTIES_FETCH_TIME,
     FLAG_EVALUATE_ALL_CONDITIONS_TIME, FLAG_EVALUATION_ERROR_COUNTER, FLAG_EVALUATION_TIME,
-    FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER, FLAG_GET_MATCH_TIME, FLAG_GROUP_CACHE_FETCH_TIME,
-    FLAG_GROUP_DB_FETCH_TIME, FLAG_HASH_KEY_PROCESSING_TIME, FLAG_HASH_KEY_WRITES_COUNTER,
-    PROPERTY_CACHE_HITS_COUNTER, PROPERTY_CACHE_MISSES_COUNTER,
+    FLAG_EXPERIENCE_CONTINUITY_OPTIMIZED, FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER,
+    FLAG_GET_MATCH_TIME, FLAG_GROUP_CACHE_FETCH_TIME, FLAG_GROUP_DB_FETCH_TIME,
+    FLAG_HASH_KEY_PROCESSING_TIME, FLAG_HASH_KEY_WRITES_COUNTER, PROPERTY_CACHE_HITS_COUNTER,
+    PROPERTY_CACHE_MISSES_COUNTER,
 };
 use crate::metrics::utils::parse_exception_for_prometheus_label;
 use crate::properties::property_models::PropertyFilter;
@@ -219,11 +218,13 @@ impl FeatureFlagMatcher {
     /// * `person_property_overrides` - Any overrides for person properties.
     /// * `group_property_overrides` - Any overrides for group properties.
     /// * `hash_key_override` - Optional hash key overrides for experience continuity.
+    /// * `optimize_experience_continuity_lookups` - When true, skip lookups for flags that don't need them.
     ///
     /// ## Returns
     ///
     /// * `FlagsResponse` - The result containing flag evaluations and any errors.
     #[instrument(skip_all, fields(team_id = %self.team_id, distinct_id = %self.distinct_id, flags_len = feature_flags.flags.len()))]
+    #[allow(clippy::too_many_arguments)]
     pub async fn evaluate_all_feature_flags(
         &mut self,
         feature_flags: FeatureFlagList,
@@ -232,17 +233,90 @@ impl FeatureFlagMatcher {
         hash_key_override: Option<String>, // Aka $anon_distinct_id
         request_id: Uuid,
         flag_keys: Option<Vec<String>>,
+        optimize_experience_continuity_lookups: bool,
     ) -> FlagsResponse {
         let eval_timer = common_metrics::timing_guard(FLAG_EVALUATION_TIME, &[]);
-        let flags_need_hash_key_override = feature_flags.flags.iter().any(|flag| {
-            flag.ensure_experience_continuity.unwrap_or(false)
-                && flag.get_group_type_index().is_none()
-                && flag.get_bucketing_identifier() == BucketingIdentifier::DistinctId
-        });
+
+        // Build dependency graph once - reused for both optimization check and evaluation
+        let (global_dependency_graph, graph_errors) =
+            match build_dependency_graph(&feature_flags, self.team_id) {
+                Some((graph, errors)) => (graph, errors),
+                None => return FlagsResponse::new(true, HashMap::new(), None, request_id),
+            };
+
+        // Filter graph by flag_keys if specified (includes transitive dependencies)
+        let dependency_graph = if let Some(ref keys) = flag_keys {
+            match filter_graph_by_keys(&global_dependency_graph, keys) {
+                Some(filtered_graph) => filtered_graph,
+                None => return FlagsResponse::new(true, HashMap::new(), None, request_id),
+            }
+        } else {
+            global_dependency_graph
+        };
+
+        // Track graph construction errors for the response
+        let has_graph_errors = !graph_errors.is_empty();
+        if has_graph_errors {
+            log_dependency_graph_construction_errors(&graph_errors, self.team_id);
+        }
+
+        // Compute experience continuity stats from the filtered graph.
+        // This considers all flags that will actually be evaluated (including dependencies).
+        let (has_experience_continuity, any_flag_needs_override) = {
+            let mut has_continuity = false;
+            let mut needs_override = false;
+
+            for flag in dependency_graph.iter_nodes() {
+                if flag.has_experience_continuity() {
+                    has_continuity = true;
+                    if flag.needs_hash_key_override() {
+                        needs_override = true;
+                        break; // Early exit once we know we need the lookup
+                    }
+                }
+            }
+
+            (has_continuity, needs_override)
+        };
+
+        // Determine if we need to do the hash key override lookup.
+        // In legacy mode (optimization disabled), we always do the lookup if any flag has continuity.
+        // In optimized mode, we only do it if any flag actually needs it.
+        let do_hash_key_lookup = if optimize_experience_continuity_lookups {
+            any_flag_needs_override
+        } else {
+            has_experience_continuity
+        };
+
+        // A request is optimizable when it has experience continuity flags but none require the lookup
+        let request_is_optimizable = has_experience_continuity && !any_flag_needs_override;
+
+        // Track optimization metric: status="skipped" when we skip, "eligible" when we could have
+        if request_is_optimizable {
+            let status = if optimize_experience_continuity_lookups {
+                "skipped"
+            } else {
+                "eligible"
+            };
+
+            inc(
+                FLAG_EXPERIENCE_CONTINUITY_OPTIMIZED,
+                &[
+                    ("status".to_string(), status.to_string()),
+                    ("team_id".to_string(), self.team_id.to_string()),
+                ],
+                1,
+            );
+        }
+
+        // Record when the optimization actually skips the lookup
+        if request_is_optimizable && optimize_experience_continuity_lookups {
+            with_canonical_log(|log| log.hash_key_override_skipped = true);
+        }
 
         // Process any hash key overrides
         let (hash_key_overrides, flag_hash_key_override_error) = self
-            .process_hash_key_override_if_needed(flags_need_hash_key_override, hash_key_override)
+            .process_hash_key_override_if_needed(do_hash_key_lookup, hash_key_override)
             .await;
 
         let overrides = FlagEvaluationOverrides {
@@ -252,27 +326,20 @@ impl FeatureFlagMatcher {
             hash_key_override_error: flag_hash_key_override_error,
         };
 
+        // Pass the pre-built graph to avoid redundant graph construction
         let flags_response = self
-            .evaluate_flags_with_overrides(feature_flags, overrides, request_id, flag_keys)
+            .evaluate_flags_with_overrides(overrides, request_id, dependency_graph)
             .await;
 
+        let has_errors = flag_hash_key_override_error
+            || flags_response.errors_while_computing_flags
+            || has_graph_errors;
+
         eval_timer
-            .label(
-                "outcome",
-                if flags_response.errors_while_computing_flags || flag_hash_key_override_error {
-                    "error"
-                } else {
-                    "success"
-                },
-            )
+            .label("outcome", if has_errors { "error" } else { "success" })
             .fin();
 
-        FlagsResponse::new(
-            flag_hash_key_override_error || flags_response.errors_while_computing_flags,
-            flags_response.flags,
-            None,
-            request_id,
-        )
+        FlagsResponse::new(has_errors, flags_response.flags, None, request_id)
     }
 
     /// Processes hash key overrides for feature flags with experience continuity enabled.
@@ -428,27 +495,27 @@ impl FeatureFlagMatcher {
     }
 
     /// Evaluates feature flags with property and hash key overrides.
-    /// If any flags require DB properties, we prepare the evaluation state in advance
-    /// and cache the properties in the flag_evaluation_state. Then we evaluate the flags.
+    ///
+    /// Takes a pre-built dependency graph which should already be filtered by flag_keys if needed.
+    /// The graph determines which flags are evaluated and in what order.
     pub async fn evaluate_flags_with_overrides(
         &mut self,
-        feature_flags: FeatureFlagList,
         overrides: FlagEvaluationOverrides,
         request_id: Uuid,
-        flag_keys: Option<Vec<String>>,
+        dependency_graph: DependencyGraph<FeatureFlag>,
     ) -> FlagsResponse {
         let mut errors_while_computing_flags = overrides.hash_key_override_error;
         let mut evaluated_flags_map = HashMap::new();
 
+        // Collect flags from the graph for preparation steps
+        let flags: Vec<&FeatureFlag> = dependency_graph.iter_nodes().collect();
+
         // Handle hash key override errors by creating error responses for flags that need experience continuity
         if overrides.hash_key_override_error && overrides.hash_key_overrides.is_none() {
-            let flags_needing_continuity: Vec<&FeatureFlag> = feature_flags
-                .flags
+            for flag in flags
                 .iter()
                 .filter(|flag| flag.ensure_experience_continuity.unwrap_or(false))
-                .collect();
-
-            for flag in flags_needing_continuity {
+            {
                 evaluated_flags_map.insert(
                     flag.key.clone(),
                     FlagDetails::create_error(flag, "hash_key_override_error", None),
@@ -457,43 +524,19 @@ impl FeatureFlagMatcher {
         }
 
         // Step 1: Initialize group type mappings if needed
-        errors_while_computing_flags |= self
-            .initialize_group_type_mappings_if_needed(&feature_flags)
-            .await;
+        errors_while_computing_flags |= self.initialize_group_type_mappings_if_needed(&flags).await;
 
         // Step 2: Prepare evaluation state for flags requiring DB properties
         let db_prep_errors = self
             .prepare_evaluation_state_if_needed(
-                &feature_flags,
+                &flags,
                 &overrides.person_property_overrides,
                 &mut evaluated_flags_map,
             )
             .await;
         errors_while_computing_flags |= db_prep_errors;
 
-        // Step 3: Build dependency graph
-        let (global_dependency_graph, graph_errors) =
-            match build_dependency_graph(&feature_flags, self.team_id) {
-                Some((graph, errors)) => (graph, errors),
-                None => return FlagsResponse::new(true, evaluated_flags_map, None, request_id),
-            };
-
-        // Step 4: Filter graph by flag keys if specified
-        let dependency_graph = if let Some(keys) = flag_keys {
-            match filter_graph_by_keys(&global_dependency_graph, &keys) {
-                Some(filtered_graph) => filtered_graph,
-                None => return FlagsResponse::new(true, evaluated_flags_map, None, request_id),
-            }
-        } else {
-            global_dependency_graph
-        };
-
-        if !graph_errors.is_empty() {
-            errors_while_computing_flags = true;
-            log_dependency_graph_construction_errors(&graph_errors, self.team_id);
-        }
-
-        // Step 5: Evaluate flags using the dependency graph
+        // Step 3: Evaluate flags using the dependency graph
         let graph_evaluation_errors = self
             .evaluate_flags_with_dependency_graph(
                 dependency_graph,
@@ -556,12 +599,12 @@ impl FeatureFlagMatcher {
     #[instrument(skip_all, fields(team_id = %self.team_id, distinct_id = %self.distinct_id))]
     async fn prepare_evaluation_state_if_needed(
         &mut self,
-        feature_flags: &FeatureFlagList,
+        flags: &[&FeatureFlag],
         person_property_overrides: &Option<HashMap<String, Value>>,
         evaluated_flags_map: &mut HashMap<String, FlagDetails>,
     ) -> bool {
         let flags_requiring_db_preparation = flags_require_db_preparation(
-            &feature_flags.flags,
+            flags,
             person_property_overrides
                 .as_ref()
                 .unwrap_or(&HashMap::new()),
@@ -1578,13 +1621,9 @@ impl FeatureFlagMatcher {
     ///
     /// This function checks if any of the feature flags have group type indices and initializes the group type mapping cache if needed.
     /// It returns a boolean indicating if there were any errors while initializing the group type mapping cache.
-    async fn initialize_group_type_mappings_if_needed(
-        &mut self,
-        feature_flags: &FeatureFlagList,
-    ) -> bool {
+    async fn initialize_group_type_mappings_if_needed(&mut self, flags: &[&FeatureFlag]) -> bool {
         // Check if we need to fetch group type mappings – we have flags that use group properties (have group type indices)
-        let has_type_indexes = feature_flags
-            .flags
+        let has_type_indexes = flags
             .iter()
             .any(|flag| flag.active && !flag.deleted && flag.get_group_type_index().is_some());
 

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -97,6 +97,7 @@ static INITIAL_PROPERTY_MAP: Lazy<HashMap<&'static str, &'static str>> = Lazy::n
 #[cfg(test)]
 thread_local! {
     static FETCH_CALLS: RefCell<u64> = const { RefCell::new(0) };
+    static HASH_KEY_OVERRIDE_LOOKUPS: RefCell<u64> = const { RefCell::new(0) };
 }
 
 /// Calculates a deterministic hash value between 0 and 1 for a given identifier and salt.
@@ -586,6 +587,10 @@ pub async fn get_feature_flag_hash_key_overrides(
     team_id: TeamId,
     distinct_id_and_hash_key_override: Vec<String>,
 ) -> Result<HashMap<String, String>, FlagError> {
+    // Track hash key override lookups for testing
+    #[cfg(test)]
+    increment_hash_key_override_lookup_count();
+
     let retry_strategy = ExponentialBackoff::from_millis(50)
         .max_delay(Duration::from_millis(300))
         .take(3)
@@ -1347,6 +1352,21 @@ pub fn reset_fetch_calls_count() {
 #[cfg(test)]
 pub fn increment_fetch_calls_count() {
     FETCH_CALLS.with(|counter| *counter.borrow_mut() += 1);
+}
+
+#[cfg(test)]
+pub fn get_hash_key_override_lookup_count() -> u64 {
+    HASH_KEY_OVERRIDE_LOOKUPS.with(|counter| *counter.borrow())
+}
+
+#[cfg(test)]
+pub fn reset_hash_key_override_lookup_count() {
+    HASH_KEY_OVERRIDE_LOOKUPS.with(|counter| *counter.borrow_mut() = 0);
+}
+
+#[cfg(test)]
+fn increment_hash_key_override_lookup_count() {
+    HASH_KEY_OVERRIDE_LOOKUPS.with(|counter| *counter.borrow_mut() += 1);
 }
 
 #[cfg(test)]

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -40,16 +40,90 @@ impl FeatureFlag {
     pub fn requires_db_preparation(&self, overrides: &HashMap<String, Value>) -> bool {
         self.filters.requires_db_properties(overrides) || self.filters.requires_cohort_filters()
     }
+
+    /// Returns true if this flag has experience continuity enabled and is eligible for it.
+    ///
+    /// Experience continuity is only supported for person-based flags using distinct_id bucketing.
+    /// Group-based flags and device_id bucketing flags are not eligible.
+    pub fn has_experience_continuity(&self) -> bool {
+        self.ensure_experience_continuity.unwrap_or(false)
+            && self.get_group_type_index().is_none()
+            && self.get_bucketing_identifier() == BucketingIdentifier::DistinctId
+    }
+
+    /// Returns true if the flag has multivariate variants that depend on hashing.
+    ///
+    /// A flag with no variants or any variant at 100% is effectively not multivariate,
+    /// since the variant assignment doesn't depend on hashing. When any variant has
+    /// 100% rollout, that variant wins for everyone regardless of their hash bucket.
+    pub fn has_hash_dependent_variants(&self) -> bool {
+        match &self.filters.multivariate {
+            None => false,
+            Some(multivariate) => {
+                let variants = &multivariate.variants;
+                // No variants = not multivariate
+                if variants.is_empty() {
+                    return false;
+                }
+                // Any variant at 100% wins for everyone, making hashing irrelevant
+                if variants.iter().any(|v| v.rollout_percentage >= 100.0) {
+                    return false;
+                }
+                // Multiple variants with partial rollouts = truly multivariate
+                true
+            }
+        }
+    }
+
+    /// Returns true if any condition group has less than 100% rollout.
+    ///
+    /// When all groups are at 100%, the hash doesn't affect the result since
+    /// everyone in each group gets the flag enabled.
+    pub fn has_partial_rollout(&self) -> bool {
+        self.filters
+            .groups
+            .iter()
+            .any(|group| group.rollout_percentage_unwrapped() < 100.0)
+    }
+
+    /// Returns true if this flag requires a hash key override lookup for experience continuity.
+    ///
+    /// Experience continuity lookups are only meaningful when the hash affects the result:
+    /// - Partial rollouts need consistent bucketing across distinct_id changes
+    /// - Multivariate flags need consistent variant assignment
+    ///
+    /// For flags at 100% rollout with no hash-dependent variants, everyone gets the same
+    /// result regardless of their hash, so the lookup is unnecessary.
+    pub fn needs_hash_key_override(&self) -> bool {
+        // Must have experience continuity enabled and be eligible for it
+        if !self.has_experience_continuity() {
+            return false;
+        }
+
+        // If flag has hash-dependent variants, need hash for consistent variant assignment
+        if self.has_hash_dependent_variants() {
+            return true;
+        }
+
+        // If any condition group has < 100% rollout, need hash for consistent bucketing
+        if self.has_partial_rollout() {
+            return true;
+        }
+
+        // Flag is 100% rollout with no hash-dependent variants - skip the lookup
+        false
+    }
 }
 
 /// Returns the set of flags that require DB preparation
 pub fn flags_require_db_preparation<'a>(
-    flags: &'a [FeatureFlag],
+    flags: &[&'a FeatureFlag],
     overrides: &HashMap<String, Value>,
 ) -> Vec<&'a FeatureFlag> {
     flags
         .iter()
         .filter(|flag| flag.requires_db_preparation(overrides))
+        .copied()
         .collect()
 }
 
@@ -96,7 +170,7 @@ mod tests {
 
     use super::*;
     use crate::utils::test_utils::{
-        insert_flags_for_team_in_redis, setup_redis_client, TestContext,
+        create_test_flag, insert_flags_for_team_in_redis, setup_redis_client, TestContext,
     };
 
     #[test]
@@ -1512,5 +1586,263 @@ mod tests {
         ]);
 
         assert!(!flag.requires_db_preparation(&HashMap::new()));
+    }
+
+    // ======== Tests for experience continuity optimization helper methods ========
+
+    #[test]
+    fn test_has_hash_dependent_variants_none() {
+        let flag = create_test_flag(None, None, None, None, None, None, None, None);
+        assert!(!flag.has_hash_dependent_variants());
+    }
+
+    #[test]
+    fn test_has_hash_dependent_variants_empty() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.filters.multivariate = Some(MultivariateFlagOptions { variants: vec![] });
+        assert!(!flag.has_hash_dependent_variants());
+    }
+
+    #[test]
+    fn test_has_hash_dependent_variants_single_100_percent() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.filters.multivariate = Some(MultivariateFlagOptions {
+            variants: vec![MultivariateFlagVariant {
+                key: "control".to_string(),
+                name: Some("Control".to_string()),
+                rollout_percentage: 100.0,
+            }],
+        });
+        // Single variant at 100% is effectively not multivariate
+        assert!(!flag.has_hash_dependent_variants());
+    }
+
+    #[test]
+    fn test_has_hash_dependent_variants_two_variants() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.filters.multivariate = Some(MultivariateFlagOptions {
+            variants: vec![
+                MultivariateFlagVariant {
+                    key: "control".to_string(),
+                    name: Some("Control".to_string()),
+                    rollout_percentage: 50.0,
+                },
+                MultivariateFlagVariant {
+                    key: "test".to_string(),
+                    name: Some("Test".to_string()),
+                    rollout_percentage: 50.0,
+                },
+            ],
+        });
+        assert!(flag.has_hash_dependent_variants());
+    }
+
+    #[test]
+    fn test_has_hash_dependent_variants_multiple_with_one_at_100_percent() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.filters.multivariate = Some(MultivariateFlagOptions {
+            variants: vec![
+                MultivariateFlagVariant {
+                    key: "control".to_string(),
+                    name: Some("Control".to_string()),
+                    rollout_percentage: 100.0, // This variant wins for everyone
+                },
+                MultivariateFlagVariant {
+                    key: "test".to_string(),
+                    name: Some("Test".to_string()),
+                    rollout_percentage: 0.0,
+                },
+            ],
+        });
+        // When any variant is at 100%, hashing doesn't matter - that variant always wins
+        assert!(!flag.has_hash_dependent_variants());
+    }
+
+    #[test]
+    fn test_has_partial_rollout_100_percent() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.filters.groups = vec![FlagPropertyGroup {
+            properties: None,
+            rollout_percentage: Some(100.0),
+            variant: None,
+        }];
+        assert!(!flag.has_partial_rollout());
+    }
+
+    #[test]
+    fn test_has_partial_rollout_50_percent() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.filters.groups = vec![FlagPropertyGroup {
+            properties: None,
+            rollout_percentage: Some(50.0),
+            variant: None,
+        }];
+        assert!(flag.has_partial_rollout());
+    }
+
+    #[test]
+    fn test_has_partial_rollout_none_defaults_to_100() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.filters.groups = vec![FlagPropertyGroup {
+            properties: None,
+            rollout_percentage: None, // Defaults to 100%
+            variant: None,
+        }];
+        assert!(!flag.has_partial_rollout());
+    }
+
+    #[test]
+    fn test_has_partial_rollout_mixed_groups() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.filters.groups = vec![
+            FlagPropertyGroup {
+                properties: None,
+                rollout_percentage: Some(100.0),
+                variant: None,
+            },
+            FlagPropertyGroup {
+                properties: None,
+                rollout_percentage: Some(50.0),
+                variant: None,
+            },
+        ];
+        assert!(flag.has_partial_rollout());
+    }
+
+    #[test]
+    fn test_needs_hash_key_override_no_continuity() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.ensure_experience_continuity = Some(false);
+        assert!(!flag.needs_hash_key_override());
+    }
+
+    #[test]
+    fn test_needs_hash_key_override_continuity_none() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.ensure_experience_continuity = None;
+        flag.filters.groups = vec![FlagPropertyGroup {
+            properties: None,
+            rollout_percentage: Some(50.0),
+            variant: None,
+        }];
+        // None defaults to false, so no continuity means no lookup needed
+        assert!(!flag.needs_hash_key_override());
+    }
+
+    #[test]
+    fn test_needs_hash_key_override_100_percent_no_variants() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.ensure_experience_continuity = Some(true);
+        flag.filters.groups = vec![FlagPropertyGroup {
+            properties: None,
+            rollout_percentage: Some(100.0),
+            variant: None,
+        }];
+        // 100% rollout with no variants -> doesn't need lookup
+        assert!(!flag.needs_hash_key_override());
+    }
+
+    #[test]
+    fn test_needs_hash_key_override_partial_rollout() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.ensure_experience_continuity = Some(true);
+        flag.filters.groups = vec![FlagPropertyGroup {
+            properties: None,
+            rollout_percentage: Some(50.0),
+            variant: None,
+        }];
+        // Partial rollout needs consistent bucketing
+        assert!(flag.needs_hash_key_override());
+    }
+
+    #[test]
+    fn test_needs_hash_key_override_with_variants() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.ensure_experience_continuity = Some(true);
+        flag.filters.groups = vec![FlagPropertyGroup {
+            properties: None,
+            rollout_percentage: Some(100.0),
+            variant: None,
+        }];
+        flag.filters.multivariate = Some(MultivariateFlagOptions {
+            variants: vec![
+                MultivariateFlagVariant {
+                    key: "control".to_string(),
+                    name: None,
+                    rollout_percentage: 50.0,
+                },
+                MultivariateFlagVariant {
+                    key: "test".to_string(),
+                    name: None,
+                    rollout_percentage: 50.0,
+                },
+            ],
+        });
+        // Has variants -> needs consistent variant assignment
+        assert!(flag.needs_hash_key_override());
+    }
+
+    #[test]
+    fn test_needs_hash_key_override_group_based_flag() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.ensure_experience_continuity = Some(true);
+        flag.filters.aggregation_group_type_index = Some(0); // Group-based flag
+        flag.filters.groups = vec![FlagPropertyGroup {
+            properties: None,
+            rollout_percentage: Some(50.0),
+            variant: None,
+        }];
+        // Group-based flags don't use hash key overrides
+        assert!(!flag.needs_hash_key_override());
+    }
+
+    #[test]
+    fn test_needs_hash_key_override_device_id_bucketing() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.ensure_experience_continuity = Some(true);
+        flag.bucketing_identifier = Some("device_id".to_string());
+        flag.filters.groups = vec![FlagPropertyGroup {
+            properties: None,
+            rollout_percentage: Some(50.0),
+            variant: None,
+        }];
+        // Device ID bucketing doesn't use hash key overrides
+        assert!(!flag.needs_hash_key_override());
+    }
+
+    #[test]
+    fn test_needs_hash_key_override_empty_groups() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.ensure_experience_continuity = Some(true);
+        flag.filters.groups = vec![];
+        // Empty groups means no partial rollout, doesn't need lookup
+        assert!(!flag.needs_hash_key_override());
+    }
+
+    #[test]
+    fn test_needs_hash_key_override_both_partial_and_variants() {
+        let mut flag = create_test_flag(None, None, None, None, None, None, None, None);
+        flag.ensure_experience_continuity = Some(true);
+        flag.filters.groups = vec![FlagPropertyGroup {
+            properties: None,
+            rollout_percentage: Some(50.0), // Partial rollout
+            variant: None,
+        }];
+        flag.filters.multivariate = Some(MultivariateFlagOptions {
+            variants: vec![
+                MultivariateFlagVariant {
+                    key: "control".to_string(),
+                    name: None,
+                    rollout_percentage: 50.0,
+                },
+                MultivariateFlagVariant {
+                    key: "test".to_string(),
+                    name: None,
+                    rollout_percentage: 50.0,
+                },
+            ],
+        });
+        // Both conditions satisfied -> needs lookup
+        assert!(flag.needs_hash_key_override());
     }
 }

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -14,7 +14,8 @@ mod tests {
             flag_match_reason::FeatureFlagMatchReason,
             flag_matching::{FeatureFlagMatch, FeatureFlagMatcher},
             flag_matching_utils::{
-                get_fetch_calls_count, reset_fetch_calls_count, set_feature_flag_hash_key_overrides,
+                get_fetch_calls_count, get_hash_key_override_lookup_count, reset_fetch_calls_count,
+                reset_hash_key_override_lookup_count, set_feature_flag_hash_key_overrides,
             },
             flag_models::{
                 FeatureFlag, FeatureFlagList, FlagFilters, FlagPropertyGroup,
@@ -22,7 +23,10 @@ mod tests {
             },
         },
         properties::property_models::{OperatorType, PropertyFilter, PropertyType},
-        utils::test_utils::{create_test_flag, TestContext},
+        utils::{
+            graph_utils::build_dependency_graph,
+            test_utils::{create_test_flag, TestContext},
+        },
     };
 
     #[tokio::test]
@@ -201,7 +205,15 @@ mod tests {
             flags: vec![flag.clone()],
         };
         let result = matcher
-            .evaluate_all_feature_flags(flags, Some(overrides), None, None, Uuid::new_v4(), None)
+            .evaluate_all_feature_flags(
+                flags,
+                Some(overrides),
+                None,
+                None,
+                Uuid::new_v4(),
+                None,
+                false,
+            )
             .await;
         assert!(!result.errors_while_computing_flags);
         assert_eq!(
@@ -290,6 +302,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -380,6 +393,7 @@ mod tests {
                     None,
                     Uuid::new_v4(),
                     None,
+                    false,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -403,7 +417,15 @@ mod tests {
         {
             // Leaf flag evaluates to false
             let result = matcher
-                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4(), None)
+                .evaluate_all_feature_flags(
+                    flags.clone(),
+                    None,
+                    None,
+                    None,
+                    Uuid::new_v4(),
+                    None,
+                    false,
+                )
                 .await;
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
@@ -533,6 +555,7 @@ mod tests {
                     None,
                     Uuid::new_v4(),
                     None,
+                    false,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -555,6 +578,7 @@ mod tests {
                     None,
                     Uuid::new_v4(),
                     None,
+                    false,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -577,6 +601,7 @@ mod tests {
                     None,
                     Uuid::new_v4(),
                     None,
+                    false,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -688,7 +713,15 @@ mod tests {
         reset_fetch_calls_count();
 
         let result = matcher
-            .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4(), None)
+            .evaluate_all_feature_flags(
+                flags.clone(),
+                None,
+                None,
+                None,
+                Uuid::new_v4(),
+                None,
+                false,
+            )
             .await;
         // Add this assertion to check the call count
         let fetch_calls = get_fetch_calls_count();
@@ -823,6 +856,7 @@ mod tests {
                     None,
                     Uuid::new_v4(),
                     None,
+                    false,
                 )
                 .await;
             assert!(result.errors_while_computing_flags);
@@ -846,7 +880,15 @@ mod tests {
         {
             // Leaf flag evaluates to false
             let result = matcher
-                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4(), None)
+                .evaluate_all_feature_flags(
+                    flags.clone(),
+                    None,
+                    None,
+                    None,
+                    Uuid::new_v4(),
+                    None,
+                    false,
+                )
                 .await;
             assert!(result.errors_while_computing_flags);
             assert_eq!(
@@ -967,6 +1009,7 @@ mod tests {
                     None,
                     Uuid::new_v4(),
                     None,
+                    false,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -990,6 +1033,7 @@ mod tests {
                     None,
                     Uuid::new_v4(),
                     None,
+                    false,
                 )
                 .await;
             assert!(!result.errors_while_computing_flags);
@@ -1005,7 +1049,15 @@ mod tests {
         {
             // Leaf flag evaluates to false
             let result = matcher
-                .evaluate_all_feature_flags(flags.clone(), None, None, None, Uuid::new_v4(), None)
+                .evaluate_all_feature_flags(
+                    flags.clone(),
+                    None,
+                    None,
+                    None,
+                    Uuid::new_v4(),
+                    None,
+                    false,
+                )
                 .await;
             assert!(!result.errors_while_computing_flags);
             assert_eq!(
@@ -1310,6 +1362,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -3488,6 +3541,7 @@ mod tests {
             Some("hash_key_continuity".to_string()),
             Uuid::new_v4(),
             None,
+            false,
         )
         .await;
 
@@ -3573,7 +3627,7 @@ mod tests {
             Some(group_type_mapping_cache),
             None,
         )
-        .evaluate_all_feature_flags(flags, None, None, None, Uuid::new_v4(), None)
+        .evaluate_all_feature_flags(flags, None, None, None, Uuid::new_v4(), None, false)
         .await;
 
         assert!(result.flags.get("flag_continuity_missing").unwrap().enabled);
@@ -3708,6 +3762,7 @@ mod tests {
             Some("hash_key_mixed".to_string()),
             Uuid::new_v4(),
             None,
+            false,
         )
         .await;
 
@@ -4392,6 +4447,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -5136,6 +5192,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -5176,6 +5233,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -5210,6 +5268,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -5246,6 +5305,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -5403,6 +5463,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -5443,6 +5504,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -5483,6 +5545,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -5519,6 +5582,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -5559,6 +5623,7 @@ mod tests {
                 None,
                 Uuid::new_v4(),
                 None,
+                false,
             )
             .await;
 
@@ -5757,6 +5822,10 @@ mod tests {
             flags: vec![flag_with_continuity, flag_without_continuity],
         };
 
+        // Build dependency graph for the flags
+        let (dependency_graph, _) =
+            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+
         // Test the scenario where hash key override reading fails
         // This simulates the case where we have experience continuity flags but hash override reads fail
         let overrides = crate::flags::flag_matching::FlagEvaluationOverrides {
@@ -5767,12 +5836,7 @@ mod tests {
         };
 
         let response = matcher
-            .evaluate_flags_with_overrides(
-                flags,
-                overrides,
-                Uuid::new_v4(),
-                None, // flag_keys
-            )
+            .evaluate_flags_with_overrides(overrides, Uuid::new_v4(), dependency_graph)
             .await;
 
         // Should have errors_while_computing_flags set to true
@@ -5916,6 +5980,10 @@ mod tests {
             flags: vec![base_flag, dependent_flag],
         };
 
+        // Build dependency graph for the flags
+        let (dependency_graph, _) =
+            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
             "test_user".to_string(),
@@ -5928,7 +5996,7 @@ mod tests {
         );
 
         let result = matcher
-            .evaluate_flags_with_overrides(flags, Default::default(), Uuid::new_v4(), None)
+            .evaluate_flags_with_overrides(Default::default(), Uuid::new_v4(), dependency_graph)
             .await;
 
         // Base flag should be disabled
@@ -5951,6 +6019,910 @@ mod tests {
         assert_ne!(
             dependent_result.reason.code, "flag_disabled",
             "Dependent flag should not have flag_disabled reason"
+        );
+    }
+
+    // ======== Integration tests for experience continuity optimization ========
+
+    #[tokio::test]
+    async fn test_optimization_enabled_100_percent_rollout_evaluates_correctly() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+        let distinct_id = "optimization_user_1".to_string();
+
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "opt_user@example.com"})),
+            )
+            .await
+            .unwrap();
+
+        // Create a flag with 100% rollout and experience continuity enabled
+        // This flag should NOT need a hash key override lookup
+        let flag = create_test_flag(
+            Some(1),
+            Some(team.id),
+            None,
+            Some("opt_100_percent".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: None,
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(true), // ensure_experience_continuity = true
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag.clone()],
+        };
+
+        // Reset counter before the test
+        reset_hash_key_override_lookup_count();
+
+        let router = context.create_postgres_router();
+        let result = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            None,
+            team.id,
+            router,
+            cohort_cache.clone(),
+            None,
+            None,
+        )
+        .evaluate_all_feature_flags(
+            flags,
+            None,
+            None,
+            Some("anon_distinct_id".to_string()),
+            Uuid::new_v4(),
+            None,
+            true, // optimization enabled
+        )
+        .await;
+
+        // Verify the optimization actually skipped the hash key override lookup
+        let lookup_count = get_hash_key_override_lookup_count();
+        assert_eq!(
+            lookup_count, 0,
+            "100% rollout flag should skip hash key override lookup, but got {lookup_count} lookups"
+        );
+
+        // Flag should evaluate correctly even with optimization enabled
+        assert!(
+            result.flags.get("opt_100_percent").unwrap().enabled,
+            "100% rollout flag should be enabled with optimization"
+        );
+        assert!(
+            !result.errors_while_computing_flags,
+            "No errors should occur"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_optimization_enabled_partial_rollout_evaluates_correctly() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+        let distinct_id = "optimization_user_2".to_string();
+
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "opt_user2@example.com"})),
+            )
+            .await
+            .unwrap();
+
+        // Create a flag with 50% rollout and experience continuity enabled
+        // This flag SHOULD need a hash key override lookup
+        let flag = create_test_flag(
+            Some(2),
+            Some(team.id),
+            None,
+            Some("opt_partial_rollout".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: None,
+                    rollout_percentage: Some(50.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(true), // ensure_experience_continuity = true
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag.clone()],
+        };
+
+        // Reset counter before the test
+        reset_hash_key_override_lookup_count();
+
+        let router = context.create_postgres_router();
+        let result = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            None,
+            team.id,
+            router,
+            cohort_cache.clone(),
+            None,
+            None,
+        )
+        .evaluate_all_feature_flags(
+            flags,
+            None,
+            None,
+            Some("anon_distinct_id".to_string()),
+            Uuid::new_v4(),
+            None,
+            true, // optimization enabled
+        )
+        .await;
+
+        // Verify the lookup DID happen for partial rollout (optimization doesn't skip it)
+        let lookup_count = get_hash_key_override_lookup_count();
+        assert_eq!(
+            lookup_count, 1,
+            "Partial rollout flag should perform hash key override lookup, but got {lookup_count} lookups"
+        );
+
+        // Flag should evaluate (result depends on hash)
+        assert!(
+            result.flags.contains_key("opt_partial_rollout"),
+            "Partial rollout flag should be evaluated with optimization"
+        );
+        assert!(
+            !result.errors_while_computing_flags,
+            "No errors should occur"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_optimization_enabled_multivariate_evaluates_correctly() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+        let distinct_id = "optimization_user_3".to_string();
+
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "opt_user3@example.com"})),
+            )
+            .await
+            .unwrap();
+
+        // Create a multivariate flag with experience continuity
+        // This flag SHOULD need a hash key override lookup
+        let flag = create_test_flag(
+            Some(3),
+            Some(team.id),
+            None,
+            Some("opt_multivariate".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: None,
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: Some(MultivariateFlagOptions {
+                    variants: vec![
+                        MultivariateFlagVariant {
+                            key: "control".to_string(),
+                            name: Some("Control".to_string()),
+                            rollout_percentage: 50.0,
+                        },
+                        MultivariateFlagVariant {
+                            key: "test".to_string(),
+                            name: Some("Test".to_string()),
+                            rollout_percentage: 50.0,
+                        },
+                    ],
+                }),
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(true), // ensure_experience_continuity = true
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag.clone()],
+        };
+
+        // Reset counter before the test
+        reset_hash_key_override_lookup_count();
+
+        let router = context.create_postgres_router();
+        let result = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            None,
+            team.id,
+            router,
+            cohort_cache.clone(),
+            None,
+            None,
+        )
+        .evaluate_all_feature_flags(
+            flags,
+            None,
+            None,
+            Some("anon_distinct_id".to_string()),
+            Uuid::new_v4(),
+            None,
+            true, // optimization enabled
+        )
+        .await;
+
+        // Verify the lookup DID happen for multivariate (optimization doesn't skip it)
+        let lookup_count = get_hash_key_override_lookup_count();
+        assert_eq!(
+            lookup_count, 1,
+            "Multivariate flag should perform hash key override lookup, but got {lookup_count} lookups"
+        );
+
+        // Flag should evaluate with a variant
+        let flag_result = result.flags.get("opt_multivariate").unwrap();
+        assert!(
+            flag_result.enabled,
+            "Multivariate flag should be enabled with optimization"
+        );
+        assert!(
+            flag_result.variant.is_some(),
+            "Multivariate flag should have a variant assigned"
+        );
+        assert!(
+            !result.errors_while_computing_flags,
+            "No errors should occur"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_optimization_enabled_multivariate_with_100_percent_variant() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+        let distinct_id = "optimization_user_4".to_string();
+
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "opt_user4@example.com"})),
+            )
+            .await
+            .unwrap();
+
+        // Create a multivariate flag where one variant is at 100%
+        // This flag should NOT need a hash key override lookup (optimization applies)
+        let flag = create_test_flag(
+            Some(4),
+            Some(team.id),
+            None,
+            Some("opt_multivariate_100".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: None,
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: Some(MultivariateFlagOptions {
+                    variants: vec![
+                        MultivariateFlagVariant {
+                            key: "control".to_string(),
+                            name: Some("Control".to_string()),
+                            rollout_percentage: 100.0, // 100% variant
+                        },
+                        MultivariateFlagVariant {
+                            key: "test".to_string(),
+                            name: Some("Test".to_string()),
+                            rollout_percentage: 0.0,
+                        },
+                    ],
+                }),
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(true), // ensure_experience_continuity = true
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag.clone()],
+        };
+
+        // Reset counter before the test
+        reset_hash_key_override_lookup_count();
+
+        let router = context.create_postgres_router();
+        let result = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            None,
+            team.id,
+            router,
+            cohort_cache.clone(),
+            None,
+            None,
+        )
+        .evaluate_all_feature_flags(
+            flags,
+            None,
+            None,
+            Some("anon_distinct_id".to_string()),
+            Uuid::new_v4(),
+            None,
+            true, // optimization enabled
+        )
+        .await;
+
+        // Verify the optimization skipped the lookup (100% variant = no hashing needed)
+        let lookup_count = get_hash_key_override_lookup_count();
+        assert_eq!(
+            lookup_count, 0,
+            "Multivariate flag with 100% variant should skip hash key override lookup, but got {lookup_count} lookups"
+        );
+
+        // Flag should evaluate with the 100% variant
+        let flag_result = result.flags.get("opt_multivariate_100").unwrap();
+        assert!(
+            flag_result.enabled,
+            "Flag with 100% variant should be enabled"
+        );
+        assert_eq!(
+            flag_result.variant,
+            Some("control".to_string()),
+            "Should get the 100% variant"
+        );
+        assert!(
+            !result.errors_while_computing_flags,
+            "No errors should occur"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_optimization_disabled_legacy_behavior() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+        let distinct_id = "legacy_user".to_string();
+
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "legacy@example.com"})),
+            )
+            .await
+            .unwrap();
+
+        // Create a flag with 100% rollout and experience continuity
+        let flag = create_test_flag(
+            Some(5),
+            Some(team.id),
+            None,
+            Some("legacy_flag".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: None,
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(true), // ensure_experience_continuity = true
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag.clone()],
+        };
+
+        let router = context.create_postgres_router();
+        let result = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            None,
+            team.id,
+            router,
+            cohort_cache.clone(),
+            None,
+            None,
+        )
+        .evaluate_all_feature_flags(
+            flags,
+            None,
+            None,
+            Some("anon_distinct_id".to_string()),
+            Uuid::new_v4(),
+            None,
+            false, // optimization disabled (legacy behavior)
+        )
+        .await;
+
+        // Flag should still evaluate correctly in legacy mode
+        assert!(
+            result.flags.get("legacy_flag").unwrap().enabled,
+            "Flag should be enabled in legacy mode"
+        );
+        assert!(
+            !result.errors_while_computing_flags,
+            "No errors should occur"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_optimization_mixed_flags() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+        let distinct_id = "mixed_user".to_string();
+
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "mixed@example.com"})),
+            )
+            .await
+            .unwrap();
+
+        // Flag 1: 100% rollout with continuity (can be optimized)
+        let flag_optimizable = create_test_flag(
+            Some(1),
+            Some(team.id),
+            None,
+            Some("flag_optimizable".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: None,
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(true),
+        );
+
+        // Flag 2: 50% rollout with continuity (needs lookup)
+        let flag_needs_lookup = create_test_flag(
+            Some(2),
+            Some(team.id),
+            None,
+            Some("flag_needs_lookup".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: None,
+                    rollout_percentage: Some(50.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(true),
+        );
+
+        // Flag 3: 100% rollout without continuity (no lookup needed)
+        let flag_no_continuity = create_test_flag(
+            Some(3),
+            Some(team.id),
+            None,
+            Some("flag_no_continuity".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: None,
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(false),
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![
+                flag_optimizable.clone(),
+                flag_needs_lookup.clone(),
+                flag_no_continuity.clone(),
+            ],
+        };
+
+        // Reset counter before the test
+        reset_hash_key_override_lookup_count();
+
+        let router = context.create_postgres_router();
+        let result = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            None,
+            team.id,
+            router,
+            cohort_cache.clone(),
+            None,
+            None,
+        )
+        .evaluate_all_feature_flags(
+            flags,
+            None,
+            None,
+            Some("anon_distinct_id".to_string()),
+            Uuid::new_v4(),
+            None,
+            true, // optimization enabled
+        )
+        .await;
+
+        // Verify the lookup DID happen because flag_needs_lookup requires it.
+        // Even though flag_optimizable could be optimized, the presence of
+        // flag_needs_lookup forces a lookup for all flags with experience continuity.
+        let lookup_count = get_hash_key_override_lookup_count();
+        assert_eq!(
+            lookup_count, 1,
+            "Mixed flags should perform lookup when at least one flag needs it, but got {lookup_count} lookups"
+        );
+
+        // All flags should be evaluated
+        assert!(
+            result.flags.contains_key("flag_optimizable"),
+            "Optimizable flag should be evaluated"
+        );
+        assert!(
+            result.flags.contains_key("flag_needs_lookup"),
+            "Needs-lookup flag should be evaluated"
+        );
+        assert!(
+            result.flags.contains_key("flag_no_continuity"),
+            "No-continuity flag should be evaluated"
+        );
+
+        // 100% rollout flags should be enabled
+        assert!(
+            result.flags.get("flag_optimizable").unwrap().enabled,
+            "100% rollout flag should be enabled"
+        );
+        assert!(
+            result.flags.get("flag_no_continuity").unwrap().enabled,
+            "100% rollout no-continuity flag should be enabled"
+        );
+
+        assert!(
+            !result.errors_while_computing_flags,
+            "No errors should occur"
+        );
+    }
+
+    /// Tests that flag_keys filtering is applied before computing optimization stats.
+    /// When only optimizable flags are requested via flag_keys, the lookup should be skipped
+    /// even if other flags (not being evaluated) would require it.
+    #[tokio::test]
+    async fn test_optimization_respects_flag_keys_filter() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+        let distinct_id = "flag_keys_user".to_string();
+
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "flag_keys@example.com"})),
+            )
+            .await
+            .unwrap();
+
+        // Flag 1: 100% rollout with continuity (can be optimized)
+        let flag_optimizable = create_test_flag(
+            Some(1),
+            Some(team.id),
+            None,
+            Some("flag_optimizable".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: None,
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(true),
+        );
+
+        // Flag 2: 50% rollout with continuity (needs lookup)
+        let flag_needs_lookup = create_test_flag(
+            Some(2),
+            Some(team.id),
+            None,
+            Some("flag_needs_lookup".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: None,
+                    rollout_percentage: Some(50.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(true),
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag_optimizable.clone(), flag_needs_lookup.clone()],
+        };
+
+        // Reset counter before the test
+        reset_hash_key_override_lookup_count();
+
+        let router = context.create_postgres_router();
+        let result = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            None,
+            team.id,
+            router,
+            cohort_cache.clone(),
+            None,
+            None,
+        )
+        .evaluate_all_feature_flags(
+            flags,
+            None,
+            None,
+            Some("anon_distinct_id".to_string()),
+            Uuid::new_v4(),
+            Some(vec!["flag_optimizable".to_string()]), // Only request the optimizable flag
+            true,                                       // optimization enabled
+        )
+        .await;
+
+        // Verify the lookup was SKIPPED because we only requested flag_optimizable,
+        // which is 100% rollout and doesn't need the hash key override lookup.
+        // The flag_needs_lookup exists but wasn't requested, so it shouldn't trigger a lookup.
+        let lookup_count = get_hash_key_override_lookup_count();
+        assert_eq!(
+            lookup_count, 0,
+            "Lookup should be skipped when flag_keys filters to only optimizable flags, but got {lookup_count} lookups"
+        );
+
+        // Only the requested flag should be evaluated
+        assert!(
+            result.flags.contains_key("flag_optimizable"),
+            "Optimizable flag should be evaluated"
+        );
+        assert!(
+            !result.flags.contains_key("flag_needs_lookup"),
+            "Needs-lookup flag should NOT be evaluated when not in flag_keys"
+        );
+
+        // The optimizable flag should be enabled (100% rollout)
+        assert!(
+            result.flags.get("flag_optimizable").unwrap().enabled,
+            "100% rollout flag should be enabled"
+        );
+
+        assert!(
+            !result.errors_while_computing_flags,
+            "No errors should occur"
+        );
+    }
+
+    /// Tests that hash key lookup is NOT skipped when a requested flag depends on a flag that needs it.
+    /// This ensures the optimization correctly considers transitive dependencies.
+    ///
+    /// Scenario:
+    /// - Flag B: 50% rollout + experience continuity (needs hash lookup)
+    /// - Flag A: 100% rollout + experience continuity, depends on Flag B (doesn't need lookup itself)
+    /// - User requests only Flag A via flag_keys
+    /// - The lookup should happen because Flag B (a dependency) requires it
+    #[tokio::test]
+    async fn test_optimization_considers_dependencies_for_flag_keys() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+        let distinct_id = "dependency_user".to_string();
+
+        context
+            .insert_person(
+                team.id,
+                distinct_id.clone(),
+                Some(json!({"email": "test@example.com"})),
+            )
+            .await
+            .unwrap();
+
+        // Flag B: 50% rollout with experience continuity (NEEDS hash lookup)
+        // This is the dependency that requires the hash key override
+        let flag_needs_lookup = create_test_flag(
+            Some(1),
+            Some(team.id),
+            None,
+            Some("flag_needs_lookup".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: None,
+                    rollout_percentage: Some(50.0), // Partial rollout means we need consistent bucketing
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(true), // experience continuity enabled
+        );
+
+        // Flag A: Depends on Flag B, with 100% rollout and experience continuity.
+        // This flag itself wouldn't need a hash lookup (100% rollout), but its dependency does.
+        let flag_depends_on_b = create_test_flag(
+            Some(2),
+            Some(team.id),
+            None,
+            Some("flag_depends_on_b".to_string()),
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: Some(vec![PropertyFilter {
+                        key: "1".to_string(), // depends on flag with id=1
+                        value: Some(json!(true)),
+                        operator: Some(OperatorType::FlagEvaluatesTo),
+                        prop_type: PropertyType::Flag,
+                        group_type_index: None,
+                        negation: None,
+                    }]),
+                    rollout_percentage: Some(100.0), // 100% rollout - doesn't need lookup on its own
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout_groups: None,
+            }),
+            None,
+            None,
+            Some(true), // experience continuity enabled
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag_needs_lookup.clone(), flag_depends_on_b.clone()],
+        };
+
+        // Reset counter before the test
+        reset_hash_key_override_lookup_count();
+
+        let router = context.create_postgres_router();
+        let result = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            None,
+            team.id,
+            router,
+            cohort_cache.clone(),
+            None,
+            None,
+        )
+        .evaluate_all_feature_flags(
+            flags,
+            None,
+            None,
+            Some("anon_distinct_id".to_string()),
+            Uuid::new_v4(),
+            Some(vec!["flag_depends_on_b".to_string()]), // Only request the dependent flag
+            true,                                        // optimization enabled
+        )
+        .await;
+
+        // The lookup SHOULD happen because flag_needs_lookup (a dependency) requires it,
+        // even though flag_depends_on_b itself wouldn't need it (100% rollout).
+        // Before the fix, this would incorrectly be 0.
+        let lookup_count = get_hash_key_override_lookup_count();
+        assert_eq!(
+            lookup_count, 1,
+            "Hash key lookup should happen because dependency flag_needs_lookup requires it"
+        );
+
+        // The dependent flag should be evaluated
+        assert!(
+            result.flags.contains_key("flag_depends_on_b"),
+            "Dependent flag should be evaluated"
+        );
+
+        // The dependency flag should also be in the result since it was evaluated as a dependency
+        assert!(
+            result.flags.contains_key("flag_needs_lookup"),
+            "Dependency flag should also be evaluated"
+        );
+
+        assert!(
+            !result.errors_while_computing_flags,
+            "No errors should occur"
         );
     }
 }

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -112,6 +112,10 @@ pub struct FlagsCanonicalLogLine {
     pub flags_errored: usize,
     pub hash_key_override_attempted: bool,
     pub hash_key_override_succeeded: bool,
+    /// True when experience continuity lookup was skipped due to optimization.
+    /// This is set when flags have experience continuity enabled but don't need
+    /// a hash key lookup (100% rollout with no multivariate variants).
+    pub hash_key_override_skipped: bool,
 
     // Rate limiting
     pub rate_limited: bool,
@@ -150,6 +154,7 @@ impl Default for FlagsCanonicalLogLine {
             flags_errored: 0,
             hash_key_override_attempted: false,
             hash_key_override_succeeded: false,
+            hash_key_override_skipped: false,
             rate_limited: false,
             http_status: 200,
             error_code: None,
@@ -201,6 +206,7 @@ impl FlagsCanonicalLogLine {
             flags_errored = self.flags_errored,
             hash_key_override_attempted = self.hash_key_override_attempted,
             hash_key_override_succeeded = self.hash_key_override_succeeded,
+            hash_key_override_skipped = self.hash_key_override_skipped,
             rate_limited = self.rate_limited,
             error_code = ?self.error_code,
             "canonical_log_line"
@@ -255,6 +261,7 @@ mod tests {
         assert_eq!(log.flags_errored, 0);
         assert!(!log.hash_key_override_attempted);
         assert!(!log.hash_key_override_succeeded);
+        assert!(!log.hash_key_override_skipped);
         assert!(!log.rate_limited);
         assert_eq!(log.http_status, 200);
         assert!(log.error_code.is_none());

--- a/rust/feature-flags/src/handler/evaluation.rs
+++ b/rust/feature-flags/src/handler/evaluation.rs
@@ -40,6 +40,7 @@ pub async fn evaluate_feature_flags(
             context.hash_key_override, // Aka $anon_distinct_id
             request_id,
             context.flag_keys,
+            context.optimize_experience_continuity_lookups,
         )
         .await
 }

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -254,6 +254,10 @@ pub async fn evaluate_for_request(
         groups,
         hash_key_override,
         flag_keys,
+        optimize_experience_continuity_lookups: state
+            .config
+            .optimize_experience_continuity_lookups
+            .0,
     };
 
     evaluation::evaluate_feature_flags(ctx, request_id).await

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -167,14 +167,6 @@ async fn process_request_inner(
 
             tracing::debug!("Flags filtered: {} flags found", filtered_flags.flags.len());
 
-            // Count flags with experience continuity for canonical logging
-            let experience_continuity_count = filtered_flags
-                .flags
-                .iter()
-                .filter(|f| f.ensure_experience_continuity.unwrap_or(false))
-                .count();
-            with_canonical_log(|log| log.flags_experience_continuity = experience_continuity_count);
-
             let property_overrides = properties::prepare_overrides(&context, &request)?;
 
             // Evaluate flags (this will return empty if is_flags_disabled is true)

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -190,6 +190,7 @@ async fn test_evaluate_feature_flags() {
         groups: None,
         hash_key_override: None,
         flag_keys: None,
+        optimize_experience_continuity_lookups: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -280,6 +281,7 @@ async fn test_evaluate_feature_flags_with_errors() {
         groups: None,
         hash_key_override: None,
         flag_keys: None,
+        optimize_experience_continuity_lookups: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -683,6 +685,7 @@ async fn test_evaluate_feature_flags_multiple_flags() {
         groups: None,
         hash_key_override: None,
         flag_keys: None,
+        optimize_experience_continuity_lookups: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -786,6 +789,7 @@ async fn test_evaluate_feature_flags_details() {
         groups: None,
         hash_key_override: None,
         flag_keys: None,
+        optimize_experience_continuity_lookups: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -939,6 +943,7 @@ async fn test_evaluate_feature_flags_with_overrides() {
         groups: Some(groups),
         hash_key_override: None,
         flag_keys: None,
+        optimize_experience_continuity_lookups: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -1029,6 +1034,7 @@ async fn test_long_distinct_id() {
         groups: None,
         hash_key_override: None,
         flag_keys: None,
+        optimize_experience_continuity_lookups: false,
     };
 
     let request_id = Uuid::new_v4();

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -56,4 +56,7 @@ pub struct FeatureFlagEvaluationContext {
     pub hash_key_override: Option<String>,
     /// Contains explicitly requested flag keys and their dependencies. If empty, all flags will be evaluated.
     pub flag_keys: Option<Vec<String>>,
+    /// When true, skip hash key override lookups for flags that don't need them
+    /// (e.g., 100% rollout with no multivariate variants).
+    pub optimize_experience_continuity_lookups: bool,
 }

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -51,6 +51,13 @@ pub const FLAG_CONNECTION_HOLD_TIME: &str = "flags_connection_hold_time_ms";
 pub const FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER: &str =
     "flags_experience_continuity_requests_total";
 
+// Experience continuity optimization metric
+// Tracks requests where optimization could apply, with status label:
+// - status="skipped": lookup was actually skipped (optimization enabled, no flags needed it)
+// - status="eligible": lookup could be skipped but wasn't (optimization off or another flag needed it)
+pub const FLAG_EXPERIENCE_CONTINUITY_OPTIMIZED: &str =
+    "flags_experience_continuity_optimized_total";
+
 // Flag definitions rate limiting
 pub const FLAG_DEFINITIONS_RATE_LIMITED_COUNTER: &str = "flags_flag_definitions_rate_limited_total";
 pub const FLAG_DEFINITIONS_REQUESTS_COUNTER: &str = "flags_flag_definitions_requests_total";

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -54,7 +54,7 @@ pub const FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER: &str =
 // Experience continuity optimization metric
 // Tracks requests where optimization could apply, with status label:
 // - status="skipped": lookup was actually skipped (optimization enabled, no flags needed it)
-// - status="eligible": lookup could be skipped but wasn't (optimization off or another flag needed it)
+// - status="eligible": lookup could be skipped but wasn't (optimization feature is disabled)
 pub const FLAG_EXPERIENCE_CONTINUITY_OPTIMIZED: &str =
     "flags_experience_continuity_optimized_total";
 

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -274,6 +274,11 @@ where
         Self::compute_stages(&self.graph, &mut out_degree)
     }
 
+    /// Returns an iterator over all nodes (items) in the graph.
+    pub fn iter_nodes(&self) -> impl Iterator<Item = &T> {
+        self.graph.node_indices().map(|idx| &self.graph[idx])
+    }
+
     fn build_evaluation_maps(&self) -> Result<HashMap<NodeIndex, usize>, T::Error> {
         use petgraph::Direction::Outgoing;
         let node_count = self.graph.node_count();


### PR DESCRIPTION
Skip hash key override database lookups for flags with experience continuity enabled when they don't actually need them.

## Problem

Feature flags that have experience continuity enabled (aka "Persist flag across authentication steps" is checked) require additional queries to look up hash key overrides in the database. However, there are situations where flags don't actually need this work even though experience continuity is enabled.

Flags at 100% rollout with no multivariate variants return the same value for everyone, so the hash bucket doesn't affect the result


## Changes

- Add `OPTIMIZE_EXPERIENCE_CONTINUITY_LOOKUPS` config (default: false)
- Add helper methods: `has_experience_continuity()`, `has_hash_dependent_variants()`, `has_partial_rollout()`, `needs_hash_key_override()`
- Add metric with status label for observability: `flags_experience_continuity_optimized_total{status="skipped|eligible"}`
- Add comprehensive test coverage with lookup verification

## Context

The experience continuity lookup happens once per request if __any__ flag with `ensure_experience_continuity=true` needs it. The optimization skips this lookup only when __all__ continuity-enabled flags are at 100% rollout with no multivariate variants.

Query to identify teams that can benefit:

```sql
WITH continuity_flags AS (
    SELECT
        team_id,
        CASE
            WHEN jsonb_array_length(COALESCE(filters->'multivariate'->'variants', '[]'::jsonb)) > 0
            THEN true ELSE false
        END as has_variants,
        CASE
            WHEN EXISTS (
                SELECT 1 FROM jsonb_array_elements(COALESCE(filters->'groups', '[]'::jsonb)) as g
                WHERE (g->>'rollout_percentage')::numeric < 100
            )
            THEN true ELSE false
        END as has_partial_rollout
    FROM posthog_featureflag
    WHERE ensure_experience_continuity = true
        AND active = true
        AND deleted = false
),
team_summary AS (
    SELECT
        team_id,
        bool_and(NOT (has_variants OR has_partial_rollout)) as can_skip_lookup
    FROM continuity_flags
    GROUP BY team_id
)
SELECT
    COUNT(*) as teams_with_continuity,
    SUM(CASE WHEN can_skip_lookup THEN 1 ELSE 0 END) as teams_that_can_skip,
    ROUND(100.0 * SUM(CASE WHEN can_skip_lookup THEN 1 ELSE 0 END) / COUNT(*), 1) as pct_optimizable
FROM team_summary;
```

Results:

```text
| Region | Teams with continuity | Teams that can skip | % Optimizable |
|--------|-----------------------|---------------------|---------------|
| US     | 3,042                 | 1,415               | 46.5%         |
| EU     | 1,400                 | 632                 | 45.1%         |
```

Conclusion

~46% of teams using experience continuity can skip the database lookup entirely. This represents ~2,047 teams that will avoid a DB query on every `/flags` request when the optimization is enabled.

The common pattern: teams enabled continuity for A/B tests, rolled out to 100%, but left the setting enabled. This optimization handles that automatically.

## How did you test this code?

Unit Tests
Manual Testing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No