### PR TITLE
fix(batch-exports): Improve batch export query handling

### DIFF
--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -1,12 +1,14 @@
 import uuid
 import asyncio
 import datetime as dt
+import contextlib
 
 import pytest
 from unittest.mock import MagicMock, patch
 
 from posthog.clickhouse.query_tagging import QueryTags
 from posthog.temporal.common.clickhouse import (
+    ClickHouseCheckQueryStatusError,
     ClickHouseClient,
     ClickHouseError,
     ClickHouseMemoryLimitExceededError,
@@ -263,6 +265,36 @@ async def test_acheck_query_in_query_log_not_found(clickhouse_client, django_db_
     non_existent_query_id = f"test-non-existent-query-{uuid.uuid4()}"
     with pytest.raises(ClickHouseQueryNotFound):
         await clickhouse_client.acheck_query_in_query_log(non_existent_query_id)
+
+
+async def test_acheck_query_in_query_log_error(clickhouse_client, django_db_setup):
+    """Test that acheck_query_in_query_log raises ClickHouseCheckQueryStatusError for errors."""
+    # Simulate an exception from the ClickHouse client
+    # (this is an example of a response we've seen in production, where a 200 is returned but it is actually an error)
+    # because we use Format JSONEachRow we get the exception returned inside a JSON object
+    mock_response = MagicMock()
+    mock_response.status = 200
+
+    async def mock_read():
+        return b'{"exception": "Code: 202. DB::Exception: Received from dummy-ch-node.internal. DB::Exception: Too many simultaneous queries for all users. Current: 10, maximum: 10. (TOO_MANY_SIMULTANEOUS_QUERIES) (version x.x.x.x (official build))"}'
+
+    mock_response.content.read = mock_read
+
+    @contextlib.asynccontextmanager
+    async def mock_get(*args, **kwargs):
+        yield mock_response
+
+    mock_session = MagicMock()
+    mock_session.get = mock_get
+
+    with patch.object(
+        clickhouse_client,
+        "session",
+        mock_session,
+    ):
+        query_id = f"test-error-query-{uuid.uuid4()}"
+        with pytest.raises(ClickHouseCheckQueryStatusError):
+            await clickhouse_client.acheck_query_in_query_log(query_id)
 
 
 async def test_acheck_query_found(clickhouse_client, django_db_setup):

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -28,7 +28,9 @@ from structlog.contextvars import bind_contextvars
 from posthog.batch_exports.service import BackfillDetails, BatchExportField, BatchExportModel, BatchExportSchema
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.clickhouse import (
+    ClickHouseClient,
     ClickHouseClientTimeoutError,
+    ClickHouseError,
     ClickHouseQueryNotFound,
     ClickHouseQueryStatus,
     get_client,
@@ -501,56 +503,88 @@ async def _write_batch_export_record_batches_to_internal_stage(
                 await _delete_all_from_bucket_with_prefix(
                     bucket_name=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, key_prefix=base_s3_staging_folder
                 )
-            except Exception as e:
+            except Exception:
                 logger.exception(
                     "Unexpected error occurred while deleting existing objects from internal S3 staging bucket",
-                    exc_info=e,
                 )
                 raise
 
-            start_time = time.monotonic()
-            query_id = uuid.uuid4()
-            logger.info("Executing insert into internal stage query", query_id=str(query_id))
-            try:
-                await client.execute_query(
-                    query, query_parameters=query_parameters, query_id=str(query_id), timeout=300
-                )
-            except ClickHouseClientTimeoutError:
-                logger.warning(
-                    "Timed-out waiting for insert into S3. Will attempt to check query status before continuing",
-                    query_id=str(query_id),
-                )
-                # Sometimes we can't find the query in the query log, so make sure we retry a few times
-                num_attempts = 5
-                check_query = make_retryable_with_exponential_backoff(
-                    client.acheck_query,
-                    max_attempts=num_attempts,
-                    max_retry_delay=1,
-                    retryable_exceptions=(ClickHouseQueryNotFound,),
-                )
+            await _execute_query(client, query, query_parameters)
 
-                try:
-                    status = await check_query(str(query_id), raise_on_error=True)
-                    while status == ClickHouseQueryStatus.RUNNING:
-                        await asyncio.sleep(10)
-                        status = await check_query(str(query_id), raise_on_error=True)
-                except ClickHouseQueryNotFound:
-                    logger.exception(
-                        f"Query not found in query log after {num_attempts} attempts",
-                        query_id=str(query_id),
-                    )
-                    try:
-                        await client.acancel_query(str(query_id))
-                    except Exception as cancel_error:
-                        logger.warning("Failed to cancel query", query_id=str(query_id), error=str(cancel_error))
-                    raise
 
-            except Exception as e:
-                logger.exception(
-                    "Unexpected error occurred while writing record batches to internal S3 staging bucket",
-                    exc_info=e,
-                )
-                raise
+async def _execute_query(client: ClickHouseClient, query: str, query_parameters: dict[str, typing.Any]) -> None:
+    """Execute the batch exports query and wait for it to complete.
 
-            execution_time = time.monotonic() - start_time
-            logger.info("Query completed successfully", query_id=str(query_id), query_duration_seconds=execution_time)
+    If the query takes longer than 300 seconds, we time out and wait for the query to complete by checking the query log
+    and process list.
+    If the query fails, we will raise an error.
+    """
+    query_id = uuid.uuid4()
+    logger = LOGGER.bind(query_id=str(query_id))
+    start_time = time.monotonic()
+    logger.info("Executing insert into internal stage query")
+    try:
+        await client.execute_query(query, query_parameters=query_parameters, query_id=str(query_id), timeout=300)
+    except ClickHouseClientTimeoutError:
+        logger.warning(
+            "Timed-out waiting for insert into S3. Will attempt to check query status and wait for completion",
+        )
+        await _wait_for_query_completion(client, str(query_id))
+    except ClickHouseError:
+        logger.exception(
+            "ClickHouse error occurred while writing record batches to internal S3 staging bucket",
+        )
+        raise
+    except Exception:
+        logger.exception(
+            "Unexpected error occurred while writing record batches to internal S3 staging bucket",
+        )
+        raise
+
+    execution_time = time.monotonic() - start_time
+    logger.info("Query completed successfully", query_id=str(query_id), query_duration_seconds=execution_time)
+
+
+async def _wait_for_query_completion(client: ClickHouseClient, query_id: str) -> None:
+    """Wait for the query to complete.
+
+    This function will check the query log and process list for the query and wait for it to complete.
+    Sometimes this check can fail, especially when ClickHouse is under heavy load, so we retry a few times
+    If the query is not found in the query log or process list after the retries, we cancel the query and raise an
+    error.
+    """
+    logger = LOGGER.bind(query_id=query_id)
+    num_attempts = 5
+    check_query = make_retryable_with_exponential_backoff(
+        client.acheck_query,
+        max_attempts=num_attempts,
+        max_retry_delay=1,
+        retryable_exceptions=(ClickHouseQueryNotFound,),
+    )
+
+    try:
+        status = await check_query(str(query_id), raise_on_error=True)
+        while status == ClickHouseQueryStatus.RUNNING:
+            await asyncio.sleep(10)
+            status = await check_query(str(query_id), raise_on_error=True)
+    except ClickHouseQueryNotFound:
+        logger.exception(
+            f"Query not found in query_log or processes after {num_attempts} attempts",
+        )
+        try:
+            await client.acancel_query(str(query_id))
+        except Exception as cancel_error:
+            logger.warning("Failed to cancel query", error=str(cancel_error))
+        raise
+    except ClickHouseError:
+        # this could be raised if the original query failed, or if the query to check the query status failed.
+        # TODO: we should add a way to differentiate between these two cases.
+        logger.exception(
+            "ClickHouse error occurred while writing record batches to internal S3 staging bucket",
+        )
+        raise
+    except Exception:
+        logger.exception(
+            "Unexpected error occurred while writing record batches to internal S3 staging bucket",
+        )
+        raise

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -564,14 +564,14 @@ async def _wait_for_query_completion(client: ClickHouseClient, query_id: str) ->
     )
 
     try:
-        status = await check_query(str(query_id), raise_on_error=True)
+        status = await check_query(query_id, raise_on_error=True)
         while status == ClickHouseQueryStatus.RUNNING:
             await asyncio.sleep(10)
-            status = await check_query(str(query_id), raise_on_error=True)
+            status = await check_query(query_id, raise_on_error=True)
     except (ClickHouseQueryNotFound, ClickHouseCheckQueryStatusError):
         logger.exception("Wait for query failed", num_attempts=num_attempts)
         try:
-            await client.acancel_query(str(query_id))
+            await client.acancel_query(query_id)
         except Exception:
             logger.warning("Failed to cancel query", exc_info=True)
         raise

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -568,10 +568,10 @@ async def _wait_for_query_completion(client: ClickHouseClient, query_id: str) ->
         while status == ClickHouseQueryStatus.RUNNING:
             await asyncio.sleep(10)
             status = await check_query(str(query_id), raise_on_error=True)
-    except (ClickHouseQueryNotFound, ClickHouseCheckQueryStatusError) as e:
+    except (ClickHouseQueryNotFound, ClickHouseCheckQueryStatusError):
         logger.exception("Wait for query failed", num_attempts=num_attempts)
         try:
             await client.acancel_query(str(query_id))
-        except Exception as cancel_error:
+        except Exception:
             logger.warning("Failed to cancel query", exc_info=True)
         raise


### PR DESCRIPTION
## Problem

When executing batch export queries we can encounter various ClickHouse errors that need proper handling. Previously:
- Query timeout handling was mixed with the main execution logic
- ClickHouse could return errors as JSON with 200 status codes (e.g., `{"exception": "..."}`) which weren't properly detected
- When checking the query status we had no way to differentiate between errors in the original query and errors in fetching the original query.

## Changes

- Added new `ClickHouseCheckQueryStatusError` exception to differentiate errors that occur while checking query status from errors in the query itself
- Added `read_query_as_jsonl` helper method to parse JSONEachRow responses
- Improved `acheck_query_in_query_log` to:
  - Detect JSON error responses from ClickHouse (when a single row with only "exception" key is returned)
  - Properly wrap errors when checking query status
- Improved `acheck_query_in_process_list` to wrap errors when checking
- Refactored batch export query execution into separate `_execute_query` and `_wait_for_query_completion` functions for better separation of concerns
- Made `ClickHouseCheckQueryStatusError` retryable in the wait loop, so transient errors during status checks don't fail the whole export

## How did you test this code?

- Added unit test `test_acheck_query_in_query_log_error` that verifies the new error handling when ClickHouse returns a JSON error response with 200 status
- Existing tests continue to pass

## Publish to changelog?

No