### PR TITLE
feat(experiments): adding access control to shared metrics.

### DIFF
--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
@@ -3,6 +3,7 @@ import { useActions, useValues } from 'kea'
 import { IconBalance, IconCheckCircle, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDialog, Spinner } from '@posthog/lemon-ui'
 
+import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { SceneTags } from 'lib/components/Scenes/SceneTags'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -19,7 +20,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { tagsModel } from '~/models/tagsModel'
 import { ExperimentMetric, NodeKind } from '~/queries/schema/schema-general'
-import { ExperimentsTabs } from '~/types'
+import { AccessControlLevel, AccessControlResourceType, ExperimentsTabs } from '~/types'
 
 import { ExperimentMetricForm } from '../ExperimentMetricForm'
 import { getDefaultFunnelsMetric, getDefaultTrendsMetric } from '../utils'
@@ -123,31 +124,39 @@ export function SharedMetric(): JSX.Element {
                 <ScenePanelDivider />
                 <ScenePanelActionsSection>
                     {action === 'update' && (
-                        <ButtonPrimitive
-                            variant="danger"
-                            menuItem
-                            onClick={() => {
-                                LemonDialog.open({
-                                    title: 'Delete this metric?',
-                                    content: (
-                                        <div className="text-sm text-secondary">This action cannot be undone.</div>
-                                    ),
-                                    primaryButton: {
-                                        children: 'Delete',
-                                        type: 'primary',
-                                        onClick: () => deleteSharedMetric(),
-                                        size: 'small',
-                                    },
-                                    secondaryButton: {
-                                        children: 'Cancel',
-                                        type: 'tertiary',
-                                        size: 'small',
-                                    },
-                                })
-                            }}
+                        <AccessControlAction
+                            resourceType={AccessControlResourceType.Experiment}
+                            minAccessLevel={AccessControlLevel.Editor}
+                            userAccessLevel={sharedMetric.user_access_level}
                         >
-                            <IconTrash /> Delete
-                        </ButtonPrimitive>
+                            <ButtonPrimitive
+                                variant="danger"
+                                menuItem
+                                onClick={() => {
+                                    LemonDialog.open({
+                                        title: 'Delete this metric?',
+                                        content: (
+                                            <div className="text-sm text-secondary">
+                                                This action cannot be undone.
+                                            </div>
+                                        ),
+                                        primaryButton: {
+                                            children: 'Delete',
+                                            type: 'primary',
+                                            onClick: () => deleteSharedMetric(),
+                                            size: 'small',
+                                        },
+                                        secondaryButton: {
+                                            children: 'Cancel',
+                                            type: 'tertiary',
+                                            size: 'small',
+                                        },
+                                    })
+                                }}
+                            >
+                                <IconTrash /> Delete
+                            </ButtonPrimitive>
+                        </AccessControlAction>
                     )}
                 </ScenePanelActionsSection>
             </ScenePanel>
@@ -174,21 +183,27 @@ export function SharedMetric(): JSX.Element {
                     key: ExperimentsTabs.SharedMetrics,
                 }}
                 actions={
-                    <LemonButton
-                        disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}
-                        size="small"
-                        type="primary"
-                        onClick={() => {
-                            if (['create', 'duplicate'].includes(action)) {
-                                createSharedMetric()
-                                return
-                            }
-
-                            updateSharedMetric()
-                        }}
+                    <AccessControlAction
+                        resourceType={AccessControlResourceType.Experiment}
+                        minAccessLevel={AccessControlLevel.Editor}
+                        userAccessLevel={sharedMetric.user_access_level}
                     >
-                        Save
-                    </LemonButton>
+                        <LemonButton
+                            disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}
+                            size="small"
+                            type="primary"
+                            onClick={() => {
+                                if (['create', 'duplicate'].includes(action)) {
+                                    createSharedMetric()
+                                    return
+                                }
+
+                                updateSharedMetric()
+                            }}
+                        >
+                            Save
+                        </LemonButton>
+                    </AccessControlAction>
                 }
             />
 
@@ -236,21 +251,27 @@ export function SharedMetric(): JSX.Element {
                         Delete
                     </LemonButton>
                 )} */}
