### PR TITLE
feat: don't apply breakdown_limit to export of table

### DIFF
--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -138,8 +138,17 @@ export const insightDataLogic = kea<insightDataLogicType>([
                     sourceQuery = query.source
                 }
 
+                // Don't apply breakdown_limit to exports
+                const exportQuery = { ...sourceQuery }
+                if ('breakdownFilter' in exportQuery && exportQuery.breakdownFilter?.breakdown_limit) {
+                    exportQuery.breakdownFilter = {
+                        ...exportQuery.breakdownFilter,
+                        breakdown_limit: undefined,
+                    }
+                }
+
                 return {
-                    ...queryExportContext(sourceQuery, undefined, undefined),
+                    ...queryExportContext(exportQuery, undefined, undefined),
                     filename,
                 } as ExportContext
             },


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #44445

## Changes
Modify export context selector in insightDataLogic.tsx, so the breakdown_limit set in the UI is not applied when exporting an insight as a table.

Setting breakdown_limit to undefined causes the backend to fall back to the breakdown_limit of 512 defined in the following code sections:
https://github.com/PostHog/posthog/blob/356d3dc68f33ae8a9d716195f07fa6ab43fcf317/posthog/hogql/constants.py#L91-L96

https://github.com/PostHog/posthog/blob/356d3dc68f33ae8a9d716195f07fa6ab43fcf317/posthog/hogql/constants.py#L38



## How did you test this code?
Test manually:
- Create insight of any type that allows "breakdown" (e.g. trends)
- Add breakdown by a property (e.g. browser type) and set breakdown limit to number lower than the actual count of different values of this property (e.g. if 3 different browsers are shown in the data, choose a limit of 2)
- The table below the chart should show a row with "Other (i.e. all remaining values)".
- When exporting this table as CSV or XLSX, all rows should be shown, regardless of the breakdown limit
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
