### PR TITLE
feat(sparkline): enhance tooltip functionality with zero value filtering and sorting options

### DIFF
--- a/frontend/src/lib/components/Sparkline.tsx
+++ b/frontend/src/lib/components/Sparkline.tsx
@@ -50,6 +50,10 @@ interface SparklineProps {
     onSelectionChange?: (selection: { startIndex: number; endIndex: number }) => void
     /** Maximum number of series to show in tooltip. @default 8 */
     tooltipRowCutoff?: number
+    /** Hide series with zero values from tooltip. @default false */
+    hideZerosInTooltip?: boolean
+    /** Sort tooltip items by count (descending). @default false */
+    sortTooltipByCount?: boolean
 }
 
 export function Sparkline({
@@ -68,6 +72,8 @@ export function Sparkline({
     onSelectionChange,
     className,
     tooltipRowCutoff,
+    hideZerosInTooltip = false,
+    sortTooltipByCount = false,
 }: SparklineProps): JSX.Element {
     const tooltipRef = useRef<HTMLDivElement | null>(null)
 
@@ -328,15 +334,18 @@ export function Sparkline({
                                         : toolTipDataPoints[0].label
                                     : ''
                             }
-                            seriesData={toolTipDataPoints.map((dp, i) => ({
-                                id: i,
-                                dataIndex: 0,
-                                datasetIndex: 0,
-                                order: i,
-                                label: dp.dataset.label,
-                                color: dp.dataset.borderColor as string,
-                                count: (dp.dataset.data?.[dp.dataIndex] as number) || 0,
-                            }))}
+                            seriesData={toolTipDataPoints
+                                .map((dp, i) => ({
+                                    id: i,
+                                    dataIndex: 0,
+                                    datasetIndex: 0,
+                                    order: i,
+                                    label: dp.dataset.label,
+                                    color: dp.dataset.borderColor as string,
+                                    count: (dp.dataset.data?.[dp.dataIndex] as number) || 0,
+                                }))
+                                .filter((item) => !hideZerosInTooltip || item.count > 0)
+                                .sort((a, b) => (sortTooltipByCount ? b.count - a.count : a.order - b.order))}
                             renderSeries={(value) => value}
                             renderCount={(count) => humanFriendlyNumber(count)}
                             rowCutoff={tooltipRowCutoff}

--- a/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/index.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerSparkline/index.tsx
@@ -140,7 +140,9 @@ export function LogsSparkline({
                         onSelectionChange={onSelectionChange}
                         withXScale={withXScale}
                         renderLabel={renderLabel}
-                        tooltipRowCutoff={20}
+                        tooltipRowCutoff={100}
+                        hideZerosInTooltip
+                        sortTooltipByCount
                     />
                 ) : !sparklineLoading ? (
                     <div className="h-full text-muted flex items-center justify-center">


### PR DESCRIPTION
## Problem

The Sparkline component's tooltip functionality needs enhancement to better handle zero values and provide sorting options, particularly for the Logs Viewer.

## Changes

- Added two new props to the Sparkline component:
  - `hideZerosInTooltip`: Hides series with zero values from the tooltip (default: false)
  - `sortTooltipByCount`: Sorts tooltip items by count in descending order (default: false)
- Updated the LogsViewerSparkline to:
  - Increase tooltip row cutoff from 20 to 100
  - Enable hiding zeros in tooltip
  - Enable sorting tooltip items by count

## How did you test this code?

Local dev

## Publish to changelog?

No