### PR TITLE
feat(hobby): support OPT_OUT_CAPTURE env var override

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -127,6 +127,7 @@ services:
             OTEL_SDK_DISABLED: 'true'
             USE_GRANIAN: 'true'
             GRANIAN_WORKERS: '2'
+            OPT_OUT_CAPTURE: ${OPT_OUT_CAPTURE:-false}
         depends_on:
             - db
             - redis


### PR DESCRIPTION
## Problem
If you want to set OPT_OUT_CAPTURE=true and have this persist through upgrades, it needs to be set in a .env file as the docker-compose files are overwritten on deployment. It would be great to be able to set this once and not have to keep adding it in if you are upgrading with the hobby deployment.

It would be very helpful for Hobby deployments who want to disable OPT_OUT_CAPTURE but upgrade to the latest somewhat regularly.

## Changes
Adding default for OPT_OUT_CAPTURE to false that can be overridden via a var in a .env file.

## How did you test this code?

Manually updated my docker-compose.yml on my self hosted deployment to verify that setting this var in the .env file that's generated by the setup script correctly updates the OPT_OUT_CAPTURE variable.

Discussed on the forum here https://posthog.com/questions/disable-self-hosted-data-egress 

## Publish to changelog?
do not publish to changelog
