### PR TITLE
feat(replay): pass funnel session ids to replay playlist

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -761,6 +761,45 @@ describe('sessionRecordingsPlaylistLogic', () => {
                 properties: [],
             })
         })
+
+        it('passes through session_ids when provided', () => {
+            const result = convertUniversalFiltersToRecordingsQuery({
+                ...DEFAULT_RECORDING_FILTERS,
+                filter_group: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [],
+                        },
+                    ],
+                },
+                session_ids: ['session-1', 'session-2', 'session-3'],
+            })
+
+            expect(result).toEqual({
+                actions: [],
+                console_log_filters: [],
+                date_from: '-3d',
+                date_to: null,
+                events: [],
+                filter_test_accounts: false,
+                having_predicates: [
+                    {
+                        key: 'active_seconds',
+                        operator: 'gt',
+                        type: 'recording',
+                        value: 5,
+                    },
+                ],
+                kind: 'RecordingsQuery',
+                operand: 'AND',
+                order: 'start_time',
+                order_direction: 'DESC',
+                properties: [],
+                session_ids: ['session-1', 'session-2', 'session-3'],
+            })
+        })
     })
 
     describe('convertLegacyFiltersToUniversalFilters', () => {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -319,6 +319,7 @@ export function convertUniversalFiltersToRecordingsQuery(universalFilters: Recor
         filter_test_accounts: universalFilters.filter_test_accounts,
         operand: universalFilters.filter_group.type,
         limit: universalFilters.limit,
+        session_ids: universalFilters.session_ids,
     }
 }
 

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
@@ -1,0 +1,135 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { PersonActorType } from '~/types'
+
+import { personsModalLogic } from './personsModalLogic'
+
+describe('personsModalLogic', () => {
+    let logic: ReturnType<typeof personsModalLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/session_recordings': () => [200, { results: [] }],
+            },
+        })
+        initKeaTests()
+    })
+
+    describe('sessionIdsFromLoadedActors', () => {
+        it('extracts session IDs from loaded actors with matched_recordings', () => {
+            const mockActorsQuery = {
+                kind: NodeKind.ActorsQuery,
+                source: {
+                    kind: NodeKind.FunnelsActorsQuery,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [],
+                    },
+                    funnelStep: -2,
+                },
+                select: ['actor'],
+                orderBy: [],
+            } as any
+
+            logic = personsModalLogic({
+                query: mockActorsQuery,
+                url: null,
+            })
+            logic.mount()
+
+            // Simulate loaded actors with matched recordings
+            const mockActors: PersonActorType[] = [
+                {
+                    type: 'person',
+                    id: 'person-1',
+                    distinct_ids: ['user-1'],
+                    is_identified: true,
+                    properties: {},
+                    created_at: '2024-01-01',
+                    matched_recordings: [
+                        { session_id: 'session-1', events: [] },
+                        { session_id: 'session-2', events: [] },
+                    ],
+                    value_at_data_point: null,
+                },
+                {
+                    type: 'person',
+                    id: 'person-2',
+                    distinct_ids: ['user-2'],
+                    is_identified: true,
+                    properties: {},
+                    created_at: '2024-01-01',
+                    matched_recordings: [{ session_id: 'session-3', events: [] }],
+                    value_at_data_point: null,
+                },
+                {
+                    type: 'person',
+                    id: 'person-3',
+                    distinct_ids: ['user-3'],
+                    is_identified: false,
+                    properties: {},
+                    created_at: '2024-01-01',
+                    matched_recordings: [],
+                    value_at_data_point: null,
+                },
+            ]
+
+            logic.actions.loadActorsSuccess({
+                results: [{ count: 3, people: mockActors }],
+                missing_persons: 0,
+            })
+
+            expectLogic(logic).toMatchValues({
+                sessionIdsFromLoadedActors: ['session-1', 'session-2', 'session-3'],
+            })
+        })
+
+        it('returns empty array when actors have no matched_recordings', () => {
+            const mockActorsQuery = {
+                kind: NodeKind.ActorsQuery,
+                source: {
+                    kind: NodeKind.FunnelsActorsQuery,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [],
+                    },
+                    funnelStep: -2,
+                },
+                select: ['actor'],
+                orderBy: [],
+            } as any
+
+            logic = personsModalLogic({
+                query: mockActorsQuery,
+                url: null,
+            })
+            logic.mount()
+
+            const mockActors: PersonActorType[] = [
+                {
+                    type: 'person',
+                    id: 'person-1',
+                    distinct_ids: ['user-1'],
+                    is_identified: true,
+                    properties: {},
+                    created_at: '2024-01-01',
+                    matched_recordings: [],
+                    value_at_data_point: null,
+                },
+            ]
+
+            logic.actions.loadActorsSuccess({
+                results: [{ count: 1, people: mockActors }],
+                missing_persons: 0,
+            })
+
+            expectLogic(logic).toMatchValues({
+                sessionIdsFromLoadedActors: [],
+            })
+        })
+    })
+})

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1257,6 +1257,7 @@ export interface RecordingUniversalFilters {
     duration: RecordingDurationFilter[]
     filter_test_accounts?: boolean
     filter_group: UniversalFiltersGroup
+    session_ids?: string[]
     order?: RecordingsQuery['order']
     order_direction?: RecordingsQuery['order_direction']
     limit?: RecordingsQuery['limit']


### PR DESCRIPTION
## Problem

Suggestion from adam (ty)
its really expensive/annoying to requery all these IDs when we already know from the funnel dropoff request what sessions we care about -- so lets just pass the session IDs into replay directly

## Changes

- allow sessionIDs to be passed as a filter
- pass those IDs we care about (ones that have a replay) from funnel Persons Modal
- write some tests
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- wrote a test
- theres no funnel dummy data :bufo-hide: 
- we test in prod????

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
