### PR TITLE
feat(gateway): add product specific endpoints

### DIFF
--- a/services/llm-gateway/src/llm_gateway/analytics/service.py
+++ b/services/llm-gateway/src/llm_gateway/analytics/service.py
@@ -73,6 +73,7 @@ class LLMAnalyticsService:
         input_tokens_field: str = "input_tokens",
         output_tokens_field: str = "output_tokens",
         trace_id: str | None = None,
+        product: str = "llm_gateway",
     ) -> None:
         """Capture an LLM generation event."""
         try:
@@ -108,7 +109,7 @@ class LLMAnalyticsService:
                 "$ai_output_tokens": output_tokens,
                 "$ai_is_streaming": is_streaming,
                 "team_id": user.team_id,
-                "ai_product": "llm_gateway",
+                "ai_product": product,
             }
 
             if output_choices:

--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -66,6 +66,7 @@ async def handle_llm_request(
     is_streaming: bool,
     provider_config: ProviderConfig,
     llm_call: Callable[..., Awaitable[Any]],
+    product: str = "llm_gateway",
 ) -> dict[str, Any] | StreamingResponse:
     settings = get_settings()
     start_time = time.monotonic()
@@ -86,6 +87,7 @@ async def handle_llm_request(
             llm_call=llm_call,
             start_time=start_time,
             timeout=settings.streaming_timeout,
+            product=product,
         )
 
     CONCURRENT_REQUESTS.inc()
@@ -98,6 +100,7 @@ async def handle_llm_request(
             llm_call=llm_call,
             start_time=start_time,
             timeout=settings.request_timeout,
+            product=product,
         )
 
     except TimeoutError:
@@ -136,6 +139,7 @@ async def _handle_streaming_request(
     llm_call: Callable[..., Awaitable[Any]],
     start_time: float,
     timeout: float,
+    product: str = "llm_gateway",
 ) -> StreamingResponse:
     async def stream_generator() -> AsyncGenerator[bytes, None]:
         ACTIVE_STREAMS.labels(provider=provider_config.name).inc()
@@ -200,6 +204,7 @@ async def _handle_streaming_request(
                         is_streaming=True,
                         input_tokens_field=provider_config.input_tokens_field,
                         output_tokens_field=provider_config.output_tokens_field,
+                        product=product,
                     )
             except Exception as analytics_error:
                 logger.warning("Failed to capture analytics", error=str(analytics_error))
@@ -219,6 +224,7 @@ async def _handle_non_streaming_request(
     llm_call: Callable[..., Awaitable[Any]],
     start_time: float,
     timeout: float,
+    product: str = "llm_gateway",
 ) -> dict[str, Any]:
     provider_start = time.monotonic()
     response_dict: dict[str, Any] | None = None
@@ -273,6 +279,7 @@ async def _handle_non_streaming_request(
                     is_streaming=False,
                     input_tokens_field=provider_config.input_tokens_field,
                     output_tokens_field=provider_config.output_tokens_field,
+                    product=product,
                 )
         except Exception as analytics_error:
             logger.warning("Failed to capture analytics", error=str(analytics_error))

--- a/services/llm-gateway/src/llm_gateway/api/openai.py
+++ b/services/llm-gateway/src/llm_gateway/api/openai.py
@@ -5,16 +5,24 @@ from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
 from llm_gateway.api.handler import OPENAI_CONFIG, OPENAI_RESPONSES_CONFIG, handle_llm_request
+from llm_gateway.api.products import validate_product
 from llm_gateway.dependencies import RateLimitedUser
 from llm_gateway.models.openai import ChatCompletionRequest, ResponsesRequest
 
 openai_router = APIRouter()
 
 
