### PR TITLE
chore(batch-exports): Add bucket name validation in UI

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
@@ -30,8 +30,8 @@ function validateBucketName(bucketName: string): string | undefined {
         return undefined // Let required field validation handle empty values
     }
 
-    if (bucketName.length < 3 || bucketName.length > 63) {
-        return 'Bucket name must be between 3 and 63 characters'
+    if (/\s/.test(bucketName)) {
+        return 'Bucket name cannot contain whitespace'
     }
 
     if (bucketName !== bucketName.toLowerCase()) {

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
@@ -19,6 +19,40 @@ import {
 import type { batchExportConfigurationLogicType } from './batchExportConfigurationLogicType'
 import { humanizeBatchExportName } from './utils'
 
+// Bucket naming rules (supports both S3 and GCS):
+// S3: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+// GCS: https://cloud.google.com/storage/docs/buckets#naming
+const BUCKET_NAME_REGEX = /^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$/
+const IP_ADDRESS_REGEX = /^(\d{1,3}\.){3}\d{1,3}$/
+
+function validateBucketName(bucketName: string): string | undefined {
+    if (!bucketName) {
+        return undefined // Let required field validation handle empty values
+    }
+
+    if (bucketName.length < 3 || bucketName.length > 63) {
+        return 'Bucket name must be between 3 and 63 characters'
+    }
+
+    if (bucketName !== bucketName.toLowerCase()) {
+        return 'Bucket name must be lowercase'
+    }
+
+    if (bucketName.includes('..')) {
+        return 'Bucket name cannot contain consecutive periods'
+    }
+
+    if (IP_ADDRESS_REGEX.test(bucketName)) {
+        return 'Bucket name cannot be formatted as an IP address'
+    }
+
+    if (!BUCKET_NAME_REGEX.test(bucketName)) {
+        return 'Bucket name can only contain lowercase letters, numbers, hyphens, and periods, and must start and end with a letter or number'
+    }
+
+    return undefined
+}
+
 export interface BatchExportConfigurationLogicProps {
     service: BatchExportService['type'] | null
     id: string | null
@@ -1056,12 +1090,28 @@ export const batchExportConfigurationLogic = kea<batchExportConfigurationLogicTy
     forms(({ asyncActions, values }) => ({
         configuration: {
             errors: (formdata) => {
-                return Object.fromEntries(
+                const requiredFieldErrors = Object.fromEntries(
                     values.requiredFields.map((field) => [
                         field,
                         formdata[field] ? undefined : 'This field is required',
                     ])
                 )
+
+                // Bucket name validation (S3/GCS compatible)
+                const bucketNameError =
+                    values.service === 'S3'
+                        ? validateBucketName(formdata.bucket_name)
+                        : values.service === 'Redshift' && formdata.mode === 'COPY'
+                          ? validateBucketName(formdata.redshift_s3_bucket)
+                          : undefined
+
+                return {
+                    ...requiredFieldErrors,
+                    ...(values.service === 'S3' && bucketNameError ? { bucket_name: bucketNameError } : {}),
+                    ...(values.service === 'Redshift' && formdata.mode === 'COPY' && bucketNameError
+                        ? { redshift_s3_bucket: bucketNameError }
+                        : {}),
+                }
             },
             submit: async (formdata) => {
                 await asyncActions.updateBatchExportConfig(formdata)


### PR DESCRIPTION
## Problem

We don't currently have any validation for bucket name fields in the UI which sometimes leads to errors in batch exports.

## Changes

Prevent issues with invalid bucket names by validating these in the front end. We support rules common across S3 and GCS.

## How did you test this code?

Local testing.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

