### PR TITLE
fix(data-warehouse): Add schema name to the validate creds method and update stripes

### DIFF
--- a/posthog/temporal/data_imports/sources/ashby/source.py
+++ b/posthog/temporal/data_imports/sources/ashby/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -34,7 +34,9 @@ class AshbySource(SimpleSource[AshbySourceConfig]):
             unreleasedSource=True,
         )
 
-    def validate_credentials(self, config: AshbySourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: AshbySourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         # TODO(Andrew J. McGehee): implement the logic to validate the credentials of your source,
         # e.g. check the validity of API keys. returns a tuple of whether the credentials are valid,
         # and if not, returns an error message to return to the user

--- a/posthog/temporal/data_imports/sources/bigquery/source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/source.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -68,7 +68,9 @@ class BigQuerySource(SimpleSource[BigQuerySourceConfig]):
             if not table_name.startswith(build_destination_table_prefix(None))
         ]
 
-    def validate_credentials(self, config: BigQuerySourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: BigQuerySourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         region: str | None = None
         if (
             config.use_custom_region

--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -57,7 +57,9 @@ class BingAdsSource(SimpleSource[BingAdsSourceConfig], OAuthMixin):
             ),
         )
 
-    def validate_credentials(self, config: BingAdsSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: BingAdsSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         if not config.account_id or not config.bing_ads_integration_id:
             return False, "Account ID and Bing Ads integration are required"
 

--- a/posthog/temporal/data_imports/sources/chargebee/source.py
+++ b/posthog/temporal/data_imports/sources/chargebee/source.py
@@ -1,5 +1,5 @@
 import re
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -46,7 +46,9 @@ class ChargebeeSource(SimpleSource[ChargebeeSourceConfig]):
             for endpoint in list(ENDPOINTS)
         ]
 
