### PR TITLE
feat(vercel): add SSO path=secrets for credential rotation

### DIFF
--- a/ee/api/vercel/test/test_vercel_sso.py
+++ b/ee/api/vercel/test/test_vercel_sso.py
@@ -258,7 +258,7 @@ class TestSSORedirectValidation:
         response = SSOTestHelper.make_sso_request(sso_setup["client"], sso_setup["url"], path="invalid_path")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    @pytest.mark.parametrize("path_value", ["billing", "usage", "support"])
+    @pytest.mark.parametrize("path_value", ["billing", "usage", "support", "secrets"])
     def test_sso_redirect_accepts_valid_paths(self, path_value, sso_setup):
         """Valid path values should be accepted and redirect successfully."""
         with (

--- a/ee/api/vercel/vercel_sso.py
+++ b/ee/api/vercel/vercel_sso.py
@@ -25,7 +25,7 @@ class VercelSSOSerializer(DataclassSerializer[SSOParams]):
         return value
 
     def validate_path(self, value: str | None) -> str | None:
-        valid_paths = {"billing", "usage", "support"}
+        valid_paths = {"billing", "usage", "support", "secrets"}
         if value and value not in valid_paths:
             raise serializers.ValidationError(f"Path must be one of: {', '.join(valid_paths)}")
         return value

--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -127,6 +127,7 @@ class VercelIntegration:
         "billing": "/organization/billing/overview",
         "usage": "/organization/billing/usage",
         "support": "/#panel=support",
+        "secrets": "/settings/environment-integrations",
     }
     SSO_DEFAULT_REDIRECT = "/"
 


### PR DESCRIPTION
## Problem

When Vercel initiates SSO with `path=secrets` (used for credential rotation flows), PostHog returns an "Invalid parameters" error because this path wasn't recognized.

## Changes

- Added `secrets` to the list of valid SSO paths in `VercelSSOSerializer`
- Added `secrets` → `/settings/environment-integrations` mapping in `SSO_PATH_REDIRECT_MAP`
- Updated tests to include the new path

## How did you test this code?

- [x] Unit tests pass (`pytest ee/api/vercel/test/test_vercel_sso.py` - 32 tests pass)
- [ ] Manual testing: Trigger SSO from Vercel with `path=secrets` and verify redirect to integrations settings

To test manually:
1. Deploy to a test environment
2. From Vercel integration dashboard, trigger a "manage secrets" or credential rotation action
3. Verify you're redirected to PostHog and land on `/settings/environment-integrations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)