### PR TITLE
feat(phai): vector search for actions

### DIFF
--- a/ee/hogai/tools/full_text_search/hybrid_action_search.py
+++ b/ee/hogai/tools/full_text_search/hybrid_action_search.py
@@ -130,11 +130,8 @@ class HybridActionSearchTool(MaxSubtool):
             if not settings.AZURE_INFERENCE_ENDPOINT or not settings.AZURE_INFERENCE_CREDENTIAL:
                 return []
 
-            client = get_async_azure_embeddings_client()
-            try:
+            async with get_async_azure_embeddings_client() as client:
                 embedding = await aembed_search_query(client, query)
-            finally:
-                await client.close()
 
             runner = VectorSearchQueryRunner(
                 team=self._team,

--- a/ee/hogai/tools/full_text_search/hybrid_action_search.py
+++ b/ee/hogai/tools/full_text_search/hybrid_action_search.py
@@ -1,0 +1,240 @@
+import time
+import asyncio
+from typing import Any
+
+from django.conf import settings
+
+import posthoganalytics
+from azure.core.exceptions import HttpResponseError as AzureHttpResponseError
+from prometheus_client import Histogram
+
+from posthog.schema import CachedVectorSearchQueryResponse, VectorSearchQuery
+
+from posthog.api.search import search_entities
+from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.hogql_queries.ai.vector_search_query_runner import (
+    LATEST_ACTIONS_EMBEDDING_VERSION,
+    VectorSearchQueryRunner,
+)
+from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.models import Action
+from posthog.sync import database_sync_to_async
+
+from ee.hogai.tool import MaxSubtool
+from ee.hogai.tools.full_text_search.tool import ENTITY_MAP
+from ee.hogai.utils.embeddings import aembed_search_query, get_async_azure_embeddings_client
+
+HYBRID_SEARCH_VECTOR_TIMING_HISTOGRAM = Histogram(
+    "posthog_ai_hybrid_search_vector_duration_seconds",
+    "Time for vector search in hybrid action search",
+    buckets=[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float("inf")],
+)
+
+HYBRID_SEARCH_FTS_TIMING_HISTOGRAM = Histogram(
+    "posthog_ai_hybrid_search_fts_duration_seconds",
+    "Time for FTS in hybrid action search",
+    buckets=[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float("inf")],
+)
+
+HYBRID_SEARCH_TOTAL_TIMING_HISTOGRAM = Histogram(
+    "posthog_ai_hybrid_search_total_duration_seconds",
+    "Total time for hybrid action search",
+    buckets=[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float("inf")],
+)
+
+
+class HybridActionSearchTool(MaxSubtool):
+    """
+    Hybrid search for Actions combining vector search (semantic) with FTS (keyword),
+    using Reciprocal Rank Fusion (RRF) for reranking.
+
+    RRF Formula: score(d) = Σ 1/(k + rank(d)) for each retriever
+    - k=60 is the standard constant that balances contribution of top vs. lower-ranked results
+    - No score normalization needed - works directly with ranks
+    """
+
+    RRF_K = 60  # Standard RRF constant
+    MAX_RESULTS = 10
+
+    async def execute(self, query: str) -> list[dict[str, Any]]:
+        """
+        Execute hybrid search combining vector and FTS results.
+
+        Returns list of action dicts with: id, name, description, rrf_score, sources
+        """
+        total_start = time.time()
+
+        try:
+            # Run both searches in parallel
+            vector_task = self._vector_search(query)
+            fts_task = self._fts_search(query)
+
+            results = await asyncio.gather(vector_task, fts_task, return_exceptions=True)
+            vector_results = results[0] if not isinstance(results[0], BaseException) else []
+            fts_results = results[1] if not isinstance(results[1], BaseException) else []
+
+            # Log exceptions but continue with available results
+            for i, result in enumerate(results):
+                if isinstance(result, BaseException):
+                    source = "vector" if i == 0 else "fts"
+                    posthoganalytics.capture_exception(
+                        result,
+                        distinct_id=self._user.distinct_id,
+                        properties={"source": source, "query": query},
+                    )
+
+            # Apply RRF reranking
+            merged_ids = self._reciprocal_rank_fusion(vector_results, fts_results)
+
+            if not merged_ids:
+                return []
+
+            # Fetch action details
+            actions = await self._fetch_actions(merged_ids[: self.MAX_RESULTS])
+
+            # Build result with metadata
+            vector_id_set = {id for id, _ in vector_results}
+            fts_id_set = {id for id, _ in fts_results}
+
+            result = []
+            for action in actions:
+                action_id = str(action.id)
+                sources = []
+                if action_id in vector_id_set:
+                    sources.append("vector")
+                if action_id in fts_id_set:
+                    sources.append("fts")
+
+                result.append(
+                    {
+                        "id": action_id,
+                        "name": action.name,
+                        "description": action.description,
+                        "sources": sources,
+                    }
+                )
+
+            return result
+
+        finally:
+            HYBRID_SEARCH_TOTAL_TIMING_HISTOGRAM.observe(time.time() - total_start)
+
+    async def _vector_search(self, query: str) -> list[tuple[str, float]]:
+        """
+        Perform vector search using embeddings.
+
+        Returns list of (action_id, distance) sorted by distance ASC (lower = better).
+        """
+        start_time = time.time()
+        try:
+            if not settings.AZURE_INFERENCE_ENDPOINT or not settings.AZURE_INFERENCE_CREDENTIAL:
+                return []
+
+            client = get_async_azure_embeddings_client()
+            try:
+                embedding = await aembed_search_query(client, query)
+            finally:
+                await client.close()
+
+            runner = VectorSearchQueryRunner(
+                team=self._team,
+                query=VectorSearchQuery(embedding=embedding, embeddingVersion=LATEST_ACTIONS_EMBEDDING_VERSION),
+            )
+
+            with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
+                response = await database_sync_to_async(runner.run, thread_sensitive=False)(
+                    ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
+                )
+
+            if isinstance(response, CachedVectorSearchQueryResponse) and response.results:
+                return [(row.id, row.distance) for row in response.results]
+
+            return []
+
+        except (AzureHttpResponseError, ValueError):
+            # Will be caught and logged by the caller
+            raise
+        finally:
+            HYBRID_SEARCH_VECTOR_TIMING_HISTOGRAM.observe(time.time() - start_time)
+
+    async def _fts_search(self, query: str) -> list[tuple[str, float]]:
+        """
+        Perform full-text search using PostgreSQL.
+
+        Returns list of (action_id, rank) sorted by rank DESC (higher = better).
+        """
+        start_time = time.time()
+        try:
+            results, _ = await database_sync_to_async(search_entities, thread_sensitive=False)(
+                {"action"},
+                query,
+                self._team.project_id,
+                self,
+                ENTITY_MAP,
+            )
+
+            return [(r["result_id"], r.get("rank", 0)) for r in results]
+
+        finally:
+            HYBRID_SEARCH_FTS_TIMING_HISTOGRAM.observe(time.time() - start_time)
+
+    def _reciprocal_rank_fusion(
+        self,
+        vector_results: list[tuple[str, float]],
+        fts_results: list[tuple[str, float]],
+    ) -> list[str]:
+        """
+        Merge results using Reciprocal Rank Fusion (RRF).
+
+        RRF score = Σ 1/(k + rank) for each retriever where result appears.
+
+        Args:
+            vector_results: List of (id, distance) from vector search, sorted by distance ASC
+            fts_results: List of (id, rank) from FTS, sorted by rank DESC
+
+        Returns:
+            List of action IDs sorted by RRF score DESC (best first)
+        """
+        # Convert to 1-indexed ranks
+        vector_ranks = {id: i + 1 for i, (id, _) in enumerate(vector_results)}
+        fts_ranks = {id: i + 1 for i, (id, _) in enumerate(fts_results)}
+
+        all_ids = set(vector_ranks.keys()) | set(fts_ranks.keys())
+
+        rrf_scores: dict[str, float] = {}
+        for id in all_ids:
+            score = 0.0
+            if id in vector_ranks:
+                score += 1.0 / (self.RRF_K + vector_ranks[id])
+            if id in fts_ranks:
+                score += 1.0 / (self.RRF_K + fts_ranks[id])
+            rrf_scores[id] = score
+
+        return sorted(all_ids, key=lambda x: rrf_scores[x], reverse=True)
+
+    async def _fetch_actions(self, action_ids: list[str]) -> list[Action]:
+        """Fetch actions from database, preserving the order of action_ids."""
+        if not action_ids:
+            return []
+
+        actions = await database_sync_to_async(
+            lambda: list(
+                Action.objects.filter(
+                    team__project_id=self._team.project_id,
+                    id__in=action_ids,
+                    deleted=False,
+                ).only("id", "name", "description")
+            ),
+            thread_sensitive=False,
+        )()
+
+        # Preserve ordering from RRF ranking
+        action_map = {str(a.id): a for a in actions}
+        return [action_map[id] for id in action_ids if id in action_map]
+
+    # Required for search_entities compatibility
+    @property
+    def user_access_control(self):
+        from posthog.rbac.user_access_control import UserAccessControl
+
+        return UserAccessControl(user=self._user, team=self._team, organization_id=self._team.organization.id)

--- a/ee/hogai/tools/full_text_search/hybrid_action_search.py
+++ b/ee/hogai/tools/full_text_search/hybrid_action_search.py
@@ -214,16 +214,14 @@ class HybridActionSearchTool(MaxSubtool):
         if not action_ids:
             return []
 
-        actions = await database_sync_to_async(
-            lambda: list(
-                Action.objects.filter(
-                    team__project_id=self._team.project_id,
-                    id__in=action_ids,
-                    deleted=False,
-                ).only("id", "name", "description")
-            ),
-            thread_sensitive=False,
-        )()
+        actions = [
+            action
+            async for action in Action.objects.filter(
+                team__project_id=self._team.project_id,
+                id__in=action_ids,
+                deleted=False,
+            ).only("id", "name", "description")
+        ]
 
         # Preserve ordering from RRF ranking
         action_map = {str(a.id): a for a in actions}

--- a/ee/hogai/tools/full_text_search/hybrid_action_search.py
+++ b/ee/hogai/tools/full_text_search/hybrid_action_search.py
@@ -18,6 +18,7 @@ from posthog.hogql_queries.ai.vector_search_query_runner import (
 )
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Action
+from posthog.rbac.user_access_control import UserAccessControl
 from posthog.sync import database_sync_to_async
 
 from ee.hogai.tool import MaxSubtool
@@ -230,6 +231,4 @@ class HybridActionSearchTool(MaxSubtool):
     # Required for search_entities compatibility
     @property
     def user_access_control(self):
-        from posthog.rbac.user_access_control import UserAccessControl
-
         return UserAccessControl(user=self._user, team=self._team, organization_id=self._team.organization.id)

--- a/ee/hogai/tools/full_text_search/test/test_hybrid_action_search.py
+++ b/ee/hogai/tools/full_text_search/test/test_hybrid_action_search.py
@@ -115,6 +115,8 @@ class TestHybridActionSearchTool(NonAtomicBaseTest):
         mock_settings.AZURE_INFERENCE_CREDENTIAL = "test-credential"
 
         mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
         mock_get_client.return_value = mock_client
         mock_embed.return_value = [0.1] * 1024
 
@@ -134,7 +136,7 @@ class TestHybridActionSearchTool(NonAtomicBaseTest):
         result = await self.tool._vector_search("test query")
 
         self.assertEqual(result, [("1", 0.1), ("2", 0.2)])
-        mock_client.close.assert_called_once()
+        mock_client.__aexit__.assert_called_once()
 
     @patch("ee.hogai.tools.full_text_search.hybrid_action_search.search_entities")
     async def test_fts_search_returns_results(self, mock_search):

--- a/ee/hogai/tools/full_text_search/test/test_hybrid_action_search.py
+++ b/ee/hogai/tools/full_text_search/test/test_hybrid_action_search.py
@@ -124,7 +124,12 @@ class TestHybridActionSearchTool(NonAtomicBaseTest):
             results=[
                 VectorSearchResponseItem(id="1", distance=0.1),
                 VectorSearchResponseItem(id="2", distance=0.2),
-            ]
+            ],
+            cache_key="test_cache_key",
+            is_cached=False,
+            last_refresh="2024-01-01T00:00:00Z",
+            next_allowed_client_refresh="2024-01-01T00:01:00Z",
+            timezone="UTC",
         )
 
         # Mock database_sync_to_async to return an async function that returns mock_response

