### PR TITLE
fix: use CLICKHOUSE_MAX_MEMORY setting when executing queries

### DIFF
--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
@@ -1,5 +1,5 @@
+import json
 import math
-import asyncio
 import datetime as dt
 import dataclasses
 from typing import Any, TypedDict
@@ -10,9 +10,8 @@ import temporalio.common
 import temporalio.activity
 import temporalio.workflow
 
-from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.client.connection import ClickHouseUser, Workload
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.logger import get_logger
 from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
     BackfillPrecalculatedPersonPropertiesInputs,
@@ -80,22 +79,18 @@ async def get_person_count_activity(
             GROUP BY id
             HAVING max(is_deleted) = 0
         )
+        FORMAT JSONEachRow
     """
 
     query_params = {"team_id": inputs.team_id}
 
-    # Execute query using sync_execute in a thread to avoid blocking the event loop
-    results = await asyncio.to_thread(
-        sync_execute,
-        query,
-        query_params,
-        workload=Workload.OFFLINE,
-        team_id=inputs.team_id,
-        ch_user=ClickHouseUser.COHORTS,
-    )
-
-    if results:
-        return PersonCountResult(count=int(results[0][0]))
+    # Execute query using async ClickHouse client
+    async with get_client(team_id=inputs.team_id) as client:
+        response = await client.read_query(query, query_parameters=query_params)
+        for line in response.decode("utf-8").splitlines():
+            if line.strip():
+                row = json.loads(line)
+                return PersonCountResult(count=int(row["count"]))
 
     return PersonCountResult(count=0)
 

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
@@ -89,8 +89,12 @@ async def get_person_count_activity(
         response = await client.read_query(query, query_parameters=query_params)
         for line in response.decode("utf-8").splitlines():
             if line.strip():
-                row = json.loads(line)
-                return PersonCountResult(count=int(row["count"]))
+                try:
+                    row = json.loads(line)
+                    return PersonCountResult(count=int(row["count"]))
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    LOGGER.exception("Failed to parse person count result", line=line)
+                    raise
 
     return PersonCountResult(count=0)
 

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -179,8 +179,18 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                         results = []
                         for line in response.decode("utf-8").splitlines():
                             if line.strip():
-                                row = json.loads(line)
-                                results.append((row["person_id"], row["status"]))
+                                try:
+                                    row = json.loads(line)
+                                    results.append((row["person_id"], row["status"]))
+                                except (json.JSONDecodeError, KeyError) as e:
+                                    logger.warning(
+                                        f"Failed to parse cohort query result line: {e}",
+                                        cohort_id=cohort.id,
+                                        line=line,
+                                        error=str(e),
+                                    )
+                                    # Skip malformed lines but continue processing
+                                    continue
 
                     # Process results
                     for row in results:


### PR DESCRIPTION
Follow up to #44163 to use `get_client` so that `CLICKHOUSE_MAX_MEMORY` is used.

After stopping using the `get_client`, some queries are failing due to memory limit.

```
Code: 241. DB::Exception: Query memory limit exceeded: would use 42.00 GiB (attempt to allocate chunk of 4.50 MiB bytes), maximum: 42.00 GiB: While executing AggregatingTransform. (MEMORY_LIMIT_EXCEEDED) (version 25.8.11.66 (official build))
```