### PR TITLE
fix(ci): squash merge browserslist update PR

### DIFF
--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -52,4 +52,4 @@ jobs:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   PR_NUMBER: ${{ steps.update-browserlist.outputs.pr_number }}
               run: |
-                  gh pr merge "$PR_NUMBER" --auto --merge
+                  gh pr merge "$PR_NUMBER" --auto --squash


### PR DESCRIPTION
Merge strategy is disallowed. Action is currently failing: https://github.com/PostHog/posthog/actions/runs/20714743447/job/59626349875

