### PR TITLE
chore: increase max custom limit to 50k

### DIFF
--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -760,8 +760,8 @@ export const billingProductLogic = kea<billingProductLogicType>([
             errors: ({ input }) => ({
                 input:
                     input === null || Number.isInteger(input)
-                        ? input > 25000
-                            ? 'Please enter a number less than 25,000'
+                        ? input > 50000
+                            ? 'Please enter a number less than 50,000'
                             : undefined
                         : 'Please enter a whole number',
             }),


### PR DESCRIPTION
## Changes

We had a 25K limit (see #24754) due to inefficient calculations when converting limits into max limited usage count - some customers have ran into this limitation and asked for higher limits.

Since then we made some other significant performance improvements in billing API so these inefficiencies are now less magnified, so we can increase it. We will be switching over to a new calculation method soon anyway so we'll be able to remove these limits altogether.

For more context see: https://posthog.slack.com/archives/C08ERRQT41E/p1767796026394229

## How did you test this code?

n/a