### PR TITLE
fix(phai): generate insight schemas in isolated context

### DIFF
--- a/ee/hogai/chat_agent/funnels/prompts.py
+++ b/ee/hogai/chat_agent/funnels/prompts.py
@@ -1,25 +1,25 @@
 FUNNEL_SYSTEM_PROMPT = """
-Act as an expert product manager. Your task is to generate a JSON schema of funnel insights. You will be given a generation plan describing a series sequence, filters, exclusion steps, and breakdown. Use the plan and following instructions to create a correct query answering the user's question.
+Act as an expert product manager. Your task is to generate a JSON schema of funnel insights. You will be given a generation plan describing a series sequence, filters, exclusion steps, and breakdown. Use the plan and following instructions to create a correct query based on the provided plan.
 
 Follow this instruction to create a query:
 * Build series according to the series sequence and filters in the plan. Properties can be of multiple types: String, Numeric, Bool, and DateTime. A property can be an array of those types and only has a single type.
 * Apply the exclusion steps and breakdown according to the plan.
 * When evaluating property filter operators, replace the `equals` or `doesn't equal` operators with `contains` or `doesn't contain` if the query value is likely a personal name, company name, or any other name-sensitive term where letter casing matters. For instance, if the value is ‘John Doe’ or ‘Acme Corp’, replace `equals` with `contains` and change the value to lowercase from `John Doe` to `john doe` or `Acme Corp` to `acme corp`. Do not apply this to event names, as they are strictly case-sensitive!
-* Determine what metric the user seeks from the funnel and choose the correct funnel type.
-* Determine the funnel order type, aggregation type, and visualization type that will answer the user's question in the best way. Use the provided defaults.
+* Determine what metric the plan specifies from the funnel and choose the correct funnel type.
+* Determine the funnel order type, aggregation type, and visualization type that best represent the data described in the plan. Use the provided defaults.
 * Determine the window interval and unit. Use the provided defaults.
 * Use the date range and the interval from the plan.
-* Determine if the user wants to name the series or use the default names.
-* Determine if the user wants to filter out internal and test users. If the user didn't specify, filter out internal and test users by default.
-* Determine if you need to apply a sampling factor, different layout, bin count,  etc. Only specify those if the user has explicitly asked.
-* Use your judgment if there are any other parameters that the user might want to adjust that aren't listed here.
+* Determine if the plan specifies custom series names or use the default names.
+* Determine if the plan specifies filtering out internal and test users. If not specified in the plan, filter out internal and test users by default.
+* Determine if the plan specifies applying a sampling factor, different layout, bin count,  etc. Only specify those if explicitly specified in the plan.
+* Use your judgment if there are any other parameters that aren't listed here.
 
-The user might want to receive insights about groups. A group aggregates events based on entities, such as organizations or sellers. The user might provide a list of group names and their numeric indexes. Instead of a group's name, always use its numeric index.
+The plan might specify insights about groups. A group aggregates events based on entities, such as organizations or sellers. The plan might provide a list of group names and their numeric indexes. Instead of a group's name, always use its numeric index.
 
 The funnel has following types and metrics:
 - `steps` - shows a step-by-step funnel. Perfect to show a conversion rate of a sequence of events or actions. Returns a conversion rate, drop-off rate, average time to convert, and median time to convert. Use this type by default.
 - `time_to_convert` - shows a histogram of the time it took to complete the funnel. Returns the distribution of average conversion time across users.
-- `trends` - shows a trend of the whole sequence's conversion rate over time. Use this if the user wants to see how the conversion or drop-off rate changes over time.
+- `trends` - shows a trend of the whole sequence's conversion rate over time. Use this if the plan indicates showing how the conversion or drop-off rate changes over time.
 
 The funnel can be aggregated by:
 - Unique users (default, do not specify anything to use it). Use this option unless the user states otherwise.
@@ -119,10 +119,8 @@ Output:
 ```
 
 ---
-Obey these rules:
-- If the date range is not specified, use the best judgment to select a reasonable date range. By default, use the last 30 days.
-- Filter internal users by default if the user doesn't specify.
+Follow these rules:
+- If the date range is not specified in the plan, use the best judgment to select a reasonable date range. By default, use the last 30 days.
+- Filter internal users by default if not specified in the plan.
 - You can't create new events or property definitions. Stick to the plan.
-
-Remember, your efforts will be rewarded by the company's founders. Do not hallucinate.
 """.strip()

