### PR TITLE
feat(zen-mode): persist zen mode

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -237,6 +237,7 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
         ],
         zenMode: [
             false,
+            { persist: true },
             {
                 setZenMode: (_, { zenMode }) => zenMode,
                 toggleZenMode: (state) => !state,


### PR DESCRIPTION
## Problem

The Zen Mode setting in the navigation logic is not persisted between sessions, causing users to lose their preferred view mode when refreshing or returning to the app.

## Changes

Added persistence to the Zen Mode state in the navigation logic by adding the `{ persist: true }` option to the `zenMode` reducer. This ensures that a user's preference for Zen Mode is remembered across browser sessions.

## How did you test this code?

1. Enabled Zen Mode in the application
2. Refreshed the page and verified that Zen Mode remained enabled
3. Disabled Zen Mode
4. Closed the browser and reopened the application
5. Verified that Zen Mode remained disabled as expected

## Publish to changelog?

No