### PR TITLE
feat(kafka-deduplicator): more robust orphaned store checks 

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -77,6 +77,10 @@ pub struct Config {
     // 2 minutes default - interval for checking and cleaning up old data when capacity is exceeded
     pub cleanup_interval_secs: u64,
 
+    #[envconfig(default = "900")]
+    // 15 minutes default - minimum staleness (no recent WAL activity) before orphan directories can be deleted
+    pub orphan_cleanup_min_staleness_secs: u64,
+
     // Consumer processing configuration
     #[envconfig(default = "100")]
     pub max_in_flight_messages: usize,
@@ -314,6 +318,11 @@ impl Config {
     /// Get cleanup interval as Duration
     pub fn cleanup_interval(&self) -> Duration {
         Duration::from_secs(self.cleanup_interval_secs)
+    }
+
+    /// Get orphan cleanup minimum staleness as Duration
+    pub fn orphan_cleanup_min_staleness(&self) -> Duration {
+        Duration::from_secs(self.orphan_cleanup_min_staleness_secs)
     }
 
     /// Get producer send timeout as Duration

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -80,7 +80,11 @@ impl KafkaDeduplicatorService {
         };
 
         // Create store manager for handling concurrent store creation
-        let store_manager = Arc::new(StoreManager::new(store_config.clone()));
+        let orphan_min_staleness = config.orphan_cleanup_min_staleness();
+        let store_manager = Arc::new(StoreManager::new_with_orphan_staleness(
+            store_config.clone(),
+            orphan_min_staleness,
+        ));
 
         // Start periodic cleanup task if max_capacity is configured
         let cleanup_task_handle = if store_config.max_capacity > 0 {

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -80,18 +80,15 @@ impl KafkaDeduplicatorService {
         };
 
         // Create store manager for handling concurrent store creation
-        let orphan_min_staleness = config.orphan_cleanup_min_staleness();
-        let store_manager = Arc::new(StoreManager::new_with_orphan_staleness(
-            store_config.clone(),
-            orphan_min_staleness,
-        ));
+        let store_manager = Arc::new(StoreManager::new(store_config.clone()));
 
         // Start periodic cleanup task if max_capacity is configured
         let cleanup_task_handle = if store_config.max_capacity > 0 {
             let cleanup_interval = config.cleanup_interval();
+            let orphan_min_staleness = config.orphan_cleanup_min_staleness();
             let handle = store_manager
                 .clone()
-                .start_periodic_cleanup(cleanup_interval);
+                .start_periodic_cleanup(cleanup_interval, orphan_min_staleness);
             info!(
                 "Started periodic cleanup task with interval: {:?} for max capacity: {} bytes",
                 cleanup_interval, store_config.max_capacity


### PR DESCRIPTION
## Problem
Our candidate selection for potentially stale/orphaned store directories is naive and allows for TOCTOU races between selection and rebalances, checkpoint imports
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement a more robust but (fairly) cheap, high-signal second pass check on each candidate before deletion:
    * Has the parent store dir (topic-partition-timestamp) been modified since staleness threshold?
    * Has the WAL file in the dir been modified since staleness threshold?
    * Does the dir have an active RocksDB lock file set?

The first catches long-downloading checkpoint imports and restarts, the other two catch legit local stores that could have been missed due to TOCTOU building the candidate list prior to rebalance or reassignment clearing the store manager. I'm hopeful this is still cheap enough to ensure we don't keep deleting whole stores at random (and killing good local checkpoint attempts too!) when these processes race.

* New unit tests & config var to control staleness interval (15 min should be fine as default)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; new unit tests; will smoke test in PoC staging env
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