--- a/ee/hogai/chat_agent/retention/prompts.py
+++ b/ee/hogai/chat_agent/retention/prompts.py
@@ -1,19 +1,19 @@
 RETENTION_SYSTEM_PROMPT = """
-Act as an expert product manager. Your task is to generate a JSON schema of retention insights. You will be given a generation plan describing a target event or action, returning event or action, target/returning parameters, and filters. Use the plan and following instructions to create a correct query answering the user's question.
+Act as an expert product manager. Your task is to generate a JSON schema of retention insights. You will be given a generation plan describing a target event or action, returning event or action, target/returning parameters, and filters. Use the plan and following instructions to create a correct query based on the provided plan.
 
 Follow this instruction to create a query:
 * Build the insight according to the plan. Properties can be of multiple types: String, Numeric, Bool, and DateTime. A property can be an array of those types and only has a single type.
 * When evaluating property filter operators, replace the `equals` or `doesn't equal` operators with `contains` or `doesn't contain` if the query value is likely a personal name, company name, or any other name-sensitive term where letter casing matters. For instance, if the value is ‘John Doe' or ‘Acme Corp', replace `equals` with `contains` and change the value to lowercase from `John Doe` to `john doe` or `Acme Corp` to `acme corp`. Do not apply this to event names, as they are strictly case-sensitive!
-* Determine the activation type that will answer the user's question in the best way. Use the provided defaults.
+* Determine the activation type that best represents the data described in the plan. Use the provided defaults.
 * Use the time period as the retention period from the plan and determine the number of periods to look back.
-* Determine if the user wants to filter out internal and test users. If the user didn't specify, filter out internal and test users by default.
-* Determine if you need to apply a sampling factor. Only specify those if the user has explicitly asked.
-* Use your judgment if there are any other parameters that the user might want to adjust that aren't listed here.
+* Determine if the plan specifies filtering out internal and test users. If not specified in the plan, filter out internal and test users by default.
+* Determine if the plan specifies applying a sampling factor. Only specify those if explicitly specified in the plan.
+* Use your judgment if there are any other parameters that aren't listed here.
 
-The user might want to receive insights about groups. A group aggregates events based on entities, such as organizations or sellers. The user might provide a list of group names and their numeric indexes. Instead of a group's name, always use its numeric index.
+The plan might specify insights about groups. A group aggregates events based on entities, such as organizations or sellers. The plan might provide a list of group names and their numeric indexes. Instead of a group's name, always use its numeric index.
 
 Retention can be aggregated by:
-- Unique users (default, do not specify anything to use it). Use this option unless the user states otherwise.
+- Unique users (default, do not specify anything to use it). Use this option unless the plan states otherwise.
 - Unique groups (specify the group index using `aggregation_group_type_index`) according to the group mapping.
 
 <actions>
@@ -38,9 +38,7 @@ Output:
 {"kind":"RetentionQuery","retentionFilter":{"period":"Week","totalIntervals":9,"targetEntity":{"id":"insight created","name":"insight created","type":"events","order":0},"returningEntity":{"id":"insight created","name":"insight created","type":"events","order":0},"retentionType":"retention_first_time","retentionReference":"total","cumulative":false},"filterTestAccounts":true}
 ```
 
-Obey these rules:
-- Filter internal users by default if the user doesn't specify.
+Follow these rules:
+- Filter internal users by default if not specified in the plan.
 - You can't create new events or property definitions. Stick to the plan.
-
-Remember, your efforts will be rewarded by the company's founders. Do not hallucinate.
 """.strip()

--- a/ee/hogai/chat_agent/schema_generator/nodes.py
+++ b/ee/hogai/chat_agent/schema_generator/nodes.py
@@ -45,7 +45,7 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
     @property
     def _model(self):
         return MaxChatOpenAI(
-            model="gpt-5.1",
+            model="gpt-5.2",
             temperature=0.3,
             disable_streaming=True,
             user=self._user,

--- a/ee/hogai/chat_agent/schema_generator/nodes.py
+++ b/ee/hogai/chat_agent/schema_generator/nodes.py
@@ -4,11 +4,7 @@ from typing import Generic, Optional, cast
 
 from langchain_core.agents import AgentAction
 from langchain_core.exceptions import OutputParserException
-from langchain_core.messages import (
-    AIMessage as LangchainAssistantMessage,
-    BaseMessage,
-    merge_message_runs,
-)
+from langchain_core.messages import BaseMessage, merge_message_runs
 from langchain_core.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
 from langchain_core.runnables import RunnableConfig
 
@@ -18,19 +14,10 @@ from posthog.models.group_type_mapping import GroupTypeMapping
 
 from ee.hogai.core.node import AssistantNode
 from ee.hogai.llm import MaxChatOpenAI
-from ee.hogai.utils.helpers import find_start_message
 from ee.hogai.utils.types import AssistantState, IntermediateStep, PartialAssistantState
-from ee.hogai.utils.types.base import ArtifactRefMessage
 
 from .parsers import PydanticOutputParserException, parse_pydantic_structured_output
-from .prompts import (
-    FAILOVER_OUTPUT_PROMPT,
-    FAILOVER_PROMPT,
-    GROUP_MAPPING_PROMPT,
-    NEW_PLAN_PROMPT,
-    PLAN_PROMPT,
-    QUESTION_PROMPT,
-)
+from .prompts import FAILOVER_OUTPUT_PROMPT, FAILOVER_PROMPT, GROUP_MAPPING_PROMPT, PLAN_PROMPT
 from .utils import Q, SchemaGeneratorOutput
 
 RETRIES_ALLOWED = 2
@@ -189,15 +176,11 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
         self, state: AssistantState, validation_error_message: str | None = None
     ) -> list[BaseMessage]:
         """
-        Reconstruct the conversation for the generation. Take all previously generated questions, plans, and schemas, and return the history.
+        Construct the prompt for schema generation with only the plan and a static generation instruction.
         """
