### PR TITLE
feat(temporal/metrics): Enable dual metric emission in temporal

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -23,7 +23,7 @@ from posthog.temporal.ai import (
     WORKFLOWS as AI_WORKFLOWS,
 )
 from posthog.temporal.common.logger import configure_logger, get_logger
-from posthog.temporal.common.worker import WorkerWithShutdown, create_worker
+from posthog.temporal.common.worker import ManagedWorker, create_worker
 from posthog.temporal.data_imports.settings import (
     ACTIVITIES as DATA_SYNC_ACTIVITIES,
     WORKFLOWS as DATA_SYNC_WORKFLOWS,
@@ -355,7 +355,7 @@ class Command(BaseCommand):
 
         tag_queries(kind="temporal")
 
-        def shutdown_worker_on_signal(worker: WorkerWithShutdown, sig: signal.Signals, loop: asyncio.AbstractEventLoop):
+        def shutdown_worker_on_signal(worker: ManagedWorker, sig: signal.Signals, loop: asyncio.AbstractEventLoop):
             """Shutdown Temporal worker on receiving signal."""
             nonlocal shutdown_task
 
@@ -414,7 +414,7 @@ class Command(BaseCommand):
             for sig in (signal.SIGTERM, signal.SIGINT):
                 loop.add_signal_handler(
                     sig,
-                    functools.partial(shutdown_worker_on_signal, worker_resources=worker, sig=sig, loop=loop),
+                    functools.partial(shutdown_worker_on_signal, worker=worker, sig=sig, loop=loop),
                 )
 
             runner.run(worker.run())

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -361,7 +361,7 @@ class Command(BaseCommand):
 
             logger.info("Signal %s received", sig)
 
-            if worker.is_shutdown:
+            if worker.is_shutdown():
                 logger.info("Temporal worker already shut down")
                 return
 

--- a/posthog/temporal/common/combined_metrics_server.py
+++ b/posthog/temporal/common/combined_metrics_server.py
@@ -39,13 +39,15 @@ def create_handler(temporal_metrics_url: str, registry: CollectorRegistry) -> ty
                 output = temporal_output + client_output
 
                 self.send_response(200)
-                self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+                self.send_header(
+                    "Content-Type", response.getheader("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+                )
                 self.end_headers()
                 self.wfile.write(output)
 
             except Exception as e:
-                logger.exception("combined_metrics_server.error", error=str(e))
                 capture_exception(e)
+                logger.exception("combined_metrics_server.error", error=str(e))
                 self.send_response(500)
                 self.end_headers()
                 self.wfile.write(f"Error: {e}".encode())

--- a/posthog/temporal/common/combined_metrics_server.py
+++ b/posthog/temporal/common/combined_metrics_server.py
@@ -108,6 +108,8 @@ class CombinedMetricsServer:
             return
 
         self._server.shutdown()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
         self._server = None
         self._thread = None
         logger.info("combined_metrics_server.stopped")

--- a/posthog/temporal/common/combined_metrics_server.py
+++ b/posthog/temporal/common/combined_metrics_server.py
@@ -31,7 +31,7 @@ def create_handler(temporal_metrics_url: str, registry: CollectorRegistry) -> ty
                     with urllib.request.urlopen(temporal_metrics_url, timeout=5) as response:
                         temporal_output = response.read()
                         content_type = response.getheader("Content-Type", content_type)
-                except urllib.error.URLError as e:
+                except (urllib.error.URLError, TimeoutError) as e:
                     logger.warning("combined_metrics_server.temporal_fetch_failed", error=str(e))
 
                 # Get prometheus_client metrics

--- a/posthog/temporal/common/combined_metrics_server.py
+++ b/posthog/temporal/common/combined_metrics_server.py
@@ -1,5 +1,4 @@
 import threading
-import urllib.error
 import urllib.request
 from http.server import BaseHTTPRequestHandler, HTTPServer
 

--- a/posthog/temporal/common/combined_metrics_server.py
+++ b/posthog/temporal/common/combined_metrics_server.py
@@ -1,0 +1,199 @@
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Union
+
+from prometheus_client import REGISTRY, Counter, Gauge, Histogram, generate_latest
+from temporalio.runtime import (
+    BUFFERED_METRIC_KIND_COUNTER,
+    BUFFERED_METRIC_KIND_GAUGE,
+    BUFFERED_METRIC_KIND_HISTOGRAM,
+    BufferedMetricUpdate,
+    MetricBuffer,
+)
+
+from posthog.temporal.common.logger import get_write_only_logger
+
+logger = get_write_only_logger(__name__)
+
+# Default histogram buckets suitable for Temporal metrics (in milliseconds when using MILLISECONDS format)
+# These cover a wide range from 1ms to 24 hours
+DEFAULT_HISTOGRAM_BUCKETS = (
+    1.0,
+    5.0,
+    10.0,
+    25.0,
+    50.0,
+    75.0,
+    100.0,
+    250.0,
+    500.0,
+    750.0,
+    1000.0,
+    2500.0,
+    5000.0,
+    7500.0,
+    10000.0,
+    30000.0,
+    60000.0,
+    300000.0,
+    600000.0,
+    900000.0,
+    1800000.0,
+    3600000.0,
+    float("inf"),
+)
+
+
+class TemporalMetricsCollector:
+    """Collects metrics from Temporal's MetricBuffer and converts them to prometheus_client metrics."""
+
+    def __init__(self, metric_buffer: MetricBuffer, metric_prefix: str = ""):
+        self._metric_buffer = metric_buffer
+        self._metric_prefix = metric_prefix
+        self._metrics: dict[str, Union[Counter, Gauge, Histogram]] = {}
+        self._lock = threading.Lock()
+
+    def _get_metric_key(self, name: str, label_names: tuple[str, ...]) -> str:
+        return f"{self._metric_prefix}{name}:{','.join(sorted(label_names))}"
+
+    def _get_or_create_metric(
+        self,
+        update: BufferedMetricUpdate,
+        label_names: tuple[str, ...],
+    ) -> Union[Counter, Gauge, Histogram]:
+        """Get an existing metric or create a new one based on the update."""
+        metric_name = f"{self._metric_prefix}{update.metric.name}"
+        key = self._get_metric_key(update.metric.name, label_names)
+
+        if key in self._metrics:
+            return self._metrics[key]
+
+        description = update.metric.description or f"Temporal metric: {update.metric.name}"
+        kind = update.metric.kind
+
+        if kind == BUFFERED_METRIC_KIND_COUNTER:
+            self._metrics[key] = Counter(metric_name, description, labelnames=label_names)
+        elif kind == BUFFERED_METRIC_KIND_GAUGE:
+            self._metrics[key] = Gauge(metric_name, description, labelnames=label_names)
+        elif kind == BUFFERED_METRIC_KIND_HISTOGRAM:
+            self._metrics[key] = Histogram(
+                metric_name,
+                description,
+                labelnames=label_names,
+                buckets=DEFAULT_HISTOGRAM_BUCKETS,
+            )
+        else:
+            raise ValueError(f"Unknown metric kind: {kind}")
+
+        return self._metrics[key]
+
+    def collect_updates(self) -> None:
+        """Pull metrics from the buffer and update prometheus_client metrics.
+
+        This should be called before serving metrics to ensure fresh data.
+        """
+        with self._lock:
+            try:
+                updates = self._metric_buffer.retrieve_updates()
+            except Exception as e:
+                logger.warning("temporal_metrics_collector.retrieve_failed", error=str(e))
+                return
+
+            for update in updates:
+                try:
+                    label_names = tuple(sorted(update.attributes.keys()))
+                    label_values = {k: str(v) for k, v in update.attributes.items()}
+
+                    metric = self._get_or_create_metric(update, label_names)
+                    kind = update.metric.kind
+
+                    # Handle metrics with and without labels
+                    if label_names:
+                        labeled_metric = metric.labels(**label_values)
+                    else:
+                        labeled_metric = metric
+
+                    if kind == BUFFERED_METRIC_KIND_COUNTER:
+                        labeled_metric.inc(update.value)
+                    elif kind == BUFFERED_METRIC_KIND_GAUGE:
+                        labeled_metric.set(update.value)
+                    elif kind == BUFFERED_METRIC_KIND_HISTOGRAM:
+                        labeled_metric.observe(update.value)
+                except Exception as e:
+                    logger.warning(
+                        "temporal_metrics_collector.update_failed",
+                        metric_name=update.metric.name,
+                        error=str(e),
+                    )
+
+
+class CombinedMetricsHandler(BaseHTTPRequestHandler):
+    """HTTP handler that serves combined Temporal SDK and prometheus_client metrics."""
+
+    temporal_collector: TemporalMetricsCollector | None = None
+
+    def do_GET(self) -> None:
+        if self.path in ("/metrics", "/"):
+            self._serve_combined_metrics()
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _serve_combined_metrics(self) -> None:
+        try:
+            # Collect latest Temporal metrics from the buffer before serving
+            if self.temporal_collector:
+                self.temporal_collector.collect_updates()
+
+            # All metrics (Temporal + app) are now in prometheus_client registry
+            output = generate_latest(REGISTRY)
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(output)
+
+        except Exception as e:
+            logger.exception("combined_metrics_server.error", error=str(e))
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(f"Error: {e}".encode())
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def start_combined_metrics_server(
+    port: int,
+    metric_buffer: MetricBuffer,
+    metric_prefix: str = "",
+) -> HTTPServer:
+    """Start a metrics server combining Temporal SDK and prometheus_client metrics.
+
+    This uses Temporal's MetricBuffer to access metrics directly without any HTTP
+    calls. All metrics are served from a single prometheus_client registry.
+
+    Args:
+        port: Port to expose combined metrics on (e.g., 8001)
+        metric_buffer: The MetricBuffer instance configured in Temporal's Runtime
+        metric_prefix: Prefix to apply to Temporal metric names (e.g., "temporal_")
+
+    Returns:
+        The HTTPServer instance
+    """
+    collector = TemporalMetricsCollector(metric_buffer, metric_prefix=metric_prefix)
+
+    handler = CombinedMetricsHandler
+    handler.temporal_collector = collector
+
+    server = HTTPServer(("0.0.0.0", port), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True, name="combined-metrics-server")
+    thread.start()
+
+    logger.info(
+        "combined_metrics_server.started",
+        port=port,
+        metric_prefix=metric_prefix,
+    )
+
+    return server

--- a/posthog/temporal/common/combined_metrics_server.py
+++ b/posthog/temporal/common/combined_metrics_server.py
@@ -24,11 +24,13 @@ def create_handler(temporal_metrics_url: str, registry: CollectorRegistry) -> ty
 
         def _serve_combined_metrics(self) -> None:
             try:
+                content_type = "text/plain; version=0.0.4; charset=utf-8"
                 # Fetch Temporal SDK metrics from its Prometheus endpoint
                 temporal_output = b""
                 try:
                     with urllib.request.urlopen(temporal_metrics_url, timeout=5) as response:
                         temporal_output = response.read()
+                        content_type = response.getheader("Content-Type")
                 except urllib.error.URLError as e:
                     logger.warning("combined_metrics_server.temporal_fetch_failed", error=str(e))
 
@@ -39,9 +41,7 @@ def create_handler(temporal_metrics_url: str, registry: CollectorRegistry) -> ty
                 output = temporal_output + client_output
 
                 self.send_response(200)
-                self.send_header(
-                    "Content-Type", response.getheader("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-                )
+                self.send_header("Content-Type", content_type)
                 self.end_headers()
                 self.wfile.write(output)
 

--- a/posthog/temporal/common/combined_metrics_server.py
+++ b/posthog/temporal/common/combined_metrics_server.py
@@ -38,11 +38,11 @@ def create_handler(temporal_metrics_url: str, registry: CollectorRegistry) -> ty
                 client_output = generate_latest(registry)
 
                 # Combine both outputs, ensuring proper newline separation.
-                # Prometheus text format requires metrics to be separated by newlines.
-                # If Temporal output doesn't end with a newline, we add one to prevent
-                # malformed output like "temporal_metric 5prometheus_metric 10".
-                if temporal_output and not temporal_output.endswith(b"\n"):
-                    temporal_output += b"\n"
+                # Prometheus text format requires metrics to be separated by exactly one newline.
+                # Strip any trailing newlines from Temporal output and add exactly one to prevent
+                # malformed output or extra blank lines between metric blocks.
+                if temporal_output:
+                    temporal_output = temporal_output.rstrip(b"\n") + b"\n"
 
                 output = temporal_output + client_output
 

--- a/posthog/temporal/common/combined_metrics_server.py
+++ b/posthog/temporal/common/combined_metrics_server.py
@@ -127,11 +127,11 @@ class TemporalMetricsCollector:
                         labeled_metric = metric
 
                     if kind == BUFFERED_METRIC_KIND_COUNTER:
-                        labeled_metric.inc(update.value)
+                        labeled_metric.inc(update.value)  # type: ignore[union-attr]
                     elif kind == BUFFERED_METRIC_KIND_GAUGE:
-                        labeled_metric.set(update.value)
+                        labeled_metric.set(update.value)  # type: ignore[union-attr]
                     elif kind == BUFFERED_METRIC_KIND_HISTOGRAM:
-                        labeled_metric.observe(update.value)
+                        labeled_metric.observe(update.value)  # type: ignore[union-attr]
                 except Exception as e:
                     logger.warning(
                         "temporal_metrics_collector.update_failed",

--- a/posthog/temporal/common/combined_metrics_server.py
+++ b/posthog/temporal/common/combined_metrics_server.py
@@ -24,14 +24,12 @@ def create_handler(temporal_metrics_url: str, registry: CollectorRegistry) -> ty
 
         def _serve_combined_metrics(self) -> None:
             try:
-                content_type = "text/plain; version=0.0.4; charset=utf-8"
                 # Fetch Temporal SDK metrics from its Prometheus endpoint
                 temporal_output = b""
                 try:
                     with urllib.request.urlopen(temporal_metrics_url, timeout=5) as response:
                         temporal_output = response.read()
-                        content_type = response.getheader("Content-Type", content_type)
-                except (urllib.error.URLError, TimeoutError) as e:
+                except Exception as e:
                     logger.warning("combined_metrics_server.temporal_fetch_failed", error=str(e))
 
                 # Get prometheus_client metrics
@@ -47,7 +45,7 @@ def create_handler(temporal_metrics_url: str, registry: CollectorRegistry) -> ty
                 output = temporal_output + client_output
 
                 self.send_response(200)
-                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
                 self.end_headers()
                 self.wfile.write(output)
 

--- a/posthog/temporal/common/combined_metrics_server.py
+++ b/posthog/temporal/common/combined_metrics_server.py
@@ -66,7 +66,7 @@ class TemporalMetricsCollector:
         self._metrics: dict[str, Union[Counter, Gauge, Histogram]] = {}
         # prometheus_client requires label names to be declared at metric creation and raises
         # ValueError('Incorrect label names') if different names are used later.
-        # See: https://prometheus.github.io/client_python/instrumenting/labels/
+        # See: https://prometheus.io/docs/instrumenting/writing_clientlibs/#labels
         # Source: https://github.com/prometheus/client_python/blob/e8f8bae6554de11ebffffcc878ab19abd67528f2/prometheus_client/metrics.py#L175
         # We track the first-seen label set for each metric and skip updates with different labels.
         self._label_names_by_metric: dict[str, tuple[str, ...]] = {}

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -188,7 +188,12 @@ async def create_worker(
 
 
 def get_free_port() -> int:
-    """Find an available port on localhost."""
+    """Find an available port on localhost.
+
+    Note: There's a small race window between this returning and binding.
+    Acceptable for localhost internal ports where collisions are rare,
+    and would fail fast with a port-in-use exception if it occurs.
+    """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -105,7 +105,7 @@ async def create_worker(
             Defaults to 1.0. Only takes effect if target_memory_usage is set.
     """
 
-    temporal_metrics_port = _get_free_port()
+    temporal_metrics_port = get_free_port()
     temporal_metrics_bind_address = f"127.0.0.1:{temporal_metrics_port}"
 
     # Use PrometheusConfig to expose Temporal SDK metrics on an internal port.
@@ -187,7 +187,7 @@ async def create_worker(
     return ManagedWorker(worker=worker, metrics_server=metrics_server)
 
 
-def _get_free_port() -> int:
+def get_free_port() -> int:
     """Find an available port on localhost."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -46,7 +46,7 @@ BATCH_EXPORTS_LATENCY_HISTOGRAM_METRICS = (
     "batch_exports_activity_interval_execution_latency",
     "batch_exports_workflow_interval_execution_latency",
 )
-BATCH_EXPORTS_LATENCY_HISTOGRAM_BUCKETS = [
+BATCH_EXPORTS_LATENCY_HISTOGRAM_BUCKETS = (
     1_000.0,
     30_000.0,  # 30 seconds
     60_000.0,  # 1 minute
@@ -57,7 +57,7 @@ BATCH_EXPORTS_LATENCY_HISTOGRAM_BUCKETS = [
     21_600_000.0,  # 6 hours
     43_200_000.0,  # 12 hours
     86_400_000.0,  # 24 hours
-]
+)
 
 
 async def create_worker(
@@ -131,7 +131,7 @@ async def create_worker(
                 itertools.repeat(BATCH_EXPORTS_LATENCY_HISTOGRAM_BUCKETS),
             )
         )
-        | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0, 100.0]},
+        | {"batch_exports_activity_attempt": (1.0, 5.0, 10.0, 100.0)},
     )
     client = await connect(
         host,

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -1,0 +1,246 @@
+import socket
+import urllib.error
+import urllib.request
+
+import pytest
+from unittest.mock import MagicMock
+
+from prometheus_client import REGISTRY, Counter
+from temporalio.runtime import (
+    BUFFERED_METRIC_KIND_COUNTER,
+    BUFFERED_METRIC_KIND_GAUGE,
+    BUFFERED_METRIC_KIND_HISTOGRAM,
+    MetricBuffer,
+)
+
+from posthog.temporal.common.combined_metrics_server import (
+    DEFAULT_HISTOGRAM_BUCKETS,
+    TemporalMetricsCollector,
+    start_combined_metrics_server,
+)
+
+
+def get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def create_mock_metric_update(name: str, kind: int, value: float, attributes: dict[str, str] | None = None):
+    """Create a mock BufferedMetricUpdate."""
+    mock_metric = MagicMock()
+    mock_metric.name = name
+    mock_metric.description = f"Description for {name}"
+    mock_metric.unit = "ms"
+    mock_metric.kind = kind
+
+    mock_update = MagicMock()
+    mock_update.metric = mock_metric
+    mock_update.value = value
+    mock_update.attributes = attributes or {}
+
+    return mock_update
+
+
+@pytest.fixture
+def mock_metric_buffer():
+    """Create a mock MetricBuffer that returns simulated metrics."""
+    buffer = MagicMock(spec=MetricBuffer)
+    buffer.retrieve_updates.return_value = [
+        create_mock_metric_update("workflow_completed", BUFFERED_METRIC_KIND_COUNTER, 42, {"namespace": "default"}),
+        create_mock_metric_update("active_workers", BUFFERED_METRIC_KIND_GAUGE, 5, {"task_queue": "main"}),
+    ]
+    return buffer
+
+
+@pytest.fixture
+def test_counter():
+    """Create a test prometheus_client counter."""
+    counter_name = f"test_counter_{get_free_port()}"
+    counter = Counter(counter_name, "A test counter for combined metrics")
+    counter.inc()
+    yield counter_name
+    try:
+        REGISTRY.unregister(counter)
+    except Exception:
+        pass
+
+
+class TestTemporalMetricsCollector:
+    def test_collects_counter_metrics(self):
+        unique_prefix = f"tc_{get_free_port()}_"
+        buffer = MagicMock(spec=MetricBuffer)
+        buffer.retrieve_updates.return_value = [
+            create_mock_metric_update("counter", BUFFERED_METRIC_KIND_COUNTER, 10, {"label": "value"}),
+        ]
+
+        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector.collect_updates()
+
+        assert f"{unique_prefix}counter:label" in collector._metrics
+        metric = collector._metrics[f"{unique_prefix}counter:label"]
+        assert metric._name == f"{unique_prefix}counter"
+
+    def test_collects_gauge_metrics(self):
+        unique_prefix = f"tg_{get_free_port()}_"
+        buffer = MagicMock(spec=MetricBuffer)
+        buffer.retrieve_updates.return_value = [
+            create_mock_metric_update("gauge", BUFFERED_METRIC_KIND_GAUGE, 25.5, {"host": "worker1"}),
+        ]
+
+        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector.collect_updates()
+
+        assert f"{unique_prefix}gauge:host" in collector._metrics
+
+    def test_collects_histogram_metrics(self):
+        unique_prefix = f"th_{get_free_port()}_"
+        buffer = MagicMock(spec=MetricBuffer)
+        buffer.retrieve_updates.return_value = [
+            create_mock_metric_update("histogram", BUFFERED_METRIC_KIND_HISTOGRAM, 150.0, {}),
+        ]
+
+        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector.collect_updates()
+
+        assert f"{unique_prefix}histogram:" in collector._metrics
+
+    def test_handles_empty_buffer(self):
+        unique_prefix = f"te_{get_free_port()}_"
+        buffer = MagicMock(spec=MetricBuffer)
+        buffer.retrieve_updates.return_value = []
+
+        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector.collect_updates()
+
+        assert len(collector._metrics) == 0
+
+    def test_handles_buffer_error(self):
+        unique_prefix = f"terr_{get_free_port()}_"
+        buffer = MagicMock(spec=MetricBuffer)
+        buffer.retrieve_updates.side_effect = RuntimeError("Buffer error")
+
+        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector.collect_updates()
+
+        assert len(collector._metrics) == 0
+
+    def test_accumulates_counter_increments(self):
+        unique_prefix = f"tacc_{get_free_port()}_"
+        buffer = MagicMock(spec=MetricBuffer)
+        buffer.retrieve_updates.return_value = [
+            create_mock_metric_update("accumulated", BUFFERED_METRIC_KIND_COUNTER, 5, {}),
+        ]
+
+        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector.collect_updates()
+
+        buffer.retrieve_updates.return_value = [
+            create_mock_metric_update("accumulated", BUFFERED_METRIC_KIND_COUNTER, 3, {}),
+        ]
+        collector.collect_updates()
+
+        metric = collector._metrics[f"{unique_prefix}accumulated:"]
+        # Counter should have been incremented twice (5 + 3 = 8)
+        assert metric._value.get() == 8.0
+
+
+class TestCombinedMetricsServer:
+    def test_serves_combined_metrics(self, mock_metric_buffer, test_counter):
+        port = get_free_port()
+        # Use unique prefix to avoid conflicts with other tests
+        unique_prefix = f"test_{port}_"
+
+        server = start_combined_metrics_server(
+            port=port,
+            metric_buffer=mock_metric_buffer,
+            metric_prefix=unique_prefix,
+        )
+
+        try:
+            url = f"http://127.0.0.1:{port}/metrics"
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode("utf-8")
+
+            # Check Temporal metrics from buffer (with unique prefix)
+            assert f"{unique_prefix}workflow_completed" in content
+            assert f"{unique_prefix}active_workers" in content
+            # Check prometheus_client metrics
+            assert test_counter in content
+        finally:
+            server.shutdown()
+
+    def test_serves_metrics_when_buffer_empty(self, test_counter):
+        port = get_free_port()
+        empty_buffer = MagicMock(spec=MetricBuffer)
+        empty_buffer.retrieve_updates.return_value = []
+        # Use unique prefix that won't match any existing metrics
+        unique_prefix = f"empty_test_{port}_"
+
+        server = start_combined_metrics_server(
+            port=port,
+            metric_buffer=empty_buffer,
+            metric_prefix=unique_prefix,
+        )
+
+        try:
+            url = f"http://127.0.0.1:{port}/metrics"
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode("utf-8")
+
+            # No metrics with our unique prefix since buffer is empty
+            assert f"{unique_prefix}" not in content
+            # But prometheus_client metrics should still be there
+            assert test_counter in content
+        finally:
+            server.shutdown()
+
+    def test_returns_404_for_unknown_paths(self, mock_metric_buffer):
+        port = get_free_port()
+        unique_prefix = f"test404_{port}_"
+
+        server = start_combined_metrics_server(
+            port=port,
+            metric_buffer=mock_metric_buffer,
+            metric_prefix=unique_prefix,
+        )
+
+        try:
+            url = f"http://127.0.0.1:{port}/unknown"
+            with pytest.raises(urllib.error.HTTPError) as exc_info:
+                urllib.request.urlopen(url, timeout=5)
+
+            assert exc_info.value.code == 404
+        finally:
+            server.shutdown()
+
+    def test_root_path_serves_metrics(self, mock_metric_buffer, test_counter):
+        port = get_free_port()
+        unique_prefix = f"testroot_{port}_"
+
+        server = start_combined_metrics_server(
+            port=port,
+            metric_buffer=mock_metric_buffer,
+            metric_prefix=unique_prefix,
+        )
+
+        try:
+            url = f"http://127.0.0.1:{port}/"
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode("utf-8")
+
+            assert f"{unique_prefix}workflow_completed" in content
+            assert test_counter in content
+        finally:
+            server.shutdown()
+
+
+class TestDefaultHistogramBuckets:
+    def test_buckets_cover_wide_range(self):
+        assert DEFAULT_HISTOGRAM_BUCKETS[0] == 1.0  # 1ms
+        assert DEFAULT_HISTOGRAM_BUCKETS[-1] == float("inf")
+        assert 3600000.0 in DEFAULT_HISTOGRAM_BUCKETS  # 1 hour in ms
+
+    def test_buckets_are_sorted(self):
+        finite_buckets = [b for b in DEFAULT_HISTOGRAM_BUCKETS if b != float("inf")]
+        assert finite_buckets == sorted(finite_buckets)

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -1,3 +1,4 @@
+import time
 import socket
 import threading
 import urllib.error
@@ -6,7 +7,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
-from prometheus_client import CollectorRegistry, Counter
+from prometheus_client import CollectorRegistry, Counter, Gauge
 
 from posthog.temporal.common.combined_metrics_server import CombinedMetricsServer
 from posthog.temporal.common.worker import get_free_port
@@ -29,6 +30,39 @@ def create_mock_temporal_server(port: int, metrics_content: bytes) -> HTTPServer
     return server
 
 
+def create_mock_temporal_server_with_error(port: int, status_code: int) -> HTTPServer:
+    """Create a mock HTTP server that returns an HTTP error."""
+
+    class ErrorHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(status_code)
+            self.end_headers()
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    server = HTTPServer(("127.0.0.1", port), ErrorHandler)
+    return server
+
+
+def create_mock_temporal_server_with_delay(port: int, delay_seconds: float) -> HTTPServer:
+    """Create a mock HTTP server that delays before responding."""
+
+    class SlowHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            time.sleep(delay_seconds)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"# HELP slow_metric A slow metric\n")
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    server = HTTPServer(("127.0.0.1", port), SlowHandler)
+    return server
+
+
 @pytest.fixture
 def isolated_registry():
     """Create an isolated CollectorRegistry for test isolation."""
@@ -42,6 +76,18 @@ def test_counter(isolated_registry):
     counter = Counter(counter_name, "A test counter for combined metrics", registry=isolated_registry)
     counter.inc()
     return counter_name
+
+
+@pytest.fixture
+def test_gauge(isolated_registry):
+    """Create a test prometheus_client gauge in an isolated registry.
+
+    Uses Gauge instead of Counter to avoid _created metric for cleaner test comparisons.
+    """
+    gauge_name = "test_gauge"
+    gauge = Gauge(gauge_name, "A test gauge", registry=isolated_registry)
+    gauge.set(100)
+    return gauge_name
 
 
 class TestCombinedMetricsServer:
@@ -202,6 +248,257 @@ temporal_request{operation="DescribeNamespace"} 2
         finally:
             server.stop()
             mock_server.shutdown()
+
+    def test_adds_newline_when_temporal_output_missing_trailing_newline(self, test_gauge, isolated_registry):
+        """Ensure proper newline separation when Temporal output doesn't end with newline."""
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
+
+        # Temporal output WITHOUT trailing newline (one should be added)
+        temporal_metrics = b"# HELP temporal_metric A metric\n# TYPE temporal_metric gauge\ntemporal_metric 42"
+
+        mock_server = create_mock_temporal_server(temporal_port, temporal_metrics)
+        mock_thread = threading.Thread(target=mock_server.serve_forever, daemon=True)
+        mock_thread.start()
+
+        server = CombinedMetricsServer(
+            port=metrics_port,
+            temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
+            registry=isolated_registry,
+        )
+        server.start()
+
+        try:
+            url = f"http://127.0.0.1:{metrics_port}/metrics"
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode("utf-8")
+
+            # Full expected output - newline added after temporal_metric 42
+            expected = """# HELP temporal_metric A metric
+# TYPE temporal_metric gauge
+temporal_metric 42
+# HELP test_gauge A test gauge
+# TYPE test_gauge gauge
+test_gauge 100.0
+"""
+            assert content == expected
+        finally:
+            server.stop()
+            mock_server.shutdown()
+
+    def test_no_extra_newlines_when_temporal_output_empty(self, test_counter, isolated_registry):
+        """No extra newlines when Temporal returns empty response."""
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
+
+        # Empty Temporal output
+        temporal_metrics = b""
+
+        mock_server = create_mock_temporal_server(temporal_port, temporal_metrics)
+        mock_thread = threading.Thread(target=mock_server.serve_forever, daemon=True)
+        mock_thread.start()
+
+        server = CombinedMetricsServer(
+            port=metrics_port,
+            temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
+            registry=isolated_registry,
+        )
+        server.start()
+
+        try:
+            url = f"http://127.0.0.1:{metrics_port}/metrics"
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode("utf-8")
+
+            # prometheus_client metrics should be present
+            assert test_counter in content
+            # Output should not start with empty lines
+            assert not content.startswith("\n")
+        finally:
+            server.stop()
+            mock_server.shutdown()
+
+    def test_duplicate_metric_names_both_present_in_output(self, isolated_registry):
+        """Document: if both sources have same metric name, both appear in output.
+
+        This is intentional - we pass through both outputs as-is and let Prometheus
+        handle any duplicates. In practice, metric names should be unique across
+        Temporal SDK metrics and application metrics.
+        """
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
+
+        # Create a prometheus_client gauge with a name that could conflict
+        # (using Gauge instead of Counter to avoid _total suffix for cleaner comparison)
+        duplicate_name = "duplicate_metric"
+        gauge = Gauge(duplicate_name, "App metric", registry=isolated_registry)
+        gauge.set(100)
+
+        # Temporal output with same metric name
+        temporal_metrics = f"""# HELP {duplicate_name} Temporal metric
+# TYPE {duplicate_name} counter
+{duplicate_name} 42
+""".encode()
+
+        mock_server = create_mock_temporal_server(temporal_port, temporal_metrics)
+        mock_thread = threading.Thread(target=mock_server.serve_forever, daemon=True)
+        mock_thread.start()
+
+        server = CombinedMetricsServer(
+            port=metrics_port,
+            temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
+            registry=isolated_registry,
+        )
+        server.start()
+
+        try:
+            url = f"http://127.0.0.1:{metrics_port}/metrics"
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode("utf-8")
+
+            # Full diff comparison - Temporal metrics first, then prometheus_client
+            # Note: Both sources may define the same metric name, resulting in duplicates
+            expected = f"""# HELP {duplicate_name} Temporal metric
+# TYPE {duplicate_name} counter
+{duplicate_name} 42
+# HELP {duplicate_name} App metric
+# TYPE {duplicate_name} gauge
+{duplicate_name} 100.0
+"""
+            assert content == expected
+        finally:
+            server.stop()
+            mock_server.shutdown()
+
+    def test_strips_multiple_trailing_newlines(self, test_gauge, isolated_registry):
+        """Strip multiple trailing newlines to ensure exactly one newline separates outputs."""
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
+
+        # Temporal output with MULTIPLE trailing newlines (these should be stripped to exactly one)
+        temporal_metrics = b"# HELP temporal_metric A metric\n# TYPE temporal_metric gauge\ntemporal_metric 42\n\n\n"
+
+        mock_server = create_mock_temporal_server(temporal_port, temporal_metrics)
+        mock_thread = threading.Thread(target=mock_server.serve_forever, daemon=True)
+        mock_thread.start()
+
+        server = CombinedMetricsServer(
+            port=metrics_port,
+            temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
+            registry=isolated_registry,
+        )
+        server.start()
+
+        try:
+            url = f"http://127.0.0.1:{metrics_port}/metrics"
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode("utf-8")
+
+            # Full expected output - note exactly ONE newline between temporal and prometheus_client
+            expected = """# HELP temporal_metric A metric
+# TYPE temporal_metric gauge
+temporal_metric 42
+# HELP test_gauge A test gauge
+# TYPE test_gauge gauge
+test_gauge 100.0
+"""
+            assert content == expected
+        finally:
+            server.stop()
+            mock_server.shutdown()
+
+    def test_handles_temporal_http_error(self, test_counter, isolated_registry):
+        """Gracefully degrade when Temporal returns HTTP error (e.g., 500)."""
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
+
+        mock_server = create_mock_temporal_server_with_error(temporal_port, 500)
+        mock_thread = threading.Thread(target=mock_server.serve_forever, daemon=True)
+        mock_thread.start()
+
+        server = CombinedMetricsServer(
+            port=metrics_port,
+            temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
+            registry=isolated_registry,
+        )
+        server.start()
+
+        try:
+            url = f"http://127.0.0.1:{metrics_port}/metrics"
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode("utf-8")
+
+            # prometheus_client metrics should still be served despite Temporal error
+            assert test_counter in content
+            # No Temporal metrics since it returned an error
+            assert "temporal" not in content.lower() or "temporal_metrics" not in content
+        finally:
+            server.stop()
+            mock_server.shutdown()
+
+    def test_handles_temporal_timeout(self, test_counter, isolated_registry):
+        """Gracefully degrade when Temporal is too slow to respond."""
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
+
+        # Create a server that delays longer than our 5s timeout
+        mock_server = create_mock_temporal_server_with_delay(temporal_port, delay_seconds=7)
+        mock_thread = threading.Thread(target=mock_server.serve_forever, daemon=True)
+        mock_thread.start()
+
+        server = CombinedMetricsServer(
+            port=metrics_port,
+            temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
+            registry=isolated_registry,
+        )
+        server.start()
+
+        try:
+            url = f"http://127.0.0.1:{metrics_port}/metrics"
+            # Use a longer timeout for the test request since we need to wait for the internal timeout
+            with urllib.request.urlopen(url, timeout=15) as response:
+                content = response.read().decode("utf-8")
+
+            # prometheus_client metrics should still be served despite Temporal timeout
+            assert test_counter in content
+            # No Temporal metrics since it returned an error
+            assert "temporal" not in content.lower() or "temporal_metrics" not in content
+        finally:
+            server.stop()
+            mock_server.shutdown()
+
+    def test_start_twice_raises_error(self, isolated_registry):
+        """Starting server twice should raise RuntimeError."""
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
+
+        server = CombinedMetricsServer(
+            port=metrics_port,
+            temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
+            registry=isolated_registry,
+        )
+        server.start()
+
+        try:
+            with pytest.raises(RuntimeError, match="Server already started"):
+                server.start()
+        finally:
+            server.stop()
+
+    def test_stop_when_not_started_is_noop(self, isolated_registry):
+        """Stopping server that wasn't started should be safe no-op."""
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
+
+        server = CombinedMetricsServer(
+            port=metrics_port,
+            temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
+            registry=isolated_registry,
+        )
+
+        # Should not raise any exception
+        server.stop()
+        server.stop()  # Multiple stops should also be safe
 
 
 class TestGetFreePort:

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -5,7 +5,7 @@ import urllib.request
 import pytest
 from unittest.mock import MagicMock
 
-from prometheus_client import REGISTRY, Counter
+from prometheus_client import CollectorRegistry, Counter
 from temporalio.runtime import (
     BUFFERED_METRIC_KIND_COUNTER,
     BUFFERED_METRIC_KIND_GAUGE,
@@ -43,6 +43,12 @@ def create_mock_metric_update(name: str, kind: int, value: float, attributes: di
 
 
 @pytest.fixture
+def isolated_registry():
+    """Create an isolated CollectorRegistry for test isolation."""
+    return CollectorRegistry()
+
+
+@pytest.fixture
 def mock_metric_buffer():
     """Create a mock MetricBuffer that returns simulated metrics."""
     buffer = MagicMock(spec=MetricBuffer)
@@ -54,85 +60,75 @@ def mock_metric_buffer():
 
 
 @pytest.fixture
-def test_counter():
-    """Create a test prometheus_client counter."""
-    counter_name = f"test_counter_{get_free_port()}"
-    counter = Counter(counter_name, "A test counter for combined metrics")
+def test_counter(isolated_registry):
+    """Create a test prometheus_client counter in an isolated registry."""
+    counter_name = "test_counter"
+    counter = Counter(counter_name, "A test counter for combined metrics", registry=isolated_registry)
     counter.inc()
-    yield counter_name
-    try:
-        REGISTRY.unregister(counter)
-    except Exception:
-        pass
+    return counter_name
 
 
 class TestTemporalMetricsCollector:
-    def test_collects_counter_metrics(self):
-        unique_prefix = f"tc_{get_free_port()}_"
+    def test_collects_counter_metrics(self, isolated_registry):
         buffer = MagicMock(spec=MetricBuffer)
         buffer.retrieve_updates.return_value = [
             create_mock_metric_update("counter", BUFFERED_METRIC_KIND_COUNTER, 10, {"label": "value"}),
         ]
 
-        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
         collector.collect_updates()
 
-        assert f"{unique_prefix}counter:label" in collector._metrics
-        metric = collector._metrics[f"{unique_prefix}counter:label"]
-        assert metric._name == f"{unique_prefix}counter"
+        assert "test_counter:label" in collector._metrics
+        metric = collector._metrics["test_counter:label"]
+        assert metric._name == "test_counter"
 
-    def test_collects_gauge_metrics(self):
-        unique_prefix = f"tg_{get_free_port()}_"
+    def test_collects_gauge_metrics(self, isolated_registry):
         buffer = MagicMock(spec=MetricBuffer)
         buffer.retrieve_updates.return_value = [
             create_mock_metric_update("gauge", BUFFERED_METRIC_KIND_GAUGE, 25.5, {"host": "worker1"}),
         ]
 
-        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
         collector.collect_updates()
 
-        assert f"{unique_prefix}gauge:host" in collector._metrics
+        assert "test_gauge:host" in collector._metrics
 
-    def test_collects_histogram_metrics(self):
-        unique_prefix = f"th_{get_free_port()}_"
+    def test_collects_histogram_metrics(self, isolated_registry):
         buffer = MagicMock(spec=MetricBuffer)
         buffer.retrieve_updates.return_value = [
             create_mock_metric_update("histogram", BUFFERED_METRIC_KIND_HISTOGRAM, 150.0, {}),
         ]
 
-        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
         collector.collect_updates()
 
-        assert f"{unique_prefix}histogram:" in collector._metrics
+        assert "test_histogram:" in collector._metrics
 
-    def test_handles_empty_buffer(self):
-        unique_prefix = f"te_{get_free_port()}_"
+    def test_handles_empty_buffer(self, isolated_registry):
         buffer = MagicMock(spec=MetricBuffer)
         buffer.retrieve_updates.return_value = []
 
-        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
         collector.collect_updates()
 
         assert len(collector._metrics) == 0
 
-    def test_handles_buffer_error(self):
-        unique_prefix = f"terr_{get_free_port()}_"
+    def test_handles_buffer_error(self, isolated_registry):
         buffer = MagicMock(spec=MetricBuffer)
         buffer.retrieve_updates.side_effect = RuntimeError("Buffer error")
 
-        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
         collector.collect_updates()
 
         assert len(collector._metrics) == 0
 
-    def test_accumulates_counter_increments(self):
-        unique_prefix = f"tacc_{get_free_port()}_"
+    def test_accumulates_counter_increments(self, isolated_registry):
         buffer = MagicMock(spec=MetricBuffer)
         buffer.retrieve_updates.return_value = [
             create_mock_metric_update("accumulated", BUFFERED_METRIC_KIND_COUNTER, 5, {}),
         ]
 
-        collector = TemporalMetricsCollector(buffer, metric_prefix=unique_prefix)
+        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
         collector.collect_updates()
 
         buffer.retrieve_updates.return_value = [
@@ -140,21 +136,20 @@ class TestTemporalMetricsCollector:
         ]
         collector.collect_updates()
 
-        metric = collector._metrics[f"{unique_prefix}accumulated:"]
+        metric = collector._metrics["test_accumulated:"]
         # Counter should have been incremented twice (5 + 3 = 8)
         assert metric._value.get() == 8.0
 
 
 class TestCombinedMetricsServer:
-    def test_serves_combined_metrics(self, mock_metric_buffer, test_counter):
+    def test_serves_combined_metrics(self, mock_metric_buffer, test_counter, isolated_registry):
         port = get_free_port()
-        # Use unique prefix to avoid conflicts with other tests
-        unique_prefix = f"test_{port}_"
 
         server = start_combined_metrics_server(
             port=port,
             metric_buffer=mock_metric_buffer,
-            metric_prefix=unique_prefix,
+            metric_prefix="test_",
+            registry=isolated_registry,
         )
 
         try:
@@ -162,25 +157,24 @@ class TestCombinedMetricsServer:
             with urllib.request.urlopen(url, timeout=5) as response:
                 content = response.read().decode("utf-8")
 
-            # Check Temporal metrics from buffer (with unique prefix)
-            assert f"{unique_prefix}workflow_completed" in content
-            assert f"{unique_prefix}active_workers" in content
+            # Check Temporal metrics from buffer (with prefix)
+            assert "test_workflow_completed" in content
+            assert "test_active_workers" in content
             # Check prometheus_client metrics
             assert test_counter in content
         finally:
             server.shutdown()
 
-    def test_serves_metrics_when_buffer_empty(self, test_counter):
+    def test_serves_metrics_when_buffer_empty(self, test_counter, isolated_registry):
         port = get_free_port()
         empty_buffer = MagicMock(spec=MetricBuffer)
         empty_buffer.retrieve_updates.return_value = []
-        # Use unique prefix that won't match any existing metrics
-        unique_prefix = f"empty_test_{port}_"
 
         server = start_combined_metrics_server(
             port=port,
             metric_buffer=empty_buffer,
-            metric_prefix=unique_prefix,
+            metric_prefix="empty_",
+            registry=isolated_registry,
         )
 
         try:
@@ -188,21 +182,21 @@ class TestCombinedMetricsServer:
             with urllib.request.urlopen(url, timeout=5) as response:
                 content = response.read().decode("utf-8")
 
-            # No metrics with our unique prefix since buffer is empty
-            assert f"{unique_prefix}" not in content
+            # No Temporal metrics with our prefix since buffer is empty
+            assert "empty_" not in content
             # But prometheus_client metrics should still be there
             assert test_counter in content
         finally:
             server.shutdown()
 
-    def test_returns_404_for_unknown_paths(self, mock_metric_buffer):
+    def test_returns_404_for_unknown_paths(self, mock_metric_buffer, isolated_registry):
         port = get_free_port()
-        unique_prefix = f"test404_{port}_"
 
         server = start_combined_metrics_server(
             port=port,
             metric_buffer=mock_metric_buffer,
-            metric_prefix=unique_prefix,
+            metric_prefix="test_",
+            registry=isolated_registry,
         )
 
         try:
@@ -214,14 +208,14 @@ class TestCombinedMetricsServer:
         finally:
             server.shutdown()
 
-    def test_root_path_serves_metrics(self, mock_metric_buffer, test_counter):
+    def test_root_path_serves_metrics(self, mock_metric_buffer, test_counter, isolated_registry):
         port = get_free_port()
-        unique_prefix = f"testroot_{port}_"
 
         server = start_combined_metrics_server(
             port=port,
             metric_buffer=mock_metric_buffer,
-            metric_prefix=unique_prefix,
+            metric_prefix="test_",
+            registry=isolated_registry,
         )
 
         try:
@@ -229,7 +223,7 @@ class TestCombinedMetricsServer:
             with urllib.request.urlopen(url, timeout=5) as response:
                 content = response.read().decode("utf-8")
 
-            assert f"{unique_prefix}workflow_completed" in content
+            assert "test_workflow_completed" in content
             assert test_counter in content
         finally:
             server.shutdown()
@@ -240,7 +234,47 @@ class TestDefaultHistogramBuckets:
         assert DEFAULT_HISTOGRAM_BUCKETS[0] == 1.0  # 1ms
         assert DEFAULT_HISTOGRAM_BUCKETS[-1] == float("inf")
         assert 3600000.0 in DEFAULT_HISTOGRAM_BUCKETS  # 1 hour in ms
+        assert 21600000.0 in DEFAULT_HISTOGRAM_BUCKETS  # 6 hours in ms
+        assert 43200000.0 in DEFAULT_HISTOGRAM_BUCKETS  # 12 hours in ms
+        assert 86400000.0 in DEFAULT_HISTOGRAM_BUCKETS  # 24 hours in ms
 
     def test_buckets_are_sorted(self):
         finite_buckets = [b for b in DEFAULT_HISTOGRAM_BUCKETS if b != float("inf")]
         assert finite_buckets == sorted(finite_buckets)
+
+
+class TestHistogramBucketOverrides:
+    def test_uses_custom_buckets_for_specified_metric(self, isolated_registry):
+        buffer = MagicMock(spec=MetricBuffer)
+        buffer.retrieve_updates.return_value = [
+            create_mock_metric_update("custom_histogram", BUFFERED_METRIC_KIND_HISTOGRAM, 3.0, {}),
+        ]
+
+        custom_buckets = (1.0, 5.0, 10.0, float("inf"))
+        collector = TemporalMetricsCollector(
+            buffer,
+            metric_prefix="test_",
+            histogram_bucket_overrides={"custom_histogram": custom_buckets},
+            registry=isolated_registry,
+        )
+        collector.collect_updates()
+
+        metric = collector._metrics["test_custom_histogram:"]
+        assert tuple(metric._upper_bounds) == custom_buckets
+
+    def test_uses_default_buckets_for_unspecified_metric(self, isolated_registry):
+        buffer = MagicMock(spec=MetricBuffer)
+        buffer.retrieve_updates.return_value = [
+            create_mock_metric_update("default_histogram", BUFFERED_METRIC_KIND_HISTOGRAM, 100.0, {}),
+        ]
+
+        collector = TemporalMetricsCollector(
+            buffer,
+            metric_prefix="test_",
+            histogram_bucket_overrides={"other_metric": (1.0, 2.0, float("inf"))},
+            registry=isolated_registry,
+        )
+        collector.collect_updates()
+
+        metric = collector._metrics["test_default_histogram:"]
+        assert tuple(metric._upper_bounds) == DEFAULT_HISTOGRAM_BUCKETS

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -1,62 +1,37 @@
 import socket
+import threading
 import urllib.error
 import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
-from unittest.mock import MagicMock
 
 from prometheus_client import CollectorRegistry, Counter
-from temporalio.runtime import (
-    BUFFERED_METRIC_KIND_COUNTER,
-    BUFFERED_METRIC_KIND_GAUGE,
-    BUFFERED_METRIC_KIND_HISTOGRAM,
-    MetricBuffer,
-)
 
-from posthog.temporal.common.combined_metrics_server import (
-    DEFAULT_HISTOGRAM_BUCKETS,
-    CombinedMetricsServer,
-    TemporalMetricsCollector,
-)
+from posthog.temporal.common.combined_metrics_server import CombinedMetricsServer, get_free_port
 
 
-def get_free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+def create_mock_temporal_server(port: int, metrics_content: bytes) -> HTTPServer:
+    """Create a mock HTTP server that returns the given metrics content."""
 
+    class MockHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(metrics_content)
 
-def create_mock_metric_update(name: str, kind: int, value: float, attributes: dict[str, str] | None = None):
-    """Create a mock BufferedMetricUpdate."""
-    mock_metric = MagicMock()
-    mock_metric.name = name
-    mock_metric.description = f"Description for {name}"
-    mock_metric.unit = "ms"
-    mock_metric.kind = kind
+        def log_message(self, format: str, *args: object) -> None:
+            pass  # Suppress logging
 
-    mock_update = MagicMock()
-    mock_update.metric = mock_metric
-    mock_update.value = value
-    mock_update.attributes = attributes or {}
-
-    return mock_update
+    server = HTTPServer(("127.0.0.1", port), MockHandler)
+    return server
 
 
 @pytest.fixture
 def isolated_registry():
     """Create an isolated CollectorRegistry for test isolation."""
     return CollectorRegistry()
-
-
-@pytest.fixture
-def mock_metric_buffer():
-    """Create a mock MetricBuffer that returns simulated metrics."""
-    buffer = MagicMock(spec=MetricBuffer)
-    buffer.retrieve_updates.return_value = [
-        create_mock_metric_update("workflow_completed", BUFFERED_METRIC_KIND_COUNTER, 42, {"namespace": "default"}),
-        create_mock_metric_update("active_workers", BUFFERED_METRIC_KIND_GAUGE, 5, {"task_queue": "main"}),
-    ]
-    return buffer
 
 
 @pytest.fixture
@@ -68,159 +43,76 @@ def test_counter(isolated_registry):
     return counter_name
 
 
-class TestTemporalMetricsCollector:
-    def test_collects_counter_metrics(self, isolated_registry):
-        buffer = MagicMock(spec=MetricBuffer)
-        buffer.retrieve_updates.return_value = [
-            create_mock_metric_update("counter", BUFFERED_METRIC_KIND_COUNTER, 10, {"label": "value"}),
-        ]
-
-        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
-        collector.collect_updates()
-
-        assert "test_counter:label" in collector._metrics
-        metric = collector._metrics["test_counter:label"]
-        assert metric._name == "test_counter"
-
-    def test_collects_gauge_metrics(self, isolated_registry):
-        buffer = MagicMock(spec=MetricBuffer)
-        buffer.retrieve_updates.return_value = [
-            create_mock_metric_update("gauge", BUFFERED_METRIC_KIND_GAUGE, 25.5, {"host": "worker1"}),
-        ]
-
-        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
-        collector.collect_updates()
-
-        assert "test_gauge:host" in collector._metrics
-
-    def test_collects_histogram_metrics(self, isolated_registry):
-        buffer = MagicMock(spec=MetricBuffer)
-        buffer.retrieve_updates.return_value = [
-            create_mock_metric_update("histogram", BUFFERED_METRIC_KIND_HISTOGRAM, 150.0, {}),
-        ]
-
-        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
-        collector.collect_updates()
-
-        assert "test_histogram:" in collector._metrics
-
-    def test_handles_empty_buffer(self, isolated_registry):
-        buffer = MagicMock(spec=MetricBuffer)
-        buffer.retrieve_updates.return_value = []
-
-        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
-        collector.collect_updates()
-
-        assert len(collector._metrics) == 0
-
-    def test_handles_buffer_error(self, isolated_registry):
-        buffer = MagicMock(spec=MetricBuffer)
-        buffer.retrieve_updates.side_effect = RuntimeError("Buffer error")
-
-        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
-        collector.collect_updates()
-
-        assert len(collector._metrics) == 0
-
-    def test_accumulates_counter_increments(self, isolated_registry):
-        buffer = MagicMock(spec=MetricBuffer)
-        buffer.retrieve_updates.return_value = [
-            create_mock_metric_update("accumulated", BUFFERED_METRIC_KIND_COUNTER, 5, {}),
-        ]
-
-        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
-        collector.collect_updates()
-
-        buffer.retrieve_updates.return_value = [
-            create_mock_metric_update("accumulated", BUFFERED_METRIC_KIND_COUNTER, 3, {}),
-        ]
-        collector.collect_updates()
-
-        metric = collector._metrics["test_accumulated:"]
-        # Counter should have been incremented twice (5 + 3 = 8)
-        assert metric._value.get() == 8.0  # type: ignore[union-attr]
-
-    def test_skips_updates_with_mismatched_label_sets(self, isolated_registry):
-        buffer = MagicMock(spec=MetricBuffer)
-        buffer.retrieve_updates.return_value = [
-            create_mock_metric_update("my_metric", BUFFERED_METRIC_KIND_COUNTER, 10, {"label_a": "value"}),
-        ]
-
-        collector = TemporalMetricsCollector(buffer, metric_prefix="test_", registry=isolated_registry)
-        collector.collect_updates()
-
-        buffer.retrieve_updates.return_value = [
-            create_mock_metric_update("my_metric", BUFFERED_METRIC_KIND_COUNTER, 5, {"label_b": "value"}),
-        ]
-        collector.collect_updates()
-
-        assert len(collector._metrics) == 1
-        assert "test_my_metric:label_a" in collector._metrics
-
-
 class TestCombinedMetricsServer:
-    def test_serves_combined_metrics(self, mock_metric_buffer, test_counter, isolated_registry):
-        port = get_free_port()
+    def test_serves_combined_metrics(self, test_counter, isolated_registry):
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
+
+        # Mock Temporal metrics
+        temporal_metrics = b"""# HELP temporal_workflow_completed Workflow completions
+# TYPE temporal_workflow_completed counter
+temporal_workflow_completed{namespace="default"} 42
+"""
+
+        mock_server = create_mock_temporal_server(temporal_port, temporal_metrics)
+        mock_thread = threading.Thread(target=mock_server.serve_forever, daemon=True)
+        mock_thread.start()
 
         server = CombinedMetricsServer(
-            port=port,
-            metric_buffer=mock_metric_buffer,
-            metric_prefix="test_",
+            port=metrics_port,
+            temporal_metrics_port=temporal_port,
             registry=isolated_registry,
         )
         server.start()
 
         try:
-            url = f"http://127.0.0.1:{port}/metrics"
+            url = f"http://127.0.0.1:{metrics_port}/metrics"
             with urllib.request.urlopen(url, timeout=5) as response:
                 content = response.read().decode("utf-8")
 
-            # Check Temporal metrics from buffer (with prefix)
-            assert "test_workflow_completed" in content
-            assert "test_active_workers" in content
-            # Check prometheus_client metrics
+            # Check Temporal metrics are included
+            assert "temporal_workflow_completed" in content
+            assert 'namespace="default"' in content
+            # Check prometheus_client metrics are included
+            assert test_counter in content
+        finally:
+            server.stop()
+            mock_server.shutdown()
+
+    def test_serves_metrics_when_temporal_unavailable(self, test_counter, isolated_registry):
+        temporal_port = get_free_port()  # No server running on this port
+        metrics_port = get_free_port()
+
+        server = CombinedMetricsServer(
+            port=metrics_port,
+            temporal_metrics_port=temporal_port,
+            registry=isolated_registry,
+        )
+        server.start()
+
+        try:
+            url = f"http://127.0.0.1:{metrics_port}/metrics"
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode("utf-8")
+
+            # prometheus_client metrics should still be served
             assert test_counter in content
         finally:
             server.stop()
 
-    def test_serves_metrics_when_buffer_empty(self, test_counter, isolated_registry):
-        port = get_free_port()
-        empty_buffer = MagicMock(spec=MetricBuffer)
-        empty_buffer.retrieve_updates.return_value = []
+    def test_returns_404_for_unknown_paths(self, isolated_registry):
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
 
         server = CombinedMetricsServer(
-            port=port,
-            metric_buffer=empty_buffer,
-            metric_prefix="empty_",
+            port=metrics_port,
+            temporal_metrics_port=temporal_port,
             registry=isolated_registry,
         )
         server.start()
 
         try:
-            url = f"http://127.0.0.1:{port}/metrics"
-            with urllib.request.urlopen(url, timeout=5) as response:
-                content = response.read().decode("utf-8")
-
-            # No Temporal metrics with our prefix since buffer is empty
-            assert "empty_" not in content
-            # But prometheus_client metrics should still be there
-            assert test_counter in content
-        finally:
-            server.stop()
-
-    def test_returns_404_for_unknown_paths(self, mock_metric_buffer, isolated_registry):
-        port = get_free_port()
-
-        server = CombinedMetricsServer(
-            port=port,
-            metric_buffer=mock_metric_buffer,
-            metric_prefix="test_",
-            registry=isolated_registry,
-        )
-        server.start()
-
-        try:
-            url = f"http://127.0.0.1:{port}/unknown"
+            url = f"http://127.0.0.1:{metrics_port}/unknown"
             with pytest.raises(urllib.error.HTTPError) as exc_info:
                 urllib.request.urlopen(url, timeout=5)
 
@@ -228,74 +120,83 @@ class TestCombinedMetricsServer:
         finally:
             server.stop()
 
-    def test_root_path_serves_metrics(self, mock_metric_buffer, test_counter, isolated_registry):
-        port = get_free_port()
+    def test_root_path_serves_metrics(self, test_counter, isolated_registry):
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
+
+        temporal_metrics = b"""# HELP temporal_active_workers Active workers
+# TYPE temporal_active_workers gauge
+temporal_active_workers{task_queue="main"} 5
+"""
+
+        mock_server = create_mock_temporal_server(temporal_port, temporal_metrics)
+        mock_thread = threading.Thread(target=mock_server.serve_forever, daemon=True)
+        mock_thread.start()
 
         server = CombinedMetricsServer(
-            port=port,
-            metric_buffer=mock_metric_buffer,
-            metric_prefix="test_",
+            port=metrics_port,
+            temporal_metrics_port=temporal_port,
             registry=isolated_registry,
         )
         server.start()
 
         try:
-            url = f"http://127.0.0.1:{port}/"
+            url = f"http://127.0.0.1:{metrics_port}/"
             with urllib.request.urlopen(url, timeout=5) as response:
                 content = response.read().decode("utf-8")
 
-            assert "test_workflow_completed" in content
+            assert "temporal_active_workers" in content
             assert test_counter in content
         finally:
             server.stop()
+            mock_server.shutdown()
 
 
-class TestDefaultHistogramBuckets:
-    def test_buckets_cover_wide_range(self):
-        assert DEFAULT_HISTOGRAM_BUCKETS[0] == 1.0  # 1ms
-        assert DEFAULT_HISTOGRAM_BUCKETS[-1] == float("inf")
-        assert 3600000.0 in DEFAULT_HISTOGRAM_BUCKETS  # 1 hour in ms
-        assert 21600000.0 in DEFAULT_HISTOGRAM_BUCKETS  # 6 hours in ms
-        assert 43200000.0 in DEFAULT_HISTOGRAM_BUCKETS  # 12 hours in ms
-        assert 86400000.0 in DEFAULT_HISTOGRAM_BUCKETS  # 24 hours in ms
+class TestTemporalMetricFormat:
+    def test_counter_metrics_preserve_type_without_total_suffix(self, isolated_registry):
+        """Verify that Temporal counter metrics preserve their format when passed through."""
+        temporal_port = get_free_port()
+        metrics_port = get_free_port()
 
-    def test_buckets_are_sorted(self):
-        finite_buckets = [b for b in DEFAULT_HISTOGRAM_BUCKETS if b != float("inf")]
-        assert finite_buckets == sorted(finite_buckets)
+        # This is the format Temporal produces with counters_total_suffix=False
+        temporal_metrics = b"""# HELP temporal_request Count of requests
+# TYPE temporal_request counter
+temporal_request{operation="GetSystemInfo"} 1
+temporal_request{operation="DescribeNamespace"} 2
+"""
 
+        mock_server = create_mock_temporal_server(temporal_port, temporal_metrics)
+        mock_thread = threading.Thread(target=mock_server.serve_forever, daemon=True)
+        mock_thread.start()
 
-class TestHistogramBucketOverrides:
-    def test_uses_custom_buckets_for_specified_metric(self, isolated_registry):
-        buffer = MagicMock(spec=MetricBuffer)
-        buffer.retrieve_updates.return_value = [
-            create_mock_metric_update("custom_histogram", BUFFERED_METRIC_KIND_HISTOGRAM, 3.0, {}),
-        ]
-
-        custom_buckets = (1.0, 5.0, 10.0, float("inf"))
-        collector = TemporalMetricsCollector(
-            buffer,
-            metric_prefix="test_",
-            histogram_bucket_overrides={"custom_histogram": custom_buckets},
+        server = CombinedMetricsServer(
+            port=metrics_port,
+            temporal_metrics_port=temporal_port,
             registry=isolated_registry,
         )
-        collector.collect_updates()
+        server.start()
 
-        metric = collector._metrics["test_custom_histogram:"]
-        assert tuple(metric._upper_bounds) == custom_buckets  # type: ignore[union-attr]
+        try:
+            url = f"http://127.0.0.1:{metrics_port}/metrics"
+            with urllib.request.urlopen(url, timeout=5) as response:
+                content = response.read().decode("utf-8")
 
-    def test_uses_default_buckets_for_unspecified_metric(self, isolated_registry):
-        buffer = MagicMock(spec=MetricBuffer)
-        buffer.retrieve_updates.return_value = [
-            create_mock_metric_update("default_histogram", BUFFERED_METRIC_KIND_HISTOGRAM, 100.0, {}),
-        ]
+            # Verify counter type is preserved
+            assert "# TYPE temporal_request counter" in content
+            # Verify metric name has no _total suffix
+            assert "temporal_request{" in content
+            assert "temporal_request_total" not in content
+        finally:
+            server.stop()
+            mock_server.shutdown()
 
-        collector = TemporalMetricsCollector(
-            buffer,
-            metric_prefix="test_",
-            histogram_bucket_overrides={"other_metric": (1.0, 2.0, float("inf"))},
-            registry=isolated_registry,
-        )
-        collector.collect_updates()
 
-        metric = collector._metrics["test_default_histogram:"]
-        assert tuple(metric._upper_bounds) == DEFAULT_HISTOGRAM_BUCKETS  # type: ignore[union-attr]
+class TestGetFreePort:
+    def test_returns_available_port(self):
+        port = get_free_port()
+        assert isinstance(port, int)
+        assert port > 0
+
+        # Verify the port is actually available
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", port))

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -22,7 +22,7 @@ from posthog.temporal.common.combined_metrics_server import (
 
 def get_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
+        s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
 
 

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -37,6 +37,7 @@ def create_mock_temporal_server_with_error(port: int, status_code: int) -> HTTPS
         def do_GET(self) -> None:
             self.send_response(status_code)
             self.end_headers()
+            self.wfile.write(b"# temporal metrics are not included")
 
         def log_message(self, format: str, *args: object) -> None:
             pass
@@ -462,7 +463,7 @@ test_gauge 100.0
             # prometheus_client metrics should still be served despite Temporal timeout
             assert test_counter in content
             # No Temporal metrics since it returned an error
-            assert "temporal" not in content.lower() or "temporal_metrics" not in content
+            assert "temporal" not in content.lower()
         finally:
             server.stop()
             mock_server.shutdown()

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -85,7 +85,7 @@ temporal_long_request_latency_bucket{namespace="default",operation="PollActivity
                 content = response.read().decode("utf-8")
 
             # Check Temporal metrics are included
-            assert temporal_metrics in content
+            assert str(temporal_metrics) in content
             # Check prometheus_client metrics are included
             assert test_counter in content
         finally:
@@ -159,7 +159,7 @@ temporal_active_workers{task_queue="main"} 5
             with urllib.request.urlopen(url, timeout=5) as response:
                 content = response.read().decode("utf-8")
 
-            assert temporal_metrics in content
+            assert str(temporal_metrics) in content
             assert test_counter in content
         finally:
             server.stop()

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -85,7 +85,7 @@ temporal_long_request_latency_bucket{namespace="default",operation="PollActivity
                 content = response.read().decode("utf-8")
 
             # Check Temporal metrics are included
-            assert str(temporal_metrics) in content
+            assert temporal_metrics.decode() in content
             # Check prometheus_client metrics are included
             assert test_counter in content
         finally:
@@ -159,7 +159,7 @@ temporal_active_workers{task_queue="main"} 5
             with urllib.request.urlopen(url, timeout=5) as response:
                 content = response.read().decode("utf-8")
 
-            assert str(temporal_metrics) in content
+            assert temporal_metrics.decode() in content
             assert test_counter in content
         finally:
             server.stop()

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -138,7 +138,7 @@ class TestTemporalMetricsCollector:
 
         metric = collector._metrics["test_accumulated:"]
         # Counter should have been incremented twice (5 + 3 = 8)
-        assert metric._value.get() == 8.0
+        assert metric._value.get() == 8.0  # type: ignore[union-attr]
 
 
 class TestCombinedMetricsServer:
@@ -260,7 +260,7 @@ class TestHistogramBucketOverrides:
         collector.collect_updates()
 
         metric = collector._metrics["test_custom_histogram:"]
-        assert tuple(metric._upper_bounds) == custom_buckets
+        assert tuple(metric._upper_bounds) == custom_buckets  # type: ignore[union-attr]
 
     def test_uses_default_buckets_for_unspecified_metric(self, isolated_registry):
         buffer = MagicMock(spec=MetricBuffer)
@@ -277,4 +277,4 @@ class TestHistogramBucketOverrides:
         collector.collect_updates()
 
         metric = collector._metrics["test_default_histogram:"]
-        assert tuple(metric._upper_bounds) == DEFAULT_HISTOGRAM_BUCKETS
+        assert tuple(metric._upper_bounds) == DEFAULT_HISTOGRAM_BUCKETS  # type: ignore[union-attr]


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Whilst working on a refactor for the metrics emitted in our subscription / export flow (PR: https://github.com/PostHog/posthog/pull/44247), I noticed that we currently only emit `Temporal` metrics within the temporal workers. E.g. code needs to explicitly export metrics through the Temporal metric runner in order for metrics to be exported. This however means that:

- Code using the "django flow" (e.g. celery or the main app) will not emit Temporal metrics (acceptable as Temporal is a subflow)
- Code using the "temporal flow" will not emit any PromQL metrics exported by the Django flow (unacceptable, this leaves a gap in our observability)

The reason for this is that the Temporal workers use their own PromQLRegistry, which excludes / ignores any metrics emitted from the main django flow unless they use the specific Temporal `get_metric_meter()` function.

([Slack thread with more context](https://posthog.slack.com/archives/C09BDQLM8KA/p1767622989159989))

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR introduces a "dual metric emittence" solution for the metrics within the Temporal workers. Effectively it merges the metrics from Temporal and PromQL into a single unified view, resulting in a `/metrics` endpoint which returns both temporal and promql metrics.

I've gone back and forth on the implementation, and the following segment is only relevant if you want a bit of the architectural scope of the solution:

So after some research, it turned out there were a total of 6 options:

  | Option                        | Approach                                                          | Pros                                                   | Cons                                                                |
  |-------------------------------|-------------------------------------------------------------------|--------------------------------------------------------|---------------------------------------------------------------------|
  | 1. Shared Registry            | Have Temporal SDK use prometheus_client.REGISTRY directly         | Single source of truth                                 | Not possible - Temporal SDK uses internal Rust-based metrics system |
  | 2. HTTP Fetching ✅           | Expose Temporal metrics on internal port, fetch and merge         | Preserves exact Temporal format, simple implementation | Extra HTTP call per scrape (few ms latency)                                          |
  | 3. MetricBuffer Interception  | Capture Temporal metrics via buffer, convert to prometheus_client | Direct in-memory access                                | Format incompatibilities (see below)                                |
  | 4. Custom Prometheus Exporter | Write custom exporter handling both metric sources                | Full control                                           | High complexity, maintenance burden                                 |
  | 5. Migrate to OpenTelemetry   | Switch entire metrics stack to OTEL (Temporal supports it natively) | Modern standard, unified metrics pipeline              | Large migration effort, requires changing all existing prometheus_client usage |
  | 6. Separate Endpoints         | Expose two endpoints, configure Prometheus to scrape both           | No code changes needed | Requires Helm/infra changes, two scrape configs to maintain                    |

Initially we looked at option 5, however this is such a massive migration for, currently, little to none added value. Whilst it would be nice to be vendor agnostic, I don't see a situation in the near future where we would move all of our metrics away from Prometheus, and as such, new metrics likely would still be added in the Prometheus format (instead of the OTEL format). Option 6 was dropped as it would complicate our helm-charts for our temporal workers as we would need to add a new scrape target (making use of a different helm chart / operator in order to facilitate this) + it would not be clear from an application PoV which metrics are going where.

__Why `MetricBuffer` Didn't Work__

We initially attempted Option 3 using Temporal's MetricBuffer to intercept metrics and convert them to `prometheus_client` format. This ran into several incompatibilities:

  1. Counter `_total` suffix - `prometheus_client.Counter` hardcodes the `_total` suffix in `generate_latest()`. Temporal emits counters without this suffix (e.g., `temporal_request` not `temporal_request_total`), causing TYPE/name mismatches that Prometheus rejects.
  2. Label validation - Python's `prometheus_client` enforces strict label name validation at metric creation time. Temporal's metric labels don't always conform to these rules, causing runtime errors when trying to create equivalent `prometheus_client` metrics ([code for this can be found here](https://github.com/prometheus/client_python/blob/e8f8bae6554de11ebffffcc878ab19abd67528f2/prometheus_client/metrics.py#L175) and [docs](https://prometheus.io/docs/instrumenting/writing_clientlibs/#labels)).

- [Docs](https://python.temporal.io/temporalio.runtime.TelemetryConfig.html)
- [Someone in a similar situation](https://community.temporal.io/t/merging-prometheus-metrics-from-temporal-sdk-and-local-services-in-a-python-application/12858) 

__Chosen Solution: HTTP Fetching__

We therefore opted for Option 2 - exposing Temporal SDK metrics on an internal localhost port via `PrometheusConfig`, then fetching and merging with `prometheus_client metrics`. This:

- Preserves Temporal's exact metric format (no conversion needed)
- Gracefully degrades if Temporal endpoint is unavailable
- Adds minimal overhead (localhost HTTP call, which gets called every scrape interval, thus roughly every ~15-30s)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

✅ New tests are passing
✅ All metrics from Temporal are present in the new output:

1. Switch to `master` and navigate towards http://localhost:8001/metrics, saving the output as "old.txt"
2. Switch to this branch and navigate towards http://localhost:8001/metrics ,saving the output as "new.txt"
3. Run: `comm -23 <(grep -v '^#' old.txt | grep -v '^$' | sed 's/ [^ ]*$//' | sort -u) \
           <(grep -v '^#' new.txt | grep -v '^$' | sed 's/ [^ ]*$//' | sort -u)` (ignoring the values, but checking if labels match as well)
<img width="1439" height="333" alt="CleanShot 2026-01-06 at 21 26 33" src="https://github.com/user-attachments/assets/35b303e3-6466-4a48-a252-e8bb53005feb" />

The diff here is accepted / fine as that is a uniquely generated ID, the rest all matches which confirms this is working as expected.

✅ Running the subscription flow, correctly increments the `django promql` metrics

<img width="853" height="922" alt="CleanShot 2026-01-06 at 21 50 34" src="https://github.com/user-attachments/assets/b75c422a-c023-48c0-8e02-b85b84ad81d6" />

✅ Passing the metric output through `promtool` validates as expected:

```
❯ curl -s http://localhost:8001/metrics | promtool check metrics
cohort_staleness_hours use base unit "seconds" instead of "hours"
cohort_stuck_count non-histogram and non-summary metrics should not have "_count" suffix
posthog_redis_could_not_decompress_value_counter_total metric name should not include type 'counter'
posthog_session_summary_tokens_in_prompt_histogram metric name should not include type 'histogram'
posthog_survey_summary_tokens_in_prompt_histogram metric name should not include type 'histogram'
replay_playlists_in_redis_gauge metric name should not include type 'gauge'
replay_total_playlists_gauge metric name should not include type 'gauge'
session_snapshots_generate_pre_signed_url_histogram metric name should not include type 'histogram'
session_snapshots_loading_v2_lts_counter_total metric name should not include type 'counter'
subscription_queued counter metrics should have "_total" suffix
subscription_send_failure counter metrics should have "_total" suffix
subscription_send_success counter metrics should have "_total" suffix
temporal_activity_poll_no_task counter metrics should have "_total" suffix
temporal_activity_task_received counter metrics should have "_total" suffix
temporal_long_request counter metrics should have "_total" suffix
temporal_request counter metrics should have "_total" suffix
temporal_sticky_cache_hit counter metrics should have "_total" suffix
temporal_worker_start counter metrics should have "_total" suffix
temporal_workflow_completed counter metrics should have "_total" suffix
temporal_workflow_task_queue_poll_empty counter metrics should have "_total" suffix
temporal_workflow_task_queue_poll_succeed counter metrics should have "_total" suffix
```

All these warnings are "fine" and are expected.

- The "seconds instead of hours" is a naming thing, which is not a regression introduced here.
- The "metrics should not have '_count' suffix" is a naming thing, which is not a regression introduced here.
- The "metric name should not include type 'xxx'" is a naming thing, which is not a regression introduced here (and you can find them as is in the code definition).
- The "metrics should have '_total' suffix" is the result of how temporal manages their counters where it omits the "_total" suffix, which is not a regression introduced here.

All in all, prometheus parsed the metrics fine and it just flagged some metrics which might not adhere to their best practices which is acceptable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No