### PR TITLE
chore(experiments): Stop recalculating timeseries after 30 days

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
@@ -45,7 +45,7 @@ export function TimeseriesModal({
     const isStaleExperiment =
         !experiment.start_date || experiment.end_date
             ? false
-            : dayjs(experiment.start_date).isBefore(dayjs().subtract(90, 'days'))
+            : dayjs(experiment.start_date).isBefore(dayjs().subtract(30, 'days'))
 
     const handleRecalculate = (): void => {
         LemonDialog.open({
@@ -112,7 +112,7 @@ export function TimeseriesModal({
                                     <div className="flex items-center justify-between">
                                         <div className="flex-1">
                                             <div className="text-sm">
-                                                This experiment has been running for more than 90 days. Automatic
+                                                This experiment has been running for more than 30 days. Automatic
                                                 timeseries updates are disabled. You can still manually recalculate the
                                                 data.
                                             </div>

--- a/products/experiments/dags/experiment_regular_metrics_timeseries.py
+++ b/products/experiments/dags/experiment_regular_metrics_timeseries.py
@@ -247,13 +247,13 @@ def _get_experiment_regular_metrics_timeseries(
     experiment_metrics = []
 
     # Query experiments that are eligible for timeseries analysis (running experiments only)
-    # Exclude experiments running for longer than 3 months to avoid continuously recalculating
+    # Exclude experiments running for longer than 30 days to avoid continuously recalculating
     # likely stale experiments. Users can still manually backfill those.
     experiments = Experiment.objects.filter(
         deleted=False,
         scheduling_config__timeseries=True,
         start_date__isnull=False,
-        start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=90),
+        start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=30),
         end_date__isnull=True,
     ).exclude(
         # Exclude if both metrics and metrics_secondary are empty or null

--- a/products/experiments/dags/experiment_saved_metrics_timeseries.py
+++ b/products/experiments/dags/experiment_saved_metrics_timeseries.py
@@ -255,13 +255,13 @@ def _get_experiment_saved_metrics_timeseries(context: dagster.SensorEvaluationCo
     experiment_saved_metrics = []
 
     # Query experiments that are eligible for timeseries analysis (running experiments only)
-    # Exclude experiments running for longer than 3 months to avoid continuously recalculating
+    # Exclude experiments running for longer than 30 days to avoid continuously recalculating
     # likely stale experiments. Users can still manually backfill those.
     experiments = Experiment.objects.filter(
         deleted=False,
         scheduling_config__timeseries=True,
         start_date__isnull=False,
-        start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=90),
+        start_date__gte=datetime.now(ZoneInfo("UTC")) - timedelta(days=30),
         end_date__isnull=True,
     ).prefetch_related("experimenttosavedmetric_set__saved_metric")
 


### PR DESCRIPTION
## Problem
Recalculating timeseries is costing us a lot of credits right now.

## Changes
Stop recalculating for every experiment after 30 days. Users can still choose to manually backfill at any time.

## How did you test this code?
👀 