### PR TITLE
feat: discord and slack templates for spikes

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -250,6 +250,7 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING_ISSUE_SPLITTING: 'error-tracking-issue-splitting', // owner: @david #team-error-tracking
     ERROR_TRACKING_RELATED_ISSUES: 'error-tracking-related-issues', // owner: #team-error-tracking
     ERROR_TRACKING_REVENUE_SORTING: 'error-tracking-revenue-sorting', // owner: @david #team-error-tracking
+    ERROR_TRACKING_SPIKE_ALERTING: 'error-tracking-spike-alerting', // owner: #team-error-tracking
     EXPERIMENT_AI_SUMMARY: 'experiment-ai-summary', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_BREAKDOWN_FILTER: 'experiments-breakdown-filter', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_NEW_CALCULATOR: 'experiments-new-calculator', // owner: @jurajmajerik #team-experiments

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -481,12 +481,15 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     // Capture error tracking specific alert event
                     if (
                         res.template?.id === 'error-tracking-issue-created' ||
-                        res.template?.id === 'error-tracking-issue-reopened'
+                        res.template?.id === 'error-tracking-issue-reopened' ||
+                        res.template?.id === 'error-tracking-issue-spiking'
                     ) {
-                        const triggerEvent =
-                            res.template.id === 'error-tracking-issue-created'
-                                ? '$error_tracking_issue_created'
-                                : '$error_tracking_issue_reopened'
+                        const triggerEventMap: Record<string, string> = {
+                            'error-tracking-issue-created': '$error_tracking_issue_created',
+                            'error-tracking-issue-reopened': '$error_tracking_issue_reopened',
+                            'error-tracking-issue-spiking': '$error_tracking_issue_spiking',
+                        }
+                        const triggerEvent = triggerEventMap[res.template.id]
 
                         posthog.capture('error_tracking_alert_created', {
                             trigger_event: triggerEvent,

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -1,4 +1,4 @@
-import { INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID } from 'lib/constants'
+import { FEATURE_FLAGS, INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID } from 'lib/constants'
 
 import {
     HogFunctionConfigurationContextId,
@@ -66,6 +66,7 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
         type: 'internal_destination',
         context_id: 'error-tracking',
         filters: { events: [{ id: '$error_tracking_issue_spiking', type: 'events' }] },
+        flag: FEATURE_FLAGS.ERROR_TRACKING_SPIKE_ALERTING,
     },
     [INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID]: {
         sub_template_id: INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID,

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -462,7 +462,12 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             description: 'Posts a message to Discord when an issue is spiking',
             inputs: {
                 content: {
-                    value: '**📈 {event.properties.name} spiking:** {event.properties.description}',
+                    value: `**📈 Issue spiking: {event.properties.name}**
+
+{event.properties.description}
+
+**View issue:** {project.url}/error_tracking/{event.distinct_id}
+**Project:** {project.name}`,
                 },
             },
         },
@@ -483,7 +488,6 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                         {
                             type: 'context',
                             elements: [
-                                { type: 'plain_text', text: 'Status: {event.properties.status}' },
                                 { type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' },
                                 { type: 'mrkdwn', text: 'Alert: <{source.url}|{source.name}>' },
                             ],
@@ -493,7 +497,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                             type: 'actions',
                             elements: [
                                 {
-                                    url: '{project.url}/error_tracking/{event.distinct_id}?fingerprint={event.properties.fingerprint}&timestamp={event.properties.exception_timestamp}',
+                                    url: '{project.url}/error_tracking/{event.distinct_id}',
                                     text: { text: 'View Issue', type: 'plain_text' },
                                     type: 'button',
                                 },

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -463,12 +463,12 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             description: 'Posts a message to Discord when an issue is spiking',
             inputs: {
                 content: {
-                    value: `**📈 Issue is spiking**
+                    value: `**📈 Issue spiking**
                     
 \`\`\`
 {event.properties.name}: {substring(event.properties.description, 1, 1000)}
 \`\`\`
-**Current:** {event.properties.current_bucket_value} exceptions (baseline: {round(event.properties.computed_baseline)})
+**Exceptions in last 5 minutes:** {event.properties.current_bucket_value} ({round(((event.properties.current_bucket_value - event.properties.computed_baseline) / event.properties.computed_baseline) * 100)}% over baseline)
 **Project:** [{project.name}]({project.url})
 **Alert:** [{source.name}]({source.url})
 
@@ -484,7 +484,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             inputs: {
                 blocks: {
                     value: [
-                        { type: 'header', text: { type: 'plain_text', text: '📈 Issue is spiking' } },
+                        { type: 'header', text: { type: 'plain_text', text: '📈 Issue spiking' } },
                         {
                             type: 'section',
                             text: {
@@ -497,7 +497,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                             elements: [
                                 {
                                     type: 'plain_text',
-                                    text: 'Current: {event.properties.current_bucket_value} exceptions (baseline: {round(event.properties.computed_baseline)})',
+                                    text: 'Exceptions in last 5 minutes: {event.properties.current_bucket_value} ({round(((event.properties.current_bucket_value - event.properties.computed_baseline) / event.properties.computed_baseline) * 100)}% over baseline)',
                                 },
                                 { type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' },
                                 { type: 'mrkdwn', text: 'Alert: <{source.url}|{source.name}>' },

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -466,6 +466,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
 
 {event.properties.description}
 
+**Current:** {event.properties.current_bucket_value} errors (baseline: {event.properties.computed_baseline})
 **View issue:** {project.url}/error_tracking/{event.distinct_id}
 **Project:** {project.name}`,
                 },
@@ -479,15 +480,21 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             inputs: {
                 blocks: {
                     value: [
-                        { type: 'header', text: { type: 'plain_text', text: '📈 {event.properties.name}' } },
-                        { type: 'section', text: { type: 'plain_text', text: 'Issue is spiking' } },
+                        { type: 'header', text: { type: 'plain_text', text: '📈 Issue is spiking' } },
                         {
                             type: 'section',
-                            text: { type: 'mrkdwn', text: '```{substring(event.properties.description, 1, 150)}```' },
+                            text: {
+                                type: 'mrkdwn',
+                                text: '```{event.properties.name}: {substring(event.properties.description, 1, 150)}```',
+                            },
                         },
                         {
                             type: 'context',
                             elements: [
+                                {
+                                    type: 'plain_text',
+                                    text: 'Current: {event.properties.current_bucket_value} errors (baseline: {event.properties.computed_baseline})',
+                                },
                                 { type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' },
                                 { type: 'mrkdwn', text: 'Alert: <{source.url}|{source.name}>' },
                             ],

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -468,7 +468,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
 \`\`\`
 {event.properties.name}: {substring(event.properties.description, 1, 1000)}
 \`\`\`
-**Exceptions in last 5 minutes:** {event.properties.current_bucket_value} ({round(((event.properties.current_bucket_value - event.properties.computed_baseline) / event.properties.computed_baseline) * 100)}% over baseline)
+**Exceptions in last 5 minutes:** {event.properties.current_bucket_value} ({event.properties.computed_baseline > 0 ? concat(round(((event.properties.current_bucket_value - event.properties.computed_baseline) / event.properties.computed_baseline) * 100), '% over baseline') : 'no baseline yet'})
 **Project:** [{project.name}]({project.url})
 **Alert:** [{source.name}]({source.url})
 
@@ -497,7 +497,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                             elements: [
                                 {
                                     type: 'plain_text',
-                                    text: 'Exceptions in last 5 minutes: {event.properties.current_bucket_value} ({round(((event.properties.current_bucket_value - event.properties.computed_baseline) / event.properties.computed_baseline) * 100)}% over baseline)',
+                                    text: "Exceptions in last 5 minutes: {event.properties.current_bucket_value} ({event.properties.computed_baseline > 0 ? concat(round(((event.properties.current_bucket_value - event.properties.computed_baseline) / event.properties.computed_baseline) * 100), '% over baseline') : 'no baseline yet'})",
                                 },
                                 { type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' },
                                 { type: 'mrkdwn', text: 'Alert: <{source.url}|{source.name}>' },

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -463,13 +463,16 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             description: 'Posts a message to Discord when an issue is spiking',
             inputs: {
                 content: {
-                    value: `**📈 Issue spiking: {event.properties.name}**
+                    value: `**📈 Issue is spiking**
+                    
+\`\`\`
+{event.properties.name}: {substring(event.properties.description, 1, 1000)}
+\`\`\`
+**Current:** {event.properties.current_bucket_value} exceptions (baseline: {round(event.properties.computed_baseline)})
+**Project:** [{project.name}]({project.url})
+**Alert:** [{source.name}]({source.url})
 
-{event.properties.description}
-
-**Current:** {event.properties.current_bucket_value} errors (baseline: {event.properties.computed_baseline})
-**View issue:** {project.url}/error_tracking/{event.distinct_id}
-**Project:** {project.name}`,
+[View issue]({project.url}/error_tracking/{event.distinct_id})`,
                 },
             },
         },
@@ -486,7 +489,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                             type: 'section',
                             text: {
                                 type: 'mrkdwn',
-                                text: '```{event.properties.name}: {substring(event.properties.description, 1, 150)}```',
+                                text: '```{event.properties.name}: {substring(event.properties.description, 1, 1000)}```',
                             },
                         },
                         {
@@ -494,7 +497,7 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
                             elements: [
                                 {
                                     type: 'plain_text',
-                                    text: 'Current: {event.properties.current_bucket_value} errors (baseline: {event.properties.computed_baseline})',
+                                    text: 'Current: {event.properties.current_bucket_value} exceptions (baseline: {round(event.properties.computed_baseline)})',
                                 },
                                 { type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' },
                                 { type: 'mrkdwn', text: 'Alert: <{source.url}|{source.name}>' },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5802,6 +5802,7 @@ export type HogFunctionSubTemplateIdType =
     | 'activity-log'
     | 'error-tracking-issue-created'
     | 'error-tracking-issue-reopened'
+    | 'error-tracking-issue-spiking'
     | 'insight-alert-firing'
 
 export type HogFunctionConfigurationType = Omit<

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5824,6 +5824,7 @@ export type HogFunctionSubTemplateType = Pick<
     sub_template_id: HogFunctionSubTemplateIdType
     name?: string
     description?: string
+    flag?: string
 }
 
 export type HogFunctionTemplateType = Pick<

--- a/posthog/cdp/templates/hog_function_template.py
+++ b/posthog/cdp/templates/hog_function_template.py
@@ -14,6 +14,7 @@ SubTemplateId = Literal[
     "activity-log",
     "error-tracking-issue-created",
     "error-tracking-issue-reopened",
+    "error-tracking-issue-spiking",
     "insight-alert-firing",
 ]
 

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/alerting/ErrorTrackingAlerting.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/alerting/ErrorTrackingAlerting.tsx
@@ -4,7 +4,11 @@ export function ErrorTrackingAlerting(): JSX.Element {
     return (
         <LinkedHogFunctions
             type="internal_destination"
-            subTemplateIds={['error-tracking-issue-created', 'error-tracking-issue-reopened']}
+            subTemplateIds={[
+                'error-tracking-issue-created',
+                'error-tracking-issue-reopened',
+                'error-tracking-issue-spiking',
+            ]}
         />
     )
 }


### PR DESCRIPTION
## Problem

We added issue spiking internal events for team 2 but we have no templates for them.

## Changes

Added templates for discord and slack.

| Discord | Slack |
|--------|--------|
| <img width="1732" height="499" alt="image" src="https://github.com/user-attachments/assets/e89177e3-c8eb-4403-8251-d077c48bcbf2" /> | <img width="1383" height="428" alt="image" src="https://github.com/user-attachments/assets/f877f84e-28e4-4ab5-a9de-df9e37f4f55e" /> | 

## How did you test this code?

Tested locally

## Publish to changelog?

no
