### PR TITLE
fix(data-warehouse): Remove setting credentials from our dbt endpoint

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -828,6 +828,7 @@ products/data_warehouse/backend/api/external_data_schema.py:0: error: Incompatib
 products/data_warehouse/backend/api/external_data_source.py:0: error: Incompatible return value type (got "Any | None", expected "str")  [return-value]
 products/data_warehouse/backend/api/lineage.py:0: error: Item "None" of "Any | None" has no attribute "__iter__" (not iterable)  [union-attr]
 products/data_warehouse/backend/api/lineage.py:0: error: Item "None" of "Any | None" has no attribute "__iter__" (not iterable)  [union-attr]
+products/data_warehouse/backend/api/table.py:0: error: Incompatible type for "created_by" of "DataWarehouseTable" (got "User | AnonymousUser", expected "User | Combinable | None")  [misc]
 products/data_warehouse/backend/api/table.py:0: error: Item "None" of "Any | None" has no attribute "keys"  [union-attr]
 products/data_warehouse/backend/api/table.py:0: error: Unsupported target for indexed assignment ("Any | None")  [index]
 products/data_warehouse/backend/api/table.py:0: error: Value of type "Any | None" is not indexable  [index]


### PR DESCRIPTION
## Problem
- We have an endpoint that still sets the `DataWarehouseCredential` object when adding files to our S3 bucket

## Changes
- Remove the credential setting part of this code path, the files are accessible by clickhouse without explicit credentials

## How did you test this code?
Existing tests pass