### PR TITLE
feat(signals): Skip inactivity when exporting session video

### DIFF
--- a/frontend/src/lib/utils/router-utils.ts
+++ b/frontend/src/lib/utils/router-utils.ts
@@ -14,6 +14,7 @@ const pathsWithoutProjectId = [
     'account',
     'oauth',
     'shared',
+    'exporter',
     'embedded',
     'cli',
     'render_query',

--- a/frontend/src/scenes/session-recordings/player/PlayerFrameMetaOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameMetaOverlay.tsx
@@ -21,7 +21,7 @@ export function PlayerFrameMetaOverlay(): JSX.Element | null {
             </span>
             {isInactive && (
                 <span>
-                    <span className="font-bold text-yellow-400">[IDLE]</span>
+                    <span className="font-bold text-yellow-400">[IDLE - SKIPPING INACTIVITY]</span>
                 </span>
             )}
         </div>

--- a/frontend/src/scenes/session-recordings/player/PlayerFrameMetaOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameMetaOverlay.tsx
@@ -3,7 +3,7 @@ import { useValues } from 'kea'
 import { sessionRecordingPlayerLogic } from './sessionRecordingPlayerLogic'
 
 export function PlayerFrameMetaOverlay(): JSX.Element | null {
-    const { currentURL, currentPlayerTime, currentSegment } = useValues(sessionRecordingPlayerLogic)
+    const { currentURL, currentPlayerTime, currentSegment, endReached } = useValues(sessionRecordingPlayerLogic)
 
     if (!currentURL || currentPlayerTime === undefined) {
         return null
@@ -12,18 +12,18 @@ export function PlayerFrameMetaOverlay(): JSX.Element | null {
     const isInactive = currentSegment?.isActive === false
 
     return (
-        <div className="bg-black text-white text-md px-2 pt-1 pb-2 flex justify-center gap-4 font-mono truncate">
+        <div className="bg-black text-white text-md px-2 pt-1 pb-2 h-8 flex items-center justify-center gap-4 font-mono truncate">
             <span className="truncate">
                 <span className="font-bold">URL:</span> {currentURL}
             </span>
             <span>
                 <span className="font-bold">REC_T:</span> {Math.floor(currentPlayerTime / 1000)}
             </span>
-            {isInactive && (
-                <span>
-                    <span className="font-bold text-yellow-400">[IDLE - SKIPPING INACTIVITY]</span>
-                </span>
-            )}
+            {endReached ? (
+                <span className="font-bold text-green-400">[REACHED THE END OF THE RECORDING]</span>
+            ) : isInactive ? (
+                <span className="font-bold text-yellow-400">[IDLE - SKIPPING INACTIVITY]</span>
+            ) : null}
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -79,6 +79,8 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
         quickEmojiIsOpen,
         showingClipParams,
         isMuted,
+        endReached,
+        resolution,
     } = useValues(sessionRecordingPlayerLogic)
 
     const { isNotFound, isRecentAndInvalid } = useValues(sessionRecordingDataCoordinatorLogic(logicProps))
@@ -86,6 +88,13 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
 
     const { isCinemaMode, showMetadataFooter } = useValues(playerSettingsLogic)
     const { setIsCinemaMode } = useActions(playerSettingsLogic)
+
+    useEffect(() => {
+        // For video export: expose player state via global variable
+        if (typeof window !== 'undefined') {
+            ;(window as any).__POSTHOG_PLAYER_STATE__ = { endReached, resolution }
+        }
+    }, [endReached])
 
     const mode = logicProps.mode ?? SessionRecordingPlayerMode.Standard
     const hidePlayerElements =

--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -57,7 +57,6 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
         seekBackward,
         seekForward,
         setSpeed,
-        setSkipInactivitySetting,
         closeExplorer,
         setIsHovering,
         allowPlayerChromeToHide,
@@ -91,12 +90,6 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
     const mode = logicProps.mode ?? SessionRecordingPlayerMode.Standard
     const hidePlayerElements =
         mode === SessionRecordingPlayerMode.Screenshot || mode === SessionRecordingPlayerMode.Video
-
-    useEffect(() => {
-        if (hidePlayerElements) {
-            setSkipInactivitySetting(false)
-        }
-    }, [mode, setSkipInactivitySetting, hidePlayerElements])
 
     useEffect(
         () => {

--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -94,7 +94,7 @@ export function PurePlayer({ noMeta = false, noBorder = false, playerRef }: Pure
         if (typeof window !== 'undefined') {
             ;(window as any).__POSTHOG_PLAYER_STATE__ = { endReached, resolution }
         }
-    }, [endReached])
+    }, [endReached, resolution])
 
     const mode = logicProps.mode ?? SessionRecordingPlayerMode.Standard
     const hidePlayerElements =

--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.test.ts
@@ -1,3 +1,4 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { initKeaTests } from '~/test/init'
@@ -36,6 +37,61 @@ describe('playerSettingsLogic', () => {
             expectLogic(logic, () => {
                 logic.actions.setSkipInactivitySetting(false)
             }).toMatchValues({ skipInactivitySetting: false })
+        })
+    })
+
+    describe('exporter URL parameters', () => {
+        it('sets skipInactivitySetting to true when showMetadataFooter is true', async () => {
+            router.actions.push('/recordings/exporter', { showMetadataFooter: true })
+            await expectLogic(logic).toFinishAllListeners()
+            expectLogic(logic).toMatchValues({
+                skipInactivitySetting: true,
+                showMetadataFooter: true,
+            })
+        })
+
+        it('sets skipInactivitySetting to false when showMetadataFooter is false', async () => {
+            router.actions.push('/recordings/exporter', { showMetadataFooter: false })
+            await expectLogic(logic).toFinishAllListeners()
+            expectLogic(logic).toMatchValues({
+                skipInactivitySetting: false,
+                showMetadataFooter: false,
+            })
+        })
+
+        it('sets skipInactivitySetting to false when showMetadataFooter is not provided', async () => {
+            router.actions.push('/recordings/exporter')
+            await expectLogic(logic).toFinishAllListeners()
+            expectLogic(logic).toMatchValues({
+                skipInactivitySetting: false,
+                showMetadataFooter: false,
+            })
+        })
+
+        it('sets player speed from URL parameter', async () => {
+            router.actions.push('/recordings/exporter', { playerSpeed: '2' })
+            await expectLogic(logic).toFinishAllListeners()
+            expectLogic(logic).toMatchValues({
+                speed: 2,
+            })
+        })
+
+        it('sets player speed to default when not provided', async () => {
+            router.actions.push('/recordings/exporter')
+            await expectLogic(logic).toFinishAllListeners()
+            expectLogic(logic).toMatchValues({
+                speed: 1,
+            })
+        })
+
+        it('sets both speed and metadata footer from URL parameters', async () => {
+            router.actions.push('/recordings/exporter', { playerSpeed: '4', showMetadataFooter: true })
+            await expectLogic(logic).toFinishAllListeners()
+            expectLogic(logic).toMatchValues({
+                speed: 4,
+                skipInactivitySetting: true,
+                showMetadataFooter: true,
+            })
         })
     })
 })

