### PR TITLE
fix(batch-exports): HTTP batch exports - retry on 408 errors

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/http_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/http_batch_export.py
@@ -37,14 +37,14 @@ LOGGER = get_logger(__name__)
 
 
 class RetryableResponseError(Exception):
-    """Error for HTTP status >=500 (plus 429)."""
+    """Error for HTTP status >=500 (plus 429 and 408)."""
 
     def __init__(self, status):
         super().__init__(f"RetryableResponseError status: {status}")
 
 
 class NonRetryableResponseError(Exception):
-    """Error for HTTP status >= 400 and < 500 (excluding 429)."""
+    """Error for HTTP status >= 400 and < 500 (excluding 429 and 408)."""
 
     def __init__(self, status, content):
         super().__init__(f"NonRetryableResponseError (status: {status}): {content}")
@@ -54,7 +54,7 @@ async def raise_for_status(response: aiohttp.ClientResponse):
     """Like aiohttp raise_for_status, but it distinguishes between retryable and non-retryable
     errors."""
     if not response.ok:
-        if response.status >= 500 or response.status == 429:
+        if response.status >= 500 or response.status == 429 or response.status == 408:
             raise RetryableResponseError(response.status)
         else:
             text = await response.text()


### PR DESCRIPTION
## Problem

Currently our HTTP batch exports often fail with `NonRetryableResponseError (status: 408): client stopped sending data`

## Changes

Let's retry on 408 errors as it's better than retrying these batch exports manually

## How did you test this code?

I didn't

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No