### PR TITLE
fix(logs): remove LIMIT 1000 from sparkline query

### DIFF
--- a/products/logs/backend/sparkline_query_runner.py
+++ b/products/logs/backend/sparkline_query_runner.py
@@ -79,7 +79,6 @@ class SparklineQueryRunner(LogsQueryRunner):
                     GROUP BY {breakdown_field}, time
                 ) AS ac ON am.time_bucket = ac.time
                 ORDER BY time asc, {breakdown_field} asc
-                LIMIT 1000
         """,
             placeholders={
                 **self.query_date_range.to_placeholders(),


### PR DESCRIPTION
## Problem

The current implementation of the sparkline query runner includes a hard-coded `LIMIT 1000` clause, which was preventing breakdown-by-service from returning all rows.

## Changes

Removed the `LIMIT 1000` clause from the SQL query in the `to_query` method of the sparkline query runner. This allows the query to return all relevant data points without artificial limitations.

## How did you test this code?

Tested by running queries with large datasets that would previously be truncated by the limit. Verified that all data points are now properly returned and displayed in the sparkline visualizations.

## Publish to changelog?

No