### PR TITLE
feat(analytics-platform): Fix poor performance for is_not_set by removing jsonhas

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28373,7 +28373,7 @@ snapshots:
       commander: 9.4.1
       expect-playwright: 0.8.0
       glob: 10.4.5
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -35011,7 +35011,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -35291,7 +35291,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.4.1
-      jest: 29.7.0(@types/node@22.15.17)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.15.17)(typescript@5.2.2))
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@22.18.8)(typescript@5.2.2))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -183,30 +183,11 @@ def _expr_to_compare_op(
             right=ast.Constant(value=None),
         )
     elif operator == PropertyOperator.IS_NOT_SET:
-        exprs: list[ast.Expr] = [
-            ast.CompareOperation(
-                op=ast.CompareOperationOp.Eq,
-                left=expr,
-                right=ast.Constant(value=None),
-            )
-        ]
-
-        if is_json_field:
-            if not isinstance(expr, ast.Field):
-                raise Exception(f"Requires a Field expression")
-
-            field = ast.Field(chain=expr.chain[:-1])
-
-            exprs.append(
-                ast.Not(
-                    expr=ast.Call(
-                        name="JSONHas",
-                        args=[field, ast.Constant(value=property.key)],
-                    )
-                )
-            )
-
-        return ast.Or(exprs=exprs)
+        return ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=expr,
+            right=ast.Constant(value=None),
+        )
     elif operator == PropertyOperator.ICONTAINS:
         return ast.CompareOperation(
             op=ast.CompareOperationOp.ILike,

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -3362,6 +3362,7 @@ class TestMaterializedColumnOptimization(BaseTest):
             query=query_ast,
             modifiers=HogQLQueryModifiers(personsOnEventsMode=poe_mode),
         )
+        assert result.clickhouse
 
         # Note: When columns are materialized, empty strings become NULL due to
         # nullIf(nullIf(..., ''), 'null') wrapping. This affects both POE modes.

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -3265,11 +3265,12 @@ class TestMaterializedColumnOptimization(BaseTest):
         and different PersonsOnEventsMode settings.
 
         Expected behavior:
-        - with_email: is_not_set=0 (False) - property has a value
-        - with_null: is_not_set=1 (True) - null is treated as "not set"
-        - without: is_not_set=1 (True) - property doesn't exist
+        - with_email: is_not_set=0 - property has a value
+        - test_with_empty_string: is_not_set=0 - property has a value
+        - with_null: is_not_set=1 - null is treated as "not set"
+        - without: is_not_set=1 - property doesn't exist
 
