### PR TITLE
fix(ci): prevent cache race condition in master CI status

### DIFF
--- a/.github/scripts/master-ci-status.js
+++ b/.github/scripts/master-ci-status.js
@@ -51,7 +51,10 @@ function handleFailure(state, event, commitTs, core, fs) {
 
     if (isNew) {
         state = {
-            since: new Date().toISOString(),
+            // Use the failing commit's timestamp as incident start, not wall clock.
+            // This ensures pendingWorkflows check compares against when the failure
+            // was authored, not when we detected it (which could be much later).
+            since: new Date(commitTs).toISOString(),
             sha_ts: { [event.head_sha]: commitTs },
             fail_ts: { [event.name]: commitTs },
             ok_ts: {},

--- a/.github/scripts/master-ci-status.js
+++ b/.github/scripts/master-ci-status.js
@@ -106,6 +106,10 @@ function handleSuccess(state, event, commitTs, core, fs) {
     const pendingWorkflows = requiredWorkflows.filter((wf) => (state.ok_ts[wf] ?? 0) < incidentStart);
     const resolved = failing.length === 0 && pendingWorkflows.length === 0;
 
+    if (resolved) {
+        state.resolved = true;
+    }
+
     pruneOldShas(state);
     fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
 
@@ -117,7 +121,7 @@ function handleSuccess(state, event, commitTs, core, fs) {
     core.setOutput('since', state.since);
     core.setOutput('channel', state.channel || '');
     core.setOutput('ts', state.ts || '');
-    core.setOutput('save_cache', resolved ? 'false' : 'true');
+    core.setOutput('save_cache', 'true');
 
     console.log(`Action: ${wasFailing ? 'resolve' : 'none'}`);
     console.log(`Recovered: ${wasFailing ? event.name : 'none'}`);
@@ -138,14 +142,19 @@ module.exports = async ({ github, context, core }) => {
     if (fs.existsSync(STATE_FILE)) {
         try {
             const raw = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
-            // Ensure required fields exist (handles old format or corrupted state)
-            state = {
-                ...raw,
-                sha_ts: raw.sha_ts || {},
-                fail_ts: raw.fail_ts || {},
-                ok_ts: raw.ok_ts || {},
-            };
-            console.log('Loaded existing incident state');
+            // If incident was already resolved, treat as no incident
+            if (raw.resolved) {
+                console.log('Found resolved incident, treating as no active incident');
+            } else {
+                // Ensure required fields exist (handles old format or corrupted state)
+                state = {
+                    ...raw,
+                    sha_ts: raw.sha_ts || {},
+                    fail_ts: raw.fail_ts || {},
+                    ok_ts: raw.ok_ts || {},
+                };
+                console.log('Loaded existing incident state');
+            }
         } catch (e) {
             console.log('Failed to parse state file, treating as no incident');
         }

--- a/.github/workflows/ci-master-status.yml
+++ b/.github/workflows/ci-master-status.yml
@@ -227,10 +227,6 @@ jobs:
                       thread_ts: "${{ steps.process.outputs.ts }}"
                       text: ":white_check_mark: Resolved: *${{ github.event.workflow_run.name }}* passed (${{ steps.commit.outputs.short_sha }})"
 
-            - name: Clear state on full resolution
-              if: steps.process.outputs.resolved == 'true'
-              run: rm -f .master-ci-incident
-
             # ============ CACHE ============
             # Use unique keys to avoid race conditions where concurrent runs
             # delete the cache before saving (see logs showing "Cache not found")
@@ -241,12 +237,3 @@ jobs:
               with:
                   path: .master-ci-incident
                   key: master-ci-incident-${{ github.run_id }}
-
-            - name: Cleanup old incident caches
-              if: steps.process.outputs.resolved == 'true'
-              continue-on-error: true
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: |
-                  # Delete all incident caches on full resolution
-                  gh cache list --key master-ci-incident- --json id -q '.[].id' | xargs -I {} gh cache delete {} || true

--- a/.github/workflows/ci-master-status.yml
+++ b/.github/workflows/ci-master-status.yml
@@ -34,7 +34,9 @@ jobs:
               uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
               with:
                   path: .master-ci-incident
-                  key: master-ci-incident
+                  # Use prefix matching to get the most recently saved cache
+                  key: master-ci-incident-${{ github.run_id }}
+                  restore-keys: master-ci-incident-
 
             - name: Read incident state
               id: incident
@@ -230,24 +232,21 @@ jobs:
               run: rm -f .master-ci-incident
 
             # ============ CACHE ============
-
-            - name: Delete old cache
-              if: steps.process.outputs.save_cache == 'true'
-              continue-on-error: true
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: gh cache delete master-ci-incident || true
+            # Use unique keys to avoid race conditions where concurrent runs
+            # delete the cache before saving (see logs showing "Cache not found")
 
             - name: Save incident to cache
               if: steps.process.outputs.save_cache == 'true'
               uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
               with:
                   path: .master-ci-incident
-                  key: master-ci-incident
+                  key: master-ci-incident-${{ github.run_id }}
 
-            - name: Delete cache on full resolution
+            - name: Cleanup old incident caches
               if: steps.process.outputs.resolved == 'true'
               continue-on-error: true
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: gh cache delete master-ci-incident || true
+              run: |
+                  # Delete all incident caches on full resolution
+                  gh cache list --key master-ci-incident- --json id -q '.[].id' | xargs -I {} gh cache delete {} || true


### PR DESCRIPTION
**Fixes cache race condition causing duplicate Slack incidents**

When multiple CI workflows complete concurrently, the delete-before-save cache pattern caused races where one run would delete the cache while another was trying to restore it, leading to:
- "Cache not found" errors
- New incidents created instead of updating existing ones
- Orphaned Slack threads

**Changes:**

1. Use unique cache keys per run with `restore-keys` prefix matching - each run writes its own cache and reads the most recent
2. Use commit timestamp for incident start - better aligns pendingWorkflows check with actual failure timing  
3. Mark incidents as `resolved: true` in state file instead of deleting cache - avoids race on cleanup, lets cache expire naturally