### PR TITLE
chore(batch-exports): Add `ParamValidationError` to non-retryable errors for Redshift

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -117,6 +117,8 @@ NON_RETRYABLE_ERROR_TYPES = (
     "ClientError",
     # An S3 bucket doesn't exist when using `copy_into_redshift_activity_from_stage`.
     "NoSuchBucket",
+    # S3 parameter validation failed.
+    "ParamValidationError",
 )
 
 


### PR DESCRIPTION
## Problem

When using `COPY` mode in Redshift batch exports, if there's a validation error (e.g. an invalid bucket name provided) we continually retry without any feedback to the end user.

## Changes

Add `ParamValidationError` as a non-retryable error (we already have it for S3 batch exports but not Redshift)

## How did you test this code?

I didn't but this is a small change so fairly confident it should work.