-@openai_router.post("/v1/chat/completions", response_model=None)
-async def chat_completions(
+def _normalize_model_name(model: str) -> str:
+    """Ensure model name has openai/ prefix for litellm routing."""
+    if model.startswith("openai/"):
+        return model
+    return f"openai/{model}"
+
+
+async def _handle_chat_completions(
     request: ChatCompletionRequest,
     user: RateLimitedUser,
+    product: str = "llm_gateway",
 ) -> dict[str, Any] | StreamingResponse:
     data = request.model_dump(exclude_none=True)
 
@@ -25,19 +33,14 @@ async def chat_completions(
         is_streaming=request.stream or False,
         provider_config=OPENAI_CONFIG,
         llm_call=litellm.acompletion,
+        product=product,
     )
-
-
-def _normalize_model_name(model: str) -> str:
-    """Ensure model name has openai/ prefix for litellm routing."""
-    if model.startswith("openai/"):
-        return model
-    return f"openai/{model}"
 
 
 async def _handle_responses(
     request: ResponsesRequest,
     user: RateLimitedUser,
+    product: str = "llm_gateway",
 ) -> dict[str, Any] | StreamingResponse:
     """Handle OpenAI Responses API request.
 
@@ -46,7 +49,6 @@ async def _handle_responses(
     """
     data = request.model_dump(exclude_none=True)
 
-    # Normalize model name for litellm routing
     original_model = request.model
     normalized_model = _normalize_model_name(original_model)
     data["model"] = normalized_model
@@ -59,14 +61,31 @@ async def _handle_responses(
             is_streaming=request.stream or False,
             provider_config=OPENAI_RESPONSES_CONFIG,
             llm_call=litellm.aresponses,
+            product=product,
         )
         return result
     except Exception:
         raise
 
 
-# Support both /v1/responses and /responses paths
-# The Codex SDK may call either depending on how OPENAI_BASE_URL is configured
+@openai_router.post("/v1/chat/completions", response_model=None)
+async def chat_completions(
+    request: ChatCompletionRequest,
+    user: RateLimitedUser,
+) -> dict[str, Any] | StreamingResponse:
+    return await _handle_chat_completions(request, user)
+
+
+@openai_router.post("/{product}/v1/chat/completions", response_model=None)
+async def chat_completions_with_product(
+    request: ChatCompletionRequest,
+    user: RateLimitedUser,
+    product: str,
+) -> dict[str, Any] | StreamingResponse:
+    validate_product(product)
+    return await _handle_chat_completions(request, user, product=product)
+
+
 @openai_router.post("/v1/responses", response_model=None)
 async def responses_v1(
     request: ResponsesRequest,
@@ -75,9 +94,29 @@ async def responses_v1(
     return await _handle_responses(request, user)
 
 
+@openai_router.post("/{product}/v1/responses", response_model=None)
+async def responses_v1_with_product(
+    request: ResponsesRequest,
+    user: RateLimitedUser,
+    product: str,
+) -> dict[str, Any] | StreamingResponse:
+    validate_product(product)
+    return await _handle_responses(request, user, product=product)
+
+
 @openai_router.post("/responses", response_model=None)
 async def responses(
     request: ResponsesRequest,
     user: RateLimitedUser,
 ) -> dict[str, Any] | StreamingResponse:
     return await _handle_responses(request, user)
+
+
+@openai_router.post("/{product}/responses", response_model=None)
+async def responses_with_product(
+    request: ResponsesRequest,
+    user: RateLimitedUser,
+    product: str,
+) -> dict[str, Any] | StreamingResponse:
+    validate_product(product)
+    return await _handle_responses(request, user, product=product)

--- a/services/llm-gateway/src/llm_gateway/api/products.py
+++ b/services/llm-gateway/src/llm_gateway/api/products.py
@@ -1,0 +1,12 @@
+from fastapi import HTTPException
+
+ALLOWED_PRODUCTS = frozenset({"llm_gateway", "wizard", "array"})
+
+
+def validate_product(product: str) -> str:
+    if product not in ALLOWED_PRODUCTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid product '{product}'. Allowed products: {', '.join(sorted(ALLOWED_PRODUCTS))}",
+        )
+    return product


### PR DESCRIPTION
Multiple products use the llm gateway, like array and the wizard, we need this to split out the traces from each product in llm analytics