### PR TITLE
feat(data-warehouse): Move towards using S3 table functions without access keys

### DIFF
--- a/posthog/hogql/database/s3_table.py
+++ b/posthog/hogql/database/s3_table.py
@@ -23,7 +23,7 @@ def build_function_call(
     context: Optional[HogQLContext] = None,
     table_size_mib: Optional[float] = None,
 ) -> str:
-    if access_key is None and access_secret is None:
+    if access_key is None and access_secret is None and (settings.DEBUG or settings.TEST):
         access_key = settings.AIRBYTE_BUCKET_KEY
         access_secret = settings.AIRBYTE_BUCKET_SECRET
 

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -435,3 +435,20 @@ class TestS3Table(BaseTest):
             res
             == "s3Cluster('posthog', 'http://url.com/path/to/table_name__query_12345/**.parquet', 'key', 'secret', 'Parquet', 'some structure')"
         )
+
+    def test_s3_build_function_call_with_debug_disabled(self):
+        with override_settings(DEBUG=False, TEST=False):
+            res = build_function_call(
+                "http://url.com/path/to/table_name",
+                DataWarehouseTable.TableFormat.DeltaS3Wrapper,
+                "table_name__query_12345",
+                None,
+                None,
+                "some structure",
+                None,
+                4000,
+            )
+            assert (
+                res
+                == "s3Cluster('posthog', 'http://url.com/path/to/table_name__query_12345/**.parquet', 'Parquet', 'some structure')"
+            )


### PR DESCRIPTION
## Problem
- We explicitly add aws access key/secret to all S3 queries to our dwh bucket - there is a risk of accidentally leaking these credentials 

## Changes
- Clickhouse now supports access to our dwh S3 bucket without explicit access keys, so we no longer need to add them into the Clickhouse queries, reducing the risk of the keys getting leaked via error messages
- Local dev will still use an access key/secret, but in cloud/prod, it'll be keyless 

## How did you test this code?
- Tested locally and added a unit test
