### PR TITLE
fix(zen): fix zenmode title for e.g. dashboard pages

### DIFF
--- a/frontend/src/layout/navigation-3000/components/MinimalNavigation.tsx
+++ b/frontend/src/layout/navigation-3000/components/MinimalNavigation.tsx
@@ -12,6 +12,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+import { FileSystemIconType } from '~/queries/schema/schema-general'
 
 import { navigation3000Logic } from '../navigationLogic'
 import { ZenModeButton } from './ZenModeButton'
@@ -20,19 +21,23 @@ export function MinimalNavigation(): JSX.Element {
     const { user } = useValues(userLogic)
     const { currentOrganization } = useValues(organizationLogic)
     const { hasOnboardedAnyProduct, currentTeam } = useValues(teamLogic)
-    const { sceneConfig } = useValues(sceneLogic)
+    const { titleAndIcon } = useValues(sceneLogic)
     const { zenMode } = useValues(navigation3000Logic)
 
     const shouldShowOnboarding = !hasOnboardedAnyProduct && !currentTeam?.ingested_event
     const logoUrl = shouldShowOnboarding ? urls.useCaseSelection() : urls.projectRoot()
 
+    const iconType: FileSystemIconType | undefined = ['loading', 'blank'].includes(titleAndIcon.iconType)
+        ? undefined
+        : (titleAndIcon.iconType as FileSystemIconType)
+
     return (
         <nav className="flex items-center gap-2 p-2 border-b">
             <LemonButton noPadding icon={<IconLogomark className="text-3xl mx-2" />} to={logoUrl} />
-            {sceneConfig?.name && zenMode && (
+            {zenMode && (
                 <span className="font-semibold text-base flex items-center gap-2">
-                    {sceneConfig.iconType ? iconForType(sceneConfig.iconType) : null}
-                    {sceneConfig.name}
+                    {iconType ? iconForType(iconType) : null}
+                    {titleAndIcon.title}
                 </span>
             )}
             <div className="flex items-center justify-end gap-2 flex-1">


### PR DESCRIPTION
## Problem

some pages (e.g. dashboards, maybe others) don't get the title from the sceneConfig. 

<img width="661" height="257" alt="image" src="https://github.com/user-attachments/assets/5a4665c9-53a7-4a62-9d34-2d7cb8767e78" />

## Changes

Use titleAndIcon instead which works for everything
<img width="627" height="236" alt="image" src="https://github.com/user-attachments/assets/d5754786-a1c7-4852-a396-ee4ecbbf2f97" />


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
