### PR TITLE
fix(flags): Add dependency_graph_errors to canonical log

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -256,6 +256,9 @@ impl FeatureFlagMatcher {
 
         // Track graph construction errors for the response (errors already logged in build_dependency_graph)
         let has_graph_errors = !graph_errors.is_empty();
+        if has_graph_errors {
+            with_canonical_log(|log| log.dependency_graph_errors = graph_errors.len());
+        }
 
         // Compute experience continuity stats from the filtered graph.
         // This considers all flags that will actually be evaluated (including dependencies).

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -110,6 +110,10 @@ pub struct FlagsCanonicalLogLine {
     pub group_properties_not_cached: bool,
     pub cohorts_evaluated: usize,
     pub flags_errored: usize,
+    /// Number of errors encountered during dependency graph construction.
+    /// These errors (like missing dependencies or cycles) set errors_while_computing_flags=true
+    /// in the response but don't increment flags_errored.
+    pub dependency_graph_errors: usize,
     pub hash_key_override_attempted: bool,
     pub hash_key_override_succeeded: bool,
     /// True when experience continuity lookup was skipped due to optimization.
@@ -152,6 +156,7 @@ impl Default for FlagsCanonicalLogLine {
             group_properties_not_cached: false,
             cohorts_evaluated: 0,
             flags_errored: 0,
+            dependency_graph_errors: 0,
             hash_key_override_attempted: false,
             hash_key_override_succeeded: false,
             hash_key_override_skipped: false,
@@ -204,6 +209,7 @@ impl FlagsCanonicalLogLine {
             group_properties_not_cached = self.group_properties_not_cached,
             cohorts_evaluated = self.cohorts_evaluated,
             flags_errored = self.flags_errored,
+            dependency_graph_errors = self.dependency_graph_errors,
             hash_key_override_attempted = self.hash_key_override_attempted,
             hash_key_override_succeeded = self.hash_key_override_succeeded,
             hash_key_override_skipped = self.hash_key_override_skipped,
@@ -259,6 +265,7 @@ mod tests {
         assert!(!log.group_properties_not_cached);
         assert_eq!(log.cohorts_evaluated, 0);
         assert_eq!(log.flags_errored, 0);
+        assert_eq!(log.dependency_graph_errors, 0);
         assert!(!log.hash_key_override_attempted);
         assert!(!log.hash_key_override_succeeded);
         assert!(!log.hash_key_override_skipped);
@@ -350,6 +357,22 @@ mod tests {
         assert_eq!(final_log.cohorts_evaluated, 5);
         assert!(final_log.hash_key_override_attempted);
         assert!(final_log.hash_key_override_succeeded);
+    }
+
+    #[tokio::test]
+    async fn test_dependency_graph_errors_is_tracked() {
+        let log = FlagsCanonicalLogLine::new(Uuid::new_v4(), "10.0.0.1".to_string());
+
+        let graph_errors_count = 2;
+        let (_, final_log) = run_with_canonical_log(log, async {
+            with_canonical_log(|l| l.dependency_graph_errors = graph_errors_count);
+        })
+        .await;
+
+        assert_eq!(
+            final_log.dependency_graph_errors, graph_errors_count,
+            "dependency_graph_errors should track the count of graph construction errors"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Responses may contain `errorsWhileComputingFlags: true` while the canonical line reports no flags errored. This can be caused by an error that occurs in the construction of the dependency graph, which also results in `errorsWhileComputingFlags: true`.

## Changes

Added `dependency_graph_errors` to the canonical log line. This property will indicate the number of dependency graph errors encountered.

## How did you test this code?

Added and updated unit tests
