### PR TITLE
fix: Lock table before merging in Redshift

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -311,7 +311,10 @@ class RedshiftClient(PostgreSQLClient):
         merge_query = sql.SQL(
             """\
         MERGE INTO {final_table}
-        USING (SELECT {select_stage_table_fields} FROM {stage_table}) AS stage
+        USING (
+            SELECT {select_stage_table_fields}
+            FROM {stage_table}
+        ) AS stage
         ON {merge_condition}
         """
         ).format(
@@ -347,6 +350,7 @@ class RedshiftClient(PostgreSQLClient):
 
         async with self.connection.transaction():
             async with self.connection.cursor() as cursor:
+                await cursor.execute(sql.SQL("LOCK TABLE {final_table}").format(final_table=final_table_identifier))
                 try:
                     await cursor.execute(delete_query)
                 except psycopg.errors.UndefinedFunction:


### PR DESCRIPTION
## Problem

Multiple concurrent merges can conflict with each other.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Lock the table to ensure only one merge is allowed to run at a time.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I could not reproduce conflicting merges unfortunately, but I did run the Redshift tests and they are all passing. 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