--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -191,14 +191,11 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
         },
         ['**/exporter']: (_, searchParams) => {
             const playerSpeed = Number(searchParams.playerSpeed ?? 1)
-            if (values.speed !== playerSpeed) {
-                actions.setSpeed(playerSpeed)
-            }
+            actions.setSpeed(playerSpeed)
             const showMetadataFooter =
                 'showMetadataFooter' in searchParams && (searchParams.showMetadataFooter ?? false)
-            if (values.showMetadataFooter !== showMetadataFooter) {
-                actions.setShowMetadataFooter(showMetadataFooter)
-            }
+            actions.setSkipInactivitySetting(showMetadataFooter)
+            actions.setShowMetadataFooter(showMetadataFooter)
         },
         // Putting `*` last to match it only if more specific routes don't match, as the matching seems to be exclusive
         '*': (_, searchParams, hashParams) => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -968,11 +968,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     height: snapshot.data?.['height'],
                 }
 
-                // For video export: expose resolution via global variable
-                if (typeof window !== 'undefined') {
-                    ;(window as any).__POSTHOG_RESOLUTION__ = resolution
-                }
-
                 return resolution
             },
             {


### PR DESCRIPTION
## Problem

Exporting hours-long recordings to video takes time – but most of these are usually idle periods. Let's skip the idle activity, the same way a human watching a session does.

## Changes

- Updated the idle indicator text from `[IDLE]` to `[IDLE - SKIPPING INACTIVITY]` to make it clearer to the LLM that the player is skipping inactive periods
- Removed unnecessary (I think – @veryayskiy?) code in `PurePlayer.tsx` that was disabling skip inactivity in screenshot/video modes
- Improved the URL parameter handling in `playerSettingsLogic.ts` to properly set skip inactivity settings when `showMetadataFooter` is true – this is because the metadata header is the only indication of the real timestamp then, or when skipping is taking place

Example exported session – 1min 15s in real time, 16 s after 2x speedup (already in #43805) + skipping inactivity (this PR):

[session-video-summary_019b3465-ebec-70d9-b8c7-a65a2aecef23_8c7c3602-e632-4975-8a46-020d8f6c174c.webm](https://github.com/user-attachments/assets/deb0b30d-0c3f-4749-b329-c5d650612060)

## How did you test this code?


Added `playerSettingsLogic.test.ts` tests for the `/exporter` params handling.
Exported sessions locally.