### PR TITLE
feat(experiments): adding ACL to shared metrics backend.

### DIFF
--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -16,7 +16,6 @@ from posthog.schema import (
     ExperimentTrendsQuery,
 )
 
-from ee.api.rbac.access_control import AccessControlViewSetMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin
@@ -24,6 +23,8 @@ from posthog.models.activity_logging.activity_log import Detail, changes_between
 from posthog.models.experiment import ExperimentSavedMetric, ExperimentToSavedMetric
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
+
+from ee.api.rbac.access_control import AccessControlViewSetMixin
 
 
 class ExperimentToSavedMetricSerializer(serializers.ModelSerializer):

--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -16,12 +16,14 @@ from posthog.schema import (
     ExperimentTrendsQuery,
 )
 
+from ee.api.rbac.access_control import AccessControlViewSetMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.experiment import ExperimentSavedMetric, ExperimentToSavedMetric
 from posthog.models.signals import model_activity_signal, mutable_receiver
+from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 
 
 class ExperimentToSavedMetricSerializer(serializers.ModelSerializer):
@@ -45,7 +47,9 @@ class ExperimentToSavedMetricSerializer(serializers.ModelSerializer):
         ]
 
 
-class ExperimentSavedMetricSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
+class ExperimentSavedMetricSerializer(
+    UserAccessControlSerializerMixin, TaggedItemSerializerMixin, serializers.ModelSerializer
+):
     created_by = UserBasicSerializer(read_only=True)
 
     class Meta:
@@ -59,12 +63,14 @@ class ExperimentSavedMetricSerializer(TaggedItemSerializerMixin, serializers.Mod
             "created_at",
             "updated_at",
             "tags",
+            "user_access_level",
         ]
         read_only_fields = [
             "id",
             "created_by",
             "created_at",
             "updated_at",
+            "user_access_level",
         ]
 
     def validate_query(self, value):
@@ -111,8 +117,8 @@ class ExperimentSavedMetricSerializer(TaggedItemSerializerMixin, serializers.Mod
         return super().create(validated_data)
 
 
-class ExperimentSavedMetricViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
-    scope_object = "experiment"
+class ExperimentSavedMetricViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.ModelViewSet):
+    scope_object = "experiment_saved_metric"
     queryset = ExperimentSavedMetric.objects.prefetch_related("created_by").order_by(Lower("name")).all()
     serializer_class = ExperimentSavedMetricSerializer
 

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -9,7 +9,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 
-import { UserBasicType } from '~/types'
+import { AccessControlLevel, UserBasicType } from '~/types'
 
 import { getDefaultFunnelMetric } from '../utils'
 import type { sharedMetricLogicType } from './sharedMetricLogicType'
@@ -30,6 +30,7 @@ export interface SharedMetric {
     updated_at: string | null
     tags: string[]
     metadata?: Record<string, any>
+    user_access_level: AccessControlLevel
 }
 
 export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
@@ -37,6 +38,7 @@ export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
     description: '',
     query: undefined,
     tags: [],
+    user_access_level: AccessControlLevel.Editor,
 }
 
 export const sharedMetricLogic = kea<sharedMetricLogicType>([

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -9,7 +9,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 
-import { AccessControlLevel, UserBasicType } from '~/types'
+import { UserBasicType } from '~/types'
 
 import { getDefaultFunnelMetric } from '../utils'
 import type { sharedMetricLogicType } from './sharedMetricLogicType'
@@ -30,7 +30,6 @@ export interface SharedMetric {
     updated_at: string | null
     tags: string[]
     metadata?: Record<string, any>
-    user_access_level: AccessControlLevel
 }
 
 export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
@@ -38,7 +37,6 @@ export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
     description: '',
     query: undefined,
     tags: [],
-    user_access_level: AccessControlLevel.Editor,
 }
 
 export const sharedMetricLogic = kea<sharedMetricLogicType>([

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -165,6 +165,8 @@ def model_to_resource(model: Model) -> Optional[APIScopeObject]:
         return "session_recording"
     if name == "sessionrecordingplaylist":
         return "session_recording_playlist"
+    if name == "experimentsavedmetric":
+        return "experiment_saved_metric"
 
     if name not in API_SCOPE_OBJECTS:
         return None

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -58,6 +58,7 @@ ACCESS_CONTROL_RESOURCES: tuple[APIScopeObject, ...] = (
     "revenue_analytics",
     "survey",
     "experiment",
+    "experiment_saved_metric",
     "web_analytics",
     "activity_log",
 )

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -28,6 +28,7 @@ APIScopeObject = Literal[
     "evaluation",
     "event_definition",
     "experiment",
+    "experiment_saved_metric",
     "export",
     "feature_flag",
     "file_system",


### PR DESCRIPTION
## Problem

The shared metrics backend does not support access control lists.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Adding the `UserAccessControlSerializerMixin` and `AccessControlViewSetMixin` to the shared metrics serializer and view set, so the backend can return the current user access and the resource can be configured.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/28aa4ee7-90ff-48d6-a8b6-501e5e5fdad0)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #44376 
- <kbd>&nbsp;2&nbsp;</kbd> #44374 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #44300 
<!-- GitButler Footer Boundary Bottom -->

