### PR TITLE
fix: Use kw-only formatter when preparing query

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -219,14 +219,18 @@ def add_log_comment_param(params: dict[str, typing.Any], query_tags: typing.Opti
 class KeywordOnlyFormatter(Formatter):
     """Formatter supporting only keyword arguments.
 
-    Positional arguments are unchanged.
+    Positional arguments are unchanged, missing keys are also left unchanged.
     """
 
     def get_value(self, key, args, kwargs):
         if isinstance(key, int):
             # Returns '{n}' unchanged, where n is a numerical index.
             return f"{{{key}}}"
-        return kwargs[key]
+        try:
+            return kwargs[key]
+        except KeyError:
+            # Returns '{key}' unchanged
+            return f"{{{key}}}"
 
 
 class ClickHouseClient:

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -174,6 +174,11 @@ def test_clickhouse_memory_limit_exceeded_error(clickhouse_client):
             {"event": "index_{1}", "another": "event"},
             "select * from events where event = 'index_{1}' and event != 'event'",
         ),
+        (
+            "select * from events where event = %(event)s and event != {another}",
+            {"event": "index_{something}", "another": "event"},
+            "select * from events where event = 'index_{something}' and event != 'event'",
+        ),
     ],
 )
 def test_prepare_query(clickhouse_client, query, query_parameters, expected):

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -156,6 +156,32 @@ def test_clickhouse_memory_limit_exceeded_error(clickhouse_client):
                 pass
 
 
+@pytest.mark.parametrize(
+    "query,query_parameters,expected",
+    [
+        (
+            "select * from events where event = {event}",
+            {"event": "hello"},
+            "select * from events where event = 'hello'",
+        ),
+        (
+            "select * from events where event = %(event)s",
+            {"event": "world"},
+            "select * from events where event = 'world'",
+        ),
+        (
+            "select * from events where event = %(event)s and event != {another}",
+            {"event": "index_{1}", "another": "event"},
+            "select * from events where event = 'index_{1}' and event != 'event'",
+        ),
+    ],
+)
+def test_prepare_query(clickhouse_client, query, query_parameters, expected):
+    """Test data is encoded as expected."""
+    result = clickhouse_client.prepare_query(query, query_parameters)
+    assert result == expected
+
+
 async def test_acancel_query(clickhouse_client, django_db_setup):
     """Test that acancel_query successfully cancels a long-running query."""
     query_id = f"test-long-running-query-{uuid.uuid4()}"


### PR DESCRIPTION
## Problem

When preparing a query using `ClickHouseClient` we still sometimes rely on formatting query parameters into the query. Notably, this is used for filters. The problem is that filters can contain values like `{2}` which are interpreted by `str.format` as a positional argument index, and we don't pass any positional arguments when formatting (because there are none to pass).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Switch to a new keyword only formatter that returns a numerical index unchanged. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually verified first, then added a new unit test. Unit test fails on `master`, but passes here. 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
