### PR TITLE
chore: keep persons db if the keepdb flag is true

### DIFF
--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -146,12 +146,15 @@ def reset_clickhouse_tables():
     run_clickhouse_statement_in_parallel(list(CREATE_DATA_QUERIES))
 
 
-def run_persons_sqlx_migrations():
+def run_persons_sqlx_migrations(keepdb: bool = False):
     """Run sqlx migrations for persons tables in separate test_posthog_persons database.
 
     This creates posthog_person_new and related tables needed for dual-table
     person model migration. Mirrors production migrations in rust/persons_migrations/.
     Uses a separate database to mirror production setup where persons live in their own DB.
+
+    Args:
+        keepdb: If True, reuse existing database (only create if missing). If False, drop and recreate.
     """
     # Build database URL for test_posthog_persons (separate from main test_posthog)
     db_config = settings.DATABASES["default"]
@@ -173,19 +176,20 @@ def run_persons_sqlx_migrations():
 
     env = {**os.environ, "DATABASE_URL": database_url}
 
-    # Drop and recreate database to ensure clean state
-    try:
-        subprocess.run(
-            ["sqlx", "database", "drop", "-y"],
-            env=env,
-            check=True,
-            capture_output=True,
-        )
-    except subprocess.CalledProcessError:
-        # Database might not exist, which is fine
-        pass
+    if not keepdb:
+        # Drop and recreate database to ensure clean state
+        try:
+            subprocess.run(
+                ["sqlx", "database", "drop", "-y"],
+                env=env,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            # Database might not exist, which is fine
+            pass
 
-    # Create fresh database
+    # Create database (idempotent - will succeed if already exists)
     try:
         subprocess.run(
             ["sqlx", "database", "create"],
@@ -194,12 +198,14 @@ def run_persons_sqlx_migrations():
             capture_output=True,
         )
     except subprocess.CalledProcessError as e:
-        raise RuntimeError(
-            f"Failed to create test database with sqlx. "
-            f"Ensure sqlx-cli is installed. Error: {e.stderr.decode() if e.stderr else str(e)}"
-        ) from e
+        # If keepdb=True and database exists, this is expected to fail - that's fine
+        if not keepdb:
+            raise RuntimeError(
+                f"Failed to create test database with sqlx. "
+                f"Ensure sqlx-cli is installed. Error: {e.stderr.decode() if e.stderr else str(e)}"
+            ) from e
 
-    # Run migrations
+    # Run migrations (idempotent - sqlx tracks which migrations have run)
     try:
         subprocess.run(
             ["sqlx", "migrate", "run", "--source", migrations_path],
@@ -274,7 +280,7 @@ def django_db_setup(django_db_setup, django_db_keepdb, django_db_blocker):
             """)
 
     # Run sqlx migrations to create posthog_person_new and related tables
-    run_persons_sqlx_migrations()
+    run_persons_sqlx_migrations(keepdb=django_db_keepdb)
 
     database = Database(
         settings.CLICKHOUSE_DATABASE,


### PR DESCRIPTION
## Problem

The Persons DB is now deleted between test runs, so subsequent pytest commands recreate databases, which takes quite a lot of development time.

## Changes

- Fixed the Persons DB script to keep the database if the flag is active.

## How did you test this code?

Manual testing only
