### PR TITLE
fix(ci): use inline script metadata for grimp dependency

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -283,11 +283,14 @@ jobs:
                   # Check for non-Python files that can't be detected via import analysis
                   echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
 
+            - name: Install uv for dependency analysis
+              uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+
             - name: Check for Python dependency changes that affect analytics platform temporal worker
               id: check_python_changes_analytics_platform_temporal_worker
               run: |
                   CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | tr '\n' ' ')
-                  RESULT=$(python3 bin/find_python_dependencies.py posthog.temporal.subscriptions --check-changes "$CHANGED_FILES" | jq -r '.affected') || RESULT="true"
+                  RESULT=$(uv run bin/find_python_dependencies.py posthog.temporal.subscriptions --check-changes "$CHANGED_FILES" | jq -r '.affected') || RESULT="true"
                   echo "changed=$RESULT" >> $GITHUB_OUTPUT
 
             - name: Trigger Billing Temporal Worker Cloud deployment

--- a/bin/find_python_dependencies.py
+++ b/bin/find_python_dependencies.py
@@ -1,4 +1,10 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "grimp==3.13",
+# ]
+# ///
 """
 Find all local Python dependencies for a given entrypoint file.
 


### PR DESCRIPTION
**Alternative to #44302** - simpler fix for the missing grimp dependency.

**Problem**
The CI workflow `container-images-cd.yml` calls `python3 bin/find_python_dependencies.py` but grimp isn't installed at that point.

**Solution**
Use PEP 723 inline script metadata (same pattern as `bin/hobby-ci.py`):

```python
#!/usr/bin/env -S uv run --script
# /// script
# requires-python = ">=3.12"
# dependencies = [
#     "grimp==3.13",
# ]
# ///
```

When you run `uv run bin/find_python_dependencies.py`, uv reads the inline metadata and installs dependencies automatically.

**Why this over #44302**
- No separate `bin/pyproject.toml` (158-line lockfile)
- No pytest.ini changes or `--ignore=bin` workarounds
- Follows existing pattern (`bin/hobby-ci.py` does exactly this)
- Script is self-contained
- 2 files changed vs 9 files

**Test**
```
$ uv run bin/find_python_dependencies.py posthog.temporal.subscriptions --check-changes "posthog/utils.py"
Installed 2 packages in 3ms
{"affected": true, "matching_files": ["posthog/utils.py"]}

$ pytest bin/test/test_find_python_dependencies.py -v
47 passed in 0.30s
```