### PR TITLE
fix(sparkline_query_runner): increase query limit from 1000 to 100000 to account for breaking down by service

### DIFF
--- a/products/logs/backend/sparkline_query_runner.py
+++ b/products/logs/backend/sparkline_query_runner.py
@@ -79,7 +79,7 @@ class SparklineQueryRunner(LogsQueryRunner):
                     GROUP BY {breakdown_field}, time
                 ) AS ac ON am.time_bucket = ac.time
                 ORDER BY time asc, {breakdown_field} asc
-                LIMIT 1000
+                LIMIT 100000
         """,
             placeholders={
                 **self.query_date_range.to_placeholders(),


### PR DESCRIPTION
## Problem

The current limit of 1000 rows in the sparkline query is too restrictive for queries with many breakdown values, causing incomplete data in visualizations.

This replaces [this pr](https://github.com/PostHog/posthog/pull/44350) as it turns out that without a limit, a default of 99 is applied.

## Changes

Increased the `LIMIT` in the sparkline query from 1000 to 100000 to accommodate queries with a large number of breakdown values.

## How did you test this code?

Tested with queries containing many breakdown values to verify that all data points are now properly returned in the results.

## Publish to changelog?

No