### PR TITLE
fix: Fix login email prefilled with invalid email after running demo data

### DIFF
--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -7,6 +7,7 @@ import secrets
 import datetime as dt
 from time import monotonic
 from typing import Optional
+from urllib.parse import quote
 
 from django.core import exceptions
 from django.core.management.base import BaseCommand
@@ -216,10 +217,10 @@ class Command(BaseCommand):
                     if existing_team_id is not None
                     else f"\nDemo data ready for {user.email}!\n\n"
                     "Pre-fill the login form with this link:\n"
-                    f"http://localhost:8010/login?email={user.email}\n"
+                    f"http://localhost:8010/login?email={quote(user.email)}\n"
                     f"The password is:\n{password}\n\n"
                     "If running demo mode (DEMO=1), log in instantly with this link:\n"
-                    f"http://localhost:8010/signup?email={user.email}\n"
+                    f"http://localhost:8010/signup?email={quote(user.email)}\n"
                 )
             )
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Developers running demo data multiple times saw instructions like this:

> Pre-fill the login form with this link:
> http://localhost:8010/login?email=test+2@posthog.com

When clicking on the URL, the email was prefilled with an empty space instead of a plus symbol.

## Changes

<img width="1740" height="781" alt="invalid-email-pr" src="https://github.com/user-attachments/assets/c05dd28a-c6e3-4207-973d-bcebe3ad8e95" />


## How did you test this code?

Manually

## Publish to changelog?

do not publish to changelog