### PR TITLE
feat(logs): disable logs prettify button if log line is not json

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogRowFAB/LogRowFAB.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogRowFAB/LogRowFAB.tsx
@@ -74,9 +74,11 @@ export function LogRowFAB({
                         e.preventDefault()
                         onTogglePrettify?.(log)
                     }}
+                    active={isPrettified}
                     tooltip={isPrettified ? 'Collapse JSON' : 'Prettify JSON'}
                     aria-label={isPrettified ? 'Collapse JSON' : 'Prettify JSON'}
                     className={cn(isPrettified ? 'text-brand-blue' : 'text-muted')}
+                    disabledReason={log.parsedBody === null ? 'Log body is not valid JSON' : undefined}
                 />
                 <LemonButton
                     size="xsmall"


### PR DESCRIPTION
## Problem

currently the prettify json button exists for all log lines, but does nothing if it's not a json line. Make it disabled in this case
## Changes

disable pretty json button if log line is not json
<img width="1042" height="224" alt="image" src="https://github.com/user-attachments/assets/eeeb176f-83ff-4523-8fb9-304be3ba9320" />

also made it highlight while active:
<img width="295" height="193" alt="image" src="https://github.com/user-attachments/assets/8fed64cb-880d-4838-8b3d-b209d807d111" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
just locally

## Publish to changelog?
no, too minor
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
