### PR TITLE
fix(ci): trigger analytics-platform rebuild on temporal/common changes

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -280,8 +280,10 @@ jobs:
             - name: Check for config file changes that affect analytics platform temporal worker
               id: check_non_python_changes_analytics_platform_temporal_worker
               run: |
-                  # Check for non-Python files that can't be detected via import analysis
-                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+                  # Check for files not detected by import analysis (which only traces static imports):
+                  # - posthog/temporal/common: shared code configured at worker startup (e.g., logger)
+                  # - Config files: pyproject.toml, bin/temporal-django-worker, start command
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
 
             - name: Check for Python dependency changes that affect analytics platform temporal worker
               id: check_python_changes_analytics_platform_temporal_worker


### PR DESCRIPTION
## Problem

`temporal-worker-analytics-platform` doesn't rebuild when `posthog/temporal/common/` changes. This was accidentally(?) removed in #42385 when the trigger was refactored to use Python import analysis.

The import analyzer only traces static imports, but `posthog/temporal/common/` contains shared code configured at worker startup (like the logger) that isn't detected via import analysis.

`temporal-worker-analytics-platform` missed the recent logging fix (#44284)due to this

## Changes

- Add `^posthog/temporal/common` back to the analytics-platform CI trigger
- Add comment explaining why these paths need explicit checking

## How did you test this code?

Verified that all other temporal workers have this path in their trigger. This restores the pattern that was present before #42385.

Current state:
- All temporal workers on at least `335c84a` with fix

After this merges, CI will detect the workflow file change and rebuild analytics-platform.

## Publish to changelog?

no
