### PR TITLE
refactor(cohorts): use query for duplicating existing cohorts

### DIFF
--- a/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.test.ts
@@ -14,6 +14,7 @@ import { urls } from 'scenes/urls'
 
 import { useMocks } from '~/mocks/jest'
 import { cohortsModel } from '~/models/cohortsModel'
+import { NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { mockCohort } from '~/test/mocks'
 import {
@@ -870,14 +871,21 @@ describe('cohortEditLogic', () => {
                 name: 'Static Cohort (static copy)',
             }
 
-            jest.spyOn(api.cohorts, 'duplicate').mockResolvedValue(duplicatedCohort)
+            jest.spyOn(api, 'create').mockResolvedValue(duplicatedCohort)
 
             await expectLogic(logic, () => {
                 logic.actions.setCohort(staticCohort)
                 logic.actions.duplicateCohort(true)
             }).toFinishAllListeners()
 
-            expect(api.cohorts.duplicate).toHaveBeenCalledWith(1)
+            expect(api.create).toHaveBeenCalledWith('api/cohort', {
+                is_static: true,
+                name: 'Static Cohort (static copy)',
+                query: {
+                    kind: NodeKind.HogQLQuery,
+                    query: 'SELECT person_id FROM static_cohort_people WHERE cohort_id = 1',
+                },
+            })
         })
 
         it('duplicate dynamic cohort as static', async () => {
@@ -897,14 +905,21 @@ describe('cohortEditLogic', () => {
                 is_static: true,
             }
 
-            jest.spyOn(api.cohorts, 'duplicate').mockResolvedValue(duplicatedCohort)
+            jest.spyOn(api, 'create').mockResolvedValue(duplicatedCohort)
 
             await expectLogic(logic, () => {
                 logic.actions.setCohort(dynamicCohort)
                 logic.actions.duplicateCohort(true)
             }).toFinishAllListeners()
 
-            expect(api.cohorts.duplicate).toHaveBeenCalledWith(1)
+            expect(api.create).toHaveBeenCalledWith('api/cohort', {
+                is_static: true,
+                name: 'Dynamic Cohort (static copy)',
+                query: {
+                    kind: NodeKind.HogQLQuery,
+                    query: 'SELECT person_id FROM cohort_people WHERE cohort_id = 1',
+                },
+            })
         })
 
         it('duplicate dynamic cohort as dynamic', async () => {


### PR DESCRIPTION
## Problem

We are calling `insert_cohort_from_insight_filter` when duplicating a cohort. This in turn calls `insert_cohort_actors_into_ch`, which contains [legacy insight calculations code](https://github.com/PostHog/posthog/blob/master/posthog/api/cohort.py#L1467-L1502). This method is not used anywhere besides the cohort duplication any more. 

## Changes

We want to get rid of the legacy insight calculations code. I could just have removed the now unused code path related to that, but decided to go a step further and replace the cohort calculation with the modern query-based variant.

This is PR 1/2 where I replace the frontend side call with the query-based approach. PR 2/2 removes the legacy code: https://github.com/PostHog/posthog/pull/44481

## How did you test this code?

Duplicated a static and a dynamic cohort locally. Adapted tests in the follow up PR.