-        # Only process the last five artifact messages.
-        artifact_messages = await self.context_manager.artifacts.aenrich_messages(
-            [message for message in state.messages if isinstance(message, ArtifactRefMessage)][-5:]
-        )
-        generated_plan = state.plan
+        generated_plan = state.plan or ""
 
-        # Add the group mapping prompt to the beginning of the conversation.
+        # Add the group mapping prompt.
         group_mapping = await self._get_group_mapping_prompt()
         conversation: list[BaseMessage] = [
             HumanMessagePromptTemplate.from_template(GROUP_MAPPING_PROMPT, template_format="mustache").format(
@@ -205,42 +188,10 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
             )
         ]
 
-        # Batch fetch all artifact contents (pass full state.messages for State source lookup)
-        artifact_contents = await self.context_manager.artifacts.aget_contents_by_message_id(state.messages)
-
-        for message in artifact_messages:
-            content = artifact_contents.get(message.id or "")
-            if not content:
-                continue
-            plan = content.plan or ""
-            query = content.name or ""
-            answer = content.query
-
-            # Plans go first.
-            conversation.append(
-                HumanMessagePromptTemplate.from_template(PLAN_PROMPT, template_format="mustache").format(plan=plan)
-            )
-            # Then questions.
-            conversation.append(
-                HumanMessagePromptTemplate.from_template(QUESTION_PROMPT, template_format="mustache").format(
-                    question=query
-                )
-            )
-            # Then the answer.
-            if answer:
-                conversation.append(LangchainAssistantMessage(content=answer.model_dump_json()))
-
-        # Add the initiator message and the generated plan to the end, so instructions are clear.
-        if generated_plan:
-            prompt = NEW_PLAN_PROMPT if artifact_messages else PLAN_PROMPT
-            conversation.append(
-                HumanMessagePromptTemplate.from_template(prompt, template_format="mustache").format(
-                    plan=generated_plan or ""
-                )
-            )
+        # Add the plan with generation instruction.
         conversation.append(
-            HumanMessagePromptTemplate.from_template(QUESTION_PROMPT, template_format="mustache").format(
-                question=self._get_insight_plan(state)
+            HumanMessagePromptTemplate.from_template(PLAN_PROMPT, template_format="mustache").format(
+                plan=generated_plan
             )
         )
 
@@ -253,14 +204,6 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
             )
 
         return conversation
-
-    def _get_insight_plan(self, state: AssistantState) -> str:
-        if state.root_tool_insight_plan:
-            return state.root_tool_insight_plan
-        start_message = find_start_message(state.messages, state.start_id)
-        if start_message:
-            return start_message.content
-        return ""
 
 
 class SchemaGeneratorToolsNode(AssistantNode):

--- a/ee/hogai/chat_agent/schema_generator/prompts.py
+++ b/ee/hogai/chat_agent/schema_generator/prompts.py
@@ -6,15 +6,8 @@ Here is the group mapping:
 PLAN_PROMPT = """
 Here is the plan:
 {{{plan}}}
-""".strip()
 
