### PR TITLE
fix(dags): dagster job for reconciling missed person prop updates

### DIFF
--- a/posthog/dags/common/resources.py
+++ b/posthog/dags/common/resources.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from urllib.parse import urlparse
 
 import dagster
@@ -106,7 +107,7 @@ class PostgresURLResource(dagster.ConfigurableResource):
 
 
 @dagster.resource
-def kafka_producer_resource(context: dagster.InitResourceContext) -> _KafkaProducer:
+def kafka_producer_resource(context: dagster.InitResourceContext) -> Generator[_KafkaProducer, None, None]:
     """
     Kafka producer resource with proper cleanup.
     Flushes pending messages on teardown.

--- a/posthog/dags/common/resources.py
+++ b/posthog/dags/common/resources.py
@@ -105,10 +105,14 @@ class PostgresURLResource(dagster.ConfigurableResource):
         return pg.create_resource(context)
 
 
-class KafkaProducerResource(dagster.ConfigurableResource):
+@dagster.resource
+def kafka_producer_resource(context: dagster.InitResourceContext) -> _KafkaProducer:
     """
-    Kafka producer resource - auto-configured from Django settings.
+    Kafka producer resource with proper cleanup.
+    Flushes pending messages on teardown.
     """
-
-    def create_resource(self, context: dagster.InitResourceContext) -> _KafkaProducer:
-        return _KafkaProducer()
+    producer = _KafkaProducer()
+    try:
+        yield producer
+    finally:
+        producer.flush()

--- a/posthog/dags/locations/__init__.py
+++ b/posthog/dags/locations/__init__.py
@@ -7,10 +7,10 @@ from dagster_aws.s3.resources import S3Resource
 
 from posthog.dags.common.resources import (
     ClickhouseClusterResource,
-    KafkaProducerResource,
     PostgresResource,
     PostgresURLResource,
     RedisResource,
+    kafka_producer_resource,
 )
 
 # Define resources for different environments
@@ -37,7 +37,7 @@ resources_by_env = {
             connection_url=dagster.EnvVar("PERSONS_DB_WRITER_URL"),
         ),
         # Kafka producer (auto-configured from Django settings)
-        "kafka_producer": KafkaProducerResource(),
+        "kafka_producer": kafka_producer_resource,
     },
     "local": {
         "cluster": ClickhouseClusterResource.configure_at_launch(),
@@ -62,7 +62,7 @@ resources_by_env = {
             connection_url=dagster.EnvVar("PERSONS_DB_WRITER_URL"),
         ),
         # Kafka producer (auto-configured from Django settings)
-        "kafka_producer": KafkaProducerResource(),
+        "kafka_producer": kafka_producer_resource,
     },
 }
 

--- a/posthog/dags/locations/__init__.py
+++ b/posthog/dags/locations/__init__.py
@@ -5,7 +5,13 @@ import dagster_slack
 from dagster_aws.s3.io_manager import s3_pickle_io_manager
 from dagster_aws.s3.resources import S3Resource
 
-from posthog.dags.common.resources import ClickhouseClusterResource, PostgresResource, RedisResource
+from posthog.dags.common.resources import (
+    ClickhouseClusterResource,
+    KafkaProducerResource,
+    PostgresResource,
+    PostgresURLResource,
+    RedisResource,
+)
 
 # Define resources for different environments
 resources_by_env = {
@@ -26,6 +32,12 @@ resources_by_env = {
             user=dagster.EnvVar("POSTGRES_USER"),
             password=dagster.EnvVar("POSTGRES_PASSWORD"),
         ),
+        # Persons DB resource (parses connection URL)
+        "persons_database": PostgresURLResource(
+            connection_url=dagster.EnvVar("PERSONS_DB_WRITER_URL"),
+        ),
+        # Kafka producer (auto-configured from Django settings)
+        "kafka_producer": KafkaProducerResource(),
     },
     "local": {
         "cluster": ClickhouseClusterResource.configure_at_launch(),
@@ -45,6 +57,12 @@ resources_by_env = {
             user=dagster.EnvVar("POSTGRES_USER"),
             password=dagster.EnvVar("POSTGRES_PASSWORD"),
         ),
+        # Persons DB resource (parses connection URL)
+        "persons_database": PostgresURLResource(
+            connection_url=dagster.EnvVar("PERSONS_DB_WRITER_URL"),
+        ),
+        # Kafka producer (auto-configured from Django settings)
+        "kafka_producer": KafkaProducerResource(),
     },
 }
 

--- a/posthog/dags/locations/ingestion.py
+++ b/posthog/dags/locations/ingestion.py
@@ -3,6 +3,7 @@ import dagster
 from posthog.dags import (
     delete_persons_from_trigger_log,
     ingestion_assets,
+    person_property_reconciliation,
     persondistinctids_without_person_cleanup,
     persons_new_backfill,
     persons_without_distinct_ids_cleanup,
@@ -16,6 +17,7 @@ defs = dagster.Definitions(
     ],
     jobs=[
         delete_persons_from_trigger_log.delete_persons_from_trigger_log_job,
+        person_property_reconciliation.person_property_reconciliation_job,
         persondistinctids_without_person_cleanup.persondistinctids_without_person_cleanup_job,
         persons_new_backfill.persons_new_backfill_job,
         persons_without_distinct_ids_cleanup.persons_without_distinct_ids_cleanup_job,

--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -608,6 +608,10 @@ def reconcile_team_chunk(
                         context.log.warning(
                             f"Failed to publish person to Kafka: {person_data['id']}, error: {kafka_error}"
                         )
+                try:
+                    kafka_producer.flush()
+                except Exception as flush_error:
+                    context.log.warning(f"Failed to flush Kafka producer: {flush_error}")
                 context.log.info(f"Applied {len(persons_to_publish)} updates for team_id={team_id} (PG + Kafka)")
             elif persons_to_publish and config.dry_run:
                 context.log.info(f"[DRY RUN] Would apply {len(persons_to_publish)} updates for team_id={team_id}")

--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -229,7 +229,7 @@ def get_person_property_updates_from_clickhouse(
             updates.append(
                 PropertyUpdate(
                     key=key,
-                    value=value,
+                    value=json.loads(value),  # Parse raw JSON: strip quotes from strings, convert types
                     timestamp=timestamp,
                     operation="set",
                 )
@@ -240,7 +240,7 @@ def get_person_property_updates_from_clickhouse(
             updates.append(
                 PropertyUpdate(
                     key=key,
-                    value=value,
+                    value=json.loads(value),  # Parse raw JSON: strip quotes from strings, convert types
                     timestamp=timestamp,
                     operation="set_once",
                 )

--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -334,7 +334,6 @@ def publish_person_to_kafka(person_data: dict, producer: _KafkaProducer) -> None
         "is_deleted": int(person_data.get("is_deleted", 0)),
         "created_at": created_at_str,
         "version": person_data["version"],
-        "_timestamp": now().strftime("%Y-%m-%d %H:%M:%S"),
     }
 
     producer.produce(topic=KAFKA_PERSON, data=kafka_data)

--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -321,7 +321,7 @@ def publish_person_to_kafka(person_data: dict, producer: _KafkaProducer) -> None
 
     # Format data for Kafka/ClickHouse
     created_at = person_data.get("created_at")
-    if hasattr(created_at, "strftime"):
+    if created_at is not None and hasattr(created_at, "strftime"):
         created_at_str = created_at.strftime("%Y-%m-%d %H:%M:%S.%f")
     else:
         created_at_str = str(created_at) if created_at else now().strftime("%Y-%m-%d %H:%M:%S.%f")

--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -1,0 +1,745 @@
+"""Dagster job for reconciling person properties that were missed due to a bug where
+PERSON_BATCH_WRITING_DB_WRITE_MODE=ASSERT_VERSION caused updatePersonAssertVersion()
+to not properly merge properties.
+
+This job reads events from ClickHouse to find property updates ($set, $set_once, $unset)
+within a bug window, compares timestamps with properties_last_updated_at in Postgres,
+and applies any missed updates.
+"""
+
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import dagster
+import psycopg2
+import psycopg2.errors
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.cluster import ClickhouseCluster
+from posthog.clickhouse.custom_metrics import MetricsClient
+from posthog.dags.common import JobOwners
+from posthog.kafka_client.client import KafkaProducer
+from posthog.kafka_client.topics import KAFKA_PERSON
+
+MAX_RETRY_ATTEMPTS = 5
+
+
+class PersonPropertyReconciliationConfig(dagster.Config):
+    """Configuration for the person property reconciliation job."""
+
+    bug_window_start: str  # ISO format: "2024-12-01T00:00:00Z"
+    bug_window_end: str  # ISO format: "2024-12-15T00:00:00Z"
+    batch_size: int = 500  # Persons per batch within a team
+    team_ids: list[int] | None = None  # Optional: filter to specific teams
+    dry_run: bool = False  # Log changes without applying
+
+
+# Max concurrent team processing - controls parallelism of the dynamic mapping
+MAX_CONCURRENT_TEAMS = 4
+
+
+@dataclass
+class PropertyUpdate:
+    """A single property update from ClickHouse events."""
+
+    key: str
+    value: Any
+    timestamp: datetime
+    operation: str  # "set" or "set_once"
+
+
+@dataclass
+class PersonPropertyUpdates:
+    """Aggregated property updates for a single person from ClickHouse."""
+
+    person_id: str
+    updates: list[PropertyUpdate]
+
+
+def parse_datetime(dt_str: str) -> datetime:
+    """Parse an ISO format datetime string."""
+    if dt_str.endswith("Z"):
+        dt_str = dt_str[:-1] + "+00:00"
+    return datetime.fromisoformat(dt_str)
+
+
+def get_person_property_updates_from_clickhouse(
+    team_id: int,
+    bug_window_start: str,
+    bug_window_end: str,
+    last_person_id: str | None,
+    limit: int,
+) -> list[PersonPropertyUpdates]:
+    """
+    Query ClickHouse to get property updates per person that differ from current state.
+
+    This query:
+    1. Joins events with person_distinct_id_overrides to resolve merged persons
+    2. Extracts $set (argMax for latest) and $set_once (argMin for first) properties
+    3. Compares with current person properties in ClickHouse
+    4. Returns only persons where properties differ or are missing
+
+    Returns a list of PersonPropertyUpdates for persons needing reconciliation.
+    """
+    pagination_filter = "AND merged.person_id > %(last_person_id)s" if last_person_id else ""
+
+    query = f"""
+    SELECT
+        merged.person_id,
+        merged.merged_keys AS set_keys,
+        merged.merged_vals AS set_vals,
+        merged.merged_timestamps AS set_timestamps,
+        merged.set_once_keys,
+        merged.set_once_vals,
+        merged.set_once_timestamps,
+        arrayMap(x -> x.1, JSONExtractKeysAndValues(p.person_properties, 'String')) AS person_keys,
+        arrayMap(x -> x.2, JSONExtractKeysAndValues(p.person_properties, 'String')) AS person_vals,
+        arrayFilter(
+            i -> (
+                indexOf(person_keys, set_keys[i]) > 0
+                AND set_vals[i] != person_vals[indexOf(person_keys, set_keys[i])]
+            ),
+            arrayEnumerate(set_keys)
+        ) AS differing_set_indices,
+        arrayFilter(
+            i -> indexOf(person_keys, merged.set_once_keys[i]) = 0,
+            arrayEnumerate(merged.set_once_keys)
+        ) AS missing_set_once_indices
+    FROM (
+        SELECT
+            person_id,
+            groupArrayIf(key, prop_type = 'set') AS merged_keys,
+            groupArrayIf(value, prop_type = 'set') AS merged_vals,
+            groupArrayIf(kv_timestamp, prop_type = 'set') AS merged_timestamps,
+            groupArrayIf(key, prop_type = 'set_once') AS set_once_keys,
+            groupArrayIf(value, prop_type = 'set_once') AS set_once_vals,
+            groupArrayIf(kv_timestamp, prop_type = 'set_once') AS set_once_timestamps
+        FROM (
+            SELECT
+                if(notEmpty(overrides.distinct_id), overrides.person_id, e.person_id) AS person_id,
+                kv_tuple.2 AS key,
+                kv_tuple.1 AS prop_type,
+                if(kv_tuple.1 = 'set', argMax(kv_tuple.3, e.timestamp), argMin(kv_tuple.3, e.timestamp)) AS value,
+                if(kv_tuple.1 = 'set', max(e.timestamp), min(e.timestamp)) AS kv_timestamp
+            FROM events e
+            LEFT OUTER JOIN (
+                SELECT
+                    argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                    person_distinct_id_overrides.distinct_id AS distinct_id
+                FROM person_distinct_id_overrides
+                WHERE equals(person_distinct_id_overrides.team_id, %(team_id)s)
+                GROUP BY person_distinct_id_overrides.distinct_id
+                HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0)
+            ) AS overrides ON e.distinct_id = overrides.distinct_id
+            ARRAY JOIN
+                arrayConcat(
+                    arrayMap(x -> tuple('set', x.1, x.2), JSONExtractKeysAndValues(e.properties, '$set', 'String')),
+                    arrayMap(x -> tuple('set_once', x.1, x.2), JSONExtractKeysAndValues(e.properties, '$set_once', 'String'))
+                ) AS kv_tuple
+            WHERE e.team_id = %(team_id)s
+              AND e.timestamp >= %(bug_window_start)s
+              AND e.timestamp < %(bug_window_end)s
+              AND (JSONExtractString(e.properties, '$set') != '' OR JSONExtractString(e.properties, '$set_once') != '')
+            GROUP BY person_id, kv_tuple.2, kv_tuple.1
+        )
+        GROUP BY person_id
+    ) AS merged
+    INNER JOIN (
+        SELECT
+            id,
+            argMax(properties, version) as person_properties
+        FROM person
+        WHERE team_id = %(team_id)s
+          AND _timestamp >= %(bug_window_start)s
+          AND _timestamp < %(bug_window_end)s
+        GROUP BY id
+    ) AS p ON p.id = merged.person_id
+    WHERE (length(differing_set_indices) > 0 OR length(missing_set_once_indices) > 0)
+        {pagination_filter}
+    ORDER BY merged.person_id
+    LIMIT %(limit)s
+    SETTINGS
+        readonly=2,
+        max_execution_time=1200,
+        allow_experimental_object_type=1,
+        format_csv_allow_double_quotes=0,
+        max_ast_elements=4000000,
+        max_expanded_ast_elements=4000000,
+        max_bytes_before_external_group_by=0,
+        allow_experimental_analyzer=1,
+        transform_null_in=1,
+        optimize_min_equality_disjunction_chain_length=4294967295,
+        allow_experimental_join_condition=1,
+        use_hive_partitioning=0
+    """
+
+    params = {
+        "team_id": team_id,
+        "bug_window_start": bug_window_start,
+        "bug_window_end": bug_window_end,
+        "last_person_id": last_person_id or "00000000-0000-0000-0000-000000000000",
+        "limit": limit,
+    }
+
+    rows = sync_execute(query, params)
+
+    results: list[PersonPropertyUpdates] = []
+    for row in rows:
+        (
+            person_id,
+            set_keys,
+            set_vals,
+            set_timestamps,
+            set_once_keys,
+            set_once_vals,
+            set_once_timestamps,
+            _person_keys,
+            _person_vals,
+            differing_set_indices,
+            missing_set_once_indices,
+        ) = row
+
+        updates: list[PropertyUpdate] = []
+
+        # Add differing $set properties
+        for idx in differing_set_indices:
+            # ClickHouse arrays are 1-indexed, Python is 0-indexed
+            i = idx - 1
+            if 0 <= i < len(set_keys):
+                updates.append(
+                    PropertyUpdate(
+                        key=set_keys[i],
+                        value=set_vals[i],
+                        timestamp=set_timestamps[i],
+                        operation="set",
+                    )
+                )
+
+        # Add missing $set_once properties
+        for idx in missing_set_once_indices:
+            i = idx - 1
+            if 0 <= i < len(set_once_keys):
+                updates.append(
+                    PropertyUpdate(
+                        key=set_once_keys[i],
+                        value=set_once_vals[i],
+                        timestamp=set_once_timestamps[i],
+                        operation="set_once",
+                    )
+                )
+
+        if updates:
+            results.append(PersonPropertyUpdates(person_id=str(person_id), updates=updates))
+
+    return results
+
+
+def reconcile_person_properties(
+    person: dict,
+    property_updates: list[PropertyUpdate],
+) -> dict | None:
+    """
+    Compute updated properties by comparing ClickHouse updates with current Postgres state.
+
+    The CH query pre-filters to only return:
+    - $set properties where the CH value differs from current person state
+    - $set_once properties that are missing from current person state
+
+    Args:
+        person: From Postgres with uuid, properties, properties_last_updated_at, properties_last_operation
+        property_updates: List of PropertyUpdate from ClickHouse, representing potential updates
+
+    Returns:
+        Dict with updated properties/metadata if changes needed, None otherwise.
+    """
+    properties = dict(person["properties"] or {})
+    properties_last_updated_at = dict(person["properties_last_updated_at"] or {})
+    properties_last_operation = dict(person["properties_last_operation"] or {})
+
+    changed = False
+
+    for update in property_updates:
+        key = update.key
+        value = update.value
+        event_ts = update.timestamp
+        operation = update.operation
+        event_ts_str = event_ts.isoformat()
+
+        existing_ts_str = properties_last_updated_at.get(key)
+
+        if operation == "set_once":
+            # set_once: these are properties missing from PG that should exist
+            # Only add if property doesn't already exist in PG
+            if key not in properties:
+                properties[key] = value
+                properties_last_updated_at[key] = event_ts_str
+                properties_last_operation[key] = "set_once"
+                changed = True
+        else:
+            # set: these are properties where CH value differs from PG
+            # Only update if property exists in PG and CH timestamp is newer
+            if key in properties and (existing_ts_str is None or event_ts > parse_datetime(existing_ts_str)):
+                properties[key] = value
+                properties_last_updated_at[key] = event_ts_str
+                properties_last_operation[key] = "set"
+                changed = True
+
+    if changed:
+        return {
+            "properties": properties,
+            "properties_last_updated_at": properties_last_updated_at,
+            "properties_last_operation": properties_last_operation,
+        }
+    return None
+
+
+def publish_person_to_kafka(person_data: dict) -> None:
+    """
+    Publish a person update to the Kafka topic for ClickHouse ingestion.
+
+    Args:
+        person_data: Dict with id, team_id, properties, is_identified, is_deleted, created_at, version
+    """
+    from django.utils.timezone import now
+
+    # Format data for Kafka/ClickHouse
+    created_at = person_data.get("created_at")
+    if hasattr(created_at, "strftime"):
+        created_at_str = created_at.strftime("%Y-%m-%d %H:%M:%S.%f")
+    else:
+        created_at_str = str(created_at) if created_at else now().strftime("%Y-%m-%d %H:%M:%S.%f")
+
+    kafka_data = {
+        "id": str(person_data["id"]),
+        "team_id": person_data["team_id"],
+        "properties": json.dumps(person_data["properties"]),
+        "is_identified": int(person_data.get("is_identified", False)),
+        "is_deleted": int(person_data.get("is_deleted", 0)),
+        "created_at": created_at_str,
+        "version": person_data["version"],
+        "_timestamp": now().strftime("%Y-%m-%d %H:%M:%S"),
+    }
+
+    producer = KafkaProducer()
+    producer.produce(topic=KAFKA_PERSON, data=kafka_data)
+
+
+def fetch_person_from_postgres(cursor, team_id: int, person_uuid: str) -> dict | None:
+    """Fetch a single person record from Postgres."""
+    cursor.execute(
+        """
+        SELECT
+            uuid::text,
+            properties,
+            properties_last_updated_at,
+            properties_last_operation,
+            version,
+            is_identified,
+            created_at
+        FROM posthog_person
+        WHERE team_id = %s AND uuid = %s::uuid
+        """,
+        (team_id, person_uuid),
+    )
+    row = cursor.fetchone()
+    return dict(row) if row else None
+
+
+def update_person_with_version_check(
+    cursor,
+    team_id: int,
+    person_uuid: str,
+    property_updates: list[PropertyUpdate],
+    dry_run: bool = False,
+    max_retries: int = 3,
+) -> tuple[bool, dict | None]:
+    """
+    Update a person's properties with optimistic locking.
+
+    Fetches the person, computes updates, and writes with version check.
+    If version changed (concurrent modification), re-fetches and retries.
+
+    Args:
+        cursor: Database cursor
+        team_id: Team ID
+        person_uuid: Person UUID
+        property_updates: Property updates from ClickHouse
+        dry_run: If True, don't actually write
+        max_retries: Maximum retry attempts on version mismatch
+
+    Returns:
+        Tuple of (success: bool, updated_person_data: dict | None)
+        updated_person_data contains the final state for Kafka publishing
+    """
+    for _attempt in range(max_retries):
+        # Fetch current person state
+        person = fetch_person_from_postgres(cursor, team_id, person_uuid)
+        if not person:
+            return False, None
+
+        current_version = person.get("version") or 0
+
+        # Compute updates
+        update = reconcile_person_properties(person, property_updates)
+        if not update:
+            # No changes needed
+            return True, None
+
+        if dry_run:
+            return True, None
+
+        # Write with version check
+        cursor.execute(
+            """
+            UPDATE posthog_person SET
+                properties = %s,
+                properties_last_updated_at = %s,
+                properties_last_operation = %s,
+                version = %s
+            WHERE team_id = %s AND uuid = %s::uuid AND version = %s
+            RETURNING uuid
+            """,
+            (
+                json.dumps(update["properties"]),
+                json.dumps(update["properties_last_updated_at"]),
+                json.dumps(update["properties_last_operation"]),
+                current_version + 1,
+                team_id,
+                person_uuid,
+                current_version,
+            ),
+        )
+
+        if cursor.rowcount > 0:
+            # Success - return data for Kafka publishing
+            return True, {
+                "id": person_uuid,
+                "team_id": team_id,
+                "properties": update["properties"],
+                "is_identified": person.get("is_identified", False),
+                "is_deleted": 0,
+                "created_at": person.get("created_at"),
+                "version": current_version + 1,
+            }
+
+        # Version mismatch - retry with fresh data
+        # (loop will re-fetch person)
+
+    # Exhausted retries
+    return False, None
+
+
+@dagster.op
+def get_team_ids_to_reconcile(
+    context: dagster.OpExecutionContext,
+    config: PersonPropertyReconciliationConfig,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> list[int]:
+    """
+    Query ClickHouse for distinct team_ids with property-setting events in the bug window.
+    """
+    if config.team_ids:
+        context.log.info(f"Using configured team_ids: {config.team_ids}")
+        return config.team_ids
+
+    query = """
+        SELECT DISTINCT team_id
+        FROM events
+        WHERE timestamp >= %(bug_window_start)s
+          AND timestamp < %(bug_window_end)s
+          AND (
+            JSONHas(properties, '$set') = 1
+            OR JSONHas(properties, '$set_once') = 1
+            OR JSONHas(properties, '$unset') = 1
+          )
+        ORDER BY team_id
+    """
+
+    context.log.info(
+        f"Querying for team_ids with property events between {config.bug_window_start} and {config.bug_window_end}"
+    )
+
+    results = sync_execute(
+        query,
+        {
+            "bug_window_start": config.bug_window_start,
+            "bug_window_end": config.bug_window_end,
+        },
+    )
+
+    team_ids = [int(row[0]) for row in results]
+
+    if not team_ids:
+        context.log.info("No team IDs found with property events in bug window")
+        return []
+
+    context.log.info(f"Found {len(team_ids)} teams with property events")
+    context.log.info(f"Sample of teams to process: {team_ids[:10]}" + ("..." if len(team_ids) > 10 else ""))
+    context.add_output_metadata({"team_count": dagster.MetadataValue.int(len(team_ids))})
+
+    return team_ids
+
+
+@dagster.op(out=dagster.DynamicOut(int))
+def create_team_chunks(
+    context: dagster.OpExecutionContext,
+    team_ids: list[int],
+):
+    """
+    Create a chunk for each team_id.
+    Yields DynamicOutput for each team.
+    """
+    if not team_ids:
+        context.log.info("No teams to process")
+        return
+
+    context.log.info(f"Creating {len(team_ids)} team chunks")
+
+    for team_id in team_ids:
+        chunk_key = f"team_{team_id}"
+        context.log.info(f"Yielding chunk for team_id: {team_id}")
+        yield dagster.DynamicOutput(
+            value=team_id,
+            mapping_key=chunk_key,
+        )
+
+
+@dagster.op
+def reconcile_team_chunk(
+    context: dagster.OpExecutionContext,
+    config: PersonPropertyReconciliationConfig,
+    chunk: int,
+    database: dagster.ResourceParam[psycopg2.extensions.connection],
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> dict[str, Any]:
+    """
+    Reconcile person properties for all affected persons in a team.
+    """
+    team_id = chunk
+    batch_size = config.batch_size
+    chunk_id = f"team_{team_id}"
+    job_name = context.run.job_name
+
+    metrics_client = MetricsClient(cluster)
+
+    context.log.info(f"Starting reconciliation for team_id: {team_id}")
+
+    total_persons_processed = 0
+    total_persons_updated = 0
+    total_persons_skipped = 0
+    last_person_id: str | None = None
+
+    try:
+        with database.cursor() as cursor:
+            cursor.execute("SET application_name = 'person_property_reconciliation'")
+            cursor.execute("SET lock_timeout = '5s'")
+            cursor.execute("SET statement_timeout = '30min'")
+            cursor.execute("SET synchronous_commit = off")
+
+            retry_attempt = 0
+            while True:
+                try:
+                    batch_start_time = time.time()
+
+                    # Query ClickHouse for persons with property updates in this team
+                    person_property_updates = get_person_property_updates_from_clickhouse(
+                        team_id=team_id,
+                        bug_window_start=config.bug_window_start,
+                        bug_window_end=config.bug_window_end,
+                        last_person_id=last_person_id,
+                        limit=batch_size,
+                    )
+
+                    if not person_property_updates:
+                        break
+
+                    last_person_id = person_property_updates[-1].person_id
+
+                    context.log.info(
+                        f"Processing batch of {len(person_property_updates)} persons for team_id={team_id}"
+                    )
+
+                    # Process each person with version check and retry
+                    persons_to_publish = []
+                    for person_updates in person_property_updates:
+                        success, person_data = update_person_with_version_check(
+                            cursor=cursor,
+                            team_id=team_id,
+                            person_uuid=person_updates.person_id,
+                            property_updates=person_updates.updates,
+                            dry_run=config.dry_run,
+                        )
+
+                        if not success:
+                            context.log.warning(f"Failed to update person after retries: {person_updates.person_id}")
+                            total_persons_skipped += 1
+                        elif person_data:
+                            # Successfully updated - queue for Kafka publishing
+                            persons_to_publish.append(person_data)
+                            total_persons_updated += 1
+                        else:
+                            # No changes needed
+                            total_persons_skipped += 1
+
+                        total_persons_processed += 1
+
+                    # Publish to Kafka
+                    if persons_to_publish and not config.dry_run:
+                        for person_data in persons_to_publish:
+                            try:
+                                publish_person_to_kafka(person_data)
+                            except Exception as kafka_error:
+                                context.log.warning(
+                                    f"Failed to publish person to Kafka: {person_data['id']}, error: {kafka_error}"
+                                )
+                        context.log.info(
+                            f"Applied {len(persons_to_publish)} updates for team_id={team_id} (PG + Kafka)"
+                        )
+                    elif persons_to_publish and config.dry_run:
+                        context.log.info(
+                            f"[DRY RUN] Would apply {len(persons_to_publish)} updates for team_id={team_id}"
+                        )
+
+                    # Track metrics
+                    batch_duration = time.time() - batch_start_time
+                    try:
+                        metrics_client.increment(
+                            "person_property_reconciliation_persons_processed_total",
+                            labels={"job_name": job_name, "chunk_id": chunk_id},
+                            value=float(len(person_property_updates)),
+                        ).result()
+                        metrics_client.increment(
+                            "person_property_reconciliation_batch_duration_seconds_total",
+                            labels={"job_name": job_name, "chunk_id": chunk_id},
+                            value=batch_duration,
+                        ).result()
+                    except Exception:
+                        pass
+
+                    retry_attempt = 0
+
+                except Exception as batch_error:
+                    try:
+                        cursor.execute("ROLLBACK")
+                    except Exception:
+                        pass
+
+                    # Handle deadlock/serialization failures with retry
+                    serialization_failure_class = getattr(psycopg2.errors, "SerializationFailure", None)
+                    is_serialization_failure = (
+                        serialization_failure_class is not None and isinstance(batch_error, serialization_failure_class)
+                    ) or (isinstance(batch_error, psycopg2.Error) and getattr(batch_error, "pgcode", None) == "40001")
+
+                    deadlock_detected_class = getattr(psycopg2.errors, "DeadlockDetected", None)
+                    is_deadlock = (
+                        deadlock_detected_class is not None and isinstance(batch_error, deadlock_detected_class)
+                    ) or (isinstance(batch_error, psycopg2.Error) and getattr(batch_error, "pgcode", None) == "40P01")
+
+                    if (is_serialization_failure or is_deadlock) and retry_attempt < MAX_RETRY_ATTEMPTS:
+                        retry_attempt += 1
+                        context.log.warning(
+                            f"Retryable error for team_id={team_id}: {batch_error}. Retry {retry_attempt}/{MAX_RETRY_ATTEMPTS}"
+                        )
+                        time.sleep(1)
+                        continue
+
+                    error_msg = (
+                        f"Failed to process batch for team_id={team_id}, last_person_id={last_person_id}: {batch_error}"
+                    )
+                    context.log.exception(error_msg)
+
+                    try:
+                        metrics_client.increment(
+                            "person_property_reconciliation_error",
+                            labels={"job_name": job_name, "chunk_id": chunk_id, "reason": "batch_failed"},
+                            value=1.0,
+                        ).result()
+                    except Exception:
+                        pass
+
+                    raise dagster.Failure(
+                        description=error_msg,
+                        metadata={
+                            "team_id": dagster.MetadataValue.int(team_id),
+                            "last_person_id": dagster.MetadataValue.text(
+                                str(last_person_id) if last_person_id else "N/A"
+                            ),
+                            "error_message": dagster.MetadataValue.text(str(batch_error)),
+                            "persons_processed_before_failure": dagster.MetadataValue.int(total_persons_processed),
+                        },
+                    ) from batch_error
+
+    except dagster.Failure:
+        raise
+    except Exception as e:
+        error_msg = f"Unexpected error for team_id={team_id}: {e}"
+        context.log.exception(error_msg)
+
+        try:
+            metrics_client.increment(
+                "person_property_reconciliation_error",
+                labels={"job_name": job_name, "chunk_id": chunk_id, "reason": "unexpected_error"},
+                value=1.0,
+            ).result()
+        except Exception:
+            pass
+
+        raise dagster.Failure(
+            description=error_msg,
+            metadata={
+                "team_id": dagster.MetadataValue.int(team_id),
+                "error_message": dagster.MetadataValue.text(str(e)),
+                "persons_processed_before_failure": dagster.MetadataValue.int(total_persons_processed),
+            },
+        ) from e
+
+    context.log.info(
+        f"Completed team_id={team_id}: processed={total_persons_processed}, updated={total_persons_updated}, skipped={total_persons_skipped}"
+    )
+
+    try:
+        metrics_client.increment(
+            "person_property_reconciliation_persons_updated_total",
+            labels={"job_name": job_name, "chunk_id": chunk_id},
+            value=float(total_persons_updated),
+        ).result()
+        metrics_client.increment(
+            "person_property_reconciliation_persons_skipped_total",
+            labels={"job_name": job_name, "chunk_id": chunk_id},
+            value=float(total_persons_skipped),
+        ).result()
+    except Exception:
+        pass
+
+    context.add_output_metadata(
+        {
+            "team_id": dagster.MetadataValue.int(team_id),
+            "persons_processed": dagster.MetadataValue.int(total_persons_processed),
+            "persons_updated": dagster.MetadataValue.int(total_persons_updated),
+            "persons_skipped": dagster.MetadataValue.int(total_persons_skipped),
+        }
+    )
+
+    return {
+        "team_id": team_id,
+        "persons_processed": total_persons_processed,
+        "persons_updated": total_persons_updated,
+        "persons_skipped": total_persons_skipped,
+    }
+
+
+@dagster.job(
+    tags={"owner": JobOwners.TEAM_INGESTION.value},
+    executor_def=dagster.multiprocess_executor.configured({"max_concurrent": MAX_CONCURRENT_TEAMS}),
+)
+def person_property_reconciliation_job():
+    """
+    One-time job to reconcile person properties that were missed due to the
+    ASSERT_VERSION bug. Processes teams in parallel with capped concurrency.
+    """
+    team_ids = get_team_ids_to_reconcile()
+    chunks = create_team_chunks(team_ids)
+    chunks.map(reconcile_team_chunk)

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -1,0 +1,632 @@
+"""Tests for the person property reconciliation job."""
+
+from datetime import UTC, datetime
+
+from unittest.mock import MagicMock, patch
+
+from posthog.dags.person_property_reconciliation import (
+    PersonPropertyUpdates,
+    PropertyUpdate,
+    get_person_property_updates_from_clickhouse,
+    reconcile_person_properties,
+    update_person_with_version_check,
+)
+
+
+class TestClickHouseResultParsing:
+    """Test that ClickHouse query results are correctly parsed into PropertyUpdate objects."""
+
+    def test_parses_set_diff_tuples(self):
+        """Test that set_diff array of tuples is correctly parsed."""
+        # Simulate ClickHouse returning: (person_id, set_diff, set_once_diff)
+        # set_diff is an array of (key, value, timestamp) tuples
+        mock_rows = [
+            (
+                "018d1234-5678-0000-0000-000000000001",  # person_id (UUID as string)
+                [  # set_diff - array of tuples
+                    ("email", "new@example.com", datetime(2024, 1, 15, 12, 0, 0)),
+                    ("name", "John Doe", datetime(2024, 1, 15, 12, 30, 0)),
+                ],
+                [],  # set_once_diff - empty
+            )
+        ]
+
+        with patch("posthog.dags.person_property_reconciliation.sync_execute", return_value=mock_rows):
+            results = get_person_property_updates_from_clickhouse(
+                team_id=1,
+                bug_window_start="2024-01-01T00:00:00Z",
+                bug_window_end="2024-01-31T00:00:00Z",
+            )
+
+        assert len(results) == 1
+        person_updates = results[0]
+        assert person_updates.person_id == "018d1234-5678-0000-0000-000000000001"
+        assert len(person_updates.updates) == 2
+
+        # Verify first update
+        assert person_updates.updates[0].key == "email"
+        assert person_updates.updates[0].value == "new@example.com"
+        assert person_updates.updates[0].timestamp == datetime(2024, 1, 15, 12, 0, 0)
+        assert person_updates.updates[0].operation == "set"
+
+        # Verify second update
+        assert person_updates.updates[1].key == "name"
+        assert person_updates.updates[1].value == "John Doe"
+        assert person_updates.updates[1].operation == "set"
+
+    def test_parses_set_once_diff_tuples(self):
+        """Test that set_once_diff array of tuples is correctly parsed."""
+        mock_rows = [
+            (
+                "018d1234-5678-0000-0000-000000000002",
+                [],  # set_diff - empty
+                [  # set_once_diff - array of tuples
+                    ("initial_referrer", "google.com", datetime(2024, 1, 10, 8, 0, 0)),
+                    ("first_seen", "2024-01-10", datetime(2024, 1, 10, 8, 0, 0)),
+                ],
+            )
+        ]
+
+        with patch("posthog.dags.person_property_reconciliation.sync_execute", return_value=mock_rows):
+            results = get_person_property_updates_from_clickhouse(
+                team_id=1,
+                bug_window_start="2024-01-01T00:00:00Z",
+                bug_window_end="2024-01-31T00:00:00Z",
+            )
+
+        assert len(results) == 1
+        person_updates = results[0]
+        assert len(person_updates.updates) == 2
+
+        # Verify set_once updates
+        assert person_updates.updates[0].key == "initial_referrer"
+        assert person_updates.updates[0].value == "google.com"
+        assert person_updates.updates[0].operation == "set_once"
+
+        assert person_updates.updates[1].key == "first_seen"
+        assert person_updates.updates[1].operation == "set_once"
+
+    def test_parses_mixed_set_and_set_once(self):
+        """Test parsing when both set_diff and set_once_diff have values."""
+        mock_rows = [
+            (
+                "018d1234-5678-0000-0000-000000000003",
+                [("email", "updated@example.com", datetime(2024, 1, 15, 12, 0, 0))],  # set_diff
+                [("initial_source", "organic", datetime(2024, 1, 10, 8, 0, 0))],  # set_once_diff
+            )
+        ]
+
+        with patch("posthog.dags.person_property_reconciliation.sync_execute", return_value=mock_rows):
+            results = get_person_property_updates_from_clickhouse(
+                team_id=1,
+                bug_window_start="2024-01-01T00:00:00Z",
+                bug_window_end="2024-01-31T00:00:00Z",
+            )
+
+        assert len(results) == 1
+        updates = results[0].updates
+        assert len(updates) == 2
+
+        # set updates come first
+        set_updates = [u for u in updates if u.operation == "set"]
+        set_once_updates = [u for u in updates if u.operation == "set_once"]
+
+        assert len(set_updates) == 1
+        assert len(set_once_updates) == 1
+        assert set_updates[0].key == "email"
+        assert set_once_updates[0].key == "initial_source"
+
+    def test_handles_multiple_persons(self):
+        """Test parsing results for multiple persons."""
+        mock_rows = [
+            (
+                "018d1234-0000-0000-0000-000000000001",
+                [("prop1", "val1", datetime(2024, 1, 15, 12, 0, 0))],
+                [],
+            ),
+            (
+                "018d1234-0000-0000-0000-000000000002",
+                [("prop2", "val2", datetime(2024, 1, 15, 13, 0, 0))],
+                [],
+            ),
+            (
+                "018d1234-0000-0000-0000-000000000003",
+                [],
+                [("prop3", "val3", datetime(2024, 1, 10, 8, 0, 0))],
+            ),
+        ]
+
+        with patch("posthog.dags.person_property_reconciliation.sync_execute", return_value=mock_rows):
+            results = get_person_property_updates_from_clickhouse(
+                team_id=1,
+                bug_window_start="2024-01-01T00:00:00Z",
+                bug_window_end="2024-01-31T00:00:00Z",
+            )
+
+        assert len(results) == 3
+        assert results[0].person_id == "018d1234-0000-0000-0000-000000000001"
+        assert results[1].person_id == "018d1234-0000-0000-0000-000000000002"
+        assert results[2].person_id == "018d1234-0000-0000-0000-000000000003"
+
+    def test_skips_persons_with_no_updates(self):
+        """Test that persons with empty set_diff and set_once_diff are skipped."""
+        mock_rows = [
+            (
+                "018d1234-0000-0000-0000-000000000001",
+                [],  # empty set_diff
+                [],  # empty set_once_diff
+            ),
+        ]
+
+        with patch("posthog.dags.person_property_reconciliation.sync_execute", return_value=mock_rows):
+            results = get_person_property_updates_from_clickhouse(
+                team_id=1,
+                bug_window_start="2024-01-01T00:00:00Z",
+                bug_window_end="2024-01-31T00:00:00Z",
+            )
+
+        # Person with no updates should be filtered out
+        assert len(results) == 0
+
+    def test_handles_empty_results(self):
+        """Test handling when ClickHouse returns no rows."""
+        with patch("posthog.dags.person_property_reconciliation.sync_execute", return_value=[]):
+            results = get_person_property_updates_from_clickhouse(
+                team_id=1,
+                bug_window_start="2024-01-01T00:00:00Z",
+                bug_window_end="2024-01-31T00:00:00Z",
+            )
+
+        assert results == []
+
+
+class TestReconcilePersonProperties:
+    """Test the reconcile_person_properties function."""
+
+    def test_set_creates_new_property(self):
+        """Test that $set creates a property that doesn't exist in PG."""
+        person = {
+            "properties": {},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        updates = [
+            PropertyUpdate(
+                key="email",
+                value="test@example.com",
+                timestamp=datetime(2024, 1, 15, 12, 0, 0),
+                operation="set",
+            )
+        ]
+
+        result = reconcile_person_properties(person, updates)
+
+        assert result is not None
+        assert result["properties"]["email"] == "test@example.com"
+        assert "email" in result["properties_last_updated_at"]
+        assert result["properties_last_operation"]["email"] == "set"
+
+    def test_set_updates_existing_property_when_newer(self):
+        """Test that $set updates an existing property when CH timestamp is newer."""
+        person = {
+            "properties": {"email": "old@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-10T00:00:00+00:00"},
+            "properties_last_operation": {"email": "set"},
+        }
+        updates = [
+            PropertyUpdate(
+                key="email",
+                value="new@example.com",
+                timestamp=datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC),
+                operation="set",
+            )
+        ]
+
+        result = reconcile_person_properties(person, updates)
+
+        assert result is not None
+        assert result["properties"]["email"] == "new@example.com"
+
+    def test_set_skips_when_pg_is_newer(self):
+        """Test that $set is skipped when PG timestamp is newer than CH."""
+        person = {
+            "properties": {"email": "current@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-20T00:00:00+00:00"},
+            "properties_last_operation": {"email": "set"},
+        }
+        updates = [
+            PropertyUpdate(
+                key="email",
+                value="older@example.com",
+                timestamp=datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC),
+                operation="set",
+            )
+        ]
+
+        result = reconcile_person_properties(person, updates)
+
+        # No changes needed
+        assert result is None
+
+    def test_set_once_creates_missing_property(self):
+        """Test that $set_once creates a property that doesn't exist in PG."""
+        person = {
+            "properties": {"other_prop": "value"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        updates = [
+            PropertyUpdate(
+                key="initial_referrer",
+                value="google.com",
+                timestamp=datetime(2024, 1, 10, 8, 0, 0),
+                operation="set_once",
+            )
+        ]
+
+        result = reconcile_person_properties(person, updates)
+
+        assert result is not None
+        assert result["properties"]["initial_referrer"] == "google.com"
+        assert result["properties_last_operation"]["initial_referrer"] == "set_once"
+
+    def test_set_once_skips_existing_property(self):
+        """Test that $set_once doesn't overwrite an existing property."""
+        person = {
+            "properties": {"initial_referrer": "facebook.com"},
+            "properties_last_updated_at": {"initial_referrer": "2024-01-05T00:00:00+00:00"},
+            "properties_last_operation": {"initial_referrer": "set_once"},
+        }
+        updates = [
+            PropertyUpdate(
+                key="initial_referrer",
+                value="google.com",
+                timestamp=datetime(2024, 1, 10, 8, 0, 0),
+                operation="set_once",
+            )
+        ]
+
+        result = reconcile_person_properties(person, updates)
+
+        # No changes - property already exists
+        assert result is None
+
+    def test_handles_multiple_updates(self):
+        """Test processing multiple updates for different properties."""
+        person = {
+            "properties": {"existing": "value"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        updates = [
+            PropertyUpdate(key="prop1", value="val1", timestamp=datetime(2024, 1, 15, 12, 0, 0), operation="set"),
+            PropertyUpdate(key="prop2", value="val2", timestamp=datetime(2024, 1, 15, 12, 0, 0), operation="set"),
+            PropertyUpdate(key="prop3", value="val3", timestamp=datetime(2024, 1, 10, 8, 0, 0), operation="set_once"),
+        ]
+
+        result = reconcile_person_properties(person, updates)
+
+        assert result is not None
+        assert result["properties"]["prop1"] == "val1"
+        assert result["properties"]["prop2"] == "val2"
+        assert result["properties"]["prop3"] == "val3"
+        # Original property preserved
+        assert result["properties"]["existing"] == "value"
+
+    def test_handles_null_properties(self):
+        """Test handling when person has None for properties fields."""
+        person = {
+            "properties": None,
+            "properties_last_updated_at": None,
+            "properties_last_operation": None,
+        }
+        updates = [
+            PropertyUpdate(
+                key="email", value="test@example.com", timestamp=datetime(2024, 1, 15, 12, 0, 0), operation="set"
+            ),
+        ]
+
+        result = reconcile_person_properties(person, updates)
+
+        assert result is not None
+        assert result["properties"]["email"] == "test@example.com"
+
+    def test_returns_none_when_no_changes(self):
+        """Test that None is returned when no updates are applicable."""
+        person = {
+            "properties": {"email": "current@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-20T00:00:00+00:00"},
+            "properties_last_operation": {"email": "set"},
+        }
+        updates = [
+            # This update is older than PG, should be skipped
+            PropertyUpdate(
+                key="email",
+                value="older@example.com",
+                timestamp=datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC),
+                operation="set",
+            )
+        ]
+
+        result = reconcile_person_properties(person, updates)
+        assert result is None
+
+
+class TestUpdatePersonWithVersionCheck:
+    """Test the update_person_with_version_check function."""
+
+    def create_mock_cursor(self, person_data=None, update_success=True):
+        """Create a mock cursor with configurable behavior."""
+        cursor = MagicMock()
+
+        # Mock fetchone to return person data
+        cursor.fetchone.return_value = person_data
+
+        # Mock rowcount for UPDATE success/failure
+        cursor.rowcount = 1 if update_success else 0
+
+        return cursor
+
+    def test_successful_update(self):
+        """Test successful update with version check."""
+        person_data = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
+            "properties": {"existing": "value"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+            "version": 5,
+            "is_identified": True,
+            "created_at": datetime(2024, 1, 1, 0, 0, 0),
+        }
+        cursor = self.create_mock_cursor(person_data=person_data, update_success=True)
+
+        updates = [
+            PropertyUpdate(
+                key="email", value="test@example.com", timestamp=datetime(2024, 1, 15, 12, 0, 0), operation="set"
+            ),
+        ]
+
+        success, result_data = update_person_with_version_check(
+            cursor=cursor,
+            team_id=1,
+            person_uuid="018d1234-5678-0000-0000-000000000001",
+            property_updates=updates,
+            dry_run=False,
+        )
+
+        assert success is True
+        assert result_data is not None
+        assert result_data["version"] == 6  # version incremented
+        assert result_data["properties"]["email"] == "test@example.com"
+        assert result_data["properties"]["existing"] == "value"
+
+        # Verify UPDATE was executed
+        update_calls = [call for call in cursor.execute.call_args_list if "UPDATE posthog_person" in str(call)]
+        assert len(update_calls) == 1
+
+    def test_dry_run_does_not_write(self):
+        """Test that dry_run=True doesn't execute UPDATE."""
+        person_data = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
+            "properties": {},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+            "version": 1,
+            "is_identified": False,
+            "created_at": datetime(2024, 1, 1, 0, 0, 0),
+        }
+        cursor = self.create_mock_cursor(person_data=person_data)
+
+        updates = [
+            PropertyUpdate(
+                key="email", value="test@example.com", timestamp=datetime(2024, 1, 15, 12, 0, 0), operation="set"
+            ),
+        ]
+
+        success, result_data = update_person_with_version_check(
+            cursor=cursor,
+            team_id=1,
+            person_uuid="018d1234-5678-0000-0000-000000000001",
+            property_updates=updates,
+            dry_run=True,
+        )
+
+        assert success is True
+        assert result_data is None  # No data returned for Kafka in dry run
+
+        # Verify UPDATE was NOT executed
+        update_calls = [call for call in cursor.execute.call_args_list if "UPDATE posthog_person" in str(call)]
+        assert len(update_calls) == 0
+
+    def test_person_not_found(self):
+        """Test handling when person doesn't exist in PG."""
+        cursor = self.create_mock_cursor(person_data=None)
+
+        updates = [
+            PropertyUpdate(
+                key="email", value="test@example.com", timestamp=datetime(2024, 1, 15, 12, 0, 0), operation="set"
+            ),
+        ]
+
+        success, result_data = update_person_with_version_check(
+            cursor=cursor,
+            team_id=1,
+            person_uuid="018d1234-5678-0000-0000-nonexistent",
+            property_updates=updates,
+        )
+
+        assert success is False
+        assert result_data is None
+
+    def test_no_changes_needed(self):
+        """Test when reconciliation determines no changes are needed."""
+        person_data = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
+            "properties": {"email": "current@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-20T00:00:00+00:00"},
+            "properties_last_operation": {"email": "set"},
+            "version": 5,
+            "is_identified": True,
+            "created_at": datetime(2024, 1, 1, 0, 0, 0),
+        }
+        cursor = self.create_mock_cursor(person_data=person_data)
+
+        # This update is older than what's in PG
+        updates = [
+            PropertyUpdate(
+                key="email",
+                value="older@example.com",
+                timestamp=datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC),
+                operation="set",
+            ),
+        ]
+
+        success, result_data = update_person_with_version_check(
+            cursor=cursor,
+            team_id=1,
+            person_uuid="018d1234-5678-0000-0000-000000000001",
+            property_updates=updates,
+        )
+
+        assert success is True
+        assert result_data is None  # No changes, no Kafka publish needed
+
+    def test_version_mismatch_retry(self):
+        """Test retry on version mismatch (concurrent modification)."""
+        person_data_v1 = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
+            "properties": {},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+            "version": 1,
+            "is_identified": False,
+            "created_at": datetime(2024, 1, 1, 0, 0, 0),
+        }
+        person_data_v2 = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
+            "properties": {},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+            "version": 2,  # Version changed by concurrent update
+            "is_identified": False,
+            "created_at": datetime(2024, 1, 1, 0, 0, 0),
+        }
+
+        cursor = MagicMock()
+        # First fetch returns v1, second fetch returns v2
+        cursor.fetchone.side_effect = [person_data_v1, person_data_v2]
+        # First update fails (version mismatch), second succeeds
+        cursor.rowcount = 0  # Will be set by side_effect
+
+        update_attempt = [0]
+
+        def execute_side_effect(query, *args):
+            if "UPDATE posthog_person" in query:
+                update_attempt[0] += 1
+                # First attempt fails, second succeeds
+                cursor.rowcount = 1 if update_attempt[0] > 1 else 0
+
+        cursor.execute.side_effect = execute_side_effect
+
+        updates = [
+            PropertyUpdate(
+                key="email", value="test@example.com", timestamp=datetime(2024, 1, 15, 12, 0, 0), operation="set"
+            ),
+        ]
+
+        success, result_data = update_person_with_version_check(
+            cursor=cursor,
+            team_id=1,
+            person_uuid="018d1234-5678-0000-0000-000000000001",
+            property_updates=updates,
+            max_retries=3,
+        )
+
+        assert success is True
+        assert result_data is not None
+        assert result_data["version"] == 3  # v2 + 1
+
+    def test_exhausted_retries(self):
+        """Test failure after exhausting all retries."""
+        person_data = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
+            "properties": {},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+            "version": 1,
+            "is_identified": False,
+            "created_at": datetime(2024, 1, 1, 0, 0, 0),
+        }
+
+        cursor = MagicMock()
+        cursor.fetchone.return_value = person_data
+        cursor.rowcount = 0  # Always fail version check
+
+        updates = [
+            PropertyUpdate(
+                key="email", value="test@example.com", timestamp=datetime(2024, 1, 15, 12, 0, 0), operation="set"
+            ),
+        ]
+
+        success, result_data = update_person_with_version_check(
+            cursor=cursor,
+            team_id=1,
+            person_uuid="018d1234-5678-0000-0000-000000000001",
+            property_updates=updates,
+            max_retries=3,
+        )
+
+        assert success is False
+        assert result_data is None
+
+
+class TestPropertyUpdateDataclass:
+    """Test the PropertyUpdate dataclass structure."""
+
+    def test_property_update_fields(self):
+        """Test that PropertyUpdate has expected fields."""
+        update = PropertyUpdate(
+            key="test_key",
+            value="test_value",
+            timestamp=datetime(2024, 1, 15, 12, 0, 0),
+            operation="set",
+        )
+
+        assert update.key == "test_key"
+        assert update.value == "test_value"
+        assert update.timestamp == datetime(2024, 1, 15, 12, 0, 0)
+        assert update.operation == "set"
+
+    def test_property_update_accepts_any_value_type(self):
+        """Test that value field accepts various types."""
+        # String
+        update1 = PropertyUpdate(key="k", value="string", timestamp=datetime.now(), operation="set")
+        assert update1.value == "string"
+
+        # Number (as string from CH)
+        update2 = PropertyUpdate(key="k", value="123", timestamp=datetime.now(), operation="set")
+        assert update2.value == "123"
+
+        # Boolean (as string from CH)
+        update3 = PropertyUpdate(key="k", value="true", timestamp=datetime.now(), operation="set")
+        assert update3.value == "true"
+
+
+class TestPersonPropertyUpdatesDataclass:
+    """Test the PersonPropertyUpdates dataclass structure."""
+
+    def test_person_property_updates_fields(self):
+        """Test that PersonPropertyUpdates has expected fields."""
+        updates = [
+            PropertyUpdate(key="k1", value="v1", timestamp=datetime.now(), operation="set"),
+            PropertyUpdate(key="k2", value="v2", timestamp=datetime.now(), operation="set_once"),
+        ]
+        person_updates = PersonPropertyUpdates(
+            person_id="018d1234-5678-0000-0000-000000000001",
+            updates=updates,
+        )
+
+        assert person_updates.person_id == "018d1234-5678-0000-0000-000000000001"
+        assert len(person_updates.updates) == 2
+        assert person_updates.updates[0].key == "k1"
+        assert person_updates.updates[1].key == "k2"

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -186,6 +186,7 @@ class TestReconcilePersonProperties:
     def test_set_creates_new_property(self):
         """Test that $set creates a property that doesn't exist in PG."""
         person = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
             "properties": {},
             "properties_last_updated_at": {},
             "properties_last_operation": {},
