### PR TITLE
fix(web-analytics): render web analytics insights on dashboards

### DIFF
--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -56,8 +56,10 @@ export function WebOverview(props: {
     const showWarning = hasReverseProxy === false && !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_EMPTY_ONBOARDING]
 
     // Convert WebOverviewItem to OverviewItem
+    // Handle both `results` (from direct query response) and `result` (from cached insight)
+    const resultsArray = webOverviewQueryResponse?.results ?? (response as any)?.result
     const overviewItems: OverviewItem[] =
-        webOverviewQueryResponse?.results?.map((item) => ({
+        resultsArray?.map((item: any) => ({
             key: item.key,
             value: item.value,
             previous: item.previous,

--- a/frontend/src/scenes/web-analytics/WebAnalyticsInsight.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsInsight.tsx
@@ -1,6 +1,7 @@
 import { useValues } from 'kea'
 
 import { Query } from '~/queries/Query/Query'
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { DataTableNode, InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { isWebOverviewQuery, isWebStatsTableQuery } from '~/queries/utils'
@@ -17,6 +18,10 @@ export interface WebAnalyticsInsightProps {
 export function WebAnalyticsInsight({ context, editMode }: WebAnalyticsInsightProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { querySource } = useValues(insightVizDataLogic(insightProps))
+
+    // Use the same dataNodeLogic key as InsightViz so we reuse the existing logic
+    // instance with its cached data instead of creating a new one
+    const vizKey = insightVizDataNodeKey(insightProps)
 
     if (isWebStatsTableQuery(querySource)) {
         // Wrap WebStatsTableQuery in DataTableNode with the same structure as Web Analytics uses
@@ -38,9 +43,9 @@ export function WebAnalyticsInsight({ context, editMode }: WebAnalyticsInsightPr
             compareFilter: querySource.compareFilter,
         } as QueryContext
 
-        return <Query query={wrappedQuery} context={webAnalyticsContext} readOnly={!editMode} />
+        return <Query query={wrappedQuery} uniqueKey={vizKey} context={webAnalyticsContext} readOnly={!editMode} />
     } else if (isWebOverviewQuery(querySource)) {
-        return <Query query={querySource} context={context} readOnly={!editMode} />
+        return <Query query={querySource} uniqueKey={vizKey} context={context} readOnly={!editMode} />
     }
 
     return null


### PR DESCRIPTION
## Problem

Context: https://posthoghelp.zendesk.com/agent/tickets/46414 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49684)

When rendering the insights on dashboards, AND the results were cached, we would sometimes not render the cached results, as this was hardcoded to the `results` property. 

## Changes

- Be more resilient on the formats we accept.

## How did you test this code?

Manually.

## Publish to changelog?

No.