-NEW_PLAN_PROMPT = """
-Here is the new plan:
-{{{plan}}}
-""".strip()
-
-QUESTION_PROMPT = """
-Answer to this question: {{{question}}}
+Generate a schema from this plan.
 """.strip()
 
 FAILOVER_OUTPUT_PROMPT = """

--- a/ee/hogai/chat_agent/schema_generator/test/test_nodes.py
+++ b/ee/hogai/chat_agent/schema_generator/test/test_nodes.py
@@ -1,7 +1,6 @@
 import json
 from collections.abc import Iterable
 from typing import Any, cast
-from uuid import uuid4
 
 from posthog.test.base import BaseTest
 from unittest.mock import patch
@@ -15,9 +14,7 @@ from langchain_core.runnables import RunnableConfig, RunnableLambda
 from posthog.schema import (
     ArtifactContentType,
     ArtifactSource,
-    AssistantMessage,
     AssistantTrendsQuery,
-    FailureMessage,
     HumanMessage,
     VisualizationArtifactContent,
 )
@@ -145,7 +142,20 @@ class TestSchemaGeneratorNode(BaseTest):
             self.assertEqual(content.description, "Description")
             self.assertEqual(content.plan, "")
 
-    async def test_agent_reconstructs_conversation_and_does_not_add_an_empty_plan(self):
+    async def test_construct_messages_includes_group_mapping_and_plan(self):
+        node = DummyGeneratorNode(self.team, self.user)
+        history = await node._construct_messages(
+            AssistantState(messages=[HumanMessage(content="Text", id="0")], plan="randomplan", start_id="0")
+        )
+        self.assertEqual(len(history), 2)
+        self.assertEqual(history[0].type, "human")
+        self.assertIn("mapping", history[0].content)
+        self.assertEqual(history[1].type, "human")
+        self.assertIn("the plan", history[1].content)
+        self.assertIn("randomplan", history[1].content)
+        self.assertIn("Generate a schema", history[1].content)
+
+    async def test_construct_messages_with_empty_plan(self):
         node = DummyGeneratorNode(self.team, self.user)
         history = await node._construct_messages(
             AssistantState(messages=[HumanMessage(content="Text", id="0")], start_id="0")
@@ -154,201 +164,22 @@ class TestSchemaGeneratorNode(BaseTest):
         self.assertEqual(history[0].type, "human")
         self.assertIn("mapping", history[0].content)
         self.assertEqual(history[1].type, "human")
-        self.assertIn("Answer to this question:", history[1].content)
-        self.assertNotIn("{{question}}", history[1].content)
-
-    async def test_agent_reconstructs_conversation_adds_plan(self):
-        node = DummyGeneratorNode(self.team, self.user)
-        history = await node._construct_messages(
-            AssistantState(
-                messages=[HumanMessage(content="Text", id="0")],
-                plan="randomplan",
-                start_id="0",
-                root_tool_insight_plan="Text",
-            )
-        )
-        self.assertEqual(len(history), 3)
-        self.assertEqual(history[0].type, "human")
-        self.assertIn("mapping", history[0].content)
-        self.assertEqual(history[1].type, "human")
-        self.assertIn("the plan", history[1].content)
-        self.assertNotIn("{{plan}}", history[1].content)
-        self.assertIn("randomplan", history[1].content)
-        self.assertEqual(history[2].type, "human")
-        self.assertIn("Answer to this question:", history[2].content)
-        self.assertNotIn("{{question}}", history[2].content)
-        self.assertIn("Text", history[2].content)
-
-    async def test_agent_reconstructs_conversation_can_handle_follow_ups(self):
-        node = DummyGeneratorNode(self.team, self.user)
-        artifact = await AgentArtifact.objects.acreate(
-            team=self.team,
-            conversation=self.conversation,
-            name="Test Artifact",
-            type=AgentArtifact.Type.VISUALIZATION,
-            data=VisualizationArtifactContent(
-                query=self.basic_trends, name="Query", description="Description 1", plan="randomplan"
-            ).model_dump(),
-        )
-        history = await node._construct_messages(
-            AssistantState(
-                messages=[
-                    HumanMessage(content="Multiple questions", id="0"),
-                    ArtifactRefMessage(
-                        content_type=ArtifactContentType.VISUALIZATION,
-                        source=ArtifactSource.ARTIFACT,
-                        artifact_id=str(artifact.short_id),
-                        id="1",
-                    ),
-                    HumanMessage(content="Follow Up", id="2"),
-                ],
-                plan="newrandomplan",
-                start_id="2",
-            )
-        )
-
-        self.assertEqual(len(history), 6)
-        self.assertEqual(history[0].type, "human")
-        self.assertIn("mapping", history[0].content)
-        self.assertEqual(history[1].type, "human")
-        self.assertIn("the plan", history[1].content)
-        self.assertNotIn("{{plan}}", history[1].content)
-        self.assertIn("randomplan", history[1].content)
-        self.assertEqual(history[2].type, "human")
-        self.assertIn("Answer to this question:", history[2].content)
-        self.assertNotIn("{{question}}", history[2].content)
-        self.assertIn("Query", history[2].content)
-        self.assertEqual(history[3].type, "ai")
-        self.assertEqual(history[3].content, self.basic_trends.model_dump_json())
-        self.assertEqual(history[4].type, "human")
-        self.assertIn("the new plan", history[4].content)
-        self.assertNotIn("{{plan}}", history[4].content)
-        self.assertIn("newrandomplan", history[4].content)
-        self.assertEqual(history[5].type, "human")
-        self.assertIn("Answer to this question:", history[5].content)
-        self.assertNotIn("{{question}}", history[5].content)
-        self.assertIn("Follow Up", history[5].content)
-
-    async def test_agent_reconstructs_typical_conversation(self):
-        node = DummyGeneratorNode(self.team, self.user)
-        artifact1 = await AgentArtifact.objects.acreate(
-            team=self.team,
-            conversation=self.conversation,
-            name="Test Artifact 1",
-            type=AgentArtifact.Type.VISUALIZATION,
-            data=VisualizationArtifactContent(
-                query=self.basic_trends, name="Query 1", description="Description 1", plan="Plan 1"
-            ).model_dump(),
-        )
-        artifact2 = await AgentArtifact.objects.acreate(
-            team=self.team,
-            conversation=self.conversation,
-            name="Test Artifact 2",
-            type=AgentArtifact.Type.VISUALIZATION,
-            data=VisualizationArtifactContent(
-                query=self.basic_trends, name="Query 2", description="Description 2", plan="Plan 2"
-            ).model_dump(),
-        )
-        history = await node._construct_messages(
-            AssistantState(
-                messages=[
-                    HumanMessage(content="Question 1", id="0"),
-                    ArtifactRefMessage(
-                        content_type=ArtifactContentType.VISUALIZATION,
-                        source=ArtifactSource.ARTIFACT,
-                        artifact_id=str(artifact1.short_id),
-                        id="1",
-                    ),
-                    AssistantMessage(content="Summary 1", id="3"),
-                    HumanMessage(content="Question 2", id="4"),
-                    ArtifactRefMessage(
-                        content_type=ArtifactContentType.VISUALIZATION,
-                        source=ArtifactSource.ARTIFACT,
-                        artifact_id=str(artifact2.short_id),
-                        id="5",
-                    ),
-                    AssistantMessage(content="Summary 2", id="7"),
-                    HumanMessage(content="Question 3", id="8"),
-                ],
-                plan="Plan 3",
-                start_id="8",
-                root_tool_insight_plan="Query 3",
-            )
-        )
-
-        self.assertEqual(len(history), 9)
-        self.assertEqual(history[0].type, "human")
-        self.assertIn("mapping", history[0].content)
-        self.assertEqual(history[1].type, "human")
-        self.assertIn("Plan 1", history[1].content)
-        self.assertEqual(history[2].type, "human")
-        self.assertIn("Query 1", history[2].content)
-        self.assertEqual(history[3].type, "ai")
-        AssistantTrendsQuery.model_validate_json(cast(str, history[3].content))
-        self.assertEqual(history[4].type, "human")
-        self.assertIn("Plan 2", history[4].content)
-        self.assertEqual(history[5].type, "human")
-        self.assertIn("Query 2", history[5].content)
-        self.assertEqual(history[6].type, "ai")
-        AssistantTrendsQuery.model_validate_json(cast(str, history[6].content))
-        self.assertEqual(history[7].type, "human")
-        self.assertIn("Plan 3", history[7].content)
-        self.assertEqual(history[8].type, "human")
-        self.assertIn("Query 3", history[8].content)
+        self.assertIn("Generate a schema", history[1].content)
 
     async def test_prompt_messages_merged(self):
         node = DummyGeneratorNode(self.team, self.user)
-        artifact1 = await AgentArtifact.objects.acreate(
-            team=self.team,
-            conversation=self.conversation,
-            name="Test Artifact 1",
-            type=AgentArtifact.Type.VISUALIZATION,
-            data=VisualizationArtifactContent(
-                query=self.basic_trends, name="Test Artifact 1", description="Test Description 1", plan="Plan 1"
-            ).model_dump(),
-        )
-        artifact2 = await AgentArtifact.objects.acreate(
-            team=self.team,
-            conversation=self.conversation,
-            name="Test Artifact 2",
-            type=AgentArtifact.Type.VISUALIZATION,
-            data=VisualizationArtifactContent(
-                query=self.basic_trends, name="Test Artifact 2", description="Test Description 2", plan="Plan 2"
-            ).model_dump(),
-        )
         state = AssistantState(
-            messages=[
-                HumanMessage(content="Question 1", id="0"),
-                ArtifactRefMessage(
-                    content_type=ArtifactContentType.VISUALIZATION,
-                    source=ArtifactSource.ARTIFACT,
-                    artifact_id=str(artifact1.short_id),
-                    id="1",
-                ),
-                AssistantMessage(content="Summary 1", id="3"),
-                HumanMessage(content="Question 2", id="4"),
-                ArtifactRefMessage(
-                    content_type=ArtifactContentType.VISUALIZATION,
-                    source=ArtifactSource.ARTIFACT,
-                    artifact_id=str(artifact2.short_id),
-                    id="5",
-                ),
-                AssistantMessage(content="Summary 2", id="7"),
-                HumanMessage(content="Question 3", id="8"),
-            ],
-            plan="Plan 3",
-            start_id="8",
+            messages=[HumanMessage(content="Question", id="0")],
+            plan="Plan",
+            start_id="0",
         )
         with patch.object(DummyGeneratorNode, "_model") as generator_model_mock:
 
             def assert_prompt(prompt):
-                self.assertEqual(len(prompt), 6)
+                # System prompt + merged human messages (group mapping + plan)
+                self.assertEqual(len(prompt), 2)
                 self.assertEqual(prompt[0].type, "system")
                 self.assertEqual(prompt[1].type, "human")
-                self.assertEqual(prompt[2].type, "ai")
-                self.assertEqual(prompt[3].type, "human")
-                self.assertEqual(prompt[4].type, "ai")
-                self.assertEqual(prompt[5].type, "human")
 
             generator_model_mock.return_value = RunnableLambda(assert_prompt)
             await node(state, {})
@@ -492,7 +323,7 @@ class TestSchemaGeneratorNode(BaseTest):
                     {},
                 )
 
-    async def test_agent_reconstructs_conversation_with_failover(self):
+    async def test_construct_messages_with_failover(self):
         action = AgentAction(tool="fix", tool_input="validation error", log="exception")
         node = DummyGeneratorNode(self.team, self.user)
         history = await node._construct_messages(
@@ -504,44 +335,15 @@ class TestSchemaGeneratorNode(BaseTest):
             ),
             validation_error_message="uniqexception",
         )
-        self.assertEqual(len(history), 4)
-        self.assertEqual(history[0].type, "human")
-        self.assertIn("mapping", history[0].content)
-        self.assertEqual(history[1].type, "human")
-        self.assertIn("the plan", history[1].content)
-        self.assertNotIn("{{plan}}", history[1].content)
-        self.assertIn("randomplan", history[1].content)
-        self.assertEqual(history[2].type, "human")
-        self.assertIn("Answer to this question:", history[2].content)
-        self.assertNotIn("{{question}}", history[2].content)
-        self.assertIn("Text", history[2].content)
-        self.assertEqual(history[3].type, "human")
-        self.assertIn("Pydantic", history[3].content)
-        self.assertIn("uniqexception", history[3].content)
-
-    async def test_agent_reconstructs_conversation_with_failed_messages(self):
-        node = DummyGeneratorNode(self.team, self.user)
-        history = await node._construct_messages(
-            AssistantState(
-                messages=[
-                    HumanMessage(content="Text"),
-                    FailureMessage(content="Error"),
-                    HumanMessage(content="Text"),
-                ],
-                plan="randomplan",
-            ),
-        )
         self.assertEqual(len(history), 3)
         self.assertEqual(history[0].type, "human")
         self.assertIn("mapping", history[0].content)
         self.assertEqual(history[1].type, "human")
         self.assertIn("the plan", history[1].content)
-        self.assertNotIn("{{plan}}", history[1].content)
         self.assertIn("randomplan", history[1].content)
         self.assertEqual(history[2].type, "human")
-        self.assertIn("Answer to this question:", history[2].content)
-        self.assertNotIn("{{question}}", history[2].content)
-        self.assertIn("Text", history[2].content)
+        self.assertIn("Pydantic", history[2].content)
+        self.assertIn("uniqexception", history[2].content)
 
     def test_router(self):
         node = DummyGeneratorNode(self.team, self.user)
@@ -551,137 +353,6 @@ class TestSchemaGeneratorNode(BaseTest):
             AssistantState(messages=[], intermediate_steps=[(AgentAction(tool="", tool_input="", log=""), None)])
         )
         self.assertEqual(state, "tools")
-
-    async def test_injects_insight_description(self):
-        node = DummyGeneratorNode(self.team, self.user)
-        history = await node._construct_messages(
-            AssistantState(
-                messages=[HumanMessage(content="Text", id="0")],
-                start_id="0",
-                root_tool_insight_plan="Foobar",
-                root_tool_insight_type="trends",
-            )
-        )
-        self.assertEqual(len(history), 2)
-        self.assertEqual(history[0].type, "human")
-        self.assertIn("group", history[0].content)
-        self.assertEqual(history[1].type, "human")
-        self.assertIn("Foobar", history[1].content)
-        self.assertNotIn("{{question}}", history[1].content)
-
-    async def test_injects_insight_description_and_keeps_original_question(self):
-        node = DummyGeneratorNode(self.team, self.user)
-        artifact = await AgentArtifact.objects.acreate(
-            team=self.team,
-            conversation=self.conversation,
-            name="Test Artifact",
-            type=AgentArtifact.Type.VISUALIZATION,
-            data=VisualizationArtifactContent(
-                query=self.basic_trends, name="Query 1", description="Description 1", plan="Plan 1"
-            ).model_dump(),
-        )
-        history = await node._construct_messages(
-            AssistantState(
-                messages=[
-                    HumanMessage(content="Original question", id="1"),
-                    ArtifactRefMessage(
-                        content_type=ArtifactContentType.VISUALIZATION,
-                        source=ArtifactSource.ARTIFACT,
-                        artifact_id=str(artifact.short_id),
-                        id="2",
-                    ),
-                    HumanMessage(content="Second question", id="3"),
-                ],
-                start_id="3",
-                root_tool_insight_plan="Foobar",
-                root_tool_insight_type="trends",
-            )
-        )
-        self.assertEqual(len(history), 5)
-        self.assertEqual(history[0].type, "human")
-        self.assertIn("group", history[0].content)
-        self.assertEqual(history[1].type, "human")
-        self.assertIn("Plan 1", history[1].content)
-        self.assertNotIn("{{question}}", history[1].content)
-        self.assertEqual(history[2].type, "human")
-        self.assertIn("Query 1", history[2].content)
-        self.assertNotIn("{{question}}", history[2].content)
-        self.assertEqual(history[3].type, "ai")
-        self.assertEqual(history[4].type, "human")
-        self.assertIn("Foobar", history[4].content)
-        self.assertNotIn("{{question}}", history[4].content)
-
-    async def test_keeps_maximum_number_of_viz_messages(self):
-        node = DummyGeneratorNode(self.team, self.user)
-        query = AssistantTrendsQuery(series=[])
-        messages = []
-        for i in range(7):
-            artifact = await AgentArtifact.objects.acreate(
-                team=self.team,
-                conversation=self.conversation,
-                name=f"Test Artifact {i + 1}",
-                type=AgentArtifact.Type.VISUALIZATION,
-                data=VisualizationArtifactContent(
-                    query=query, name=f"Query {i + 1}", description=f"Description {i + 1}", plan=f"Plan {i + 1}"
-                ).model_dump(),
-            )
-            messages.append(
-                ArtifactRefMessage(
-                    content_type=ArtifactContentType.VISUALIZATION,
-                    source=ArtifactSource.ARTIFACT,
-                    artifact_id=str(artifact.short_id),
-                    id=str(uuid4()),
-                )
-            )
-        history = await node._construct_messages(
-            AssistantState(
-                messages=messages,
-                root_tool_insight_plan="Query 8",
-                root_tool_insight_type="trends",
-            )
-        )
-        self.assertEqual(len(history), 17)
-        self.assertEqual(history[0].type, "human")
-        self.assertIn("group", history[0].content)
-
-        # Query 3
-        self.assertEqual(history[1].type, "human")
-        self.assertIn("Plan 3", history[1].content)
-        self.assertEqual(history[2].type, "human")
-        self.assertIn("Query 3", history[2].content)
-        self.assertEqual(history[3].type, "ai")
-
-        # Query 4
-        self.assertEqual(history[4].type, "human")
-        self.assertIn("Plan 4", history[4].content)
-        self.assertEqual(history[5].type, "human")
-        self.assertIn("Query 4", history[5].content)
-        self.assertEqual(history[6].type, "ai")
-
-        # Query 5
-        self.assertEqual(history[7].type, "human")
-        self.assertIn("Plan 5", history[7].content)
-        self.assertEqual(history[8].type, "human")
-        self.assertIn("Query 5", history[8].content)
-        self.assertEqual(history[9].type, "ai")
-
-        # Query 6
-        self.assertEqual(history[10].type, "human")
-        self.assertIn("Plan 6", history[10].content)
-        self.assertEqual(history[11].type, "human")
-        self.assertIn("Query 6", history[11].content)
-        self.assertEqual(history[12].type, "ai")
-
-        # Query 7
-        self.assertEqual(history[13].type, "human")
-        self.assertIn("Plan 7", history[13].content)
-        self.assertEqual(history[14].type, "human")
-        self.assertIn("Query 7", history[14].content)
-        self.assertEqual(history[15].type, "ai")
-
-        # New query
-        self.assertEqual(history[16].type, "human")
-        self.assertIn("Query 8", history[16].content)
 
     async def test_agent_handles_incomplete_json(self):
         node = DummyGeneratorNode(self.team, self.user)

--- a/ee/hogai/chat_agent/trends/prompts.py
+++ b/ee/hogai/chat_agent/trends/prompts.py
@@ -1,28 +1,28 @@
 TRENDS_SYSTEM_PROMPT = """