@@ -209,6 +210,7 @@ class TestReconcilePersonProperties:
     def test_set_updates_existing_property_when_newer(self):
         """Test that $set updates an existing property when CH timestamp is newer."""
         person = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
             "properties": {"email": "old@example.com"},
             "properties_last_updated_at": {"email": "2024-01-10T00:00:00+00:00"},
             "properties_last_operation": {"email": "set"},
@@ -230,6 +232,7 @@ class TestReconcilePersonProperties:
     def test_set_skips_when_pg_is_newer(self):
         """Test that $set is skipped when PG timestamp is newer than CH."""
         person = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
             "properties": {"email": "current@example.com"},
             "properties_last_updated_at": {"email": "2024-01-20T00:00:00+00:00"},
             "properties_last_operation": {"email": "set"},
@@ -251,6 +254,7 @@ class TestReconcilePersonProperties:
     def test_set_once_creates_missing_property(self):
         """Test that $set_once creates a property that doesn't exist in PG."""
         person = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
             "properties": {"other_prop": "value"},
             "properties_last_updated_at": {},
             "properties_last_operation": {},
@@ -273,6 +277,7 @@ class TestReconcilePersonProperties:
     def test_set_once_skips_existing_property(self):
         """Test that $set_once doesn't overwrite an existing property."""
         person = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
             "properties": {"initial_referrer": "facebook.com"},
             "properties_last_updated_at": {"initial_referrer": "2024-01-05T00:00:00+00:00"},
             "properties_last_operation": {"initial_referrer": "set_once"},
