### PR TITLE
fix(logs): handle hasLogs API failures gracefully

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -47,6 +47,7 @@ import {
     parseTagsFilter,
     pluralize,
     range,
+    retryWithBackoff,
     reverseColonDelimitedDuration,
     roundToDecimal,
     selectorOperatorMap,
@@ -1273,6 +1274,166 @@ describe('lib/utils', () => {
             const from = dayjs('2025-03-15T12:00:00')
             const to = dayjs('2025-03-15T12:01:00')
             expect(formatDateTimeRange(from, to)).toEqual('12:00 - 12:01')
+        })
+    })
+
+    describe('retryWithBackoff()', () => {
+        it('returns result on first successful attempt', async () => {
+            const fn = jest.fn().mockResolvedValue('success')
+            const result = await retryWithBackoff(fn, { initialDelayMs: 0 })
+            expect(result).toBe('success')
+            expect(fn).toHaveBeenCalledTimes(1)
+        })
+
+        it('retries on failure and succeeds', async () => {
+            const fn = jest
+                .fn()
+                .mockRejectedValueOnce(new Error('fail 1'))
+                .mockRejectedValueOnce(new Error('fail 2'))
+                .mockResolvedValue('success')
+
+            const result = await retryWithBackoff(fn, { maxAttempts: 3, initialDelayMs: 0 })
+            expect(result).toBe('success')
+            expect(fn).toHaveBeenCalledTimes(3)
+        })
+
+        it('throws last error after all attempts exhausted', async () => {
+            const errors = [new Error('fail 1'), new Error('fail 2'), new Error('fail 3')]
+            let callCount = 0
+            const fn = jest.fn().mockImplementation(() => Promise.reject(errors[callCount++]))
+
+            await expect(retryWithBackoff(fn, { maxAttempts: 3, initialDelayMs: 0 })).rejects.toThrow('fail 3')
+            expect(fn).toHaveBeenCalledTimes(3)
+        })
+
+        it('re-throws AbortError immediately without retrying', async () => {
+            const fn = jest.fn().mockImplementation(() => {
+                const error = new DOMException('Aborted', 'AbortError')
+                return Promise.reject(error)
+            })
+
+            await expect(retryWithBackoff(fn, { maxAttempts: 3, initialDelayMs: 0 })).rejects.toThrow('Aborted')
+            expect(fn).toHaveBeenCalledTimes(1)
+        })
+
+        it('throws immediately if signal is already aborted', async () => {
+            const controller = new AbortController()
+            controller.abort()
+
+            const fn = jest.fn().mockResolvedValue('success')
+            await expect(retryWithBackoff(fn, { signal: controller.signal })).rejects.toThrow('Aborted')
+            expect(fn).not.toHaveBeenCalled()
+        })
+
+        it('applies exponential backoff between retries', async () => {
+            jest.useFakeTimers()
+            try {
+                let callCount = 0
+                const fn = jest.fn().mockImplementation(() => {
+                    callCount++
+                    if (callCount < 3) {
+                        return Promise.reject(new Error('fail'))
+                    }
+                    return Promise.resolve('success')
+                })
+
+                const promise = retryWithBackoff(fn, {
+                    maxAttempts: 3,
+                    initialDelayMs: 1000,
+                    backoffMultiplier: 2,
+                })
+
+                // First call happens immediately
+                await Promise.resolve()
+                expect(fn).toHaveBeenCalledTimes(1)
+
+                // After 1000ms (initialDelayMs * 2^0), second attempt
+                await jest.advanceTimersByTimeAsync(1000)
+                expect(fn).toHaveBeenCalledTimes(2)
+
+                // After 2000ms (initialDelayMs * 2^1), third attempt
+                await jest.advanceTimersByTimeAsync(2000)
+                expect(fn).toHaveBeenCalledTimes(3)
+
+                await expect(promise).resolves.toBe('success')
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
+        it('uses default options when none provided', async () => {
+            const errors = [new Error('fail'), new Error('fail'), new Error('fail')]
+            let callCount = 0
+            const fn = jest.fn().mockImplementation(() => Promise.reject(errors[callCount++]))
+
+            await expect(retryWithBackoff(fn, { initialDelayMs: 0 })).rejects.toThrow('fail')
+            expect(fn).toHaveBeenCalledTimes(3) // default maxAttempts is 3
+        })
+
+        it('handles maxAttempts of 1 (no retries)', async () => {
+            const fn = jest.fn().mockImplementation(() => Promise.reject(new Error('fail')))
+
+            await expect(retryWithBackoff(fn, { maxAttempts: 1, initialDelayMs: 0 })).rejects.toThrow('fail')
+            expect(fn).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not retry when shouldRetry returns false', async () => {
+            const error = new Error('non-retryable')
+            const fn = jest.fn().mockImplementation(() => Promise.reject(error))
+
+            await expect(
+                retryWithBackoff(fn, {
+                    maxAttempts: 3,
+                    initialDelayMs: 0,
+                    shouldRetry: () => false,
+                })
+            ).rejects.toThrow('non-retryable')
+            expect(fn).toHaveBeenCalledTimes(1)
+        })
+
+        it('retries when shouldRetry returns true', async () => {
+            let callCount = 0
+            const fn = jest.fn().mockImplementation(() => {
+                callCount++
+                if (callCount < 3) {
+                    return Promise.reject(new Error('retryable'))
+                }
+                return Promise.resolve('success')
+            })
+
+            const result = await retryWithBackoff(fn, {
+                maxAttempts: 3,
+                initialDelayMs: 0,
+                shouldRetry: () => true,
+            })
+            expect(result).toBe('success')
+            expect(fn).toHaveBeenCalledTimes(3)
+        })
+
+        it('stops retrying when shouldRetry returns false for specific error', async () => {
+            const errors = [new Error('retry-me'), new Error('stop-here'), new Error('never-reached')]
+            let callCount = 0
+            const fn = jest.fn().mockImplementation(() => Promise.reject(errors[callCount++]))
+
+            await expect(
+                retryWithBackoff(fn, {
+                    maxAttempts: 3,
+                    initialDelayMs: 0,
+                    shouldRetry: (e) => e instanceof Error && e.message !== 'stop-here',
+                })
+            ).rejects.toThrow('stop-here')
+            expect(fn).toHaveBeenCalledTimes(2)
+        })
+
+        it('receives the error in shouldRetry callback', async () => {
+            const testError = new Error('test-error')
+            const fn = jest.fn().mockImplementation(() => Promise.reject(testError))
+            const shouldRetry = jest.fn().mockReturnValue(false)
+
+            await expect(retryWithBackoff(fn, { maxAttempts: 3, initialDelayMs: 0, shouldRetry })).rejects.toThrow(
+                'test-error'
+            )
+            expect(shouldRetry).toHaveBeenCalledWith(testError)
         })
     })
 })

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -11,6 +11,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { LogsFilters } from 'products/logs/frontend/components/LogsFilters'
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
 import { LogsSetupPrompt } from 'products/logs/frontend/components/SetupPrompt/SetupPrompt'
+import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPrompt/logsIngestionLogic'
 
 import { logsLogic } from './logsLogic'
 
@@ -42,6 +43,7 @@ const LogsSceneContent = (): JSX.Element => {
         sparklineData,
         sparklineBreakdownBy,
     } = useValues(logsLogic)
+    const { teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
     const { runQuery, fetchNextLogsPage, setOrderBy, addFilter, setDateRange, setSparklineBreakdownBy } =
         useActions(logsLogic)
 
@@ -54,6 +56,19 @@ const LogsSceneContent = (): JSX.Element => {
                     type: sceneConfigurations[Scene.Logs].iconType || 'default_icon_type',
                 }}
             />
+            {teamHasLogsCheckFailed && (
+                <LemonBanner
+                    type="info"
+                    dismissKey="logs-setup-hint-banner"
+                    action={{
+                        to: 'https://posthog.com/docs/logs/',
+                        targetBlank: true,
+                        children: 'Setup guide',
+                    }}
+                >
+                    Unable to verify logs setup. If you haven't configured logging yet, check out our setup guide.
+                </LemonBanner>
+            )}
             <LemonBanner
                 type="warning"
                 dismissKey="logs-beta-banner"

--- a/products/logs/frontend/components/SetupPrompt/SetupPrompt.tsx
+++ b/products/logs/frontend/components/SetupPrompt/SetupPrompt.tsx
@@ -18,10 +18,10 @@ export const LogsSetupPrompt = ({
     children: React.ReactNode
     className?: string
 }): JSX.Element => {
-    const { hasLogs, hasLogsLoading } = useValues(logsIngestionLogic)
+    const { teamHasLogs, teamHasLogsLoading, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
     const { currentTeam } = useValues(teamLogic)
 
-    if (hasLogsLoading || !currentTeam) {
+    if (teamHasLogsLoading || !currentTeam) {
         return (
             <div className="flex justify-center">
                 <Spinner />
@@ -29,7 +29,11 @@ export const LogsSetupPrompt = ({
         )
     }
 
-    if (!hasLogs) {
+    if (teamHasLogsCheckFailed || teamHasLogs === undefined) {
+        return <>{children}</>
+    }
+
+    if (!teamHasLogs) {
         return <NoLogsPrompt className={className} />
     }
 

--- a/products/logs/frontend/components/SetupPrompt/logsIngestionLogic.tsx
+++ b/products/logs/frontend/components/SetupPrompt/logsIngestionLogic.tsx
@@ -1,22 +1,34 @@
-import { afterMount, kea, path } from 'kea'
+import { afterMount, kea, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
+import { retryWithBackoff } from 'lib/utils'
 
 import type { logsIngestionLogicType } from './logsIngestionLogicType'
 
 export const logsIngestionLogic = kea<logsIngestionLogicType>([
     path(['products', 'logs', 'components', 'SetupPrompt', 'logsIngestionLogic']),
     loaders({
-        hasLogs: {
+        teamHasLogs: {
             __default: undefined as boolean | undefined,
-            loadHasLogs: async (): Promise<boolean> => {
-                return await api.logs.hasLogs()
+            loadTeamHasLogs: async (): Promise<boolean> => {
+                return await retryWithBackoff(() => api.logs.hasLogs(), { maxAttempts: 3 })
             },
         },
     }),
 
+    reducers({
+        teamHasLogsCheckFailed: [
+            false,
+            {
+                loadTeamHasLogs: () => false,
+                loadTeamHasLogsSuccess: () => false,
+                loadTeamHasLogsFailure: () => true,
+            },
+        ],
+    }),
+
     afterMount(({ actions }) => {
-        actions.loadHasLogs()
+        actions.loadTeamHasLogs()
     }),
 ])


### PR DESCRIPTION
## Problem

When checking if a team has logs, we're making unnecessary API calls and not handling failures gracefully. This impacts the user experience when the logs API is unavailable or slow.

## Changes

- Added a `retryWithBackoff` utility function to handle transient failures with exponential backoff
- Implemented caching for the `has_logs` endpoint to reduce unnecessary API calls
  - Cache positive results for 7 days (once you have logs, you always have logs)
- Improved error handling in the logs ingestion logic
  - Added a `teamHasLogsCheckFailed` state to track API failures
  - Show the logs viewer even when the has_logs check fails
- Added a helpful banner with setup guide link when logs setup check fails

## How did you test this code?

- Tested the retry utility with various error scenarios to ensure proper backoff behavior
- Verified caching works by checking network requests after initial load
- Simulated API failures to confirm the UI gracefully handles errors and shows the appropriate guidance
- Tested the full user flow to ensure a smooth experience in both success and failure cases

## Publish to changelog?

No