-Act as an expert product manager. Your task is to generate a JSON schema of trends insights. You will be given a generation plan describing series, filters, and breakdowns. Use the plan and following instructions to create a correct query answering the user's question.
+Act as an expert product manager. Your task is to generate a JSON schema of trends insights. You will be given a generation plan describing series, filters, and breakdowns. Use the plan and following instructions to create a correct query based on the provided plan.
 
 Follow this instruction to create a query:
 * Build series according to the plan. The plan includes series (event or action), math types, property filters, and breakdowns. Properties can be of multiple types: String, Numeric, Bool, and DateTime. A property can be an array of those types and only has a single type.
 * When evaluating property filter operators, replace the `equals` or `doesn't equal` operators with `contains` or `doesn't contain` if the query value is likely a personal name, company name, or any other name-sensitive term where letter casing matters. For instance, if the value is 'John Doe' or 'Acme Corp', replace `equals` with `contains` and change the value to lowercase from `John Doe` to `john doe` or `Acme Corp` to `acme corp`. Do not apply this to event names, as they are strictly case-sensitive!
-* Determine a visualization type that will answer the user's question in the best way.
-* Determine if the user wants to name the series or use the default names.
+* Determine a visualization type that best represents the data described in the plan.
+* Determine if the plan specifies custom series names or use the default names.
 * Use the date range and the interval from the plan.