@@ -294,6 +299,7 @@ class TestReconcilePersonProperties:
     def test_handles_multiple_updates(self):
         """Test processing multiple updates for different properties."""
         person = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
             "properties": {"existing": "value"},
             "properties_last_updated_at": {},
             "properties_last_operation": {},
@@ -316,6 +322,7 @@ class TestReconcilePersonProperties:
     def test_handles_null_properties(self):
         """Test handling when person has None for properties fields."""
         person = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
             "properties": None,
             "properties_last_updated_at": None,
             "properties_last_operation": None,
@@ -334,6 +341,7 @@ class TestReconcilePersonProperties:
     def test_returns_none_when_no_changes(self):
         """Test that None is returned when no updates are applicable."""
         person = {
+            "uuid": "018d1234-5678-0000-0000-000000000001",
             "properties": {"email": "current@example.com"},
             "properties_last_updated_at": {"email": "2024-01-20T00:00:00+00:00"},
             "properties_last_operation": {"email": "set"},

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -1,6 +1,7 @@
 """Tests for the person property reconciliation job."""
 
 from datetime import UTC, datetime
+from typing import Any
 
 from unittest.mock import MagicMock, patch
 
@@ -20,7 +21,7 @@ class TestClickHouseResultParsing:
         """Test that set_diff array of tuples is correctly parsed."""
         # Simulate ClickHouse returning: (person_id, set_diff, set_once_diff)
         # set_diff is an array of (key, value, timestamp) tuples
-        mock_rows = [
+        mock_rows: list[tuple[str, list[tuple[str, Any, datetime]], list[tuple[str, Any, datetime]]]] = [
             (
                 "018d1234-5678-0000-0000-000000000001",  # person_id (UUID as string)
                 [  # set_diff - array of tuples
@@ -56,7 +57,7 @@ class TestClickHouseResultParsing:
 
     def test_parses_set_once_diff_tuples(self):
         """Test that set_once_diff array of tuples is correctly parsed."""
-        mock_rows = [
+        mock_rows: list[tuple[str, list[tuple[str, Any, datetime]], list[tuple[str, Any, datetime]]]] = [
             (
                 "018d1234-5678-0000-0000-000000000002",
                 [],  # set_diff - empty
@@ -150,7 +151,7 @@ class TestClickHouseResultParsing:
 
     def test_skips_persons_with_no_updates(self):
         """Test that persons with empty set_diff and set_once_diff are skipped."""
-        mock_rows = [
+        mock_rows: list[tuple[str, list[tuple[str, Any, datetime]], list[tuple[str, Any, datetime]]]] = [
             (
                 "018d1234-0000-0000-0000-000000000001",
                 [],  # empty set_diff

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -21,12 +21,13 @@ class TestClickHouseResultParsing:
         """Test that set_diff array of tuples is correctly parsed."""
         # Simulate ClickHouse returning: (person_id, set_diff, set_once_diff)
         # set_diff is an array of (key, value, timestamp) tuples
+        # Values are raw JSON strings from JSONExtractKeysAndValuesRaw (strings are double-quoted)
         mock_rows: list[tuple[str, list[tuple[str, Any, datetime]], list[tuple[str, Any, datetime]]]] = [
             (
                 "018d1234-5678-0000-0000-000000000001",  # person_id (UUID as string)
-                [  # set_diff - array of tuples
-                    ("email", "new@example.com", datetime(2024, 1, 15, 12, 0, 0)),
-                    ("name", "John Doe", datetime(2024, 1, 15, 12, 30, 0)),
+                [  # set_diff - array of tuples (values are raw JSON)
+                    ("email", '"new@example.com"', datetime(2024, 1, 15, 12, 0, 0)),
+                    ("name", '"John Doe"', datetime(2024, 1, 15, 12, 30, 0)),
                 ],
                 [],  # set_once_diff - empty
             )
@@ -44,26 +45,27 @@ class TestClickHouseResultParsing:
         assert person_updates.person_id == "018d1234-5678-0000-0000-000000000001"
         assert len(person_updates.updates) == 2
 
-        # Verify first update
+        # Verify first update - quotes should be stripped
         assert person_updates.updates[0].key == "email"
         assert person_updates.updates[0].value == "new@example.com"
         assert person_updates.updates[0].timestamp == datetime(2024, 1, 15, 12, 0, 0)
         assert person_updates.updates[0].operation == "set"
 
-        # Verify second update
+        # Verify second update - quotes should be stripped
         assert person_updates.updates[1].key == "name"
         assert person_updates.updates[1].value == "John Doe"
         assert person_updates.updates[1].operation == "set"
 
     def test_parses_set_once_diff_tuples(self):
         """Test that set_once_diff array of tuples is correctly parsed."""
+        # Values are raw JSON strings from JSONExtractKeysAndValuesRaw
         mock_rows: list[tuple[str, list[tuple[str, Any, datetime]], list[tuple[str, Any, datetime]]]] = [
             (
                 "018d1234-5678-0000-0000-000000000002",
                 [],  # set_diff - empty
-                [  # set_once_diff - array of tuples
-                    ("initial_referrer", "google.com", datetime(2024, 1, 10, 8, 0, 0)),
-                    ("first_seen", "2024-01-10", datetime(2024, 1, 10, 8, 0, 0)),
+                [  # set_once_diff - array of tuples (values are raw JSON)
+                    ("initial_referrer", '"google.com"', datetime(2024, 1, 10, 8, 0, 0)),
+                    ("first_seen", '"2024-01-10"', datetime(2024, 1, 10, 8, 0, 0)),
                 ],
             )
         ]
@@ -79,21 +81,23 @@ class TestClickHouseResultParsing:
         person_updates = results[0]
         assert len(person_updates.updates) == 2
 
-        # Verify set_once updates
+        # Verify set_once updates - quotes should be stripped
         assert person_updates.updates[0].key == "initial_referrer"
         assert person_updates.updates[0].value == "google.com"
         assert person_updates.updates[0].operation == "set_once"
 
         assert person_updates.updates[1].key == "first_seen"
+        assert person_updates.updates[1].value == "2024-01-10"
         assert person_updates.updates[1].operation == "set_once"
 
     def test_parses_mixed_set_and_set_once(self):
         """Test parsing when both set_diff and set_once_diff have values."""
+        # Values are raw JSON strings from JSONExtractKeysAndValuesRaw
         mock_rows = [
             (
                 "018d1234-5678-0000-0000-000000000003",
-                [("email", "updated@example.com", datetime(2024, 1, 15, 12, 0, 0))],  # set_diff
-                [("initial_source", "organic", datetime(2024, 1, 10, 8, 0, 0))],  # set_once_diff
+                [("email", '"updated@example.com"', datetime(2024, 1, 15, 12, 0, 0))],  # set_diff
+                [("initial_source", '"organic"', datetime(2024, 1, 10, 8, 0, 0))],  # set_once_diff
             )
         ]
 
@@ -115,25 +119,28 @@ class TestClickHouseResultParsing:
         assert len(set_updates) == 1
         assert len(set_once_updates) == 1
         assert set_updates[0].key == "email"
+        assert set_updates[0].value == "updated@example.com"  # quotes stripped
         assert set_once_updates[0].key == "initial_source"
+        assert set_once_updates[0].value == "organic"  # quotes stripped
 
     def test_handles_multiple_persons(self):
         """Test parsing results for multiple persons."""
+        # Values are raw JSON strings from JSONExtractKeysAndValuesRaw
         mock_rows = [
             (
                 "018d1234-0000-0000-0000-000000000001",
-                [("prop1", "val1", datetime(2024, 1, 15, 12, 0, 0))],
+                [("prop1", '"val1"', datetime(2024, 1, 15, 12, 0, 0))],
                 [],
             ),
             (
                 "018d1234-0000-0000-0000-000000000002",
-                [("prop2", "val2", datetime(2024, 1, 15, 13, 0, 0))],
+                [("prop2", '"val2"', datetime(2024, 1, 15, 13, 0, 0))],
                 [],
             ),
             (
                 "018d1234-0000-0000-0000-000000000003",
                 [],
-                [("prop3", "val3", datetime(2024, 1, 10, 8, 0, 0))],
+                [("prop3", '"val3"', datetime(2024, 1, 10, 8, 0, 0))],
             ),
         ]
 
@@ -146,8 +153,11 @@ class TestClickHouseResultParsing:
 
         assert len(results) == 3
         assert results[0].person_id == "018d1234-0000-0000-0000-000000000001"
+        assert results[0].updates[0].value == "val1"  # quotes stripped
         assert results[1].person_id == "018d1234-0000-0000-0000-000000000002"
+        assert results[1].updates[0].value == "val2"  # quotes stripped
         assert results[2].person_id == "018d1234-0000-0000-0000-000000000003"
+        assert results[2].updates[0].value == "val3"  # quotes stripped
 
     def test_skips_persons_with_no_updates(self):
         """Test that persons with empty set_diff and set_once_diff are skipped."""
@@ -179,6 +189,66 @@ class TestClickHouseResultParsing:
             )
 
         assert results == []
+
+    def test_parses_raw_json_value_types(self):
+        """Test that raw JSON values from CH are correctly parsed to Python types."""
+        # JSONExtractKeysAndValuesRaw returns raw JSON representations:
+        # - strings are double-quoted: "hello"
+        # - numbers are unquoted: 123, 3.14
+        # - booleans are lowercase: true, false
+        # - null is literal: null
+        mock_rows = [
+            (
+                "018d1234-5678-0000-0000-000000000001",
+                [
+                    ("string_prop", '"hello"', datetime(2024, 1, 15, 12, 0, 0)),
+                    ("int_prop", "123", datetime(2024, 1, 15, 12, 0, 0)),
+                    ("float_prop", "3.14", datetime(2024, 1, 15, 12, 0, 0)),
+                    ("bool_true_prop", "true", datetime(2024, 1, 15, 12, 0, 0)),
+                    ("bool_false_prop", "false", datetime(2024, 1, 15, 12, 0, 0)),
+                    ("null_prop", "null", datetime(2024, 1, 15, 12, 0, 0)),
+                ],
+                [],
+            )
+        ]
+
+        with patch("posthog.dags.person_property_reconciliation.sync_execute", return_value=mock_rows):
+            results = get_person_property_updates_from_clickhouse(
+                team_id=1,
+                bug_window_start="2024-01-01T00:00:00Z",
+                bug_window_end="2024-01-31T00:00:00Z",
+            )
+
+        assert len(results) == 1
+        updates = results[0].updates
+        assert len(updates) == 6
+
+        # String - quotes stripped
+        assert updates[0].key == "string_prop"
+        assert updates[0].value == "hello"
+        assert isinstance(updates[0].value, str)
+
+        # Integer
+        assert updates[1].key == "int_prop"
+        assert updates[1].value == 123
+        assert isinstance(updates[1].value, int)
+
+        # Float
+        assert updates[2].key == "float_prop"
+        assert updates[2].value == 3.14
+        assert isinstance(updates[2].value, float)
+
+        # Boolean true
+        assert updates[3].key == "bool_true_prop"
+        assert updates[3].value is True
+
+        # Boolean false
+        assert updates[4].key == "bool_false_prop"
+        assert updates[4].value is False
+
+        # Null
+        assert updates[5].key == "null_prop"
+        assert updates[5].value is None
 
 
 class TestReconcilePersonProperties:

--- a/posthog/dags/tests/test_person_property_reconciliation.py
+++ b/posthog/dags/tests/test_person_property_reconciliation.py
@@ -93,7 +93,7 @@ class TestClickHouseResultParsing:
     def test_parses_mixed_set_and_set_once(self):
         """Test parsing when both set_diff and set_once_diff have values."""
         # Values are raw JSON strings from JSONExtractKeysAndValuesRaw
-        mock_rows = [
+        mock_rows: list[tuple[str, list[tuple[str, Any, datetime]], list[tuple[str, Any, datetime]]]] = [
             (
                 "018d1234-5678-0000-0000-000000000003",
                 [("email", '"updated@example.com"', datetime(2024, 1, 15, 12, 0, 0))],  # set_diff
@@ -126,7 +126,7 @@ class TestClickHouseResultParsing:
     def test_handles_multiple_persons(self):
         """Test parsing results for multiple persons."""
         # Values are raw JSON strings from JSONExtractKeysAndValuesRaw
-        mock_rows = [
+        mock_rows: list[tuple[str, list[tuple[str, Any, datetime]], list[tuple[str, Any, datetime]]]] = [
             (
                 "018d1234-0000-0000-0000-000000000001",
                 [("prop1", '"val1"', datetime(2024, 1, 15, 12, 0, 0))],
@@ -197,7 +197,7 @@ class TestClickHouseResultParsing:
         # - numbers are unquoted: 123, 3.14
         # - booleans are lowercase: true, false
         # - null is literal: null
-        mock_rows = [
+        mock_rows: list[tuple[str, list[tuple[str, Any, datetime]], list[tuple[str, Any, datetime]]]] = [
             (
                 "018d1234-5678-0000-0000-000000000001",
                 [

--- a/posthog/management/commands/generate_test_events.py
+++ b/posthog/management/commands/generate_test_events.py
@@ -58,6 +58,7 @@ def generate_random_property(key_prefix: str, index: int) -> GeneratedProperty:
     key = f"{key_prefix}_{index}"
     prop_type = random.choice(list(PropType))
 
+    value: Any
     if prop_type == PropType.STRING:
         value = f"initial_value_{random.randint(1000, 9999)}"
     elif prop_type == PropType.NUMBER:
@@ -198,7 +199,7 @@ class Command(BaseCommand):
                 for prop in person.set_once_props:
                     mutate_property(prop, event_num)
 
-                properties = {
+                properties: dict[str, Any] = {
                     "$current_url": f"https://example.com/page/{event_num}",
                     "$pathname": f"/page/{event_num}",
                     "$set_once": person.get_set_once_dict(),

--- a/posthog/management/commands/generate_test_events.py
+++ b/posthog/management/commands/generate_test_events.py
@@ -1,0 +1,242 @@
+"""
+Generate test persons and events with evolving person properties.
+
+Usage:
+    ./manage.py generate_test_events --team-id=1 --num-persons=10 --events-per-person=5
+"""
+
+import uuid
+import random
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+import structlog
+
+from posthog.api.capture import capture_internal
+from posthog.models import Team
+
+logger = structlog.get_logger(__name__)
+
+
+class PropType(Enum):
+    STRING = "string"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    DATETIME = "datetime"
+
+
+@dataclass
+class GeneratedProperty:
+    """A generated property with its type tracked for mutation."""
+
+    key: str
+    value: Any
+    prop_type: PropType
+
+
+@dataclass
+class GeneratedPerson:
+    """A generated person with distinct_id and properties."""
+
+    distinct_id: str
+    set_once_props: list[GeneratedProperty] = field(default_factory=list)
+    set_props: list[GeneratedProperty] = field(default_factory=list)
+
+    def get_set_once_dict(self) -> dict[str, Any]:
+        return {p.key: p.value for p in self.set_once_props}
+
+    def get_set_dict(self) -> dict[str, Any]:
+        return {p.key: p.value for p in self.set_props}
+
+
+def generate_random_property(key_prefix: str, index: int) -> GeneratedProperty:
+    """Generate a random property with a random type."""
+    key = f"{key_prefix}_{index}"
+    prop_type = random.choice(list(PropType))
+
+    if prop_type == PropType.STRING:
+        value = f"initial_value_{random.randint(1000, 9999)}"
+    elif prop_type == PropType.NUMBER:
+        value = random.randint(1, 1000)
+    elif prop_type == PropType.BOOLEAN:
+        value = random.choice([True, False])
+    elif prop_type == PropType.DATETIME:
+        value = datetime.now(UTC).isoformat()
+    else:
+        raise ValueError(f"Unknown property type: {prop_type}")
+
+    return GeneratedProperty(key=key, value=value, prop_type=prop_type)
+
+
+def mutate_property(prop: GeneratedProperty, event_number: int) -> None:
+    """Mutate a property value in-place according to its type."""
+    if prop.prop_type == PropType.STRING:
+        prop.value = f"new_value_{event_number}"
+    elif prop.prop_type == PropType.NUMBER:
+        prop.value = prop.value + 1
+    elif prop.prop_type == PropType.BOOLEAN:
+        prop.value = not prop.value
+    elif prop.prop_type == PropType.DATETIME:
+        prop.value = datetime.now(UTC).isoformat()
+    else:
+        raise ValueError(f"Unknown property type: {prop.prop_type}")
+
+
+def generate_person(seed_index: int) -> GeneratedPerson:
+    """Generate a person with UUID distinct_id and random properties."""
+    distinct_id = str(uuid.uuid4())
+
+    # Generate 5 $set_once properties
+    set_once_props = [generate_random_property("set_once_prop", i) for i in range(5)]
+
+    # Generate 10 $set properties
+    set_props = [generate_random_property("set_prop", i) for i in range(10)]
+
+    return GeneratedPerson(
+        distinct_id=distinct_id,
+        set_once_props=set_once_props,
+        set_props=set_props,
+    )
+
+
+class Command(BaseCommand):
+    help = "Generate test persons and events with evolving person properties via capture_internal"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--team-id",
+            type=int,
+            required=True,
+            help="Team ID to create events for",
+        )
+        parser.add_argument(
+            "--num-persons",
+            type=int,
+            default=10,
+            help="Number of persons to generate (default: 10)",
+        )
+        parser.add_argument(
+            "--events-per-person",
+            type=int,
+            default=5,
+            help="Number of $pageview events per person (default: 5)",
+        )
+        parser.add_argument(
+            "--seed",
+            type=int,
+            help="Random seed for reproducibility",
+        )
+
+    def handle(self, *args, **options):
+        team_id = options["team_id"]
+        num_persons = options["num_persons"]
+        events_per_person = options["events_per_person"]
+        seed = options.get("seed")
+
+        if seed is not None:
+            random.seed(seed)
+
+        # Look up team and get API token
+        try:
+            team = Team.objects.get(pk=team_id)
+        except Team.DoesNotExist:
+            self.stderr.write(self.style.ERROR(f"Team with ID {team_id} does not exist!"))
+            return
+
+        token = team.api_token
+        self.stdout.write(f"Generating events for team '{team.name}' (ID: {team_id})")
+        self.stdout.write(f"  Persons: {num_persons}")
+        self.stdout.write(f"  Events per person: {events_per_person}")
+
+        # Generate all persons up front
+        self.stdout.write("Generating persons...")
+        persons = [generate_person(i) for i in range(num_persons)]
+
+        # Send $identify events for all persons
+        self.stdout.write("Sending $identify events...")
+        identify_failures = 0
+        for i, person in enumerate(persons):
+            properties = {
+                "$set_once": person.get_set_once_dict(),
+                "$set": person.get_set_dict(),
+            }
+
+            try:
+                resp = capture_internal(
+                    token=token,
+                    event_name="$identify",
+                    event_source="generate_test_events",
+                    distinct_id=person.distinct_id,
+                    timestamp=datetime.now(UTC),
+                    properties=properties,
+                    process_person_profile=True,
+                )
+                resp.raise_for_status()
+            except Exception as e:
+                identify_failures += 1
+                logger.warning("identify_event_failed", distinct_id=person.distinct_id, error=str(e))
+
+            if (i + 1) % 10 == 0:
+                self.stdout.write(f"  Sent {i + 1}/{num_persons} $identify events...")
+
+        self.stdout.write(self.style.SUCCESS(f"Sent {num_persons - identify_failures}/{num_persons} $identify events"))
+
+        # Send $pageview events for each person
+        self.stdout.write("Sending $pageview events...")
+        pageview_count = 0
+        pageview_failures = 0
+
+        for person_idx, person in enumerate(persons):
+            for event_num in range(1, events_per_person + 1):
+                # Mutate all properties before each event
+                for prop in person.set_props:
+                    mutate_property(prop, event_num)
+                for prop in person.set_once_props:
+                    mutate_property(prop, event_num)
+
+                properties = {
+                    "$current_url": f"https://example.com/page/{event_num}",
+                    "$pathname": f"/page/{event_num}",
+                    "$set_once": person.get_set_once_dict(),
+                    "$set": person.get_set_dict(),
+                }
+
+                try:
+                    resp = capture_internal(
+                        token=token,
+                        event_name="$pageview",
+                        event_source="generate_test_events",
+                        distinct_id=person.distinct_id,
+                        timestamp=datetime.now(UTC),
+                        properties=properties,
+                        process_person_profile=True,
+                    )
+                    resp.raise_for_status()
+                    pageview_count += 1
+                except Exception as e:
+                    pageview_failures += 1
+                    logger.warning(
+                        "pageview_event_failed",
+                        distinct_id=person.distinct_id,
+                        event_num=event_num,
+                        error=str(e),
+                    )
+
+            if (person_idx + 1) % 10 == 0:
+                self.stdout.write(
+                    f"  Processed {person_idx + 1}/{num_persons} persons ({pageview_count} $pageview events)..."
+                )
+
+        total_events = num_persons + pageview_count
+        total_failures = identify_failures + pageview_failures
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done! Sent {total_events} events ({num_persons} $identify + {pageview_count} $pageview), "
+                f"{total_failures} failures"
+            )
+        )

--- a/posthog/management/commands/generate_test_events.py
+++ b/posthog/management/commands/generate_test_events.py
@@ -161,7 +161,7 @@ class Command(BaseCommand):
         self.stdout.write("Sending $identify events...")
         identify_failures = 0
         for i, person in enumerate(persons):
-            properties = {
+            identify_properties = {
                 "$set_once": person.get_set_once_dict(),
                 "$set": person.get_set_dict(),
             }
@@ -173,7 +173,7 @@ class Command(BaseCommand):
                     event_source="generate_test_events",
                     distinct_id=person.distinct_id,
                     timestamp=datetime.now(UTC),
-                    properties=properties,
+                    properties=identify_properties,
                     process_person_profile=True,
                 )
                 resp.raise_for_status()
@@ -199,7 +199,7 @@ class Command(BaseCommand):
                 for prop in person.set_once_props:
                     mutate_property(prop, event_num)
 
-                properties: dict[str, Any] = {
+                pageview_properties: dict[str, Any] = {
                     "$current_url": f"https://example.com/page/{event_num}",
                     "$pathname": f"/page/{event_num}",
                     "$set_once": person.get_set_once_dict(),
@@ -213,7 +213,7 @@ class Command(BaseCommand):
                         event_source="generate_test_events",
                         distinct_id=person.distinct_id,
                         timestamp=datetime.now(UTC),
-                        properties=properties,
+                        properties=pageview_properties,
                         process_person_profile=True,
                     )
                     resp.raise_for_status()


### PR DESCRIPTION
## Problem

A bug was introduced to the ingestion pipeline which resulted in the dropping of person property updates

## Changes

A dagster job that is outlined as follows:

Parent task:

* Fetch all teams from CH events effected by the incident window
* Farm out one child job (with capped pool) for every team effected

Child task:

* Query CH for all all persons effected for 1 team
* Run single person update logic in loop

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
