### PR TITLE
fix(data-warehouse): Update the redis context manager to not throw on yield

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -55,19 +55,22 @@ class ImportDataActivityInputs:
 
 @contextmanager
 def _get_redis():
+    redis_client = None
     try:
         if not settings.DATA_WAREHOUSE_REDIS_HOST or not settings.DATA_WAREHOUSE_REDIS_PORT:
             raise Exception(
                 "Missing env vars for dwh row tracking: DATA_WAREHOUSE_REDIS_HOST or DATA_WAREHOUSE_REDIS_PORT"
             )
 
-        redis = get_client(f"redis://{settings.DATA_WAREHOUSE_REDIS_HOST}:{settings.DATA_WAREHOUSE_REDIS_PORT}/")
-        redis.ping()
-
-        yield redis
+        redis_client = get_client(f"redis://{settings.DATA_WAREHOUSE_REDIS_HOST}:{settings.DATA_WAREHOUSE_REDIS_PORT}/")
+        redis_client.ping()
     except Exception as e:
         capture_exception(e)
-        yield None
+
+    try:
+        yield redis_client
+    finally:
+        pass
 
 
 def _non_retryable_errors_key(job_inputs: PipelineInputs) -> str:


### PR DESCRIPTION
## Problem
- Some source errors are getting masked behind a redis client contextmanager error - down to how we're yielding the redis client (and are double yielding in some cases)

<img width="845" height="528" alt="image" src="https://github.com/user-attachments/assets/001ba42c-f958-4c8a-bdeb-d98d3ed420bf" />


## Changes
- Only yield once from the context manager