### PR TITLE
feat: Include additional debug data in GitHub secrets scanning analytics

### DIFF
--- a/posthog/api/github.py
+++ b/posthog/api/github.py
@@ -163,14 +163,17 @@ class SecretAlert(APIView):
 
         results = []
         for item in items:
+            # Strip whitespace from token in case GitHub sends it with extra formatting
+            token = item["token"].strip()
+
             result = {
-                "token_hash": sha256(item["token"].encode("utf-8")).hexdigest(),
+                "token_hash": sha256(token.encode("utf-8")).hexdigest(),
                 "token_type": item["type"],
                 "label": "false_positive",
             }
 
             if item["type"] == "posthog_personal_api_key":
-                key_lookup = find_personal_api_key(item["token"])
+                key_lookup = find_personal_api_key(token)
                 posthoganalytics.capture(
                     distinct_id=None,
                     event="github_secret_alert",
@@ -199,7 +202,7 @@ class SecretAlert(APIView):
             elif item["type"] == "posthog_feature_flags_secure_api_key":
                 found = False
                 try:
-                    _ = Team.objects.get(Q(secret_api_token=item["token"]) | Q(secret_api_token_backup=item["token"]))
+                    _ = Team.objects.get(Q(secret_api_token=token) | Q(secret_api_token_backup=token))
                     found = True
                     # TODO send email to team members
                     result["label"] = "true_positive"

--- a/posthog/api/github.py
+++ b/posthog/api/github.py
@@ -172,6 +172,13 @@ class SecretAlert(APIView):
                 "label": "false_positive",
             }
 
+            # Debug info while token lookups continue to fail
+            token_debug = {
+                "token_length": len(token),
+                "token_prefix": token[:10] if len(token) > 10 else "[REDACTED]",
+                "token_suffix": token[-8:] if len(token) > 8 else "[REDACTED]",
+            }
+
             if item["type"] == "posthog_personal_api_key":
                 key_lookup = find_personal_api_key(token)
                 posthoganalytics.capture(
@@ -182,6 +189,7 @@ class SecretAlert(APIView):
                         "source": item["source"],
                         "url": item["url"],
                         "found": key_lookup is not None,
+                        **token_debug,
                     },
                 )
 
@@ -220,6 +228,7 @@ class SecretAlert(APIView):
                         "source": item["source"],
                         "url": item["url"],
                         "found": found,
+                        **token_debug,
                     },
                 )
 

--- a/posthog/api/test/test_github.py
+++ b/posthog/api/test/test_github.py
@@ -9,6 +9,9 @@ from rest_framework import status
 
 from posthog import redis
 from posthog.api.github import SignatureVerificationError, verify_github_signature
+from posthog.models import PersonalAPIKey
+from posthog.models.personal_api_key import hash_key_value
+from posthog.models.utils import generate_random_token_personal, mask_key_value
 
 
 class TestGitHubSignatureVerification(TestCase):
@@ -289,3 +292,162 @@ dYtHUlWNMx0y6YwVG8nlBiJk2e0n+zpzs2WwszrnC7wfCqgU6rU3TkDvBQ==
         # Verify it's complaining about headers, not content type
         data = response.json()
         self.assertIn("Github-Public-Key-Identifier", str(data))
+
+    @patch("posthog.api.github.verify_github_signature")
+    @patch("posthog.api.github.send_personal_api_key_exposed")
+    def test_secret_alert_finds_and_rolls_existing_personal_api_key(self, mock_send_email, mock_verify):
+        """Test that an existing personal API key is found, rolled, and email is sent."""
+        mock_verify.return_value = None
+
+        # Create a real key
+        token = generate_random_token_personal()
+        key = PersonalAPIKey.objects.create(
+            user=self.user,
+            label="Test Key",
+            secure_value=hash_key_value(token),
+            mask_value=mask_key_value(token),
+        )
+        original_secure_value = key.secure_value
+
+        # Send alert with the token
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": token,
+                        "type": "posthog_personal_api_key",
+                        "url": "https://github.com/test/repo/blob/main/secrets.txt",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["label"], "true_positive")
+        self.assertEqual(data[0]["token_type"], "posthog_personal_api_key")
+
+        # Verify key was rolled (secure_value changed)
+        key.refresh_from_db()
+        self.assertNotEqual(key.secure_value, original_secure_value)
+        self.assertIsNotNone(key.last_rolled_at)
+
+        # Verify email was sent
+        mock_send_email.assert_called_once()
+        call_args = mock_send_email.call_args
+        self.assertEqual(call_args[0][0], self.user.id)
+        self.assertEqual(call_args[0][1], key.id)
+
+    @patch("posthog.api.github.verify_github_signature")
+    def test_secret_alert_returns_false_positive_for_unknown_key(self, mock_verify):
+        """Test that an unknown token returns false_positive."""
+        mock_verify.return_value = None
+
+        # Send alert with a non-existent token
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": "phx_nonexistent_token_12345678901234567890",
+                        "type": "posthog_personal_api_key",
+                        "url": "https://github.com/test/repo/blob/main/config.py",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["label"], "false_positive")
+
+    @patch("posthog.api.github.verify_github_signature")
+    @patch("posthog.api.github.send_personal_api_key_exposed")
+    def test_secret_alert_finds_key_with_legacy_pbkdf2_hash(self, mock_send_email, mock_verify):
+        """Test that keys stored with legacy PBKDF2 hash are still found."""
+        mock_verify.return_value = None
+
+        # Create a key with legacy PBKDF2 hash (260000 iterations)
+        token = generate_random_token_personal()
+        legacy_hash = hash_key_value(token, mode="pbkdf2", iterations=260000)
+        key = PersonalAPIKey.objects.create(
+            user=self.user,
+            label="Legacy Key",
+            secure_value=legacy_hash,
+            mask_value=mask_key_value(token),
+        )
+
+        # Send alert with the token
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": token,
+                        "type": "posthog_personal_api_key",
+                        "url": "https://github.com/test/repo/blob/main/old_secrets.txt",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["label"], "true_positive")
+
+        # Verify key was rolled
+        key.refresh_from_db()
+        self.assertIsNotNone(key.last_rolled_at)
+
+    @patch("posthog.api.github.verify_github_signature")
+    def test_secret_alert_does_not_find_key_for_inactive_user(self, mock_verify):
+        """Test that keys for inactive users are not found (returns false_positive)."""
+        mock_verify.return_value = None
+
+        # Create a key for an inactive user
+        self.user.is_active = False
+        self.user.save()
+
+        token = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            user=self.user,
+            label="Inactive User Key",
+            secure_value=hash_key_value(token),
+            mask_value=mask_key_value(token),
+        )
+
+        # Send alert with the token
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": token,
+                        "type": "posthog_personal_api_key",
+                        "url": "https://github.com/test/repo/blob/main/inactive_secrets.txt",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        # Key should NOT be found because user is inactive
+        self.assertEqual(data[0]["label"], "false_positive")


### PR DESCRIPTION
## Problem

Every token that GitHub sends us is failing to be found, including our known-valid test tokens. This means revocation of exposed is currently not working.

## Changes

Add additional debug data so we can figure out what's wrong. Once this is fixed, this debug data should be removed.
