### PR TITLE
chore: add conventional commits instruction to agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,35 @@
   - Frontend: `pnpm --filter=@posthog/frontend build`
   - Start dev: `./bin/start`
 
+## Commits and Pull Requests
+
+Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for all commit messages and PR titles.
+
+### Commit types
+
+- `feat`: New feature or functionality (touches production code)
+- `fix`: Bug fix (touches production code)
+- `chore`: Non-production changes (docs, tests, config, CI, refactoring agents instructions, etc.)
+
+### Format
+
+```text
+<type>(<scope>): <description>
+```
+
+Examples:
+
+- `feat(insights): add retention graph export`
+- `fix(cohorts): handle empty cohort in query builder`
+- `chore(ci): update GitHub Actions workflow`
+- `chore: update AGENTS.md instructions`
+
+### Rules
+
+- Scope is optional but encouraged when the change is specific to a feature area
+- Description should be lowercase and not end with a period
+- Keep the first line under 72 characters
+
 ## ClickHouse Migrations
 
 ### Migration structure


### PR DESCRIPTION
let's try and get agents to create PRs with conventional commit titles

(ofc it didn't manage it in this PR so 🙈)