### PR TITLE
fix: notification dropdown alignment

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -242,7 +242,7 @@ export const SidePanelActivity = (): JSX.Element => {
                                             ] as LemonMenuItems
                                         }
                                     >
-                                        <LemonButton size="xsmall" type="secondary" tooltip="Subscribe">
+                                        <LemonButton size="small" type="secondary" tooltip="Subscribe">
                                             <IconBell />
                                         </LemonButton>
                                     </LemonMenu>


### PR DESCRIPTION
## Problem

The notification dropdown button in the Side panel -> Team activity -> Activity tab was not the same size as the user picker dropdown and was misaligned vertically.

## Changes

Updated the notification bell button in `SidePanelActivity.tsx` from `size="xsmall"` to `size="small"` to match the `MemberSelect` component's button size. This change also resolves the vertical alignment issue due to the existing flex container properties.

## How did you test this code?

Manually verified the button size and alignment in the UI within the Team activity panel.

## Publish to changelog?

no

---
[Slack Thread](https://posthog.slack.com/archives/C08UM214Z50/p1767865492622799?thread_ts=1767865492.622799&cid=C08UM214Z50)

<a href="https://cursor.com/background-agent?bcId=bc-3a62f062-0a6b-462a-a95d-a2c780035ff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a62f062-0a6b-462a-a95d-a2c780035ff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

