### PR TITLE
feat: Add Claude Code LSP plugins for Python and TypeScript

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+    "enabledPlugins": {
+        "pyright-lsp@claude-plugins-official": true,
+        "typescript-lsp@claude-plugins-official": true
+    }
+}


### PR DESCRIPTION
## Problem

Claude Code users working on the PostHog codebase don't have LSP support enabled by default, missing out on real-time diagnostics and code navigation.

## Changes

Add `.claude/settings.json` to enable team-wide LSP plugins:
- `pyright-lsp` for Python
- `typescript-lsp` for TypeScript/JavaScript

## How did you test this code?

Verified the settings file is valid JSON and follows the Claude Code plugin format.

## Publish to changelog?

No