### PR TITLE
feat(Sparkline): add tooltipRowCutoff prop to limit series in tooltip

### DIFF
--- a/frontend/src/lib/components/Sparkline.tsx
+++ b/frontend/src/lib/components/Sparkline.tsx
@@ -48,6 +48,8 @@ interface SparklineProps {
     renderLabel?: (label: string) => string
     className?: string
     onSelectionChange?: (selection: { startIndex: number; endIndex: number }) => void
+    /** Maximum number of series to show in tooltip. @default 8 */
+    tooltipRowCutoff?: number
 }
 
 export function Sparkline({
@@ -65,6 +67,7 @@ export function Sparkline({
     renderLabel,
     onSelectionChange,
     className,
+    tooltipRowCutoff,
 }: SparklineProps): JSX.Element {
     const tooltipRef = useRef<HTMLDivElement | null>(null)
 
@@ -336,6 +339,7 @@ export function Sparkline({
                             }))}
                             renderSeries={(value) => value}
                             renderCount={(count) => humanFriendlyNumber(count)}
+                            rowCutoff={tooltipRowCutoff}
                         />
                     }
                     placement="bottom-start"


### PR DESCRIPTION
## Problem

The Sparkline component currently doesn't allow customization of the number of series shown in the tooltip, which means that we can't show more than 8 series - which is needed for the logs sparkline.

## Changes

Added a new optional prop `tooltipRowCutoff` to the Sparkline component that allows limiting the number of series displayed in the tooltip. The default value is set to 8 rows.

- Added TypeScript prop definition with JSDoc comment
- Added the prop to the component's parameter list
- Passed the value to the tooltip component via the `rowCutoff` prop

## How did you test this code?

Tested by rendering Sparkline components with various numbers of data series and verifying that:
- The tooltip correctly limits displayed rows to the specified cutoff value
- The default behavior (8 rows) works as expected when no value is provided
- The component continues to function properly with all other existing features

## Publish to changelog?

No