### PR TITLE
fix(ph-ai): validate mode is in registry

### DIFF
--- a/ee/hogai/chat_agent/mode_manager.py
+++ b/ee/hogai/chat_agent/mode_manager.py
@@ -205,6 +205,9 @@ class ChatAgentModeManager(AgentModeManager):
         mode: AgentMode | None = None,
     ):
         super().__init__(team=team, user=user, node_path=node_path, context_manager=context_manager, mode=mode)
+        # Validate mode is in registry, fall back to default mode if not
+        if mode and mode not in self.mode_registry:
+            mode = AgentMode.PRODUCT_ANALYTICS
         self._mode = mode or AgentMode.PRODUCT_ANALYTICS
 
     @property

--- a/ee/hogai/chat_agent/test/test_mode_manager.py
+++ b/ee/hogai/chat_agent/test/test_mode_manager.py
@@ -15,6 +15,7 @@ from langchain_core.runnables import RunnableConfig
 from parameterized import parameterized
 
 from posthog.schema import (
+    AgentMode,
     AssistantMessage,
     AssistantToolCall,
     AssistantToolCallMessage,
@@ -175,6 +176,21 @@ class TestAgentToolkit(BaseTest):
                 self.assertIn(expected, mode_names)
             for unexpected in unexpected_modes:
                 self.assertNotIn(unexpected, mode_names)
+
+    def test_unavailable_mode_falls_back_to_product_analytics(self):
+        with patch("ee.hogai.chat_agent.mode_manager.has_error_tracking_mode_feature_flag", return_value=False):
+            node_path = (NodePath(name=AssistantNodeName.ROOT, message_id="test_id", tool_call_id="test_tool_call_id"),)
+            context_manager = AssistantContextManager(
+                team=self.team, user=self.user, config=RunnableConfig(configurable={})
+            )
+            mode_manager = ChatAgentModeManager(
+                team=self.team,
+                user=self.user,
+                node_path=node_path,
+                context_manager=context_manager,
+                mode=AgentMode.ERROR_TRACKING,
+            )
+            self.assertEqual(mode_manager.mode, AgentMode.PRODUCT_ANALYTICS)
 
 
 class TestAgentNode(ClickhouseTestMixin, BaseTest):


### PR DESCRIPTION
## Problem

We observed a [KeyError in prod](https://us.posthog.com/project/2/error_tracking/019b859d-f3f1-72e1-81af-6fe2fb84f437?timestamp=2026-01-06%2016:39:04.291000-08:00) that could occur when:

  1. conversation state had `agent_mode=ERROR_TRACKING` persisted
  2. the feature flag that controls the mode (if undeer ff) was disabled
  3. look up the mode in `self.mode_registry[self._mode]` with failure

## Changes

* added defensive validation and fallback to our default mode (`PRODUCT_ANALYTICS`)

## How did you test this code?

- [x] unit tests