-    def validate_credentials(self, config: ChargebeeSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: ChargebeeSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         subdomain_regex = re.compile("^[a-zA-Z-]+$")
         if not subdomain_regex.match(config.site_name):
             return False, "Chargebee site name is incorrect"

--- a/posthog/temporal/data_imports/sources/common/base.py
+++ b/posthog/temporal/data_imports/sources/common/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, Union
+from typing import Generic, Optional, TypeVar, Union
 
 from posthog.schema import (
     SourceConfig,
@@ -78,7 +78,9 @@ class _BaseSource(ABC, Generic[ConfigType]):
     def validate_config(self, job_inputs: dict) -> tuple[bool, list[str]]:
         return self._config_class.validate_dict(job_inputs)
 
-    def validate_credentials(self, config: ConfigType, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: ConfigType, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         """Check whether the provided credentials are valid for this source. Returns an optional error message"""
         return True, None
 

--- a/posthog/temporal/data_imports/sources/customer_io/source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -34,7 +34,9 @@ class CustomerIOSource(SimpleSource[CustomerIOSourceConfig]):
             unreleasedSource=True,
         )
 
-    def validate_credentials(self, config: CustomerIOSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: CustomerIOSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         # TODO(Andrew J. McGehee): implement the logic to validate the credentials of your source,
         # e.g. check the validity of API keys. returns a tuple of whether the credentials are valid,
         # and if not, returns an error message to return to the user

--- a/posthog/temporal/data_imports/sources/github/source.py
+++ b/posthog/temporal/data_imports/sources/github/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -34,7 +34,9 @@ class GithubSource(SimpleSource[GithubSourceConfig]):
             unreleasedSource=True,
         )
 
-    def validate_credentials(self, config: GithubSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: GithubSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         # TODO(Andrew J. McGehee): implement the logic to validate the credentials of your source,
         # e.g. check the validity of API keys. returns a tuple of whether the credentials are valid,
         # and if not, returns an error message to return to the user

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -1,5 +1,5 @@
 import re
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -180,7 +180,10 @@ class GoogleAdsSource(SimpleSource[GoogleAdsSourceConfig | GoogleAdsServiceAccou
             raise
 
     def validate_credentials(
-        self, config: GoogleAdsSourceConfig | GoogleAdsServiceAccountSourceConfig, team_id: int
+        self,
+        config: GoogleAdsSourceConfig | GoogleAdsServiceAccountSourceConfig,
+        team_id: int,
+        schema_name: Optional[str] = None,
     ) -> tuple[bool, str | None]:
         try:
             client = google_ads_client(config, team_id)

--- a/posthog/temporal/data_imports/sources/google_sheets/source.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 import gspread
 
@@ -68,7 +68,9 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
             else None,
         )
 
-    def validate_credentials(self, config: GoogleSheetsSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: GoogleSheetsSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         client = google_sheets_client()
         try:
             client.open_by_url(config.spreadsheet_url)

--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -66,7 +66,9 @@ class LinkedInAdsSource(SimpleSource[LinkedinAdsSourceConfig]):
             ),
         )
 
-    def validate_credentials(self, config: LinkedinAdsSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: LinkedinAdsSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         if not config.account_id or not config.linkedin_ads_integration_id:
             return False, "Account ID and LinkedIn Ads integration are required"
 

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -64,7 +64,9 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             for name, incremental_fields in filtered_results
         ]
 
-    def validate_credentials(self, config: MongoDBSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: MongoDBSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         from pymongo.errors import OperationFailure
 
         try:

--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from sshtunnel import BaseSSHTunnelForwarderError
 
@@ -133,7 +133,9 @@ class MSSQLSource(SimpleSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatab
 
         return schemas
 
-    def validate_credentials(self, config: MSSQLSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: MSSQLSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         from pymssql import OperationalError
 
         is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config)

--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from sshtunnel import BaseSSHTunnelForwarderError
 
@@ -150,7 +150,9 @@ class MySQLSource(SimpleSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatab
 
         return schemas
 
-    def validate_credentials(self, config: MySQLSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: MySQLSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config)
         if not is_ssh_valid:
             return is_ssh_valid, ssh_valid_errors

--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from psycopg import OperationalError
 from sshtunnel import BaseSSHTunnelForwarderError
@@ -189,7 +189,9 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
 
         return schemas
 
-    def validate_credentials(self, config: PostgresSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: PostgresSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config)
         if not is_ssh_valid:
             return is_ssh_valid, ssh_valid_errors

--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -59,7 +59,9 @@ class RedditAdsSource(SimpleSource[RedditAdsSourceConfig], OAuthMixin):
             ),
         )
 
-    def validate_credentials(self, config: RedditAdsSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: RedditAdsSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         if not config.account_id or not config.reddit_integration_id:
             return False, "Account ID and Reddit Ads integration are required"
 

--- a/posthog/temporal/data_imports/sources/shopify/source.py
+++ b/posthog/temporal/data_imports/sources/shopify/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -66,7 +66,9 @@ class ShopifySource(SimpleSource[ShopifySourceConfig]):
             featureFlag="shopify-dwh",
         )
 
-    def validate_credentials(self, config: ShopifySourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: ShopifySourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         try:
             if validate_shopify_credentials(
                 config.shopify_store_id, config.shopify_client_id, config.shopify_client_secret

--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from snowflake.connector.errors import DatabaseError, ForbiddenError, ProgrammingError
 
@@ -192,7 +192,9 @@ class SnowflakeSource(SimpleSource[SnowflakeSourceConfig]):
 
         return schemas
 
-    def validate_credentials(self, config: SnowflakeSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: SnowflakeSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         if config.auth_type.selection == "password" and (not config.auth_type.user or not config.auth_type.password):
             return False, "Missing required parameters: username, password"
 

--- a/posthog/temporal/data_imports/sources/source.template
+++ b/posthog/temporal/data_imports/sources/source.template
@@ -65,7 +65,7 @@ class TemplateSource(SimpleSource[Config]):  # rename this class and replace `Co
         )
 
     def validate_credentials(
-        self, config: Config, team_id: int
+        self, config: Config, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:  # replace `Config` with the generated class
         return (
             True,

--- a/posthog/temporal/data_imports/sources/source.template
+++ b/posthog/temporal/data_imports/sources/source.template
@@ -32,7 +32,7 @@
 #       source will appear in frontend dropdowns and menus.
 # 14. TODO: phew! you're done. just delete these TODOs before you PR
 
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,

--- a/posthog/temporal/data_imports/sources/stripe/source.py
+++ b/posthog/temporal/data_imports/sources/stripe/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -144,9 +144,11 @@ These permissions are automatically pre-filled in the API key creation form if y
             for endpoint in STRIPE_ENDPOINTS
         ]
 
-    def validate_credentials(self, config: StripeSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: StripeSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         try:
-            if validate_stripe_credentials(config.stripe_secret_key):
+            if validate_stripe_credentials(config.stripe_secret_key, schema_name):
                 return True, None
             else:
                 return False, "Invalid Stripe credentials"

--- a/posthog/temporal/data_imports/sources/stripe/stripe.py
+++ b/posthog/temporal/data_imports/sources/stripe/stripe.py
@@ -283,6 +283,9 @@ def validate_credentials(api_key: str, table_name: Optional[str] = None) -> bool
     if table_name:
         resources_to_check = [r for r in resources_to_check if r.get("name") == table_name]
 
+    if table_name and len(resources_to_check) == 0:
+        raise StripePermissionError({table_name: f"{table_name} does not exist"})
+
     for resource in resources_to_check:
         try:
             # This will raise an exception if we don't have access

--- a/posthog/temporal/data_imports/sources/stripe/stripe.py
+++ b/posthog/temporal/data_imports/sources/stripe/stripe.py
@@ -251,7 +251,7 @@ class StripePermissionError(Exception):
         super().__init__(message)
 
 
-def validate_credentials(api_key: str) -> bool:
+def validate_credentials(api_key: str, table_name: Optional[str] = None) -> bool:
     """
     Validates Stripe API credentials and checks permissions for all required resources.
     This function will:
@@ -279,6 +279,9 @@ def validate_credentials(api_key: str) -> bool:
     ]
 
     missing_permissions = {}
+
+    if table_name:
+        resources_to_check = [r for r in resources_to_check if r.get("name") == table_name]
 
     for resource in resources_to_check:
         try:

--- a/posthog/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -56,7 +56,9 @@ class TikTokAdsSource(SimpleSource[TikTokAdsSourceConfig], OAuthMixin):
             ),
         )
 
-    def validate_credentials(self, config: TikTokAdsSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: TikTokAdsSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         if not config.advertiser_id or not config.tiktok_integration_id:
             return False, "Advertiser ID and TikTok Ads integration are required"
 

--- a/posthog/temporal/data_imports/sources/vitally/source.py
+++ b/posthog/temporal/data_imports/sources/vitally/source.py
@@ -1,5 +1,5 @@
 import re
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -44,7 +44,9 @@ class VitallySource(SimpleSource[VitallySourceConfig]):
             for endpoint in VITALLY_ENDPOINTS
         ]
 
-    def validate_credentials(self, config: VitallySourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: VitallySourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         subdomain_regex = re.compile("^[a-zA-Z-]+$")
         if config.region.selection == "US" and not subdomain_regex.match(config.region.subdomain):
             return False, "Vitally subdomain is incorrect"

--- a/posthog/temporal/data_imports/sources/zendesk/source.py
+++ b/posthog/temporal/data_imports/sources/zendesk/source.py
@@ -1,5 +1,5 @@
 import re
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -50,7 +50,9 @@ class ZendeskSource(SimpleSource[ZendeskSourceConfig]):
             + [resource for resource, endpoint_url, data_key, cursor_paginated in SUPPORT_ENDPOINTS]
         ]
 
-    def validate_credentials(self, config: ZendeskSourceConfig, team_id: int) -> tuple[bool, str | None]:
+    def validate_credentials(
+        self, config: ZendeskSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
         subdomain_regex = re.compile("^[a-zA-Z0-9-]+$")
         if not subdomain_regex.match(config.subdomain):
             return False, "Zendesk subdomain is incorrect"

--- a/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
+++ b/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
@@ -6,7 +6,11 @@ from unittest import mock
 
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.stripe.constants import ACCOUNT_RESOURCE_NAME
-from posthog.temporal.data_imports.sources.stripe.stripe import StripeResumeConfig, validate_credentials
+from posthog.temporal.data_imports.sources.stripe.stripe import (
+    StripePermissionError,
+    StripeResumeConfig,
+    validate_credentials,
+)
 from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
 
 from products.data_warehouse.backend.models import ExternalDataSchema, ExternalDataSource
@@ -278,3 +282,45 @@ def test_validate_credentials_with_table_name():
         mock_client.subscriptions.list.assert_not_called()
         mock_client.refunds.list.assert_not_called()
         mock_client.credit_notes.list.assert_not_called()
+
+
+def test_validate_credentials_with_missing_table_name():
+    mock_client = mock.MagicMock()
+
+    # Mock each resource's list method
+    mock_client.accounts.list = mock.MagicMock()
+    mock_client.balance_transactions.list = mock.MagicMock()
+    mock_client.charges.list = mock.MagicMock()
+    mock_client.customers.list = mock.MagicMock()
+    mock_client.disputes.list = mock.MagicMock()
+    mock_client.invoice_items.list = mock.MagicMock()
+    mock_client.invoices.list = mock.MagicMock()
+    mock_client.payouts.list = mock.MagicMock()
+    mock_client.prices.list = mock.MagicMock()
+    mock_client.products.list = mock.MagicMock()
+    mock_client.subscriptions.list = mock.MagicMock()
+    mock_client.refunds.list = mock.MagicMock()
+    mock_client.credit_notes.list = mock.MagicMock()
+
+    with (
+        mock.patch("posthog.temporal.data_imports.sources.stripe.stripe.StripeClient", return_value=mock_client),
+        pytest.raises(StripePermissionError) as e,
+    ):
+        validate_credentials("api_key", "bad_table")
+
+    # No endpoint should be called
+    mock_client.accounts.list.assert_not_called()
+    mock_client.balance_transactions.list.assert_not_called()
+    mock_client.charges.list.assert_not_called()
+    mock_client.customers.list.assert_not_called()
+    mock_client.disputes.list.assert_not_called()
+    mock_client.invoice_items.list.assert_not_called()
+    mock_client.invoices.list.assert_not_called()
+    mock_client.payouts.list.assert_not_called()
+    mock_client.prices.list.assert_not_called()
+    mock_client.products.list.assert_not_called()
+    mock_client.subscriptions.list.assert_not_called()
+    mock_client.refunds.list.assert_not_called()
+    mock_client.credit_notes.list.assert_not_called()
+
+    assert "bad_table" in str(e)

--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -324,7 +324,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         new_source = SourceRegistry.get_source(source_type_enum)
         config = new_source.parse_config(source.job_inputs)
 
-        credentials_valid, credentials_error = new_source.validate_credentials(config, self.team_id)
+        credentials_valid, credentials_error = new_source.validate_credentials(config, self.team_id, instance.name)
         if not credentials_valid:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
## Problem
- If your stripe key doesnt have access to a single table, then you can't change the sync type of any table it does have access to because we check whether the key has access to all tables every time

## Changes
- Update the validation logic to check for the table we're trying to change the incrementality of 
- Update all other sources with the new parameter of the `validate_credentials` method

## How did you test this code?
Unit tests!