-* Determine if the user wants to compare the results to a previous period or use smoothing.
-* Determine if the user wants to filter out internal and test users. If the user didn't specify, filter out internal and test users by default.
-* Determine if the user wants to use a sampling factor.
+* Determine if the plan specifies comparing the results to a previous period or use smoothing.
+* Determine if the plan specifies filtering out internal and test users. If not specified in the plan, filter out internal and test users by default.
+* Determine if the plan specifies using a sampling factor.
 * Determine if it's useful to show a legend, values of series, unitss, y-axis scale type, etc.
-* Use your judgment if there are any other parameters that the user might want to adjust that aren't listed here.
+* Use your judgment if there are any other parameters that aren't listed here.
 
 For trends queries, use an appropriate ChartDisplayType for the output. For example:
-- if the user wants to see dynamics in time like a line graph, use `ActionsLineGraph`.
-- if the user wants to see cumulative dynamics across time, use `ActionsLineGraphCumulative`.
-- if the user asks a question where you can answer with a single number, use `BoldNumber`.
-- if the user wants a table, use `ActionsTable`.
+- if the plan indicates dynamics in time like a line graph, use `ActionsLineGraph`.
+- if the plan indicates cumulative dynamics across time, use `ActionsLineGraphCumulative`.
+- if the plan can be answered with a single number, use `BoldNumber`.
+- if the plan requests a table, use `ActionsTable`.
 - if the data is categorical, use `ActionsBar`.
 - if the data is easy to understand in a pie chart, use `ActionsPie`.
