### PR TITLE
feat(logs): enhance experimental sparkline query runner to handle service breakdowns by top 10 bucket

### DIFF
--- a/products/logs/backend/sparkline_query_runner.py
+++ b/products/logs/backend/sparkline_query_runner.py
@@ -34,7 +34,11 @@ class SparklineQueryRunner(LogsQueryRunner):
 
         results = []
         for result in response.results:
-            breakdown_value = result[1] if result[1] not in (None, "") else "(no value)"
+            breakdown_value = result[1]
+            if breakdown_value == "$$_other_$$":
+                breakdown_value = "Other"
+            elif breakdown_value in (None, "", "$$_no_value_$$"):
+                breakdown_value = "(no value)"
             results.append(
                 {
                     "time": result[0],
@@ -49,37 +53,63 @@ class SparklineQueryRunner(LogsQueryRunner):
         query = parse_select(
             """
                 SELECT
-                    am.time_bucket AS time,
-                    {breakdown_field},
-                    ifNull(ac.event_count, 0) AS count
+                    time,
+                    if(global_rank <= 10, breakdown_value, '$$_other_$$') AS breakdown_bucket,
+                    sum(event_count) AS count
                 FROM (
                     SELECT
-                        dateAdd({date_from_start_of_interval}, {number_interval_period}) AS time_bucket
-                    FROM numbers(
-                        floor(
-                            dateDiff({interval},
-                                     {date_from_start_of_interval},
-                                     {date_to_start_of_interval}) / {interval_count} + 1
-                                    )
-                        )
-                    WHERE
-                        time_bucket >= {date_from_start_of_interval} and
-                        time_bucket <= greatest(
-                            {date_from_start_of_interval},
-                            toStartOfInterval({date_to} - toIntervalSecond(1), {one_interval_period})
-                        )
-                ) AS am
-                LEFT JOIN (
-                    SELECT
-                        toStartOfInterval({time_field}, {one_interval_period}) AS time,
-                        {breakdown_field},
-                        count() AS event_count
-                    FROM logs
-                    WHERE {where} AND time >= {date_from_start_of_interval} AND time <= {date_to}
-                    GROUP BY {breakdown_field}, time
-                ) AS ac ON am.time_bucket = ac.time
-                ORDER BY time asc, {breakdown_field} asc
-                LIMIT 1000
+                        bucket_data.time AS time,
+                        bucket_data.breakdown_value AS breakdown_value,
+                        bucket_data.event_count AS event_count,
+                        global_ranks.global_rank AS global_rank
+                    FROM (
+                        SELECT
+                            am.time_bucket AS time,
+                            ifNull({breakdown_field}, '$$_no_value_$$') AS breakdown_value,
+                            ifNull(ac.event_count, 0) AS event_count
+                        FROM (
+                            SELECT
+                                dateAdd({date_from_start_of_interval}, {number_interval_period}) AS time_bucket
+                            FROM numbers(
+                                floor(
+                                    dateDiff({interval},
+                                             {date_from_start_of_interval},
+                                             {date_to_start_of_interval}) / {interval_count} + 1
+                                            )
+                                )
+                            WHERE
+                                time_bucket >= {date_from_start_of_interval} and
+                                time_bucket <= greatest(
+                                    {date_from_start_of_interval},
+                                    toStartOfInterval({date_to} - toIntervalSecond(1), {one_interval_period})
+                                )
+                        ) AS am
+                        LEFT JOIN (
+                            SELECT
+                                toStartOfInterval({time_field}, {one_interval_period}) AS time,
+                                {breakdown_field},
+                                count() AS event_count
+                            FROM logs
+                            WHERE {where}
+                              AND timestamp >= {date_from_start_of_interval}
+                              AND timestamp <= {date_to}
+                            GROUP BY {breakdown_field}, time
+                        ) AS ac ON am.time_bucket = ac.time
+                    ) AS bucket_data
+                    LEFT JOIN (
+                        SELECT
+                            ifNull({breakdown_field}, '$$_no_value_$$') AS breakdown_value,
+                            row_number() OVER (ORDER BY count() DESC) AS global_rank
+                        FROM logs
+                        WHERE {where}
+                          AND timestamp >= {date_from_start_of_interval}
+                          AND timestamp <= {date_to}
+                        GROUP BY breakdown_value
+                    ) AS global_ranks ON bucket_data.breakdown_value = global_ranks.breakdown_value
+                )
+                GROUP BY time, breakdown_bucket
+                ORDER BY time ASC, breakdown_bucket ASC
+                LIMIT 100000
         """,
             placeholders={
                 **self.query_date_range.to_placeholders(),


### PR DESCRIPTION
## Problem

The current sparkline query implementation doesn't properly handle special values in breakdowns and doesn't limit the number of series displayed, which can lead to cluttered visualizations and inconsistent labeling.

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/d15b481d-d93d-4eef-bfa9-ad935ad0c505.png)

1. Enhanced sparkline query to limit results to top 10 values plus an "Other" category
2. Improved handling of special values in breakdown results:
   - `$$_other_$$` is now displayed as "Other"
   - `$$_no_value_$$`, empty strings, and nulls are displayed as "(no value)"
3. Implemented deterministic color assignment for services with collision handling
   - Ensures consistent colors across queries
   - Assigns the "muted" color to the "Other" category

> [!NOTE]
> this is still experimental and hidden behind a feature flag until I get it right, just want to see what it looks like with prod data

## How did you test this code?

Tested with various log queries using different breakdown fields to verify:
- Top 10 values are displayed correctly with remaining values grouped as "Other"
- Special values are properly labeled
- Color assignments are consistent across page refreshes and query changes
- The query correctly handles all edge cases (empty values, nulls, etc.)

## Publish to changelog?

No