### PR TITLE
feat(product tours): add element screenshot to step

### DIFF
--- a/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
@@ -26,6 +26,7 @@ import {
 } from '~/types'
 
 import { StepContentEditor } from './StepContentEditor'
+import { StepScreenshotThumbnail } from './StepScreenshotThumbnail'
 import { SurveyStepEditor } from './SurveyStepEditor'
 import { prepareStepForRender } from './generateStepHtml'
 
@@ -87,6 +88,7 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
     const [selectedStepIndex, setSelectedStepIndex] = useState<number>(0)
     const [stepToDelete, setStepToDelete] = useState<number | null>(null)
     const [showPreviewModal, setShowPreviewModal] = useState(false)
+    const [showScreenshotModal, setShowScreenshotModal] = useState(false)
     const [previewElement, setPreviewElement] = useState<HTMLDivElement | null>(null)
     const [surveyPreviewElement, setSurveyPreviewElement] = useState<HTMLDivElement | null>(null)
 
@@ -201,10 +203,20 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
                             <div className="flex items-center gap-2">
                                 <LemonBadge.Number count={selectedStepIndex + 1} size="medium" />
                                 <span className="font-semibold">{STEP_TYPE_LABELS[selectedStep.type]} step</span>
-                                {selectedStep.type === 'element' && selectedStep.selector && (
-                                    <code className="text-xs bg-fill-primary px-2 py-0.5 rounded">
-                                        {selectedStep.selector}
-                                    </code>
+                                {selectedStep.type === 'element' && (
+                                    <>
+                                        {selectedStep.screenshotMediaId && (
+                                            <StepScreenshotThumbnail
+                                                mediaId={selectedStep.screenshotMediaId}
+                                                onClick={() => setShowScreenshotModal(true)}
+                                            />
+                                        )}
+                                        {selectedStep.selector && (
+                                            <code className="text-xs bg-fill-primary px-2 py-0.5 rounded">
+                                                {selectedStep.selector}
+                                            </code>
+                                        )}
+                                    </>
                                 )}
                             </div>
                             <div className="flex items-center gap-2">
@@ -338,6 +350,21 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
                     <div ref={setPreviewElement} />
                 </div>
             </LemonModal>
+
+            {selectedStep?.screenshotMediaId && (
+                <LemonModal
+                    isOpen={showScreenshotModal}
+                    onClose={() => setShowScreenshotModal(false)}
+                    title="Element screenshot"
+                    width="auto"
+                >
+                    <img
+                        src={`/uploaded_media/${selectedStep.screenshotMediaId}`}
+                        alt="Element screenshot"
+                        className="max-w-full max-h-[70vh]"
+                    />
+                </LemonModal>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/product-tours/editor/StepScreenshotThumbnail.tsx
+++ b/frontend/src/scenes/product-tours/editor/StepScreenshotThumbnail.tsx
@@ -1,0 +1,32 @@
+import clsx from 'clsx'
+import { useState } from 'react'
+
+export interface StepScreenshotThumbnailProps {
+    mediaId: string
+    onClick?: () => void
+    className?: string
+}
+
+export function StepScreenshotThumbnail({
+    mediaId,
+    onClick,
+    className,
+}: StepScreenshotThumbnailProps): JSX.Element | null {
+    const [hasError, setHasError] = useState(false)
+
+    if (hasError) {
+        return null
+    }
+
+    return (
+        <img
+            src={`/uploaded_media/${mediaId}`}
+            alt="Element screenshot"
+            className={clsx('rounded cursor-pointer border hover:border-primary transition-colors', className)}
+            style={{ maxHeight: 48, maxWidth: 150 }}
+            onClick={onClick}
+            title="Click to view screenshot"
+            onError={() => setHasError(true)}
+        />
+    )
+}

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -158,7 +158,7 @@ export interface ToolbarMediaUploadResponse {
  * This is a separate function from toolbarFetch because it needs to handle FormData
  * instead of JSON payloads.
  */
-export async function toolbarUploadMedia(file: File): Promise<{ url: string; fileName: string }> {
+export async function toolbarUploadMedia(file: File): Promise<{ id: string; url: string; fileName: string }> {
     const temporaryToken = toolbarConfigLogic.findMounted()?.values.temporaryToken
     const apiURL = toolbarConfigLogic.findMounted()?.values.apiURL
 
@@ -196,6 +196,7 @@ export async function toolbarUploadMedia(file: File): Promise<{ url: string; fil
 
     const data: ToolbarMediaUploadResponse = await response.json()
     return {
+        id: data.id,
         url: data.image_location,
         fileName: data.name,
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3332,6 +3332,8 @@ export interface ProductTourStep {
     progressionTrigger?: ProductTourProgressionTriggerType
     /** Custom width for the tooltip - can be a preset name or pixel value */
     maxWidth?: ProductTourStepWidth | number
+    /** Screenshot media ID from uploaded_media - for element steps */
+    screenshotMediaId?: string
 }
 
 /** Tracks a snapshot of steps at a point in time for funnel analysis */


### PR DESCRIPTION
## Problem

a css selector isn't often helpful to a human, and we might not even have these soon when we switch to element inference

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

when a user selects an element, we screenshot it, then display it in the step editor in the main app

|  |  |
| --- | --- |
| ![Screenshot 2026-01-07 at 1.54.48 PM.png](https://app.graphite.com/user-attachments/assets/b27c241f-c7ec-40d2-ad0b-52c466e774b0.png)<br> | ![Screenshot 2026-01-07 at 1.54.50 PM.png](https://app.graphite.com/user-attachments/assets/f64f605f-fae8-48cc-8cb8-b0c6be811e73.png)<br> |

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->