### PR TITLE
fix: Bump max record batch size for Redshift (INSERT)

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -1114,7 +1114,7 @@ async def insert_into_redshift_activity_from_stage(inputs: RedshiftInsertInputs)
             batch_export_id=inputs.batch_export.batch_export_id,
             data_interval_start=inputs.batch_export.data_interval_start,
             data_interval_end=inputs.batch_export.data_interval_end,
-            max_record_batch_size_bytes=1024 * 1024 * 2,  # 2MB
+            max_record_batch_size_bytes=1024 * 1024 * 10,  # 10MB
             stage_folder=inputs.batch_export.stage_folder,
         )
 


### PR DESCRIPTION
## Problem

`max_record_batch_size_bytes` is set low in Redshift (INSERT) as there is a relatively tight max query size that we must follow.

However, the value of `max_record_batch_size_bytes` is inconsequential for this: The transformer already splits up record batches into individual records, processing one at a time. Whether the record batch is 2MB or 10MB won't make it go over the query size limit, as the transformer will cut off the stream at the individual record level.

I *think* that since we slice record batches to really small sizes in a synchronous fashion in the code we may not be allowing requests from S3 to resume quickly enough, so I want to try bumping the `max_record_batch_size_bytes` to avoid frequent slicing.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Bump `max_record_batch_size_bytes` to 10MB for Redshift (INSERT). May bump this more later.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
