### PR TITLE
feat(product tours): toolbar media upload

### DIFF
--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -146,3 +146,57 @@ export async function toolbarFetch(
     }
     return response
 }
+
+export interface ToolbarMediaUploadResponse {
+    id: string
+    image_location: string
+    name: string
+}
+
+/**
+ * Upload media (images) from the toolbar using temporary token authentication.
+ * This is a separate function from toolbarFetch because it needs to handle FormData
+ * instead of JSON payloads.
+ */
+export async function toolbarUploadMedia(file: File): Promise<{ url: string; fileName: string }> {
+    const temporaryToken = toolbarConfigLogic.findMounted()?.values.temporaryToken
+    const apiURL = toolbarConfigLogic.findMounted()?.values.apiURL
+
+    if (!temporaryToken || !apiURL) {
+        throw new Error('Toolbar not authenticated')
+    }
+
+    const formData = new FormData()
+    formData.append('image', file)
+
+    const url = `${apiURL}/api/projects/@current/uploaded_media/${encodeParams({ temporary_token: temporaryToken }, '?')}`
+
+    const response = await fetch(url, {
+        method: 'POST',
+        body: formData,
+    })
+
+    if (response.status === 401) {
+        toolbarConfigLogic.actions.tokenExpired()
+        throw new Error('Authentication expired')
+    }
+
+    if (response.status === 403) {
+        const responseData = await response.json()
+        if (responseData.detail === "You don't have access to the project.") {
+            toolbarConfigLogic.actions.authenticate()
+        }
+        throw new Error(responseData.detail || 'Access denied')
+    }
+
+    if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(errorData.detail || `Upload failed: ${response.status}`)
+    }
+
+    const data: ToolbarMediaUploadResponse = await response.json()
+    return {
+        url: data.image_location,
+        fileName: data.name,
+    }
+}

--- a/posthog/api/uploaded_media.py
+++ b/posthog/api/uploaded_media.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 from statshog.defaults.django import statsd
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.auth import TemporaryTokenAuthentication
 from posthog.models import UploadedMedia
 from posthog.models.uploaded_media import ObjectStorageUnavailable
 from posthog.storage import object_storage
@@ -81,6 +82,7 @@ class MediaViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "INTERNAL"
     queryset = UploadedMedia.objects.all()
     parser_classes = (MultiPartParser, FormParser)
+    authentication_classes = [TemporaryTokenAuthentication]
 
     @extend_schema(
         description="""


### PR DESCRIPTION
## Problem

need to support media upload from the toolbar to build the product tours rich text editor

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds a new helper function for multipart uploads, and TemporaryTokenAuthentication support to the media upload endpoint

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing (higher up in the stack)

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->