-                <LemonButton
-                    disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}
-                    size="medium"
-                    type="primary"
-                    onClick={() => {
-                        if (['create', 'duplicate'].includes(action)) {
-                            createSharedMetric()
-                            return
-                        }
-
-                        updateSharedMetric()
-                    }}
+                <AccessControlAction
+                    resourceType={AccessControlResourceType.Experiment}
+                    minAccessLevel={AccessControlLevel.Editor}
+                    userAccessLevel={sharedMetric.user_access_level}
                 >
-                    Save
-                </LemonButton>
+                    <LemonButton
+                        disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}
+                        size="medium"
+                        type="primary"
+                        onClick={() => {
+                            if (['create', 'duplicate'].includes(action)) {
+                                createSharedMetric()
+                                return
+                            }
+
+                            updateSharedMetric()
+                        }}
+                    >
+                        Save
+                    </LemonButton>
+                </AccessControlAction>
             </div>
         </SceneContent>
     )

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
@@ -127,7 +127,7 @@ export function SharedMetric(): JSX.Element {
                         <AccessControlAction
                             resourceType={AccessControlResourceType.Experiment}
                             minAccessLevel={AccessControlLevel.Editor}
-                            userAccessLevel={sharedMetric.user_access_level}
+                            userAccessLevel={AccessControlLevel.Editor}
                         >
                             <ButtonPrimitive
                                 variant="danger"
@@ -136,9 +136,7 @@ export function SharedMetric(): JSX.Element {
                                     LemonDialog.open({
                                         title: 'Delete this metric?',
                                         content: (
-                                            <div className="text-sm text-secondary">
-                                                This action cannot be undone.
-                                            </div>
+                                            <div className="text-sm text-secondary">This action cannot be undone.</div>
                                         ),
                                         primaryButton: {
                                             children: 'Delete',
@@ -186,7 +184,7 @@ export function SharedMetric(): JSX.Element {
                     <AccessControlAction
                         resourceType={AccessControlResourceType.Experiment}
                         minAccessLevel={AccessControlLevel.Editor}
-                        userAccessLevel={sharedMetric.user_access_level}
+                        userAccessLevel={AccessControlLevel.Editor}
                     >
                         <LemonButton
                             disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}
@@ -254,7 +252,7 @@ export function SharedMetric(): JSX.Element {
                 <AccessControlAction
                     resourceType={AccessControlResourceType.Experiment}
                     minAccessLevel={AccessControlLevel.Editor}
-                    userAccessLevel={sharedMetric.user_access_level}
+                    userAccessLevel={AccessControlLevel.Editor}
                 >
                     <LemonButton
                         disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -9,7 +9,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 
-import { UserBasicType } from '~/types'
+import { AccessControlLevel, UserBasicType } from '~/types'
 
 import { getDefaultFunnelMetric } from '../utils'
 import type { sharedMetricLogicType } from './sharedMetricLogicType'
@@ -30,6 +30,7 @@ export interface SharedMetric {
     updated_at: string | null
     tags: string[]
     metadata?: Record<string, any>
+    user_access_level: AccessControlLevel
 }
 
 export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
@@ -37,6 +38,7 @@ export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
     description: '',
     query: undefined,
     tags: [],
+    user_access_level: AccessControlLevel.Editor,
 }
 
 export const sharedMetricLogic = kea<sharedMetricLogicType>([

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -9,7 +9,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 
-import { AccessControlLevel, UserBasicType } from '~/types'
+import { UserBasicType } from '~/types'
 
 import { getDefaultFunnelMetric } from '../utils'
 import type { sharedMetricLogicType } from './sharedMetricLogicType'
@@ -30,7 +30,6 @@ export interface SharedMetric {
     updated_at: string | null
     tags: string[]
     metadata?: Record<string, any>
-    user_access_level: AccessControlLevel
 }
 
 export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
@@ -38,7 +37,6 @@ export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
     description: '',
     query: undefined,
     tags: [],
-    user_access_level: AccessControlLevel.Editor,
 }
 
 export const sharedMetricLogic = kea<sharedMetricLogicType>([


### PR DESCRIPTION
## Problem

Unlike experiments, shared metrics lack access-level controls. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are adding a default access level of `Editor` to allow creating and deleting shared metrics. We are defaulting all users to `Editor` until the backend changes are implemented.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/277c8518-21d8-4c13-b978-fc7fe3dfb745)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #44376 
- <kbd>&nbsp;2&nbsp;</kbd> #44374 
- <kbd>&nbsp;1&nbsp;</kbd> #44300 👈 
<!-- GitButler Footer Boundary Bottom -->

