### PR TITLE
fix(experiments): don't change browser history on search filter change

### DIFF
--- a/frontend/src/scenes/experiments/experimentsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.test.ts
@@ -185,23 +185,23 @@ describe('experimentsLogic', () => {
         })
 
         it('removes ff_page URL parameter when page is reset to 1 via filters', () => {
-            // Mock router to capture URL changes
-            const mockPush = jest.fn()
-            router.actions.push = mockPush
+            // Mock router to capture URL changes (uses replace, not push, to avoid polluting browser history)
+            const mockReplace = jest.fn()
+            router.actions.replace = mockReplace
 
             // User navigates to page 2 first
             logic.actions.setFeatureFlagModalFilters({ page: 2 })
 
             // This should add ff_page=2 to URL
-            expect(mockPush).toHaveBeenLastCalledWith(expect.stringContaining('ff_page=2'))
+            expect(mockReplace).toHaveBeenLastCalledWith(expect.stringContaining('ff_page=2'))
 
-            mockPush.mockClear()
+            mockReplace.mockClear()
 
             // User applies a search filter which includes page: 1
             logic.actions.setFeatureFlagModalFilters({ search: 'test', page: 1 })
 
             // This should remove ff_page from URL (since page is 1)
-            expect(mockPush).toHaveBeenLastCalledWith(expect.not.stringContaining('ff_page'))
+            expect(mockReplace).toHaveBeenLastCalledWith(expect.not.stringContaining('ff_page'))
         })
 
         it('constructs API params correctly', async () => {

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -406,7 +406,7 @@ export const experimentsLogic = kea<experimentsLogicType>([
                 searchParams['tab'] = values.tab
             }
 
-            return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: false }]
+            return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: true }]
         }
 
         const changeFeatureFlagModalUrl = ():
@@ -433,7 +433,7 @@ export const experimentsLogic = kea<experimentsLogicType>([
                 searchParams['ff_page'] = modalPage
             }
 
-            return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: false }]
+            return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: true }]
         }
 
         return {


### PR DESCRIPTION
## Problem

When typing a search query in the experiments list, each keystroke pushed a new entry to the browser history. This caused the browser back button to remove characters one at a time from the search query instead of navigating to the previous page.

## Changes

Changed URL update behavior in experimentsLogic.ts from replace: false to replace: true for filter changes. This replaces the current history entry instead of pushing new ones, so the back button works as expected.

## How did you test this code?

 Tested locally.
