### PR TITLE
feat(replay): make replay tab aware

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -17,6 +17,7 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { cn } from 'lib/utils/css-classes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
@@ -29,6 +30,10 @@ import { AccessControlLevel, AccessControlResourceType, ReplayTab, ReplayTabs } 
 import { SessionRecordingCollections } from './collections/SessionRecordingCollections'
 import { SessionRecordingsPlaylist } from './playlist/SessionRecordingsPlaylist'
 import { createPlaylist } from './playlist/playlistUtils'
+import {
+    SessionRecordingPlaylistLogicProps,
+    sessionRecordingsPlaylistLogic,
+} from './playlist/sessionRecordingsPlaylistLogic'
 import { sessionRecordingEventUsageLogic } from './sessionRecordingEventUsageLogic'
 import { sessionReplaySceneLogic } from './sessionReplaySceneLogic'
 import SessionRecordingTemplates from './templates/SessionRecordingTemplates'
@@ -172,8 +177,15 @@ function Warnings(): JSX.Element {
     )
 }
 
-function MainPanel(): JSX.Element {
+function MainPanel({ tabId }: { tabId: string }): JSX.Element {
     const { tab } = useValues(sessionReplaySceneLogic)
+
+    const playlistLogicProps: SessionRecordingPlaylistLogicProps = {
+        logicKey: `scene-${tabId}`,
+        updateSearchParams: true,
+    }
+
+    useAttachedLogic(sessionRecordingsPlaylistLogic(playlistLogicProps), sessionReplaySceneLogic({ tabId }))
 
     return (
         <SceneContent>
@@ -183,7 +195,7 @@ function MainPanel(): JSX.Element {
                 <Spinner />
             ) : tab === ReplayTabs.Home ? (
                 <div className="SessionRecordingPlaylistHeightWrapper">
-                    <SessionRecordingsPlaylist updateSearchParams />
+                    <SessionRecordingsPlaylist {...playlistLogicProps} />
                 </div>
             ) : tab === ReplayTabs.Playlists ? (
                 <SessionRecordingCollections />
@@ -266,7 +278,7 @@ export function SessionsRecordings({ tabId }: SessionsRecordingsProps = {}): JSX
         <BindLogic logic={sessionReplaySceneLogic} props={{ tabId }}>
             <SceneContent className="h-full">
                 <SessionRecordingsPageTabs />
-                <MainPanel />
+                <MainPanel tabId={tabId} />
             </SceneContent>
         </BindLogic>
     )

--- a/frontend/src/scenes/session-recordings/player/controller/seekbarLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/controller/seekbarLogic.ts
@@ -113,6 +113,15 @@ export const seekbarLogic = kea<seekbarLogicType>([
         ],
     }),
     listeners(({ values, actions, cache }) => ({
+        setSlider: () => {
+            // When the slider is set (component mounted), initialize thumb position based on current timestamp
+            if (values.slider && values.sessionPlayerData.durationMs) {
+                const xValue =
+                    ((values.currentPlayerTime ?? 0) / values.sessionPlayerData.durationMs) * values.slider.offsetWidth
+                actions.setThumbLeftPos(xValue - THUMB_OFFSET, false)
+            }
+        },
+
         setCurrentTimestamp: () => {
             if (!values.slider) {
                 return

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1234,6 +1234,10 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     actions.seekToTimestamp(values.currentTimestamp)
                 }
                 actions.syncPlayerSpeed()
+                // Ensure we respect the persisted playing state when the player is reinitialized
+                if (values.playingState === SessionPlayerState.PAUSE && values.currentTimestamp !== undefined) {
+                    values.player?.replayer?.pause(values.toRRWebPlayerTime(values.currentTimestamp))
+                }
             }
         },
         setCurrentSegment: ({ segment }) => {

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -6,11 +6,13 @@ import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { useWindowSize } from 'lib/hooks/useWindowSize'
+import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { Playlist } from 'scenes/session-recordings/playlist/Playlist'
 
 import { RecordingsUniversalFiltersEmbed } from '../filters/RecordingsUniversalFiltersEmbed'
 import { SessionRecordingPlayer } from '../player/SessionRecordingPlayer'
 import { playerSettingsLogic } from '../player/playerSettingsLogic'
+import { sessionRecordingPlayerLogic } from '../player/sessionRecordingPlayerLogic'
 import { playlistFiltersLogic } from './playlistFiltersLogic'
 import { SessionRecordingPlaylistLogicProps, sessionRecordingsPlaylistLogic } from './sessionRecordingsPlaylistLogic'
 
@@ -133,6 +135,59 @@ function VerticalLayout({
     )
 }
 
+function AttachedPlayer({
+    playlistProps,
+    activeSessionRecording,
+    matchingEventsMatchType,
+    pinnedRecordings,
+    onPlayNextRecording,
+}: {
+    playlistProps: SessionRecordingPlaylistLogicProps
+    activeSessionRecording: any
+    matchingEventsMatchType: any
+    pinnedRecordings: any[]
+    onPlayNextRecording: () => void
+}): JSX.Element {
+    const playerKey = playlistProps.logicKey ?? 'playlist'
+
+    // Attach player logic to playlist logic so it persists across tab switches
+    // Pass autoPlay from playlistProps to match what the component will use
+    useAttachedLogic(
+        sessionRecordingPlayerLogic({
+            playerKey,
+            sessionRecordingId: activeSessionRecording.id,
+            matchingEventsMatchType,
+            autoPlay: playlistProps.autoPlay,
+        }),
+        sessionRecordingsPlaylistLogic(playlistProps)
+    )
+
+    return (
+        <SessionRecordingPlayer
+            playerKey={playerKey}
+            sessionRecordingId={activeSessionRecording.id}
+            matchingEventsMatchType={matchingEventsMatchType}
+            autoPlay={playlistProps.autoPlay}
+            onRecordingDeleted={() => {
+                sessionRecordingsPlaylistLogic.actions.loadAllRecordings()
+                sessionRecordingsPlaylistLogic.actions.setSelectedRecordingId(null)
+            }}
+            pinned={!!pinnedRecordings.find((x) => x.id === activeSessionRecording.id)}
+            setPinned={
+                playlistProps.onPinnedChange
+                    ? (pinned) => {
+                          if (!activeSessionRecording.id) {
+                              return
+                          }
+                          playlistProps.onPinnedChange?.(activeSessionRecording, pinned)
+                      }
+                    : undefined
+            }
+            playNextRecording={onPlayNextRecording}
+        />
+    )
+}
+
 function PlayerWrapper({
     showContent = true,
     containerRef,
@@ -191,26 +246,12 @@ function PlayerWrapper({
                     />
                 </div>
             ) : showContent && activeSessionRecording ? (
-                <SessionRecordingPlayer
-                    playerKey={props.logicKey ?? 'playlist'}
-                    sessionRecordingId={activeSessionRecording.id}
+                <AttachedPlayer
+                    playlistProps={props}
+                    activeSessionRecording={activeSessionRecording}
                     matchingEventsMatchType={matchingEventsMatchType}
-                    onRecordingDeleted={() => {
-                        sessionRecordingsPlaylistLogic.actions.loadAllRecordings()
-                        sessionRecordingsPlaylistLogic.actions.setSelectedRecordingId(null)
-                    }}
-                    pinned={!!pinnedRecordings.find((x) => x.id === activeSessionRecording.id)}
-                    setPinned={
-                        props.onPinnedChange
-                            ? (pinned) => {
-                                  if (!activeSessionRecording.id) {
-                                      return
-                                  }
-                                  props.onPinnedChange?.(activeSessionRecording, pinned)
-                              }
-                            : undefined
-                    }
-                    playNextRecording={onPlayNextRecording}
+                    pinnedRecordings={pinnedRecordings}
+                    onPlayNextRecording={onPlayNextRecording}
                 />
             ) : (
                 <div className="mt-20">


### PR DESCRIPTION
## Problem

Whenever we navigated to a replay tab, it fully reloaded the page as if for the first time. its super annoying and slow especially if the filter query is expensive or if you were buffered signifcantly into a large (slow to buffer) video. 


<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

referenced https://posthog.com/handbook/engineering/conventions/frontend-coding for tab awareness


Added tabIds as part of logic keys, and created attachedLogic / "attachedPLayer" component so that we dont have to refresh/reload/rebuffer EVERYTHING with tab re-navigation

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
### before (not tab aware, refreshes)

[before_no_tab_aware.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/21758412-d81c-47d5-99de-c2376e80913a.mov" />](https://app.graphite.com/user-attachments/video/21758412-d81c-47d5-99de-c2376e80913a.mov)

### after (does not refresh)

[tab_aware_replay.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/9493be3e-b200-467e-84ba-f0a2d608f78a.mov" />](https://app.graphite.com/user-attachments/video/9493be3e-b200-467e-84ba-f0a2d608f78a.mov)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
