### PR TITLE
fix: handle HTTP chunks that split mid-JSON in stream_query_as_jsonl

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -744,7 +744,7 @@ class ClickHouseClient:
                 buffer += chunk
                 while line_separator in buffer:
                     line, buffer = buffer.split(line_separator, 1)
-                    if line:
+                    if line.strip():
                         yield json.loads(line)
             if buffer.strip():
                 yield json.loads(buffer)

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -741,14 +741,13 @@ class ClickHouseClient:
         buffer = b""
         async with self.apost_query(query, *data, query_parameters=query_parameters, query_id=query_id) as response:
             async for chunk in response.content.iter_any():
-                lines = chunk.split(line_separator)
-
-                yield json.loads(buffer + lines[0])
-
-                buffer = lines.pop(-1)
-
-                for line in lines[1:]:
-                    yield json.loads(line)
+                buffer += chunk
+                while line_separator in buffer:
+                    line, buffer = buffer.split(line_separator, 1)
+                    if line:
+                        yield json.loads(line)
+            if buffer.strip():
+                yield json.loads(buffer)
 
     def stream_query_as_arrow(
         self,


### PR DESCRIPTION
## Summary

Fixes a bug in `stream_query_as_jsonl` where HTTP chunks that split in the middle of a JSON object would cause `json.loads()` to fail.

The previous implementation incorrectly assumed each HTTP chunk would contain at least one complete JSON line. When a chunk split mid-JSON (e.g., `{"status": "ent | ered"}`), the code would attempt to parse incomplete JSON and fail.

## Changes

- Accumulate chunks into buffer until complete lines are found
- Only parse JSON when we have a complete line (contains `line_separator`)
- Handle final line without trailing separator
- Add comprehensive tests for split chunks and final line handling

## How did you test this code?

- [x] Added test for chunks that split mid-JSON
- [x] Added test for final line without trailing separator
- [x] All existing tests pass