### PR TITLE
feat(zen-mode): hide scene title section and place scene title in minimal nav when zen mode is on

### DIFF
--- a/frontend/src/layout/navigation-3000/components/MinimalNavigation.tsx
+++ b/frontend/src/layout/navigation-3000/components/MinimalNavigation.tsx
@@ -31,7 +31,7 @@ export function MinimalNavigation(): JSX.Element {
             <LemonButton noPadding icon={<IconLogomark className="text-3xl mx-2" />} to={logoUrl} />
             {sceneConfig?.name && zenMode && (
                 <span className="font-semibold text-base flex items-center gap-2">
-                    {sceneConfig.iconType ? iconForType(sceneConfig.iconType) : ''}
+                    {sceneConfig.iconType ? iconForType(sceneConfig.iconType) : null}
                     {sceneConfig.name}
                 </span>
             )}

--- a/frontend/src/layout/navigation-3000/components/MinimalNavigation.tsx
+++ b/frontend/src/layout/navigation-3000/components/MinimalNavigation.tsx
@@ -6,16 +6,22 @@ import { LemonButton, ProfilePicture } from '@posthog/lemon-ui'
 import { AccountMenu } from 'lib/components/Account/AccountMenu'
 import { ProjectMenu } from 'lib/components/Account/ProjectMenu'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { sceneLogic } from 'scenes/sceneLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+
+import { navigation3000Logic } from '../navigationLogic'
 import { ZenModeButton } from './ZenModeButton'
 
 export function MinimalNavigation(): JSX.Element {
     const { user } = useValues(userLogic)
     const { currentOrganization } = useValues(organizationLogic)
     const { hasOnboardedAnyProduct, currentTeam } = useValues(teamLogic)
+    const { sceneConfig } = useValues(sceneLogic)
+    const { zenMode } = useValues(navigation3000Logic)
 
     const shouldShowOnboarding = !hasOnboardedAnyProduct && !currentTeam?.ingested_event
     const logoUrl = shouldShowOnboarding ? urls.useCaseSelection() : urls.projectRoot()
@@ -23,6 +29,12 @@ export function MinimalNavigation(): JSX.Element {
     return (
         <nav className="flex items-center gap-2 p-2 border-b">
             <LemonButton noPadding icon={<IconLogomark className="text-3xl mx-2" />} to={logoUrl} />
+            {sceneConfig?.name && zenMode && (
+                <span className="font-semibold text-base flex items-center gap-2">
+                    {sceneConfig.iconType ? iconForType(sceneConfig.iconType) : ''}
+                    {sceneConfig.name}
+                </span>
+            )}
             <div className="flex items-center justify-end gap-2 flex-1">
                 <ZenModeButton />
                 {(currentOrganization?.teams?.length ?? 0 > 1) ? (

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -11,6 +11,7 @@ import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { cn } from 'lib/utils/css-classes'
 
+import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import { FileSystemIconType } from '~/queries/schema/schema-general'
 import { Breadcrumb, FileSystemIconColor } from '~/types'
@@ -147,6 +148,7 @@ export function SceneTitleSection({
     className,
 }: SceneMainTitleProps): JSX.Element | null {
     const { breadcrumbs } = useValues(breadcrumbsLogic)
+    const { zenMode } = useValues(navigation3000Logic)
     const willShowBreadcrumbs = forceBackTo || breadcrumbs.length > 2
     const [isScrolled, setIsScrolled] = useState(false)
 
@@ -176,6 +178,11 @@ export function SceneTitleSection({
     ) : (
         iconForType(resourceType.type ? (resourceType.type as FileSystemIconType) : undefined)
     )
+
+    if (zenMode) {
+        return null
+    }
+
     return (
         <>
             {/* Description is not sticky, therefor, if there is description, we render a line after scroll  */}


### PR DESCRIPTION
## Problem

In Zen Mode, the scene title takes up extra space.

Zen mode's ethos is "radical minimalism"

![image.png](https://app.graphite.com/user-attachments/assets/0574df2f-e2f2-4e50-bbad-60c6bbbb39f8.png)

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/575b668b-f46d-4d91-bd32-a88addbb2b87.png)

- Added scene name and icon to the minimal navigation bar when in Zen Mode
- Hide the SceneTitleSection component when in Zen Mode

## How did you test this code?

- Enabling Zen Mode and verifying the scene name and icon appear in the minimal navigation
- Checking that the scene title section is properly hidden when in Zen Mode
- Testing across different scenes to ensure the correct icons and names are displayed
- Verifying the layout remains consistent with the design

## Publish to changelog?

No