### PR TITLE
feat(experiments): shared metrics ACL frontend update.

### DIFF
--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -16,7 +16,6 @@ from posthog.schema import (
     ExperimentTrendsQuery,
 )
 
-from ee.api.rbac.access_control import AccessControlViewSetMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin
@@ -24,6 +23,8 @@ from posthog.models.activity_logging.activity_log import Detail, changes_between
 from posthog.models.experiment import ExperimentSavedMetric, ExperimentToSavedMetric
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
+
+from ee.api.rbac.access_control import AccessControlViewSetMixin
 
 from ee.api.rbac.access_control import AccessControlViewSetMixin
 

--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -16,6 +16,7 @@ from posthog.schema import (
     ExperimentTrendsQuery,
 )
 
+from ee.api.rbac.access_control import AccessControlViewSetMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin

--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -26,10 +26,6 @@ from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 
 from ee.api.rbac.access_control import AccessControlViewSetMixin
 
-from ee.api.rbac.access_control import AccessControlViewSetMixin
-
-from ee.api.rbac.access_control import AccessControlViewSetMixin
-
 
 class ExperimentToSavedMetricSerializer(serializers.ModelSerializer):
     query = serializers.JSONField(source="saved_metric.query", read_only=True)

--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -30,6 +30,7 @@ export const API_SCOPES: APIScope[] = [
     { key: 'event_definition', objectName: 'Event definition', objectPlural: 'event definitions' },
     { key: 'error_tracking', objectName: 'Error tracking', objectPlural: 'error tracking' },
     { key: 'experiment', objectName: 'Experiment', objectPlural: 'experiments' },
+    { key: 'experiment_saved_metric', objectName: 'Shared metric', objectPlural: 'shared metrics' },
     { key: 'export', objectName: 'Export', objectPlural: 'exports' },
     { key: 'feature_flag', objectName: 'Feature flag', objectPlural: 'feature flags' },
     { key: 'group', objectName: 'Group', objectPlural: 'groups' },

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
@@ -125,9 +125,9 @@ export function SharedMetric(): JSX.Element {
                 <ScenePanelActionsSection>
                     {action === 'update' && (
                         <AccessControlAction
-                            resourceType={AccessControlResourceType.Experiment}
+                            resourceType={AccessControlResourceType.ExperimentSavedMetric}
                             minAccessLevel={AccessControlLevel.Editor}
-                            userAccessLevel={AccessControlLevel.Editor}
+                            userAccessLevel={sharedMetric.user_access_level}
                         >
                             <ButtonPrimitive
                                 variant="danger"
@@ -182,9 +182,9 @@ export function SharedMetric(): JSX.Element {
                 }}
                 actions={
                     <AccessControlAction
-                        resourceType={AccessControlResourceType.Experiment}
+                        resourceType={AccessControlResourceType.ExperimentSavedMetric}
                         minAccessLevel={AccessControlLevel.Editor}
-                        userAccessLevel={AccessControlLevel.Editor}
+                        userAccessLevel={sharedMetric.user_access_level}
                     >
                         <LemonButton
                             disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}
@@ -250,9 +250,9 @@ export function SharedMetric(): JSX.Element {
                     </LemonButton>
                 )} */}
                 <AccessControlAction
-                    resourceType={AccessControlResourceType.Experiment}
+                    resourceType={AccessControlResourceType.ExperimentSavedMetric}
                     minAccessLevel={AccessControlLevel.Editor}
-                    userAccessLevel={AccessControlLevel.Editor}
+                    userAccessLevel={sharedMetric.user_access_level}
                 >
                     <LemonButton
                         disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -10,7 +10,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
-import { ActivityScope } from '~/types'
+import { AccessControlLevel, ActivityScope } from '~/types'
 import type { UserBasicType } from '~/types'
 
 import { getDefaultFunnelMetric } from '../utils'
@@ -32,6 +32,7 @@ export interface SharedMetric {
     updated_at: string | null
     tags: string[]
     metadata?: Record<string, any>
+    user_access_level: AccessControlLevel
 }
 
 export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
@@ -39,6 +40,7 @@ export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
     description: '',
     query: undefined,
     tags: [],
+    user_access_level: AccessControlLevel.Editor,
 }
 
 export const sharedMetricLogic = kea<sharedMetricLogicType>([

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -39,6 +39,7 @@ export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
     description: '',
     query: undefined,
     tags: [],
+    user_access_level: AccessControlLevel.Editor,
 }
 
 export const sharedMetricLogic = kea<sharedMetricLogicType>([

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -10,7 +10,8 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
-import { AccessControlLevel, ActivityScope, UserBasicType } from '~/types'
+import { ActivityScope } from '~/types'
+import type { UserBasicType } from '~/types'
 
 import { getDefaultFunnelMetric } from '../utils'
 import type { sharedMetricLogicType } from './sharedMetricLogicType'
@@ -31,7 +32,6 @@ export interface SharedMetric {
     updated_at: string | null
     tags: string[]
     metadata?: Record<string, any>
-    user_access_level: AccessControlLevel
 }
 
 export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
@@ -39,7 +39,6 @@ export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
     description: '',
     query: undefined,
     tags: [],
-    user_access_level: AccessControlLevel.Editor,
 }
 
 export const sharedMetricLogic = kea<sharedMetricLogicType>([

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -154,9 +154,9 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
             }),
         ],
         [SIDE_PANEL_CONTEXT_KEY]: [
-            (s) => [s.sharedMetric],
-            (sharedMetric: Partial<SharedMetric>): SidePanelSceneContext | null => {
-                return sharedMetric?.id && sharedMetric.id !== 'new'
+            (s) => [s.sharedMetric, s.sharedMetricId],
+            (sharedMetric: Partial<SharedMetric>, sharedMetricId: string | number): SidePanelSceneContext | null => {
+                return sharedMetric?.id && sharedMetricId !== 'new'
                     ? {
                           activity_scope: ActivityScope.EXPERIMENT,
                           activity_item_id: `${sharedMetric.id}`,

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -9,7 +9,8 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 
-import { UserBasicType } from '~/types'
+import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
+import { AccessControlLevel, ActivityScope, UserBasicType } from '~/types'
 
 import { getDefaultFunnelMetric } from '../utils'
 import type { sharedMetricLogicType } from './sharedMetricLogicType'
@@ -30,6 +31,7 @@ export interface SharedMetric {
     updated_at: string | null
     tags: string[]
     metadata?: Record<string, any>
+    user_access_level: AccessControlLevel
 }
 
 export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
@@ -149,6 +151,19 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
                 ...NEW_SHARED_METRIC,
                 query: getDefaultFunnelMetric(),
             }),
+        ],
+        [SIDE_PANEL_CONTEXT_KEY]: [
+            (s) => [s.sharedMetric],
+            (sharedMetric: Partial<SharedMetric>): SidePanelSceneContext | null => {
+                return sharedMetric?.id && sharedMetric.id !== 'new'
+                    ? {
+                          activity_scope: ActivityScope.EXPERIMENT,
+                          activity_item_id: `${sharedMetric.id}`,
+                          access_control_resource: 'experiment_saved_metric',
+                          access_control_resource_id: `${sharedMetric.id}`,
+                      }
+                    : null
+            },
         ],
     }),
 

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -9,7 +9,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 
-import { UserBasicType } from '~/types'
+import { AccessControlLevel, UserBasicType } from '~/types'
 
 import { getDefaultFunnelMetric } from '../utils'
 import type { sharedMetricLogicType } from './sharedMetricLogicType'
