### PR TITLE
chore: use PHP short array syntax

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/product-analytics/laravel.tsx
+++ b/frontend/src/scenes/onboarding/sdks/product-analytics/laravel.tsx
@@ -6,7 +6,7 @@ import { PersonModeEventPropertyInstructions } from '../shared-snippets'
 function LaravelCaptureSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.PHP}>
-            {"PostHog::capture(array(\n    'distinctId' => 'test-user',\n    'event' => 'test-event'\n));"}
+            {"PostHog::capture([\n    'distinctId' => 'test-user',\n    'event' => 'test-event'\n]);"}
         </CodeSnippet>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/product-analytics/laravel.tsx
+++ b/frontend/src/scenes/onboarding/sdks/product-analytics/laravel.tsx
@@ -6,7 +6,7 @@ import { PersonModeEventPropertyInstructions } from '../shared-snippets'
 function LaravelCaptureSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.PHP}>
-            {"PostHog::capture([\n    'distinctId' => 'test-user',\n    'event' => 'test-event'\n]);"}
+            {"PostHog::capture(['distinctId' => 'test-user', 'event' => 'test-event']);"}
         </CodeSnippet>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/product-analytics/php.tsx
+++ b/frontend/src/scenes/onboarding/sdks/product-analytics/php.tsx
@@ -6,7 +6,7 @@ import { PersonModeEventPropertyInstructions } from '../shared-snippets'
 function PHPCaptureSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.PHP}>
-            {"PostHog::capture([\n    'distinctId' => 'test-user',\n    'event' => 'test-event'\n]);"}
+            {"PostHog::capture(['distinctId' => 'test-user', 'event' => 'test-event']);"}
         </CodeSnippet>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/product-analytics/php.tsx
+++ b/frontend/src/scenes/onboarding/sdks/product-analytics/php.tsx
@@ -6,7 +6,7 @@ import { PersonModeEventPropertyInstructions } from '../shared-snippets'
 function PHPCaptureSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.PHP}>
-            {"PostHog::capture(array(\n    'distinctId' => 'test-user',\n    'event' => 'test-event'\n));"}
+            {"PostHog::capture([\n    'distinctId' => 'test-user',\n    'event' => 'test-event'\n]);"}
         </CodeSnippet>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/php.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/php.tsx
@@ -13,7 +13,8 @@ function PHPSetupSnippet(): JSX.Element {
 
     return (
         <CodeSnippet language={Language.PHP}>
-            {`PostHog\\PostHog::init('${currentTeam?.api_token}',
+            {`PostHog\\PostHog::init(
+    '${currentTeam?.api_token}',
     ['host' => '${apiHostOrigin()}']
 );`}
         </CodeSnippet>

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/php.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/php.tsx
@@ -14,7 +14,7 @@ function PHPSetupSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.PHP}>
             {`PostHog\\PostHog::init('${currentTeam?.api_token}',
-    array('host' => '${apiHostOrigin()}')
+    ['host' => '${apiHostOrigin()}']
 );`}
         </CodeSnippet>
     )


### PR DESCRIPTION
## Problem
The SDK installation instructions for PHP are using outdated syntax.

## Changes

This PR updates the PHP SDK snippets to use the short-hand array syntax that is now idiomatic and standard.

## How did you test this code?

Tested the original snippets and new snippet.

## Publish to changelog?

no
