### PR TITLE
feat(zen): remove title and description section when in zen mode

### DIFF
--- a/frontend/src/layout/navigation-3000/components/MinimalNavigation.tsx
+++ b/frontend/src/layout/navigation-3000/components/MinimalNavigation.tsx
@@ -6,16 +6,20 @@ import { LemonButton, ProfilePicture } from '@posthog/lemon-ui'
 import { AccountMenu } from 'lib/components/Account/AccountMenu'
 import { ProjectMenu } from 'lib/components/Account/ProjectMenu'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { sceneLogic } from 'scenes/sceneLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
+import { navigation3000Logic } from '../navigationLogic'
 import { ZenModeButton } from './ZenModeButton'
 
 export function MinimalNavigation(): JSX.Element {
     const { user } = useValues(userLogic)
     const { currentOrganization } = useValues(organizationLogic)
     const { hasOnboardedAnyProduct, currentTeam } = useValues(teamLogic)
+    const { zenMode } = useValues(navigation3000Logic)
+    const { titleAndIcon } = useValues(sceneLogic)
 
     const shouldShowOnboarding = !hasOnboardedAnyProduct && !currentTeam?.ingested_event
     const logoUrl = shouldShowOnboarding ? urls.useCaseSelection() : urls.projectRoot()
@@ -23,7 +27,12 @@ export function MinimalNavigation(): JSX.Element {
     return (
         <nav className="flex items-center gap-2 p-2 border-b">
             <LemonButton noPadding icon={<IconLogomark className="text-3xl mx-2" />} to={logoUrl} />
-            <div className="flex items-center justify-end gap-2 flex-1">
+            {zenMode && (
+                <div className="flex-1 flex justify-start items-center px-4">
+                    <span className="text-lg font-semibold text-primary truncate">{titleAndIcon.title}</span>
+                </div>
+            )}
+            <div className={`flex items-center justify-end gap-2 ${zenMode ? '' : 'flex-1'}`}>
                 <ZenModeButton />
                 {(currentOrganization?.teams?.length ?? 0 > 1) ? (
                     <ProjectMenu

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -12,6 +12,7 @@ import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/Wrapping
 import { cn } from 'lib/utils/css-classes'
 
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
+import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { FileSystemIconType } from '~/queries/schema/schema-general'
 import { Breadcrumb, FileSystemIconColor } from '~/types'
 
@@ -146,9 +147,15 @@ export function SceneTitleSection({
     forceBackTo,
     className,
 }: SceneMainTitleProps): JSX.Element | null {
+    const { zenMode } = useValues(navigation3000Logic)
     const { breadcrumbs } = useValues(breadcrumbsLogic)
     const willShowBreadcrumbs = forceBackTo || breadcrumbs.length > 2
     const [isScrolled, setIsScrolled] = useState(false)
+
+    // Hide entire title section in zen mode
+    if (zenMode) {
+        return null
+    }
 
     const effectiveDescription = description
 
@@ -409,8 +416,14 @@ function SceneDescription({
     renameDebounceMs = 100,
     saveOnBlur = false,
 }: SceneDescriptionProps): JSX.Element | null {
+    const { zenMode } = useValues(navigation3000Logic)
     const [description, setDescription] = useState(initialDescription)
     const [isEditing, setIsEditing] = useState(forceEdit)
+    
+    // Hide descriptions in zen mode
+    if (zenMode) {
+        return null
+    }
 
     const textClasses = 'text-sm my-0 select-auto'
 

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -416,14 +416,8 @@ function SceneDescription({
     renameDebounceMs = 100,
     saveOnBlur = false,
 }: SceneDescriptionProps): JSX.Element | null {
-    const { zenMode } = useValues(navigation3000Logic)
     const [description, setDescription] = useState(initialDescription)
     const [isEditing, setIsEditing] = useState(forceEdit)
-    
-    // Hide descriptions in zen mode
-    if (zenMode) {
-        return null
-    }
 
     const textClasses = 'text-sm my-0 select-auto'
 

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -11,8 +11,8 @@ import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { cn } from 'lib/utils/css-classes'
 
-import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
+import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import { FileSystemIconType } from '~/queries/schema/schema-general'
 import { Breadcrumb, FileSystemIconColor } from '~/types'
 
@@ -152,11 +152,6 @@ export function SceneTitleSection({
     const willShowBreadcrumbs = forceBackTo || breadcrumbs.length > 2
     const [isScrolled, setIsScrolled] = useState(false)
 
-    // Hide entire title section in zen mode
-    if (zenMode) {
-        return null
-    }
-
     const effectiveDescription = description
 
     useEffect(() => {
@@ -175,6 +170,11 @@ export function SceneTitleSection({
         observer.observe(stickyElement)
         return () => observer.disconnect()
     }, [])
+
+    // Hide entire title section in zen mode
+    if (zenMode) {
+        return null
+    }
 
     const icon = resourceType.forceIcon ? (
         <ProductIconWrapper type={resourceType.type} colorOverride={resourceType.forceIconColorOverride}>


### PR DESCRIPTION
## Problem

the title + description take up a lot of space, remove them in zen-mode and move title to the top bar instead

## Changes

before:
<img width="673" height="396" alt="image" src="https://github.com/user-attachments/assets/f246f140-8848-43d0-ac4d-dadc84be6cb3" />

after:
<img width="1340" height="738" alt="image" src="https://github.com/user-attachments/assets/3ce0dff2-9a82-4c9f-ad8f-a6b0b1b7f194" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no
