### PR TITLE
fix: target the sharded data table for metadata deletes

### DIFF
--- a/posthog/temporal/delete_recordings/activities.py
+++ b/posthog/temporal/delete_recordings/activities.py
@@ -333,9 +333,10 @@ async def perform_recording_metadata_deletion(input: DeleteRecordingMetadataInpu
     session_id_list = [sid.decode("utf-8") for sid in session_ids]
     logger.info(f"Found {len(session_id_list)} session IDs to delete")
 
-    # Delete from ClickHouse
+    # Delete from ClickHouse - must target the sharded data table directly,
+    # not the Distributed table (which doesn't support mutations)
     query = """
-        ALTER TABLE session_replay_events
+        ALTER TABLE sharded_session_replay_events
         DELETE WHERE session_id IN %(session_ids)s
     """
 

--- a/posthog/temporal/tests/delete_recordings/test_activities.py
+++ b/posthog/temporal/tests/delete_recordings/test_activities.py
@@ -533,7 +533,7 @@ async def test_perform_recording_metadata_deletion_with_sessions():
     call_args = mock_client.execute_query.call_args
     query = call_args.args[0] if call_args.args else call_args.kwargs.get("query")
     query_parameters = call_args.kwargs.get("query_parameters")
-    assert "ALTER TABLE session_replay_events" in query
+    assert "ALTER TABLE sharded_session_replay_events" in query
     assert "DELETE WHERE session_id IN" in query
     assert set(query_parameters["session_ids"]) == {"session-1", "session-2", "session-3"}
 


### PR DESCRIPTION
Metadata deletion is currently not working since the query targets the distributed table when it should in fact target the sharded data table.