### PR TITLE
fix(ci): exclude cymbal test fixtures from CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,6 +75,9 @@ jobs:
                   # is never reused, causing ~2GB of wasted cache space.
                   # See: https://github.com/github/codeql-action/issues/2030
                   trap-caching: false
+                  config: |
+                      paths-ignore:
+                        - rust/cymbal/tests/static/
 
             # If the analyze step fails for one of the languages you are analyzing with
             # "We were unable to automatically build your code", modify the matrix above


### PR DESCRIPTION
Test JS chunks in `rust/cymbal/tests/static/` use the ES2022 regex `d` flag (indices/hasIndices) which CodeQL's parser doesn't support yet, causing parse error warnings during analysis.

These are minified test fixtures for source map resolution testing, not production code.