### PR TITLE
chore: Add `disallow_if_impersonated` decorator

### DIFF
--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -8,7 +8,6 @@ from django.db.models import Case, F, IntegerField, Q, QuerySet, Value, When
 from django.db.models.functions import Concat, Lower
 
 from drf_spectacular.utils import extend_schema
-from loginas.utils import is_impersonated_session
 from rest_framework import filters, pagination, serializers, status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -23,6 +22,7 @@ from posthog.api.file_system.file_system_logging import log_api_file_system_view
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action
+from posthog.decorators import disallow_if_impersonated
 from posthog.models.file_system.file_system import FileSystem, create_or_update_file, join_path, split_path
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.file_system.file_system_view_log import FileSystemViewLog, annotate_file_system_with_view_logs
@@ -700,15 +700,10 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         )
 
     @action(methods=["GET", "POST"], detail=False, url_path="log_view")
+    @disallow_if_impersonated(message="Impersonated sessions cannot log file system views.", allowed_methods=["GET"])
     def log_view(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         if request.method == "GET":
             return self._list_log_views(request)
-
-        if is_impersonated_session(request):
-            return Response(
-                {"detail": "Impersonated sessions cannot log file system views."},
-                status=status.HTTP_403_FORBIDDEN,
-            )
 
         serializer = FileSystemViewLogSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -25,6 +25,7 @@ from posthog.api.team import (
 from posthog.api.utils import raise_if_user_provided_url_unsafe
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.constants import AvailableFeature
+from posthog.decorators import disallow_if_impersonated
 from posthog.event_usage import report_user_action
 from posthog.geoip import get_geoip_properties
 from posthog.jwt import PosthogJwtAudience, encode_jwt
@@ -726,6 +727,7 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
         detail=True,
         required_scopes=["project:read"],
     )
+    @disallow_if_impersonated(message="Impersonated sessions cannot set product intents.")
     def add_product_intent(self, request: request.Request, *args, **kwargs):
         project = self.get_object()
         team = project.passthrough_team
@@ -752,6 +754,7 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
         detail=True,
         required_scopes=["project:read"],
     )
+    @disallow_if_impersonated(message="Impersonated sessions cannot set product intents.")
     def complete_product_onboarding(self, request: request.Request, *args, **kwargs):
         project = self.get_object()
         team = project.passthrough_team

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -21,6 +21,7 @@ from posthog.api.shared import TeamBasicSerializer
 from posthog.api.utils import action, raise_if_user_provided_url_unsafe
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.constants import AvailableFeature
+from posthog.decorators import disallow_if_impersonated
 from posthog.event_usage import report_user_action
 from posthog.geoip import get_geoip_properties
 from posthog.jwt import PosthogJwtAudience, encode_jwt
@@ -1321,6 +1322,7 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
         detail=True,
         required_scopes=["project:read"],
     )
+    @disallow_if_impersonated(message="Impersonated sessions cannot set product intents.")
     def add_product_intent(self, request: request.Request, *args, **kwargs):
         team = self.get_object()
         user = request.user
@@ -1346,6 +1348,7 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
         detail=True,
         required_scopes=["project:read"],
     )
+    @disallow_if_impersonated(message="Impersonated sessions cannot set product intents.")
     def complete_product_onboarding(self, request: request.Request, *args, **kwargs):
         team = self.get_object()
         product_type = request.data.get("product_type")

--- a/posthog/api/test/test_file_system.py
+++ b/posthog/api/test/test_file_system.py
@@ -474,8 +474,8 @@ class TestFileSystemLogViewEndpoint(APIBaseTest):
         representation = obj.get_file_system_representation()
 
         with (
-            patch("posthog.api.file_system.file_system.is_impersonated_session", return_value=True),
-            patch("posthog.api.file_system.file_system.log_api_file_system_view") as mock_logger,
+            patch("posthog.decorators.is_impersonated_session", return_value=True),
+            patch("posthog.api.file_system.file_system_logging.log_api_file_system_view") as mock_logger,
         ):
             response = self.client.post(
                 f"/api/environments/{self.team.id}/file_system/log_view/",

--- a/posthog/api/test/test_file_system.py
+++ b/posthog/api/test/test_file_system.py
@@ -473,17 +473,13 @@ class TestFileSystemLogViewEndpoint(APIBaseTest):
         obj, _ = _create_feature_flag_case(self)  # type: ignore
         representation = obj.get_file_system_representation()
 
-        with (
-            patch("posthog.decorators.is_impersonated_session", return_value=True),
-            patch("posthog.api.file_system.file_system_logging.log_api_file_system_view") as mock_logger,
-        ):
+        with patch("posthog.decorators.is_impersonated_session", return_value=True):
             response = self.client.post(
                 f"/api/environments/{self.team.id}/file_system/log_view/",
                 {"type": representation.type, "ref": str(representation.ref)},
             )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        mock_logger.assert_not_called()
         assert FileSystemViewLog.objects.count() == 0
 
     def test_log_view_endpoint_lists_entries(self) -> None:


### PR DESCRIPTION
## Problem

Certain actions should not be allowed while logged in as another user - such as registering product intents. I noticed errors for these actions while 'read-only' impersonating a user that hadn't completed the intents.

## Changes

Adds a `disallow_if_impersonated` decorator to apply to certain actions + apply it in places we're already blocking things during impersonation.

## How did you test this code?

Added unit tests