### PR TITLE
chore(flags): Read team data from HyperCache instead of legacy Redis cache

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3073,7 +3073,6 @@ dependencies = [
  "petgraph",
  "rand 0.8.5",
  "rayon",
- "redis",
  "regex",
  "reqwest 0.12.15",
  "rstest",

--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -145,6 +145,17 @@ pub enum CacheSource {
     Fallback,
 }
 
+impl CacheSource {
+    /// Returns a consistent string representation for canonical logging.
+    pub fn as_log_str(&self) -> &'static str {
+        match self {
+            CacheSource::Redis => "redis",
+            CacheSource::S3 => "s3",
+            CacheSource::Fallback => "fallback",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct HyperCacheConfig {
     pub s3_bucket: String,

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -26,7 +26,6 @@ bytes = { workspace = true }
 url = "2.5"
 once_cell = "1.18.0"
 rand = { workspace = true }
-redis = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 json5 = "0.4"

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -65,8 +65,6 @@ pub enum FlagError {
     RedisDataParsingError,
     #[error("failed to deserialize filters")]
     DeserializeFiltersError,
-    #[error("failed to update redis cache")]
-    CacheUpdateError,
     #[error("redis unavailable")]
     RedisUnavailable,
     #[error("database unavailable")]
@@ -149,7 +147,6 @@ impl FlagError {
 
             // Internal server errors (500)
             FlagError::Internal(_) => ("internal_error", 500),
-            FlagError::CacheUpdateError => ("cache_update_error", 500),
             FlagError::DeserializeFiltersError => ("deserialize_filters_error", 500),
             FlagError::DatabaseError(_, _) => ("database_error", 500),
             FlagError::NoGroupTypeMappings => ("no_group_type_mappings", 500),
@@ -193,7 +190,6 @@ impl FlagError {
             }
             FlagError::ClientFacing(_) => return false, // All other ClientFacing are 4XX
             FlagError::Internal(_)
-            | FlagError::CacheUpdateError
             | FlagError::DeserializeFiltersError
             | FlagError::DatabaseError(_, _)
             | FlagError::NoGroupTypeMappings
@@ -297,13 +293,6 @@ impl IntoResponse for FlagError {
                 (
                     StatusCode::SERVICE_UNAVAILABLE,
                     "Failed to parse internal data. This is likely a temporary issue. Please try again later.".to_string(),
-                )
-            }
-            FlagError::CacheUpdateError => {
-                tracing::error!("Cache update error: {:?}", self);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Failed to update internal cache. This is likely a temporary issue. Please try again later.".to_string(),
                 )
             }
             FlagError::DeserializeFiltersError => {
@@ -493,7 +482,6 @@ mod tests {
     fn test_is_5xx() {
         // Test 5XX errors
         assert!(FlagError::Internal("test".to_string()).is_5xx());
-        assert!(FlagError::CacheUpdateError.is_5xx());
         assert!(FlagError::DatabaseUnavailable.is_5xx());
         assert!(FlagError::RedisUnavailable.is_5xx());
         assert!(FlagError::TimeoutError(None).is_5xx());
@@ -602,7 +590,6 @@ mod tests {
             FlagError::RowNotFound,
             FlagError::RedisDataParsingError,
             FlagError::DeserializeFiltersError,
-            FlagError::CacheUpdateError,
             FlagError::RedisUnavailable,
             FlagError::DatabaseUnavailable,
             FlagError::DatabaseError(sqlx::Error::RowNotFound, Some("test context".to_string())),
@@ -665,7 +652,6 @@ mod tests {
             FlagError::ClientFacing(ClientFacingError::ServiceUnavailable).status_code(),
             503
         );
-        assert_eq!(FlagError::CacheUpdateError.status_code(), 500);
         assert_eq!(FlagError::RowNotFound.status_code(), 500);
     }
 
@@ -689,7 +675,6 @@ mod tests {
         // Server errors should be 5xx
         let server_errors = vec![
             FlagError::Internal("".into()),
-            FlagError::CacheUpdateError,
             FlagError::DeserializeFiltersError,
             FlagError::NoGroupTypeMappings,
             FlagError::RowNotFound,
@@ -707,7 +692,6 @@ mod tests {
         // Verify that status_code() >= 500 matches is_5xx() for ALL 5xx errors
         let errors_5xx = vec![
             FlagError::Internal("test".to_string()),
-            FlagError::CacheUpdateError,
             FlagError::DeserializeFiltersError,
             FlagError::DatabaseError(sqlx::Error::RowNotFound, None),
             FlagError::NoGroupTypeMappings,
@@ -795,7 +779,6 @@ mod tests {
             FlagError::RowNotFound,
             FlagError::RedisDataParsingError,
             FlagError::DeserializeFiltersError,
-            FlagError::CacheUpdateError,
             FlagError::RedisUnavailable,
             FlagError::DatabaseUnavailable,
             FlagError::DatabaseError(sqlx::Error::RowNotFound, Some("test context".to_string())),

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -1,7 +1,8 @@
 use crate::{
     api::{auth, errors::FlagError},
+    metrics::consts::DB_TEAM_READS_COUNTER,
     router::State as AppState,
-    team::{team_models::Team, team_operations},
+    team::team_models::Team,
 };
 use axum::{
     debug_handler,
@@ -9,10 +10,11 @@ use axum::{
     http::{HeaderMap, Method, StatusCode},
     response::{IntoResponse, Json, Response},
 };
-use common_hypercache::{CacheSource, HyperCacheConfig, HyperCacheReader, KeyType};
+use common_hypercache::{CacheSource, KeyType};
+use common_metrics::inc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{info, warn};
+use tracing::info;
 
 /// Response for flag definitions endpoint
 /// This is returned as raw JSON from cache to avoid deserialization overhead
@@ -98,26 +100,31 @@ fn handle_non_get_method(method: &Method) -> Response {
     }
 }
 
-/// Fetches a team by its API token
-/// Tries Redis cache first, then falls back to PostgreSQL
+/// Fetches a team by its API token from HyperCache or PostgreSQL
 async fn fetch_team_by_token(state: &AppState, token: &str) -> Result<Team, FlagError> {
+    let key = KeyType::string(token);
     let pg_reader = state.database_pools.non_persons_reader.clone();
-    let token_str = token.to_string();
+    let token_owned = token.to_string();
 
-    team_operations::fetch_team_from_redis_with_fallback(
-        state.redis_client.clone(),
-        token,
-        Some(state.config.team_cache_ttl_seconds),
-        || async move {
-            Team::from_pg(pg_reader, &token_str)
+    let (data, _source) = state
+        .team_hypercache_reader
+        .get_with_source_or_fallback(&key, || async move {
+            let team = Team::from_pg(pg_reader, &token_owned)
                 .await
-                .map_err(|_| FlagError::TokenValidationError)
-        },
-    )
-    .await
+                .map_err(|_| FlagError::TokenValidationError)?;
+            inc(DB_TEAM_READS_COUNTER, &[], 1);
+            let value = serde_json::to_value(&team).map_err(|e| {
+                tracing::error!("Failed to serialize team from PG: {}", e);
+                FlagError::Internal(format!("Failed to serialize team: {e}"))
+            })?;
+            Ok::<Option<serde_json::Value>, FlagError>(Some(value))
+        })
+        .await?;
+
+    Team::from_hypercache_value(data)
 }
 
-/// Retrieves the cached response using HyperCache (Redis + S3 fallback)
+/// Retrieves the cached response using the pre-initialized HyperCacheReader
 ///
 /// Always uses the cache with cohorts included to match Django's behavior and ensure
 /// consistency across all clients accessing the same team's data. The cohorts are required
@@ -126,34 +133,15 @@ async fn get_from_cache(
     state: &AppState,
     team: &Team,
 ) -> Result<FlagDefinitionsResponse, FlagError> {
-    // Configure HyperCache to use the flags_with_cohorts.json cache key
-    // This ensures we always return cohort definitions along with flag definitions
-    let hypercache_config = HyperCacheConfig::new(
-        "feature_flags".to_string(),
-        "flags_with_cohorts.json".to_string(),
-        state.config.object_storage_region.clone(),
-        state.config.object_storage_bucket.clone(),
-    );
-
-    // Set S3 endpoint if configured
-    let mut config = hypercache_config;
-    if !state.config.object_storage_endpoint.is_empty() {
-        config.s3_endpoint = Some(state.config.object_storage_endpoint.clone());
-    }
-
-    // Create HyperCacheReader with the Redis client from state
-    let hypercache_reader = HyperCacheReader::new(state.redis_client.clone(), config)
-        .await
-        .map_err(|e| {
-            warn!(team_id = team.id, error = %e, "Failed to create HyperCacheReader");
-            FlagError::CacheMiss
-        })?;
-
     // Use KeyType::team() to generate the proper cache key
     let team_key = KeyType::team(team.clone());
 
-    // Try to get data from cache (Redis first, then S3 fallback)
-    let (data, source) = hypercache_reader.get_with_source(&team_key).await?;
+    // Use the pre-initialized HyperCacheReader for flags with cohorts
+    // This avoids per-request AWS SDK initialization overhead
+    let (data, source) = state
+        .flags_with_cohorts_hypercache_reader
+        .get_with_source(&team_key)
+        .await?;
 
     let source_name = match source {
         CacheSource::Redis => "Redis",

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -340,42 +340,6 @@ pub struct Config {
     #[envconfig(from = "CACHE_TTL_SECONDS", default = "300")]
     pub cache_ttl_seconds: u64,
 
-    /// Redis TTL for team cache entries in seconds
-    ///
-    /// Controls how long team data is cached in Redis before expiring.
-    /// This prevents indefinite cache growth and ensures stale data is refreshed.
-    ///
-    /// Default: 432000 seconds (5 days) - matches Django's FIVE_DAYS constant
-    /// Environment variable: TEAM_CACHE_TTL_SECONDS
-    ///
-    /// Common values:
-    /// - 3600 (1 hour) - For frequently changing team data
-    /// - 86400 (1 day) - For moderate refresh rate
-    /// - 432000 (5 days) - Default, balances performance and freshness
-    ///
-    /// Minimum value: 1 second (Redis setex does not accept 0 or negative values)
-    #[envconfig(from = "TEAM_CACHE_TTL_SECONDS", default = "432000")]
-    pub team_cache_ttl_seconds: u64,
-
-    /// Redis TTL for feature flags cache entries in seconds
-    ///
-    /// Controls how long feature flag data is cached in Redis before expiring.
-    /// This prevents indefinite cache growth and ensures flag changes are visible
-    /// within a reasonable time.
-    ///
-    /// Default: 432000 seconds (5 days) - matches Django's FIVE_DAYS constant
-    /// Environment variable: FLAGS_CACHE_TTL_SECONDS
-    ///
-    /// Common values:
-    /// - 300 (5 minutes) - For rapid flag development/testing
-    /// - 3600 (1 hour) - For frequently changing flags
-    /// - 86400 (1 day) - For stable flag deployments
-    /// - 432000 (5 days) - Default, balances performance and freshness
-    ///
-    /// Minimum value: 1 second (Redis setex does not accept 0 or negative values)
-    #[envconfig(from = "FLAGS_CACHE_TTL_SECONDS", default = "432000")]
-    pub flags_cache_ttl_seconds: u64,
-
     // cookieless, should match the values in plugin-server/src/types.ts, except we don't use sessions here
     #[envconfig(from = "COOKIELESS_DISABLED", default = "false")]
     pub cookieless_disabled: bool,
@@ -587,8 +551,6 @@ impl Config {
             team_ids_to_track: TeamIdCollection::All,
             cohort_cache_capacity_bytes: 268_435_456, // 256 MB
             cache_ttl_seconds: 300,
-            team_cache_ttl_seconds: 432000,
-            flags_cache_ttl_seconds: 432000,
             cookieless_disabled: false,
             cookieless_force_stateless: false,
             cookieless_identifies_ttl_seconds: 345600,

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -2,13 +2,12 @@ use crate::{
     api::errors::FlagError,
     flags::flag_models::FeatureFlagList,
     metrics::consts::{
-        DB_TEAM_READS_COUNTER, TEAM_CACHE_ERRORS_COUNTER, TEAM_CACHE_HIT_COUNTER,
-        TOKEN_VALIDATION_ERRORS_COUNTER,
+        DB_TEAM_READS_COUNTER, TEAM_CACHE_HIT_COUNTER, TOKEN_VALIDATION_ERRORS_COUNTER,
     },
     team::team_models::Team,
 };
 use common_database::PostgresReader;
-use common_hypercache::HyperCacheReader;
+use common_hypercache::{CacheSource, HyperCacheReader, KeyType};
 use common_metrics::inc;
 use common_redis::Client as RedisClient;
 use common_types::TeamId;
@@ -24,33 +23,34 @@ pub struct FlagResult {
 
 /// Service layer for handling feature flag operations
 pub struct FlagService {
-    /// Shared Redis client for team cache operations
+    /// Shared Redis client for non-critical path operations
+    /// Reserved for future use (analytics counters, billing limits, etc.)
+    #[allow(dead_code)]
     shared_redis_client: Arc<dyn RedisClient + Send + Sync>,
     pg_client: PostgresReader,
-    team_cache_ttl_seconds: u64,
+    /// HyperCache reader for fetching team metadata from Redis/S3
+    team_hypercache_reader: Arc<HyperCacheReader>,
     /// HyperCache reader for fetching flags from Redis/S3
     /// Arc-wrapped to allow sharing across requests
-    hypercache_reader: Arc<HyperCacheReader>,
+    flags_hypercache_reader: Arc<HyperCacheReader>,
 }
 
 impl FlagService {
     pub fn new(
         shared_redis_client: Arc<dyn RedisClient + Send + Sync>,
         pg_client: PostgresReader,
-        team_cache_ttl_seconds: u64,
-        hypercache_reader: Arc<HyperCacheReader>,
+        team_hypercache_reader: Arc<HyperCacheReader>,
+        flags_hypercache_reader: Arc<HyperCacheReader>,
     ) -> Self {
         Self {
             shared_redis_client,
             pg_client,
-            team_cache_ttl_seconds,
-            hypercache_reader,
+            team_hypercache_reader,
+            flags_hypercache_reader,
         }
     }
 
-    /// Verifies the Project API token against the cache or the database.
-    /// If the token is not found in the cache, it will be verified against the database,
-    /// and the result will be cached in redis.
+    /// Verifies the Project API token against HyperCache or the database.
     pub async fn verify_token(&self, token: &str) -> Result<String, FlagError> {
         match self.get_team_from_cache_or_pg(token).await {
             Ok(_) => Ok(token.to_string()),
@@ -66,36 +66,34 @@ impl FlagService {
         }
     }
 
-    /// Fetches the team from the cache or the database.
-    /// If the team is not found in the cache, it will be fetched from the database and stored in the cache.
-    /// Returns the team if found, otherwise an error.
+    /// Fetches the team from HyperCache or the database.
+    ///
+    /// Uses team_metadata HyperCache (Redis → S3 → PostgreSQL fallback).
+    /// This is a read-only cache - Django handles cache writes.
     pub async fn get_team_from_cache_or_pg(&self, token: &str) -> Result<Team, FlagError> {
-        let (team_result, cache_hit) =
-            match Team::from_redis(self.shared_redis_client.clone(), token).await {
-                Ok(team) => (Ok(team), true),
-                Err(_) => match Team::from_pg(self.pg_client.clone(), token).await {
-                    Ok(team) => {
-                        inc(DB_TEAM_READS_COUNTER, &[], 1);
-                        // If we have the team in postgres, but not redis, update redis so we're faster next time
-                        if let Err(e) = Team::update_redis_cache(
-                            self.shared_redis_client.clone(),
-                            &team,
-                            Some(self.team_cache_ttl_seconds),
-                        )
-                        .await
-                        {
-                            tracing::warn!("Failed to update Redis cache: {}", e);
-                            inc(
-                                TEAM_CACHE_ERRORS_COUNTER,
-                                &[("reason".to_string(), "redis_update_failed".to_string())],
-                                1,
-                            );
-                        }
-                        (Ok(team), false)
-                    }
-                    Err(e) => (Err(e), false),
-                },
-            };
+        let key = KeyType::string(token);
+        let pg_client = self.pg_client.clone();
+        let token_owned = token.to_string();
+
+        let (data, source) = self
+            .team_hypercache_reader
+            .get_with_source_or_fallback(&key, || async move {
+                // Fallback: load from PostgreSQL and convert to JSON Value
+                let team = Team::from_pg(pg_client, &token_owned).await?;
+                inc(DB_TEAM_READS_COUNTER, &[], 1);
+
+                // Convert team to JSON value for consistency with cache format
+                let value = serde_json::to_value(&team).map_err(|e| {
+                    tracing::error!("Failed to serialize team from PG: {}", e);
+                    FlagError::Internal(format!("Failed to serialize team: {e}"))
+                })?;
+                Ok::<Option<serde_json::Value>, FlagError>(Some(value))
+            })
+            .await?;
+
+        // Parse the result (from cache or fallback)
+        let team = Team::from_hypercache_value(data)?;
+        let cache_hit = !matches!(source, CacheSource::Fallback);
 
         inc(
             TEAM_CACHE_HIT_COUNTER,
@@ -103,7 +101,7 @@ impl FlagService {
             1,
         );
 
-        team_result
+        Ok(team)
     }
 
     /// Fetches the flags from the hypercache or falls back to the database.
@@ -117,11 +115,11 @@ impl FlagService {
         &self,
         team_id: TeamId,
     ) -> Result<FlagResult, FlagError> {
-        let key = common_hypercache::KeyType::int(team_id);
+        let key = KeyType::int(team_id);
         let pg_client = self.pg_client.clone();
 
         let (data, source) = self
-            .hypercache_reader
+            .flags_hypercache_reader
             .get_with_source_or_fallback(&key, || async move {
                 // Fallback: load from PostgreSQL and convert to JSON Value
                 let flags = FeatureFlagList::from_pg(pg_client, team_id).await?;
@@ -161,7 +159,7 @@ mod tests {
         utils::test_utils::{
             insert_new_team_in_redis, setup_hypercache_reader,
             setup_hypercache_reader_with_mock_redis, setup_pg_reader_client, setup_redis_client,
-            TestContext,
+            setup_team_hypercache_reader, TestContext,
         },
     };
 
@@ -171,6 +169,7 @@ mod tests {
     async fn test_verify_token() {
         let redis_client = setup_redis_client(None).await;
         let pg_client = setup_pg_reader_client(None).await;
+        let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
         let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
         let team = insert_new_team_in_redis(redis_client.clone())
             .await
@@ -179,22 +178,11 @@ mod tests {
         let flag_service = FlagService::new(
             redis_client.clone(),
             pg_client.clone(),
-            432000, // team_cache_ttl_seconds
+            team_hypercache_reader,
             hypercache_reader,
         );
 
-        // Test valid token in Redis
-        let result = flag_service.verify_token(&team.api_token).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), team.api_token);
-
-        // Test valid token in PostgreSQL (simulate Redis miss)
-        // First, remove the team from Redis
-        redis_client
-            .del(format!("team:{}", team.api_token))
-            .await
-            .expect("Failed to remove team from Redis");
-
+        // Test valid token in HyperCache
         let result = flag_service.verify_token(&team.api_token).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), team.api_token);
@@ -202,16 +190,13 @@ mod tests {
         // Test invalid token
         let result = flag_service.verify_token("invalid_token").await;
         assert!(matches!(result, Err(FlagError::TokenValidationError)));
-
-        // Verify that the team was re-added to Redis after PostgreSQL hit
-        let redis_team = Team::from_redis(redis_client.clone(), &team.api_token).await;
-        assert!(redis_team.is_ok());
     }
 
     #[tokio::test]
     async fn test_get_team_from_cache_or_pg() {
         let redis_client = setup_redis_client(None).await;
         let pg_client = setup_pg_reader_client(None).await;
+        let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
         let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
         let team = insert_new_team_in_redis(redis_client.clone())
             .await
@@ -220,41 +205,44 @@ mod tests {
         let flag_service = FlagService::new(
             redis_client.clone(),
             pg_client.clone(),
-            432000, // team_cache_ttl_seconds
+            team_hypercache_reader,
             hypercache_reader,
         );
 
-        // Test fetching from Redis
+        // Test fetching from HyperCache
         let result = flag_service
             .get_team_from_cache_or_pg(&team.api_token)
             .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap().id, team.id);
+    }
 
-        // Test fetching from PostgreSQL (simulate Redis miss)
-        // First, remove the team from Redis
-        redis_client
-            .del(format!("team:{}", team.api_token))
-            .await
-            .expect("Failed to remove team from Redis");
-
+    #[tokio::test]
+    async fn test_get_team_from_pg_fallback() {
+        let redis_client = setup_redis_client(None).await;
+        let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
         let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
+
+        // Insert a team in PG but not in HyperCache
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team in pg");
+
         let flag_service = FlagService::new(
             redis_client.clone(),
-            pg_client.clone(),
-            432000, // team_cache_ttl_seconds
+            context.non_persons_reader.clone(),
+            team_hypercache_reader,
             hypercache_reader,
         );
 
+        // Test fetching from PostgreSQL (cache miss)
         let result = flag_service
             .get_team_from_cache_or_pg(&team.api_token)
             .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap().id, team.id);
-
-        // Verify that the team was re-added to Redis
-        let redis_team = Team::from_redis(redis_client.clone(), &team.api_token).await;
-        assert!(redis_team.is_ok());
     }
 
     #[tokio::test]
@@ -361,11 +349,12 @@ mod tests {
             .await
             .expect("Failed to insert mock flags in hypercache");
 
+        let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
         let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
         let flag_service = FlagService::new(
             redis_client.clone(),
             pg_client.clone(),
-            432000, // team_cache_ttl_seconds
+            team_hypercache_reader,
             hypercache_reader,
         );
 
@@ -499,11 +488,12 @@ mod tests {
             .expect("Failed to write compressed data to Redis");
 
         // Create FlagService and verify it can read the compressed data
+        let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
         let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
         let flag_service = FlagService::new(
             redis_client.clone(),
             pg_client.clone(),
-            432000, // team_cache_ttl_seconds
+            team_hypercache_reader,
             hypercache_reader,
         );
 
@@ -548,6 +538,7 @@ mod tests {
     async fn test_get_flags_falls_back_to_pg_on_hypercache_miss() {
         let redis_client = setup_redis_client(None).await;
         let pg_client = setup_pg_reader_client(None).await;
+        let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
         let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
         let context = TestContext::new(None).await;
         let team = context
@@ -560,7 +551,7 @@ mod tests {
         let flag_service = FlagService::new(
             redis_client.clone(),
             pg_client.clone(),
-            432000, // team_cache_ttl_seconds
+            team_hypercache_reader,
             hypercache_reader,
         );
 
@@ -594,11 +585,14 @@ mod tests {
 
         let redis_client: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_client.clone());
         let hypercache_reader = setup_hypercache_reader_with_mock_redis(redis_client.clone());
+        // Use a real Redis client for team hypercache since we're only mocking flags cache
+        let team_redis_client = setup_redis_client(None).await;
+        let team_hypercache_reader = setup_team_hypercache_reader(team_redis_client).await;
 
         let flag_service = FlagService::new(
             redis_client,
             context.non_persons_reader.clone(),
-            432000, // team_cache_ttl_seconds
+            team_hypercache_reader,
             hypercache_reader,
         );
 
@@ -636,11 +630,14 @@ mod tests {
 
         let redis_client: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_client.clone());
         let hypercache_reader = setup_hypercache_reader_with_mock_redis(redis_client.clone());
+        // Use a real Redis client for team hypercache since we're only mocking flags cache
+        let team_redis_client = setup_redis_client(None).await;
+        let team_hypercache_reader = setup_team_hypercache_reader(team_redis_client).await;
 
         let flag_service = FlagService::new(
             redis_client,
             context.non_persons_reader.clone(),
-            432000, // team_cache_ttl_seconds
+            team_hypercache_reader,
             hypercache_reader,
         );
 
@@ -653,11 +650,21 @@ mod tests {
             flag_result.cache_source,
             common_hypercache::CacheSource::Fallback
         ));
+
+        // Verify SET was NOT called (cache write was skipped)
+        // This is tested via FlagsReadThroughCache behavior
+        let client_calls = mock_client.get_calls();
+        assert!(
+            !client_calls.iter().any(|call| call.op == "set"),
+            "Expected SET to NOT be called for RedisUnavailable error, but it was"
+        );
     }
 
+    /// Verifies that the Rust service never writes to cache on PG fallback.
+    /// Django now handles cache population via HyperCache; Rust is read-only.
     #[tokio::test]
-    async fn test_team_cache_ttl_is_used() {
-        use common_redis::{CustomRedisError, MockRedisClient, MockRedisValue};
+    async fn test_cache_write_never_performed_on_pg_fallback() {
+        use common_redis::MockRedisClient;
 
         let context = TestContext::new(None).await;
         let team = context
@@ -665,50 +672,41 @@ mod tests {
             .await
             .expect("Failed to insert team");
 
-        // Set up mock redis client to return NotFound (cache miss) and track setex calls
-        let mut mock_client = MockRedisClient::new();
-        mock_client.get_ret(&team.api_token, Err(CustomRedisError::NotFound));
+        // Set up mock redis client with no return value for the key.
+        // MockRedisClient returns NotFound for keys with no mock set up,
+        // which triggers the PG fallback path.
+        let mock_client = MockRedisClient::new();
 
         let redis_client: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_client.clone());
         let hypercache_reader = setup_hypercache_reader_with_mock_redis(redis_client.clone());
-
-        // Test with custom TTL values
-        let custom_team_ttl = 7200u64; // 2 hours
+        let team_redis_client = setup_redis_client(None).await;
+        let team_hypercache_reader = setup_team_hypercache_reader(team_redis_client).await;
 
         let flag_service = FlagService::new(
             redis_client,
             context.non_persons_reader.clone(),
-            custom_team_ttl,
+            team_hypercache_reader,
             hypercache_reader,
         );
 
-        // Trigger team cache operation
-        let _result = flag_service
-            .get_team_from_cache_or_pg(&team.api_token)
-            .await;
+        let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
 
-        // Verify setex was called with the custom team TTL
+        // Should succeed by falling back to PostgreSQL
+        assert!(result.is_ok());
+        let flag_result = result.unwrap();
+        assert!(
+            !flag_result.was_cache_hit,
+            "Expected cache miss since mock returned NotFound"
+        );
+
+        // Verify no SET calls were made - Django handles cache writes, not Rust
         let client_calls = mock_client.get_calls();
-        let setex_calls: Vec<_> = client_calls
-            .iter()
-            .filter(|call| call.op == "setex")
-            .collect();
-
-        assert!(!setex_calls.is_empty(), "Expected setex to be called");
-
-        // Verify the TTL value used matches our custom config
-        let team_setex_call = setex_calls
-            .iter()
-            .find(|call| call.key.contains(&team.api_token))
-            .expect("Expected setex call for team token");
-
-        if let MockRedisValue::StringWithTTL(_, ttl) = &team_setex_call.value {
-            assert_eq!(
-                *ttl, custom_team_ttl,
-                "Expected team cache TTL to be {custom_team_ttl} but got {ttl}",
-            );
-        } else {
-            panic!("Expected setex call to have TTL value");
-        }
+        assert!(
+            !client_calls
+                .iter()
+                .any(|call| call.op == "set" || call.op == "set_bytes"),
+            "Cache write detected after PG fallback. Rust should be read-only; \
+             Django handles cache population via HyperCache. Found calls: {client_calls:?}",
+        );
     }
 }

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -96,13 +96,7 @@ impl FlagService {
         let team = Team::from_hypercache_value(data)?;
         let cache_hit = !matches!(source, CacheSource::Fallback);
 
-        // Convert CacheSource to static string for canonical log
-        let source_str: &'static str = match source {
-            CacheSource::Redis => "redis",
-            CacheSource::S3 => "s3",
-            CacheSource::Fallback => "pg",
-        };
-        with_canonical_log(|log| log.team_cache_source = Some(source_str));
+        with_canonical_log(|log| log.team_cache_source = Some(source.as_log_str()));
 
         inc(
             TEAM_CACHE_HIT_COUNTER,
@@ -704,7 +698,10 @@ mod tests {
         assert!(result.is_ok());
         let flag_result = result.unwrap();
         assert!(
-            matches!(flag_result.cache_source, common_hypercache::CacheSource::Fallback),
+            matches!(
+                flag_result.cache_source,
+                common_hypercache::CacheSource::Fallback
+            ),
             "Expected fallback to PostgreSQL since mock returned NotFound"
         );
 

--- a/rust/feature-flags/src/flags/test_helpers.rs
+++ b/rust/feature-flags/src/flags/test_helpers.rs
@@ -181,7 +181,7 @@ pub async fn update_flags_in_hypercache(
         .await
         .map_err(|e| {
             tracing::error!("Failed to update hypercache for project {}: {}", team_id, e);
-            FlagError::CacheUpdateError
+            FlagError::Internal(format!("Failed to update cache: {e}"))
         })?;
 
     Ok(())

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -539,7 +539,6 @@ mod tests {
         #[case(FlagError::RowNotFound, 500, "row_not_found")]
         #[case(FlagError::RedisDataParsingError, 503, "redis_parsing_error")]
         #[case(FlagError::DeserializeFiltersError, 500, "deserialize_filters_error")]
-        #[case(FlagError::CacheUpdateError, 500, "cache_update_error")]
         #[case(FlagError::RedisUnavailable, 503, "redis_unavailable")]
         #[case(FlagError::DatabaseUnavailable, 503, "database_unavailable")]
         #[case(FlagError::TimeoutError(None), 503, "timeout")]

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -126,6 +126,10 @@ pub struct FlagsCanonicalLogLine {
     // Rate limiting
     pub rate_limited: bool,
 
+    // Cache sources (populated during data fetching)
+    /// Where team metadata was fetched from: "redis", "s3", "pg", or None if not fetched
+    pub team_cache_source: Option<&'static str>,
+
     // Outcome (populated at response time)
     pub http_status: u16,
     /// Error code from FlagError::error_code(). Uses &'static str to avoid allocation.
@@ -164,6 +168,7 @@ impl Default for FlagsCanonicalLogLine {
             hash_key_override_succeeded: false,
             hash_key_override_skipped: false,
             rate_limited: false,
+            team_cache_source: None,
             http_status: 200,
             error_code: None,
         }
@@ -218,6 +223,7 @@ impl FlagsCanonicalLogLine {
             hash_key_override_succeeded = self.hash_key_override_succeeded,
             hash_key_override_skipped = self.hash_key_override_skipped,
             rate_limited = self.rate_limited,
+            team_cache_source = self.team_cache_source,
             error_code = self.error_code,
             "canonical_log_line"
         );
@@ -275,6 +281,7 @@ mod tests {
         assert!(!log.hash_key_override_succeeded);
         assert!(!log.hash_key_override_skipped);
         assert!(!log.rate_limited);
+        assert!(log.team_cache_source.is_none());
         assert_eq!(log.http_status, 200);
         assert!(log.error_code.is_none());
     }
@@ -307,6 +314,7 @@ mod tests {
         log.hash_key_override_attempted = true;
         log.hash_key_override_succeeded = true;
         log.rate_limited = false;
+        log.team_cache_source = Some("redis");
         log.http_status = 200;
         log.emit();
     }

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -127,7 +127,7 @@ pub struct FlagsCanonicalLogLine {
     pub rate_limited: bool,
 
     // Cache sources (populated during data fetching)
-    /// Where team metadata was fetched from: "redis", "s3", "pg", or None if not fetched
+    /// Where team metadata was fetched from: "redis", "s3", "fallback", or None if not fetched
     pub team_cache_source: Option<&'static str>,
 
     // Outcome (populated at response time)
@@ -305,7 +305,7 @@ mod tests {
         log.flags_experience_continuity = 2;
         log.flags_disabled = false;
         log.quota_limited = true;
-        log.flags_cache_source = Some("Redis");
+        log.flags_cache_source = Some("redis");
         log.db_property_fetches = 3;
         log.property_cache_hits = 5;
         log.property_cache_misses = 2;

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -97,12 +97,12 @@ async fn process_request_inner(
     };
 
     let result = async {
-        // Use the pre-initialized HyperCacheReader from state
+        // Use the pre-initialized HyperCacheReaders from state (for team and flags)
         // This avoids per-request AWS SDK initialization overhead
         let flag_service = FlagService::new(
             context.state.redis_client.clone(),
             context.state.database_pools.non_persons_reader.clone(),
-            context.state.config.team_cache_ttl_seconds,
+            context.state.team_hypercache_reader.clone(),
             context.state.flags_hypercache_reader.clone(),
         );
 

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -21,7 +21,7 @@ use crate::{
     properties::property_models::{OperatorType, PropertyFilter, PropertyType},
     utils::test_utils::{
         insert_flags_for_team_in_redis, setup_hypercache_reader, setup_pg_reader_client,
-        setup_pg_writer_client, setup_redis_client, TestContext,
+        setup_pg_writer_client, setup_redis_client, setup_team_hypercache_reader, TestContext,
     },
 };
 use axum::http::HeaderMap;
@@ -1161,11 +1161,12 @@ fn test_decode_request_content_types() {
 async fn test_fetch_and_filter_flags() {
     let redis_client = setup_redis_client(None).await;
     let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None).await;
+    let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
     let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
     let flag_service = FlagService::new(
         redis_client.clone(),
         reader.clone(),
-        432000, // team_cache_ttl_seconds
+        team_hypercache_reader,
         hypercache_reader,
     );
     let context = TestContext::new(None).await;

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -3,7 +3,6 @@ pub const FLAG_EVALUATION_ERROR_COUNTER: &str = "flags_flag_evaluation_error_tot
 pub const FLAG_HASH_KEY_WRITES_COUNTER: &str = "flags_flag_hash_key_writes_total";
 pub const FLAG_HASH_KEY_RETRIES_COUNTER: &str = "flags_hash_key_retries_total";
 pub const TEAM_CACHE_HIT_COUNTER: &str = "flags_team_cache_hit_total";
-pub const TEAM_CACHE_ERRORS_COUNTER: &str = "flags_team_cache_errors_total";
 pub const DB_TEAM_READS_COUNTER: &str = "flags_db_team_reads_total";
 pub const TOKEN_VALIDATION_ERRORS_COUNTER: &str = "flags_token_validation_errors_total";
 pub const DB_COHORT_READS_COUNTER: &str = "flags_db_cohort_reads_total";

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -62,6 +62,12 @@ pub struct State {
     /// Pre-initialized HyperCacheReader for feature flags (flags.json)
     /// Initialized once at startup to avoid per-request AWS SDK initialization
     pub flags_hypercache_reader: Arc<HyperCacheReader>,
+    /// Pre-initialized HyperCacheReader for feature flags with cohorts (flags_with_cohorts.json)
+    /// Used by the /flags/definitions endpoint
+    pub flags_with_cohorts_hypercache_reader: Arc<HyperCacheReader>,
+    /// Pre-initialized HyperCacheReader for team metadata (full_metadata.json)
+    /// Uses token-based lookup instead of team_id
+    pub team_hypercache_reader: Arc<HyperCacheReader>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -76,6 +82,8 @@ pub fn router(
     session_replay_billing_limiter: SessionReplayLimiter,
     cookieless_manager: Arc<CookielessManager>,
     flags_hypercache_reader: Arc<HyperCacheReader>,
+    flags_with_cohorts_hypercache_reader: Arc<HyperCacheReader>,
+    team_hypercache_reader: Arc<HyperCacheReader>,
     config: Config,
 ) -> Router {
     // Initialize flag definitions rate limiter with default and custom team rates
@@ -140,6 +148,8 @@ pub fn router(
         flags_rate_limiter,
         ip_rate_limiter,
         flags_hypercache_reader,
+        flags_with_cohorts_hypercache_reader,
+        team_hypercache_reader,
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/feature-flags/src/team/team_models.rs
+++ b/rust/feature-flags/src/team/team_models.rs
@@ -3,8 +3,6 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::types::{Json, Uuid};
 
-pub const TEAM_TOKEN_CACHE_PREFIX: &str = "posthog:1:team_token:";
-
 #[derive(Clone, Debug, Default, Deserialize, Serialize, sqlx::FromRow)]
 pub struct Team {
     pub id: TeamId,
@@ -41,7 +39,7 @@ pub struct Team {
     pub session_recording_event_trigger_config: Option<Vec<Option<String>>>, // text[] in postgres. NB: this also contains NULL entries along with strings.
     pub session_recording_trigger_match_type_config: Option<String>, // character varying(24) in postgres
     pub recording_domains: Option<Vec<String>>, // character varying(200)[] in postgres
-    #[serde(with = "option_i16_as_i16")]
+    #[serde(default, with = "option_i16_as_i16")]
     pub cookieless_server_hash_mode: Option<i16>,
     #[serde(default = "default_timezone")]
     pub timezone: String,

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -1,64 +1,8 @@
 use crate::{
-    api::errors::FlagError,
-    database::get_connection_with_metrics,
-    team::team_models::{Team, TEAM_TOKEN_CACHE_PREFIX},
+    api::errors::FlagError, database::get_connection_with_metrics, team::team_models::Team,
 };
 use common_database::PostgresReader;
-use common_redis::Client as RedisClient;
-use std::{future::Future, sync::Arc};
-use tracing::{debug, warn};
-
-/// Fetches a team from Redis cache with PostgreSQL fallback
-///
-/// This helper consolidates the common pattern of:
-/// 1. Try Redis cache first
-/// 2. On cache miss, fetch from PostgreSQL using the provided lookup function
-/// 3. Update Redis cache on successful database fetch
-/// 4. Return the team
-///
-/// # Arguments
-/// * `redis_client` - Redis client (ReadWriteClient automatically routes reads to replica, writes to primary)
-/// * `token` - Token to use for cache key lookup
-/// * `db_lookup` - Async function to fetch team from PostgreSQL on cache miss
-/// * `cache_ttl_seconds` - Optional TTL for Redis cache entries in seconds
-pub async fn fetch_team_from_redis_with_fallback<F, Fut>(
-    redis_client: Arc<dyn RedisClient + Send + Sync>,
-    token: &str,
-    cache_ttl_seconds: Option<u64>,
-    db_lookup: F,
-) -> Result<Team, FlagError>
-where
-    F: FnOnce() -> Fut,
-    Fut: Future<Output = Result<Team, FlagError>>,
-{
-    // Try to get team from cache first (ReadWriteClient routes reads to replica)
-    match Team::from_redis(redis_client.clone(), token).await {
-        Ok(team) => {
-            debug!(team_id = team.id, "Found team in Redis cache");
-            Ok(team)
-        }
-        Err(e) => {
-            debug!(error = %e, "Team not found in Redis cache");
-            // Fallback to database using provided lookup function
-            match db_lookup().await {
-                Ok(team) => {
-                    debug!(team_id = team.id, "Found team in PostgreSQL");
-                    // Update Redis cache for next time (ReadWriteClient routes writes to primary)
-                    if let Err(e) =
-                        Team::update_redis_cache(redis_client, &team, cache_ttl_seconds).await
-                    {
-                        warn!(team_id = team.id, error = %e, "Failed to update Redis cache");
-                    }
-                    Ok(team)
-                }
-                Err(e) => {
-                    warn!(error = %e, "Team not found in PostgreSQL");
-                    Err(e)
-                }
-            }
-        }
-    }
-}
+use serde_json::Value;
 
 /// SQL fragment for selecting all Team columns
 const TEAM_COLUMNS: &str = "
@@ -100,93 +44,12 @@ const TEAM_COLUMNS: &str = "
 ";
 
 impl Team {
-    /// Validates a token, and returns a team if it exists.
-    pub async fn from_redis(
-        client: Arc<dyn RedisClient + Send + Sync>,
-        token: &str,
-    ) -> Result<Team, FlagError> {
-        tracing::debug!(
-            "Attempting to read team from Redis at key '{TEAM_TOKEN_CACHE_PREFIX}{token}'"
-        );
-
-        // NB: if this lookup fails, we fall back to the database before returning an error
-        let serialized_team = client
-            .get(format!("{TEAM_TOKEN_CACHE_PREFIX}{token}"))
-            .await?;
-
-        // TODO: Consider an LRU cache for teams as well, with small TTL to skip redis/pg lookups
-        let team: Team = serde_json::from_str(&serialized_team).map_err(|e| {
-            tracing::error!("failed to parse data to team for token {token}: {e}");
+    /// Parse team from HyperCache JSON value (team_metadata cache format).
+    pub fn from_hypercache_value(value: Value) -> Result<Team, FlagError> {
+        serde_json::from_value(value).map_err(|e| {
+            tracing::error!("Failed to deserialize team from HyperCache: {e}");
             FlagError::RedisDataParsingError
-        })?;
-
-        tracing::debug!(
-            "Successfully read team {} from Redis at key '{}{}'",
-            team.id,
-            TEAM_TOKEN_CACHE_PREFIX,
-            token
-        );
-
-        Ok(team)
-    }
-
-    pub async fn update_redis_cache(
-        client: Arc<dyn RedisClient + Send + Sync>,
-        team: &Team,
-        ttl_seconds: Option<u64>,
-    ) -> Result<(), FlagError> {
-        let serialized_team = serde_json::to_string(&team).map_err(|e| {
-            tracing::error!(
-                "Failed to serialize team {} (token {}): {}",
-                team.id,
-                team.api_token,
-                e
-            );
-            FlagError::RedisDataParsingError
-        })?;
-
-        let cache_key = format!("{TEAM_TOKEN_CACHE_PREFIX}{}", team.api_token);
-
-        match ttl_seconds {
-            Some(ttl) => {
-                tracing::info!(
-                    "Writing team to Redis at key '{}' with TTL {} seconds: team_id={}",
-                    cache_key,
-                    ttl,
-                    team.id
-                );
-                client
-                    .setex(cache_key, serialized_team, ttl)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(
-                            "Failed to update Redis cache with TTL for team {} (token {}): {}",
-                            team.id,
-                            team.api_token,
-                            e
-                        );
-                        FlagError::CacheUpdateError
-                    })?;
-            }
-            None => {
-                tracing::info!(
-                    "Writing team to Redis at key '{}' without TTL: team_id={}",
-                    cache_key,
-                    team.id
-                );
-                client.set(cache_key, serialized_team).await.map_err(|e| {
-                    tracing::error!(
-                        "Failed to update Redis cache for team {} (token {}): {}",
-                        team.id,
-                        team.api_token,
-                        e
-                    );
-                    FlagError::CacheUpdateError
-                })?;
-            }
-        }
-
-        Ok(())
+        })
     }
 
     pub async fn from_pg(client: PostgresReader, token: &str) -> Result<Team, FlagError> {
@@ -224,86 +87,29 @@ impl Team {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
-    use redis::AsyncCommands;
-    use sqlx::types::Json;
-    use uuid::Uuid;
+    use serde_json::json;
 
     use super::*;
     use crate::utils::test_utils::{
-        insert_new_team_in_redis, random_string, setup_redis_client, TestContext,
+        insert_new_team_in_redis, setup_redis_client, setup_team_hypercache_reader, TestContext,
     };
 
     #[tokio::test]
-    async fn test_fetch_team_from_redis() {
+    async fn test_fetch_team_from_hypercache() {
         let client = setup_redis_client(None).await;
 
         let team = insert_new_team_in_redis(client.clone())
             .await
             .expect("Failed to insert team in redis");
 
-        let target_token = team.api_token;
+        // Verify we can fetch team from HyperCache
+        let team_hypercache_reader = setup_team_hypercache_reader(client.clone()).await;
+        let key = common_hypercache::KeyType::string(&team.api_token);
+        let (data, _source) = team_hypercache_reader.get_with_source(&key).await.unwrap();
 
-        let team_from_redis = Team::from_redis(client.clone(), &target_token)
-            .await
-            .unwrap();
-        assert_eq!(team_from_redis.api_token, target_token);
-        assert_eq!(team_from_redis.id, team.id);
-    }
-
-    #[tokio::test]
-    async fn test_fetch_invalid_team_from_redis() {
-        let client = setup_redis_client(None).await;
-
-        match Team::from_redis(client.clone(), "banana").await {
-            Err(FlagError::TokenValidationError) => (),
-            _ => panic!("Expected TokenValidationError"),
-        };
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "Failed to create redis client")]
-    async fn test_cant_connect_to_redis_error_is_not_token_validation_error() {
-        // Test that client creation fails when Redis is unavailable
-        setup_redis_client(Some("redis://localhost:1111/".to_string())).await;
-    }
-
-    #[tokio::test]
-    async fn test_corrupted_data_in_redis_is_handled() {
-        let id = rand::thread_rng().gen_range(1_000_000..100_000_000);
-        let token = random_string("phc_", 12);
-        let team = Team {
-            id,
-            name: "team".to_string(),
-            api_token: token,
-            cookieless_server_hash_mode: Some(0),
-            timezone: "UTC".to_string(),
-            ..Default::default()
-        };
-        let serialized_team = serde_json::to_string(&team).expect("Failed to serialise team");
-
-        // manually insert non-pickled data in redis
-        let client =
-            redis::Client::open("redis://localhost:6379/").expect("Failed to create redis client");
-        let mut conn = client
-            .get_multiplexed_async_connection()
-            .await
-            .expect("Failed to get redis connection");
-        conn.set::<String, String, ()>(
-            format!("{}{}", TEAM_TOKEN_CACHE_PREFIX, team.api_token.clone()),
-            serialized_team,
-        )
-        .await
-        .expect("Failed to write data to redis");
-
-        // now get client connection for data
-        let client = setup_redis_client(None).await;
-
-        match Team::from_redis(client.clone(), team.api_token.as_str()).await {
-            Err(FlagError::RedisDataParsingError) => (),
-            Err(other) => panic!("Expected DataParsingError, got {other:?}"),
-            Ok(_) => panic!("Expected DataParsingError"),
-        };
+        let team_from_cache = Team::from_hypercache_value(data).unwrap();
+        assert_eq!(team_from_cache.api_token, team.api_token);
+        assert_eq!(team_from_cache.id, team.id);
     }
 
     #[tokio::test]
@@ -391,135 +197,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fetch_team_from_redis_with_fallback_writes_on_not_found() {
-        use common_redis::{CustomRedisError, MockRedisClient};
-
-        let team_id = rand::thread_rng().gen_range(1_000_000..100_000_000);
-        let token = random_string("phc_", 12);
-        let test_team = Team {
-            id: team_id,
-            name: "team".to_string(),
-            api_token: token.clone(),
-            organization_id: Some(Uuid::new_v4()),
-            ..Default::default()
-        };
-
-        // Set up mock redis client to return NotFound (which maps to TokenValidationError)
-        let mut mock_client = MockRedisClient::new();
-        mock_client.get_ret(
-            &format!("{TEAM_TOKEN_CACHE_PREFIX}{token}"),
-            Err(CustomRedisError::NotFound),
-        );
-
-        let redis_client: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_client.clone());
-
-        // Call the function with a DB lookup that returns the team
-        let result =
-            fetch_team_from_redis_with_fallback(redis_client, &token, Some(3600), || async {
-                Ok(test_team.clone())
-            })
-            .await;
-
-        // Should succeed and return the team
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().id, team_id);
-
-        // Verify SETEX was called (cache write happened with TTL)
-        let client_calls = mock_client.get_calls();
-        assert!(
-            client_calls.iter().any(|call| call.op == "setex"),
-            "Expected SETEX to be called for NotFound error, but it wasn't"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_fetch_team_from_redis_with_fallback_skips_write_on_timeout() {
-        use common_redis::{CustomRedisError, MockRedisClient};
-
-        let team_id = rand::thread_rng().gen_range(1_000_000..100_000_000);
-        let token = random_string("phc_", 12);
-        let test_team = Team {
-            id: team_id,
-            name: "team".to_string(),
-            api_token: token.clone(),
-            organization_id: Some(Uuid::new_v4()),
-            ..Default::default()
-        };
-
-        // Set up mock redis client to return Timeout
-        let mut mock_client = MockRedisClient::new();
-        mock_client.get_ret(
-            &format!("{TEAM_TOKEN_CACHE_PREFIX}{token}"),
-            Err(CustomRedisError::Timeout),
-        );
-
-        let redis_client: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_client.clone());
-
-        // Call the function with a DB lookup that returns the team
-        let result =
-            fetch_team_from_redis_with_fallback(redis_client, &token, Some(3600), || async {
-                Ok(test_team.clone())
-            })
-            .await;
-
-        // Should succeed and return the team
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().id, team_id);
-
-        // Verify SET was NOT called (cache write was skipped)
-        let client_calls = mock_client.get_calls();
-        assert!(
-            !client_calls.iter().any(|call| call.op == "set"),
-            "Expected SET to NOT be called for Timeout error, but it was"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_fetch_team_from_redis_with_fallback_skips_write_on_redis_unavailable() {
-        use common_redis::{CustomRedisError, MockRedisClient, RedisErrorKind};
-
-        let team_id = rand::thread_rng().gen_range(1_000_000..100_000_000);
-        let token = random_string("phc_", 12);
-        let test_team = Team {
-            id: team_id,
-            name: "team".to_string(),
-            api_token: token.clone(),
-            organization_id: Some(Uuid::new_v4()),
-            ..Default::default()
-        };
-
-        // Set up mock redis client to return Redis error (unavailable)
-        let mut mock_client = MockRedisClient::new();
-        mock_client.get_ret(
-            &format!("{TEAM_TOKEN_CACHE_PREFIX}{token}"),
-            Err(CustomRedisError::from_redis_kind(
-                RedisErrorKind::IoError,
-                "Connection refused",
-            )),
-        );
-
-        let redis_client: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_client.clone());
-
-        // Call the function with a DB lookup that returns the team
-        let result =
-            fetch_team_from_redis_with_fallback(redis_client, &token, Some(3600), || async {
-                Ok(test_team.clone())
-            })
-            .await;
-
-        // Should succeed and return the team
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().id, team_id);
-
-        // Verify SET was NOT called (cache write was skipped)
-        let client_calls = mock_client.get_calls();
-        assert!(
-            !client_calls.iter().any(|call| call.op == "set"),
-            "Expected SET to NOT be called for Redis unavailable error, but it was"
-        );
-    }
-
-    #[tokio::test]
     async fn test_fetch_team_with_extra_settings_from_pg() {
         let context = TestContext::new(None).await;
 
@@ -603,44 +280,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fetch_team_with_extra_settings_from_redis() {
-        let client = setup_redis_client(None).await;
-
-        let team_id = rand::thread_rng().gen_range(1_000_000..100_000_000);
-        let token = random_string("phc_", 12);
-
-        let extra_settings = serde_json::json!({
-            "recorder_script": "posthog-recorder"
+    async fn test_from_hypercache_value_parses_extra_settings() {
+        let extra_settings = json!({
+            "recorder_script": "posthog-recorder",
+            "something_else": 123
         });
 
-        let team = Team {
-            id: team_id,
-            name: "team".to_string(),
-            api_token: token.clone(),
-            extra_settings: Some(Json(extra_settings.clone())),
-            cookieless_server_hash_mode: Some(0),
-            timezone: "UTC".to_string(),
-            ..Default::default()
-        };
+        let team_data = json!({
+            "id": 12345,
+            "name": "Test Team",
+            "api_token": "phc_test123",
+            "uuid": "00000000-0000-0000-0000-000000012345",
+            "timezone": "America/New_York",
+            "extra_settings": extra_settings,
+        });
 
-        // Manually set team with extra_settings in Redis
-        let serialized_team = serde_json::to_string(&team).expect("Failed to serialize team");
+        let team = Team::from_hypercache_value(team_data).expect("Failed to parse team");
+        assert_eq!(team.id, 12345);
+        assert_eq!(team.api_token, "phc_test123");
+        assert_eq!(team.timezone, "America/New_York");
+        assert!(team.extra_settings.is_some());
 
-        client
-            .set(format!("{TEAM_TOKEN_CACHE_PREFIX}{token}"), serialized_team)
-            .await
-            .expect("Failed to write team to redis");
-
-        // Fetch from Redis and verify extra_settings deserializes correctly
-        let team_from_redis = Team::from_redis(client.clone(), &token)
-            .await
-            .expect("Failed to fetch team with extra_settings from redis");
-
-        assert_eq!(team_from_redis.api_token, token);
-        assert_eq!(team_from_redis.id, team_id);
-        assert!(team_from_redis.extra_settings.is_some());
-
-        let config = team_from_redis.extra_settings.unwrap();
+        let config = team.extra_settings.unwrap();
         assert_eq!(
             config.get("recorder_script").and_then(|v| v.as_str()),
             Some("posthog-recorder")
@@ -648,42 +309,117 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fetch_team_with_empty_recorder_script_from_redis() {
-        let client = setup_redis_client(None).await;
-
-        let team_id = rand::thread_rng().gen_range(1_000_000..100_000_000);
-        let token = random_string("phc_", 12);
-
-        let extra_settings = serde_json::json!({
-            "recorder_script": ""
+    async fn test_from_hypercache_value_handles_all_optional_fields() {
+        let team_data = json!({
+            "id": 99999,
+            "name": "Minimal Team",
+            "api_token": "phc_minimal",
+            "uuid": "00000000-0000-0000-0000-000000000001",
+            "organization_id": "00000000-0000-0000-0000-000000000002",
+            "autocapture_opt_out": true,
+            "session_recording_opt_in": false,
+            "session_recording_sample_rate": "0.75",
+            "cookieless_server_hash_mode": 1,
+            "timezone": "Europe/London",
         });
 
-        let team = Team {
-            id: team_id,
-            name: "team".to_string(),
-            api_token: token.clone(),
-            extra_settings: Some(Json(extra_settings.clone())),
-            cookieless_server_hash_mode: Some(0),
-            timezone: "UTC".to_string(),
-            ..Default::default()
-        };
+        let team = Team::from_hypercache_value(team_data).expect("Failed to parse team");
+        assert_eq!(team.id, 99999);
+        assert_eq!(team.api_token, "phc_minimal");
+        assert_eq!(team.autocapture_opt_out, Some(true));
+        assert!(!team.session_recording_opt_in);
+        assert_eq!(team.cookieless_server_hash_mode, Some(1));
+        assert_eq!(team.timezone, "Europe/London");
+    }
 
-        // Manually set team with empty recorder_script in Redis
-        let serialized_team = serde_json::to_string(&team).expect("Failed to serialize team");
+    #[tokio::test]
+    async fn test_from_hypercache_value_rejects_non_object() {
+        // Test with array
+        let result = Team::from_hypercache_value(json!(["not", "an", "object"]));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
 
-        client
-            .set(format!("{TEAM_TOKEN_CACHE_PREFIX}{token}"), serialized_team)
-            .await
-            .expect("Failed to write team to redis");
+        // Test with string
+        let result = Team::from_hypercache_value(json!("just a string"));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
 
-        // Fetch from Redis and verify empty recorder_script is preserved
-        let team_from_redis = Team::from_redis(client.clone(), &token)
-            .await
-            .expect("Failed to fetch team with empty recorder_script from redis");
+        // Test with number
+        let result = Team::from_hypercache_value(json!(42));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
 
-        assert!(team_from_redis.extra_settings.is_some());
-        let config = team_from_redis.extra_settings.unwrap();
-        let recorder_script = config.get("recorder_script").and_then(|v| v.as_str());
-        assert_eq!(recorder_script, Some(""));
+        // Test with null
+        let result = Team::from_hypercache_value(json!(null));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
+    }
+
+    #[tokio::test]
+    async fn test_from_hypercache_value_rejects_missing_required_fields() {
+        // Missing id
+        let result = Team::from_hypercache_value(json!({
+            "api_token": "phc_test",
+            "uuid": "00000000-0000-0000-0000-000000000001"
+        }));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
+
+        // Missing api_token
+        let result = Team::from_hypercache_value(json!({
+            "id": 123,
+            "uuid": "00000000-0000-0000-0000-000000000001"
+        }));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
+
+        // Missing uuid
+        let result = Team::from_hypercache_value(json!({
+            "id": 123,
+            "api_token": "phc_test"
+        }));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
+
+        // Empty object
+        let result = Team::from_hypercache_value(json!({}));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
+    }
+
+    #[tokio::test]
+    async fn test_from_hypercache_value_rejects_invalid_uuid() {
+        let result = Team::from_hypercache_value(json!({
+            "id": 123,
+            "api_token": "phc_test",
+            "uuid": "not-a-valid-uuid"
+        }));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
+
+        let result = Team::from_hypercache_value(json!({
+            "id": 123,
+            "api_token": "phc_test",
+            "uuid": ""
+        }));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
+    }
+
+    #[tokio::test]
+    async fn test_from_hypercache_value_rejects_wrong_field_types() {
+        // id as string instead of number
+        let result = Team::from_hypercache_value(json!({
+            "id": "not-a-number",
+            "api_token": "phc_test",
+            "uuid": "00000000-0000-0000-0000-000000000001"
+        }));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
+
+        // api_token as number instead of string
+        let result = Team::from_hypercache_value(json!({
+            "id": 123,
+            "api_token": 12345,
+            "uuid": "00000000-0000-0000-0000-000000000001"
+        }));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
+
+        // uuid as number instead of string
+        let result = Team::from_hypercache_value(json!({
+            "id": 123,
+            "api_token": "phc_test",
+            "uuid": 12345
+        }));
+        assert!(matches!(result, Err(FlagError::RedisDataParsingError)));
     }
 }

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -49,11 +49,7 @@ pub async fn insert_new_team_in_redis(
     };
 
     let serialized_team = serde_json::to_string(&team)?;
-    // HyperCache format: posthog:1:cache/team_tokens/{api_token}/team_metadata/full_metadata.json
-    let cache_key = format!(
-        "posthog:1:cache/team_tokens/{}/team_metadata/full_metadata.json",
-        team.api_token
-    );
+    let cache_key = team_token_hypercache_key(&team.api_token);
     client.set(cache_key, serialized_team).await?;
 
     Ok(team)

--- a/rust/feature-flags/tests/test_flags.rs
+++ b/rust/feature-flags/tests/test_flags.rs
@@ -14,7 +14,7 @@ use crate::common::*;
 use feature_flags::config::{FlexBool, TeamIdCollection, DEFAULT_TEST_CONFIG};
 use feature_flags::utils::test_utils::{
     insert_flags_for_team_in_redis, insert_new_team_in_redis, setup_pg_reader_client,
-    setup_redis_client, TestContext,
+    setup_redis_client, team_token_hypercache_key, TestContext,
 };
 
 pub mod common;
@@ -2199,14 +2199,7 @@ async fn test_config_site_apps_with_actual_plugins() -> Result<()> {
     // Update the team in Redis with inject_web_apps enabled
     let serialized_team = serde_json::to_string(&team).unwrap();
     client
-        .set(
-            format!(
-                "{}{}",
-                feature_flags::team::team_models::TEAM_TOKEN_CACHE_PREFIX,
-                team.api_token.clone()
-            ),
-            serialized_team,
-        )
+        .set(team_token_hypercache_key(&team.api_token), serialized_team)
         .await
         .unwrap();
 
@@ -2324,14 +2317,7 @@ async fn test_config_comprehensive_enterprise_team() -> Result<()> {
     // Update team in Redis
     let serialized_team = serde_json::to_string(&team).unwrap();
     client
-        .set(
-            format!(
-                "{}{}",
-                feature_flags::team::team_models::TEAM_TOKEN_CACHE_PREFIX,
-                team.api_token.clone()
-            ),
-            serialized_team,
-        )
+        .set(team_token_hypercache_key(&team.api_token), serialized_team)
         .await
         .unwrap();
 
@@ -2487,14 +2473,7 @@ async fn test_config_comprehensive_minimal_team() -> Result<()> {
     // Update team in Redis
     let serialized_team = serde_json::to_string(&team).unwrap();
     client
-        .set(
-            format!(
-                "{}{}",
-                feature_flags::team::team_models::TEAM_TOKEN_CACHE_PREFIX,
-                team.api_token.clone()
-            ),
-            serialized_team,
-        )
+        .set(team_token_hypercache_key(&team.api_token), serialized_team)
         .await
         .unwrap();
 
@@ -2588,14 +2567,7 @@ async fn test_config_mixed_feature_combinations() -> Result<()> {
     // Update team in Redis
     let serialized_team = serde_json::to_string(&team).unwrap();
     client
-        .set(
-            format!(
-                "{}{}",
-                feature_flags::team::team_models::TEAM_TOKEN_CACHE_PREFIX,
-                team.api_token.clone()
-            ),
-            serialized_team,
-        )
+        .set(team_token_hypercache_key(&team.api_token), serialized_team)
         .await
         .unwrap();
 
@@ -2688,14 +2660,7 @@ async fn test_config_team_exclusions_and_overrides() -> Result<()> {
     // Update team in Redis
     let serialized_team = serde_json::to_string(&team).unwrap();
     client
-        .set(
-            format!(
-                "{}{}",
-                feature_flags::team::team_models::TEAM_TOKEN_CACHE_PREFIX,
-                team.api_token.clone()
-            ),
-            serialized_team,
-        )
+        .set(team_token_hypercache_key(&team.api_token), serialized_team)
         .await
         .unwrap();
 
@@ -2764,14 +2729,7 @@ async fn test_config_legacy_vs_v2_consistency() -> Result<()> {
     // Update team in Redis
     let serialized_team = serde_json::to_string(&team).unwrap();
     client
-        .set(
-            format!(
-                "{}{}",
-                feature_flags::team::team_models::TEAM_TOKEN_CACHE_PREFIX,
-                team.api_token.clone()
-            ),
-            serialized_team,
-        )
+        .set(team_token_hypercache_key(&team.api_token), serialized_team)
         .await
         .unwrap();
 
@@ -2852,14 +2810,7 @@ async fn test_config_error_tracking_with_suppression_rules() -> Result<()> {
     // Update team in Redis
     let serialized_team = serde_json::to_string(&team).unwrap();
     client
-        .set(
-            format!(
-                "{}{}",
-                feature_flags::team::team_models::TEAM_TOKEN_CACHE_PREFIX,
-                team.api_token.clone()
-            ),
-            serialized_team,
-        )
+        .set(team_token_hypercache_key(&team.api_token), serialized_team)
         .await
         .unwrap();
 
@@ -5995,17 +5946,9 @@ async fn test_session_recording_script_config(
     team.extra_settings = extra_settings.map(sqlx::types::Json);
 
     let serialized_team = serde_json::to_string(&team).unwrap();
-    client
-        .set(
-            format!(
-                "{}{}",
-                feature_flags::team::team_models::TEAM_TOKEN_CACHE_PREFIX,
-                team.api_token.clone()
-            ),
-            serialized_team,
-        )
-        .await
-        .unwrap();
+    let cache_key =
+        feature_flags::utils::test_utils::team_token_hypercache_key(&team.api_token.clone());
+    client.set(cache_key, serialized_team).await.unwrap();
 
     let context = TestContext::new(None).await;
     context.insert_new_team(Some(team.id)).await.unwrap();


### PR DESCRIPTION
Follow-up to https://github.com/PostHog/posthog/pull/43334

## Problem

The feature-flags Rust service reads team metadata from a legacy Redis cache with a read-through pattern. This is inconsistent with how we now read flag data (from HyperCache) and doesn't benefit from the always-warm cache maintained by Django's scheduled tasks and signals.

> [!IMPORTANT]
> Don't get too caught up in reviewing the code related to `/flag-definitions`. That code is not yet publicly accessible. It's part of a port of local evaluation to Rust that's ongoing work. I'll revisit that code later.

## Changes

- Read team metadata from HyperCache (Redis → S3 → PostgreSQL fallback) instead of legacy Redis cache
- Add `team_cache_source` to canonical log line for observability ("redis", "s3", or "pg")
- Remove unused `FlagError::CacheUpdateError` variant (no longer writing to cache)
- Remove `team_cache_ttl_seconds` and `flags_cache_ttl_seconds` config (TTL managed by Django)
- Remove `redis` dependency from feature-flags crate (using HyperCache now)

## How did you test this code?

**Unit tests** - All existing tests pass, added tests for new canonical log field

**Manual testing:**

### Cache Hit (Redis)
- Made request to `http://localhost:3001/flags?v=2&config=true`
- Verified team properties returned correctly (e.g., `heatmaps`, `surveys`)
- Changed team setting in UI (e.g., toggle heatmaps)
- Made request again, verified change reflected
- Checked logs for `team_cache_source = Some("redis")`

### Cache Miss → PostgreSQL Fallback
- Deleted team cache key: `redis-cli DEL "posthog:1:cache/team_tokens/<token>/team_metadata/full_metadata.json"`
- Made request, verified response still correct
- Checked logs for `team_cache_source = Some("pg")` and HyperCache miss log

## Publish to changelog?

no
