### PR TITLE
fix(ci): prevent cache branch divergence in master CI status

### DIFF
--- a/.github/scripts/master-ci-status.js
+++ b/.github/scripts/master-ci-status.js
@@ -123,8 +123,10 @@ function handleSuccess(state, event, commitTs, core, fs) {
     core.setOutput('since', state.since);
     core.setOutput('channel', state.channel || '');
     core.setOutput('ts', state.ts || '');
-    // Only save cache when state changes meaningfully (resolve/resolved)
-    // Don't save on 'none' to prevent creating divergent cache branches
+    // Only save cache when state changes meaningfully:
+    //   - when a failing workflow recovers (wasFailing => action='resolve'), or
+    //   - when the incident becomes fully resolved (resolved=true)
+    // Avoid saving on plain 'none' to prevent creating divergent cache branches.
     core.setOutput('save_cache', wasFailing || resolved ? 'true' : 'false');
 
     console.log(`Action: ${wasFailing ? 'resolve' : 'none'}`);

--- a/.github/scripts/master-ci-status.js
+++ b/.github/scripts/master-ci-status.js
@@ -75,6 +75,8 @@ function handleFailure(state, event, commitTs, core, fs) {
     core.setOutput('failing_count', String(failing.length));
     core.setOutput('commit_count', String(Object.keys(state.sha_ts).length));
     core.setOutput('save_cache', 'true');
+    // Delete old caches when creating new incident to prevent divergent cache branches
+    core.setOutput('delete_old_caches', isNew ? 'true' : 'false');
 
     console.log(`Action: ${isNew ? 'create' : 'update'}`);
     console.log(`Failing workflows: ${failing.join(', ')}`);
@@ -121,7 +123,9 @@ function handleSuccess(state, event, commitTs, core, fs) {
     core.setOutput('since', state.since);
     core.setOutput('channel', state.channel || '');
     core.setOutput('ts', state.ts || '');
-    core.setOutput('save_cache', 'true');
+    // Only save cache when state changes meaningfully (resolve/resolved)
+    // Don't save on 'none' to prevent creating divergent cache branches
+    core.setOutput('save_cache', wasFailing || resolved ? 'true' : 'false');
 
     console.log(`Action: ${wasFailing ? 'resolve' : 'none'}`);
     console.log(`Recovered: ${wasFailing ? event.name : 'none'}`);

--- a/.github/scripts/master-ci-status.test.js
+++ b/.github/scripts/master-ci-status.test.js
@@ -72,6 +72,7 @@ describe('master-ci-status', () => {
             expect(outputs.failing_count).toBe('1')
             expect(outputs.commit_count).toBe('1')
             expect(outputs.save_cache).toBe('true')
+            expect(outputs.delete_old_caches).toBe('true')
 
             // Verify state was written with timestamps
             const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
@@ -150,6 +151,7 @@ describe('master-ci-status', () => {
             expect(outputs.failing_workflows).toBe('Backend CI')
             expect(outputs.failing_count).toBe('1')
             expect(outputs.commit_count).toBe('2')
+            expect(outputs.delete_old_caches).toBe('false') // Only delete on create
 
             const writtenState = JSON.parse(fs.writeFileSync.mock.calls[0][1])
             expect(writtenState.fail_ts['Backend CI']).toBe(T2) // Updated to newer
@@ -178,6 +180,7 @@ describe('master-ci-status', () => {
             expect(outputs.action).toBe('none')
             expect(outputs.resolved).toBe('false')
             expect(outputs.still_failing).toBe('Backend CI')
+            expect(outputs.save_cache).toBe('false') // Don't save on 'none' to prevent divergent branches
         })
 
         it('resolves when failing workflow succeeds on newer commit', async () => {
@@ -190,7 +193,7 @@ describe('master-ci-status', () => {
             expect(outputs.action).toBe('resolve')
             expect(outputs.resolved).toBe('true')
             expect(outputs.still_failing).toBe('')
-            expect(outputs.save_cache).toBe('false')
+            expect(outputs.save_cache).toBe('true') // Save to persist resolved state
         })
 
         it('does NOT resolve when failing workflow succeeds on older commit', async () => {

--- a/.github/workflows/ci-master-status.yml
+++ b/.github/workflows/ci-master-status.yml
@@ -231,6 +231,20 @@ jobs:
             # Use unique keys to avoid race conditions where concurrent runs
             # delete the cache before saving (see logs showing "Cache not found")
 
+            - name: Delete old caches on new incident
+              if: steps.process.outputs.delete_old_caches == 'true'
+              continue-on-error: true
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  # Delete ALL old incident caches to prevent divergent cache branches
+                  # This ensures the new incident cache becomes the single source of truth
+                  echo "Deleting old incident caches..."
+                  gh cache list --key master-ci-incident- --json id,key -q '.[] | "\(.id) \(.key)"' | while read id key; do
+                    echo "Deleting cache: $key"
+                    gh cache delete "$id" || true
+                  done
+
             - name: Save incident to cache
               if: steps.process.outputs.save_cache == 'true'
               uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1


### PR DESCRIPTION
**Problem**

Incidents were being duplicated instead of updated. Found another possible cause: GitHub cache prefix matching returns "most recently **created** cache", not the one with the latest state. When concurrent runs exist, older runs could create cache entries that get restored instead of the newer incident cache.

**Fix**

1. Delete ALL old caches when creating a new incident - wipes the slate clean
2. Don't save cache on "action: none" - prevents divergent branches from "no-op" runs
