### PR TITLE
fix(product analytics): insights were overwriting the previously saved insight when creating a new one

### DIFF
--- a/frontend/src/scenes/insights/InsightAsScene.tsx
+++ b/frontend/src/scenes/insights/InsightAsScene.tsx
@@ -30,13 +30,14 @@ export interface InsightAsSceneProps {
 
 export function InsightAsScene({ insightId, attachTo, tabId }: InsightAsSceneProps): JSX.Element | null {
     // insightSceneLogic
-    const { insightMode, insight, filtersOverride, variablesOverride, hasOverrides, freshQuery } =
+    const { insightMode, insight, filtersOverride, variablesOverride, hasOverrides, freshQuery, dashboardId } =
         useValues(insightSceneLogic)
     const { currentTeamId } = useValues(teamLogic)
 
     // insightLogic
     const logic = insightLogic({
         dashboardItemId: insightId || `new-${tabId}`,
+        dashboardId: dashboardId ?? undefined,
         tabId,
         // don't use cached insight if we have overrides
         cachedInsight: hasOverrides && insight?.short_id === insightId ? insight : null,


### PR DESCRIPTION
## Problem

When creating insights in a dashboard, the second insight you create would overwrite the first one

[broken-insights.webm](https://github.com/user-attachments/assets/9abd1c6a-b37b-43eb-87d0-8db01e79367c)


## Changes

Stop using the cached insight when creating a new one and the previous insight was already saved

[postfix-dashboard-insights.webm](https://github.com/user-attachments/assets/7d684e9a-27fc-47de-b420-4d38c72c6ec1)


It looks like there's an issue with setting the name of an insight; it saves correctly, but doesn't update correctly in the UI (you can see it happening in the post-fix video). This is already happening on prd and not introduced in this change

## How did you test this code?

Manually
