### PR TITLE
fix(phai): search error tracking issues tool tests

### DIFF
--- a/products/error_tracking/backend/tools/search_issues.py
+++ b/products/error_tracking/backend/tools/search_issues.py
@@ -155,6 +155,9 @@ class SearchErrorTrackingIssuesTool(MaxTool):
     args_schema: type[BaseModel] = SearchErrorTrackingIssuesArgs
     description: str = TOOL_DESCRIPTION
 
+    def get_required_resource_access(self):
+        return [("error_tracking", "viewer")]
+
     async def _arun_impl(self, query: ErrorTrackingQuery) -> tuple[str, ToolMessagesArtifact | None]:
         # Adding some sane default limits
         if query.limit is None or query.limit <= 0:


### PR DESCRIPTION
## Problem

The `SearchErrorTrackingIssuesTool` was missing the `get_required_resource_access()` method, causing the `TestToolAccessControlDeclarations` test to fail and indicating a potential access control gap.

## Changes

Added the `get_required_resource_access()` method to `SearchErrorTrackingIssuesTool`, declaring its requirement for `("error_tracking", "viewer")` access. This aligns with other error tracking tools that read similar data.

## How did you test this code?

- Ran `ee/hogai/test/test_tool.py` which now passes.
- Ran `mypy` checks, no new issues found.

## Publish to changelog?

no

---
<a href="https://cursor.com/background-agent?bcId=bc-02398be8-e14b-4588-9a48-db0cb0a8702c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02398be8-e14b-4588-9a48-db0cb0a8702c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

