### PR TITLE
fix(ph-ai): handling prompt on re-auth onboarding

### DIFF
--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -79,14 +79,12 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
         setShowAutocomplete(isSlashCommand)
     }, [question, showAutocomplete])
 
-    let disabledReason = !threadLoading
-        ? !dataProcessingAccepted
-            ? 'Pending approval'
-            : submissionDisabledReason
-        : undefined
+    const pendingApproval = !dataProcessingAccepted && !threadLoading
+    let disabledReason = !threadLoading ? submissionDisabledReason : undefined
     if (cancelLoading) {
         disabledReason = 'Cancelling...'
     }
+    const tooltipReason = pendingApproval ? 'Pending approval' : disabledReason
 
     return (
         <div
@@ -210,8 +208,8 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                                     askMax(question)
                                 }}
                                 tooltip={
-                                    disabledReason ? (
-                                        disabledReason
+                                    tooltipReason ? (
+                                        tooltipReason
                                     ) : threadLoading ? (
                                         <>
                                             Let's bail <KeyboardShortcut enter />
@@ -224,7 +222,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                                 }
                                 loading={threadLoading && !dataProcessingAccepted}
                                 disabledReason={disabledReason}
-                                className={disabledReason ? 'opacity-[0.5]' : ''}
+                                className={tooltipReason ? 'opacity-[0.5]' : ''}
                                 size="small"
                                 icon={
                                     threadLoading ? (

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -24,7 +24,11 @@ import { Breadcrumb, Conversation, ConversationDetail, ConversationStatus, SideP
 import { maxContextLogic } from './maxContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
 import type { maxLogicType } from './maxLogicType'
+import { PENDING_AI_PROMPT_KEY } from './maxThreadLogic'
 import { MaxUIContext } from './maxTypes'
+
+/** Maximum age for restored prompts (5 minutes) */
+const PENDING_PROMPT_MAX_AGE_MS = 5 * 60 * 1000
 
 export type MessageStatus = 'loading' | 'completed' | 'error'
 
@@ -431,6 +435,23 @@ export const maxLogic = kea<maxLogicType>([
     })),
 
     afterMount(({ actions, values }) => {
+        // Restore pending prompt from sessionStorage (e.g., after OAuth redirect during consent flow)
+        if (!values.question) {
+            try {
+                const stored = sessionStorage.getItem(PENDING_AI_PROMPT_KEY)
+                if (stored) {
+                    const { prompt, timestamp } = JSON.parse(stored)
+                    const isRecent = Date.now() - timestamp < PENDING_PROMPT_MAX_AGE_MS
+                    if (isRecent && prompt) {
+                        actions.setQuestion(prompt)
+                    }
+                    sessionStorage.removeItem(PENDING_AI_PROMPT_KEY)
+                }
+            } catch {
+                // sessionStorage might be unavailable or data malformed
+            }
+        }
+
         // If there is a prefill question from side panel state (from opening Max within the app), use it
         if (
             !values.question &&


### PR DESCRIPTION
## Problem

A [ticket](https://posthoghelp.zendesk.com/agent/tickets/46218) from a user highlighted a poor onboarding experience from PostHog AI, namely:

* long prompt to agent
* ai consent modal popped-up
* submitted approval
* re-auth triggered
* lost prompt

**Bonus**: submit button prior to consent been approved wasn't clickable, the user could only send the prompt (and thus init onboarding via the `return` key)
<img width="429" height="270" alt="re_auth_flow" src="https://github.com/user-attachments/assets/6077797b-d916-485c-a79b-f5e2d72cc1dc" />

https://github.com/user-attachments/assets/74b97469-5107-4a5d-be09-f73d2a42c6f4

(triggered re-auth manually since oauth flow cannot be replicated locally, same high-level flow tough)

## Changes

* persist pending prompt to sessionStorage when user submits but consent isn't (yet) accepted
* restore prompt on page load after redirect completes
* make submit button clickable during "Pending approval" state so it triggers consent flow (same as pressing return key)

## How did you test this code?

- [x] manual tests