--- a/ee/hogai/tools/full_text_search/test/test_hybrid_action_search.py
+++ b/ee/hogai/tools/full_text_search/test/test_hybrid_action_search.py
@@ -1,0 +1,255 @@
+from posthog.test.base import NonAtomicBaseTest
+from unittest.mock import AsyncMock, patch
+
+from langchain_core.runnables import RunnableConfig
+from parameterized import parameterized
+
+from posthog.schema import CachedVectorSearchQueryResponse, VectorSearchResponseItem
+
+from posthog.models import Action
+
+from ee.hogai.context import AssistantContextManager
+from ee.hogai.tools.full_text_search.hybrid_action_search import HybridActionSearchTool
+from ee.hogai.utils.types.base import AssistantState
+
+
+class TestHybridActionSearchTool(NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        self.tool = HybridActionSearchTool(
+            team=self.team,
+            user=self.user,
+            state=AssistantState(messages=[]),
+            config=RunnableConfig(configurable={}),
+            context_manager=AssistantContextManager(self.team, self.user, {}),
+        )
+
+    @parameterized.expand(
+        [
+            # Vector only
+            (
+                [("1", 0.1), ("2", 0.2)],
+                [],
+                ["1", "2"],
+            ),
+            # FTS only
+            (
+                [],
+                [("3", 0.9), ("4", 0.8)],
+                ["3", "4"],
+            ),
+            # Empty both
+            (
+                [],
+                [],
+                [],
+            ),
+        ]
+    )
+    def test_reciprocal_rank_fusion(self, vector_results, fts_results, expected_order):
+        result = self.tool._reciprocal_rank_fusion(vector_results, fts_results)
+        self.assertEqual(result, expected_order)
+
+    def test_rrf_overlapping_results_ranked_higher(self):
+        """Items appearing in both result sets should rank higher."""
+        vector_results = [("1", 0.1), ("2", 0.2), ("3", 0.3)]
+        fts_results = [("1", 0.9), ("4", 0.8), ("5", 0.7)]
+
+        result = self.tool._reciprocal_rank_fusion(vector_results, fts_results)
+
+        # "1" appears in both, so it must be ranked first
+        self.assertEqual(result[0], "1")
+        # All IDs should be present
+        self.assertEqual(set(result), {"1", "2", "3", "4", "5"})
+
+    def test_rrf_all_overlapping(self):
+        """When all items overlap, order depends on combined rank positions."""
+        # Vector: 1 at rank 1, 2 at rank 2, 3 at rank 3
+        vector_results = [("1", 0.1), ("2", 0.2), ("3", 0.3)]
+        # FTS: 1 at rank 1, 2 at rank 2, 3 at rank 3
+        fts_results = [("1", 0.9), ("2", 0.8), ("3", 0.7)]
+
+        result = self.tool._reciprocal_rank_fusion(vector_results, fts_results)
+
+        # All items overlap, check all are present
+        self.assertEqual(set(result), {"1", "2", "3"})
+        # "1" appears at rank 1 in both → highest combined score
+        # "2" appears at rank 2 in both → second highest
+        # "3" appears at rank 3 in both → lowest
+        # 1's score: 1/(60+1) + 1/(60+1) = 2/61 ≈ 0.0328
+        # 2's score: 1/(60+2) + 1/(60+2) = 2/62 ≈ 0.0323
+        # 3's score: 1/(60+3) + 1/(60+3) = 2/63 ≈ 0.0317
+        self.assertEqual(result, ["1", "2", "3"])
+
+    def test_rrf_scoring_formula(self):
+        """Verify the RRF formula: score = sum(1/(k + rank)) for each retriever."""
+        # Doc appears at rank 1 in vector, rank 2 in FTS
+        vector_results = [("doc1", 0.1), ("doc2", 0.2)]
+        fts_results = [("doc3", 0.9), ("doc1", 0.8)]
+
+        result = self.tool._reciprocal_rank_fusion(vector_results, fts_results)
+
+        # With k=60:
+        # doc1: 1/(60+1) + 1/(60+2) = 0.01639 + 0.01613 = 0.03252
+        # doc3: 1/(60+1) = 0.01639
+        # doc2: 1/(60+2) = 0.01613
+        # Expected order: doc1, doc3, doc2
+        self.assertEqual(result[0], "doc1")
+
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.settings")
+    async def test_vector_search_disabled_when_no_credentials(self, mock_settings):
+        mock_settings.AZURE_INFERENCE_ENDPOINT = None
+        mock_settings.AZURE_INFERENCE_CREDENTIAL = None
+
+        result = await self.tool._vector_search("test query")
+        self.assertEqual(result, [])
+
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.database_sync_to_async")
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.get_async_azure_embeddings_client")
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.aembed_search_query")
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.settings")
+    async def test_vector_search_returns_results(self, mock_settings, mock_embed, mock_get_client, mock_db_sync):
+        mock_settings.AZURE_INFERENCE_ENDPOINT = "https://test.endpoint"
+        mock_settings.AZURE_INFERENCE_CREDENTIAL = "test-credential"
+
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+        mock_embed.return_value = [0.1] * 1024
+
+        mock_response = CachedVectorSearchQueryResponse(
+            results=[
+                VectorSearchResponseItem(id="1", distance=0.1),
+                VectorSearchResponseItem(id="2", distance=0.2),
+            ]
+        )
+
+        # Mock database_sync_to_async to return an async function that returns mock_response
+        async def mock_run(*args, **kwargs):
+            return mock_response
+
+        mock_db_sync.return_value = mock_run
+
+        result = await self.tool._vector_search("test query")
+
+        self.assertEqual(result, [("1", 0.1), ("2", 0.2)])
+        mock_client.close.assert_called_once()
+
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.search_entities")
+    async def test_fts_search_returns_results(self, mock_search):
+        mock_search.return_value = (
+            [
+                {"result_id": "1", "rank": 0.9},
+                {"result_id": "2", "rank": 0.8},
+            ],
+            {"action": 2},
+        )
+
+        result = await self.tool._fts_search("test query")
+
+        self.assertEqual(result, [("1", 0.9), ("2", 0.8)])
+
+    async def test_fetch_actions_preserves_order(self):
+        action1 = await Action.objects.acreate(team=self.team, name="First Action", created_by=self.user)
+        action2 = await Action.objects.acreate(team=self.team, name="Second Action", created_by=self.user)
+        action3 = await Action.objects.acreate(team=self.team, name="Third Action", created_by=self.user)
+
+        # Request in specific order (reversed)
+        action_ids = [str(action3.id), str(action1.id), str(action2.id)]
+
+        result = await self.tool._fetch_actions(action_ids)
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0].id, action3.id)
+        self.assertEqual(result[1].id, action1.id)
+        self.assertEqual(result[2].id, action2.id)
+
+    async def test_fetch_actions_excludes_deleted(self):
+        active = await Action.objects.acreate(team=self.team, name="Active", deleted=False, created_by=self.user)
+        deleted = await Action.objects.acreate(team=self.team, name="Deleted", deleted=True, created_by=self.user)
+
+        result = await self.tool._fetch_actions([str(active.id), str(deleted.id)])
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, active.id)
+
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.HybridActionSearchTool._vector_search")
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.HybridActionSearchTool._fts_search")
+    async def test_execute_combines_results(self, mock_fts, mock_vector):
+        action1 = await Action.objects.acreate(
+            team=self.team, name="Signup Action", description="User signup", created_by=self.user
+        )
+        action2 = await Action.objects.acreate(
+            team=self.team, name="Login Action", description="User login", created_by=self.user
+        )
+
+        mock_vector.return_value = [(str(action1.id), 0.1)]
+        mock_fts.return_value = [(str(action2.id), 0.9), (str(action1.id), 0.8)]
+
+        result = await self.tool.execute("signup")
+
+        self.assertEqual(len(result), 2)
+        # action1 should be first (appears in both)
+        self.assertEqual(result[0]["id"], str(action1.id))
+        self.assertEqual(result[0]["name"], "Signup Action")
+        self.assertIn("vector", result[0]["sources"])
+        self.assertIn("fts", result[0]["sources"])
+
+        self.assertEqual(result[1]["id"], str(action2.id))
+        self.assertIn("fts", result[1]["sources"])
+        self.assertNotIn("vector", result[1]["sources"])
+
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.HybridActionSearchTool._vector_search")
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.HybridActionSearchTool._fts_search")
+    async def test_execute_handles_vector_failure_gracefully(self, mock_fts, mock_vector):
+        action = await Action.objects.acreate(team=self.team, name="Test Action", created_by=self.user)
+
+        mock_vector.side_effect = Exception("Embedding service unavailable")
+        mock_fts.return_value = [(str(action.id), 0.9)]
+
+        result = await self.tool.execute("test")
+
+        # Should still return FTS results
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], str(action.id))
+
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.HybridActionSearchTool._vector_search")
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.HybridActionSearchTool._fts_search")
+    async def test_execute_handles_fts_failure_gracefully(self, mock_fts, mock_vector):
+        action = await Action.objects.acreate(team=self.team, name="Test Action", created_by=self.user)
+
+        mock_vector.return_value = [(str(action.id), 0.1)]
+        mock_fts.side_effect = Exception("Database unavailable")
+
+        result = await self.tool.execute("test")
+
+        # Should still return vector results
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], str(action.id))
+
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.HybridActionSearchTool._vector_search")
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.HybridActionSearchTool._fts_search")
+    async def test_execute_returns_empty_when_both_fail(self, mock_fts, mock_vector):
+        mock_vector.side_effect = Exception("Embedding service unavailable")
+        mock_fts.side_effect = Exception("Database unavailable")
+
+        result = await self.tool.execute("test")
+
+        self.assertEqual(result, [])
+
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.HybridActionSearchTool._vector_search")
+    @patch("ee.hogai.tools.full_text_search.hybrid_action_search.HybridActionSearchTool._fts_search")
+    async def test_execute_respects_max_results(self, mock_fts, mock_vector):
+        # Create more actions than MAX_RESULTS
+        actions = []
+        for i in range(15):
+            action = await Action.objects.acreate(team=self.team, name=f"Action {i}", created_by=self.user)
+            actions.append(action)
+
+        mock_vector.return_value = [(str(a.id), i * 0.1) for i, a in enumerate(actions[:10])]
+        mock_fts.return_value = [(str(a.id), 1 - i * 0.1) for i, a in enumerate(actions[5:])]
+
+        result = await self.tool.execute("test")
+
+        self.assertLessEqual(len(result), self.tool.MAX_RESULTS)

