### PR TITLE
feat(llma): add Prometheus metrics for AI event processing

### DIFF
--- a/nodejs/src/ingestion/ai/errors/index.ts
+++ b/nodejs/src/ingestion/ai/errors/index.ts
@@ -1,5 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
+import { aiErrorNormalizationCounter } from '../metrics'
 import { normalizeError } from './normalize-error'
 
 /**
@@ -51,10 +52,12 @@ export function processAiErrorNormalization<T extends PluginEvent>(event: T): T 
         // Only set if we have a non-empty normalized error
         if (normalizedError) {
             event.properties['$ai_error_normalized'] = normalizedError
+            aiErrorNormalizationCounter.labels({ status: 'normalized' }).inc()
         }
 
         return event
     } catch {
+        aiErrorNormalizationCounter.labels({ status: 'error' }).inc()
         return event
     }
 }

--- a/nodejs/src/ingestion/ai/metrics.ts
+++ b/nodejs/src/ingestion/ai/metrics.ts
@@ -1,0 +1,13 @@
+import { Counter } from 'prom-client'
+
+export const aiCostLookupCounter = new Counter({
+    name: 'ai_cost_lookup_total',
+    help: 'AI model cost lookup outcomes',
+    labelNames: ['status'],
+})
+
+export const aiErrorNormalizationCounter = new Counter({
+    name: 'ai_error_normalization_total',
+    help: 'AI error normalization outcomes',
+    labelNames: ['status'],
+})


### PR DESCRIPTION
## Problem

AI event processing (cost lookup and error normalization) had no observability. The error normalization catch block was completely silent, making it impossible to know if failures were occurring.

## Changes

Add two Prometheus counters:
- `ai_cost_lookup_total{status}` - tracks cost lookup outcomes (found, not_found, custom)
- `ai_error_normalization_total{status}` - tracks error normalization outcomes (normalized, error)

Files:
- `nodejs/src/ingestion/ai/metrics.ts` - new metrics definitions
- `nodejs/src/ingestion/ai/costs/index.ts` - cost lookup tracking
- `nodejs/src/ingestion/ai/errors/index.ts` - error normalization tracking

## How did you test this code?

- All 368 existing tests pass
- Verified metrics appearing locally via `curl http://localhost:6738/metrics`
- Confirmed counters increment as expected with local AI events

## Publish to changelog?

no