### PR TITLE
fix(product tours): add feature flag check to product tours pages

### DIFF
--- a/frontend/src/scenes/product-tours/ProductTour.tsx
+++ b/frontend/src/scenes/product-tours/ProductTour.tsx
@@ -2,8 +2,12 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
 import { NotFound } from 'lib/components/NotFound'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
+
+import { Error404 } from '~/layout/Error404'
 
 import { ProductTourEdit } from './ProductTourEdit'
 import { ProductTourView } from './ProductTourView'
@@ -16,6 +20,7 @@ export const scene: SceneExport<ProductTourLogicProps> = {
 }
 
 export function ProductTourComponent({ id }: ProductTourLogicProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
     const { productTourMissing, isEditingProductTour } = useValues(productTourLogic({ id }))
     const { editingProductTour } = useActions(productTourLogic({ id }))
 
@@ -24,6 +29,10 @@ export function ProductTourComponent({ id }: ProductTourLogicProps): JSX.Element
             editingProductTour(false)
         }
     }, [editingProductTour])
+
+    if (!featureFlags[FEATURE_FLAGS.PRODUCT_TOURS]) {
+        return <Error404 />
+    }
 
     if (productTourMissing) {
         return <NotFound object="product tour" />

--- a/frontend/src/scenes/product-tours/ProductTours.tsx
+++ b/frontend/src/scenes/product-tours/ProductTours.tsx
@@ -5,10 +5,13 @@ import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
 import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
 
+import { Error404 } from '~/layout/Error404'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
@@ -48,8 +51,13 @@ function NewTourButton(): JSX.Element {
 }
 
 function ProductTours(): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
     const { tab } = useValues(productToursLogic)
     const { setTab } = useActions(productToursLogic)
+
+    if (!featureFlags[FEATURE_FLAGS.PRODUCT_TOURS]) {
+        return <Error404 />
+    }
 
     return (
         <SceneContent>


### PR DESCRIPTION
## Problem

i misunderstood the scene flag logic, and product tours are currently accessible if you guess the URL lol - had a customer do this

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

adds explicit flag checks to product tours pages

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

local testing

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no