--- a/ee/hogai/utils/embeddings.py
+++ b/ee/hogai/utils/embeddings.py
@@ -46,3 +46,16 @@ def embed_search_query(client: EmbeddingsClient, text: str) -> list[float]:
     if not response.data:
         raise ValueError("No embeddings returned")
     return cast(list[float], response.data[0].embedding)
+
+
+async def aembed_search_query(client: EmbeddingsClientAsync, text: str) -> list[float]:
+    """Async embed a search query for semantic search by stored documents."""
+    response = await client.embed(
+        input=[text],
+        encoding_format="float",
+        model="embed-v-4-0",
+        input_type="query",
+    )
+    if not response.data:
+        raise ValueError("No embeddings returned")
+    return cast(list[float], response.data[0].embedding)


### PR DESCRIPTION
## Problem

The existing search tool for Actions relies solely on Full-Text Search (FTS), which can miss semantically relevant results. Users need a more intelligent search mechanism that combines keyword matching with semantic understanding to improve the relevance of Action search results for the AI assistant.

## Changes

This PR introduces a hybrid search capability for Actions, combining vector search and full-text search (FTS) with Reciprocal Rank Fusion (RRF) for reranking.

1.  **`HybridActionSearchTool`**: A new subtool that orchestrates parallel vector search (using Azure Embeddings and ClickHouse) and FTS (using PostgreSQL).
2.  **Reciprocal Rank Fusion (RRF)**: Implemented to merge and rerank results from both search methods, prioritizing items that appear high in both lists.
3.  **`SearchTool` Integration**: The main `SearchTool` now conditionally uses `HybridActionSearchTool` for `kind="actions"` if Azure embedding services are configured, falling back to FTS otherwise.
4.  **Async Embedding Utility**: Added `aembed_search_query` for asynchronous embedding of search queries.
5.  **Observability**: Prometheus metrics (`hybrid_search_vector_duration_seconds`, `hybrid_search_fts_duration_seconds`, `hybrid_search_total_duration_seconds`) have been added to monitor performance.

## How did you test this code?

Comprehensive unit tests were added for `HybridActionSearchTool` (`ee/hogai/tools/full_text_search/test/test_hybrid_action_search.py`), covering:
*   Correctness of the RRF algorithm, including scenarios with overlapping and non-overlapping results.
*   Graceful degradation when either vector search or FTS fails.
*   Result limits and order preservation.
*   Disabling vector search when credentials are not available.

## Publish to changelog?

Yes

---
<a href="https://cursor.com/background-agent?bcId=bc-ece421b8-dde5-4431-a2bb-03fb1f704f4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ece421b8-dde5-4431-a2bb-03fb1f704f4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

