### PR TITLE
fix: apply assert non-batched person updates correctly

### DIFF
--- a/nodejs/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
+++ b/nodejs/src/worker/ingestion/persons/repositories/postgres-person-repository.ts
@@ -1127,6 +1127,15 @@ export class PostgresPersonRepository
 
     async updatePersonAssertVersion(personUpdate: PersonUpdate): Promise<[number | undefined, TopicMessage[]]> {
         try {
+            // Calculate final properties by applying set and unset operations
+            const finalProperties = { ...personUpdate.properties }
+            Object.entries(personUpdate.properties_to_set).forEach(([key, value]) => {
+                finalProperties[key] = value
+            })
+            personUpdate.properties_to_unset.forEach((key) => {
+                delete finalProperties[key]
+            })
+
             const { rows } = await this.postgres.query<RawPerson>(
                 PostgresUse.PERSONS_WRITE,
                 `
@@ -1140,7 +1149,7 @@ export class PostgresPersonRepository
                 RETURNING *
                 `,
                 [
-                    JSON.stringify(personUpdate.properties),
+                    JSON.stringify(finalProperties),
                     JSON.stringify(personUpdate.properties_last_updated_at),
                     JSON.stringify(personUpdate.properties_last_operation),
                     personUpdate.is_identified,


### PR DESCRIPTION
## Problem

We were dropping person updates after switching off batching due to a bug in the assert version logic.

## Changes

- Adds regression tests
- Fixes the `properties_to_set` and `properties_to_unset` not being applied

## How did you test this code?

- Added regression tests
- Existing tests