### PR TITLE
fix(data-modeling): temporal schedule not paused on no-resync

### DIFF
--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -376,7 +376,7 @@ class DataWarehouseSavedQuerySerializer(DataWarehouseSavedQuerySerializerMixin, 
                 except Exception as e:
                     capture_exception(e)
                     logger.exception(
-                        "Failed to update temporal schedule when updating sync frequency for view %s to value %s",
+                        "Failed to update temporal schedule when updating view: view=%s sync_frequency=%s",
                         view.name,
                         sync_frequency,
                     )

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -366,13 +366,15 @@ class DataWarehouseSavedQuerySerializer(DataWarehouseSavedQuerySerializerMixin, 
                     .first()
                 )
                 self.context["activity_log"] = latest_activity_log
-            # update the temporal schedule if the view is materialized
-            if view.is_materialized:
+            # update the temporal schedule if it exists
+            view_id = str(view.id)
+            temporal_schedule_exists = saved_query_workflow_exists(view_id)
+            if temporal_schedule_exists:
                 try:
                     if sync_frequency == "never":
-                        pause_saved_query_schedule(str(locked_instance.id))
+                        pause_saved_query_schedule(view_id)
                     elif sync_frequency:
-                        sync_saved_query_workflow(view, create=not saved_query_workflow_exists(str(view.id)))
+                        sync_saved_query_workflow(view, create=not temporal_schedule_exists)
                 except Exception as e:
                     capture_exception(e)
                     logger.exception(

--- a/products/data_warehouse/backend/api/test/test_saved_query.py
+++ b/products/data_warehouse/backend/api/test/test_saved_query.py
@@ -412,28 +412,21 @@ class TestSavedQuery(APIBaseTest):
         self.assertEqual(response.status_code, 201)
         saved_query = response.json()
 
-        # materialize the query
         with (
-            patch("products.data_warehouse.backend.data_load.saved_query_service.sync_saved_query_workflow"),
             patch(
-                "products.data_warehouse.backend.data_load.saved_query_service.saved_query_workflow_exists",
-                return_value=False,
-            ),
+                "products.data_warehouse.backend.api.saved_query.saved_query_workflow_exists",
+                return_value=True,
+            ) as mock_workflow_exists,
+            patch(
+                "products.data_warehouse.backend.api.saved_query.pause_saved_query_schedule"
+            ) as mock_pause_saved_query_schedule,
         ):
-            response = self.client.post(
-                f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}/materialize",
-            )
-            assert response.status_code == 200
-
-        with patch(
-            "products.data_warehouse.backend.api.saved_query.pause_saved_query_schedule"
-        ) as mock_pause_saved_query_schedule:
             response = self.client.patch(
                 f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
                 {"sync_frequency": "never"},
             )
-
             self.assertEqual(response.status_code, 200)
+            mock_workflow_exists.assert_called_once_with(saved_query["id"])
             mock_pause_saved_query_schedule.assert_called_once_with(saved_query["id"])
 
     def test_update_with_types(self):

--- a/products/data_warehouse/backend/api/test/test_saved_query.py
+++ b/products/data_warehouse/backend/api/test/test_saved_query.py
@@ -412,6 +412,19 @@ class TestSavedQuery(APIBaseTest):
         self.assertEqual(response.status_code, 201)
         saved_query = response.json()
 
+        # materialize the query
+        with (
+            patch("products.data_warehouse.backend.data_load.saved_query_service.sync_saved_query_workflow"),
+            patch(
+                "products.data_warehouse.backend.data_load.saved_query_service.saved_query_workflow_exists",
+                return_value=False,
+            ),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}/materialize",
+            )
+            assert response.status_code == 200
+
         with patch(
             "products.data_warehouse.backend.api.saved_query.pause_saved_query_schedule"
         ) as mock_pause_saved_query_schedule:


### PR DESCRIPTION
## Problem

Temporal schedules not pausing when matview set to "no resync."

## Changes

Fix that. The temporal schedule logic is easier to follow now that its colocated. If this doesn't fix the customer reported issue it might be customer specific and they've gotten into a weird state somehow. Will validate via django admin and temporal cloud.

## How did you test this code?

Manually

https://github.com/user-attachments/assets/c9d3a754-ccaa-46be-94f3-632705bcc4b4

## Publish to changelog?

no