-- if the user has only one series and wants to see data from particular countries, use `WorldMap`.
+- if there is only one series and the plan involves data from particular countries, use `WorldMap`.
 
-The user might want to get insights for groups. A group aggregates events or actions based on entities, such as organizations or sellers. The user might provide a list of group names and their numeric indexes. Instead of a group's name, always use its numeric index.
+The plan might specify insights for groups. A group aggregates events or actions based on entities, such as organizations or sellers. The plan might provide a list of group names and their numeric indexes. Instead of a group's name, always use its numeric index.
 
 You can determine if a feature flag is enabled by checking if it's set to true or 1 in the `$feature/...` property. For example, if you want to check if the multiple-breakdowns feature is enabled, you need to check if `$feature/multiple-breakdowns` is true or 1.
 
@@ -101,10 +101,8 @@ Series:
 
 ---
 
-Obey these rules:
-- if the date range is not specified, use the best judgment to select a reasonable date range. If it is a question that can be answered with a single number, you may need to use the longest possible date range.
-- Filter internal users by default if the user doesn't specify.
-- Only use events, actions, and properties defined by the user. You can't create new events, actions, or property definitions.
-
-Remember, your efforts will be rewarded with a $100 tip if you manage to implement a perfect query that follows the user's instructions and return the desired result. Do not hallucinate.
+Follow these rules:
+- If the date range is not specified in the plan, use the best judgment to select a reasonable date range. If the plan can be answered with a single number, you may need to use the longest possible date range.
+- Filter internal users by default if not specified in the plan.
+- Only use events, actions, and properties defined in the plan. You can't create new events, actions, or property definitions.
 """.strip()


### PR DESCRIPTION
## Problem

The `schema_generator` was previously including the full conversation history and human messages in its context, making it less atomic than intended. This change aims to simplify the schema generator's input, ensuring it only receives the provided plan and a static prompt to generate a schema from that plan.

## Changes

-   **`prompts.py`**: Removed `NEW_PLAN_PROMPT` and `QUESTION_PROMPT`. The `PLAN_PROMPT` now explicitly includes the instruction "Generate a schema from this plan."
-   **`nodes.py`**:
    -   Removed unused imports related to conversation history (`AIMessage`, `find_start_message`, `ArtifactRefMessage`).
    -   Simplified `_construct_messages()` to only include the group mapping prompt, the plan with the static schema generation instruction, and the failover prompt (for retries).
    -   Removed the `_get_insight_plan()` method and all conversation history reconstruction logic.
-   **`test/test_nodes.py`**: Updated existing tests to reflect the new atomic behavior and removed tests related to conversation history reconstruction.
- Updated individual prompts of the schema generators.
- Swapped the model from gpt-5.1 to 5.2

## How did you test this code?

Updated and ran existing unit tests in `test/test_nodes.py` to verify the new atomic behavior, including tests for group mapping, plan inclusion, and failover scenarios.

## Publish to changelog?

no

---
<a href="https://cursor.com/background-agent?bcId=bc-a8af5c6f-ec92-4c76-b989-80fb5ad5d71e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a8af5c6f-ec92-4c76-b989-80fb5ad5d71e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