-        When materialized, the SQL should NOT use JSON operations (currently fails).
+        the clickhouse SQL should NOT include JSON operations
         """
         self.addCleanup(cleanup_materialized_columns)
 
@@ -3279,7 +3280,7 @@ class TestMaterializedColumnOptimization(BaseTest):
 
         # Generate unique IDs to avoid collision with previous test runs
         distinct_id_with_email = f"test_with_email"
-        distinct_id_with_empty = f"test_with_empty"
+        distinct_id_with_empty = f"test_with_empty_string"
         distinct_id_with_null = f"test_with_null"
         distinct_id_without = f"test_without"
         event_name = f"is_not_set_test"
@@ -3382,11 +3383,10 @@ class TestMaterializedColumnOptimization(BaseTest):
 
         # The query should never touch the json properties object if we are using the materialized column, these asserts protects against regression for the performance the bug in
         # https://posthog.slack.com/archives/C09B0SSQEDA/p1767698123669229?thread_ts=1767672165.250289&cid=C09B0SSQEDA
-        if is_materialized:
-            sql_lower = result.clickhouse.lower()
-            # should only appear in is_not_set_result_historical
-            assert sql_lower.count("json") == 1
-            assert sql_lower.count("has") == 1
+        sql_lower = result.clickhouse.lower()
+        # should only appear in is_not_set_result_historical
+        assert sql_lower.count("json") == 1
+        assert sql_lower.count("has") == 1
 
 
 class TestPrinted(APIBaseTest):

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1,5 +1,4 @@
 import json
-import uuid
 from collections.abc import Mapping
 from typing import Any, Literal, Optional, cast
 
@@ -3279,12 +3278,11 @@ class TestMaterializedColumnOptimization(BaseTest):
             materialize("person", "email")
 
         # Generate unique IDs to avoid collision with previous test runs
-        test_id = str(uuid.uuid4())[:8]
-        distinct_id_with_email = f"test_{test_id}_with_email"
-        distinct_id_with_empty = f"test_{test_id}_with_empty"
-        distinct_id_with_null = f"test_{test_id}_with_null"
-        distinct_id_without = f"test_{test_id}_without"
-        event_name = f"is_not_set_test_{test_id}"
+        distinct_id_with_email = f"test_with_email"
+        distinct_id_with_empty = f"test_with_empty"
+        distinct_id_with_null = f"test_with_null"
+        distinct_id_without = f"test_without"
+        event_name = f"is_not_set_test"
 
         # Create four persons with different email property states:
         # 1. email set to a real value

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Any, Literal, Optional, Union, cast
 
 from posthog.test.base import APIBaseTest, BaseTest, _create_event, cleanup_materialized_columns
@@ -1188,7 +1189,8 @@ class TestPropertyIsSetIsNotSetWithData(APIBaseTest):
         )
 
         result = execute_hogql_query(team=self.team, query=query_ast)
-        row = result.results[0]
+        assert result.columns
+        row: Iterable[Any] = result.results[0]
         assert row
         results = dict(zip(result.columns, row))
 
@@ -1224,7 +1226,8 @@ class TestPropertyIsSetIsNotSetWithData(APIBaseTest):
         )
 
         result = execute_hogql_query(team=self.team, query=query_ast)
-        row = result.results[0]
+        assert result.columns
+        row: Iterable[Any] = result.results[0]
         assert row
         results = dict(zip(result.columns, row))
 

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -1,7 +1,9 @@
 from typing import Any, Literal, Optional, Union, cast
 
-from posthog.test.base import BaseTest
+from posthog.test.base import APIBaseTest, BaseTest, _create_event, cleanup_materialized_columns
 from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
 
 from posthog.schema import EmptyPropertyFilter, HogQLPropertyFilter, RetentionEntity
 
@@ -16,6 +18,7 @@ from posthog.hogql.property import (
     selector_to_expr,
     tag_name_to_expr,
 )
+from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.visitor import clear_locations
 
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS, PropertyOperatorType
@@ -24,6 +27,8 @@ from posthog.models.property import PropertyGroup
 from posthog.models.property_definition import PropertyType
 
 from products.data_warehouse.backend.models import DataWarehouseCredential, DataWarehouseJoin, DataWarehouseTable
+
+from ee.clickhouse.materialized_columns.columns import materialize
 
 elements_chain_match = lambda x: parse_expr("elements_chain =~ {regex}", {"regex": ast.Constant(value=str(x))})
 elements_chain_imatch = lambda x: parse_expr("elements_chain =~* {regex}", {"regex": ast.Constant(value=str(x))})
@@ -1074,3 +1079,149 @@ class TestProperty(BaseTest):
             self._property_to_expr({"type": "person", "key": "score", "operator": "max", "value": 100}),
             self._parse_expr("person.properties.score <= 100"),
         )
+
+
+class TestPropertyIsSetIsNotSetWithData(APIBaseTest):
+    # Sentinel to indicate a property should not be included in the event
+    NOT_SET: Any = object()
+
+    # Expected is_set value can be True, False, or a callable(is_materialized) -> bool
+    # When materialized, empty string and "null" string become NULL due to nullIf wrapping
+    # (this is a long-standing bug, and it's ok to change these tests if you fix it!)
+    ONLY_WHEN_NOT_MATERIALIZED = staticmethod(lambda m: not m)
+
+    def setUp(self):
+        super().setUp()
+        self.event_name = "test_is_set_event"
+
+        # (property_name, value, property_type, expected_is_set)
+        # expected_is_set: True, False, or callable(is_materialized) -> bool
+        self.test_cases: list[tuple[str, Any, PropertyType, Any]] = [
+            # String type: value, empty, "null" literal, null, not set
+            ("string_value_prop", "hello", PropertyType.String, True),
+            ("string_empty_prop", "", PropertyType.String, self.ONLY_WHEN_NOT_MATERIALIZED),
+            ("string_null_literal_prop", "null", PropertyType.String, self.ONLY_WHEN_NOT_MATERIALIZED),
+            ("string_null_prop", None, PropertyType.String, False),
+            ("string_not_set_prop", self.NOT_SET, PropertyType.String, False),
+            # Numeric type: zero, non-zero int, non-zero float, string values, null, not set
+            # Type coercion converts invalid strings to NULL
+            ("numeric_zero_prop", 0, PropertyType.Numeric, True),
+            ("numeric_int_prop", 42, PropertyType.Numeric, True),
+            ("numeric_float_prop", 3.14, PropertyType.Numeric, True),
+            ("numeric_string_valid_prop", "42", PropertyType.Numeric, True),
+            ("numeric_string_invalid_prop", "invalid_number", PropertyType.Numeric, False),
+            ("numeric_string_empty_prop", "", PropertyType.Numeric, False),
+            ("numeric_null_prop", None, PropertyType.Numeric, False),
+            ("numeric_not_set_prop", self.NOT_SET, PropertyType.Numeric, False),
+            # Boolean type: true, false, string variants, invalid, null, not set
+            # Only lowercase "true"/"false" strings are recognized
+            ("bool_true_prop", True, PropertyType.Boolean, True),
+            ("bool_false_prop", False, PropertyType.Boolean, True),
+            ("bool_string_true_lower_prop", "true", PropertyType.Boolean, True),
+            ("bool_string_true_title_prop", "True", PropertyType.Boolean, False),
+            ("bool_string_true_upper_prop", "TRUE", PropertyType.Boolean, False),
+            ("bool_string_false_lower_prop", "false", PropertyType.Boolean, True),
+            ("bool_string_invalid_prop", "invalid_bool", PropertyType.Boolean, False),
+            ("bool_string_empty_prop", "", PropertyType.Boolean, False),
+            ("bool_null_prop", None, PropertyType.Boolean, False),
+            ("bool_not_set_prop", self.NOT_SET, PropertyType.Boolean, False),
+        ]
+
+        # Create PropertyDefinitions for each property
+        for prop_name, _, prop_type, _ in self.test_cases:
+            PropertyDefinition.objects.create(
+                team=self.team,
+                name=prop_name,
+                type=PropertyDefinition.Type.EVENT,
+                property_type=prop_type,
+            )
+
+        # Create a single event with all properties (except NOT_SET ones)
+        properties = {prop_name: value for prop_name, value, _, _ in self.test_cases if value is not self.NOT_SET}
+
+        _create_event(
+            team=self.team,
+            event=self.event_name,
+            distinct_id="test_user",
+            properties=properties,
+        )
+
+    def _expected_is_set_values(self, is_materialized: bool) -> dict[str, int]:
+        result = {}
+        for prop_name, _, _, expected in self.test_cases:
+            if callable(expected):
+                result[prop_name] = 1 if expected(is_materialized) else 0
+            else:
+                result[prop_name] = 1 if expected else 0
+        return result
+
+    def _expected_is_not_set_values(self, is_materialized: bool) -> dict[str, int]:
+        return {k: 1 - v for k, v in self._expected_is_set_values(is_materialized).items()}
+
+    @parameterized.expand([("not_materialized", False), ("materialized", True)])
+    def test_is_set_operator(self, _name: str, is_materialized: bool):
+        if is_materialized:
+            self.addCleanup(cleanup_materialized_columns)
+            for prop_name, _, _, _ in self.test_cases:
+                materialize("events", prop_name)
+
+        select_exprs = [
+            ast.Alias(
+                alias=prop_name,
+                expr=property_to_expr(
+                    {"type": "event", "key": prop_name, "operator": "is_set"},
+                    team=self.team,
+                    scope="event",
+                ),
+            )
+            for prop_name, _, _, _ in self.test_cases
+        ]
+
+        query_ast = ast.SelectQuery(
+            select=select_exprs,
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ast.Field(chain=["event"]),
+                right=ast.Constant(value=self.event_name),
+            ),
+        )
+
+        result = execute_hogql_query(team=self.team, query=query_ast)
+        results = dict(zip(result.columns, result.results[0]))
+
+        assert results == self._expected_is_set_values(is_materialized)
+
+    @parameterized.expand([("not_materialized", False), ("materialized", True)])
+    def test_is_not_set_operator(self, _name: str, is_materialized: bool):
+        if is_materialized:
+            self.addCleanup(cleanup_materialized_columns)
+            for prop_name, _, _, _ in self.test_cases:
+                materialize("events", prop_name)
+
+        select_exprs = [
+            ast.Alias(
+                alias=prop_name,
+                expr=property_to_expr(
+                    {"type": "event", "key": prop_name, "operator": "is_not_set"},
+                    team=self.team,
+                    scope="event",
+                ),
+            )
+            for prop_name, _, _, _ in self.test_cases
+        ]
+
+        query_ast = ast.SelectQuery(
+            select=select_exprs,
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ast.Field(chain=["event"]),
+                right=ast.Constant(value=self.event_name),
+            ),
+        )
+
+        result = execute_hogql_query(team=self.team, query=query_ast)
+        results = dict(zip(result.columns, result.results[0]))
+
+        assert results == self._expected_is_not_set_values(is_materialized)

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -1165,7 +1165,7 @@ class TestPropertyIsSetIsNotSetWithData(APIBaseTest):
             for prop_name, _, _, _ in self.test_cases:
                 materialize("events", prop_name)
 
-        select_exprs = [
+        select_exprs: list[ast.Expr] = [
             ast.Alias(
                 alias=prop_name,
                 expr=property_to_expr(
@@ -1188,7 +1188,9 @@ class TestPropertyIsSetIsNotSetWithData(APIBaseTest):
         )
 
         result = execute_hogql_query(team=self.team, query=query_ast)
-        results = dict(zip(result.columns, result.results[0]))
+        row = result.results[0]
+        assert row
+        results = dict(zip(result.columns, row))
 
         assert results == self._expected_is_set_values(is_materialized)
 
@@ -1199,7 +1201,7 @@ class TestPropertyIsSetIsNotSetWithData(APIBaseTest):
             for prop_name, _, _, _ in self.test_cases:
                 materialize("events", prop_name)
 
-        select_exprs = [
+        select_exprs: list[ast.Expr] = [
             ast.Alias(
                 alias=prop_name,
                 expr=property_to_expr(
@@ -1222,6 +1224,8 @@ class TestPropertyIsSetIsNotSetWithData(APIBaseTest):
         )
 
         result = execute_hogql_query(team=self.team, query=query_ast)
-        results = dict(zip(result.columns, result.results[0]))
+        row = result.results[0]
+        assert row
+        results = dict(zip(result.columns, row))
 
         assert results == self._expected_is_not_set_values(is_materialized)

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -80,7 +80,7 @@ class TestProperty(BaseTest):
             self._parse_expr("group_3.properties.a = 'b'"),
         )
         self.assertEqual(
-            self._parse_expr("group_0.properties.a = NULL OR (NOT JSONHas(group_0.properties, 'a'))"),
+            self._parse_expr("group_0.properties.a = NULL"),
             self._property_to_expr(
                 {"type": "group", "group_type_index": 0, "key": "a", "value": "b", "operator": "is_not_set"}
             ),
@@ -144,7 +144,7 @@ class TestProperty(BaseTest):
             self._parse_expr("properties.a != NULL"),
         )
         self.assertEqual(
-            self._parse_expr("properties.a = NULL OR (NOT JSONHas(properties, 'a'))"),
+            self._parse_expr("properties.a = NULL"),
             self._property_to_expr({"type": "event", "key": "a", "value": "b", "operator": "is_not_set"}),
         )
         self.assertEqual(

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -2452,7 +2452,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-26 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_source'), ''), 'null'), '^"|"$', '')), not(JSONHas(events.properties, 'utm_source'))), 1))
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-26 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_source'), ''), 'null'), '^"|"$', '')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`


### PR DESCRIPTION
## Problem
When using `is_not_set` we compare against NULL, but we also add a `JSONHas` operation to the query. This is terrible for performance with materialized columns, as it means we need to touch the massive `properties` object, which somewhat defeats the point of using a materialized column.

## Changes
I was a bit cautious about removing the `JSONHas`, as I was worried that it would cause inconsistent behaviour when the column was/wasn't materialized. It turns out that we have inconsistent behaviour anyway, so let's fix performance while not changing the existing behaviour.

## How did you test this code?

See `test_person_property_is_not_set_behavior`

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