@@ -30,6 +30,7 @@ export interface SharedMetric {
     updated_at: string | null
     tags: string[]
     metadata?: Record<string, any>
+    user_access_level: AccessControlLevel
 }
 
 export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
@@ -37,6 +38,7 @@ export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
     description: '',
     query: undefined,
     tags: [],
+    user_access_level: AccessControlLevel.Editor,
 }
 
 export const sharedMetricLogic = kea<sharedMetricLogicType>([

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -9,7 +9,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 
-import { AccessControlLevel, UserBasicType } from '~/types'
+import { UserBasicType } from '~/types'
 
 import { getDefaultFunnelMetric } from '../utils'
 import type { sharedMetricLogicType } from './sharedMetricLogicType'
@@ -30,7 +30,6 @@ export interface SharedMetric {
     updated_at: string | null
     tags: string[]
     metadata?: Record<string, any>
-    user_access_level: AccessControlLevel
 }
 
 export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
@@ -38,7 +37,6 @@ export const NEW_SHARED_METRIC: Partial<SharedMetric> = {
     description: '',
     query: undefined,
     tags: [],
-    user_access_level: AccessControlLevel.Editor,
 }
 
 export const sharedMetricLogic = kea<sharedMetricLogicType>([

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -284,6 +284,7 @@ export enum AccessControlResourceType {
     Survey = 'survey',
     ProductTour = 'product_tour',
     Experiment = 'experiment',
+    ExperimentSavedMetric = 'experiment_saved_metric',
     WebAnalytics = 'web_analytics',
     ActivityLog = 'activity_log',
 }
@@ -4785,6 +4786,7 @@ export type APIScopeObject =
     | 'evaluation'
     | 'event_definition'
     | 'experiment'
+    | 'experiment_saved_metric'
     | 'export'
     | 'feature_flag'
     | 'group'


### PR DESCRIPTION
## Problem

The shared metrics frontend is defaulting to a hardcoded user access level, and it’s not showing the sidebar panel.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

| shared metric with ACL side panel open |
| - |
| <img width="1739" height="1234" alt="image" src="https://github.com/user-attachments/assets/22c2cde8-42b1-4fb0-88d1-9927bd06957c" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type.gif](https://app.gitbutler.com/uploads/dca95bcb-5b5c-45f6-83b3-f806480771d3)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #44376 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #44374 
- <kbd>&nbsp;1&nbsp;</kbd> #44300 
<!-- GitButler Footer Boundary Bottom -->

