### PR TITLE
fix(orval): add alias stub to work around esbuild scss bundling

### DIFF
--- a/frontend/bin/generate-openapi-types.mjs
+++ b/frontend/bin/generate-openapi-types.mjs
@@ -312,6 +312,8 @@ const results = await Promise.allSettled(
         const configFile = path.join(tmpDir, `orval-${label}.config.mjs`)
         const outputFile = path.join(outputDir, 'api.ts')
         const mutatorPath = path.resolve(frontendRoot, 'src', 'lib', 'api-orval-mutator.ts')
+        // Stub for orval's esbuild bundling - avoids scss import chain
+        const apiStubPath = path.resolve(frontendRoot, 'src', 'lib', 'api-stub-for-orval.ts')
 
         fs.mkdirSync(outputDir, { recursive: true })
 
@@ -338,6 +340,9 @@ export default defineConfig({
         mutator: {
           path: '${mutatorPath}',
           name: 'apiMutator',
+          alias: {
+            'lib/api': '${apiStubPath}',
+          },
         },
         components: {
           schemas: { suffix: 'Api' },

--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -7,6 +7,71 @@
  * PostHog API - core
  * OpenAPI spec version: 1.0.0
  */
+/**
+ * * `engineering` - Engineering
+ * `data` - Data
+ * `product` - Product Management
+ * `founder` - Founder
+ * `leadership` - Leadership
+ * `marketing` - Marketing
+ * `sales` - Sales / Success
+ * `other` - Other
+ */
+export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RoleAtOrganizationEnumApi = {
+    engineering: 'engineering',
+    data: 'data',
+    product: 'product',
+    founder: 'founder',
+    leadership: 'leadership',
+    marketing: 'marketing',
+    sales: 'sales',
+    other: 'other',
+} as const
+
+export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const BlankEnumApi = {
+    '': '',
+} as const
+
+export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const NullEnumApi = {} as const
+
+export type UserBasicApiHedgehogConfigAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type UserBasicApiHedgehogConfig = UserBasicApiHedgehogConfigAnyOf | null | null
+
+export type UserBasicApiRoleAtOrganization = RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
+    /** @nullable */
+    is_email_verified?: boolean | null
+    /** @nullable */
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: UserBasicApiRoleAtOrganization
+}
 
 /**
  * * `default` - Default
@@ -24,11 +89,21 @@ export const CreationModeEnumApi = {
     unlisted: 'unlisted',
 } as const
 
+/**
+ * * `21` - Everyone in the project can edit
+ * `37` - Only those invited to this dashboard can edit
+ */
+export type DashboardRestrictionLevelApi =
+    (typeof DashboardRestrictionLevelApi)[keyof typeof DashboardRestrictionLevelApi]
+
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DashboardRestrictionLevelApi = {
     NUMBER_21: 21,
     NUMBER_37: 37,
 } as const
+
+export type EffectiveRestrictionLevelEnumApi =
+    (typeof EffectiveRestrictionLevelEnumApi)[keyof typeof EffectiveRestrictionLevelEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EffectiveRestrictionLevelEnumApi = {
@@ -36,11 +111,230 @@ export const EffectiveRestrictionLevelEnumApi = {
     NUMBER_37: 37,
 } as const
 
+export type EffectivePrivilegeLevelEnumApi =
+    (typeof EffectivePrivilegeLevelEnumApi)[keyof typeof EffectivePrivilegeLevelEnumApi]
+
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EffectivePrivilegeLevelEnumApi = {
     NUMBER_21: 21,
     NUMBER_37: 37,
 } as const
+
+/**
+ * Serializer mixin that resolves appropriate response for tags depending on license.
+ */
+export interface DashboardBasicApi {
+    readonly id: number
+    /** @nullable */
+    readonly name: string | null
+    readonly description: string
+    readonly pinned: boolean
+    readonly created_at: string
+    readonly created_by: UserBasicApi
+    /** @nullable */
+    readonly last_accessed_at: string | null
+    /** @nullable */
+    readonly last_viewed_at: string | null
+    readonly is_shared: boolean
+    readonly deleted: boolean
+    readonly creation_mode: CreationModeEnumApi
+    tags?: unknown[]
+    readonly restriction_level: DashboardRestrictionLevelApi
+    readonly effective_restriction_level: EffectiveRestrictionLevelEnumApi
+    readonly effective_privilege_level: EffectivePrivilegeLevelEnumApi
+    /**
+     * The effective access level the user has for this object
+     * @nullable
+     */
+    readonly user_access_level: string | null
+    readonly access_control_version: string
+    /** @nullable */
+    readonly last_refresh: string | null
+    readonly team_id: number
+}
+
+export interface PaginatedDashboardBasicListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: DashboardBasicApi[]
+}
+
+export type DashboardApiFilters = { [key: string]: unknown }
+
+export type DashboardApiVariablesAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type DashboardApiVariables = DashboardApiVariablesAnyOf | null | null
+
+export type DashboardApiPersistedFiltersAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type DashboardApiPersistedFilters = DashboardApiPersistedFiltersAnyOf | null | null
+
+export type DashboardApiPersistedVariablesAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type DashboardApiPersistedVariables = DashboardApiPersistedVariablesAnyOf | null | null
+
+export type DashboardApiTilesItem = { [key: string]: unknown }
+
+/**
+ * Serializer mixin that resolves appropriate response for tags depending on license.
+ */
+export interface DashboardApi {
+    readonly id: number
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    name?: string | null
+    description?: string
+    pinned?: boolean
+    readonly created_at: string
+    readonly created_by: UserBasicApi
+    /** @nullable */
+    last_accessed_at?: string | null
+    /** @nullable */
+    readonly last_viewed_at: string | null
+    readonly is_shared: boolean
+    deleted?: boolean
+    readonly creation_mode: CreationModeEnumApi
+    readonly filters: DashboardApiFilters
+    /** @nullable */
+    readonly variables: DashboardApiVariables
+    breakdown_colors?: unknown
+    /** @nullable */
+    data_color_theme_id?: number | null
+    tags?: unknown[]
+    /**
+     * @minimum 0
+     * @maximum 32767
+     */
+    restriction_level?: DashboardRestrictionLevelApi
+    readonly effective_restriction_level: EffectiveRestrictionLevelEnumApi
+    readonly effective_privilege_level: EffectivePrivilegeLevelEnumApi
+    /**
+     * The effective access level the user has for this object
+     * @nullable
+     */
+    readonly user_access_level: string | null
+    readonly access_control_version: string
+    /** @nullable */
+    last_refresh?: string | null
+    /** @nullable */
+    readonly persisted_filters: DashboardApiPersistedFilters
+    /** @nullable */
+    readonly persisted_variables: DashboardApiPersistedVariables
+    readonly team_id: number
+    /** @nullable */
+    readonly tiles: readonly DashboardApiTilesItem[] | null
+    use_template?: string
+    /** @nullable */
+    use_dashboard?: number | null
+    delete_insights?: boolean
+    _create_in_folder?: string
+}
+
+export interface SharingConfigurationApi {
+    readonly created_at: string
+    enabled?: boolean
+    /** @nullable */
+    readonly access_token: string | null
+    settings?: unknown
+    password_required?: boolean
+    readonly share_passwords: string
+}
+
+export type PatchedDashboardApiFilters = { [key: string]: unknown }
+
+export type PatchedDashboardApiVariablesAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type PatchedDashboardApiVariables = PatchedDashboardApiVariablesAnyOf | null | null
+
+export type PatchedDashboardApiPersistedFiltersAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type PatchedDashboardApiPersistedFilters = PatchedDashboardApiPersistedFiltersAnyOf | null | null
+
+export type PatchedDashboardApiPersistedVariablesAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type PatchedDashboardApiPersistedVariables = PatchedDashboardApiPersistedVariablesAnyOf | null | null
+
+export type PatchedDashboardApiTilesItem = { [key: string]: unknown }
+
+/**
+ * Serializer mixin that resolves appropriate response for tags depending on license.
+ */
+export interface PatchedDashboardApi {
+    readonly id?: number
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    name?: string | null
+    description?: string
+    pinned?: boolean
+    readonly created_at?: string
+    readonly created_by?: UserBasicApi
+    /** @nullable */
+    last_accessed_at?: string | null
+    /** @nullable */
+    readonly last_viewed_at?: string | null
+    readonly is_shared?: boolean
+    deleted?: boolean
+    readonly creation_mode?: CreationModeEnumApi
+    readonly filters?: PatchedDashboardApiFilters
+    /** @nullable */
+    readonly variables?: PatchedDashboardApiVariables
+    breakdown_colors?: unknown
+    /** @nullable */
+    data_color_theme_id?: number | null
+    tags?: unknown[]
+    /**
+     * @minimum 0
+     * @maximum 32767
+     */
+    restriction_level?: DashboardRestrictionLevelApi
+    readonly effective_restriction_level?: EffectiveRestrictionLevelEnumApi
+    readonly effective_privilege_level?: EffectivePrivilegeLevelEnumApi
+    /**
+     * The effective access level the user has for this object
+     * @nullable
+     */
+    readonly user_access_level?: string | null
+    readonly access_control_version?: string
+    /** @nullable */
+    last_refresh?: string | null
+    /** @nullable */
+    readonly persisted_filters?: PatchedDashboardApiPersistedFilters
+    /** @nullable */
+    readonly persisted_variables?: PatchedDashboardApiPersistedVariables
+    readonly team_id?: number
+    /** @nullable */
+    readonly tiles?: readonly PatchedDashboardApiTilesItem[] | null
+    use_template?: string
+    /** @nullable */
+    use_dashboard?: number | null
+    delete_insights?: boolean
+    _create_in_folder?: string
+}
 
 /**
  * * `image/png` - image/png
@@ -66,6 +360,119 @@ export const ExportFormatEnumApi = {
     'image/gif': 'image/gif',
     'application/json': 'application/json',
 } as const
+
+/**
+ * Standard ExportedAsset serializer that doesn't return content.
+ */
+export interface ExportedAssetApi {
+    readonly id: number
+    /** @nullable */
+    dashboard?: number | null
+    /** @nullable */
+    insight?: number | null
+    export_format: ExportFormatEnumApi
+    readonly created_at: string
+    readonly has_content: string
+    export_context?: unknown
+    readonly filename: string
+    /** @nullable */
+    readonly expires_after: string | null
+    /** @nullable */
+    readonly exception: string | null
+}
+
+export interface PaginatedExportedAssetListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ExportedAssetApi[]
+}
+
+export interface FileSystemApi {
+    readonly id: string
+    path: string
+    /** @nullable */
+    readonly depth: number | null
+    /** @maxLength 100 */
+    type?: string
+    /**
+     * @maxLength 100
+     * @nullable
+     */
+    ref?: string | null
+    /** @nullable */
+    href?: string | null
+    meta?: unknown
+    /** @nullable */
+    shortcut?: boolean | null
+    readonly created_at: string
+    /** @nullable */
+    readonly last_viewed_at: string | null
+}
+
+export interface PaginatedFileSystemListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: FileSystemApi[]
+}
+
+export interface PatchedFileSystemApi {
+    readonly id?: string
+    path?: string
+    /** @nullable */
+    readonly depth?: number | null
+    /** @maxLength 100 */
+    type?: string
+    /**
+     * @maxLength 100
+     * @nullable
+     */
+    ref?: string | null
+    /** @nullable */
+    href?: string | null
+    meta?: unknown
+    /** @nullable */
+    shortcut?: boolean | null
+    readonly created_at?: string
+    /** @nullable */
+    readonly last_viewed_at?: string | null
+}
+
+export interface GroupApi {
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     */
+    group_type_index: number
+    /** @maxLength 400 */
+    group_key: string
+    group_properties?: unknown
+    readonly created_at: string
+}
+
+export interface PaginatedGroupListApi {
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: GroupApi[]
+}
+
+export interface CreateGroupApi {
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     */
+    group_type_index: number
+    /** @maxLength 400 */
+    group_key: string
+    group_properties?: unknown
+}
 
 /**
  * * `slack` - Slack
@@ -120,6 +527,28 @@ export const KindEnumApi = {
 } as const
 
 /**
+ * Standard Integration serializer.
+ */
+export interface IntegrationApi {
+    readonly id: number
+    kind: KindEnumApi
+    config?: unknown
+    readonly created_at: string
+    readonly created_by: UserBasicApi
+    readonly errors: string
+    readonly display_name: string
+}
+
+export interface PaginatedIntegrationListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: IntegrationApi[]
+}
+
+/**
  * * `email` - Email
  * `slack` - Slack
  * `webhook` - Webhook
@@ -171,6 +600,200 @@ export const ByweekdayEnumApi = {
     sunday: 'sunday',
 } as const
 
+/**
+ * Standard Subscription serializer.
+ */
+export interface SubscriptionApi {
+    readonly id: number
+    /** @nullable */
+    dashboard?: number | null
+    /** @nullable */
+    insight?: number | null
+    target_type: TargetTypeEnumApi
+    target_value: string
+    frequency: FrequencyEnumApi
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     */
+    interval?: number
+    /** @nullable */
+    byweekday?: ByweekdayEnumApi[] | null
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     * @nullable
+     */
+    bysetpos?: number | null
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     * @nullable
+     */
+    count?: number | null
+    start_date: string
+    /** @nullable */
+    until_date?: string | null
+    readonly created_at: string
+    readonly created_by: UserBasicApi
+    deleted?: boolean
+    /**
+     * @maxLength 100
+     * @nullable
+     */
+    title?: string | null
+    readonly summary: string
+    /** @nullable */
+    readonly next_delivery_date: string | null
+    /** @nullable */
+    invite_message?: string | null
+}
+
+export interface PaginatedSubscriptionListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: SubscriptionApi[]
+}
+
+/**
+ * Standard Subscription serializer.
+ */
+export interface PatchedSubscriptionApi {
+    readonly id?: number
+    /** @nullable */
+    dashboard?: number | null
+    /** @nullable */
+    insight?: number | null
+    target_type?: TargetTypeEnumApi
+    target_value?: string
+    frequency?: FrequencyEnumApi
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     */
+    interval?: number
+    /** @nullable */
+    byweekday?: ByweekdayEnumApi[] | null
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     * @nullable
+     */
+    bysetpos?: number | null
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     * @nullable
+     */
+    count?: number | null
+    start_date?: string
+    /** @nullable */
+    until_date?: string | null
+    readonly created_at?: string
+    readonly created_by?: UserBasicApi
+    deleted?: boolean
+    /**
+     * @maxLength 100
+     * @nullable
+     */
+    title?: string | null
+    readonly summary?: string
+    /** @nullable */
+    readonly next_delivery_date?: string | null
+    /** @nullable */
+    invite_message?: string | null
+}
+
+export interface OrganizationDomainApi {
+    readonly id: string
+    /** @maxLength 128 */
+    domain: string
+    /** Determines whether a domain is verified or not. */
+    readonly is_verified: boolean
+    /** @nullable */
+    readonly verified_at: string | null
+    readonly verification_challenge: string
+    jit_provisioning_enabled?: boolean
+    /** @maxLength 28 */
+    sso_enforcement?: string
+    /** Returns whether SAML is configured for the instance. Does not validate the user has the required license (that check is performed in other places). */
+    readonly has_saml: boolean
+    /**
+     * @maxLength 512
+     * @nullable
+     */
+    saml_entity_id?: string | null
+    /**
+     * @maxLength 512
+     * @nullable
+     */
+    saml_acs_url?: string | null
+    /** @nullable */
+    saml_x509_cert?: string | null
+    /** Returns whether SCIM is configured and enabled for this domain. */
+    readonly has_scim: boolean
+    scim_enabled?: boolean
+    /** @nullable */
+    readonly scim_base_url: string | null
+    /** @nullable */
+    readonly scim_bearer_token: string | null
+}
+
+export interface PaginatedOrganizationDomainListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: OrganizationDomainApi[]
+}
+
+export interface PatchedOrganizationDomainApi {
+    readonly id?: string
+    /** @maxLength 128 */
+    domain?: string
+    /** Determines whether a domain is verified or not. */
+    readonly is_verified?: boolean
+    /** @nullable */
+    readonly verified_at?: string | null
+    readonly verification_challenge?: string
+    jit_provisioning_enabled?: boolean
+    /** @maxLength 28 */
+    sso_enforcement?: string
+    /** Returns whether SAML is configured for the instance. Does not validate the user has the required license (that check is performed in other places). */
+    readonly has_saml?: boolean
+    /**
+     * @maxLength 512
+     * @nullable
+     */
+    saml_entity_id?: string | null
+    /**
+     * @maxLength 512
+     * @nullable
+     */
+    saml_acs_url?: string | null
+    /** @nullable */
+    saml_x509_cert?: string | null
+    /** Returns whether SCIM is configured and enabled for this domain. */
+    readonly has_scim?: boolean
+    scim_enabled?: boolean
+    /** @nullable */
+    readonly scim_base_url?: string | null
+    /** @nullable */
+    readonly scim_bearer_token?: string | null
+}
+
+/**
+ * * `1` - member
+ * `8` - administrator
+ * `15` - owner
+ */
+export type OrganizationMembershipLevelApi =
+    (typeof OrganizationMembershipLevelApi)[keyof typeof OrganizationMembershipLevelApi]
+
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const OrganizationMembershipLevelApi = {
     NUMBER_1: 1,
@@ -178,12 +801,78 @@ export const OrganizationMembershipLevelApi = {
     NUMBER_15: 15,
 } as const
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EffectiveMembershipLevelEnumApi = {
-    NUMBER_1: 1,
-    NUMBER_8: 8,
-    NUMBER_15: 15,
-} as const
+export interface OrganizationInviteApi {
+    readonly id: string
+    /** @maxLength 254 */
+    target_email: string
+    /** @maxLength 30 */
+    first_name?: string
+    readonly emailing_attempt_made: boolean
+    /**
+     * @minimum 0
+     * @maximum 32767
+     */
+    level?: OrganizationMembershipLevelApi
+    /** Check if invite is older than INVITE_DAYS_VALIDITY days. */
+    readonly is_expired: boolean
+    readonly created_by: UserBasicApi
+    readonly created_at: string
+    readonly updated_at: string
+    /** @nullable */
+    message?: string | null
+    /** List of team IDs and corresponding access levels to private projects. */
+    private_project_access?: unknown
+    send_email?: boolean
+    combine_pending_invites?: boolean
+}
+
+export interface PaginatedOrganizationInviteListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: OrganizationInviteApi[]
+}
+
+export interface OrganizationMemberApi {
+    readonly id: string
+    readonly user: UserBasicApi
+    /**
+     * @minimum 0
+     * @maximum 32767
+     */
+    level?: OrganizationMembershipLevelApi
+    readonly joined_at: string
+    readonly updated_at: string
+    readonly is_2fa_enabled: boolean
+    readonly has_social_auth: boolean
+    readonly last_login: string
+}
+
+export interface PaginatedOrganizationMemberListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: OrganizationMemberApi[]
+}
+
+export interface PatchedOrganizationMemberApi {
+    readonly id?: string
+    readonly user?: UserBasicApi
+    /**
+     * @minimum 0
+     * @maximum 32767
+     */
+    level?: OrganizationMembershipLevelApi
+    readonly joined_at?: string
+    readonly updated_at?: string
+    readonly is_2fa_enabled?: boolean
+    readonly has_social_auth?: boolean
+    readonly last_login?: string
+}
 
 /**
  * * `Africa/Abidjan` - Africa/Abidjan
@@ -1386,6 +2075,37 @@ export const TimezoneEnumApi = {
 } as const
 
 /**
+ * Like `ProjectBasicSerializer`, but also works as a drop-in replacement for `TeamBasicSerializer` by way of
+passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
+backward compatibility of the REST API.
+Do not use this in greenfield endpoints!
+ */
+export interface ProjectBackwardCompatBasicApi {
+    readonly id: number
+    readonly uuid: string
+    readonly organization: string
+    readonly api_token: string
+    readonly name: string
+    readonly completed_snippet_onboarding: boolean
+    readonly has_completed_onboarding_for: unknown
+    readonly ingested_event: boolean
+    readonly is_demo: boolean
+    readonly timezone: TimezoneEnumApi
+    readonly access_control: boolean
+}
+
+export interface PaginatedProjectBackwardCompatBasicListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ProjectBackwardCompatBasicApi[]
+}
+
+export type ProjectBackwardCompatApiGroupTypesItem = { [key: string]: unknown }
+
+/**
  * * `0` - Sunday
  * `1` - Monday
  */
@@ -1397,10 +2117,11 @@ export const WeekStartDayEnumApi = {
     NUMBER_1: 1,
 } as const
 
-export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const NullEnumApi = {} as const
+/**
+ * @minimum -32768
+ * @maximum 32767
+ */
+export type ProjectBackwardCompatApiWeekStartDay = WeekStartDayEnumApi | NullEnumApi
 
 /**
  * * `b2b` - B2B
@@ -1416,12 +2137,308 @@ export const BusinessModelEnumApi = {
     other: 'other',
 } as const
 
-export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
+/**
+ * Whether this project serves B2B or B2C customers, used to optimize the UI layout.
+
+* `b2b` - B2B
+* `b2c` - B2C
+* `other` - Other
+ */
+export type ProjectBackwardCompatApiBusinessModel = BusinessModelEnumApi | BlankEnumApi | NullEnumApi
+
+export type EffectiveMembershipLevelEnumApi =
+    (typeof EffectiveMembershipLevelEnumApi)[keyof typeof EffectiveMembershipLevelEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const BlankEnumApi = {
-    '': '',
+export const EffectiveMembershipLevelEnumApi = {
+    NUMBER_1: 1,
+    NUMBER_8: 8,
+    NUMBER_15: 15,
 } as const
+
+/**
+ * Like `ProjectBasicSerializer`, but also works as a drop-in replacement for `TeamBasicSerializer` by way of
+passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
+backward compatibility of the REST API.
+Do not use this in greenfield endpoints!
+ */
+export interface ProjectBackwardCompatApi {
+    readonly id: number
+    readonly organization: string
+    /**
+     * @minLength 1
+     * @maxLength 200
+     */
+    name?: string
+    /**
+     * @maxLength 1000
+     * @nullable
+     */
+    product_description?: string | null
+    readonly created_at: string
+    readonly effective_membership_level: EffectiveMembershipLevelEnumApi
+    readonly has_group_types: boolean
+    readonly group_types: readonly ProjectBackwardCompatApiGroupTypesItem[]
+    /** @nullable */
+    readonly live_events_token: string | null
+    readonly updated_at: string
+    readonly uuid: string
+    readonly api_token: string
+    app_urls?: (string | null)[]
+    /**
+     * @maxLength 500
+     * @nullable
+     */
+    slack_incoming_webhook?: string | null
+    anonymize_ips?: boolean
+    completed_snippet_onboarding?: boolean
+    readonly ingested_event: boolean
+    test_account_filters?: unknown
+    /** @nullable */
+    test_account_filters_default_checked?: boolean | null
+    path_cleaning_filters?: unknown
+    is_demo?: boolean
+    timezone?: TimezoneEnumApi
+    data_attributes?: unknown
+    /** @nullable */
+    person_display_name_properties?: string[] | null
+    correlation_config?: unknown
+    /** @nullable */
+    autocapture_opt_out?: boolean | null
+    /** @nullable */
+    autocapture_exceptions_opt_in?: boolean | null
+    /** @nullable */
+    autocapture_web_vitals_opt_in?: boolean | null
+    autocapture_web_vitals_allowed_metrics?: unknown
+    autocapture_exceptions_errors_to_ignore?: unknown
+    /** @nullable */
+    capture_console_log_opt_in?: boolean | null
+    /** @nullable */
+    capture_performance_opt_in?: boolean | null
+    session_recording_opt_in?: boolean
+    /**
+     * @nullable
+     * @pattern ^-?\d{0,1}(?:\.\d{0,2})?$
+     */
+    session_recording_sample_rate?: string | null
+    /**
+     * @minimum 0
+     * @maximum 30000
+     * @nullable
+     */
+    session_recording_minimum_duration_milliseconds?: number | null
+    session_recording_linked_flag?: unknown
+    session_recording_network_payload_capture_config?: unknown
+    session_recording_masking_config?: unknown
+    session_replay_config?: unknown
+    survey_config?: unknown
+    access_control?: boolean
+    /**
+     * @minimum -32768
+     * @maximum 32767
+     */
+    week_start_day?: ProjectBackwardCompatApiWeekStartDay
+    /** @nullable */
+    primary_dashboard?: number | null
+    /** @nullable */
+    live_events_columns?: string[] | null
+    /** @nullable */
+    recording_domains?: (string | null)[] | null
+    readonly person_on_events_querying_enabled: string
+    /** @nullable */
+    inject_web_apps?: boolean | null
+    extra_settings?: unknown
+    modifiers?: unknown
+    readonly default_modifiers: string
+    has_completed_onboarding_for?: unknown
+    /** @nullable */
+    surveys_opt_in?: boolean | null
+    /** @nullable */
+    heatmaps_opt_in?: boolean | null
+    readonly product_intents: string
+    /** @nullable */
+    flags_persistence_default?: boolean | null
+    /** @nullable */
+    readonly secret_api_token: string | null
+    /** @nullable */
+    readonly secret_api_token_backup: string | null
+    /** @nullable */
+    receive_org_level_activity_logs?: boolean | null
+    /** Whether this project serves B2B or B2C customers, used to optimize the UI layout.
+
+* `b2b` - B2B
+* `b2c` - B2C
+* `other` - Other */
+    business_model?: ProjectBackwardCompatApiBusinessModel
+    /** @nullable */
+    conversations_enabled?: boolean | null
+    conversations_settings?: unknown
+}
+
+export type PatchedProjectBackwardCompatApiGroupTypesItem = { [key: string]: unknown }
+
+/**
+ * @minimum -32768
+ * @maximum 32767
+ */
+export type PatchedProjectBackwardCompatApiWeekStartDay = WeekStartDayEnumApi | NullEnumApi
+
+/**
+ * Whether this project serves B2B or B2C customers, used to optimize the UI layout.
+
+* `b2b` - B2B
+* `b2c` - B2C
+* `other` - Other
+ */
+export type PatchedProjectBackwardCompatApiBusinessModel = BusinessModelEnumApi | BlankEnumApi | NullEnumApi
+
+/**
+ * Like `ProjectBasicSerializer`, but also works as a drop-in replacement for `TeamBasicSerializer` by way of
+passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
+backward compatibility of the REST API.
+Do not use this in greenfield endpoints!
+ */
+export interface PatchedProjectBackwardCompatApi {
+    readonly id?: number
+    readonly organization?: string
+    /**
+     * @minLength 1
+     * @maxLength 200
+     */
+    name?: string
+    /**
+     * @maxLength 1000
+     * @nullable
+     */
+    product_description?: string | null
+    readonly created_at?: string
+    readonly effective_membership_level?: EffectiveMembershipLevelEnumApi
+    readonly has_group_types?: boolean
+    readonly group_types?: readonly PatchedProjectBackwardCompatApiGroupTypesItem[]
+    /** @nullable */
+    readonly live_events_token?: string | null
+    readonly updated_at?: string
+    readonly uuid?: string
+    readonly api_token?: string
+    app_urls?: (string | null)[]
+    /**
+     * @maxLength 500
+     * @nullable
+     */
+    slack_incoming_webhook?: string | null
+    anonymize_ips?: boolean
+    completed_snippet_onboarding?: boolean
+    readonly ingested_event?: boolean
+    test_account_filters?: unknown
+    /** @nullable */
+    test_account_filters_default_checked?: boolean | null
+    path_cleaning_filters?: unknown
+    is_demo?: boolean
+    timezone?: TimezoneEnumApi
+    data_attributes?: unknown
+    /** @nullable */
+    person_display_name_properties?: string[] | null
+    correlation_config?: unknown
+    /** @nullable */
+    autocapture_opt_out?: boolean | null
+    /** @nullable */
+    autocapture_exceptions_opt_in?: boolean | null
+    /** @nullable */
+    autocapture_web_vitals_opt_in?: boolean | null
+    autocapture_web_vitals_allowed_metrics?: unknown
+    autocapture_exceptions_errors_to_ignore?: unknown
+    /** @nullable */
+    capture_console_log_opt_in?: boolean | null
+    /** @nullable */
+    capture_performance_opt_in?: boolean | null
+    session_recording_opt_in?: boolean
+    /**
+     * @nullable
+     * @pattern ^-?\d{0,1}(?:\.\d{0,2})?$
+     */
+    session_recording_sample_rate?: string | null
+    /**
+     * @minimum 0
+     * @maximum 30000
+     * @nullable
+     */
+    session_recording_minimum_duration_milliseconds?: number | null
+    session_recording_linked_flag?: unknown
+    session_recording_network_payload_capture_config?: unknown
+    session_recording_masking_config?: unknown
+    session_replay_config?: unknown
+    survey_config?: unknown
+    access_control?: boolean
+    /**
+     * @minimum -32768
+     * @maximum 32767
+     */
+    week_start_day?: PatchedProjectBackwardCompatApiWeekStartDay
+    /** @nullable */
+    primary_dashboard?: number | null
+    /** @nullable */
+    live_events_columns?: string[] | null
+    /** @nullable */
+    recording_domains?: (string | null)[] | null
+    readonly person_on_events_querying_enabled?: string
+    /** @nullable */
+    inject_web_apps?: boolean | null
+    extra_settings?: unknown
+    modifiers?: unknown
+    readonly default_modifiers?: string
+    has_completed_onboarding_for?: unknown
+    /** @nullable */
+    surveys_opt_in?: boolean | null
+    /** @nullable */
+    heatmaps_opt_in?: boolean | null
+    readonly product_intents?: string
+    /** @nullable */
+    flags_persistence_default?: boolean | null
+    /** @nullable */
+    readonly secret_api_token?: string | null
+    /** @nullable */
+    readonly secret_api_token_backup?: string | null
+    /** @nullable */
+    receive_org_level_activity_logs?: boolean | null
+    /** Whether this project serves B2B or B2C customers, used to optimize the UI layout.
+
+* `b2b` - B2B
+* `b2c` - B2C
+* `other` - Other */
+    business_model?: PatchedProjectBackwardCompatApiBusinessModel
+    /** @nullable */
+    conversations_enabled?: boolean | null
+    conversations_settings?: unknown
+}
+
+export interface RoleApi {
+    readonly id: string
+    /** @maxLength 200 */
+    name: string
+    readonly created_at: string
+    readonly created_by: UserBasicApi
+    readonly members: string
+    readonly is_default: string
+}
+
+export interface PaginatedRoleListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: RoleApi[]
+}
+
+export interface PatchedRoleApi {
+    readonly id?: string
+    /** @maxLength 200 */
+    name?: string
+    readonly created_at?: string
+    readonly created_by?: UserBasicApi
+    readonly members?: string
+    readonly is_default?: string
+}
 
 /**
  * * `USR` - user
@@ -1453,1333 +2470,6 @@ export const AnnotationScopeEnumApi = {
     recording: 'recording',
 } as const
 
-/**
- * * `static` - static
- * `person_property` - person_property
- * `behavioral` - behavioral
- * `realtime` - realtime
- * `analytical` - analytical
- */
-export type CohortTypeEnumApi = (typeof CohortTypeEnumApi)[keyof typeof CohortTypeEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const CohortTypeEnumApi = {
-    static: 'static',
-    person_property: 'person_property',
-    behavioral: 'behavioral',
-    realtime: 'realtime',
-    analytical: 'analytical',
-} as const
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DashboardTemplateScopeEnumApi = {
-    team: 'team',
-    global: 'global',
-    feature_flag: 'feature_flag',
-} as const
-
-/**
- * * `DateTime` - DateTime
- * `String` - String
- * `Numeric` - Numeric
- * `Boolean` - Boolean
- * `Duration` - Duration
- */
-export type PropertyType549EnumApi = (typeof PropertyType549EnumApi)[keyof typeof PropertyType549EnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PropertyType549EnumApi = {
-    DateTime: 'DateTime',
-    String: 'String',
-    Numeric: 'Numeric',
-    Boolean: 'Boolean',
-    Duration: 'Duration',
-} as const
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PropertyDefinitionTypeEnumApi = {
-    NUMBER_1: 1,
-    NUMBER_2: 2,
-    NUMBER_3: 3,
-    NUMBER_4: 4,
-} as const
-
-/**
- * * `FeatureFlag` - feature flag
- */
-export type ModelNameEnumApi = (typeof ModelNameEnumApi)[keyof typeof ModelNameEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ModelNameEnumApi = {
-    FeatureFlag: 'FeatureFlag',
-} as const
-
-/**
- * * `daily` - daily
- * `weekly` - weekly
- * `monthly` - monthly
- */
-export type RecurrenceIntervalEnumApi = (typeof RecurrenceIntervalEnumApi)[keyof typeof RecurrenceIntervalEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RecurrenceIntervalEnumApi = {
-    daily: 'daily',
-    weekly: 'weekly',
-    monthly: 'monthly',
-} as const
-
-/**
- * * `disabled` - disabled
- * `toolbar` - toolbar
- */
-export type ToolbarModeEnumApi = (typeof ToolbarModeEnumApi)[keyof typeof ToolbarModeEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ToolbarModeEnumApi = {
-    disabled: 'disabled',
-    toolbar: 'toolbar',
-} as const
-
-/**
- * * `light` - Light
- * `dark` - Dark
- * `system` - System
- */
-export type ThemeModeEnumApi = (typeof ThemeModeEnumApi)[keyof typeof ThemeModeEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ThemeModeEnumApi = {
-    light: 'light',
-    dark: 'dark',
-    system: 'system',
-} as const
-
-/**
- * * `above` - Above
- * `below` - Below
- * `hidden` - Hidden
- */
-export type ShortcutPositionEnumApi = (typeof ShortcutPositionEnumApi)[keyof typeof ShortcutPositionEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ShortcutPositionEnumApi = {
-    above: 'above',
-    below: 'below',
-    hidden: 'hidden',
-} as const
-
-/**
- * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
- */
-export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RoleAtOrganizationEnumApi = {
-    engineering: 'engineering',
-    data: 'data',
-    product: 'product',
-    founder: 'founder',
-    leadership: 'leadership',
-    marketing: 'marketing',
-    sales: 'sales',
-    other: 'other',
-} as const
-
-export type MembershipLevelEnumApi = (typeof MembershipLevelEnumApi)[keyof typeof MembershipLevelEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MembershipLevelEnumApi = {
-    NUMBER_1: 1,
-    NUMBER_8: 8,
-    NUMBER_15: 15,
-} as const
-
-/**
- * * `0` - none
- * `3` - config
- * `6` - install
- * `9` - root
- */
-export type PluginsAccessLevelEnumApi = (typeof PluginsAccessLevelEnumApi)[keyof typeof PluginsAccessLevelEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PluginsAccessLevelEnumApi = {
-    NUMBER_0: 0,
-    NUMBER_3: 3,
-    NUMBER_6: 6,
-    NUMBER_9: 9,
-} as const
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DefaultExperimentStatsMethodEnumApi = {
-    bayesian: 'bayesian',
-    frequentist: 'frequentist',
-} as const
-
-/**
- * * `21` - Everyone in the project can edit
- * `37` - Only those invited to this dashboard can edit
- */
-export type DashboardRestrictionLevelApi =
-    (typeof DashboardRestrictionLevelApi)[keyof typeof DashboardRestrictionLevelApi]
-
-export type EffectiveRestrictionLevelEnumApi =
-    (typeof EffectiveRestrictionLevelEnumApi)[keyof typeof EffectiveRestrictionLevelEnumApi]
-
-export type EffectivePrivilegeLevelEnumApi =
-    (typeof EffectivePrivilegeLevelEnumApi)[keyof typeof EffectivePrivilegeLevelEnumApi]
-
-/**
- * * `1` - member
- * `8` - administrator
- * `15` - owner
- */
-export type OrganizationMembershipLevelApi =
-    (typeof OrganizationMembershipLevelApi)[keyof typeof OrganizationMembershipLevelApi]
-
-export type EffectiveMembershipLevelEnumApi =
-    (typeof EffectiveMembershipLevelEnumApi)[keyof typeof EffectiveMembershipLevelEnumApi]
-
-/**
- * * `team` - Only team
- * `global` - Global
- * `feature_flag` - Feature Flag
- */
-export type DashboardTemplateScopeEnumApi =
-    (typeof DashboardTemplateScopeEnumApi)[keyof typeof DashboardTemplateScopeEnumApi]
-
-/**
- * * `1` - event
- * `2` - person
- * `3` - group
- * `4` - session
- */
-export type PropertyDefinitionTypeEnumApi =
-    (typeof PropertyDefinitionTypeEnumApi)[keyof typeof PropertyDefinitionTypeEnumApi]
-
-/**
- * * `bayesian` - Bayesian
- * `frequentist` - Frequentist
- */
-export type DefaultExperimentStatsMethodEnumApi =
-    (typeof DefaultExperimentStatsMethodEnumApi)[keyof typeof DefaultExperimentStatsMethodEnumApi]
-
-export interface PaginatedDashboardBasicListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: DashboardBasicApi[]
-}
-
-export type DashboardApiFilters = { [key: string]: unknown }
-
-/**
- * @nullable
- */
-export type DashboardApiVariables = { [key: string]: unknown } | null
-
-/**
- * @nullable
- */
-export type DashboardApiPersistedFilters = { [key: string]: unknown } | null
-
-/**
- * @nullable
- */
-export type DashboardApiPersistedVariables = { [key: string]: unknown } | null
-
-export type DashboardApiTilesItem = { [key: string]: unknown }
-
-/**
- * Serializer mixin that resolves appropriate response for tags depending on license.
- */
-export interface DashboardApi {
-    readonly id: number
-    /**
-     * @maxLength 400
-     * @nullable
-     */
-    name?: string | null
-    description?: string
-    pinned?: boolean
-    readonly created_at: string
-    readonly created_by: UserBasicApi
-    /** @nullable */
-    last_accessed_at?: string | null
-    /** @nullable */
-    readonly last_viewed_at: string | null
-    readonly is_shared: boolean
-    deleted?: boolean
-    readonly creation_mode: CreationModeEnumApi
-    readonly filters: DashboardApiFilters
-    /** @nullable */
-    readonly variables: DashboardApiVariables
-    breakdown_colors?: unknown
-    /** @nullable */
-    data_color_theme_id?: number | null
-    tags?: unknown[]
-    /**
-     * @minimum 0
-     * @maximum 32767
-     */
-    restriction_level?: DashboardRestrictionLevelApi
-    readonly effective_restriction_level: EffectiveRestrictionLevelEnumApi
-    readonly effective_privilege_level: EffectivePrivilegeLevelEnumApi
-    /**
-     * The effective access level the user has for this object
-     * @nullable
-     */
-    readonly user_access_level: string | null
-    readonly access_control_version: string
-    /** @nullable */
-    last_refresh?: string | null
-    /** @nullable */
-    readonly persisted_filters: DashboardApiPersistedFilters
-    /** @nullable */
-    readonly persisted_variables: DashboardApiPersistedVariables
-    readonly team_id: number
-    /** @nullable */
-    readonly tiles: readonly DashboardApiTilesItem[] | null
-    use_template?: string
-    /** @nullable */
-    use_dashboard?: number | null
-    delete_insights?: boolean
-    _create_in_folder?: string
-}
-
-/**
- * @nullable
- */
-export type SharingConfigurationApiSettings = unknown | null
-
-export interface SharingConfigurationApi {
-    readonly created_at: string
-    enabled?: boolean
-    /** @nullable */
-    readonly access_token: string | null
-    /** @nullable */
-    settings?: SharingConfigurationApiSettings
-    password_required?: boolean
-    readonly share_passwords: string
-}
-
-export type PatchedDashboardApiFilters = { [key: string]: unknown }
-
-/**
- * @nullable
- */
-export type PatchedDashboardApiVariables = { [key: string]: unknown } | null
-
-/**
- * @nullable
- */
-export type PatchedDashboardApiPersistedFilters = { [key: string]: unknown } | null
-
-/**
- * @nullable
- */
-export type PatchedDashboardApiPersistedVariables = { [key: string]: unknown } | null
-
-export type PatchedDashboardApiTilesItem = { [key: string]: unknown }
-
-/**
- * Serializer mixin that resolves appropriate response for tags depending on license.
- */
-export interface PatchedDashboardApi {
-    readonly id?: number
-    /**
-     * @maxLength 400
-     * @nullable
-     */
-    name?: string | null
-    description?: string
-    pinned?: boolean
-    readonly created_at?: string
-    readonly created_by?: UserBasicApi
-    /** @nullable */
-    last_accessed_at?: string | null
-    /** @nullable */
-    readonly last_viewed_at?: string | null
-    readonly is_shared?: boolean
-    deleted?: boolean
-    readonly creation_mode?: CreationModeEnumApi
-    readonly filters?: PatchedDashboardApiFilters
-    /** @nullable */
-    readonly variables?: PatchedDashboardApiVariables
-    breakdown_colors?: unknown
-    /** @nullable */
-    data_color_theme_id?: number | null
-    tags?: unknown[]
-    /**
-     * @minimum 0
-     * @maximum 32767
-     */
-    restriction_level?: DashboardRestrictionLevelApi
-    readonly effective_restriction_level?: EffectiveRestrictionLevelEnumApi
-    readonly effective_privilege_level?: EffectivePrivilegeLevelEnumApi
-    /**
-     * The effective access level the user has for this object
-     * @nullable
-     */
-    readonly user_access_level?: string | null
-    readonly access_control_version?: string
-    /** @nullable */
-    last_refresh?: string | null
-    /** @nullable */
-    readonly persisted_filters?: PatchedDashboardApiPersistedFilters
-    /** @nullable */
-    readonly persisted_variables?: PatchedDashboardApiPersistedVariables
-    readonly team_id?: number
-    /** @nullable */
-    readonly tiles?: readonly PatchedDashboardApiTilesItem[] | null
-    use_template?: string
-    /** @nullable */
-    use_dashboard?: number | null
-    delete_insights?: boolean
-    _create_in_folder?: string
-}
-
-export interface PaginatedExportedAssetListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ExportedAssetApi[]
-}
-
-/**
- * @nullable
- */
-export type ExportedAssetApiExportContext = unknown | null
-
-/**
- * Standard ExportedAsset serializer that doesn't return content.
- */
-export interface ExportedAssetApi {
-    readonly id: number
-    /** @nullable */
-    dashboard?: number | null
-    /** @nullable */
-    insight?: number | null
-    export_format: ExportFormatEnumApi
-    readonly created_at: string
-    readonly has_content: string
-    /** @nullable */
-    export_context?: ExportedAssetApiExportContext
-    readonly filename: string
-    /** @nullable */
-    readonly expires_after: string | null
-    /** @nullable */
-    readonly exception: string | null
-}
-
-export interface PaginatedFileSystemListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: FileSystemApi[]
-}
-
-/**
- * @nullable
- */
-export type FileSystemApiMeta = unknown | null
-
-export interface FileSystemApi {
-    readonly id: string
-    path: string
-    /** @nullable */
-    readonly depth: number | null
-    /** @maxLength 100 */
-    type?: string
-    /**
-     * @maxLength 100
-     * @nullable
-     */
-    ref?: string | null
-    /** @nullable */
-    href?: string | null
-    /** @nullable */
-    meta?: FileSystemApiMeta
-    /** @nullable */
-    shortcut?: boolean | null
-    readonly created_at: string
-    /** @nullable */
-    readonly last_viewed_at: string | null
-}
-
-/**
- * @nullable
- */
-export type PatchedFileSystemApiMeta = unknown | null
-
-export interface PatchedFileSystemApi {
-    readonly id?: string
-    path?: string
-    /** @nullable */
-    readonly depth?: number | null
-    /** @maxLength 100 */
-    type?: string
-    /**
-     * @maxLength 100
-     * @nullable
-     */
-    ref?: string | null
-    /** @nullable */
-    href?: string | null
-    /** @nullable */
-    meta?: PatchedFileSystemApiMeta
-    /** @nullable */
-    shortcut?: boolean | null
-    readonly created_at?: string
-    /** @nullable */
-    readonly last_viewed_at?: string | null
-}
-
-export interface PaginatedGroupListApi {
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: GroupApi[]
-}
-
-/**
- * @nullable
- */
-export type CreateGroupApiGroupProperties = unknown | null
-
-export interface CreateGroupApi {
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     */
-    group_type_index: number
-    /** @maxLength 400 */
-    group_key: string
-    /** @nullable */
-    group_properties?: CreateGroupApiGroupProperties
-}
-
-export interface GroupApi {
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     */
-    group_type_index: number
-    /** @maxLength 400 */
-    group_key: string
-    group_properties?: unknown
-    readonly created_at: string
-}
-
-export interface PaginatedIntegrationListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: IntegrationApi[]
-}
-
-/**
- * Standard Integration serializer.
- */
-export interface IntegrationApi {
-    readonly id: number
-    kind: KindEnumApi
-    config?: unknown
-    readonly created_at: string
-    readonly created_by: UserBasicApi
-    readonly errors: string
-    readonly display_name: string
-}
-
-export interface PaginatedSubscriptionListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: SubscriptionApi[]
-}
-
-/**
- * Standard Subscription serializer.
- */
-export interface SubscriptionApi {
-    readonly id: number
-    /** @nullable */
-    dashboard?: number | null
-    /** @nullable */
-    insight?: number | null
-    target_type: TargetTypeEnumApi
-    target_value: string
-    frequency: FrequencyEnumApi
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     */
-    interval?: number
-    /** @nullable */
-    byweekday?: ByweekdayEnumApi[] | null
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     * @nullable
-     */
-    bysetpos?: number | null
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     * @nullable
-     */
-    count?: number | null
-    start_date: string
-    /** @nullable */
-    until_date?: string | null
-    readonly created_at: string
-    readonly created_by: UserBasicApi
-    deleted?: boolean
-    /**
-     * @maxLength 100
-     * @nullable
-     */
-    title?: string | null
-    readonly summary: string
-    /** @nullable */
-    readonly next_delivery_date: string | null
-    /** @nullable */
-    invite_message?: string | null
-}
-
-/**
- * Standard Subscription serializer.
- */
-export interface PatchedSubscriptionApi {
-    readonly id?: number
-    /** @nullable */
-    dashboard?: number | null
-    /** @nullable */
-    insight?: number | null
-    target_type?: TargetTypeEnumApi
-    target_value?: string
-    frequency?: FrequencyEnumApi
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     */
-    interval?: number
-    /** @nullable */
-    byweekday?: ByweekdayEnumApi[] | null
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     * @nullable
-     */
-    bysetpos?: number | null
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     * @nullable
-     */
-    count?: number | null
-    start_date?: string
-    /** @nullable */
-    until_date?: string | null
-    readonly created_at?: string
-    readonly created_by?: UserBasicApi
-    deleted?: boolean
-    /**
-     * @maxLength 100
-     * @nullable
-     */
-    title?: string | null
-    readonly summary?: string
-    /** @nullable */
-    readonly next_delivery_date?: string | null
-    /** @nullable */
-    invite_message?: string | null
-}
-
-export interface PaginatedOrganizationDomainListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: OrganizationDomainApi[]
-}
-
-export interface OrganizationDomainApi {
-    readonly id: string
-    /** @maxLength 128 */
-    domain: string
-    /** Determines whether a domain is verified or not. */
-    readonly is_verified: boolean
-    /** @nullable */
-    readonly verified_at: string | null
-    readonly verification_challenge: string
-    jit_provisioning_enabled?: boolean
-    /** @maxLength 28 */
-    sso_enforcement?: string
-    /** Returns whether SAML is configured for the instance. Does not validate the user has the required license (that check is performed in other places). */
-    readonly has_saml: boolean
-    /**
-     * @maxLength 512
-     * @nullable
-     */
-    saml_entity_id?: string | null
-    /**
-     * @maxLength 512
-     * @nullable
-     */
-    saml_acs_url?: string | null
-    /** @nullable */
-    saml_x509_cert?: string | null
-    /** Returns whether SCIM is configured and enabled for this domain. */
-    readonly has_scim: boolean
-    scim_enabled?: boolean
-    /** @nullable */
-    readonly scim_base_url: string | null
-    /** @nullable */
-    readonly scim_bearer_token: string | null
-}
-
-export interface PatchedOrganizationDomainApi {
-    readonly id?: string
-    /** @maxLength 128 */
-    domain?: string
-    /** Determines whether a domain is verified or not. */
-    readonly is_verified?: boolean
-    /** @nullable */
-    readonly verified_at?: string | null
-    readonly verification_challenge?: string
-    jit_provisioning_enabled?: boolean
-    /** @maxLength 28 */
-    sso_enforcement?: string
-    /** Returns whether SAML is configured for the instance. Does not validate the user has the required license (that check is performed in other places). */
-    readonly has_saml?: boolean
-    /**
-     * @maxLength 512
-     * @nullable
-     */
-    saml_entity_id?: string | null
-    /**
-     * @maxLength 512
-     * @nullable
-     */
-    saml_acs_url?: string | null
-    /** @nullable */
-    saml_x509_cert?: string | null
-    /** Returns whether SCIM is configured and enabled for this domain. */
-    readonly has_scim?: boolean
-    scim_enabled?: boolean
-    /** @nullable */
-    readonly scim_base_url?: string | null
-    /** @nullable */
-    readonly scim_bearer_token?: string | null
-}
-
-export interface PaginatedOrganizationInviteListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: OrganizationInviteApi[]
-}
-
-/**
- * List of team IDs and corresponding access levels to private projects.
- * @nullable
- */
-export type OrganizationInviteApiPrivateProjectAccess = unknown | null
-
-export interface OrganizationInviteApi {
-    readonly id: string
-    /** @maxLength 254 */
-    target_email: string
-    /** @maxLength 30 */
-    first_name?: string
-    readonly emailing_attempt_made: boolean
-    /**
-     * @minimum 0
-     * @maximum 32767
-     */
-    level?: OrganizationMembershipLevelApi
-    /** Check if invite is older than INVITE_DAYS_VALIDITY days. */
-    readonly is_expired: boolean
-    readonly created_by: UserBasicApi
-    readonly created_at: string
-    readonly updated_at: string
-    /** @nullable */
-    message?: string | null
-    /**
-     * List of team IDs and corresponding access levels to private projects.
-     * @nullable
-     */
-    private_project_access?: OrganizationInviteApiPrivateProjectAccess
-    send_email?: boolean
-    combine_pending_invites?: boolean
-}
-
-export interface PaginatedOrganizationMemberListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: OrganizationMemberApi[]
-}
-
-export interface OrganizationMemberApi {
-    readonly id: string
-    readonly user: UserBasicApi
-    /**
-     * @minimum 0
-     * @maximum 32767
-     */
-    level?: OrganizationMembershipLevelApi
-    readonly joined_at: string
-    readonly updated_at: string
-    readonly is_2fa_enabled: boolean
-    readonly has_social_auth: boolean
-    readonly last_login: string
-}
-
-export interface PatchedOrganizationMemberApi {
-    readonly id?: string
-    readonly user?: UserBasicApi
-    /**
-     * @minimum 0
-     * @maximum 32767
-     */
-    level?: OrganizationMembershipLevelApi
-    readonly joined_at?: string
-    readonly updated_at?: string
-    readonly is_2fa_enabled?: boolean
-    readonly has_social_auth?: boolean
-    readonly last_login?: string
-}
-
-export interface PaginatedProjectBackwardCompatBasicListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ProjectBackwardCompatBasicApi[]
-}
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiEffectiveMembershipLevel = EffectiveMembershipLevelEnumApi | null
-
-export type ProjectBackwardCompatApiGroupTypesItem = { [key: string]: unknown }
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiPathCleaningFilters = unknown | null
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiCorrelationConfig = unknown | null
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiAutocaptureWebVitalsAllowedMetrics = unknown | null
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiAutocaptureExceptionsErrorsToIgnore = unknown | null
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiSessionRecordingLinkedFlag = unknown | null
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiSessionRecordingNetworkPayloadCaptureConfig = unknown | null
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiSessionRecordingMaskingConfig = unknown | null
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiSessionReplayConfig = unknown | null
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiSurveyConfig = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ProjectBackwardCompatApiWeekStartDay = { ...WeekStartDayEnumApi, ...NullEnumApi } as const
-/**
- * @minimum -32768
- * @maximum 32767
- * @nullable
- */
-export type ProjectBackwardCompatApiWeekStartDay =
-    | (typeof ProjectBackwardCompatApiWeekStartDay)[keyof typeof ProjectBackwardCompatApiWeekStartDay]
-    | null
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiExtraSettings = unknown | null
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiModifiers = unknown | null
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatApiHasCompletedOnboardingFor = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ProjectBackwardCompatApiBusinessModel = {
-    ...BusinessModelEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * Whether this project serves B2B or B2C customers, used to optimize the UI layout.
-
-* `b2b` - B2B
-* `b2c` - B2C
-* `other` - Other
- * @nullable
- */
-export type ProjectBackwardCompatApiBusinessModel =
-    | (typeof ProjectBackwardCompatApiBusinessModel)[keyof typeof ProjectBackwardCompatApiBusinessModel]
-    | null
-
-/**
- * Like `ProjectBasicSerializer`, but also works as a drop-in replacement for `TeamBasicSerializer` by way of
-passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
-backward compatibility of the REST API.
-Do not use this in greenfield endpoints!
- */
-export interface ProjectBackwardCompatApi {
-    readonly id: number
-    readonly organization: string
-    /**
-     * @minLength 1
-     * @maxLength 200
-     */
-    name?: string
-    /**
-     * @maxLength 1000
-     * @nullable
-     */
-    product_description?: string | null
-    readonly created_at: string
-    /** @nullable */
-    readonly effective_membership_level: ProjectBackwardCompatApiEffectiveMembershipLevel
-    readonly has_group_types: boolean
-    readonly group_types: readonly ProjectBackwardCompatApiGroupTypesItem[]
-    /** @nullable */
-    readonly live_events_token: string | null
-    readonly updated_at: string
-    readonly uuid: string
-    readonly api_token: string
-    app_urls?: (string | null)[]
-    /**
-     * @maxLength 500
-     * @nullable
-     */
-    slack_incoming_webhook?: string | null
-    anonymize_ips?: boolean
-    completed_snippet_onboarding?: boolean
-    readonly ingested_event: boolean
-    test_account_filters?: unknown
-    /** @nullable */
-    test_account_filters_default_checked?: boolean | null
-    /** @nullable */
-    path_cleaning_filters?: ProjectBackwardCompatApiPathCleaningFilters
-    is_demo?: boolean
-    timezone?: TimezoneEnumApi
-    data_attributes?: unknown
-    /** @nullable */
-    person_display_name_properties?: string[] | null
-    /** @nullable */
-    correlation_config?: ProjectBackwardCompatApiCorrelationConfig
-    /** @nullable */
-    autocapture_opt_out?: boolean | null
-    /** @nullable */
-    autocapture_exceptions_opt_in?: boolean | null
-    /** @nullable */
-    autocapture_web_vitals_opt_in?: boolean | null
-    /** @nullable */
-    autocapture_web_vitals_allowed_metrics?: ProjectBackwardCompatApiAutocaptureWebVitalsAllowedMetrics
-    /** @nullable */
-    autocapture_exceptions_errors_to_ignore?: ProjectBackwardCompatApiAutocaptureExceptionsErrorsToIgnore
-    /** @nullable */
-    capture_console_log_opt_in?: boolean | null
-    /** @nullable */
-    capture_performance_opt_in?: boolean | null
-    session_recording_opt_in?: boolean
-    /**
-     * @nullable
-     * @pattern ^-?\d{0,1}(?:\.\d{0,2})?$
-     */
-    session_recording_sample_rate?: string | null
-    /**
-     * @minimum 0
-     * @maximum 30000
-     * @nullable
-     */
-    session_recording_minimum_duration_milliseconds?: number | null
-    /** @nullable */
-    session_recording_linked_flag?: ProjectBackwardCompatApiSessionRecordingLinkedFlag
-    /** @nullable */
-    session_recording_network_payload_capture_config?: ProjectBackwardCompatApiSessionRecordingNetworkPayloadCaptureConfig
-    /** @nullable */
-    session_recording_masking_config?: ProjectBackwardCompatApiSessionRecordingMaskingConfig
-    /** @nullable */
-    session_replay_config?: ProjectBackwardCompatApiSessionReplayConfig
-    /** @nullable */
-    survey_config?: ProjectBackwardCompatApiSurveyConfig
-    access_control?: boolean
-    /**
-     * @minimum -32768
-     * @maximum 32767
-     * @nullable
-     */
-    week_start_day?: ProjectBackwardCompatApiWeekStartDay
-    /** @nullable */
-    primary_dashboard?: number | null
-    /** @nullable */
-    live_events_columns?: string[] | null
-    /** @nullable */
-    recording_domains?: (string | null)[] | null
-    readonly person_on_events_querying_enabled: string
-    /** @nullable */
-    inject_web_apps?: boolean | null
-    /** @nullable */
-    extra_settings?: ProjectBackwardCompatApiExtraSettings
-    /** @nullable */
-    modifiers?: ProjectBackwardCompatApiModifiers
-    readonly default_modifiers: string
-    /** @nullable */
-    has_completed_onboarding_for?: ProjectBackwardCompatApiHasCompletedOnboardingFor
-    /** @nullable */
-    surveys_opt_in?: boolean | null
-    /** @nullable */
-    heatmaps_opt_in?: boolean | null
-    readonly product_intents: string
-    /** @nullable */
-    flags_persistence_default?: boolean | null
-    /** @nullable */
-    readonly secret_api_token: string | null
-    /** @nullable */
-    readonly secret_api_token_backup: string | null
-    /** @nullable */
-    receive_org_level_activity_logs?: boolean | null
-    /**
-   * Whether this project serves B2B or B2C customers, used to optimize the UI layout.
-
-* `b2b` - B2B
-* `b2c` - B2C
-* `other` - Other
-   * @nullable
-   */
-    business_model?: ProjectBackwardCompatApiBusinessModel
-}
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiEffectiveMembershipLevel = EffectiveMembershipLevelEnumApi | null
-
-export type PatchedProjectBackwardCompatApiGroupTypesItem = { [key: string]: unknown }
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiPathCleaningFilters = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiCorrelationConfig = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiAutocaptureWebVitalsAllowedMetrics = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiAutocaptureExceptionsErrorsToIgnore = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiSessionRecordingLinkedFlag = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiSessionRecordingNetworkPayloadCaptureConfig = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiSessionRecordingMaskingConfig = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiSessionReplayConfig = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiSurveyConfig = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedProjectBackwardCompatApiWeekStartDay = { ...WeekStartDayEnumApi, ...NullEnumApi } as const
-/**
- * @minimum -32768
- * @maximum 32767
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiWeekStartDay =
-    | (typeof PatchedProjectBackwardCompatApiWeekStartDay)[keyof typeof PatchedProjectBackwardCompatApiWeekStartDay]
-    | null
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiExtraSettings = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiModifiers = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiHasCompletedOnboardingFor = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedProjectBackwardCompatApiBusinessModel = {
-    ...BusinessModelEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * Whether this project serves B2B or B2C customers, used to optimize the UI layout.
-
-* `b2b` - B2B
-* `b2c` - B2C
-* `other` - Other
- * @nullable
- */
-export type PatchedProjectBackwardCompatApiBusinessModel =
-    | (typeof PatchedProjectBackwardCompatApiBusinessModel)[keyof typeof PatchedProjectBackwardCompatApiBusinessModel]
-    | null
-
-/**
- * Like `ProjectBasicSerializer`, but also works as a drop-in replacement for `TeamBasicSerializer` by way of
-passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
-backward compatibility of the REST API.
-Do not use this in greenfield endpoints!
- */
-export interface PatchedProjectBackwardCompatApi {
-    readonly id?: number
-    readonly organization?: string
-    /**
-     * @minLength 1
-     * @maxLength 200
-     */
-    name?: string
-    /**
-     * @maxLength 1000
-     * @nullable
-     */
-    product_description?: string | null
-    readonly created_at?: string
-    /** @nullable */
-    readonly effective_membership_level?: PatchedProjectBackwardCompatApiEffectiveMembershipLevel
-    readonly has_group_types?: boolean
-    readonly group_types?: readonly PatchedProjectBackwardCompatApiGroupTypesItem[]
-    /** @nullable */
-    readonly live_events_token?: string | null
-    readonly updated_at?: string
-    readonly uuid?: string
-    readonly api_token?: string
-    app_urls?: (string | null)[]
-    /**
-     * @maxLength 500
-     * @nullable
-     */
-    slack_incoming_webhook?: string | null
-    anonymize_ips?: boolean
-    completed_snippet_onboarding?: boolean
-    readonly ingested_event?: boolean
-    test_account_filters?: unknown
-    /** @nullable */
-    test_account_filters_default_checked?: boolean | null
-    /** @nullable */
-    path_cleaning_filters?: PatchedProjectBackwardCompatApiPathCleaningFilters
-    is_demo?: boolean
-    timezone?: TimezoneEnumApi
-    data_attributes?: unknown
-    /** @nullable */
-    person_display_name_properties?: string[] | null
-    /** @nullable */
-    correlation_config?: PatchedProjectBackwardCompatApiCorrelationConfig
-    /** @nullable */
-    autocapture_opt_out?: boolean | null
-    /** @nullable */
-    autocapture_exceptions_opt_in?: boolean | null
-    /** @nullable */
-    autocapture_web_vitals_opt_in?: boolean | null
-    /** @nullable */
-    autocapture_web_vitals_allowed_metrics?: PatchedProjectBackwardCompatApiAutocaptureWebVitalsAllowedMetrics
-    /** @nullable */
-    autocapture_exceptions_errors_to_ignore?: PatchedProjectBackwardCompatApiAutocaptureExceptionsErrorsToIgnore
-    /** @nullable */
-    capture_console_log_opt_in?: boolean | null
-    /** @nullable */
-    capture_performance_opt_in?: boolean | null
-    session_recording_opt_in?: boolean
-    /**
-     * @nullable
-     * @pattern ^-?\d{0,1}(?:\.\d{0,2})?$
-     */
-    session_recording_sample_rate?: string | null
-    /**
-     * @minimum 0
-     * @maximum 30000
-     * @nullable
-     */
-    session_recording_minimum_duration_milliseconds?: number | null
-    /** @nullable */
-    session_recording_linked_flag?: PatchedProjectBackwardCompatApiSessionRecordingLinkedFlag
-    /** @nullable */
-    session_recording_network_payload_capture_config?: PatchedProjectBackwardCompatApiSessionRecordingNetworkPayloadCaptureConfig
-    /** @nullable */
-    session_recording_masking_config?: PatchedProjectBackwardCompatApiSessionRecordingMaskingConfig
-    /** @nullable */
-    session_replay_config?: PatchedProjectBackwardCompatApiSessionReplayConfig
-    /** @nullable */
-    survey_config?: PatchedProjectBackwardCompatApiSurveyConfig
-    access_control?: boolean
-    /**
-     * @minimum -32768
-     * @maximum 32767
-     * @nullable
-     */
-    week_start_day?: PatchedProjectBackwardCompatApiWeekStartDay
-    /** @nullable */
-    primary_dashboard?: number | null
-    /** @nullable */
-    live_events_columns?: string[] | null
-    /** @nullable */
-    recording_domains?: (string | null)[] | null
-    readonly person_on_events_querying_enabled?: string
-    /** @nullable */
-    inject_web_apps?: boolean | null
-    /** @nullable */
-    extra_settings?: PatchedProjectBackwardCompatApiExtraSettings
-    /** @nullable */
-    modifiers?: PatchedProjectBackwardCompatApiModifiers
-    readonly default_modifiers?: string
-    /** @nullable */
-    has_completed_onboarding_for?: PatchedProjectBackwardCompatApiHasCompletedOnboardingFor
-    /** @nullable */
-    surveys_opt_in?: boolean | null
-    /** @nullable */
-    heatmaps_opt_in?: boolean | null
-    readonly product_intents?: string
-    /** @nullable */
-    flags_persistence_default?: boolean | null
-    /** @nullable */
-    readonly secret_api_token?: string | null
-    /** @nullable */
-    readonly secret_api_token_backup?: string | null
-    /** @nullable */
-    receive_org_level_activity_logs?: boolean | null
-    /**
-   * Whether this project serves B2B or B2C customers, used to optimize the UI layout.
-
-* `b2b` - B2B
-* `b2c` - B2C
-* `other` - Other
-   * @nullable
-   */
-    business_model?: PatchedProjectBackwardCompatApiBusinessModel
-}
-
-export interface PaginatedRoleListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: RoleApi[]
-}
-
-export interface RoleApi {
-    readonly id: string
-    /** @maxLength 200 */
-    name: string
-    readonly created_at: string
-    readonly created_by: UserBasicApi
-    readonly members: string
-    readonly is_default: string
-}
-
-export interface PatchedRoleApi {
-    readonly id?: string
-    /** @maxLength 200 */
-    name?: string
-    readonly created_at?: string
-    readonly created_by?: UserBasicApi
-    readonly members?: string
-    readonly is_default?: string
-}
-
-export interface PaginatedAnnotationListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: AnnotationApi[]
-}
-
 export interface AnnotationApi {
     readonly id: number
     /**
@@ -2808,6 +2498,15 @@ export interface AnnotationApi {
     readonly updated_at: string
     deleted?: boolean
     scope?: AnnotationScopeEnumApi
+}
+
+export interface PaginatedAnnotationListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: AnnotationApi[]
 }
 
 export interface PatchedAnnotationApi {
@@ -2840,80 +2539,24 @@ export interface PatchedAnnotationApi {
     scope?: AnnotationScopeEnumApi
 }
 
-export interface PaginatedCohortListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: CohortApi[]
-}
-
 /**
- * Filters for the cohort. Examples:
-
-        # Behavioral filter (performed event)
-        {
-            "properties": {
-                "type": "OR",
-                "values": [{
-                    "type": "OR",
-                    "values": [{
-                        "key": "address page viewed",
-                        "type": "behavioral",
-                        "value": "performed_event",
-                        "negation": false,
-                        "event_type": "events",
-                        "time_value": "30",
-                        "time_interval": "day"
-                    }]
-                }]
-            }
-        }
-
-        # Person property filter
-        {
-            "properties": {
-                "type": "OR",
-                "values": [{
-                    "type": "AND",
-                    "values": [{
-                        "key": "promoCodes",
-                        "type": "person",
-                        "value": ["1234567890"],
-                        "negation": false,
-                        "operator": "exact"
-                    }]
-                }]
-            }
-        }
-
-        # Cohort filter
-        {
-            "properties": {
-                "type": "OR",
-                "values": [{
-                    "type": "AND",
-                    "values": [{
-                        "key": "id",
-                        "type": "cohort",
-                        "value": 8814,
-                        "negation": false
-                    }]
-                }]
-            }
-        }
- * @nullable
+ * * `static` - static
+ * `person_property` - person_property
+ * `behavioral` - behavioral
+ * `realtime` - realtime
+ * `analytical` - analytical
  */
-export type CohortApiFilters = unknown | null
-
-/**
- * @nullable
- */
-export type CohortApiQuery = unknown | null
+export type CohortTypeEnumApi = (typeof CohortTypeEnumApi)[keyof typeof CohortTypeEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const CohortApiCohortType = { ...CohortTypeEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
+export const CohortTypeEnumApi = {
+    static: 'static',
+    person_property: 'person_property',
+    behavioral: 'behavioral',
+    realtime: 'realtime',
+    analytical: 'analytical',
+} as const
+
 /**
  * Type of cohort based on filter complexity
 
@@ -2922,9 +2565,8 @@ export const CohortApiCohortType = { ...CohortTypeEnumApi, ...BlankEnumApi, ...N
 * `behavioral` - behavioral
 * `realtime` - realtime
 * `analytical` - analytical
- * @nullable
  */
-export type CohortApiCohortType = (typeof CohortApiCohortType)[keyof typeof CohortApiCohortType] | null
+export type CohortApiCohortType = CohortTypeEnumApi | BlankEnumApi | NullEnumApi
 
 export interface CohortApi {
     readonly id: number
@@ -2937,8 +2579,7 @@ export interface CohortApi {
     description?: string
     groups?: unknown
     deleted?: boolean
-    /**
-   * Filters for the cohort. Examples:
+    /** Filters for the cohort. Examples:
 
         # Behavioral filter (performed event)
         {
@@ -2990,12 +2631,9 @@ export interface CohortApi {
                     }]
                 }]
             }
-        }
-   * @nullable
-   */
-    filters?: CohortApiFilters
-    /** @nullable */
-    query?: CohortApiQuery
+        } */
+    filters?: unknown
+    query?: unknown
     readonly is_calculating: boolean
     readonly created_by: UserBasicApi
     /** @nullable */
@@ -3008,87 +2646,28 @@ export interface CohortApi {
     /** @nullable */
     readonly count: number | null
     is_static?: boolean
-    /**
-   * Type of cohort based on filter complexity
+    /** Type of cohort based on filter complexity
 
 * `static` - static
 * `person_property` - person_property
 * `behavioral` - behavioral
 * `realtime` - realtime
-* `analytical` - analytical
-   * @nullable
-   */
+* `analytical` - analytical */
     cohort_type?: CohortApiCohortType
     readonly experiment_set: readonly number[]
     _create_in_folder?: string
     _create_static_person_ids?: string[]
 }
 
-/**
- * Filters for the cohort. Examples:
+export interface PaginatedCohortListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: CohortApi[]
+}
 
-        # Behavioral filter (performed event)
-        {
-            "properties": {
-                "type": "OR",
-                "values": [{
-                    "type": "OR",
-                    "values": [{
-                        "key": "address page viewed",
-                        "type": "behavioral",
-                        "value": "performed_event",
-                        "negation": false,
-                        "event_type": "events",
-                        "time_value": "30",
-                        "time_interval": "day"
-                    }]
-                }]
-            }
-        }
-
-        # Person property filter
-        {
-            "properties": {
-                "type": "OR",
-                "values": [{
-                    "type": "AND",
-                    "values": [{
-                        "key": "promoCodes",
-                        "type": "person",
-                        "value": ["1234567890"],
-                        "negation": false,
-                        "operator": "exact"
-                    }]
-                }]
-            }
-        }
-
-        # Cohort filter
-        {
-            "properties": {
-                "type": "OR",
-                "values": [{
-                    "type": "AND",
-                    "values": [{
-                        "key": "id",
-                        "type": "cohort",
-                        "value": 8814,
-                        "negation": false
-                    }]
-                }]
-            }
-        }
- * @nullable
- */
-export type PatchedCohortApiFilters = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedCohortApiQuery = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedCohortApiCohortType = { ...CohortTypeEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
 /**
  * Type of cohort based on filter complexity
 
@@ -3097,11 +2676,8 @@ export const PatchedCohortApiCohortType = { ...CohortTypeEnumApi, ...BlankEnumAp
 * `behavioral` - behavioral
 * `realtime` - realtime
 * `analytical` - analytical
- * @nullable
  */
-export type PatchedCohortApiCohortType =
-    | (typeof PatchedCohortApiCohortType)[keyof typeof PatchedCohortApiCohortType]
-    | null
+export type PatchedCohortApiCohortType = CohortTypeEnumApi | BlankEnumApi | NullEnumApi
 
 export interface PatchedCohortApi {
     readonly id?: number
@@ -3114,8 +2690,7 @@ export interface PatchedCohortApi {
     description?: string
     groups?: unknown
     deleted?: boolean
-    /**
-   * Filters for the cohort. Examples:
+    /** Filters for the cohort. Examples:
 
         # Behavioral filter (performed event)
         {
@@ -3167,12 +2742,9 @@ export interface PatchedCohortApi {
                     }]
                 }]
             }
-        }
-   * @nullable
-   */
-    filters?: PatchedCohortApiFilters
-    /** @nullable */
-    query?: PatchedCohortApiQuery
+        } */
+    filters?: unknown
+    query?: unknown
     readonly is_calculating?: boolean
     readonly created_by?: UserBasicApi
     /** @nullable */
@@ -3185,16 +2757,13 @@ export interface PatchedCohortApi {
     /** @nullable */
     readonly count?: number | null
     is_static?: boolean
-    /**
-   * Type of cohort based on filter complexity
+    /** Type of cohort based on filter complexity
 
 * `static` - static
 * `person_property` - person_property
 * `behavioral` - behavioral
 * `realtime` - realtime
-* `analytical` - analytical
-   * @nullable
-   */
+* `analytical` - analytical */
     cohort_type?: PatchedCohortApiCohortType
     readonly experiment_set?: readonly number[]
     _create_in_folder?: string
@@ -3211,24 +2780,6 @@ export interface PatchedRemovePersonRequestApi {
     person_id?: string
 }
 
-export interface PaginatedCommentListApi {
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: CommentApi[]
-}
-
-/**
- * @nullable
- */
-export type CommentApiRichContent = unknown | null
-
-/**
- * @nullable
- */
-export type CommentApiItemContext = unknown | null
-
 export interface CommentApi {
     readonly id: string
     readonly created_by: UserBasicApi
@@ -3238,8 +2789,7 @@ export interface CommentApi {
     slug?: string
     /** @nullable */
     content?: string | null
-    /** @nullable */
-    rich_content?: CommentApiRichContent
+    rich_content?: unknown
     readonly version: number
     readonly created_at: string
     /**
@@ -3247,23 +2797,20 @@ export interface CommentApi {
      * @nullable
      */
     item_id?: string | null
-    /** @nullable */
-    item_context?: CommentApiItemContext
+    item_context?: unknown
     /** @maxLength 79 */
     scope: string
     /** @nullable */
     source_comment?: string | null
 }
 
-/**
- * @nullable
- */
-export type PatchedCommentApiRichContent = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedCommentApiItemContext = unknown | null
+export interface PaginatedCommentListApi {
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: CommentApi[]
+}
 
 export interface PatchedCommentApi {
     readonly id?: string
@@ -3274,8 +2821,7 @@ export interface PatchedCommentApi {
     slug?: string
     /** @nullable */
     content?: string | null
-    /** @nullable */
-    rich_content?: PatchedCommentApiRichContent
+    rich_content?: unknown
     readonly version?: number
     readonly created_at?: string
     /**
@@ -3283,46 +2829,29 @@ export interface PatchedCommentApi {
      * @nullable
      */
     item_id?: string | null
-    /** @nullable */
-    item_context?: PatchedCommentApiItemContext
+    item_context?: unknown
     /** @maxLength 79 */
     scope?: string
     /** @nullable */
     source_comment?: string | null
 }
 
-export interface PaginatedDashboardTemplateListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: DashboardTemplateApi[]
-}
-
 /**
- * @nullable
+ * * `team` - Only team
+ * `global` - Global
+ * `feature_flag` - Feature Flag
  */
-export type DashboardTemplateApiDashboardFilters = unknown | null
-
-/**
- * @nullable
- */
-export type DashboardTemplateApiTiles = unknown | null
-
-/**
- * @nullable
- */
-export type DashboardTemplateApiVariables = unknown | null
+export type DashboardTemplateScopeEnumApi =
+    (typeof DashboardTemplateScopeEnumApi)[keyof typeof DashboardTemplateScopeEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DashboardTemplateApiScope = { ...DashboardTemplateScopeEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type DashboardTemplateApiScope =
-    | (typeof DashboardTemplateApiScope)[keyof typeof DashboardTemplateApiScope]
-    | null
+export const DashboardTemplateScopeEnumApi = {
+    team: 'team',
+    global: 'global',
+    feature_flag: 'feature_flag',
+} as const
+
+export type DashboardTemplateApiScope = DashboardTemplateScopeEnumApi | BlankEnumApi | NullEnumApi
 
 export interface DashboardTemplateApi {
     readonly id: string
@@ -3336,14 +2865,11 @@ export interface DashboardTemplateApi {
      * @nullable
      */
     dashboard_description?: string | null
-    /** @nullable */
-    dashboard_filters?: DashboardTemplateApiDashboardFilters
+    dashboard_filters?: unknown
     /** @nullable */
     tags?: string[] | null
-    /** @nullable */
-    tiles?: DashboardTemplateApiTiles
-    /** @nullable */
-    variables?: DashboardTemplateApiVariables
+    tiles?: unknown
+    variables?: unknown
     /** @nullable */
     deleted?: boolean | null
     /** @nullable */
@@ -3357,39 +2883,21 @@ export interface DashboardTemplateApi {
     image_url?: string | null
     /** @nullable */
     readonly team_id: number | null
-    /** @nullable */
     scope?: DashboardTemplateApiScope
     /** @nullable */
     availability_contexts?: string[] | null
 }
 
-/**
- * @nullable
- */
-export type PatchedDashboardTemplateApiDashboardFilters = unknown | null
+export interface PaginatedDashboardTemplateListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: DashboardTemplateApi[]
+}
 
-/**
- * @nullable
- */
-export type PatchedDashboardTemplateApiTiles = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedDashboardTemplateApiVariables = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedDashboardTemplateApiScope = {
-    ...DashboardTemplateScopeEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * @nullable
- */
-export type PatchedDashboardTemplateApiScope =
-    | (typeof PatchedDashboardTemplateApiScope)[keyof typeof PatchedDashboardTemplateApiScope]
-    | null
+export type PatchedDashboardTemplateApiScope = DashboardTemplateScopeEnumApi | BlankEnumApi | NullEnumApi
 
 export interface PatchedDashboardTemplateApi {
     readonly id?: string
@@ -3403,14 +2911,11 @@ export interface PatchedDashboardTemplateApi {
      * @nullable
      */
     dashboard_description?: string | null
-    /** @nullable */
-    dashboard_filters?: PatchedDashboardTemplateApiDashboardFilters
+    dashboard_filters?: unknown
     /** @nullable */
     tags?: string[] | null
-    /** @nullable */
-    tiles?: PatchedDashboardTemplateApiTiles
-    /** @nullable */
-    variables?: PatchedDashboardTemplateApiVariables
+    tiles?: unknown
+    variables?: unknown
     /** @nullable */
     deleted?: boolean | null
     /** @nullable */
@@ -3424,10 +2929,53 @@ export interface PatchedDashboardTemplateApi {
     image_url?: string | null
     /** @nullable */
     readonly team_id?: number | null
-    /** @nullable */
     scope?: PatchedDashboardTemplateApiScope
     /** @nullable */
     availability_contexts?: string[] | null
+}
+
+/**
+ * * `DateTime` - DateTime
+ * `String` - String
+ * `Numeric` - Numeric
+ * `Boolean` - Boolean
+ * `Duration` - Duration
+ */
+export type PropertyType549EnumApi = (typeof PropertyType549EnumApi)[keyof typeof PropertyType549EnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PropertyType549EnumApi = {
+    DateTime: 'DateTime',
+    String: 'String',
+    Numeric: 'Numeric',
+    Boolean: 'Boolean',
+    Duration: 'Duration',
+} as const
+
+/**
+ * * `1` - event
+ * `2` - person
+ * `3` - group
+ * `4` - session
+ */
+export type PropertyDefinitionTypeEnumApi =
+    (typeof PropertyDefinitionTypeEnumApi)[keyof typeof PropertyDefinitionTypeEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PropertyDefinitionTypeEnumApi = {
+    NUMBER_1: 1,
+    NUMBER_2: 2,
+    NUMBER_3: 3,
+    NUMBER_4: 4,
+} as const
+
+export type PropertyDefinitionApiPropertyType = PropertyType549EnumApi | NullEnumApi
+
+export interface PropertyDefinitionApi {
+    readonly id: string
+    readonly name: string
+    readonly property_type: PropertyDefinitionApiPropertyType
+    readonly type: PropertyDefinitionTypeEnumApi
 }
 
 export interface PaginatedPropertyDefinitionListApi {
@@ -3439,35 +2987,7 @@ export interface PaginatedPropertyDefinitionListApi {
     results: PropertyDefinitionApi[]
 }
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PropertyDefinitionApiPropertyType = { ...PropertyType549EnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type PropertyDefinitionApiPropertyType =
-    | (typeof PropertyDefinitionApiPropertyType)[keyof typeof PropertyDefinitionApiPropertyType]
-    | null
-
-export interface PropertyDefinitionApi {
-    readonly id: string
-    readonly name: string
-    /** @nullable */
-    readonly property_type: PropertyDefinitionApiPropertyType
-    readonly type: PropertyDefinitionTypeEnumApi
-}
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedPropertyDefinitionApiPropertyType = {
-    ...PropertyType549EnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * @nullable
- */
-export type PatchedPropertyDefinitionApiPropertyType =
-    | (typeof PatchedPropertyDefinitionApiPropertyType)[keyof typeof PatchedPropertyDefinitionApiPropertyType]
-    | null
+export type PatchedPropertyDefinitionApiPropertyType = PropertyType549EnumApi | BlankEnumApi | NullEnumApi
 
 /**
  * Serializer mixin that resolves appropriate response for tags depending on license.
@@ -3477,33 +2997,36 @@ export interface PatchedPropertyDefinitionApi {
     /** @maxLength 400 */
     name?: string
     is_numerical?: boolean
-    /** @nullable */
     property_type?: PatchedPropertyDefinitionApiPropertyType
     tags?: unknown[]
     readonly is_seen_on_filtered_events?: string
 }
 
-export interface PaginatedScheduledChangeListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ScheduledChangeApi[]
-}
+/**
+ * * `FeatureFlag` - feature flag
+ */
+export type ModelNameEnumApi = (typeof ModelNameEnumApi)[keyof typeof ModelNameEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ScheduledChangeApiRecurrenceInterval = {
-    ...RecurrenceIntervalEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
+export const ModelNameEnumApi = {
+    FeatureFlag: 'FeatureFlag',
 } as const
+
 /**
- * @nullable
+ * * `daily` - daily
+ * `weekly` - weekly
+ * `monthly` - monthly
  */
-export type ScheduledChangeApiRecurrenceInterval =
-    | (typeof ScheduledChangeApiRecurrenceInterval)[keyof typeof ScheduledChangeApiRecurrenceInterval]
-    | null
+export type RecurrenceIntervalEnumApi = (typeof RecurrenceIntervalEnumApi)[keyof typeof RecurrenceIntervalEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RecurrenceIntervalEnumApi = {
+    daily: 'daily',
+    weekly: 'weekly',
+    monthly: 'monthly',
+} as const
+
+export type ScheduledChangeApiRecurrenceInterval = RecurrenceIntervalEnumApi | BlankEnumApi | NullEnumApi
 
 export interface ScheduledChangeApi {
     readonly id: number
@@ -3524,7 +3047,6 @@ export interface ScheduledChangeApi {
     readonly created_by: UserBasicApi
     readonly updated_at: string
     is_recurring?: boolean
-    /** @nullable */
     recurrence_interval?: ScheduledChangeApiRecurrenceInterval
     /** @nullable */
     readonly last_executed_at: string | null
@@ -3532,18 +3054,16 @@ export interface ScheduledChangeApi {
     end_date?: string | null
 }
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedScheduledChangeApiRecurrenceInterval = {
-    ...RecurrenceIntervalEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * @nullable
- */
-export type PatchedScheduledChangeApiRecurrenceInterval =
-    | (typeof PatchedScheduledChangeApiRecurrenceInterval)[keyof typeof PatchedScheduledChangeApiRecurrenceInterval]
-    | null
+export interface PaginatedScheduledChangeListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ScheduledChangeApi[]
+}
+
+export type PatchedScheduledChangeApiRecurrenceInterval = RecurrenceIntervalEnumApi | BlankEnumApi | NullEnumApi
 
 export interface PatchedScheduledChangeApi {
     readonly id?: number
@@ -3564,7 +3084,6 @@ export interface PatchedScheduledChangeApi {
     readonly created_by?: UserBasicApi
     readonly updated_at?: string
     is_recurring?: boolean
-    /** @nullable */
     recurrence_interval?: PatchedScheduledChangeApiRecurrenceInterval
     /** @nullable */
     readonly last_executed_at?: string | null
@@ -3572,47 +3091,219 @@ export interface PatchedScheduledChangeApi {
     end_date?: string | null
 }
 
-export interface PaginatedUserListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: UserApi[]
+/**
+ * * `disabled` - disabled
+ * `toolbar` - toolbar
+ */
+export type ToolbarModeEnumApi = (typeof ToolbarModeEnumApi)[keyof typeof ToolbarModeEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ToolbarModeEnumApi = {
+    disabled: 'disabled',
+    toolbar: 'toolbar',
+} as const
+
+/**
+ * Serializer for `Team` model with minimal attributes to speeed up loading and transfer times.
+Also used for nested serializers.
+ */
+export interface TeamBasicApi {
+    readonly id: number
+    readonly uuid: string
+    readonly organization: string
+    /**
+     * @minimum -9223372036854776000
+     * @maximum 9223372036854776000
+     */
+    readonly project_id: number
+    readonly api_token: string
+    readonly name: string
+    readonly completed_snippet_onboarding: boolean
+    readonly has_completed_onboarding_for: unknown
+    readonly ingested_event: boolean
+    readonly is_demo: boolean
+    readonly timezone: TimezoneEnumApi
+    readonly access_control: boolean
 }
+
+export type MembershipLevelEnumApi = (typeof MembershipLevelEnumApi)[keyof typeof MembershipLevelEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const MembershipLevelEnumApi = {
+    NUMBER_1: 1,
+    NUMBER_8: 8,
+    NUMBER_15: 15,
+} as const
+
+/**
+ * * `0` - none
+ * `3` - config
+ * `6` - install
+ * `9` - root
+ */
+export type PluginsAccessLevelEnumApi = (typeof PluginsAccessLevelEnumApi)[keyof typeof PluginsAccessLevelEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PluginsAccessLevelEnumApi = {
+    NUMBER_0: 0,
+    NUMBER_3: 3,
+    NUMBER_6: 6,
+    NUMBER_9: 9,
+} as const
+
+/**
+ * * `bayesian` - Bayesian
+ * `frequentist` - Frequentist
+ */
+export type DefaultExperimentStatsMethodEnumApi =
+    (typeof DefaultExperimentStatsMethodEnumApi)[keyof typeof DefaultExperimentStatsMethodEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DefaultExperimentStatsMethodEnumApi = {
+    bayesian: 'bayesian',
+    frequentist: 'frequentist',
+} as const
+
+export type OrganizationApiTeamsItem = { [key: string]: unknown }
+
+export type OrganizationApiProjectsItem = { [key: string]: unknown }
+
+/**
+ * Default statistical method for new experiments in this organization.
+
+* `bayesian` - Bayesian
+* `frequentist` - Frequentist
+ */
+export type OrganizationApiDefaultExperimentStatsMethod =
+    | DefaultExperimentStatsMethodEnumApi
+    | BlankEnumApi
+    | NullEnumApi
+
+export interface OrganizationApi {
+    readonly id: string
+    /** @maxLength 64 */
+    name: string
+    /** @pattern ^[-a-zA-Z0-9_]+$ */
+    readonly slug: string
+    /** @nullable */
+    logo_media_id?: string | null
+    readonly created_at: string
+    readonly updated_at: string
+    readonly membership_level: MembershipLevelEnumApi
+    readonly plugins_access_level: PluginsAccessLevelEnumApi
+    readonly teams: readonly OrganizationApiTeamsItem[]
+    readonly projects: readonly OrganizationApiProjectsItem[]
+    /** @nullable */
+    readonly available_product_features: readonly unknown[] | null
+    is_member_join_email_enabled?: boolean
+    readonly metadata: string
+    /** @nullable */
+    readonly customer_id: string | null
+    /** @nullable */
+    enforce_2fa?: boolean | null
+    /** @nullable */
+    members_can_invite?: boolean | null
+    members_can_use_personal_api_keys?: boolean
+    allow_publicly_shared_resources?: boolean
+    readonly member_count: string
+    /** @nullable */
+    is_ai_data_processing_approved?: boolean | null
+    /** Default statistical method for new experiments in this organization.
+
+* `bayesian` - Bayesian
+* `frequentist` - Frequentist */
+    default_experiment_stats_method?: OrganizationApiDefaultExperimentStatsMethod
+    /** Default setting for 'Discard client IP data' for new projects in this organization. */
+    default_anonymize_ips?: boolean
+    /**
+     * ID of the role to automatically assign to new members joining the organization
+     * @nullable
+     */
+    default_role_id?: string | null
+    /**
+     * Set this to 'No' to temporarily disable an organization.
+     * @nullable
+     */
+    readonly is_active: boolean | null
+    /**
+     * (optional) reason for why the organization has been de-activated. This will be displayed to users on the web app.
+     * @nullable
+     */
+    readonly is_not_active_reason: string | null
+}
+
+/**
+ * Serializer for `Organization` model with minimal attributes to speeed up loading and transfer times.
+Also used for nested serializers.
+ */
+export interface OrganizationBasicApi {
+    readonly id: string
+    /** @maxLength 64 */
+    name: string
+    /**
+     * @maxLength 48
+     * @pattern ^[-a-zA-Z0-9_]+$
+     */
+    slug: string
+    /** @nullable */
+    readonly logo_media_id: string | null
+    readonly membership_level: MembershipLevelEnumApi
+    members_can_use_personal_api_keys?: boolean
+    /**
+     * Set this to 'No' to temporarily disable an organization.
+     * @nullable
+     */
+    is_active?: boolean | null
+    /**
+     * (optional) reason for why the organization has been de-activated. This will be displayed to users on the web app.
+     * @maxLength 200
+     * @nullable
+     */
+    is_not_active_reason?: string | null
+}
+
+export interface ScenePersonalisationBasicApi {
+    /** @maxLength 200 */
+    scene: string
+    /** @nullable */
+    dashboard?: number | null
+}
+
+/**
+ * * `light` - Light
+ * `dark` - Dark
+ * `system` - System
+ */
+export type ThemeModeEnumApi = (typeof ThemeModeEnumApi)[keyof typeof ThemeModeEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ThemeModeEnumApi = {
+    light: 'light',
+    dark: 'dark',
+    system: 'system',
+} as const
+
+/**
+ * * `above` - Above
+ * `below` - Below
+ * `hidden` - Hidden
+ */
+export type ShortcutPositionEnumApi = (typeof ShortcutPositionEnumApi)[keyof typeof ShortcutPositionEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ShortcutPositionEnumApi = {
+    above: 'above',
+    below: 'below',
+    hidden: 'hidden',
+} as const
 
 export type UserApiNotificationSettings = { [key: string]: unknown }
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserApiToolbarMode = { ...ToolbarModeEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserApiToolbarMode = (typeof UserApiToolbarMode)[keyof typeof UserApiToolbarMode] | null
+export type UserApiToolbarMode = ToolbarModeEnumApi | BlankEnumApi | NullEnumApi
 
-/**
- * @nullable
- */
-export type UserApiHasSeenProductIntroFor = unknown | null
+export type UserApiThemeMode = ThemeModeEnumApi | BlankEnumApi | NullEnumApi
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserApiThemeMode = { ...ThemeModeEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserApiThemeMode = (typeof UserApiThemeMode)[keyof typeof UserApiThemeMode] | null
-
-/**
- * @nullable
- */
-export type UserApiHedgehogConfig = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserApiShortcutPosition = { ...ShortcutPositionEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserApiShortcutPosition = (typeof UserApiShortcutPosition)[keyof typeof UserApiShortcutPosition] | null
+export type UserApiShortcutPosition = ShortcutPositionEnumApi | BlankEnumApi | NullEnumApi
 
 export interface UserApi {
     readonly date_joined: string
@@ -3634,7 +3325,6 @@ export interface UserApi {
     anonymize_data?: boolean | null
     /** @nullable */
     allow_impersonation?: boolean | null
-    /** @nullable */
     toolbar_mode?: UserApiToolbarMode
     readonly has_password: boolean
     readonly id: number
@@ -3658,56 +3348,32 @@ export interface UserApi {
     readonly is_2fa_enabled: boolean
     readonly has_social_auth: boolean
     readonly has_sso_enforcement: boolean
-    /** @nullable */
-    has_seen_product_intro_for?: UserApiHasSeenProductIntroFor
+    has_seen_product_intro_for?: unknown
     readonly scene_personalisation: readonly ScenePersonalisationBasicApi[]
-    /** @nullable */
     theme_mode?: UserApiThemeMode
-    /** @nullable */
-    hedgehog_config?: UserApiHedgehogConfig
+    hedgehog_config?: unknown
     /** @nullable */
     allow_sidebar_suggestions?: boolean | null
-    /** @nullable */
     shortcut_position?: UserApiShortcutPosition
     role_at_organization?: RoleAtOrganizationEnumApi
 }
 
+export interface PaginatedUserListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: UserApi[]
+}
+
 export type PatchedUserApiNotificationSettings = { [key: string]: unknown }
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedUserApiToolbarMode = { ...ToolbarModeEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type PatchedUserApiToolbarMode =
-    | (typeof PatchedUserApiToolbarMode)[keyof typeof PatchedUserApiToolbarMode]
-    | null
+export type PatchedUserApiToolbarMode = ToolbarModeEnumApi | BlankEnumApi | NullEnumApi
 
-/**
- * @nullable
- */
-export type PatchedUserApiHasSeenProductIntroFor = unknown | null
+export type PatchedUserApiThemeMode = ThemeModeEnumApi | BlankEnumApi | NullEnumApi
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedUserApiThemeMode = { ...ThemeModeEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type PatchedUserApiThemeMode = (typeof PatchedUserApiThemeMode)[keyof typeof PatchedUserApiThemeMode] | null
-
-/**
- * @nullable
- */
-export type PatchedUserApiHedgehogConfig = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedUserApiShortcutPosition = { ...ShortcutPositionEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type PatchedUserApiShortcutPosition =
-    | (typeof PatchedUserApiShortcutPosition)[keyof typeof PatchedUserApiShortcutPosition]
-    | null
+export type PatchedUserApiShortcutPosition = ShortcutPositionEnumApi | BlankEnumApi | NullEnumApi
 
 export interface PatchedUserApi {
     readonly date_joined?: string
@@ -3729,7 +3395,6 @@ export interface PatchedUserApi {
     anonymize_data?: boolean | null
     /** @nullable */
     allow_impersonation?: boolean | null
-    /** @nullable */
     toolbar_mode?: PatchedUserApiToolbarMode
     readonly has_password?: boolean
     readonly id?: number
@@ -3753,268 +3418,14 @@ export interface PatchedUserApi {
     readonly is_2fa_enabled?: boolean
     readonly has_social_auth?: boolean
     readonly has_sso_enforcement?: boolean
-    /** @nullable */
-    has_seen_product_intro_for?: PatchedUserApiHasSeenProductIntroFor
+    has_seen_product_intro_for?: unknown
     readonly scene_personalisation?: readonly ScenePersonalisationBasicApi[]
-    /** @nullable */
     theme_mode?: PatchedUserApiThemeMode
-    /** @nullable */
-    hedgehog_config?: PatchedUserApiHedgehogConfig
+    hedgehog_config?: unknown
     /** @nullable */
     allow_sidebar_suggestions?: boolean | null
-    /** @nullable */
     shortcut_position?: PatchedUserApiShortcutPosition
     role_at_organization?: RoleAtOrganizationEnumApi
-}
-
-/**
- * Serializer mixin that resolves appropriate response for tags depending on license.
- */
-export interface DashboardBasicApi {
-    readonly id: number
-    /** @nullable */
-    readonly name: string | null
-    readonly description: string
-    readonly pinned: boolean
-    readonly created_at: string
-    readonly created_by: UserBasicApi
-    /** @nullable */
-    readonly last_accessed_at: string | null
-    /** @nullable */
-    readonly last_viewed_at: string | null
-    readonly is_shared: boolean
-    readonly deleted: boolean
-    readonly creation_mode: CreationModeEnumApi
-    tags?: unknown[]
-    readonly restriction_level: DashboardRestrictionLevelApi
-    readonly effective_restriction_level: EffectiveRestrictionLevelEnumApi
-    readonly effective_privilege_level: EffectivePrivilegeLevelEnumApi
-    /**
-     * The effective access level the user has for this object
-     * @nullable
-     */
-    readonly user_access_level: string | null
-    readonly access_control_version: string
-    /** @nullable */
-    readonly last_refresh: string | null
-    readonly team_id: number
-}
-
-/**
- * @nullable
- */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserBasicApiRoleAtOrganization = { ...RoleAtOrganizationEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserBasicApiRoleAtOrganization =
-    | (typeof UserBasicApiRoleAtOrganization)[keyof typeof UserBasicApiRoleAtOrganization]
-    | null
-
-export interface UserBasicApi {
-    readonly id: number
-    readonly uuid: string
-    /**
-     * @maxLength 200
-     * @nullable
-     */
-    distinct_id?: string | null
-    /** @maxLength 150 */
-    first_name?: string
-    /** @maxLength 150 */
-    last_name?: string
-    /** @maxLength 254 */
-    email: string
-    /** @nullable */
-    is_email_verified?: boolean | null
-    /** @nullable */
-    readonly hedgehog_config: UserBasicApiHedgehogConfig
-    /** @nullable */
-    role_at_organization?: UserBasicApiRoleAtOrganization
-}
-
-/**
- * @nullable
- */
-export type ProjectBackwardCompatBasicApiHasCompletedOnboardingFor = unknown | null
-
-/**
- * Like `ProjectBasicSerializer`, but also works as a drop-in replacement for `TeamBasicSerializer` by way of
-passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
-backward compatibility of the REST API.
-Do not use this in greenfield endpoints!
- */
-export interface ProjectBackwardCompatBasicApi {
-    readonly id: number
-    readonly uuid: string
-    readonly organization: string
-    readonly api_token: string
-    readonly name: string
-    readonly completed_snippet_onboarding: boolean
-    /** @nullable */
-    readonly has_completed_onboarding_for: ProjectBackwardCompatBasicApiHasCompletedOnboardingFor
-    readonly ingested_event: boolean
-    readonly is_demo: boolean
-    readonly timezone: TimezoneEnumApi
-    readonly access_control: boolean
-}
-
-/**
- * @nullable
- */
-export type TeamBasicApiHasCompletedOnboardingFor = unknown | null
-
-/**
- * Serializer for `Team` model with minimal attributes to speeed up loading and transfer times.
-Also used for nested serializers.
- */
-export interface TeamBasicApi {
-    readonly id: number
-    readonly uuid: string
-    readonly organization: string
-    /**
-     * @minimum -9223372036854776000
-     * @maximum 9223372036854776000
-     */
-    readonly project_id: number
-    readonly api_token: string
-    readonly name: string
-    readonly completed_snippet_onboarding: boolean
-    /** @nullable */
-    readonly has_completed_onboarding_for: TeamBasicApiHasCompletedOnboardingFor
-    readonly ingested_event: boolean
-    readonly is_demo: boolean
-    readonly timezone: TimezoneEnumApi
-    readonly access_control: boolean
-}
-
-/**
- * @nullable
- */
-export type OrganizationApiMembershipLevel = MembershipLevelEnumApi | null
-
-export type OrganizationApiTeamsItem = { [key: string]: unknown }
-
-export type OrganizationApiProjectsItem = { [key: string]: unknown }
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const OrganizationApiDefaultExperimentStatsMethod = {
-    ...DefaultExperimentStatsMethodEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * Default statistical method for new experiments in this organization.
-
-* `bayesian` - Bayesian
-* `frequentist` - Frequentist
- * @nullable
- */
-export type OrganizationApiDefaultExperimentStatsMethod =
-    | (typeof OrganizationApiDefaultExperimentStatsMethod)[keyof typeof OrganizationApiDefaultExperimentStatsMethod]
-    | null
-
-export interface OrganizationApi {
-    readonly id: string
-    /** @maxLength 64 */
-    name: string
-    /** @pattern ^[-a-zA-Z0-9_]+$ */
-    readonly slug: string
-    /** @nullable */
-    logo_media_id?: string | null
-    readonly created_at: string
-    readonly updated_at: string
-    /** @nullable */
-    readonly membership_level: OrganizationApiMembershipLevel
-    readonly plugins_access_level: PluginsAccessLevelEnumApi
-    readonly teams: readonly OrganizationApiTeamsItem[]
-    readonly projects: readonly OrganizationApiProjectsItem[]
-    /** @nullable */
-    readonly available_product_features: readonly unknown[] | null
-    is_member_join_email_enabled?: boolean
-    readonly metadata: string
-    /** @nullable */
-    readonly customer_id: string | null
-    /** @nullable */
-    enforce_2fa?: boolean | null
-    /** @nullable */
-    members_can_invite?: boolean | null
-    members_can_use_personal_api_keys?: boolean
-    allow_publicly_shared_resources?: boolean
-    readonly member_count: string
-    /** @nullable */
-    is_ai_data_processing_approved?: boolean | null
-    /**
-   * Default statistical method for new experiments in this organization.
-
-* `bayesian` - Bayesian
-* `frequentist` - Frequentist
-   * @nullable
-   */
-    default_experiment_stats_method?: OrganizationApiDefaultExperimentStatsMethod
-    /** Default setting for 'Discard client IP data' for new projects in this organization. */
-    default_anonymize_ips?: boolean
-    /**
-     * ID of the role to automatically assign to new members joining the organization
-     * @nullable
-     */
-    default_role_id?: string | null
-    /**
-     * Set this to 'No' to temporarily disable an organization.
-     * @nullable
-     */
-    readonly is_active: boolean | null
-    /**
-     * (optional) reason for why the organization has been de-activated. This will be displayed to users on the web app.
-     * @nullable
-     */
-    readonly is_not_active_reason: string | null
-}
-
-/**
- * @nullable
- */
-export type OrganizationBasicApiMembershipLevel = MembershipLevelEnumApi | null
-
-/**
- * Serializer for `Organization` model with minimal attributes to speeed up loading and transfer times.
-Also used for nested serializers.
- */
-export interface OrganizationBasicApi {
-    readonly id: string
-    /** @maxLength 64 */
-    name: string
-    /**
-     * @maxLength 48
-     * @pattern ^[-a-zA-Z0-9_]+$
-     */
-    slug: string
-    /** @nullable */
-    readonly logo_media_id: string | null
-    /** @nullable */
-    readonly membership_level: OrganizationBasicApiMembershipLevel
-    members_can_use_personal_api_keys?: boolean
-    /**
-     * Set this to 'No' to temporarily disable an organization.
-     * @nullable
-     */
-    is_active?: boolean | null
-    /**
-     * (optional) reason for why the organization has been de-activated. This will be displayed to users on the web app.
-     * @maxLength 200
-     * @nullable
-     */
-    is_not_active_reason?: string | null
-}
-
-export interface ScenePersonalisationBasicApi {
-    /** @maxLength 200 */
-    scene: string
-    /** @nullable */
-    dashboard?: number | null
 }
 
 export type EnvironmentsDashboardsListParams = {

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -3403,6 +3403,41 @@ export const deleteSecretTokenBackupPartialUpdate = async (
 /**
  * Projects for the current organization.
  */
+export type generateConversationsPublicTokenCreateResponse200 = {
+    data: ProjectBackwardCompatApi
+    status: 200
+}
+
+export type generateConversationsPublicTokenCreateResponseSuccess =
+    generateConversationsPublicTokenCreateResponse200 & {
+        headers: Headers
+    }
+export type generateConversationsPublicTokenCreateResponse = generateConversationsPublicTokenCreateResponseSuccess
+
+export const getGenerateConversationsPublicTokenCreateUrl = (organizationId: string, id: number) => {
+    return `/api/organizations/${organizationId}/projects/${id}/generate_conversations_public_token/`
+}
+
+export const generateConversationsPublicTokenCreate = async (
+    organizationId: string,
+    id: number,
+    projectBackwardCompatApi: NonReadonly<ProjectBackwardCompatApi>,
+    options?: RequestInit
+): Promise<generateConversationsPublicTokenCreateResponse> => {
+    return apiMutator<generateConversationsPublicTokenCreateResponse>(
+        getGenerateConversationsPublicTokenCreateUrl(organizationId, id),
+        {
+            ...options,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(projectBackwardCompatApi),
+        }
+    )
+}
+
+/**
+ * Projects for the current organization.
+ */
 export type isGeneratingDemoDataRetrieveResponse200 = {
     data: ProjectBackwardCompatApi
     status: 200

--- a/frontend/src/lib/api-stub-for-orval.ts
+++ b/frontend/src/lib/api-stub-for-orval.ts
@@ -1,0 +1,47 @@
+/**
+ * Stub for orval's esbuild bundling step.
+ *
+ * Orval v8 bundles mutator files with esbuild to parse function signatures.
+ * The real lib/api imports scss files which esbuild can't handle.
+ * This stub provides the same interface without the scss dependency chain.
+ *
+ * This file is NEVER executed - it's only used during orval type generation.
+ */
+
+type ApiMethodOptions = {
+    signal?: AbortSignal
+    headers?: Record<string, string>
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const api = {
+    get: async function <T = any>(url: string, options?: ApiMethodOptions): Promise<T> {
+        void url
+        void options
+        throw new Error('Stub - should never be called')
+    },
+    create: async function <T = any, P = any>(url: string, data?: P, options?: ApiMethodOptions): Promise<T> {
+        void url
+        void data
+        void options
+        throw new Error('Stub - should never be called')
+    },
+    update: async function <T = any, P = any>(url: string, data: P, options?: ApiMethodOptions): Promise<T> {
+        void url
+        void data
+        void options
+        throw new Error('Stub - should never be called')
+    },
+    put: async function <T = any, P = any>(url: string, data: P, options?: ApiMethodOptions): Promise<T> {
+        void url
+        void data
+        void options
+        throw new Error('Stub - should never be called')
+    },
+    delete: async function (url: string): Promise<any> {
+        void url
+        throw new Error('Stub - should never be called')
+    },
+}
+
+export default api

--- a/products/actions/frontend/generated/api.schemas.ts
+++ b/products/actions/frontend/generated/api.schemas.ts
@@ -7,7 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
 /**
  * * `contains` - contains
  * `regex` - regex
@@ -26,6 +25,36 @@ export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const NullEnumApi = {} as const
+
+export type ActionStepJSONApiPropertiesItem = { [key: string]: unknown }
+
+export type ActionStepJSONApiTextMatching = UrlMatchingEnumApi | NullEnumApi
+
+export type ActionStepJSONApiHrefMatching = UrlMatchingEnumApi | NullEnumApi
+
+export type ActionStepJSONApiUrlMatching = UrlMatchingEnumApi | NullEnumApi
+
+export interface ActionStepJSONApi {
+    /** @nullable */
+    event?: string | null
+    /** @nullable */
+    properties?: ActionStepJSONApiPropertiesItem[] | null
+    /** @nullable */
+    selector?: string | null
+    /** @nullable */
+    readonly selector_regex: string | null
+    /** @nullable */
+    tag_name?: string | null
+    /** @nullable */
+    text?: string | null
+    text_matching?: ActionStepJSONApiTextMatching
+    /** @nullable */
+    href?: string | null
+    href_matching?: ActionStepJSONApiHrefMatching
+    /** @nullable */
+    url?: string | null
+    url_matching?: ActionStepJSONApiUrlMatching
+}
 
 /**
  * * `engineering` - Engineering
@@ -58,13 +87,34 @@ export const BlankEnumApi = {
     '': '',
 } as const
 
-export interface PaginatedActionListApi {
-    count: number
+export type UserBasicApiHedgehogConfigAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type UserBasicApiHedgehogConfig = UserBasicApiHedgehogConfigAnyOf | null | null
+
+export type UserBasicApiRoleAtOrganization = RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
     /** @nullable */
-    next?: string | null
+    is_email_verified?: boolean | null
     /** @nullable */
-    previous?: string | null
-    results: ActionApi[]
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: UserBasicApiRoleAtOrganization
 }
 
 /**
@@ -103,6 +153,15 @@ export interface ActionApi {
     readonly user_access_level: string | null
 }
 
+export interface PaginatedActionListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ActionApi[]
+}
+
 /**
  * Serializer mixin that resolves appropriate response for tags depending on license.
  */
@@ -137,96 +196,6 @@ export interface PatchedActionApi {
      * @nullable
      */
     readonly user_access_level?: string | null
-}
-
-export type ActionStepJSONApiPropertiesItem = { [key: string]: unknown }
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ActionStepJSONApiTextMatching = { ...UrlMatchingEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type ActionStepJSONApiTextMatching =
-    | (typeof ActionStepJSONApiTextMatching)[keyof typeof ActionStepJSONApiTextMatching]
-    | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ActionStepJSONApiHrefMatching = { ...UrlMatchingEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type ActionStepJSONApiHrefMatching =
-    | (typeof ActionStepJSONApiHrefMatching)[keyof typeof ActionStepJSONApiHrefMatching]
-    | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ActionStepJSONApiUrlMatching = { ...UrlMatchingEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type ActionStepJSONApiUrlMatching =
-    | (typeof ActionStepJSONApiUrlMatching)[keyof typeof ActionStepJSONApiUrlMatching]
-    | null
-
-export interface ActionStepJSONApi {
-    /** @nullable */
-    event?: string | null
-    /** @nullable */
-    properties?: ActionStepJSONApiPropertiesItem[] | null
-    /** @nullable */
-    selector?: string | null
-    /** @nullable */
-    readonly selector_regex: string | null
-    /** @nullable */
-    tag_name?: string | null
-    /** @nullable */
-    text?: string | null
-    /** @nullable */
-    text_matching?: ActionStepJSONApiTextMatching
-    /** @nullable */
-    href?: string | null
-    /** @nullable */
-    href_matching?: ActionStepJSONApiHrefMatching
-    /** @nullable */
-    url?: string | null
-    /** @nullable */
-    url_matching?: ActionStepJSONApiUrlMatching
-}
-
-/**
- * @nullable
- */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserBasicApiRoleAtOrganization = { ...RoleAtOrganizationEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserBasicApiRoleAtOrganization =
-    | (typeof UserBasicApiRoleAtOrganization)[keyof typeof UserBasicApiRoleAtOrganization]
-    | null
-
-export interface UserBasicApi {
-    readonly id: number
-    readonly uuid: string
-    /**
-     * @maxLength 200
-     * @nullable
-     */
-    distinct_id?: string | null
-    /** @maxLength 150 */
-    first_name?: string
-    /** @maxLength 150 */
-    last_name?: string
-    /** @maxLength 254 */
-    email: string
-    /** @nullable */
-    is_email_verified?: boolean | null
-    /** @nullable */
-    readonly hedgehog_config: UserBasicApiHedgehogConfig
-    /** @nullable */
-    role_at_organization?: UserBasicApiRoleAtOrganization
 }
 
 export type ActionsListParams = {

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -7,7 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
 /**
  * * `events` - Events
  * `persons` - Persons
@@ -33,6 +32,60 @@ export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const NullEnumApi = {} as const
+
+/**
+ * * `S3` - S3
+ * `Snowflake` - Snowflake
+ * `Postgres` - Postgres
+ * `Redshift` - Redshift
+ * `BigQuery` - Bigquery
+ * `Databricks` - Databricks
+ * `Workflows` - Workflows
+ * `HTTP` - Http
+ * `NoOp` - Noop
+ */
+export type BatchExportDestinationTypeEnumApi =
+    (typeof BatchExportDestinationTypeEnumApi)[keyof typeof BatchExportDestinationTypeEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const BatchExportDestinationTypeEnumApi = {
+    S3: 'S3',
+    Snowflake: 'Snowflake',
+    Postgres: 'Postgres',
+    Redshift: 'Redshift',
+    BigQuery: 'BigQuery',
+    Databricks: 'Databricks',
+    Workflows: 'Workflows',
+    HTTP: 'HTTP',
+    NoOp: 'NoOp',
+} as const
+
+/**
+ * Serializer for an BatchExportDestination model.
+ */
+export interface BatchExportDestinationApi {
+    /** A choice of supported BatchExportDestination types.
+
+* `S3` - S3
+* `Snowflake` - Snowflake
+* `Postgres` - Postgres
+* `Redshift` - Redshift
+* `BigQuery` - Bigquery
+* `Databricks` - Databricks
+* `Workflows` - Workflows
+* `HTTP` - Http
+* `NoOp` - Noop */
+    type: BatchExportDestinationTypeEnumApi
+    /** A JSON field to store all configuration parameters required to access a BatchExportDestination. */
+    config?: unknown
+    /**
+     * The integration for this destination.
+     * @nullable
+     */
+    integration?: number | null
+    /** @nullable */
+    integration_id?: number | null
+}
 
 /**
  * * `hour` - hour
@@ -77,123 +130,6 @@ export const BatchExportRunStatusEnumApi = {
     Running: 'Running',
     Starting: 'Starting',
 } as const
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const BatchExportDestinationTypeEnumApi = {
-    S3: 'S3',
-    Snowflake: 'Snowflake',
-    Postgres: 'Postgres',
-    Redshift: 'Redshift',
-    BigQuery: 'BigQuery',
-    Databricks: 'Databricks',
-    HTTP: 'HTTP',
-    NoOp: 'NoOp',
-} as const
-
-/**
- * * `S3` - S3
- * `Snowflake` - Snowflake
- * `Postgres` - Postgres
- * `Redshift` - Redshift
- * `BigQuery` - Bigquery
- * `Databricks` - Databricks
- * `HTTP` - Http
- * `NoOp` - Noop
- */
-export type BatchExportDestinationTypeEnumApi =
-    (typeof BatchExportDestinationTypeEnumApi)[keyof typeof BatchExportDestinationTypeEnumApi]
-
-export interface PaginatedBatchExportListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: BatchExportApi[]
-}
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const BatchExportApiModel = { ...ModelEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * Which model this BatchExport is exporting.
-
-* `events` - Events
-* `persons` - Persons
-* `sessions` - Sessions
- * @nullable
- */
-export type BatchExportApiModel = (typeof BatchExportApiModel)[keyof typeof BatchExportApiModel] | null
-
-/**
- * A schema of custom fields to select when exporting data.
- * @nullable
- */
-export type BatchExportApiSchema = unknown | null
-
-/**
- * @nullable
- */
-export type BatchExportApiFilters = unknown | null
-
-/**
- * Serializer for a BatchExport model.
- */
-export interface BatchExportApi {
-    readonly id: string
-    /** The team this belongs to. */
-    readonly team_id: number
-    /** A human-readable name for this BatchExport. */
-    name: string
-    /**
-   * Which model this BatchExport is exporting.
-
-* `events` - Events
-* `persons` - Persons
-* `sessions` - Sessions
-   * @nullable
-   */
-    model?: BatchExportApiModel
-    destination: BatchExportDestinationApi
-    interval: IntervalEnumApi
-    /** Whether this BatchExport is paused or not. */
-    paused?: boolean
-    /** The timestamp at which this BatchExport was created. */
-    readonly created_at: string
-    /** The timestamp at which this BatchExport was last updated. */
-    readonly last_updated_at: string
-    /**
-     * The timestamp at which this BatchExport was last paused.
-     * @nullable
-     */
-    last_paused_at?: string | null
-    /**
-     * Time before which any Batch Export runs won't be triggered.
-     * @nullable
-     */
-    start_at?: string | null
-    /**
-     * Time after which any Batch Export runs won't be triggered.
-     * @nullable
-     */
-    end_at?: string | null
-    readonly latest_runs: readonly BatchExportRunApi[]
-    hogql_query?: string
-    /**
-     * A schema of custom fields to select when exporting data.
-     * @nullable
-     */
-    readonly schema: BatchExportApiSchema
-    /** @nullable */
-    filters?: BatchExportApiFilters
-}
-
-export interface PaginatedBatchExportRunListApi {
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: BatchExportRunApi[]
-}
 
 /**
  * Serializer for a BatchExportRun model.
@@ -269,30 +205,85 @@ export interface BatchExportRunApi {
     backfill?: string | null
 }
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedBatchExportApiModel = { ...ModelEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
 /**
  * Which model this BatchExport is exporting.
 
 * `events` - Events
 * `persons` - Persons
 * `sessions` - Sessions
- * @nullable
  */
-export type PatchedBatchExportApiModel =
-    | (typeof PatchedBatchExportApiModel)[keyof typeof PatchedBatchExportApiModel]
-    | null
+export type BatchExportApiModel = ModelEnumApi | BlankEnumApi | NullEnumApi
 
 /**
- * A schema of custom fields to select when exporting data.
- * @nullable
+ * Serializer for a BatchExport model.
  */
-export type PatchedBatchExportApiSchema = unknown | null
+export interface BatchExportApi {
+    readonly id: string
+    /** The team this belongs to. */
+    readonly team_id: number
+    /** A human-readable name for this BatchExport. */
+    name: string
+    /** Which model this BatchExport is exporting.
+
+* `events` - Events
+* `persons` - Persons
+* `sessions` - Sessions */
+    model?: BatchExportApiModel
+    destination: BatchExportDestinationApi
+    interval: IntervalEnumApi
+    /** Whether this BatchExport is paused or not. */
+    paused?: boolean
+    /** The timestamp at which this BatchExport was created. */
+    readonly created_at: string
+    /** The timestamp at which this BatchExport was last updated. */
+    readonly last_updated_at: string
+    /**
+     * The timestamp at which this BatchExport was last paused.
+     * @nullable
+     */
+    last_paused_at?: string | null
+    /**
+     * Time before which any Batch Export runs won't be triggered.
+     * @nullable
+     */
+    start_at?: string | null
+    /**
+     * Time after which any Batch Export runs won't be triggered.
+     * @nullable
+     */
+    end_at?: string | null
+    readonly latest_runs: readonly BatchExportRunApi[]
+    hogql_query?: string
+    /** A schema of custom fields to select when exporting data. */
+    readonly schema: unknown
+    filters?: unknown
+}
+
+export interface PaginatedBatchExportListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: BatchExportApi[]
+}
+
+export interface PaginatedBatchExportRunListApi {
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: BatchExportRunApi[]
+}
 
 /**
- * @nullable
+ * Which model this BatchExport is exporting.
+
+* `events` - Events
+* `persons` - Persons
+* `sessions` - Sessions
  */
-export type PatchedBatchExportApiFilters = unknown | null
+export type PatchedBatchExportApiModel = ModelEnumApi | BlankEnumApi | NullEnumApi
 
 /**
  * Serializer for a BatchExport model.
@@ -303,14 +294,11 @@ export interface PatchedBatchExportApi {
     readonly team_id?: number
     /** A human-readable name for this BatchExport. */
     name?: string
-    /**
-   * Which model this BatchExport is exporting.
+    /** Which model this BatchExport is exporting.
 
 * `events` - Events
 * `persons` - Persons
-* `sessions` - Sessions
-   * @nullable
-   */
+* `sessions` - Sessions */
     model?: PatchedBatchExportApiModel
     destination?: BatchExportDestinationApi
     interval?: IntervalEnumApi
@@ -337,39 +325,9 @@ export interface PatchedBatchExportApi {
     end_at?: string | null
     readonly latest_runs?: readonly BatchExportRunApi[]
     hogql_query?: string
-    /**
-     * A schema of custom fields to select when exporting data.
-     * @nullable
-     */
-    readonly schema?: PatchedBatchExportApiSchema
-    /** @nullable */
-    filters?: PatchedBatchExportApiFilters
-}
-
-/**
- * Serializer for an BatchExportDestination model.
- */
-export interface BatchExportDestinationApi {
-    /** A choice of supported BatchExportDestination types.
-
-* `S3` - S3
-* `Snowflake` - Snowflake
-* `Postgres` - Postgres
-* `Redshift` - Redshift
-* `BigQuery` - Bigquery
-* `Databricks` - Databricks
-* `HTTP` - Http
-* `NoOp` - Noop */
-    type: BatchExportDestinationTypeEnumApi
-    /** A JSON field to store all configuration parameters required to access a BatchExportDestination. */
-    config?: unknown
-    /**
-     * The integration for this destination.
-     * @nullable
-     */
-    integration?: number | null
-    /** @nullable */
-    integration_id?: number | null
+    /** A schema of custom fields to select when exporting data. */
+    readonly schema?: unknown
+    filters?: unknown
 }
 
 export type EnvironmentsBatchExportsListParams = {

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -7,7 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
 /**
  * * `engineering` - Engineering
  * `data` - Data
@@ -44,50 +43,14 @@ export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const NullEnumApi = {} as const
 
-export interface PaginatedDataColorThemeListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: DataColorThemeApi[]
-}
-
-export interface DataColorThemeApi {
-    readonly id: number
-    /** @maxLength 100 */
-    name: string
-    colors?: unknown
-    readonly is_global: string
-    /** @nullable */
-    readonly created_at: string | null
-    readonly created_by: UserBasicApi
-}
-
-export interface PatchedDataColorThemeApi {
-    readonly id?: number
-    /** @maxLength 100 */
-    name?: string
-    colors?: unknown
-    readonly is_global?: string
-    /** @nullable */
-    readonly created_at?: string | null
-    readonly created_by?: UserBasicApi
-}
+export type UserBasicApiHedgehogConfigAnyOf = { [key: string]: unknown }
 
 /**
  * @nullable
  */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
+export type UserBasicApiHedgehogConfig = UserBasicApiHedgehogConfigAnyOf | null | null
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserBasicApiRoleAtOrganization = { ...RoleAtOrganizationEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserBasicApiRoleAtOrganization =
-    | (typeof UserBasicApiRoleAtOrganization)[keyof typeof UserBasicApiRoleAtOrganization]
-    | null
+export type UserBasicApiRoleAtOrganization = RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi
 
 export interface UserBasicApi {
     readonly id: number
@@ -107,8 +70,38 @@ export interface UserBasicApi {
     is_email_verified?: boolean | null
     /** @nullable */
     readonly hedgehog_config: UserBasicApiHedgehogConfig
-    /** @nullable */
     role_at_organization?: UserBasicApiRoleAtOrganization
+}
+
+export interface DataColorThemeApi {
+    readonly id: number
+    /** @maxLength 100 */
+    name: string
+    colors?: unknown
+    readonly is_global: string
+    /** @nullable */
+    readonly created_at: string | null
+    readonly created_by: UserBasicApi
+}
+
+export interface PaginatedDataColorThemeListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: DataColorThemeApi[]
+}
+
+export interface PatchedDataColorThemeApi {
+    readonly id?: number
+    /** @maxLength 100 */
+    name?: string
+    colors?: unknown
+    readonly is_global?: string
+    /** @nullable */
+    readonly created_at?: string | null
+    readonly created_by?: UserBasicApi
 }
 
 export type EnvironmentsDataColorThemesListParams = {

--- a/products/data_warehouse/frontend/generated/api.schemas.ts
+++ b/products/data_warehouse/frontend/generated/api.schemas.ts
@@ -7,13 +7,14 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
 /**
  * * `Running` - Running
  * `Completed` - Completed
  * `Failed` - Failed
  * `Cancelled` - Cancelled
  */
+export type DataModelingJobStatusEnumApi =
+    (typeof DataModelingJobStatusEnumApi)[keyof typeof DataModelingJobStatusEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DataModelingJobStatusEnumApi = {
@@ -22,6 +23,35 @@ export const DataModelingJobStatusEnumApi = {
     Failed: 'Failed',
     Cancelled: 'Cancelled',
 } as const
+
+export interface DataModelingJobApi {
+    readonly id: string
+    /** @nullable */
+    readonly saved_query_id: string | null
+    readonly status: DataModelingJobStatusEnumApi
+    readonly rows_materialized: number
+    /** @nullable */
+    readonly error: string | null
+    readonly created_at: string
+    readonly last_run_at: string
+    /** @nullable */
+    readonly workflow_id: string | null
+    /** @nullable */
+    readonly workflow_run_id: string | null
+    /**
+     * Total rows expected to be materialized
+     * @nullable
+     */
+    readonly rows_expected: number | null
+}
+
+export interface PaginatedDataModelingJobListApi {
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: DataModelingJobApi[]
+}
 
 /**
  * * `Ashby` - Ashby
@@ -97,42 +127,65 @@ export const SourceTypeEnumApi = {
     Shopify: 'Shopify',
 } as const
 
-/**
- * * `Cancelled` - Cancelled
- * `Modified` - Modified
- * `Completed` - Completed
- * `Failed` - Failed
- * `Running` - Running
- */
-export type StatusD5cEnumApi = (typeof StatusD5cEnumApi)[keyof typeof StatusD5cEnumApi]
+export interface ExternalDataSourceRevenueAnalyticsConfigApi {
+    enabled?: boolean
+    include_invoiceless_charges?: boolean
+}
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const StatusD5cEnumApi = {
-    Cancelled: 'Cancelled',
-    Modified: 'Modified',
-    Completed: 'Completed',
-    Failed: 'Failed',
-    Running: 'Running',
-} as const
+export interface ExternalDataSourceSerializersApi {
+    readonly id: string
+    readonly created_at: string
+    /** @nullable */
+    readonly created_by: string | null
+    readonly status: string
+    client_secret: string
+    account_id: string
+    readonly source_type: SourceTypeEnumApi
+    readonly latest_error: string
+    /** @nullable */
+    readonly prefix: string | null
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    description?: string | null
+    readonly last_run_at: string
+    readonly schemas: string
+    job_inputs?: unknown
+    readonly revenue_analytics_config: ExternalDataSourceRevenueAnalyticsConfigApi
+}
 
-export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
+export interface PaginatedExternalDataSourceSerializersListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ExternalDataSourceSerializersApi[]
+}
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const NullEnumApi = {} as const
-
-/**
- * * `data_warehouse` - Data Warehouse
- * `endpoint` - Endpoint
- * `managed_viewset` - Managed Viewset
- */
-export type OriginEnumApi = (typeof OriginEnumApi)[keyof typeof OriginEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const OriginEnumApi = {
-    data_warehouse: 'data_warehouse',
-    endpoint: 'endpoint',
-    managed_viewset: 'managed_viewset',
-} as const
+export interface PatchedExternalDataSourceSerializersApi {
+    readonly id?: string
+    readonly created_at?: string
+    /** @nullable */
+    readonly created_by?: string | null
+    readonly status?: string
+    client_secret?: string
+    account_id?: string
+    readonly source_type?: SourceTypeEnumApi
+    readonly latest_error?: string
+    /** @nullable */
+    readonly prefix?: string | null
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    description?: string | null
+    readonly last_run_at?: string
+    readonly schemas?: string
+    job_inputs?: unknown
+    readonly revenue_analytics_config?: ExternalDataSourceRevenueAnalyticsConfigApi
+}
 
 /**
  * * `engineering` - Engineering
@@ -165,93 +218,126 @@ export const BlankEnumApi = {
     '': '',
 } as const
 
-export type DataModelingJobStatusEnumApi =
-    (typeof DataModelingJobStatusEnumApi)[keyof typeof DataModelingJobStatusEnumApi]
+export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
 
-export interface PaginatedDataModelingJobListApi {
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: DataModelingJobApi[]
-}
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const NullEnumApi = {} as const
 
-export interface DataModelingJobApi {
-    readonly id: string
-    /** @nullable */
-    readonly saved_query_id: string | null
-    readonly status: DataModelingJobStatusEnumApi
-    readonly rows_materialized: number
-    /** @nullable */
-    readonly error: string | null
-    readonly created_at: string
-    readonly last_run_at: string
-    /** @nullable */
-    readonly workflow_id: string | null
-    /** @nullable */
-    readonly workflow_run_id: string | null
+export type UserBasicApiHedgehogConfigAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type UserBasicApiHedgehogConfig = UserBasicApiHedgehogConfigAnyOf | null | null
+
+export type UserBasicApiRoleAtOrganization = RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
     /**
-     * Total rows expected to be materialized
+     * @maxLength 200
      * @nullable
      */
-    readonly rows_expected: number | null
-}
-
-export interface PaginatedExternalDataSourceSerializersListApi {
-    count: number
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
     /** @nullable */
-    next?: string | null
+    is_email_verified?: boolean | null
     /** @nullable */
-    previous?: string | null
-    results: ExternalDataSourceSerializersApi[]
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: UserBasicApiRoleAtOrganization
 }
 
 /**
- * @nullable
+ * * `Cancelled` - Cancelled
+ * `Modified` - Modified
+ * `Completed` - Completed
+ * `Failed` - Failed
+ * `Running` - Running
  */
-export type ExternalDataSourceSerializersApiJobInputs = unknown | null
+export type StatusD5cEnumApi = (typeof StatusD5cEnumApi)[keyof typeof StatusD5cEnumApi]
 
-export interface ExternalDataSourceSerializersApi {
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const StatusD5cEnumApi = {
+    Cancelled: 'Cancelled',
+    Modified: 'Modified',
+    Completed: 'Completed',
+    Failed: 'Failed',
+    Running: 'Running',
+} as const
+
+/**
+ * * `data_warehouse` - Data Warehouse
+ * `endpoint` - Endpoint
+ * `managed_viewset` - Managed Viewset
+ */
+export type OriginEnumApi = (typeof OriginEnumApi)[keyof typeof OriginEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const OriginEnumApi = {
+    data_warehouse: 'data_warehouse',
+    endpoint: 'endpoint',
+    managed_viewset: 'managed_viewset',
+} as const
+
+/**
+ * The status of when this SavedQuery last ran.
+
+* `Cancelled` - Cancelled
+* `Modified` - Modified
+* `Completed` - Completed
+* `Failed` - Failed
+* `Running` - Running
+ */
+export type DataWarehouseSavedQueryMinimalApiStatus = StatusD5cEnumApi | NullEnumApi
+
+/**
+ * Where this SavedQuery is created.
+
+* `data_warehouse` - Data Warehouse
+* `endpoint` - Endpoint
+* `managed_viewset` - Managed Viewset
+ */
+export type DataWarehouseSavedQueryMinimalApiOrigin = OriginEnumApi | NullEnumApi
+
+/**
+ * Lightweight serializer for list views - excludes large query field to reduce memory usage.
+ */
+export interface DataWarehouseSavedQueryMinimalApi {
     readonly id: string
+    /** @nullable */
+    readonly deleted: boolean | null
+    readonly name: string
+    readonly created_by: UserBasicApi
     readonly created_at: string
-    /** @nullable */
-    readonly created_by: string | null
-    readonly status: string
-    client_secret: string
-    account_id: string
-    readonly source_type: SourceTypeEnumApi
-    readonly latest_error: string
-    /** @nullable */
-    readonly prefix: string | null
-    readonly last_run_at: string
-    readonly schemas: string
-    /** @nullable */
-    job_inputs?: ExternalDataSourceSerializersApiJobInputs
-    readonly revenue_analytics_config: ExternalDataSourceRevenueAnalyticsConfigApi
-}
+    readonly sync_frequency: string
+    readonly columns: string
+    /** The status of when this SavedQuery last ran.
 
-/**
- * @nullable
- */
-export type PatchedExternalDataSourceSerializersApiJobInputs = unknown | null
+* `Cancelled` - Cancelled
+* `Modified` - Modified
+* `Completed` - Completed
+* `Failed` - Failed
+* `Running` - Running */
+    readonly status: DataWarehouseSavedQueryMinimalApiStatus
+    /** @nullable */
+    readonly last_run_at: string | null
+    readonly managed_viewset_kind: string
+    /** @nullable */
+    readonly latest_error: string | null
+    /** @nullable */
+    readonly is_materialized: boolean | null
+    /** Where this SavedQuery is created.
 
-export interface PatchedExternalDataSourceSerializersApi {
-    readonly id?: string
-    readonly created_at?: string
-    /** @nullable */
-    readonly created_by?: string | null
-    readonly status?: string
-    client_secret?: string
-    account_id?: string
-    readonly source_type?: SourceTypeEnumApi
-    readonly latest_error?: string
-    /** @nullable */
-    readonly prefix?: string | null
-    readonly last_run_at?: string
-    readonly schemas?: string
-    /** @nullable */
-    job_inputs?: PatchedExternalDataSourceSerializersApiJobInputs
-    readonly revenue_analytics_config?: ExternalDataSourceRevenueAnalyticsConfigApi
+* `data_warehouse` - Data Warehouse
+* `endpoint` - Endpoint
+* `managed_viewset` - Managed Viewset */
+    readonly origin: DataWarehouseSavedQueryMinimalApiOrigin
 }
 
 export interface PaginatedDataWarehouseSavedQueryMinimalListApi {
@@ -264,14 +350,6 @@ export interface PaginatedDataWarehouseSavedQueryMinimalListApi {
 }
 
 /**
- * HogQL query
- * @nullable
- */
-export type DataWarehouseSavedQueryApiQuery = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DataWarehouseSavedQueryApiStatus = { ...StatusD5cEnumApi, ...NullEnumApi } as const
-/**
  * The status of when this SavedQuery last ran.
 
 * `Cancelled` - Cancelled
@@ -279,25 +357,17 @@ export const DataWarehouseSavedQueryApiStatus = { ...StatusD5cEnumApi, ...NullEn
 * `Completed` - Completed
 * `Failed` - Failed
 * `Running` - Running
- * @nullable
  */
-export type DataWarehouseSavedQueryApiStatus =
-    | (typeof DataWarehouseSavedQueryApiStatus)[keyof typeof DataWarehouseSavedQueryApiStatus]
-    | null
+export type DataWarehouseSavedQueryApiStatus = StatusD5cEnumApi | NullEnumApi
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DataWarehouseSavedQueryApiOrigin = { ...OriginEnumApi, ...NullEnumApi } as const
 /**
  * Where this SavedQuery is created.
 
 * `data_warehouse` - Data Warehouse
 * `endpoint` - Endpoint
 * `managed_viewset` - Managed Viewset
- * @nullable
  */
-export type DataWarehouseSavedQueryApiOrigin =
-    | (typeof DataWarehouseSavedQueryApiOrigin)[keyof typeof DataWarehouseSavedQueryApiOrigin]
-    | null
+export type DataWarehouseSavedQueryApiOrigin = OriginEnumApi | NullEnumApi
 
 /**
  * Shared methods for DataWarehouseSavedQuery serializers.
@@ -310,25 +380,19 @@ export interface DataWarehouseSavedQueryApi {
     deleted?: boolean | null
     /** @maxLength 128 */
     name: string
-    /**
-     * HogQL query
-     * @nullable
-     */
-    query?: DataWarehouseSavedQueryApiQuery
+    /** HogQL query */
+    query?: unknown
     readonly created_by: UserBasicApi
     readonly created_at: string
     readonly sync_frequency: string
     readonly columns: string
-    /**
-   * The status of when this SavedQuery last ran.
+    /** The status of when this SavedQuery last ran.
 
 * `Cancelled` - Cancelled
 * `Modified` - Modified
 * `Completed` - Completed
 * `Failed` - Failed
-* `Running` - Running
-   * @nullable
-   */
+* `Running` - Running */
     readonly status: DataWarehouseSavedQueryApiStatus
     /** @nullable */
     readonly last_run_at: string | null
@@ -342,25 +406,14 @@ export interface DataWarehouseSavedQueryApi {
     soft_update?: boolean | null
     /** @nullable */
     readonly is_materialized: boolean | null
-    /**
-   * Where this SavedQuery is created.
+    /** Where this SavedQuery is created.
 
 * `data_warehouse` - Data Warehouse
 * `endpoint` - Endpoint
-* `managed_viewset` - Managed Viewset
-   * @nullable
-   */
+* `managed_viewset` - Managed Viewset */
     readonly origin: DataWarehouseSavedQueryApiOrigin
 }
 
-/**
- * HogQL query
- * @nullable
- */
-export type PatchedDataWarehouseSavedQueryApiQuery = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedDataWarehouseSavedQueryApiStatus = { ...StatusD5cEnumApi, ...NullEnumApi } as const
 /**
  * The status of when this SavedQuery last ran.
 
@@ -369,25 +422,17 @@ export const PatchedDataWarehouseSavedQueryApiStatus = { ...StatusD5cEnumApi, ..
 * `Completed` - Completed
 * `Failed` - Failed
 * `Running` - Running
- * @nullable
  */
-export type PatchedDataWarehouseSavedQueryApiStatus =
-    | (typeof PatchedDataWarehouseSavedQueryApiStatus)[keyof typeof PatchedDataWarehouseSavedQueryApiStatus]
-    | null
+export type PatchedDataWarehouseSavedQueryApiStatus = StatusD5cEnumApi | NullEnumApi
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedDataWarehouseSavedQueryApiOrigin = { ...OriginEnumApi, ...NullEnumApi } as const
 /**
  * Where this SavedQuery is created.
 
 * `data_warehouse` - Data Warehouse
 * `endpoint` - Endpoint
 * `managed_viewset` - Managed Viewset
- * @nullable
  */
-export type PatchedDataWarehouseSavedQueryApiOrigin =
-    | (typeof PatchedDataWarehouseSavedQueryApiOrigin)[keyof typeof PatchedDataWarehouseSavedQueryApiOrigin]
-    | null
+export type PatchedDataWarehouseSavedQueryApiOrigin = OriginEnumApi | NullEnumApi
 
 /**
  * Shared methods for DataWarehouseSavedQuery serializers.
@@ -400,25 +445,19 @@ export interface PatchedDataWarehouseSavedQueryApi {
     deleted?: boolean | null
     /** @maxLength 128 */
     name?: string
-    /**
-     * HogQL query
-     * @nullable
-     */
-    query?: PatchedDataWarehouseSavedQueryApiQuery
+    /** HogQL query */
+    query?: unknown
     readonly created_by?: UserBasicApi
     readonly created_at?: string
     readonly sync_frequency?: string
     readonly columns?: string
-    /**
-   * The status of when this SavedQuery last ran.
+    /** The status of when this SavedQuery last ran.
 
 * `Cancelled` - Cancelled
 * `Modified` - Modified
 * `Completed` - Completed
 * `Failed` - Failed
-* `Running` - Running
-   * @nullable
-   */
+* `Running` - Running */
     readonly status?: PatchedDataWarehouseSavedQueryApiStatus
     /** @nullable */
     readonly last_run_at?: string | null
@@ -432,24 +471,12 @@ export interface PatchedDataWarehouseSavedQueryApi {
     soft_update?: boolean | null
     /** @nullable */
     readonly is_materialized?: boolean | null
-    /**
-   * Where this SavedQuery is created.
+    /** Where this SavedQuery is created.
 
 * `data_warehouse` - Data Warehouse
 * `endpoint` - Endpoint
-* `managed_viewset` - Managed Viewset
-   * @nullable
-   */
+* `managed_viewset` - Managed Viewset */
     readonly origin?: PatchedDataWarehouseSavedQueryApiOrigin
-}
-
-export interface PaginatedDataWarehouseSavedQueryDraftListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: DataWarehouseSavedQueryDraftApi[]
 }
 
 export interface DataWarehouseSavedQueryDraftApi {
@@ -471,6 +498,15 @@ export interface DataWarehouseSavedQueryDraftApi {
     edited_history_id?: string | null
 }
 
+export interface PaginatedDataWarehouseSavedQueryDraftListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: DataWarehouseSavedQueryDraftApi[]
+}
+
 export interface PatchedDataWarehouseSavedQueryDraftApi {
     readonly id?: string
     readonly created_at?: string
@@ -490,6 +526,17 @@ export interface PatchedDataWarehouseSavedQueryDraftApi {
     edited_history_id?: string | null
 }
 
+export interface QueryTabStateApi {
+    readonly id: string
+    /** 
+            Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
+            and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
+            ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
+            for a user.
+             */
+    state?: unknown
+}
+
 export interface PaginatedQueryTabStateListApi {
     count: number
     /** @nullable */
@@ -499,166 +546,15 @@ export interface PaginatedQueryTabStateListApi {
     results: QueryTabStateApi[]
 }
 
-/**
- * 
-            Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
-            and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
-            ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
-            for a user.
-            
- * @nullable
- */
-export type QueryTabStateApiState = unknown | null
-
-export interface QueryTabStateApi {
-    readonly id: string
-    /**
-   * 
-            Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
-            and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
-            ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
-            for a user.
-            
-   * @nullable
-   */
-    state?: QueryTabStateApiState
-}
-
-/**
- * 
-            Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
-            and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
-            ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
-            for a user.
-            
- * @nullable
- */
-export type PatchedQueryTabStateApiState = unknown | null
-
 export interface PatchedQueryTabStateApi {
     readonly id?: string
-    /**
-   * 
+    /** 
             Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
             and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
             ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
             for a user.
-            
-   * @nullable
-   */
-    state?: PatchedQueryTabStateApiState
-}
-
-export interface ExternalDataSourceRevenueAnalyticsConfigApi {
-    enabled?: boolean
-    include_invoiceless_charges?: boolean
-}
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DataWarehouseSavedQueryMinimalApiStatus = { ...StatusD5cEnumApi, ...NullEnumApi } as const
-/**
- * The status of when this SavedQuery last ran.
-
-* `Cancelled` - Cancelled
-* `Modified` - Modified
-* `Completed` - Completed
-* `Failed` - Failed
-* `Running` - Running
- * @nullable
- */
-export type DataWarehouseSavedQueryMinimalApiStatus =
-    | (typeof DataWarehouseSavedQueryMinimalApiStatus)[keyof typeof DataWarehouseSavedQueryMinimalApiStatus]
-    | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DataWarehouseSavedQueryMinimalApiOrigin = { ...OriginEnumApi, ...NullEnumApi } as const
-/**
- * Where this SavedQuery is created.
-
-* `data_warehouse` - Data Warehouse
-* `endpoint` - Endpoint
-* `managed_viewset` - Managed Viewset
- * @nullable
- */
-export type DataWarehouseSavedQueryMinimalApiOrigin =
-    | (typeof DataWarehouseSavedQueryMinimalApiOrigin)[keyof typeof DataWarehouseSavedQueryMinimalApiOrigin]
-    | null
-
-/**
- * Lightweight serializer for list views - excludes large query field to reduce memory usage.
- */
-export interface DataWarehouseSavedQueryMinimalApi {
-    readonly id: string
-    /** @nullable */
-    readonly deleted: boolean | null
-    readonly name: string
-    readonly created_by: UserBasicApi
-    readonly created_at: string
-    readonly sync_frequency: string
-    readonly columns: string
-    /**
-   * The status of when this SavedQuery last ran.
-
-* `Cancelled` - Cancelled
-* `Modified` - Modified
-* `Completed` - Completed
-* `Failed` - Failed
-* `Running` - Running
-   * @nullable
-   */
-    readonly status: DataWarehouseSavedQueryMinimalApiStatus
-    /** @nullable */
-    readonly last_run_at: string | null
-    readonly managed_viewset_kind: string
-    /** @nullable */
-    readonly latest_error: string | null
-    /** @nullable */
-    readonly is_materialized: boolean | null
-    /**
-   * Where this SavedQuery is created.
-
-* `data_warehouse` - Data Warehouse
-* `endpoint` - Endpoint
-* `managed_viewset` - Managed Viewset
-   * @nullable
-   */
-    readonly origin: DataWarehouseSavedQueryMinimalApiOrigin
-}
-
-/**
- * @nullable
- */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserBasicApiRoleAtOrganization = { ...RoleAtOrganizationEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserBasicApiRoleAtOrganization =
-    | (typeof UserBasicApiRoleAtOrganization)[keyof typeof UserBasicApiRoleAtOrganization]
-    | null
-
-export interface UserBasicApi {
-    readonly id: number
-    readonly uuid: string
-    /**
-     * @maxLength 200
-     * @nullable
-     */
-    distinct_id?: string | null
-    /** @maxLength 150 */
-    first_name?: string
-    /** @maxLength 150 */
-    last_name?: string
-    /** @maxLength 254 */
-    email: string
-    /** @nullable */
-    is_email_verified?: boolean | null
-    /** @nullable */
-    readonly hedgehog_config: UserBasicApiHedgehogConfig
-    /** @nullable */
-    role_at_organization?: UserBasicApiRoleAtOrganization
+             */
+    state?: unknown
 }
 
 export type EnvironmentsDataModelingJobsListParams = {

--- a/products/data_warehouse/frontend/generated/api.ts
+++ b/products/data_warehouse/frontend/generated/api.ts
@@ -948,6 +948,42 @@ export const environmentsWarehouseSavedQueriesDescendantsCreate = async (
 }
 
 /**
+ * Enable materialization for this saved query with a 24-hour sync frequency.
+ */
+export type environmentsWarehouseSavedQueriesMaterializeCreateResponse200 = {
+    data: DataWarehouseSavedQueryApi
+    status: 200
+}
+
+export type environmentsWarehouseSavedQueriesMaterializeCreateResponseSuccess =
+    environmentsWarehouseSavedQueriesMaterializeCreateResponse200 & {
+        headers: Headers
+    }
+export type environmentsWarehouseSavedQueriesMaterializeCreateResponse =
+    environmentsWarehouseSavedQueriesMaterializeCreateResponseSuccess
+
+export const getEnvironmentsWarehouseSavedQueriesMaterializeCreateUrl = (projectId: string, id: string) => {
+    return `/api/environments/${projectId}/warehouse_saved_queries/${id}/materialize/`
+}
+
+export const environmentsWarehouseSavedQueriesMaterializeCreate = async (
+    projectId: string,
+    id: string,
+    dataWarehouseSavedQueryApi: NonReadonly<DataWarehouseSavedQueryApi>,
+    options?: RequestInit
+): Promise<environmentsWarehouseSavedQueriesMaterializeCreateResponse> => {
+    return apiMutator<environmentsWarehouseSavedQueriesMaterializeCreateResponse>(
+        getEnvironmentsWarehouseSavedQueriesMaterializeCreateUrl(projectId, id),
+        {
+            ...options,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(dataWarehouseSavedQueryApi),
+        }
+    )
+}
+
+/**
  * Undo materialization, revert back to the original view.
 (i.e. delete the materialized table and the schedule)
  */
@@ -2271,6 +2307,41 @@ export const warehouseSavedQueriesDescendantsCreate = async (
 ): Promise<warehouseSavedQueriesDescendantsCreateResponse> => {
     return apiMutator<warehouseSavedQueriesDescendantsCreateResponse>(
         getWarehouseSavedQueriesDescendantsCreateUrl(projectId, id),
+        {
+            ...options,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(dataWarehouseSavedQueryApi),
+        }
+    )
+}
+
+/**
+ * Enable materialization for this saved query with a 24-hour sync frequency.
+ */
+export type warehouseSavedQueriesMaterializeCreateResponse200 = {
+    data: DataWarehouseSavedQueryApi
+    status: 200
+}
+
+export type warehouseSavedQueriesMaterializeCreateResponseSuccess =
+    warehouseSavedQueriesMaterializeCreateResponse200 & {
+        headers: Headers
+    }
+export type warehouseSavedQueriesMaterializeCreateResponse = warehouseSavedQueriesMaterializeCreateResponseSuccess
+
+export const getWarehouseSavedQueriesMaterializeCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/warehouse_saved_queries/${id}/materialize/`
+}
+
+export const warehouseSavedQueriesMaterializeCreate = async (
+    projectId: string,
+    id: string,
+    dataWarehouseSavedQueryApi: NonReadonly<DataWarehouseSavedQueryApi>,
+    options?: RequestInit
+): Promise<warehouseSavedQueriesMaterializeCreateResponse> => {
+    return apiMutator<warehouseSavedQueriesMaterializeCreateResponse>(
+        getWarehouseSavedQueriesMaterializeCreateUrl(projectId, id),
         {
             ...options,
             method: 'POST',

--- a/products/desktop_recordings/frontend/generated/api.schemas.ts
+++ b/products/desktop_recordings/frontend/generated/api.schemas.ts
@@ -7,24 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
-/**
- * * `zoom` - zoom
- * `teams` - teams
- * `meet` - meet
- * `desktop_audio` - desktop_audio
- * `slack` - slack
- */
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const CreateRecordingRequestPlatformEnumApi = {
-    zoom: 'zoom',
-    teams: 'teams',
-    meet: 'meet',
-    desktop_audio: 'desktop_audio',
-    slack: 'slack',
-} as const
-
 /**
  * * `zoom` - Zoom
  * `teams` - Microsoft Teams
@@ -61,8 +43,100 @@ export const Status292EnumApi = {
     error: 'error',
 } as const
 
-export type CreateRecordingRequestPlatformEnumApi =
-    (typeof CreateRecordingRequestPlatformEnumApi)[keyof typeof CreateRecordingRequestPlatformEnumApi]
+/**
+ * Serializer for individual transcript segments from AssemblyAI
+ */
+export interface TranscriptSegmentApi {
+    /**
+     * Milliseconds from recording start
+     * @nullable
+     */
+    timestamp?: number | null
+    /** @nullable */
+    speaker?: string | null
+    text: string
+    /**
+     * Transcription confidence score
+     * @nullable
+     */
+    confidence?: number | null
+    /**
+     * Whether this is the final version
+     * @nullable
+     */
+    is_final?: boolean | null
+}
+
+/**
+ * Serializer for extracted tasks
+ */
+export interface TaskApi {
+    title: string
+    description?: string
+    /** @nullable */
+    assignee?: string | null
+}
+
+export interface DesktopRecordingApi {
+    readonly id: string
+    readonly team: number
+    /** @nullable */
+    readonly created_by: number | null
+    readonly sdk_upload_id: string
+    /** @nullable */
+    recall_recording_id?: string | null
+    platform: Platform9aaEnumApi
+    /**
+     * @maxLength 255
+     * @nullable
+     */
+    meeting_title?: string | null
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    meeting_url?: string | null
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     * @nullable
+     */
+    duration_seconds?: number | null
+    status?: Status292EnumApi
+    /** @nullable */
+    notes?: string | null
+    /** @nullable */
+    error_message?: string | null
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    video_url?: string | null
+    /**
+     * @minimum -9223372036854776000
+     * @maximum 9223372036854776000
+     * @nullable
+     */
+    video_size_bytes?: number | null
+    /** List of participant names */
+    participants?: string[]
+    readonly transcript_text: string
+    /** Transcript segments with timestamps */
+    transcript_segments?: TranscriptSegmentApi[]
+    /** @nullable */
+    summary?: string | null
+    /** AI-extracted tasks from transcript */
+    extracted_tasks?: TaskApi[]
+    /** @nullable */
+    tasks_generated_at?: string | null
+    /** @nullable */
+    summary_generated_at?: string | null
+    started_at?: string
+    /** @nullable */
+    completed_at?: string | null
+    readonly created_at: string
+    readonly updated_at: string
+}
 
 export interface PaginatedDesktopRecordingListApi {
     count: number
@@ -72,6 +146,25 @@ export interface PaginatedDesktopRecordingListApi {
     previous?: string | null
     results: DesktopRecordingApi[]
 }
+
+/**
+ * * `zoom` - zoom
+ * `teams` - teams
+ * `meet` - meet
+ * `desktop_audio` - desktop_audio
+ * `slack` - slack
+ */
+export type CreateRecordingRequestPlatformEnumApi =
+    (typeof CreateRecordingRequestPlatformEnumApi)[keyof typeof CreateRecordingRequestPlatformEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CreateRecordingRequestPlatformEnumApi = {
+    zoom: 'zoom',
+    teams: 'teams',
+    meet: 'meet',
+    desktop_audio: 'desktop_audio',
+    slack: 'slack',
+} as const
 
 /**
  * Request body for creating a new recording
@@ -153,67 +246,6 @@ export interface CreateRecordingResponseApi {
     upload_token: string
 }
 
-export interface DesktopRecordingApi {
-    readonly id: string
-    readonly team: number
-    /** @nullable */
-    readonly created_by: number | null
-    readonly sdk_upload_id: string
-    /** @nullable */
-    recall_recording_id?: string | null
-    platform: Platform9aaEnumApi
-    /**
-     * @maxLength 255
-     * @nullable
-     */
-    meeting_title?: string | null
-    /**
-     * @maxLength 200
-     * @nullable
-     */
-    meeting_url?: string | null
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     * @nullable
-     */
-    duration_seconds?: number | null
-    status?: Status292EnumApi
-    /** @nullable */
-    notes?: string | null
-    /** @nullable */
-    error_message?: string | null
-    /**
-     * @maxLength 200
-     * @nullable
-     */
-    video_url?: string | null
-    /**
-     * @minimum -9223372036854776000
-     * @maximum 9223372036854776000
-     * @nullable
-     */
-    video_size_bytes?: number | null
-    /** List of participant names */
-    participants?: string[]
-    readonly transcript_text: string
-    /** Transcript segments with timestamps */
-    transcript_segments?: TranscriptSegmentApi[]
-    /** @nullable */
-    summary?: string | null
-    /** AI-extracted tasks from transcript */
-    extracted_tasks?: TaskApi[]
-    /** @nullable */
-    tasks_generated_at?: string | null
-    /** @nullable */
-    summary_generated_at?: string | null
-    started_at?: string
-    /** @nullable */
-    completed_at?: string | null
-    readonly created_at: string
-    readonly updated_at: string
-}
-
 export interface PatchedDesktopRecordingApi {
     readonly id?: string
     readonly team?: number
@@ -281,40 +313,6 @@ export interface PatchedDesktopRecordingApi {
 export interface AppendSegmentsApi {
     /** @minItems 1 */
     segments: TranscriptSegmentApi[]
-}
-
-/**
- * Serializer for individual transcript segments from AssemblyAI
- */
-export interface TranscriptSegmentApi {
-    /**
-     * Milliseconds from recording start
-     * @nullable
-     */
-    timestamp?: number | null
-    /** @nullable */
-    speaker?: string | null
-    text: string
-    /**
-     * Transcription confidence score
-     * @nullable
-     */
-    confidence?: number | null
-    /**
-     * Whether this is the final version
-     * @nullable
-     */
-    is_final?: boolean | null
-}
-
-/**
- * Serializer for extracted tasks
- */
-export interface TaskApi {
-    title: string
-    description?: string
-    /** @nullable */
-    assignee?: string | null
 }
 
 export type EnvironmentsDesktopRecordingsListParams = {

--- a/products/early_access_features/frontend/generated/api.schemas.ts
+++ b/products/early_access_features/frontend/generated/api.schemas.ts
@@ -7,27 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
-/**
- * * `draft` - draft
- * `concept` - concept
- * `alpha` - alpha
- * `beta` - beta
- * `general-availability` - general availability
- * `archived` - archived
- */
-export type StageEnumApi = (typeof StageEnumApi)[keyof typeof StageEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const StageEnumApi = {
-    draft: 'draft',
-    concept: 'concept',
-    alpha: 'alpha',
-    beta: 'beta',
-    'general-availability': 'general-availability',
-    archived: 'archived',
-} as const
-
 /**
  * * `server` - Server
  * `client` - Client
@@ -66,6 +45,91 @@ export const BucketingIdentifierEnumApi = {
     device_id: 'device_id',
 } as const
 
+export type MinimalFeatureFlagApiFilters = { [key: string]: unknown }
+
+/**
+ * Specifies where this feature flag should be evaluated
+
+* `server` - Server
+* `client` - Client
+* `all` - All
+ */
+export type MinimalFeatureFlagApiEvaluationRuntime = EvaluationRuntimeEnumApi | BlankEnumApi | NullEnumApi
+
+/**
+ * Identifier used for bucketing users into rollout and variants
+
+* `distinct_id` - User ID (default)
+* `device_id` - Device ID
+ */
+export type MinimalFeatureFlagApiBucketingIdentifier = BucketingIdentifierEnumApi | BlankEnumApi | NullEnumApi
+
+export interface MinimalFeatureFlagApi {
+    readonly id: number
+    readonly team_id: number
+    name?: string
+    /** @maxLength 400 */
+    key: string
+    filters?: MinimalFeatureFlagApiFilters
+    deleted?: boolean
+    active?: boolean
+    /** @nullable */
+    ensure_experience_continuity?: boolean | null
+    /** @nullable */
+    has_encrypted_payloads?: boolean | null
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     * @nullable
+     */
+    version?: number | null
+    /** Specifies where this feature flag should be evaluated
+
+* `server` - Server
+* `client` - Client
+* `all` - All */
+    evaluation_runtime?: MinimalFeatureFlagApiEvaluationRuntime
+    /** Identifier used for bucketing users into rollout and variants
+
+* `distinct_id` - User ID (default)
+* `device_id` - Device ID */
+    bucketing_identifier?: MinimalFeatureFlagApiBucketingIdentifier
+    readonly evaluation_tags: readonly string[]
+}
+
+/**
+ * * `draft` - draft
+ * `concept` - concept
+ * `alpha` - alpha
+ * `beta` - beta
+ * `general-availability` - general availability
+ * `archived` - archived
+ */
+export type StageEnumApi = (typeof StageEnumApi)[keyof typeof StageEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const StageEnumApi = {
+    draft: 'draft',
+    concept: 'concept',
+    alpha: 'alpha',
+    beta: 'beta',
+    'general-availability': 'general-availability',
+    archived: 'archived',
+} as const
+
+export interface EarlyAccessFeatureApi {
+    readonly id: string
+    readonly feature_flag: MinimalFeatureFlagApi
+    /** @maxLength 200 */
+    name: string
+    description?: string
+    stage: StageEnumApi
+    /** @maxLength 800 */
+    documentation_url?: string
+    readonly payload: string
+    readonly created_at: string
+}
+
 export interface PaginatedEarlyAccessFeatureListApi {
     count: number
     /** @nullable */
@@ -90,19 +154,6 @@ export interface EarlyAccessFeatureSerializerCreateOnlyApi {
     _create_in_folder?: string
 }
 
-export interface EarlyAccessFeatureApi {
-    readonly id: string
-    readonly feature_flag: MinimalFeatureFlagApi
-    /** @maxLength 200 */
-    name: string
-    description?: string
-    stage: StageEnumApi
-    /** @maxLength 800 */
-    documentation_url?: string
-    readonly payload: string
-    readonly created_at: string
-}
-
 export interface PatchedEarlyAccessFeatureApi {
     readonly id?: string
     readonly feature_flag?: MinimalFeatureFlagApi
@@ -114,82 +165,6 @@ export interface PatchedEarlyAccessFeatureApi {
     documentation_url?: string
     readonly payload?: string
     readonly created_at?: string
-}
-
-export type MinimalFeatureFlagApiFilters = { [key: string]: unknown }
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MinimalFeatureFlagApiEvaluationRuntime = {
-    ...EvaluationRuntimeEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * Specifies where this feature flag should be evaluated
-
-* `server` - Server
-* `client` - Client
-* `all` - All
- * @nullable
- */
-export type MinimalFeatureFlagApiEvaluationRuntime =
-    | (typeof MinimalFeatureFlagApiEvaluationRuntime)[keyof typeof MinimalFeatureFlagApiEvaluationRuntime]
-    | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MinimalFeatureFlagApiBucketingIdentifier = {
-    ...BucketingIdentifierEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * Identifier used for bucketing users into rollout and variants
-
-* `distinct_id` - User ID (default)
-* `device_id` - Device ID
- * @nullable
- */
-export type MinimalFeatureFlagApiBucketingIdentifier =
-    | (typeof MinimalFeatureFlagApiBucketingIdentifier)[keyof typeof MinimalFeatureFlagApiBucketingIdentifier]
-    | null
-
-export interface MinimalFeatureFlagApi {
-    readonly id: number
-    readonly team_id: number
-    name?: string
-    /** @maxLength 400 */
-    key: string
-    filters?: MinimalFeatureFlagApiFilters
-    deleted?: boolean
-    active?: boolean
-    /** @nullable */
-    ensure_experience_continuity?: boolean | null
-    /** @nullable */
-    has_encrypted_payloads?: boolean | null
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     * @nullable
-     */
-    version?: number | null
-    /**
-   * Specifies where this feature flag should be evaluated
-
-* `server` - Server
-* `client` - Client
-* `all` - All
-   * @nullable
-   */
-    evaluation_runtime?: MinimalFeatureFlagApiEvaluationRuntime
-    /**
-   * Identifier used for bucketing users into rollout and variants
-
-* `distinct_id` - User ID (default)
-* `device_id` - Device ID
-   * @nullable
-   */
-    bucketing_identifier?: MinimalFeatureFlagApiBucketingIdentifier
-    readonly evaluation_tags: readonly string[]
 }
 
 export type EarlyAccessFeatureListParams = {

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -7,100 +7,511 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
+export interface DateRangeApi {
+    /** @nullable */
+    date_from?: string | null
+    /** @nullable */
+    date_to?: string | null
+    /**
+     * Whether the date_from and date_to should be used verbatim. Disables rounding to the start and end of period.
+     * @nullable
+     */
+    explicitDate?: boolean | null
+}
+
+export type PropertyOperatorApi = (typeof PropertyOperatorApi)[keyof typeof PropertyOperatorApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PropertyOperatorApi = {
+    exact: 'exact',
+    is_not: 'is_not',
+    icontains: 'icontains',
+    not_icontains: 'not_icontains',
+    regex: 'regex',
+    not_regex: 'not_regex',
+    gt: 'gt',
+    gte: 'gte',
+    lt: 'lt',
+    lte: 'lte',
+    is_set: 'is_set',
+    is_not_set: 'is_not_set',
+    is_date_exact: 'is_date_exact',
+    is_date_before: 'is_date_before',
+    is_date_after: 'is_date_after',
+    between: 'between',
+    not_between: 'not_between',
+    min: 'min',
+    max: 'max',
+    in: 'in',
+    not_in: 'not_in',
+    is_cleaned_path_exact: 'is_cleaned_path_exact',
+    flag_evaluates_to: 'flag_evaluates_to',
+} as const
+
 /**
- * @nullable
+ * Event properties
  */
+export type EventPropertyFilterApiType = (typeof EventPropertyFilterApiType)[keyof typeof EventPropertyFilterApiType]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DataWarehouseSyncIntervalApi = {
-    '5min': '5min',
-    '30min': '30min',
-    '1hour': '1hour',
-    '6hour': '6hour',
-    '12hour': '12hour',
-    '24hour': '24hour',
-    '7day': '7day',
-    '30day': '30day',
+export const EventPropertyFilterApiType = {
+    event: 'event',
 } as const
 
-export type RefreshTypeApi = (typeof RefreshTypeApi)[keyof typeof RefreshTypeApi]
+export type EventPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type EventPropertyFilterApiValue = EventPropertyFilterApiValueAnyOfItem[] | string | number | boolean
+
+export interface EventPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator?: PropertyOperatorApi
+    /** Event properties */
+    type?: EventPropertyFilterApiType
+    value?: EventPropertyFilterApiValue
+}
+
+/**
+ * Person properties
+ */
+export type PersonPropertyFilterApiType = (typeof PersonPropertyFilterApiType)[keyof typeof PersonPropertyFilterApiType]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RefreshTypeApi = {
-    async: 'async',
-    async_except_on_cache_miss: 'async_except_on_cache_miss',
-    blocking: 'blocking',
-    force_async: 'force_async',
-    force_blocking: 'force_blocking',
-    force_cache: 'force_cache',
-    lazy_async: 'lazy_async',
+export const PersonPropertyFilterApiType = {
+    person: 'person',
 } as const
 
-export type IntervalTypeApi = (typeof IntervalTypeApi)[keyof typeof IntervalTypeApi]
+export type PersonPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type PersonPropertyFilterApiValue = PersonPropertyFilterApiValueAnyOfItem[] | string | number | boolean
+
+export interface PersonPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    /** Person properties */
+    type?: PersonPropertyFilterApiType
+    value?: PersonPropertyFilterApiValue
+}
+
+export type KeyApi = (typeof KeyApi)[keyof typeof KeyApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const IntervalTypeApi = {
-    second: 'second',
-    minute: 'minute',
-    hour: 'hour',
-    day: 'day',
-    week: 'week',
-    month: 'month',
+export const KeyApi = {
+    tag_name: 'tag_name',
+    text: 'text',
+    href: 'href',
+    selector: 'selector',
 } as const
 
-export type WebStatsBreakdownApi = (typeof WebStatsBreakdownApi)[keyof typeof WebStatsBreakdownApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const WebStatsBreakdownApi = {
-    Page: 'Page',
-    InitialPage: 'InitialPage',
-    ExitPage: 'ExitPage',
-    ExitClick: 'ExitClick',
-    PreviousPage: 'PreviousPage',
-    ScreenName: 'ScreenName',
-    InitialChannelType: 'InitialChannelType',
-    InitialReferringDomain: 'InitialReferringDomain',
-    InitialUTMSource: 'InitialUTMSource',
-    InitialUTMCampaign: 'InitialUTMCampaign',
-    InitialUTMMedium: 'InitialUTMMedium',
-    InitialUTMTerm: 'InitialUTMTerm',
-    InitialUTMContent: 'InitialUTMContent',
-    InitialUTMSourceMediumCampaign: 'InitialUTMSourceMediumCampaign',
-    Browser: 'Browser',
-    OS: 'OS',
-    Viewport: 'Viewport',
-    DeviceType: 'DeviceType',
-    Country: 'Country',
-    Region: 'Region',
-    City: 'City',
-    Timezone: 'Timezone',
-    Language: 'Language',
-    FrustrationMetrics: 'FrustrationMetrics',
-} as const
+export type ElementPropertyFilterApiType =
+    (typeof ElementPropertyFilterApiType)[keyof typeof ElementPropertyFilterApiType]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const WebAnalyticsOrderByFieldsApi = {
-    Visitors: 'Visitors',
-    Views: 'Views',
-    AvgTimeOnPage: 'AvgTimeOnPage',
-    Clicks: 'Clicks',
-    BounceRate: 'BounceRate',
-    AverageScrollPercentage: 'AverageScrollPercentage',
-    ScrollGt80Percentage: 'ScrollGt80Percentage',
-    TotalConversions: 'TotalConversions',
-    UniqueConversions: 'UniqueConversions',
-    ConversionRate: 'ConversionRate',
-    ConvertingUsers: 'ConvertingUsers',
-    RageClicks: 'RageClicks',
-    DeadClicks: 'DeadClicks',
-    Errors: 'Errors',
+export const ElementPropertyFilterApiType = {
+    element: 'element',
 } as const
 
+export type ElementPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type ElementPropertyFilterApiValue = ElementPropertyFilterApiValueAnyOfItem[] | string | number | boolean
+
+export interface ElementPropertyFilterApi {
+    key: KeyApi
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: ElementPropertyFilterApiType
+    value?: ElementPropertyFilterApiValue
+}
+
+export type EventMetadataPropertyFilterApiType =
+    (typeof EventMetadataPropertyFilterApiType)[keyof typeof EventMetadataPropertyFilterApiType]
+
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const WebAnalyticsOrderByDirectionApi = {
-    ASC: 'ASC',
-    DESC: 'DESC',
+export const EventMetadataPropertyFilterApiType = {
+    event_metadata: 'event_metadata',
 } as const
+
+export type EventMetadataPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type EventMetadataPropertyFilterApiValue =
+    | EventMetadataPropertyFilterApiValueAnyOfItem[]
+    | string
+    | number
+    | boolean
+
+export interface EventMetadataPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: EventMetadataPropertyFilterApiType
+    value?: EventMetadataPropertyFilterApiValue
+}
+
+export type SessionPropertyFilterApiType =
+    (typeof SessionPropertyFilterApiType)[keyof typeof SessionPropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const SessionPropertyFilterApiType = {
+    session: 'session',
+} as const
+
+export type SessionPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type SessionPropertyFilterApiValue = SessionPropertyFilterApiValueAnyOfItem[] | string | number | boolean
+
+export interface SessionPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: SessionPropertyFilterApiType
+    value?: SessionPropertyFilterApiValue
+}
+
+export type CohortPropertyFilterApiKey = (typeof CohortPropertyFilterApiKey)[keyof typeof CohortPropertyFilterApiKey]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CohortPropertyFilterApiKey = {
+    id: 'id',
+} as const
+
+export type CohortPropertyFilterApiType = (typeof CohortPropertyFilterApiType)[keyof typeof CohortPropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CohortPropertyFilterApiType = {
+    cohort: 'cohort',
+} as const
+
+export interface CohortPropertyFilterApi {
+    /** @nullable */
+    cohort_name?: string | null
+    key?: CohortPropertyFilterApiKey
+    /** @nullable */
+    label?: string | null
+    operator?: PropertyOperatorApi
+    type?: CohortPropertyFilterApiType
+    value: number
+}
+
+export type DurationTypeApi = (typeof DurationTypeApi)[keyof typeof DurationTypeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DurationTypeApi = {
+    duration: 'duration',
+    active_seconds: 'active_seconds',
+    inactive_seconds: 'inactive_seconds',
+} as const
+
+export type RecordingPropertyFilterApiKey = DurationTypeApi | string
+
+export type RecordingPropertyFilterApiType =
+    (typeof RecordingPropertyFilterApiType)[keyof typeof RecordingPropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RecordingPropertyFilterApiType = {
+    recording: 'recording',
+} as const
+
+export type RecordingPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type RecordingPropertyFilterApiValue = RecordingPropertyFilterApiValueAnyOfItem[] | string | number | boolean
+
+export interface RecordingPropertyFilterApi {
+    key: RecordingPropertyFilterApiKey
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: RecordingPropertyFilterApiType
+    value?: RecordingPropertyFilterApiValue
+}
+
+export type LogEntryPropertyFilterApiType =
+    (typeof LogEntryPropertyFilterApiType)[keyof typeof LogEntryPropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const LogEntryPropertyFilterApiType = {
+    log_entry: 'log_entry',
+} as const
+
+export type LogEntryPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type LogEntryPropertyFilterApiValue = LogEntryPropertyFilterApiValueAnyOfItem[] | string | number | boolean
+
+export interface LogEntryPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: LogEntryPropertyFilterApiType
+    value?: LogEntryPropertyFilterApiValue
+}
+
+export type GroupPropertyFilterApiType = (typeof GroupPropertyFilterApiType)[keyof typeof GroupPropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GroupPropertyFilterApiType = {
+    group: 'group',
+} as const
+
+export type GroupPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type GroupPropertyFilterApiValue = GroupPropertyFilterApiValueAnyOfItem[] | string | number | boolean
+
+export interface GroupPropertyFilterApi {
+    /** @nullable */
+    group_type_index?: number | null
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: GroupPropertyFilterApiType
+    value?: GroupPropertyFilterApiValue
+}
+
+/**
+ * Event property with "$feature/" prepended
+ */
+export type FeaturePropertyFilterApiType =
+    (typeof FeaturePropertyFilterApiType)[keyof typeof FeaturePropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const FeaturePropertyFilterApiType = {
+    feature: 'feature',
+} as const
+
+export type FeaturePropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type FeaturePropertyFilterApiValue = FeaturePropertyFilterApiValueAnyOfItem[] | string | number | boolean
+
+export interface FeaturePropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    /** Event property with "$feature/" prepended */
+    type?: FeaturePropertyFilterApiType
+    value?: FeaturePropertyFilterApiValue
+}
+
+/**
+ * Only flag_evaluates_to operator is allowed for flag dependencies
+ */
+export type FlagPropertyFilterApiOperator =
+    (typeof FlagPropertyFilterApiOperator)[keyof typeof FlagPropertyFilterApiOperator]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const FlagPropertyFilterApiOperator = {
+    flag_evaluates_to: 'flag_evaluates_to',
+} as const
+
+/**
+ * Feature flag dependency
+ */
+export type FlagPropertyFilterApiType = (typeof FlagPropertyFilterApiType)[keyof typeof FlagPropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const FlagPropertyFilterApiType = {
+    flag: 'flag',
+} as const
+
+/**
+ * The value can be true, false, or a variant name
+ */
+export type FlagPropertyFilterApiValue = boolean | string
+
+export interface FlagPropertyFilterApi {
+    /** The key should be the flag ID */
+    key: string
+    /** @nullable */
+    label?: string | null
+    /** Only flag_evaluates_to operator is allowed for flag dependencies */
+    operator?: FlagPropertyFilterApiOperator
+    /** Feature flag dependency */
+    type?: FlagPropertyFilterApiType
+    /** The value can be true, false, or a variant name */
+    value: FlagPropertyFilterApiValue
+}
+
+export type HogQLPropertyFilterApiType = (typeof HogQLPropertyFilterApiType)[keyof typeof HogQLPropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const HogQLPropertyFilterApiType = {
+    hogql: 'hogql',
+} as const
+
+export type HogQLPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type HogQLPropertyFilterApiValue = HogQLPropertyFilterApiValueAnyOfItem[] | string | number | boolean
+
+export interface HogQLPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    type?: HogQLPropertyFilterApiType
+    value?: HogQLPropertyFilterApiValue
+}
+
+export type EmptyPropertyFilterApiType = (typeof EmptyPropertyFilterApiType)[keyof typeof EmptyPropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EmptyPropertyFilterApiType = {
+    empty: 'empty',
+} as const
+
+export interface EmptyPropertyFilterApi {
+    type?: EmptyPropertyFilterApiType
+}
+
+export type DataWarehousePropertyFilterApiType =
+    (typeof DataWarehousePropertyFilterApiType)[keyof typeof DataWarehousePropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DataWarehousePropertyFilterApiType = {
+    data_warehouse: 'data_warehouse',
+} as const
+
+export type DataWarehousePropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type DataWarehousePropertyFilterApiValue =
+    | DataWarehousePropertyFilterApiValueAnyOfItem[]
+    | string
+    | number
+    | boolean
+
+export interface DataWarehousePropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: DataWarehousePropertyFilterApiType
+    value?: DataWarehousePropertyFilterApiValue
+}
+
+export type DataWarehousePersonPropertyFilterApiType =
+    (typeof DataWarehousePersonPropertyFilterApiType)[keyof typeof DataWarehousePersonPropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DataWarehousePersonPropertyFilterApiType = {
+    data_warehouse_person_property: 'data_warehouse_person_property',
+} as const
+
+export type DataWarehousePersonPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type DataWarehousePersonPropertyFilterApiValue =
+    | DataWarehousePersonPropertyFilterApiValueAnyOfItem[]
+    | string
+    | number
+    | boolean
+
+export interface DataWarehousePersonPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: DataWarehousePersonPropertyFilterApiType
+    value?: DataWarehousePersonPropertyFilterApiValue
+}
+
+export type ErrorTrackingIssueFilterApiType =
+    (typeof ErrorTrackingIssueFilterApiType)[keyof typeof ErrorTrackingIssueFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ErrorTrackingIssueFilterApiType = {
+    error_tracking_issue: 'error_tracking_issue',
+} as const
+
+export type ErrorTrackingIssueFilterApiValueAnyOfItem = string | number | boolean
+
+export type ErrorTrackingIssueFilterApiValue = ErrorTrackingIssueFilterApiValueAnyOfItem[] | string | number | boolean
+
+export interface ErrorTrackingIssueFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: ErrorTrackingIssueFilterApiType
+    value?: ErrorTrackingIssueFilterApiValue
+}
+
+export type LogPropertyFilterTypeApi = (typeof LogPropertyFilterTypeApi)[keyof typeof LogPropertyFilterTypeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const LogPropertyFilterTypeApi = {
+    log: 'log',
+    log_attribute: 'log_attribute',
+    log_resource_attribute: 'log_resource_attribute',
+} as const
+
+export type LogPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type LogPropertyFilterApiValue = LogPropertyFilterApiValueAnyOfItem[] | string | number | boolean
+
+export interface LogPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type: LogPropertyFilterTypeApi
+    value?: LogPropertyFilterApiValue
+}
+
+export type RevenueAnalyticsPropertyFilterApiType =
+    (typeof RevenueAnalyticsPropertyFilterApiType)[keyof typeof RevenueAnalyticsPropertyFilterApiType]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RevenueAnalyticsPropertyFilterApiType = {
+    revenue_analytics: 'revenue_analytics',
+} as const
+
+export type RevenueAnalyticsPropertyFilterApiValueAnyOfItem = string | number | boolean
+
+export type RevenueAnalyticsPropertyFilterApiValue =
+    | RevenueAnalyticsPropertyFilterApiValueAnyOfItem[]
+    | string
+    | number
+    | boolean
+
+export interface RevenueAnalyticsPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: RevenueAnalyticsPropertyFilterApiType
+    value?: RevenueAnalyticsPropertyFilterApiValue
+}
+
+export type HogQLFiltersApiPropertiesItem =
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | ElementPropertyFilterApi
+    | EventMetadataPropertyFilterApi
+    | SessionPropertyFilterApi
+    | CohortPropertyFilterApi
+    | RecordingPropertyFilterApi
+    | LogEntryPropertyFilterApi
+    | GroupPropertyFilterApi
+    | FeaturePropertyFilterApi
+    | FlagPropertyFilterApi
+    | HogQLPropertyFilterApi
+    | EmptyPropertyFilterApi
+    | DataWarehousePropertyFilterApi
+    | DataWarehousePersonPropertyFilterApi
+    | ErrorTrackingIssueFilterApi
+    | LogPropertyFilterApi
+    | RevenueAnalyticsPropertyFilterApi
+
+export interface HogQLFiltersApi {
+    dateRange?: DateRangeApi
+    /** @nullable */
+    filterTestAccounts?: boolean | null
+    /** @nullable */
+    properties?: HogQLFiltersApiPropertiesItem[] | null
+}
 
 export type BounceRatePageViewModeApi = (typeof BounceRatePageViewModeApi)[keyof typeof BounceRatePageViewModeApi]
 
@@ -110,6 +521,64 @@ export const BounceRatePageViewModeApi = {
     uniq_urls: 'uniq_urls',
     uniq_page_screen_autocaptures: 'uniq_page_screen_autocaptures',
 } as const
+
+export type FilterLogicalOperatorApi = (typeof FilterLogicalOperatorApi)[keyof typeof FilterLogicalOperatorApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const FilterLogicalOperatorApi = {
+    AND: 'AND',
+    OR: 'OR',
+} as const
+
+export type CustomChannelFieldApi = (typeof CustomChannelFieldApi)[keyof typeof CustomChannelFieldApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CustomChannelFieldApi = {
+    utm_source: 'utm_source',
+    utm_medium: 'utm_medium',
+    utm_campaign: 'utm_campaign',
+    referring_domain: 'referring_domain',
+    url: 'url',
+    pathname: 'pathname',
+    hostname: 'hostname',
+} as const
+
+export type CustomChannelOperatorApi = (typeof CustomChannelOperatorApi)[keyof typeof CustomChannelOperatorApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CustomChannelOperatorApi = {
+    exact: 'exact',
+    is_not: 'is_not',
+    is_set: 'is_set',
+    is_not_set: 'is_not_set',
+    icontains: 'icontains',
+    not_icontains: 'not_icontains',
+    regex: 'regex',
+    not_regex: 'not_regex',
+} as const
+
+export type CustomChannelConditionApiValue = string | string[]
+
+export interface CustomChannelConditionApi {
+    id: string
+    key: CustomChannelFieldApi
+    op: CustomChannelOperatorApi
+    value?: CustomChannelConditionApiValue
+}
+
+export interface CustomChannelRuleApi {
+    channel_type: string
+    combiner: FilterLogicalOperatorApi
+    id: string
+    items: CustomChannelConditionApi[]
+}
+
+export interface DataWarehouseEventsModifierApi {
+    distinct_id_field: string
+    id_field: string
+    table_name: string
+    timestamp_field: string
+}
 
 export type InCohortViaApi = (typeof InCohortViaApi)[keyof typeof InCohortViaApi]
 
@@ -130,6 +599,9 @@ export const MaterializationModeApi = {
     legacy_null_as_null: 'legacy_null_as_null',
     disabled: 'disabled',
 } as const
+
+export type MaterializedColumnsOptimizationModeApi =
+    (typeof MaterializedColumnsOptimizationModeApi)[keyof typeof MaterializedColumnsOptimizationModeApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const MaterializedColumnsOptimizationModeApi = {
@@ -191,6 +663,298 @@ export const SessionsV2JoinModeApi = {
     uuid: 'uuid',
 } as const
 
+export interface HogQLQueryModifiersApi {
+    /** @nullable */
+    bounceRateDurationSeconds?: number | null
+    bounceRatePageViewMode?: BounceRatePageViewModeApi
+    /** @nullable */
+    convertToProjectTimezone?: boolean | null
+    /** @nullable */
+    customChannelTypeRules?: CustomChannelRuleApi[] | null
+    /** @nullable */
+    dataWarehouseEventsModifiers?: DataWarehouseEventsModifierApi[] | null
+    /** @nullable */
+    debug?: boolean | null
+    /** @nullable */
+    formatCsvAllowDoubleQuotes?: boolean | null
+    inCohortVia?: InCohortViaApi
+    materializationMode?: MaterializationModeApi
+    materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationModeApi
+    /** @nullable */
+    optimizeJoinedFilters?: boolean | null
+    /** @nullable */
+    optimizeProjections?: boolean | null
+    personsArgMaxVersion?: PersonsArgMaxVersionApi
+    personsJoinMode?: PersonsJoinModeApi
+    personsOnEventsMode?: PersonsOnEventsModeApi
+    propertyGroupsMode?: PropertyGroupsModeApi
+    /** @nullable */
+    s3TableUseInvalidColumns?: boolean | null
+    sessionTableVersion?: SessionTableVersionApi
+    sessionsV2JoinMode?: SessionsV2JoinModeApi
+    /** @nullable */
+    timings?: boolean | null
+    /** @nullable */
+    useMaterializedViews?: boolean | null
+    /** @nullable */
+    usePreaggregatedIntermediateResults?: boolean | null
+    /**
+     * Try to automatically convert HogQL queries to use preaggregated tables at the AST level *
+     * @nullable
+     */
+    usePreaggregatedTableTransforms?: boolean | null
+    /** @nullable */
+    usePresortedEventsTable?: boolean | null
+    /** @nullable */
+    useWebAnalyticsPreAggregatedTables?: boolean | null
+}
+
+export interface HogQLNoticeApi {
+    /** @nullable */
+    end?: number | null
+    /** @nullable */
+    fix?: string | null
+    message: string
+    /** @nullable */
+    start?: number | null
+}
+
+export type QueryIndexUsageApi = (typeof QueryIndexUsageApi)[keyof typeof QueryIndexUsageApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const QueryIndexUsageApi = {
+    undecisive: 'undecisive',
+    no: 'no',
+    partial: 'partial',
+    yes: 'yes',
+} as const
+
+export interface HogQLMetadataResponseApi {
+    /** @nullable */
+    ch_table_names?: string[] | null
+    errors: HogQLNoticeApi[]
+    isUsingIndices?: QueryIndexUsageApi
+    /** @nullable */
+    isValid?: boolean | null
+    notices: HogQLNoticeApi[]
+    /** @nullable */
+    query?: string | null
+    /** @nullable */
+    table_names?: string[] | null
+    warnings: HogQLNoticeApi[]
+}
+
+export interface ClickhouseQueryProgressApi {
+    active_cpu_time: number
+    bytes_read: number
+    estimated_rows_total: number
+    rows_read: number
+    time_elapsed: number
+}
+
+export interface QueryStatusApi {
+    /**
+     * Whether the query is still running. Will be true if the query is complete, even if it errored. Either result or error will be set.
+     * @nullable
+     */
+    complete?: boolean | null
+    /** @nullable */
+    dashboard_id?: number | null
+    /**
+     * When did the query execution task finish (whether successfully or not).
+     * @nullable
+     */
+    end_time?: string | null
+    /**
+     * If the query failed, this will be set to true. More information can be found in the error_message field.
+     * @nullable
+     */
+    error?: boolean | null
+    /** @nullable */
+    error_message?: string | null
+    /** @nullable */
+    expiration_time?: string | null
+    id: string
+    /** @nullable */
+    insight_id?: number | null
+    /** @nullable */
+    labels?: string[] | null
+    /**
+     * When was the query execution task picked up by a worker.
+     * @nullable
+     */
+    pickup_time?: string | null
+    /** ONLY async queries use QueryStatus. */
+    query_async?: boolean
+    query_progress?: ClickhouseQueryProgressApi
+    results?: unknown
+    /**
+     * When was query execution task enqueued.
+     * @nullable
+     */
+    start_time?: string | null
+    /** @nullable */
+    task_id?: string | null
+    team_id: number
+}
+
+export interface ResolvedDateRangeResponseApi {
+    date_from: string
+    date_to: string
+}
+
+export interface QueryTimingApi {
+    /** Key. Shortened to 'k' to save on data. */
+    k: string
+    /** Time in seconds. Shortened to 't' to save on data. */
+    t: number
+}
+
+export interface HogQLQueryResponseApi {
+    /**
+     * Executed ClickHouse query
+     * @nullable
+     */
+    clickhouse?: string | null
+    /**
+     * Returned columns
+     * @nullable
+     */
+    columns?: unknown[] | null
+    /**
+     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
+     * @nullable
+     */
+    error?: string | null
+    /**
+     * Query explanation output
+     * @nullable
+     */
+    explain?: string[] | null
+    /** @nullable */
+    hasMore?: boolean | null
+    /**
+     * Generated HogQL query.
+     * @nullable
+     */
+    hogql?: string | null
+    /** @nullable */
+    limit?: number | null
+    /** Query metadata output */
+    metadata?: HogQLMetadataResponseApi
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** @nullable */
+    offset?: number | null
+    /**
+     * Input query string
+     * @nullable
+     */
+    query?: string | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi
+    results: unknown[]
+    /**
+     * Measured timings for different parts of the query generation process
+     * @nullable
+     */
+    timings?: QueryTimingApi[] | null
+    /**
+     * Types of returned columns
+     * @nullable
+     */
+    types?: unknown[] | null
+}
+
+export interface QueryLogTagsApi {
+    /**
+     * Name of the query, preferably unique. For example web_analytics_vitals
+     * @nullable
+     */
+    name?: string | null
+    /**
+     * Product responsible for this query. Use string, there's no need to churn the Schema when we add a new product *
+     * @nullable
+     */
+    productKey?: string | null
+    /**
+     * Scene where this query is shown in the UI. Use string, there's no need to churn the Schema when we add a new Scene *
+     * @nullable
+     */
+    scene?: string | null
+}
+
+export interface HogQLVariableApi {
+    code_name: string
+    /** @nullable */
+    isNull?: boolean | null
+    value?: unknown
+    variableId: string
+}
+
+export type HogQLQueryApiKind = (typeof HogQLQueryApiKind)[keyof typeof HogQLQueryApiKind]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const HogQLQueryApiKind = {
+    HogQLQuery: 'HogQLQuery',
+} as const
+
+/**
+ * Constant values that can be referenced with the {placeholder} syntax in the query
+ */
+export type HogQLQueryApiValuesAnyOf = { [key: string]: unknown }
+
+/**
+ * Constant values that can be referenced with the {placeholder} syntax in the query
+ * @nullable
+ */
+export type HogQLQueryApiValues = HogQLQueryApiValuesAnyOf | null | null
+
+/**
+ * Variables to be substituted into the query
+ */
+export type HogQLQueryApiVariablesAnyOf = { [key: string]: HogQLVariableApi }
+
+/**
+ * Variables to be substituted into the query
+ * @nullable
+ */
+export type HogQLQueryApiVariables = HogQLQueryApiVariablesAnyOf | null | null
+
+export interface HogQLQueryApi {
+    /** @nullable */
+    explain?: boolean | null
+    filters?: HogQLFiltersApi
+    kind?: HogQLQueryApiKind
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /**
+     * Client provided name of the query
+     * @nullable
+     */
+    name?: string | null
+    query: string
+    response?: HogQLQueryResponseApi
+    tags?: QueryLogTagsApi
+    /**
+     * Constant values that can be referenced with the {placeholder} syntax in the query
+     * @nullable
+     */
+    values?: HogQLQueryApiValues
+    /**
+     * Variables to be substituted into the query
+     * @nullable
+     */
+    variables?: HogQLQueryApiVariables
+    /**
+     * version of the node, used for schema migrations
+     * @nullable
+     */
+    version?: number | null
+}
+
 export type BreakdownTypeApi = (typeof BreakdownTypeApi)[keyof typeof BreakdownTypeApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -207,70 +971,154 @@ export const BreakdownTypeApi = {
     revenue_analytics: 'revenue_analytics',
 } as const
 
-export type PropertyOperatorApi = (typeof PropertyOperatorApi)[keyof typeof PropertyOperatorApi]
+export type MultipleBreakdownTypeApi = (typeof MultipleBreakdownTypeApi)[keyof typeof MultipleBreakdownTypeApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PropertyOperatorApi = {
-    exact: 'exact',
-    is_not: 'is_not',
-    icontains: 'icontains',
-    not_icontains: 'not_icontains',
-    regex: 'regex',
-    not_regex: 'not_regex',
-    gt: 'gt',
-    gte: 'gte',
-    lt: 'lt',
-    lte: 'lte',
-    is_set: 'is_set',
-    is_not_set: 'is_not_set',
-    is_date_exact: 'is_date_exact',
-    is_date_before: 'is_date_before',
-    is_date_after: 'is_date_after',
-    between: 'between',
-    not_between: 'not_between',
-    min: 'min',
-    max: 'max',
-    in: 'in',
-    not_in: 'not_in',
-    is_cleaned_path_exact: 'is_cleaned_path_exact',
-    flag_evaluates_to: 'flag_evaluates_to',
+export const MultipleBreakdownTypeApi = {
+    cohort: 'cohort',
+    person: 'person',
+    event: 'event',
+    event_metadata: 'event_metadata',
+    group: 'group',
+    session: 'session',
+    hogql: 'hogql',
+    revenue_analytics: 'revenue_analytics',
 } as const
 
-export type KeyApi = (typeof KeyApi)[keyof typeof KeyApi]
+export type BreakdownApiProperty = string | number
+
+export interface BreakdownApi {
+    /** @nullable */
+    group_type_index?: number | null
+    /** @nullable */
+    histogram_bin_count?: number | null
+    /** @nullable */
+    normalize_url?: boolean | null
+    property: BreakdownApiProperty
+    type?: MultipleBreakdownTypeApi
+}
+
+export type BreakdownFilterApiBreakdownAnyOfItem = string | number
+
+export type BreakdownFilterApiBreakdown = string | BreakdownFilterApiBreakdownAnyOfItem[] | number
+
+export interface BreakdownFilterApi {
+    breakdown?: BreakdownFilterApiBreakdown
+    /** @nullable */
+    breakdown_group_type_index?: number | null
+    /** @nullable */
+    breakdown_hide_other_aggregation?: boolean | null
+    /** @nullable */
+    breakdown_histogram_bin_count?: number | null
+    /** @nullable */
+    breakdown_limit?: number | null
+    /** @nullable */
+    breakdown_normalize_url?: boolean | null
+    /** @nullable */
+    breakdown_path_cleaning?: boolean | null
+    breakdown_type?: BreakdownTypeApi
+    /**
+     * @maxItems 3
+     * @nullable
+     */
+    breakdowns?: BreakdownApi[] | null
+}
+
+export interface CompareFilterApi {
+    /**
+     * Whether to compare the current date range to a previous date range.
+     * @nullable
+     */
+    compare?: boolean | null
+    /**
+     * The date range to compare to. The value is a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-100w` for 100 weeks ago, `-14d` for 14 days ago, `-30h` for 30 hours ago.
+     * @nullable
+     */
+    compare_to?: string | null
+}
+
+export interface ActionConversionGoalApi {
+    actionId: number
+}
+
+export interface CustomEventConversionGoalApi {
+    customEventName: string
+}
+
+export type IntervalTypeApi = (typeof IntervalTypeApi)[keyof typeof IntervalTypeApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const KeyApi = {
-    tag_name: 'tag_name',
-    text: 'text',
-    href: 'href',
-    selector: 'selector',
+export const IntervalTypeApi = {
+    second: 'second',
+    minute: 'minute',
+    hour: 'hour',
+    day: 'day',
+    week: 'week',
+    month: 'month',
 } as const
 
-export type DurationTypeApi = (typeof DurationTypeApi)[keyof typeof DurationTypeApi]
+export type PropertyGroupFilterValueApiValuesItem =
+    | PropertyGroupFilterValueApi
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | ElementPropertyFilterApi
+    | EventMetadataPropertyFilterApi
+    | SessionPropertyFilterApi
+    | CohortPropertyFilterApi
+    | RecordingPropertyFilterApi
+    | LogEntryPropertyFilterApi
+    | GroupPropertyFilterApi
+    | FeaturePropertyFilterApi
+    | FlagPropertyFilterApi
+    | HogQLPropertyFilterApi
+    | EmptyPropertyFilterApi
+    | DataWarehousePropertyFilterApi
+    | DataWarehousePersonPropertyFilterApi
+    | ErrorTrackingIssueFilterApi
+    | LogPropertyFilterApi
+    | RevenueAnalyticsPropertyFilterApi
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DurationTypeApi = {
-    duration: 'duration',
-    active_seconds: 'active_seconds',
-    inactive_seconds: 'inactive_seconds',
-} as const
+export interface PropertyGroupFilterValueApi {
+    type: FilterLogicalOperatorApi
+    values: PropertyGroupFilterValueApiValuesItem[]
+}
 
-export type LogPropertyFilterTypeApi = (typeof LogPropertyFilterTypeApi)[keyof typeof LogPropertyFilterTypeApi]
+export interface PropertyGroupFilterApi {
+    type: FilterLogicalOperatorApi
+    values: PropertyGroupFilterValueApi[]
+}
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const LogPropertyFilterTypeApi = {
-    log: 'log',
-    log_attribute: 'log_attribute',
-    log_resource_attribute: 'log_resource_attribute',
-} as const
+export type TrendsQueryResponseApiResultsItem = { [key: string]: unknown }
 
-export type FilterLogicalOperatorApi = (typeof FilterLogicalOperatorApi)[keyof typeof FilterLogicalOperatorApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FilterLogicalOperatorApi = {
-    AND: 'AND',
-    OR: 'OR',
-} as const
+export interface TrendsQueryResponseApi {
+    /**
+     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
+     * @nullable
+     */
+    error?: string | null
+    /**
+     * Wether more breakdown values are available.
+     * @nullable
+     */
+    hasMore?: boolean | null
+    /**
+     * Generated HogQL query.
+     * @nullable
+     */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi
+    results: TrendsQueryResponseApiResultsItem[]
+    /**
+     * Measured timings for different parts of the query generation process
+     * @nullable
+     */
+    timings?: QueryTimingApi[] | null
+}
 
 export type BaseMathTypeApi = (typeof BaseMathTypeApi)[keyof typeof BaseMathTypeApi]
 
@@ -355,223 +1203,6 @@ export const MathGroupTypeIndexApi = {
     NUMBER_2: 2,
     NUMBER_3: 3,
     NUMBER_4: 4,
-} as const
-
-export type AggregationAxisFormatApi = (typeof AggregationAxisFormatApi)[keyof typeof AggregationAxisFormatApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AggregationAxisFormatApi = {
-    numeric: 'numeric',
-    duration: 'duration',
-    duration_ms: 'duration_ms',
-    percentage: 'percentage',
-    percentage_scaled: 'percentage_scaled',
-    currency: 'currency',
-} as const
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DetailedResultsAggregationTypeApi = {
-    total: 'total',
-    average: 'average',
-    median: 'median',
-} as const
-
-export type ChartDisplayTypeApi = (typeof ChartDisplayTypeApi)[keyof typeof ChartDisplayTypeApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ChartDisplayTypeApi = {
-    ActionsLineGraph: 'ActionsLineGraph',
-    ActionsBar: 'ActionsBar',
-    ActionsUnstackedBar: 'ActionsUnstackedBar',
-    ActionsStackedBar: 'ActionsStackedBar',
-    ActionsAreaGraph: 'ActionsAreaGraph',
-    ActionsLineGraphCumulative: 'ActionsLineGraphCumulative',
-    BoldNumber: 'BoldNumber',
-    ActionsPie: 'ActionsPie',
-    ActionsBarValue: 'ActionsBarValue',
-    ActionsTable: 'ActionsTable',
-    WorldMap: 'WorldMap',
-    CalendarHeatmap: 'CalendarHeatmap',
-} as const
-
-export type ResultCustomizationByApi = (typeof ResultCustomizationByApi)[keyof typeof ResultCustomizationByApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ResultCustomizationByApi = {
-    value: 'value',
-    position: 'position',
-} as const
-
-export type YAxisScaleTypeApi = (typeof YAxisScaleTypeApi)[keyof typeof YAxisScaleTypeApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const YAxisScaleTypeApi = {
-    log10: 'log10',
-    linear: 'linear',
-} as const
-
-export type BreakdownAttributionTypeApi = (typeof BreakdownAttributionTypeApi)[keyof typeof BreakdownAttributionTypeApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const BreakdownAttributionTypeApi = {
-    first_touch: 'first_touch',
-    last_touch: 'last_touch',
-    all_events: 'all_events',
-    step: 'step',
-} as const
-
-export type StepOrderValueApi = (typeof StepOrderValueApi)[keyof typeof StepOrderValueApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const StepOrderValueApi = {
-    strict: 'strict',
-    unordered: 'unordered',
-    ordered: 'ordered',
-} as const
-
-export type FunnelStepReferenceApi = (typeof FunnelStepReferenceApi)[keyof typeof FunnelStepReferenceApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FunnelStepReferenceApi = {
-    total: 'total',
-    previous: 'previous',
-} as const
-
-export type FunnelVizTypeApi = (typeof FunnelVizTypeApi)[keyof typeof FunnelVizTypeApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FunnelVizTypeApi = {
-    steps: 'steps',
-    time_to_convert: 'time_to_convert',
-    trends: 'trends',
-} as const
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FunnelConversionWindowTimeUnitApi = {
-    second: 'second',
-    minute: 'minute',
-    hour: 'hour',
-    day: 'day',
-    week: 'week',
-    month: 'month',
-} as const
-
-export type FunnelLayoutApi = (typeof FunnelLayoutApi)[keyof typeof FunnelLayoutApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FunnelLayoutApi = {
-    horizontal: 'horizontal',
-    vertical: 'vertical',
-} as const
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RetentionDashboardDisplayTypeApi = {
-    table_only: 'table_only',
-    graph_only: 'graph_only',
-    all: 'all',
-} as const
-
-export type MeanRetentionCalculationApi = (typeof MeanRetentionCalculationApi)[keyof typeof MeanRetentionCalculationApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MeanRetentionCalculationApi = {
-    simple: 'simple',
-    weighted: 'weighted',
-    none: 'none',
-} as const
-
-export type RetentionPeriodApi = (typeof RetentionPeriodApi)[keyof typeof RetentionPeriodApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RetentionPeriodApi = {
-    Hour: 'Hour',
-    Day: 'Day',
-    Week: 'Week',
-    Month: 'Month',
-} as const
-
-export type RetentionReferenceApi = (typeof RetentionReferenceApi)[keyof typeof RetentionReferenceApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RetentionReferenceApi = {
-    total: 'total',
-    previous: 'previous',
-} as const
-
-export type RetentionTypeApi = (typeof RetentionTypeApi)[keyof typeof RetentionTypeApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RetentionTypeApi = {
-    retention_recurring: 'retention_recurring',
-    retention_first_time: 'retention_first_time',
-    retention_first_ever_occurrence: 'retention_first_ever_occurrence',
-} as const
-
-export type TimeWindowModeApi = (typeof TimeWindowModeApi)[keyof typeof TimeWindowModeApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const TimeWindowModeApi = {
-    strict_calendar_dates: 'strict_calendar_dates',
-    '24_hour_windows': '24_hour_windows',
-} as const
-
-export type FunnelPathTypeApi = (typeof FunnelPathTypeApi)[keyof typeof FunnelPathTypeApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FunnelPathTypeApi = {
-    funnel_path_before_step: 'funnel_path_before_step',
-    funnel_path_between_steps: 'funnel_path_between_steps',
-    funnel_path_after_step: 'funnel_path_after_step',
-} as const
-
-export type PathTypeApi = (typeof PathTypeApi)[keyof typeof PathTypeApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PathTypeApi = {
-    $pageview: '$pageview',
-    $screen: '$screen',
-    custom_event: 'custom_event',
-    hogql: 'hogql',
-} as const
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const StickinessComputationModeApi = {
-    non_cumulative: 'non_cumulative',
-    cumulative: 'cumulative',
-} as const
-
-export type LifecycleToggleApi = (typeof LifecycleToggleApi)[keyof typeof LifecycleToggleApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const LifecycleToggleApi = {
-    new: 'new',
-    resurrecting: 'resurrecting',
-    returning: 'returning',
-    dormant: 'dormant',
-} as const
-
-export type QueryIndexUsageApi = (typeof QueryIndexUsageApi)[keyof typeof QueryIndexUsageApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const QueryIndexUsageApi = {
-    undecisive: 'undecisive',
-    no: 'no',
-    partial: 'partial',
-    yes: 'yes',
-} as const
-
-export type MultipleBreakdownTypeApi = (typeof MultipleBreakdownTypeApi)[keyof typeof MultipleBreakdownTypeApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MultipleBreakdownTypeApi = {
-    cohort: 'cohort',
-    person: 'person',
-    event: 'event',
-    event_metadata: 'event_metadata',
-    group: 'group',
-    session: 'session',
-    hogql: 'hogql',
-    revenue_analytics: 'revenue_analytics',
 } as const
 
 export type CurrencyCodeApi = (typeof CurrencyCodeApi)[keyof typeof CurrencyCodeApi]
@@ -732,1912 +1363,10 @@ export const CurrencyCodeApi = {
     ZMW: 'ZMW',
 } as const
 
-export type PositionApi = (typeof PositionApi)[keyof typeof PositionApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PositionApi = {
-    start: 'start',
-    end: 'end',
-} as const
-
-export type DataColorTokenApi = (typeof DataColorTokenApi)[keyof typeof DataColorTokenApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DataColorTokenApi = {
-    'preset-1': 'preset-1',
-    'preset-2': 'preset-2',
-    'preset-3': 'preset-3',
-    'preset-4': 'preset-4',
-    'preset-5': 'preset-5',
-    'preset-6': 'preset-6',
-    'preset-7': 'preset-7',
-    'preset-8': 'preset-8',
-    'preset-9': 'preset-9',
-    'preset-10': 'preset-10',
-    'preset-11': 'preset-11',
-    'preset-12': 'preset-12',
-    'preset-13': 'preset-13',
-    'preset-14': 'preset-14',
-    'preset-15': 'preset-15',
-} as const
-
-export type RetentionEntityKindApi = (typeof RetentionEntityKindApi)[keyof typeof RetentionEntityKindApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RetentionEntityKindApi = {
-    ActionsNode: 'ActionsNode',
-    EventsNode: 'EventsNode',
-} as const
-
-export type EntityTypeApi = (typeof EntityTypeApi)[keyof typeof EntityTypeApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EntityTypeApi = {
-    actions: 'actions',
-    events: 'events',
-    data_warehouse: 'data_warehouse',
-    new_entity: 'new_entity',
-} as const
-
-export type StickinessOperatorApi = (typeof StickinessOperatorApi)[keyof typeof StickinessOperatorApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const StickinessOperatorApi = {
-    gte: 'gte',
-    lte: 'lte',
-    exact: 'exact',
-} as const
-
-export type WebAnalyticsItemKindApi = (typeof WebAnalyticsItemKindApi)[keyof typeof WebAnalyticsItemKindApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const WebAnalyticsItemKindApi = {
-    unit: 'unit',
-    duration_s: 'duration_s',
-    percentage: 'percentage',
-    currency: 'currency',
-} as const
-
-export type CustomChannelFieldApi = (typeof CustomChannelFieldApi)[keyof typeof CustomChannelFieldApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const CustomChannelFieldApi = {
-    utm_source: 'utm_source',
-    utm_medium: 'utm_medium',
-    utm_campaign: 'utm_campaign',
-    referring_domain: 'referring_domain',
-    url: 'url',
-    pathname: 'pathname',
-    hostname: 'hostname',
-} as const
-
-export type CustomChannelOperatorApi = (typeof CustomChannelOperatorApi)[keyof typeof CustomChannelOperatorApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const CustomChannelOperatorApi = {
-    exact: 'exact',
-    is_not: 'is_not',
-    is_set: 'is_set',
-    is_not_set: 'is_not_set',
-    icontains: 'icontains',
-    not_icontains: 'not_icontains',
-    regex: 'regex',
-    not_regex: 'not_regex',
-} as const
-
-export type DataWarehouseSyncIntervalApi =
-    (typeof DataWarehouseSyncIntervalApi)[keyof typeof DataWarehouseSyncIntervalApi]
-
-export type WebAnalyticsOrderByFieldsApi =
-    (typeof WebAnalyticsOrderByFieldsApi)[keyof typeof WebAnalyticsOrderByFieldsApi]
-
-export type WebAnalyticsOrderByDirectionApi =
-    (typeof WebAnalyticsOrderByDirectionApi)[keyof typeof WebAnalyticsOrderByDirectionApi]
-
-export type MaterializedColumnsOptimizationModeApi =
-    (typeof MaterializedColumnsOptimizationModeApi)[keyof typeof MaterializedColumnsOptimizationModeApi]
-
-export type DetailedResultsAggregationTypeApi =
-    (typeof DetailedResultsAggregationTypeApi)[keyof typeof DetailedResultsAggregationTypeApi]
-
-export type FunnelConversionWindowTimeUnitApi =
-    (typeof FunnelConversionWindowTimeUnitApi)[keyof typeof FunnelConversionWindowTimeUnitApi]
-
-export type RetentionDashboardDisplayTypeApi =
-    (typeof RetentionDashboardDisplayTypeApi)[keyof typeof RetentionDashboardDisplayTypeApi]
-
-export type StickinessComputationModeApi =
-    (typeof StickinessComputationModeApi)[keyof typeof StickinessComputationModeApi]
-
-export type EndpointRequestApiQuery =
-    | HogQLQueryApi
-    | TrendsQueryApi
-    | FunnelsQueryApi
-    | RetentionQueryApi
-    | PathsQueryApi
-    | StickinessQueryApi
-    | LifecycleQueryApi
-    | WebStatsTableQueryApi
-    | WebOverviewQueryApi
-    | null
-
-export interface EndpointRequestApi {
+export interface RevenueCurrencyPropertyConfigApi {
     /** @nullable */
-    cache_age_seconds?: number | null
-    /** @nullable */
-    derived_from_insight?: string | null
-    /** @nullable */
-    description?: string | null
-    /** @nullable */
-    is_active?: boolean | null
-    /**
-     * Whether this endpoint's query results are materialized to S3
-     * @nullable
-     */
-    is_materialized?: boolean | null
-    /** @nullable */
-    name?: string | null
-    /** @nullable */
-    query?: EndpointRequestApiQuery
-    /**
-     * How frequently should the underlying materialized view be updated
-     * @nullable
-     */
-    sync_frequency?: DataWarehouseSyncIntervalApi
-}
-
-/**
- * Map of Insight query keys to be overridden at execution time. For example:   Assuming query = {"kind": "TrendsQuery", "series": [{"kind": "EventsNode","name": "$pageview","event": "$pageview","math": "total"}]}   If query_override = {"series": [{"kind": "EventsNode","name": "$identify","event": "$identify","math": "total"}]}   The query executed will return the count of $identify events, instead of $pageview's
- * @nullable
- */
-export type EndpointRunRequestApiQueryOverride = { [key: string]: unknown } | null
-
-/**
- * A map for overriding HogQL query variables, where the key is the variable name and the value is the variable value. Variable must be set on the endpoint's query between curly braces (i.e. {variable.from_date}) For example: {"from_date": "1970-01-01"}
- * @nullable
- */
-export type EndpointRunRequestApiVariables = { [key: string]: unknown } | null
-
-export interface EndpointRunRequestApi {
-    /**
-     * Client provided query ID. Can be used to retrieve the status or cancel the query.
-     * @nullable
-     */
-    client_query_id?: string | null
-    /**
-   * A map for overriding insight query filters.
-
-Tip: Use to get data for a specific customer or user.
-   * @nullable
-   */
-    filters_override?: DashboardFilterApi
-    /**
-     * Map of Insight query keys to be overridden at execution time. For example:   Assuming query = {"kind": "TrendsQuery", "series": [{"kind": "EventsNode","name": "$pageview","event": "$pageview","math": "total"}]}   If query_override = {"series": [{"kind": "EventsNode","name": "$identify","event": "$identify","math": "total"}]}   The query executed will return the count of $identify events, instead of $pageview's
-     * @nullable
-     */
-    query_override?: EndpointRunRequestApiQueryOverride
-    /**
-   * Whether results should be calculated sync or async, and how much to rely on the cache:
-- `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-- `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-   * @nullable
-   */
-    refresh?: RefreshTypeApi
-    /**
-     * A map for overriding HogQL query variables, where the key is the variable name and the value is the variable value. Variable must be set on the endpoint's query between curly braces (i.e. {variable.from_date}) For example: {"from_date": "1970-01-01"}
-     * @nullable
-     */
-    variables?: EndpointRunRequestApiVariables
-    /**
-     * Specific endpoint version to execute. If not provided, the latest version is used.
-     * @nullable
-     */
-    version?: number | null
-}
-
-export interface EndpointLastExecutionTimesRequestApi {
-    names: string[]
-}
-
-export interface QueryStatusResponseApi {
-    query_status: QueryStatusApi
-}
-
-export type HogQLQueryApiKind = (typeof HogQLQueryApiKind)[keyof typeof HogQLQueryApiKind]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const HogQLQueryApiKind = {
-    HogQLQuery: 'HogQLQuery',
-} as const
-
-/**
- * Constant values that can be referenced with the {placeholder} syntax in the query
- * @nullable
- */
-export type HogQLQueryApiValues = { [key: string]: unknown } | null
-
-/**
- * Variables to be substituted into the query
- * @nullable
- */
-export type HogQLQueryApiVariables = { [key: string]: HogQLVariableApi } | null
-
-export interface HogQLQueryApi {
-    /** @nullable */
-    explain?: boolean | null
-    /** @nullable */
-    filters?: HogQLFiltersApi
-    kind?: HogQLQueryApiKind
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Client provided name of the query
-     * @nullable
-     */
-    name?: string | null
-    query: string
-    /** @nullable */
-    response?: HogQLQueryResponseApi
-    /** @nullable */
-    tags?: QueryLogTagsApi
-    /**
-     * Constant values that can be referenced with the {placeholder} syntax in the query
-     * @nullable
-     */
-    values?: HogQLQueryApiValues
-    /**
-     * Variables to be substituted into the query
-     * @nullable
-     */
-    variables?: HogQLQueryApiVariables
-    /**
-     * version of the node, used for schema migrations
-     * @nullable
-     */
-    version?: number | null
-}
-
-/**
- * Whether we should be comparing against a specific conversion goal
- * @nullable
- */
-export type TrendsQueryApiConversionGoal = ActionConversionGoalApi | CustomEventConversionGoalApi | null
-
-export type TrendsQueryApiKind = (typeof TrendsQueryApiKind)[keyof typeof TrendsQueryApiKind]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const TrendsQueryApiKind = {
-    TrendsQuery: 'TrendsQuery',
-} as const
-
-export type TrendsQueryApiPropertiesAnyOfItem =
-    | EventPropertyFilterApi
-    | PersonPropertyFilterApi
-    | ElementPropertyFilterApi
-    | EventMetadataPropertyFilterApi
-    | SessionPropertyFilterApi
-    | CohortPropertyFilterApi
-    | RecordingPropertyFilterApi
-    | LogEntryPropertyFilterApi
-    | GroupPropertyFilterApi
-    | FeaturePropertyFilterApi
-    | FlagPropertyFilterApi
-    | HogQLPropertyFilterApi
-    | EmptyPropertyFilterApi
-    | DataWarehousePropertyFilterApi
-    | DataWarehousePersonPropertyFilterApi
-    | ErrorTrackingIssueFilterApi
-    | LogPropertyFilterApi
-    | RevenueAnalyticsPropertyFilterApi
-
-/**
- * Property filters for all series
- * @nullable
- */
-export type TrendsQueryApiProperties = TrendsQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi | null
-
-export type TrendsQueryApiSeriesItem = EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi
-
-export interface TrendsQueryApi {
-    /**
-     * Groups aggregation
-     * @nullable
-     */
-    aggregation_group_type_index?: number | null
-    /**
-     * Breakdown of the events and actions
-     * @nullable
-     */
-    breakdownFilter?: BreakdownFilterApi
-    /**
-     * Compare to date range
-     * @nullable
-     */
-    compareFilter?: CompareFilterApi
-    /**
-     * Whether we should be comparing against a specific conversion goal
-     * @nullable
-     */
-    conversionGoal?: TrendsQueryApiConversionGoal
-    /**
-     * Colors used in the insight's visualization
-     * @nullable
-     */
-    dataColorTheme?: number | null
-    /**
-     * Date range for the query
-     * @nullable
-     */
-    dateRange?: DateRangeApi
-    /**
-     * Exclude internal and test users by applying the respective filters
-     * @nullable
-     */
-    filterTestAccounts?: boolean | null
-    /**
-     * Granularity of the response. Can be one of `hour`, `day`, `week` or `month`
-     * @nullable
-     */
-    interval?: IntervalTypeApi
-    kind?: TrendsQueryApiKind
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Property filters for all series
-     * @nullable
-     */
-    properties?: TrendsQueryApiProperties
-    /** @nullable */
-    response?: TrendsQueryResponseApi
-    /**
-     * Sampling rate
-     * @nullable
-     */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: TrendsQueryApiSeriesItem[]
-    /**
-     * Tags that will be added to the Query log comment
-     * @nullable
-     */
-    tags?: QueryLogTagsApi
-    /**
-     * Properties specific to the trends insight
-     * @nullable
-     */
-    trendsFilter?: TrendsFilterApi
-    /**
-     * version of the node, used for schema migrations
-     * @nullable
-     */
-    version?: number | null
-}
-
-export type FunnelsQueryApiKind = (typeof FunnelsQueryApiKind)[keyof typeof FunnelsQueryApiKind]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FunnelsQueryApiKind = {
-    FunnelsQuery: 'FunnelsQuery',
-} as const
-
-export type FunnelsQueryApiPropertiesAnyOfItem =
-    | EventPropertyFilterApi
-    | PersonPropertyFilterApi
-    | ElementPropertyFilterApi
-    | EventMetadataPropertyFilterApi
-    | SessionPropertyFilterApi
-    | CohortPropertyFilterApi
-    | RecordingPropertyFilterApi
-    | LogEntryPropertyFilterApi
-    | GroupPropertyFilterApi
-    | FeaturePropertyFilterApi
-    | FlagPropertyFilterApi
-    | HogQLPropertyFilterApi
-    | EmptyPropertyFilterApi
-    | DataWarehousePropertyFilterApi
-    | DataWarehousePersonPropertyFilterApi
-    | ErrorTrackingIssueFilterApi
-    | LogPropertyFilterApi
-    | RevenueAnalyticsPropertyFilterApi
-
-/**
- * Property filters for all series
- * @nullable
- */
-export type FunnelsQueryApiProperties = FunnelsQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi | null
-
-export type FunnelsQueryApiSeriesItem = EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi
-
-export interface FunnelsQueryApi {
-    /**
-     * Groups aggregation
-     * @nullable
-     */
-    aggregation_group_type_index?: number | null
-    /**
-     * Breakdown of the events and actions
-     * @nullable
-     */
-    breakdownFilter?: BreakdownFilterApi
-    /**
-     * Colors used in the insight's visualization
-     * @nullable
-     */
-    dataColorTheme?: number | null
-    /**
-     * Date range for the query
-     * @nullable
-     */
-    dateRange?: DateRangeApi
-    /**
-     * Exclude internal and test users by applying the respective filters
-     * @nullable
-     */
-    filterTestAccounts?: boolean | null
-    /**
-     * Properties specific to the funnels insight
-     * @nullable
-     */
-    funnelsFilter?: FunnelsFilterApi
-    /**
-     * Granularity of the response. Can be one of `hour`, `day`, `week` or `month`
-     * @nullable
-     */
-    interval?: IntervalTypeApi
-    kind?: FunnelsQueryApiKind
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Property filters for all series
-     * @nullable
-     */
-    properties?: FunnelsQueryApiProperties
-    /** @nullable */
-    response?: FunnelsQueryResponseApi
-    /**
-     * Sampling rate
-     * @nullable
-     */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: FunnelsQueryApiSeriesItem[]
-    /**
-     * Tags that will be added to the Query log comment
-     * @nullable
-     */
-    tags?: QueryLogTagsApi
-    /**
-     * version of the node, used for schema migrations
-     * @nullable
-     */
-    version?: number | null
-}
-
-export type RetentionQueryApiKind = (typeof RetentionQueryApiKind)[keyof typeof RetentionQueryApiKind]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RetentionQueryApiKind = {
-    RetentionQuery: 'RetentionQuery',
-} as const
-
-export type RetentionQueryApiPropertiesAnyOfItem =
-    | EventPropertyFilterApi
-    | PersonPropertyFilterApi
-    | ElementPropertyFilterApi
-    | EventMetadataPropertyFilterApi
-    | SessionPropertyFilterApi
-    | CohortPropertyFilterApi
-    | RecordingPropertyFilterApi
-    | LogEntryPropertyFilterApi
-    | GroupPropertyFilterApi
-    | FeaturePropertyFilterApi
-    | FlagPropertyFilterApi
-    | HogQLPropertyFilterApi
-    | EmptyPropertyFilterApi
-    | DataWarehousePropertyFilterApi
-    | DataWarehousePersonPropertyFilterApi
-    | ErrorTrackingIssueFilterApi
-    | LogPropertyFilterApi
-    | RevenueAnalyticsPropertyFilterApi
-
-/**
- * Property filters for all series
- * @nullable
- */
-export type RetentionQueryApiProperties = RetentionQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi | null
-
-export interface RetentionQueryApi {
-    /**
-     * Groups aggregation
-     * @nullable
-     */
-    aggregation_group_type_index?: number | null
-    /**
-     * Breakdown of the events and actions
-     * @nullable
-     */
-    breakdownFilter?: BreakdownFilterApi
-    /**
-     * Colors used in the insight's visualization
-     * @nullable
-     */
-    dataColorTheme?: number | null
-    /**
-     * Date range for the query
-     * @nullable
-     */
-    dateRange?: DateRangeApi
-    /**
-     * Exclude internal and test users by applying the respective filters
-     * @nullable
-     */
-    filterTestAccounts?: boolean | null
-    kind?: RetentionQueryApiKind
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Property filters for all series
-     * @nullable
-     */
-    properties?: RetentionQueryApiProperties
-    /** @nullable */
-    response?: RetentionQueryResponseApi
-    /** Properties specific to the retention insight */
-    retentionFilter: RetentionFilterApi
-    /**
-     * Sampling rate
-     * @nullable
-     */
-    samplingFactor?: number | null
-    /**
-     * Tags that will be added to the Query log comment
-     * @nullable
-     */
-    tags?: QueryLogTagsApi
-    /**
-     * version of the node, used for schema migrations
-     * @nullable
-     */
-    version?: number | null
-}
-
-export type PathsQueryApiKind = (typeof PathsQueryApiKind)[keyof typeof PathsQueryApiKind]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PathsQueryApiKind = {
-    PathsQuery: 'PathsQuery',
-} as const
-
-export type PathsQueryApiPropertiesAnyOfItem =
-    | EventPropertyFilterApi
-    | PersonPropertyFilterApi
-    | ElementPropertyFilterApi
-    | EventMetadataPropertyFilterApi
-    | SessionPropertyFilterApi
-    | CohortPropertyFilterApi
-    | RecordingPropertyFilterApi
-    | LogEntryPropertyFilterApi
-    | GroupPropertyFilterApi
-    | FeaturePropertyFilterApi
-    | FlagPropertyFilterApi
-    | HogQLPropertyFilterApi
-    | EmptyPropertyFilterApi
-    | DataWarehousePropertyFilterApi
-    | DataWarehousePersonPropertyFilterApi
-    | ErrorTrackingIssueFilterApi
-    | LogPropertyFilterApi
-    | RevenueAnalyticsPropertyFilterApi
-
-/**
- * Property filters for all series
- * @nullable
- */
-export type PathsQueryApiProperties = PathsQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi | null
-
-export interface PathsQueryApi {
-    /**
-     * Groups aggregation
-     * @nullable
-     */
-    aggregation_group_type_index?: number | null
-    /**
-     * Colors used in the insight's visualization
-     * @nullable
-     */
-    dataColorTheme?: number | null
-    /**
-     * Date range for the query
-     * @nullable
-     */
-    dateRange?: DateRangeApi
-    /**
-     * Exclude internal and test users by applying the respective filters
-     * @nullable
-     */
-    filterTestAccounts?: boolean | null
-    /**
-     * Used for displaying paths in relation to funnel steps.
-     * @nullable
-     */
-    funnelPathsFilter?: FunnelPathsFilterApi
-    kind?: PathsQueryApiKind
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /** Properties specific to the paths insight */
-    pathsFilter: PathsFilterApi
-    /**
-     * Property filters for all series
-     * @nullable
-     */
-    properties?: PathsQueryApiProperties
-    /** @nullable */
-    response?: PathsQueryResponseApi
-    /**
-     * Sampling rate
-     * @nullable
-     */
-    samplingFactor?: number | null
-    /**
-     * Tags that will be added to the Query log comment
-     * @nullable
-     */
-    tags?: QueryLogTagsApi
-    /**
-     * version of the node, used for schema migrations
-     * @nullable
-     */
-    version?: number | null
-}
-
-export type StickinessQueryApiKind = (typeof StickinessQueryApiKind)[keyof typeof StickinessQueryApiKind]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const StickinessQueryApiKind = {
-    StickinessQuery: 'StickinessQuery',
-} as const
-
-export type StickinessQueryApiPropertiesAnyOfItem =
-    | EventPropertyFilterApi
-    | PersonPropertyFilterApi
-    | ElementPropertyFilterApi
-    | EventMetadataPropertyFilterApi
-    | SessionPropertyFilterApi
-    | CohortPropertyFilterApi
-    | RecordingPropertyFilterApi
-    | LogEntryPropertyFilterApi
-    | GroupPropertyFilterApi
-    | FeaturePropertyFilterApi
-    | FlagPropertyFilterApi
-    | HogQLPropertyFilterApi
-    | EmptyPropertyFilterApi
-    | DataWarehousePropertyFilterApi
-    | DataWarehousePersonPropertyFilterApi
-    | ErrorTrackingIssueFilterApi
-    | LogPropertyFilterApi
-    | RevenueAnalyticsPropertyFilterApi
-
-/**
- * Property filters for all series
- * @nullable
- */
-export type StickinessQueryApiProperties = StickinessQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi | null
-
-export type StickinessQueryApiSeriesItem = EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi
-
-export interface StickinessQueryApi {
-    /**
-     * Compare to date range
-     * @nullable
-     */
-    compareFilter?: CompareFilterApi
-    /**
-     * Colors used in the insight's visualization
-     * @nullable
-     */
-    dataColorTheme?: number | null
-    /**
-     * Date range for the query
-     * @nullable
-     */
-    dateRange?: DateRangeApi
-    /**
-     * Exclude internal and test users by applying the respective filters
-     * @nullable
-     */
-    filterTestAccounts?: boolean | null
-    /**
-     * Granularity of the response. Can be one of `hour`, `day`, `week` or `month`
-     * @nullable
-     */
-    interval?: IntervalTypeApi
-    /**
-     * How many intervals comprise a period. Only used for cohorts, otherwise default 1.
-     * @nullable
-     */
-    intervalCount?: number | null
-    kind?: StickinessQueryApiKind
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Property filters for all series
-     * @nullable
-     */
-    properties?: StickinessQueryApiProperties
-    /** @nullable */
-    response?: StickinessQueryResponseApi
-    /**
-     * Sampling rate
-     * @nullable
-     */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: StickinessQueryApiSeriesItem[]
-    /**
-     * Properties specific to the stickiness insight
-     * @nullable
-     */
-    stickinessFilter?: StickinessFilterApi
-    /**
-     * Tags that will be added to the Query log comment
-     * @nullable
-     */
-    tags?: QueryLogTagsApi
-    /**
-     * version of the node, used for schema migrations
-     * @nullable
-     */
-    version?: number | null
-}
-
-export type LifecycleQueryApiKind = (typeof LifecycleQueryApiKind)[keyof typeof LifecycleQueryApiKind]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const LifecycleQueryApiKind = {
-    LifecycleQuery: 'LifecycleQuery',
-} as const
-
-export type LifecycleQueryApiPropertiesAnyOfItem =
-    | EventPropertyFilterApi
-    | PersonPropertyFilterApi
-    | ElementPropertyFilterApi
-    | EventMetadataPropertyFilterApi
-    | SessionPropertyFilterApi
-    | CohortPropertyFilterApi
-    | RecordingPropertyFilterApi
-    | LogEntryPropertyFilterApi
-    | GroupPropertyFilterApi
-    | FeaturePropertyFilterApi
-    | FlagPropertyFilterApi
-    | HogQLPropertyFilterApi
-    | EmptyPropertyFilterApi
-    | DataWarehousePropertyFilterApi
-    | DataWarehousePersonPropertyFilterApi
-    | ErrorTrackingIssueFilterApi
-    | LogPropertyFilterApi
-    | RevenueAnalyticsPropertyFilterApi
-
-/**
- * Property filters for all series
- * @nullable
- */
-export type LifecycleQueryApiProperties = LifecycleQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi | null
-
-export type LifecycleQueryApiSeriesItem = EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi
-
-export interface LifecycleQueryApi {
-    /**
-     * Groups aggregation
-     * @nullable
-     */
-    aggregation_group_type_index?: number | null
-    /**
-     * Colors used in the insight's visualization
-     * @nullable
-     */
-    dataColorTheme?: number | null
-    /**
-     * Date range for the query
-     * @nullable
-     */
-    dateRange?: DateRangeApi
-    /**
-     * Exclude internal and test users by applying the respective filters
-     * @nullable
-     */
-    filterTestAccounts?: boolean | null
-    /**
-     * Granularity of the response. Can be one of `hour`, `day`, `week` or `month`
-     * @nullable
-     */
-    interval?: IntervalTypeApi
-    kind?: LifecycleQueryApiKind
-    /**
-     * Properties specific to the lifecycle insight
-     * @nullable
-     */
-    lifecycleFilter?: LifecycleFilterApi
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Property filters for all series
-     * @nullable
-     */
-    properties?: LifecycleQueryApiProperties
-    /** @nullable */
-    response?: LifecycleQueryResponseApi
-    /**
-     * Sampling rate
-     * @nullable
-     */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: LifecycleQueryApiSeriesItem[]
-    /**
-     * Tags that will be added to the Query log comment
-     * @nullable
-     */
-    tags?: QueryLogTagsApi
-    /**
-     * version of the node, used for schema migrations
-     * @nullable
-     */
-    version?: number | null
-}
-
-/**
- * @nullable
- */
-export type WebStatsTableQueryApiConversionGoal = ActionConversionGoalApi | CustomEventConversionGoalApi | null
-
-export type WebStatsTableQueryApiKind = (typeof WebStatsTableQueryApiKind)[keyof typeof WebStatsTableQueryApiKind]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const WebStatsTableQueryApiKind = {
-    WebStatsTableQuery: 'WebStatsTableQuery',
-} as const
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const WebStatsTableQueryApiOrderByItem = {
-    ...WebAnalyticsOrderByFieldsApi,
-    ...WebAnalyticsOrderByDirectionApi,
-} as const
-export type WebStatsTableQueryApiPropertiesItem =
-    | EventPropertyFilterApi
-    | PersonPropertyFilterApi
-    | SessionPropertyFilterApi
-
-export interface WebStatsTableQueryApi {
-    /**
-     * Groups aggregation - not used in Web Analytics but required for type compatibility
-     * @nullable
-     */
-    aggregation_group_type_index?: number | null
-    breakdownBy: WebStatsBreakdownApi
-    /** @nullable */
-    compareFilter?: CompareFilterApi
-    /** @nullable */
-    conversionGoal?: WebStatsTableQueryApiConversionGoal
-    /**
-     * Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility
-     * @nullable
-     */
-    dataColorTheme?: number | null
-    /** @nullable */
-    dateRange?: DateRangeApi
-    /** @nullable */
-    doPathCleaning?: boolean | null
-    /** @nullable */
-    filterTestAccounts?: boolean | null
-    /** @nullable */
-    includeAvgTimeOnPage?: boolean | null
-    /** @nullable */
-    includeBounceRate?: boolean | null
-    /** @nullable */
-    includeRevenue?: boolean | null
-    /** @nullable */
-    includeScrollDepth?: boolean | null
-    /**
-     * For Product Analytics UI compatibility only - not used in Web Analytics query execution
-     * @nullable
-     */
-    interval?: IntervalTypeApi
-    kind?: WebStatsTableQueryApiKind
-    /** @nullable */
-    limit?: number | null
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /** @nullable */
-    offset?: number | null
-    /** @nullable */
-    orderBy?: (typeof WebStatsTableQueryApiOrderByItem)[keyof typeof WebStatsTableQueryApiOrderByItem][] | null
-    properties: WebStatsTableQueryApiPropertiesItem[]
-    /** @nullable */
-    response?: WebStatsTableQueryResponseApi
-    /** @nullable */
-    sampling?: WebAnalyticsSamplingApi
-    /**
-     * Sampling rate
-     * @nullable
-     */
-    samplingFactor?: number | null
-    /** @nullable */
-    tags?: QueryLogTagsApi
-    /** @nullable */
-    useSessionsTable?: boolean | null
-    /**
-     * version of the node, used for schema migrations
-     * @nullable
-     */
-    version?: number | null
-}
-
-/**
- * @nullable
- */
-export type WebOverviewQueryApiConversionGoal = ActionConversionGoalApi | CustomEventConversionGoalApi | null
-
-export type WebOverviewQueryApiKind = (typeof WebOverviewQueryApiKind)[keyof typeof WebOverviewQueryApiKind]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const WebOverviewQueryApiKind = {
-    WebOverviewQuery: 'WebOverviewQuery',
-} as const
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const WebOverviewQueryApiOrderByItem = {
-    ...WebAnalyticsOrderByFieldsApi,
-    ...WebAnalyticsOrderByDirectionApi,
-} as const
-export type WebOverviewQueryApiPropertiesItem =
-    | EventPropertyFilterApi
-    | PersonPropertyFilterApi
-    | SessionPropertyFilterApi
-
-export interface WebOverviewQueryApi {
-    /**
-     * Groups aggregation - not used in Web Analytics but required for type compatibility
-     * @nullable
-     */
-    aggregation_group_type_index?: number | null
-    /** @nullable */
-    compareFilter?: CompareFilterApi
-    /** @nullable */
-    conversionGoal?: WebOverviewQueryApiConversionGoal
-    /**
-     * Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility
-     * @nullable
-     */
-    dataColorTheme?: number | null
-    /** @nullable */
-    dateRange?: DateRangeApi
-    /** @nullable */
-    doPathCleaning?: boolean | null
-    /** @nullable */
-    filterTestAccounts?: boolean | null
-    /** @nullable */
-    includeRevenue?: boolean | null
-    /**
-     * For Product Analytics UI compatibility only - not used in Web Analytics query execution
-     * @nullable
-     */
-    interval?: IntervalTypeApi
-    kind?: WebOverviewQueryApiKind
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /** @nullable */
-    orderBy?: (typeof WebOverviewQueryApiOrderByItem)[keyof typeof WebOverviewQueryApiOrderByItem][] | null
-    properties: WebOverviewQueryApiPropertiesItem[]
-    /** @nullable */
-    response?: WebOverviewQueryResponseApi
-    /** @nullable */
-    sampling?: WebAnalyticsSamplingApi
-    /**
-     * Sampling rate
-     * @nullable
-     */
-    samplingFactor?: number | null
-    /** @nullable */
-    tags?: QueryLogTagsApi
-    /** @nullable */
-    useSessionsTable?: boolean | null
-    /**
-     * version of the node, used for schema migrations
-     * @nullable
-     */
-    version?: number | null
-}
-
-export type DashboardFilterApiPropertiesItem =
-    | EventPropertyFilterApi
-    | PersonPropertyFilterApi
-    | ElementPropertyFilterApi
-    | EventMetadataPropertyFilterApi
-    | SessionPropertyFilterApi
-    | CohortPropertyFilterApi
-    | RecordingPropertyFilterApi
-    | LogEntryPropertyFilterApi
-    | GroupPropertyFilterApi
-    | FeaturePropertyFilterApi
-    | FlagPropertyFilterApi
-    | HogQLPropertyFilterApi
-    | EmptyPropertyFilterApi
-    | DataWarehousePropertyFilterApi
-    | DataWarehousePersonPropertyFilterApi
-    | ErrorTrackingIssueFilterApi
-    | LogPropertyFilterApi
-    | RevenueAnalyticsPropertyFilterApi
-
-export interface DashboardFilterApi {
-    /** @nullable */
-    breakdown_filter?: BreakdownFilterApi
-    /** @nullable */
-    date_from?: string | null
-    /** @nullable */
-    date_to?: string | null
-    /** @nullable */
-    explicitDate?: boolean | null
-    /** @nullable */
-    properties?: DashboardFilterApiPropertiesItem[] | null
-}
-
-/**
- * @nullable
- */
-export type QueryStatusApiResults = unknown | null
-
-export interface QueryStatusApi {
-    /**
-     * Whether the query is still running. Will be true if the query is complete, even if it errored. Either result or error will be set.
-     * @nullable
-     */
-    complete?: boolean | null
-    /** @nullable */
-    dashboard_id?: number | null
-    /**
-     * When did the query execution task finish (whether successfully or not).
-     * @nullable
-     */
-    end_time?: string | null
-    /**
-     * If the query failed, this will be set to true. More information can be found in the error_message field.
-     * @nullable
-     */
-    error?: boolean | null
-    /** @nullable */
-    error_message?: string | null
-    /** @nullable */
-    expiration_time?: string | null
-    id: string
-    /** @nullable */
-    insight_id?: number | null
-    /** @nullable */
-    labels?: string[] | null
-    /**
-     * When was the query execution task picked up by a worker.
-     * @nullable
-     */
-    pickup_time?: string | null
-    /** ONLY async queries use QueryStatus. */
-    query_async?: boolean
-    /** @nullable */
-    query_progress?: ClickhouseQueryProgressApi
-    /** @nullable */
-    results?: QueryStatusApiResults
-    /**
-     * When was query execution task enqueued.
-     * @nullable
-     */
-    start_time?: string | null
-    /** @nullable */
-    task_id?: string | null
-    team_id: number
-}
-
-export type HogQLFiltersApiPropertiesItem =
-    | EventPropertyFilterApi
-    | PersonPropertyFilterApi
-    | ElementPropertyFilterApi
-    | EventMetadataPropertyFilterApi
-    | SessionPropertyFilterApi
-    | CohortPropertyFilterApi
-    | RecordingPropertyFilterApi
-    | LogEntryPropertyFilterApi
-    | GroupPropertyFilterApi
-    | FeaturePropertyFilterApi
-    | FlagPropertyFilterApi
-    | HogQLPropertyFilterApi
-    | EmptyPropertyFilterApi
-    | DataWarehousePropertyFilterApi
-    | DataWarehousePersonPropertyFilterApi
-    | ErrorTrackingIssueFilterApi
-    | LogPropertyFilterApi
-    | RevenueAnalyticsPropertyFilterApi
-
-export interface HogQLFiltersApi {
-    /** @nullable */
-    dateRange?: DateRangeApi
-    /** @nullable */
-    filterTestAccounts?: boolean | null
-    /** @nullable */
-    properties?: HogQLFiltersApiPropertiesItem[] | null
-}
-
-export interface HogQLQueryModifiersApi {
-    /** @nullable */
-    bounceRateDurationSeconds?: number | null
-    /** @nullable */
-    bounceRatePageViewMode?: BounceRatePageViewModeApi
-    /** @nullable */
-    convertToProjectTimezone?: boolean | null
-    /** @nullable */
-    customChannelTypeRules?: CustomChannelRuleApi[] | null
-    /** @nullable */
-    dataWarehouseEventsModifiers?: DataWarehouseEventsModifierApi[] | null
-    /** @nullable */
-    debug?: boolean | null
-    /** @nullable */
-    formatCsvAllowDoubleQuotes?: boolean | null
-    /** @nullable */
-    inCohortVia?: InCohortViaApi
-    /** @nullable */
-    materializationMode?: MaterializationModeApi
-    /** @nullable */
-    materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationModeApi
-    /** @nullable */
-    optimizeJoinedFilters?: boolean | null
-    /** @nullable */
-    optimizeProjections?: boolean | null
-    /** @nullable */
-    personsArgMaxVersion?: PersonsArgMaxVersionApi
-    /** @nullable */
-    personsJoinMode?: PersonsJoinModeApi
-    /** @nullable */
-    personsOnEventsMode?: PersonsOnEventsModeApi
-    /** @nullable */
-    propertyGroupsMode?: PropertyGroupsModeApi
-    /** @nullable */
-    s3TableUseInvalidColumns?: boolean | null
-    /** @nullable */
-    sessionTableVersion?: SessionTableVersionApi
-    /** @nullable */
-    sessionsV2JoinMode?: SessionsV2JoinModeApi
-    /** @nullable */
-    timings?: boolean | null
-    /** @nullable */
-    useMaterializedViews?: boolean | null
-    /** @nullable */
-    usePreaggregatedIntermediateResults?: boolean | null
-    /**
-     * Try to automatically convert HogQL queries to use preaggregated tables at the AST level *
-     * @nullable
-     */
-    usePreaggregatedTableTransforms?: boolean | null
-    /** @nullable */
-    usePresortedEventsTable?: boolean | null
-    /** @nullable */
-    useWebAnalyticsPreAggregatedTables?: boolean | null
-}
-
-export interface HogQLQueryResponseApi {
-    /**
-     * Executed ClickHouse query
-     * @nullable
-     */
-    clickhouse?: string | null
-    /**
-     * Returned columns
-     * @nullable
-     */
-    columns?: unknown[] | null
-    /**
-     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
-     * @nullable
-     */
-    error?: string | null
-    /**
-     * Query explanation output
-     * @nullable
-     */
-    explain?: string[] | null
-    /** @nullable */
-    hasMore?: boolean | null
-    /**
-     * Generated HogQL query.
-     * @nullable
-     */
-    hogql?: string | null
-    /** @nullable */
-    limit?: number | null
-    /**
-     * Query metadata output
-     * @nullable
-     */
-    metadata?: HogQLMetadataResponseApi
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /** @nullable */
-    offset?: number | null
-    /**
-     * Input query string
-     * @nullable
-     */
-    query?: string | null
-    /**
-     * Query status indicates whether next to the provided data, a query is still running.
-     * @nullable
-     */
-    query_status?: QueryStatusApi
-    /**
-     * The date range used for the query
-     * @nullable
-     */
-    resolved_date_range?: ResolvedDateRangeResponseApi
-    results: unknown[]
-    /**
-     * Measured timings for different parts of the query generation process
-     * @nullable
-     */
-    timings?: QueryTimingApi[] | null
-    /**
-     * Types of returned columns
-     * @nullable
-     */
-    types?: unknown[] | null
-}
-
-export interface QueryLogTagsApi {
-    /**
-     * Product responsible for this query. Use string, there's no need to churn the Schema when we add a new product *
-     * @nullable
-     */
-    productKey?: string | null
-    /**
-     * Scene where this query is shown in the UI. Use string, there's no need to churn the Schema when we add a new Scene *
-     * @nullable
-     */
-    scene?: string | null
-}
-
-/**
- * @nullable
- */
-export type HogQLVariableApiValue = unknown | null
-
-export interface HogQLVariableApi {
-    code_name: string
-    /** @nullable */
-    isNull?: boolean | null
-    /** @nullable */
-    value?: HogQLVariableApiValue
-    variableId: string
-}
-
-export type BreakdownFilterApiBreakdownAnyOfItem = string | number
-
-/**
- * @nullable
- */
-export type BreakdownFilterApiBreakdown = string | BreakdownFilterApiBreakdownAnyOfItem[] | number | null
-
-export interface BreakdownFilterApi {
-    /** @nullable */
-    breakdown?: BreakdownFilterApiBreakdown
-    /** @nullable */
-    breakdown_group_type_index?: number | null
-    /** @nullable */
-    breakdown_hide_other_aggregation?: boolean | null
-    /** @nullable */
-    breakdown_histogram_bin_count?: number | null
-    /** @nullable */
-    breakdown_limit?: number | null
-    /** @nullable */
-    breakdown_normalize_url?: boolean | null
-    /** @nullable */
-    breakdown_type?: BreakdownTypeApi
-    /**
-     * @maxItems 3
-     * @nullable
-     */
-    breakdowns?: BreakdownApi[] | null
-}
-
-export interface CompareFilterApi {
-    /**
-     * Whether to compare the current date range to a previous date range.
-     * @nullable
-     */
-    compare?: boolean | null
-    /**
-     * The date range to compare to. The value is a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-100w` for 100 weeks ago, `-14d` for 14 days ago, `-30h` for 30 hours ago.
-     * @nullable
-     */
-    compare_to?: string | null
-}
-
-export interface ActionConversionGoalApi {
-    actionId: number
-}
-
-export interface CustomEventConversionGoalApi {
-    customEventName: string
-}
-
-export interface DateRangeApi {
-    /** @nullable */
-    date_from?: string | null
-    /** @nullable */
-    date_to?: string | null
-    /**
-     * Whether the date_from and date_to should be used verbatim. Disables rounding to the start and end of period.
-     * @nullable
-     */
-    explicitDate?: boolean | null
-}
-
-/**
- * Event properties
- */
-export type EventPropertyFilterApiType = (typeof EventPropertyFilterApiType)[keyof typeof EventPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EventPropertyFilterApiType = {
-    event: 'event',
-} as const
-
-export type EventPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type EventPropertyFilterApiValue = EventPropertyFilterApiValueAnyOfItem[] | string | number | boolean | null
-
-export interface EventPropertyFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    /** @nullable */
-    operator?: PropertyOperatorApi
-    /** Event properties */
-    type?: EventPropertyFilterApiType
-    /** @nullable */
-    value?: EventPropertyFilterApiValue
-}
-
-/**
- * Person properties
- */
-export type PersonPropertyFilterApiType = (typeof PersonPropertyFilterApiType)[keyof typeof PersonPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PersonPropertyFilterApiType = {
-    person: 'person',
-} as const
-
-export type PersonPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type PersonPropertyFilterApiValue = PersonPropertyFilterApiValueAnyOfItem[] | string | number | boolean | null
-
-export interface PersonPropertyFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Person properties */
-    type?: PersonPropertyFilterApiType
-    /** @nullable */
-    value?: PersonPropertyFilterApiValue
-}
-
-export type ElementPropertyFilterApiType =
-    (typeof ElementPropertyFilterApiType)[keyof typeof ElementPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ElementPropertyFilterApiType = {
-    element: 'element',
-} as const
-
-export type ElementPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type ElementPropertyFilterApiValue = ElementPropertyFilterApiValueAnyOfItem[] | string | number | boolean | null
-
-export interface ElementPropertyFilterApi {
-    key: KeyApi
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: ElementPropertyFilterApiType
-    /** @nullable */
-    value?: ElementPropertyFilterApiValue
-}
-
-export type EventMetadataPropertyFilterApiType =
-    (typeof EventMetadataPropertyFilterApiType)[keyof typeof EventMetadataPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EventMetadataPropertyFilterApiType = {
-    event_metadata: 'event_metadata',
-} as const
-
-export type EventMetadataPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type EventMetadataPropertyFilterApiValue =
-    | EventMetadataPropertyFilterApiValueAnyOfItem[]
-    | string
-    | number
-    | boolean
-    | null
-
-export interface EventMetadataPropertyFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: EventMetadataPropertyFilterApiType
-    /** @nullable */
-    value?: EventMetadataPropertyFilterApiValue
-}
-
-export type SessionPropertyFilterApiType =
-    (typeof SessionPropertyFilterApiType)[keyof typeof SessionPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const SessionPropertyFilterApiType = {
-    session: 'session',
-} as const
-
-export type SessionPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type SessionPropertyFilterApiValue = SessionPropertyFilterApiValueAnyOfItem[] | string | number | boolean | null
-
-export interface SessionPropertyFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: SessionPropertyFilterApiType
-    /** @nullable */
-    value?: SessionPropertyFilterApiValue
-}
-
-export type CohortPropertyFilterApiKey = (typeof CohortPropertyFilterApiKey)[keyof typeof CohortPropertyFilterApiKey]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const CohortPropertyFilterApiKey = {
-    id: 'id',
-} as const
-
-export type CohortPropertyFilterApiType = (typeof CohortPropertyFilterApiType)[keyof typeof CohortPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const CohortPropertyFilterApiType = {
-    cohort: 'cohort',
-} as const
-
-export interface CohortPropertyFilterApi {
-    /** @nullable */
-    cohort_name?: string | null
-    key?: CohortPropertyFilterApiKey
-    /** @nullable */
-    label?: string | null
-    /** @nullable */
-    operator?: PropertyOperatorApi
-    type?: CohortPropertyFilterApiType
-    value: number
-}
-
-export type RecordingPropertyFilterApiKey = DurationTypeApi | string
-
-export type RecordingPropertyFilterApiType =
-    (typeof RecordingPropertyFilterApiType)[keyof typeof RecordingPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RecordingPropertyFilterApiType = {
-    recording: 'recording',
-} as const
-
-export type RecordingPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type RecordingPropertyFilterApiValue =
-    | RecordingPropertyFilterApiValueAnyOfItem[]
-    | string
-    | number
-    | boolean
-    | null
-
-export interface RecordingPropertyFilterApi {
-    key: RecordingPropertyFilterApiKey
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: RecordingPropertyFilterApiType
-    /** @nullable */
-    value?: RecordingPropertyFilterApiValue
-}
-
-export type LogEntryPropertyFilterApiType =
-    (typeof LogEntryPropertyFilterApiType)[keyof typeof LogEntryPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const LogEntryPropertyFilterApiType = {
-    log_entry: 'log_entry',
-} as const
-
-export type LogEntryPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type LogEntryPropertyFilterApiValue =
-    | LogEntryPropertyFilterApiValueAnyOfItem[]
-    | string
-    | number
-    | boolean
-    | null
-
-export interface LogEntryPropertyFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: LogEntryPropertyFilterApiType
-    /** @nullable */
-    value?: LogEntryPropertyFilterApiValue
-}
-
-export type GroupPropertyFilterApiType = (typeof GroupPropertyFilterApiType)[keyof typeof GroupPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const GroupPropertyFilterApiType = {
-    group: 'group',
-} as const
-
-export type GroupPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type GroupPropertyFilterApiValue = GroupPropertyFilterApiValueAnyOfItem[] | string | number | boolean | null
-
-export interface GroupPropertyFilterApi {
-    /** @nullable */
-    group_type_index?: number | null
-    key: string
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: GroupPropertyFilterApiType
-    /** @nullable */
-    value?: GroupPropertyFilterApiValue
-}
-
-/**
- * Event property with "$feature/" prepended
- */
-export type FeaturePropertyFilterApiType =
-    (typeof FeaturePropertyFilterApiType)[keyof typeof FeaturePropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FeaturePropertyFilterApiType = {
-    feature: 'feature',
-} as const
-
-export type FeaturePropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type FeaturePropertyFilterApiValue = FeaturePropertyFilterApiValueAnyOfItem[] | string | number | boolean | null
-
-export interface FeaturePropertyFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Event property with "$feature/" prepended */
-    type?: FeaturePropertyFilterApiType
-    /** @nullable */
-    value?: FeaturePropertyFilterApiValue
-}
-
-/**
- * Only flag_evaluates_to operator is allowed for flag dependencies
- */
-export type FlagPropertyFilterApiOperator =
-    (typeof FlagPropertyFilterApiOperator)[keyof typeof FlagPropertyFilterApiOperator]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FlagPropertyFilterApiOperator = {
-    flag_evaluates_to: 'flag_evaluates_to',
-} as const
-
-/**
- * Feature flag dependency
- */
-export type FlagPropertyFilterApiType = (typeof FlagPropertyFilterApiType)[keyof typeof FlagPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FlagPropertyFilterApiType = {
-    flag: 'flag',
-} as const
-
-/**
- * The value can be true, false, or a variant name
- */
-export type FlagPropertyFilterApiValue = boolean | string
-
-export interface FlagPropertyFilterApi {
-    /** The key should be the flag ID */
-    key: string
-    /** @nullable */
-    label?: string | null
-    /** Only flag_evaluates_to operator is allowed for flag dependencies */
-    operator?: FlagPropertyFilterApiOperator
-    /** Feature flag dependency */
-    type?: FlagPropertyFilterApiType
-    /** The value can be true, false, or a variant name */
-    value: FlagPropertyFilterApiValue
-}
-
-export type HogQLPropertyFilterApiType = (typeof HogQLPropertyFilterApiType)[keyof typeof HogQLPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const HogQLPropertyFilterApiType = {
-    hogql: 'hogql',
-} as const
-
-export type HogQLPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type HogQLPropertyFilterApiValue = HogQLPropertyFilterApiValueAnyOfItem[] | string | number | boolean | null
-
-export interface HogQLPropertyFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    type?: HogQLPropertyFilterApiType
-    /** @nullable */
-    value?: HogQLPropertyFilterApiValue
-}
-
-export type EmptyPropertyFilterApiType = (typeof EmptyPropertyFilterApiType)[keyof typeof EmptyPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EmptyPropertyFilterApiType = {
-    empty: 'empty',
-} as const
-
-export interface EmptyPropertyFilterApi {
-    type?: EmptyPropertyFilterApiType
-}
-
-export type DataWarehousePropertyFilterApiType =
-    (typeof DataWarehousePropertyFilterApiType)[keyof typeof DataWarehousePropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DataWarehousePropertyFilterApiType = {
-    data_warehouse: 'data_warehouse',
-} as const
-
-export type DataWarehousePropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type DataWarehousePropertyFilterApiValue =
-    | DataWarehousePropertyFilterApiValueAnyOfItem[]
-    | string
-    | number
-    | boolean
-    | null
-
-export interface DataWarehousePropertyFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: DataWarehousePropertyFilterApiType
-    /** @nullable */
-    value?: DataWarehousePropertyFilterApiValue
-}
-
-export type DataWarehousePersonPropertyFilterApiType =
-    (typeof DataWarehousePersonPropertyFilterApiType)[keyof typeof DataWarehousePersonPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DataWarehousePersonPropertyFilterApiType = {
-    data_warehouse_person_property: 'data_warehouse_person_property',
-} as const
-
-export type DataWarehousePersonPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type DataWarehousePersonPropertyFilterApiValue =
-    | DataWarehousePersonPropertyFilterApiValueAnyOfItem[]
-    | string
-    | number
-    | boolean
-    | null
-
-export interface DataWarehousePersonPropertyFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: DataWarehousePersonPropertyFilterApiType
-    /** @nullable */
-    value?: DataWarehousePersonPropertyFilterApiValue
-}
-
-export type ErrorTrackingIssueFilterApiType =
-    (typeof ErrorTrackingIssueFilterApiType)[keyof typeof ErrorTrackingIssueFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ErrorTrackingIssueFilterApiType = {
-    error_tracking_issue: 'error_tracking_issue',
-} as const
-
-export type ErrorTrackingIssueFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type ErrorTrackingIssueFilterApiValue =
-    | ErrorTrackingIssueFilterApiValueAnyOfItem[]
-    | string
-    | number
-    | boolean
-    | null
-
-export interface ErrorTrackingIssueFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: ErrorTrackingIssueFilterApiType
-    /** @nullable */
-    value?: ErrorTrackingIssueFilterApiValue
-}
-
-export type LogPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type LogPropertyFilterApiValue = LogPropertyFilterApiValueAnyOfItem[] | string | number | boolean | null
-
-export interface LogPropertyFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    type: LogPropertyFilterTypeApi
-    /** @nullable */
-    value?: LogPropertyFilterApiValue
-}
-
-export type RevenueAnalyticsPropertyFilterApiType =
-    (typeof RevenueAnalyticsPropertyFilterApiType)[keyof typeof RevenueAnalyticsPropertyFilterApiType]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RevenueAnalyticsPropertyFilterApiType = {
-    revenue_analytics: 'revenue_analytics',
-} as const
-
-export type RevenueAnalyticsPropertyFilterApiValueAnyOfItem = string | number | boolean
-
-/**
- * @nullable
- */
-export type RevenueAnalyticsPropertyFilterApiValue =
-    | RevenueAnalyticsPropertyFilterApiValueAnyOfItem[]
-    | string
-    | number
-    | boolean
-    | null
-
-export interface RevenueAnalyticsPropertyFilterApi {
-    key: string
-    /** @nullable */
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: RevenueAnalyticsPropertyFilterApiType
-    /** @nullable */
-    value?: RevenueAnalyticsPropertyFilterApiValue
-}
-
-export interface PropertyGroupFilterApi {
-    type: FilterLogicalOperatorApi
-    values: PropertyGroupFilterValueApi[]
-}
-
-export type TrendsQueryResponseApiResultsItem = { [key: string]: unknown }
-
-export interface TrendsQueryResponseApi {
-    /**
-     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
-     * @nullable
-     */
-    error?: string | null
-    /**
-     * Wether more breakdown values are available.
-     * @nullable
-     */
-    hasMore?: boolean | null
-    /**
-     * Generated HogQL query.
-     * @nullable
-     */
-    hogql?: string | null
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Query status indicates whether next to the provided data, a query is still running.
-     * @nullable
-     */
-    query_status?: QueryStatusApi
-    /**
-     * The date range used for the query
-     * @nullable
-     */
-    resolved_date_range?: ResolvedDateRangeResponseApi
-    results: TrendsQueryResponseApiResultsItem[]
-    /**
-     * Measured timings for different parts of the query generation process
-     * @nullable
-     */
-    timings?: QueryTimingApi[] | null
+    property?: string | null
+    static?: CurrencyCodeApi
 }
 
 export type EventsNodeApiFixedPropertiesItem =
@@ -2678,11 +1407,6 @@ export const EventsNodeApiMath = {
     unique_group: 'unique_group',
     hogql: 'hogql',
 } as const
-/**
- * @nullable
- */
-export type EventsNodeApiMath = (typeof EventsNodeApiMath)[keyof typeof EventsNodeApiMath] | null
-
 export type EventsNodeApiPropertiesItem =
     | EventPropertyFilterApi
     | PersonPropertyFilterApi
@@ -2703,10 +1427,12 @@ export type EventsNodeApiPropertiesItem =
     | LogPropertyFilterApi
     | RevenueAnalyticsPropertyFilterApi
 
+export type EventsNodeApiResponseAnyOf = { [key: string]: unknown }
+
 /**
  * @nullable
  */
-export type EventsNodeApiResponse = { [key: string]: unknown } | null
+export type EventsNodeApiResponse = EventsNodeApiResponseAnyOf | null | null
 
 export interface EventsNodeApi {
     /** @nullable */
@@ -2724,9 +1450,7 @@ export interface EventsNodeApi {
     kind?: EventsNodeApiKind
     /** @nullable */
     limit?: number | null
-    /** @nullable */
-    math?: EventsNodeApiMath
-    /** @nullable */
+    math?: (typeof EventsNodeApiMath)[keyof typeof EventsNodeApiMath]
     math_group_type_index?: MathGroupTypeIndexApi
     /** @nullable */
     math_hogql?: string | null
@@ -2734,7 +1458,6 @@ export interface EventsNodeApi {
     math_multiplier?: number | null
     /** @nullable */
     math_property?: string | null
-    /** @nullable */
     math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi
     /** @nullable */
     math_property_type?: string | null
@@ -2799,11 +1522,6 @@ export const ActionsNodeApiMath = {
     unique_group: 'unique_group',
     hogql: 'hogql',
 } as const
-/**
- * @nullable
- */
-export type ActionsNodeApiMath = (typeof ActionsNodeApiMath)[keyof typeof ActionsNodeApiMath] | null
-
 export type ActionsNodeApiPropertiesItem =
     | EventPropertyFilterApi
     | PersonPropertyFilterApi
@@ -2824,10 +1542,12 @@ export type ActionsNodeApiPropertiesItem =
     | LogPropertyFilterApi
     | RevenueAnalyticsPropertyFilterApi
 
+export type ActionsNodeApiResponseAnyOf = { [key: string]: unknown }
+
 /**
  * @nullable
  */
-export type ActionsNodeApiResponse = { [key: string]: unknown } | null
+export type ActionsNodeApiResponse = ActionsNodeApiResponseAnyOf | null | null
 
 export interface ActionsNodeApi {
     /** @nullable */
@@ -2839,9 +1559,7 @@ export interface ActionsNodeApi {
     fixedProperties?: ActionsNodeApiFixedPropertiesItem[] | null
     id: number
     kind?: ActionsNodeApiKind
-    /** @nullable */
-    math?: ActionsNodeApiMath
-    /** @nullable */
+    math?: (typeof ActionsNodeApiMath)[keyof typeof ActionsNodeApiMath]
     math_group_type_index?: MathGroupTypeIndexApi
     /** @nullable */
     math_hogql?: string | null
@@ -2849,7 +1567,6 @@ export interface ActionsNodeApi {
     math_multiplier?: number | null
     /** @nullable */
     math_property?: string | null
-    /** @nullable */
     math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi
     /** @nullable */
     math_property_type?: string | null
@@ -2909,11 +1626,6 @@ export const DataWarehouseNodeApiMath = {
     unique_group: 'unique_group',
     hogql: 'hogql',
 } as const
-/**
- * @nullable
- */
-export type DataWarehouseNodeApiMath = (typeof DataWarehouseNodeApiMath)[keyof typeof DataWarehouseNodeApiMath] | null
-
 export type DataWarehouseNodeApiPropertiesItem =
     | EventPropertyFilterApi
     | PersonPropertyFilterApi
@@ -2934,10 +1646,12 @@ export type DataWarehouseNodeApiPropertiesItem =
     | LogPropertyFilterApi
     | RevenueAnalyticsPropertyFilterApi
 
+export type DataWarehouseNodeApiResponseAnyOf = { [key: string]: unknown }
+
 /**
  * @nullable
  */
-export type DataWarehouseNodeApiResponse = { [key: string]: unknown } | null
+export type DataWarehouseNodeApiResponse = DataWarehouseNodeApiResponseAnyOf | null | null
 
 export interface DataWarehouseNodeApi {
     /** @nullable */
@@ -2953,9 +1667,7 @@ export interface DataWarehouseNodeApi {
     id: string
     id_field: string
     kind?: DataWarehouseNodeApiKind
-    /** @nullable */
-    math?: DataWarehouseNodeApiMath
-    /** @nullable */
+    math?: (typeof DataWarehouseNodeApiMath)[keyof typeof DataWarehouseNodeApiMath]
     math_group_type_index?: MathGroupTypeIndexApi
     /** @nullable */
     math_hogql?: string | null
@@ -2963,7 +1675,6 @@ export interface DataWarehouseNodeApi {
     math_multiplier?: number | null
     /** @nullable */
     math_property?: string | null
-    /** @nullable */
     math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi
     /** @nullable */
     math_property_type?: string | null
@@ -2987,21 +1698,270 @@ export interface DataWarehouseNodeApi {
     version?: number | null
 }
 
+export type GroupNodeApiFixedPropertiesItem =
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | ElementPropertyFilterApi
+    | EventMetadataPropertyFilterApi
+    | SessionPropertyFilterApi
+    | CohortPropertyFilterApi
+    | RecordingPropertyFilterApi
+    | LogEntryPropertyFilterApi
+    | GroupPropertyFilterApi
+    | FeaturePropertyFilterApi
+    | FlagPropertyFilterApi
+    | HogQLPropertyFilterApi
+    | EmptyPropertyFilterApi
+    | DataWarehousePropertyFilterApi
+    | DataWarehousePersonPropertyFilterApi
+    | ErrorTrackingIssueFilterApi
+    | LogPropertyFilterApi
+    | RevenueAnalyticsPropertyFilterApi
+
+export type GroupNodeApiKind = (typeof GroupNodeApiKind)[keyof typeof GroupNodeApiKind]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GroupNodeApiKind = {
+    GroupNode: 'GroupNode',
+} as const
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const GroupNodeApiMath = {
+    ...BaseMathTypeApi,
+    ...FunnelMathTypeApi,
+    ...PropertyMathTypeApi,
+    ...CountPerActorMathTypeApi,
+    ...ExperimentMetricMathTypeApi,
+    ...CalendarHeatmapMathTypeApi,
+    unique_group: 'unique_group',
+    hogql: 'hogql',
+} as const
+export type GroupNodeApiNodesItem = EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi
+
+export type GroupNodeApiPropertiesItem =
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | ElementPropertyFilterApi
+    | EventMetadataPropertyFilterApi
+    | SessionPropertyFilterApi
+    | CohortPropertyFilterApi
+    | RecordingPropertyFilterApi
+    | LogEntryPropertyFilterApi
+    | GroupPropertyFilterApi
+    | FeaturePropertyFilterApi
+    | FlagPropertyFilterApi
+    | HogQLPropertyFilterApi
+    | EmptyPropertyFilterApi
+    | DataWarehousePropertyFilterApi
+    | DataWarehousePersonPropertyFilterApi
+    | ErrorTrackingIssueFilterApi
+    | LogPropertyFilterApi
+    | RevenueAnalyticsPropertyFilterApi
+
+export type GroupNodeApiResponseAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type GroupNodeApiResponse = GroupNodeApiResponseAnyOf | null | null
+
+export interface GroupNodeApi {
+    /** @nullable */
+    custom_name?: string | null
+    /**
+     * Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)
+     * @nullable
+     */
+    fixedProperties?: GroupNodeApiFixedPropertiesItem[] | null
+    kind?: GroupNodeApiKind
+    /** @nullable */
+    limit?: number | null
+    math?: (typeof GroupNodeApiMath)[keyof typeof GroupNodeApiMath]
+    math_group_type_index?: MathGroupTypeIndexApi
+    /** @nullable */
+    math_hogql?: string | null
+    /** @nullable */
+    math_multiplier?: number | null
+    /** @nullable */
+    math_property?: string | null
+    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi
+    /** @nullable */
+    math_property_type?: string | null
+    /** @nullable */
+    name?: string | null
+    /** Entities to combine in this group */
+    nodes: GroupNodeApiNodesItem[]
+    /** Group of entities combined with AND/OR operator */
+    operator: FilterLogicalOperatorApi
+    /** @nullable */
+    optionalInFunnel?: boolean | null
+    /**
+     * Columns to order by
+     * @nullable
+     */
+    orderBy?: string[] | null
+    /**
+     * Properties configurable in the interface
+     * @nullable
+     */
+    properties?: GroupNodeApiPropertiesItem[] | null
+    /** @nullable */
+    response?: GroupNodeApiResponse
+    /**
+     * version of the node, used for schema migrations
+     * @nullable
+     */
+    version?: number | null
+}
+
+export type AggregationAxisFormatApi = (typeof AggregationAxisFormatApi)[keyof typeof AggregationAxisFormatApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AggregationAxisFormatApi = {
+    numeric: 'numeric',
+    duration: 'duration',
+    duration_ms: 'duration_ms',
+    percentage: 'percentage',
+    percentage_scaled: 'percentage_scaled',
+    currency: 'currency',
+} as const
+
+export type DetailedResultsAggregationTypeApi =
+    (typeof DetailedResultsAggregationTypeApi)[keyof typeof DetailedResultsAggregationTypeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DetailedResultsAggregationTypeApi = {
+    total: 'total',
+    average: 'average',
+    median: 'median',
+} as const
+
+export type ChartDisplayTypeApi = (typeof ChartDisplayTypeApi)[keyof typeof ChartDisplayTypeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ChartDisplayTypeApi = {
+    ActionsLineGraph: 'ActionsLineGraph',
+    ActionsBar: 'ActionsBar',
+    ActionsUnstackedBar: 'ActionsUnstackedBar',
+    ActionsStackedBar: 'ActionsStackedBar',
+    ActionsAreaGraph: 'ActionsAreaGraph',
+    ActionsLineGraphCumulative: 'ActionsLineGraphCumulative',
+    BoldNumber: 'BoldNumber',
+    ActionsPie: 'ActionsPie',
+    ActionsBarValue: 'ActionsBarValue',
+    ActionsTable: 'ActionsTable',
+    WorldMap: 'WorldMap',
+    CalendarHeatmap: 'CalendarHeatmap',
+} as const
+
+export interface TrendsFormulaNodeApi {
+    /**
+     * Optional user-defined name for the formula
+     * @nullable
+     */
+    custom_name?: string | null
+    formula: string
+}
+
+export type PositionApi = (typeof PositionApi)[keyof typeof PositionApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PositionApi = {
+    start: 'start',
+    end: 'end',
+} as const
+
+export interface GoalLineApi {
+    /** @nullable */
+    borderColor?: string | null
+    /** @nullable */
+    displayIfCrossed?: boolean | null
+    /** @nullable */
+    displayLabel?: boolean | null
+    label: string
+    position?: PositionApi
+    value: number
+}
+
+export type ResultCustomizationByApi = (typeof ResultCustomizationByApi)[keyof typeof ResultCustomizationByApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ResultCustomizationByApi = {
+    value: 'value',
+    position: 'position',
+} as const
+
+export type DataColorTokenApi = (typeof DataColorTokenApi)[keyof typeof DataColorTokenApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DataColorTokenApi = {
+    'preset-1': 'preset-1',
+    'preset-2': 'preset-2',
+    'preset-3': 'preset-3',
+    'preset-4': 'preset-4',
+    'preset-5': 'preset-5',
+    'preset-6': 'preset-6',
+    'preset-7': 'preset-7',
+    'preset-8': 'preset-8',
+    'preset-9': 'preset-9',
+    'preset-10': 'preset-10',
+    'preset-11': 'preset-11',
+    'preset-12': 'preset-12',
+    'preset-13': 'preset-13',
+    'preset-14': 'preset-14',
+    'preset-15': 'preset-15',
+} as const
+
+export type ResultCustomizationByValueApiAssignmentBy =
+    (typeof ResultCustomizationByValueApiAssignmentBy)[keyof typeof ResultCustomizationByValueApiAssignmentBy]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ResultCustomizationByValueApiAssignmentBy = {
+    value: 'value',
+} as const
+
+export interface ResultCustomizationByValueApi {
+    assignmentBy?: ResultCustomizationByValueApiAssignmentBy
+    color?: DataColorTokenApi
+    /** @nullable */
+    hidden?: boolean | null
+}
+
+export type ResultCustomizationByPositionApiAssignmentBy =
+    (typeof ResultCustomizationByPositionApiAssignmentBy)[keyof typeof ResultCustomizationByPositionApiAssignmentBy]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ResultCustomizationByPositionApiAssignmentBy = {
+    position: 'position',
+} as const
+
+export interface ResultCustomizationByPositionApi {
+    assignmentBy?: ResultCustomizationByPositionApiAssignmentBy
+    color?: DataColorTokenApi
+    /** @nullable */
+    hidden?: boolean | null
+}
+
+export type YAxisScaleTypeApi = (typeof YAxisScaleTypeApi)[keyof typeof YAxisScaleTypeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const YAxisScaleTypeApi = {
+    log10: 'log10',
+    linear: 'linear',
+} as const
+
 export type TrendsFilterApiResultCustomizationsAnyOf = { [key: string]: ResultCustomizationByValueApi }
 
 export type TrendsFilterApiResultCustomizationsAnyOfTwo = { [key: string]: ResultCustomizationByPositionApi }
 
 /**
  * Customizations for the appearance of result datasets.
- * @nullable
  */
 export type TrendsFilterApiResultCustomizations =
     | TrendsFilterApiResultCustomizationsAnyOf
     | TrendsFilterApiResultCustomizationsAnyOfTwo
-    | null
 
 export interface TrendsFilterApi {
-    /** @nullable */
     aggregationAxisFormat?: AggregationAxisFormatApi
     /** @nullable */
     aggregationAxisPostfix?: string | null
@@ -3013,12 +1973,8 @@ export interface TrendsFilterApi {
     confidenceLevel?: number | null
     /** @nullable */
     decimalPlaces?: number | null
-    /**
-     * detailed results table
-     * @nullable
-     */
+    /** detailed results table */
     detailedResultsAggregationType?: DetailedResultsAggregationTypeApi
-    /** @nullable */
     display?: ChartDisplayTypeApi
     /** @nullable */
     formula?: string | null
@@ -3040,15 +1996,9 @@ export interface TrendsFilterApi {
     minDecimalPlaces?: number | null
     /** @nullable */
     movingAverageIntervals?: number | null
-    /**
-     * Wether result datasets are associated by their values or by their order.
-     * @nullable
-     */
+    /** Wether result datasets are associated by their values or by their order. */
     resultCustomizationBy?: ResultCustomizationByApi
-    /**
-     * Customizations for the appearance of result datasets.
-     * @nullable
-     */
+    /** Customizations for the appearance of result datasets. */
     resultCustomizations?: TrendsFilterApiResultCustomizations
     /** @nullable */
     showAlertThresholdLines?: boolean | null
@@ -3070,556 +2020,22 @@ export interface TrendsFilterApi {
     showValuesOnSeries?: boolean | null
     /** @nullable */
     smoothingIntervals?: number | null
-    /** @nullable */
     yAxisScaleType?: YAxisScaleTypeApi
 }
 
-export type FunnelsFilterApiExclusionsItem = FunnelExclusionEventsNodeApi | FunnelExclusionActionsNodeApi
-
 /**
- * Customizations for the appearance of result datasets.
- * @nullable
+ * Whether we should be comparing against a specific conversion goal
  */
-export type FunnelsFilterApiResultCustomizations = { [key: string]: ResultCustomizationByValueApi } | null
+export type TrendsQueryApiConversionGoal = ActionConversionGoalApi | CustomEventConversionGoalApi
 
-export interface FunnelsFilterApi {
-    /** @nullable */
-    binCount?: number | null
-    /** @nullable */
-    breakdownAttributionType?: BreakdownAttributionTypeApi
-    /** @nullable */
-    breakdownAttributionValue?: number | null
-    /** @nullable */
-    exclusions?: FunnelsFilterApiExclusionsItem[] | null
-    /** @nullable */
-    funnelAggregateByHogQL?: string | null
-    /** @nullable */
-    funnelFromStep?: number | null
-    /** @nullable */
-    funnelOrderType?: StepOrderValueApi
-    /** @nullable */
-    funnelStepReference?: FunnelStepReferenceApi
-    /**
-     * To select the range of steps for trends & time to convert funnels, 0-indexed
-     * @nullable
-     */
-    funnelToStep?: number | null
-    /** @nullable */
-    funnelVizType?: FunnelVizTypeApi
-    /** @nullable */
-    funnelWindowInterval?: number | null
-    /** @nullable */
-    funnelWindowIntervalUnit?: FunnelConversionWindowTimeUnitApi
-    /**
-     * Goal Lines
-     * @nullable
-     */
-    goalLines?: GoalLineApi[] | null
-    /** @nullable */
-    hiddenLegendBreakdowns?: string[] | null
-    /** @nullable */
-    layout?: FunnelLayoutApi
-    /**
-     * Customizations for the appearance of result datasets.
-     * @nullable
-     */
-    resultCustomizations?: FunnelsFilterApiResultCustomizations
-    /** @nullable */
-    showValuesOnSeries?: boolean | null
-    /** @nullable */
-    useUdf?: boolean | null
-}
+export type TrendsQueryApiKind = (typeof TrendsQueryApiKind)[keyof typeof TrendsQueryApiKind]
 
-export interface FunnelsQueryResponseApi {
-    /**
-     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
-     * @nullable
-     */
-    error?: string | null
-    /**
-     * Generated HogQL query.
-     * @nullable
-     */
-    hogql?: string | null
-    /** @nullable */
-    isUdf?: boolean | null
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Query status indicates whether next to the provided data, a query is still running.
-     * @nullable
-     */
-    query_status?: QueryStatusApi
-    /**
-     * The date range used for the query
-     * @nullable
-     */
-    resolved_date_range?: ResolvedDateRangeResponseApi
-    results: unknown
-    /**
-     * Measured timings for different parts of the query generation process
-     * @nullable
-     */
-    timings?: QueryTimingApi[] | null
-}
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const TrendsQueryApiKind = {
+    TrendsQuery: 'TrendsQuery',
+} as const
 
-export interface RetentionQueryResponseApi {
-    /**
-     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
-     * @nullable
-     */
-    error?: string | null
-    /**
-     * Generated HogQL query.
-     * @nullable
-     */
-    hogql?: string | null
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Query status indicates whether next to the provided data, a query is still running.
-     * @nullable
-     */
-    query_status?: QueryStatusApi
-    /**
-     * The date range used for the query
-     * @nullable
-     */
-    resolved_date_range?: ResolvedDateRangeResponseApi
-    results: RetentionResultApi[]
-    /**
-     * Measured timings for different parts of the query generation process
-     * @nullable
-     */
-    timings?: QueryTimingApi[] | null
-}
-
-export interface RetentionFilterApi {
-    /** @nullable */
-    cumulative?: boolean | null
-    /** @nullable */
-    dashboardDisplay?: RetentionDashboardDisplayTypeApi
-    /**
-     * controls the display of the retention graph
-     * @nullable
-     */
-    display?: ChartDisplayTypeApi
-    /** @nullable */
-    meanRetentionCalculation?: MeanRetentionCalculationApi
-    /** @nullable */
-    minimumOccurrences?: number | null
-    /** @nullable */
-    period?: RetentionPeriodApi
-    /**
-     * Custom brackets for retention calculations
-     * @nullable
-     */
-    retentionCustomBrackets?: number[] | null
-    /**
-     * Whether retention is with regard to initial cohort size, or that of the previous period.
-     * @nullable
-     */
-    retentionReference?: RetentionReferenceApi
-    /** @nullable */
-    retentionType?: RetentionTypeApi
-    /** @nullable */
-    returningEntity?: RetentionEntityApi
-    /**
-     * The selected interval to display across all cohorts (null = show all intervals for each cohort)
-     * @nullable
-     */
-    selectedInterval?: number | null
-    /** @nullable */
-    showTrendLines?: boolean | null
-    /** @nullable */
-    targetEntity?: RetentionEntityApi
-    /**
-     * The time window mode to use for retention calculations
-     * @nullable
-     */
-    timeWindowMode?: TimeWindowModeApi
-    /** @nullable */
-    totalIntervals?: number | null
-}
-
-export interface FunnelPathsFilterApi {
-    /** @nullable */
-    funnelPathType?: FunnelPathTypeApi
-    funnelSource: FunnelsQueryApi
-    /** @nullable */
-    funnelStep?: number | null
-}
-
-export interface PathsFilterApi {
-    /** @nullable */
-    edgeLimit?: number | null
-    /** @nullable */
-    endPoint?: string | null
-    /** @nullable */
-    excludeEvents?: string[] | null
-    /** @nullable */
-    includeEventTypes?: PathTypeApi[] | null
-    /** @nullable */
-    localPathCleaningFilters?: PathCleaningFilterApi[] | null
-    /** @nullable */
-    maxEdgeWeight?: number | null
-    /** @nullable */
-    minEdgeWeight?: number | null
-    /**
-     * Relevant only within actors query
-     * @nullable
-     */
-    pathDropoffKey?: string | null
-    /**
-     * Relevant only within actors query
-     * @nullable
-     */
-    pathEndKey?: string | null
-    /** @nullable */
-    pathGroupings?: string[] | null
-    /** @nullable */
-    pathReplacements?: boolean | null
-    /**
-     * Relevant only within actors query
-     * @nullable
-     */
-    pathStartKey?: string | null
-    /** @nullable */
-    pathsHogQLExpression?: string | null
-    /** @nullable */
-    showFullUrls?: boolean | null
-    /** @nullable */
-    startPoint?: string | null
-    /** @nullable */
-    stepLimit?: number | null
-}
-
-export interface PathsQueryResponseApi {
-    /**
-     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
-     * @nullable
-     */
-    error?: string | null
-    /**
-     * Generated HogQL query.
-     * @nullable
-     */
-    hogql?: string | null
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Query status indicates whether next to the provided data, a query is still running.
-     * @nullable
-     */
-    query_status?: QueryStatusApi
-    /**
-     * The date range used for the query
-     * @nullable
-     */
-    resolved_date_range?: ResolvedDateRangeResponseApi
-    results: PathsLinkApi[]
-    /**
-     * Measured timings for different parts of the query generation process
-     * @nullable
-     */
-    timings?: QueryTimingApi[] | null
-}
-
-export type StickinessQueryResponseApiResultsItem = { [key: string]: unknown }
-
-export interface StickinessQueryResponseApi {
-    /**
-     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
-     * @nullable
-     */
-    error?: string | null
-    /**
-     * Generated HogQL query.
-     * @nullable
-     */
-    hogql?: string | null
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Query status indicates whether next to the provided data, a query is still running.
-     * @nullable
-     */
-    query_status?: QueryStatusApi
-    /**
-     * The date range used for the query
-     * @nullable
-     */
-    resolved_date_range?: ResolvedDateRangeResponseApi
-    results: StickinessQueryResponseApiResultsItem[]
-    /**
-     * Measured timings for different parts of the query generation process
-     * @nullable
-     */
-    timings?: QueryTimingApi[] | null
-}
-
-export type StickinessFilterApiResultCustomizationsAnyOf = { [key: string]: ResultCustomizationByValueApi }
-
-export type StickinessFilterApiResultCustomizationsAnyOfTwo = { [key: string]: ResultCustomizationByPositionApi }
-
-/**
- * Customizations for the appearance of result datasets.
- * @nullable
- */
-export type StickinessFilterApiResultCustomizations =
-    | StickinessFilterApiResultCustomizationsAnyOf
-    | StickinessFilterApiResultCustomizationsAnyOfTwo
-    | null
-
-export interface StickinessFilterApi {
-    /** @nullable */
-    computedAs?: StickinessComputationModeApi
-    /** @nullable */
-    display?: ChartDisplayTypeApi
-    /** @nullable */
-    hiddenLegendIndexes?: number[] | null
-    /**
-     * Whether result datasets are associated by their values or by their order.
-     * @nullable
-     */
-    resultCustomizationBy?: ResultCustomizationByApi
-    /**
-     * Customizations for the appearance of result datasets.
-     * @nullable
-     */
-    resultCustomizations?: StickinessFilterApiResultCustomizations
-    /** @nullable */
-    showLegend?: boolean | null
-    /** @nullable */
-    showMultipleYAxes?: boolean | null
-    /** @nullable */
-    showValuesOnSeries?: boolean | null
-    /** @nullable */
-    stickinessCriteria?: StickinessCriteriaApi
-}
-
-export interface LifecycleFilterApi {
-    /** @nullable */
-    showLegend?: boolean | null
-    /** @nullable */
-    showValuesOnSeries?: boolean | null
-    /** @nullable */
-    stacked?: boolean | null
-    /** @nullable */
-    toggledLifecycles?: LifecycleToggleApi[] | null
-}
-
-export type LifecycleQueryResponseApiResultsItem = { [key: string]: unknown }
-
-export interface LifecycleQueryResponseApi {
-    /**
-     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
-     * @nullable
-     */
-    error?: string | null
-    /**
-     * Generated HogQL query.
-     * @nullable
-     */
-    hogql?: string | null
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Query status indicates whether next to the provided data, a query is still running.
-     * @nullable
-     */
-    query_status?: QueryStatusApi
-    /**
-     * The date range used for the query
-     * @nullable
-     */
-    resolved_date_range?: ResolvedDateRangeResponseApi
-    results: LifecycleQueryResponseApiResultsItem[]
-    /**
-     * Measured timings for different parts of the query generation process
-     * @nullable
-     */
-    timings?: QueryTimingApi[] | null
-}
-
-export interface WebStatsTableQueryResponseApi {
-    /** @nullable */
-    columns?: unknown[] | null
-    /**
-     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
-     * @nullable
-     */
-    error?: string | null
-    /** @nullable */
-    hasMore?: boolean | null
-    /**
-     * Generated HogQL query.
-     * @nullable
-     */
-    hogql?: string | null
-    /** @nullable */
-    limit?: number | null
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /** @nullable */
-    offset?: number | null
-    /**
-     * Query status indicates whether next to the provided data, a query is still running.
-     * @nullable
-     */
-    query_status?: QueryStatusApi
-    /**
-     * The date range used for the query
-     * @nullable
-     */
-    resolved_date_range?: ResolvedDateRangeResponseApi
-    results: unknown[]
-    /** @nullable */
-    samplingRate?: SamplingRateApi
-    /**
-     * Measured timings for different parts of the query generation process
-     * @nullable
-     */
-    timings?: QueryTimingApi[] | null
-    /** @nullable */
-    types?: unknown[] | null
-    /** @nullable */
-    usedPreAggregatedTables?: boolean | null
-}
-
-export interface WebAnalyticsSamplingApi {
-    /** @nullable */
-    enabled?: boolean | null
-    /** @nullable */
-    forceSamplingRate?: SamplingRateApi
-}
-
-export interface WebOverviewQueryResponseApi {
-    /** @nullable */
-    dateFrom?: string | null
-    /** @nullable */
-    dateTo?: string | null
-    /**
-     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
-     * @nullable
-     */
-    error?: string | null
-    /**
-     * Generated HogQL query.
-     * @nullable
-     */
-    hogql?: string | null
-    /**
-     * Modifiers used when performing the query
-     * @nullable
-     */
-    modifiers?: HogQLQueryModifiersApi
-    /**
-     * Query status indicates whether next to the provided data, a query is still running.
-     * @nullable
-     */
-    query_status?: QueryStatusApi
-    /**
-     * The date range used for the query
-     * @nullable
-     */
-    resolved_date_range?: ResolvedDateRangeResponseApi
-    results: WebOverviewItemApi[]
-    /** @nullable */
-    samplingRate?: SamplingRateApi
-    /**
-     * Measured timings for different parts of the query generation process
-     * @nullable
-     */
-    timings?: QueryTimingApi[] | null
-    /** @nullable */
-    usedPreAggregatedTables?: boolean | null
-}
-
-export interface ClickhouseQueryProgressApi {
-    active_cpu_time: number
-    bytes_read: number
-    estimated_rows_total: number
-    rows_read: number
-    time_elapsed: number
-}
-
-export interface CustomChannelRuleApi {
-    channel_type: string
-    combiner: FilterLogicalOperatorApi
-    id: string
-    items: CustomChannelConditionApi[]
-}
-
-export interface DataWarehouseEventsModifierApi {
-    distinct_id_field: string
-    id_field: string
-    table_name: string
-    timestamp_field: string
-}
-
-export interface HogQLMetadataResponseApi {
-    /** @nullable */
-    ch_table_names?: string[] | null
-    errors: HogQLNoticeApi[]
-    /** @nullable */
-    isUsingIndices?: QueryIndexUsageApi
-    /** @nullable */
-    isValid?: boolean | null
-    notices: HogQLNoticeApi[]
-    /** @nullable */
-    query?: string | null
-    /** @nullable */
-    table_names?: string[] | null
-    warnings: HogQLNoticeApi[]
-}
-
-export interface ResolvedDateRangeResponseApi {
-    date_from: string
-    date_to: string
-}
-
-export interface QueryTimingApi {
-    /** Key. Shortened to 'k' to save on data. */
-    k: string
-    /** Time in seconds. Shortened to 't' to save on data. */
-    t: number
-}
-
-export type BreakdownApiProperty = string | number
-
-export interface BreakdownApi {
-    /** @nullable */
-    group_type_index?: number | null
-    /** @nullable */
-    histogram_bin_count?: number | null
-    /** @nullable */
-    normalize_url?: boolean | null
-    property: BreakdownApiProperty
-    /** @nullable */
-    type?: MultipleBreakdownTypeApi
-}
-
-export type PropertyGroupFilterValueApiValuesItem =
-    | PropertyGroupFilterValueApi
+export type TrendsQueryApiPropertiesAnyOfItem =
     | EventPropertyFilterApi
     | PersonPropertyFilterApi
     | ElementPropertyFilterApi
@@ -3639,71 +2055,72 @@ export type PropertyGroupFilterValueApiValuesItem =
     | LogPropertyFilterApi
     | RevenueAnalyticsPropertyFilterApi
 
-export interface PropertyGroupFilterValueApi {
-    type: FilterLogicalOperatorApi
-    values: PropertyGroupFilterValueApiValuesItem[]
-}
+/**
+ * Property filters for all series
+ */
+export type TrendsQueryApiProperties = TrendsQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi
 
-export interface RevenueCurrencyPropertyConfigApi {
-    /** @nullable */
-    property?: string | null
-    /** @nullable */
-    static?: CurrencyCodeApi
-}
+export type TrendsQueryApiSeriesItem = GroupNodeApi | EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi
 
-export interface TrendsFormulaNodeApi {
+export interface TrendsQueryApi {
     /**
-     * Optional user-defined name for the formula
+     * Groups aggregation
      * @nullable
      */
-    custom_name?: string | null
-    formula: string
+    aggregation_group_type_index?: number | null
+    /** Breakdown of the events and actions */
+    breakdownFilter?: BreakdownFilterApi
+    /** Compare to date range */
+    compareFilter?: CompareFilterApi
+    /** Whether we should be comparing against a specific conversion goal */
+    conversionGoal?: TrendsQueryApiConversionGoal
+    /**
+     * Colors used in the insight's visualization
+     * @nullable
+     */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi
+    /**
+     * Exclude internal and test users by applying the respective filters
+     * @nullable
+     */
+    filterTestAccounts?: boolean | null
+    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
+    interval?: IntervalTypeApi
+    kind?: TrendsQueryApiKind
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Property filters for all series */
+    properties?: TrendsQueryApiProperties
+    response?: TrendsQueryResponseApi
+    /**
+     * Sampling rate
+     * @nullable
+     */
+    samplingFactor?: number | null
+    /** Events and actions to include */
+    series: TrendsQueryApiSeriesItem[]
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi
+    /** Properties specific to the trends insight */
+    trendsFilter?: TrendsFilterApi
+    /**
+     * version of the node, used for schema migrations
+     * @nullable
+     */
+    version?: number | null
 }
 
-export interface GoalLineApi {
-    /** @nullable */
-    borderColor?: string | null
-    /** @nullable */
-    displayIfCrossed?: boolean | null
-    /** @nullable */
-    displayLabel?: boolean | null
-    label: string
-    /** @nullable */
-    position?: PositionApi
-    value: number
-}
-
-export type ResultCustomizationByValueApiAssignmentBy =
-    (typeof ResultCustomizationByValueApiAssignmentBy)[keyof typeof ResultCustomizationByValueApiAssignmentBy]
+export type BreakdownAttributionTypeApi = (typeof BreakdownAttributionTypeApi)[keyof typeof BreakdownAttributionTypeApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ResultCustomizationByValueApiAssignmentBy = {
-    value: 'value',
+export const BreakdownAttributionTypeApi = {
+    first_touch: 'first_touch',
+    last_touch: 'last_touch',
+    all_events: 'all_events',
+    step: 'step',
 } as const
-
-export interface ResultCustomizationByValueApi {
-    assignmentBy?: ResultCustomizationByValueApiAssignmentBy
-    /** @nullable */
-    color?: DataColorTokenApi
-    /** @nullable */
-    hidden?: boolean | null
-}
-
-export type ResultCustomizationByPositionApiAssignmentBy =
-    (typeof ResultCustomizationByPositionApiAssignmentBy)[keyof typeof ResultCustomizationByPositionApiAssignmentBy]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ResultCustomizationByPositionApiAssignmentBy = {
-    position: 'position',
-} as const
-
-export interface ResultCustomizationByPositionApi {
-    assignmentBy?: ResultCustomizationByPositionApiAssignmentBy
-    /** @nullable */
-    color?: DataColorTokenApi
-    /** @nullable */
-    hidden?: boolean | null
-}
 
 export type FunnelExclusionEventsNodeApiFixedPropertiesItem =
     | EventPropertyFilterApi
@@ -3744,13 +2161,6 @@ export const FunnelExclusionEventsNodeApiMath = {
     unique_group: 'unique_group',
     hogql: 'hogql',
 } as const
-/**
- * @nullable
- */
-export type FunnelExclusionEventsNodeApiMath =
-    | (typeof FunnelExclusionEventsNodeApiMath)[keyof typeof FunnelExclusionEventsNodeApiMath]
-    | null
-
 export type FunnelExclusionEventsNodeApiPropertiesItem =
     | EventPropertyFilterApi
     | PersonPropertyFilterApi
@@ -3771,10 +2181,12 @@ export type FunnelExclusionEventsNodeApiPropertiesItem =
     | LogPropertyFilterApi
     | RevenueAnalyticsPropertyFilterApi
 
+export type FunnelExclusionEventsNodeApiResponseAnyOf = { [key: string]: unknown }
+
 /**
  * @nullable
  */
-export type FunnelExclusionEventsNodeApiResponse = { [key: string]: unknown } | null
+export type FunnelExclusionEventsNodeApiResponse = FunnelExclusionEventsNodeApiResponseAnyOf | null | null
 
 export interface FunnelExclusionEventsNodeApi {
     /** @nullable */
@@ -3794,9 +2206,7 @@ export interface FunnelExclusionEventsNodeApi {
     kind?: FunnelExclusionEventsNodeApiKind
     /** @nullable */
     limit?: number | null
-    /** @nullable */
-    math?: FunnelExclusionEventsNodeApiMath
-    /** @nullable */
+    math?: (typeof FunnelExclusionEventsNodeApiMath)[keyof typeof FunnelExclusionEventsNodeApiMath]
     math_group_type_index?: MathGroupTypeIndexApi
     /** @nullable */
     math_hogql?: string | null
@@ -3804,7 +2214,6 @@ export interface FunnelExclusionEventsNodeApi {
     math_multiplier?: number | null
     /** @nullable */
     math_property?: string | null
-    /** @nullable */
     math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi
     /** @nullable */
     math_property_type?: string | null
@@ -3870,13 +2279,6 @@ export const FunnelExclusionActionsNodeApiMath = {
     unique_group: 'unique_group',
     hogql: 'hogql',
 } as const
-/**
- * @nullable
- */
-export type FunnelExclusionActionsNodeApiMath =
-    | (typeof FunnelExclusionActionsNodeApiMath)[keyof typeof FunnelExclusionActionsNodeApiMath]
-    | null
-
 export type FunnelExclusionActionsNodeApiPropertiesItem =
     | EventPropertyFilterApi
     | PersonPropertyFilterApi
@@ -3897,10 +2299,12 @@ export type FunnelExclusionActionsNodeApiPropertiesItem =
     | LogPropertyFilterApi
     | RevenueAnalyticsPropertyFilterApi
 
+export type FunnelExclusionActionsNodeApiResponseAnyOf = { [key: string]: unknown }
+
 /**
  * @nullable
  */
-export type FunnelExclusionActionsNodeApiResponse = { [key: string]: unknown } | null
+export type FunnelExclusionActionsNodeApiResponse = FunnelExclusionActionsNodeApiResponseAnyOf | null | null
 
 export interface FunnelExclusionActionsNodeApi {
     /** @nullable */
@@ -3914,9 +2318,7 @@ export interface FunnelExclusionActionsNodeApi {
     funnelToStep: number
     id: number
     kind?: FunnelExclusionActionsNodeApiKind
-    /** @nullable */
-    math?: FunnelExclusionActionsNodeApiMath
-    /** @nullable */
+    math?: (typeof FunnelExclusionActionsNodeApiMath)[keyof typeof FunnelExclusionActionsNodeApiMath]
     math_group_type_index?: MathGroupTypeIndexApi
     /** @nullable */
     math_hogql?: string | null
@@ -3924,7 +2326,6 @@ export interface FunnelExclusionActionsNodeApi {
     math_multiplier?: number | null
     /** @nullable */
     math_property?: string | null
-    /** @nullable */
     math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi
     /** @nullable */
     math_property_type?: string | null
@@ -3946,27 +2347,325 @@ export interface FunnelExclusionActionsNodeApi {
     version?: number | null
 }
 
+export type StepOrderValueApi = (typeof StepOrderValueApi)[keyof typeof StepOrderValueApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const StepOrderValueApi = {
+    strict: 'strict',
+    unordered: 'unordered',
+    ordered: 'ordered',
+} as const
+
+export type FunnelStepReferenceApi = (typeof FunnelStepReferenceApi)[keyof typeof FunnelStepReferenceApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const FunnelStepReferenceApi = {
+    total: 'total',
+    previous: 'previous',
+} as const
+
+export type FunnelVizTypeApi = (typeof FunnelVizTypeApi)[keyof typeof FunnelVizTypeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const FunnelVizTypeApi = {
+    steps: 'steps',
+    time_to_convert: 'time_to_convert',
+    trends: 'trends',
+} as const
+
+export type FunnelConversionWindowTimeUnitApi =
+    (typeof FunnelConversionWindowTimeUnitApi)[keyof typeof FunnelConversionWindowTimeUnitApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const FunnelConversionWindowTimeUnitApi = {
+    second: 'second',
+    minute: 'minute',
+    hour: 'hour',
+    day: 'day',
+    week: 'week',
+    month: 'month',
+} as const
+
+export type FunnelLayoutApi = (typeof FunnelLayoutApi)[keyof typeof FunnelLayoutApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const FunnelLayoutApi = {
+    horizontal: 'horizontal',
+    vertical: 'vertical',
+} as const
+
+export type FunnelsFilterApiExclusionsItem = FunnelExclusionEventsNodeApi | FunnelExclusionActionsNodeApi
+
 /**
- * Optional breakdown value for retention cohorts
+ * Customizations for the appearance of result datasets.
+ */
+export type FunnelsFilterApiResultCustomizationsAnyOf = { [key: string]: ResultCustomizationByValueApi }
+
+/**
+ * Customizations for the appearance of result datasets.
  * @nullable
  */
-export type RetentionResultApiBreakdownValue = string | number | null
+export type FunnelsFilterApiResultCustomizations = FunnelsFilterApiResultCustomizationsAnyOf | null | null
 
-export interface RetentionResultApi {
+export interface FunnelsFilterApi {
+    /** @nullable */
+    binCount?: number | null
+    breakdownAttributionType?: BreakdownAttributionTypeApi
+    /** @nullable */
+    breakdownAttributionValue?: number | null
+    /** @nullable */
+    exclusions?: FunnelsFilterApiExclusionsItem[] | null
+    /** @nullable */
+    funnelAggregateByHogQL?: string | null
+    /** @nullable */
+    funnelFromStep?: number | null
+    funnelOrderType?: StepOrderValueApi
+    funnelStepReference?: FunnelStepReferenceApi
     /**
-     * Optional breakdown value for retention cohorts
+     * To select the range of steps for trends & time to convert funnels, 0-indexed
      * @nullable
      */
+    funnelToStep?: number | null
+    funnelVizType?: FunnelVizTypeApi
+    /** @nullable */
+    funnelWindowInterval?: number | null
+    funnelWindowIntervalUnit?: FunnelConversionWindowTimeUnitApi
+    /**
+     * Goal Lines
+     * @nullable
+     */
+    goalLines?: GoalLineApi[] | null
+    /** @nullable */
+    hiddenLegendBreakdowns?: string[] | null
+    layout?: FunnelLayoutApi
+    /**
+     * Customizations for the appearance of result datasets.
+     * @nullable
+     */
+    resultCustomizations?: FunnelsFilterApiResultCustomizations
+    /** @nullable */
+    showValuesOnSeries?: boolean | null
+    /** @nullable */
+    useUdf?: boolean | null
+}
+
+export interface FunnelsQueryResponseApi {
+    /**
+     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
+     * @nullable
+     */
+    error?: string | null
+    /**
+     * Generated HogQL query.
+     * @nullable
+     */
+    hogql?: string | null
+    /** @nullable */
+    isUdf?: boolean | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi
+    results: unknown
+    /**
+     * Measured timings for different parts of the query generation process
+     * @nullable
+     */
+    timings?: QueryTimingApi[] | null
+}
+
+export type FunnelsQueryApiKind = (typeof FunnelsQueryApiKind)[keyof typeof FunnelsQueryApiKind]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const FunnelsQueryApiKind = {
+    FunnelsQuery: 'FunnelsQuery',
+} as const
+
+export type FunnelsQueryApiPropertiesAnyOfItem =
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | ElementPropertyFilterApi
+    | EventMetadataPropertyFilterApi
+    | SessionPropertyFilterApi
+    | CohortPropertyFilterApi
+    | RecordingPropertyFilterApi
+    | LogEntryPropertyFilterApi
+    | GroupPropertyFilterApi
+    | FeaturePropertyFilterApi
+    | FlagPropertyFilterApi
+    | HogQLPropertyFilterApi
+    | EmptyPropertyFilterApi
+    | DataWarehousePropertyFilterApi
+    | DataWarehousePersonPropertyFilterApi
+    | ErrorTrackingIssueFilterApi
+    | LogPropertyFilterApi
+    | RevenueAnalyticsPropertyFilterApi
+
+/**
+ * Property filters for all series
+ */
+export type FunnelsQueryApiProperties = FunnelsQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi
+
+export type FunnelsQueryApiSeriesItem = EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi
+
+export interface FunnelsQueryApi {
+    /**
+     * Groups aggregation
+     * @nullable
+     */
+    aggregation_group_type_index?: number | null
+    /** Breakdown of the events and actions */
+    breakdownFilter?: BreakdownFilterApi
+    /**
+     * Colors used in the insight's visualization
+     * @nullable
+     */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi
+    /**
+     * Exclude internal and test users by applying the respective filters
+     * @nullable
+     */
+    filterTestAccounts?: boolean | null
+    /** Properties specific to the funnels insight */
+    funnelsFilter?: FunnelsFilterApi
+    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
+    interval?: IntervalTypeApi
+    kind?: FunnelsQueryApiKind
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Property filters for all series */
+    properties?: FunnelsQueryApiProperties
+    response?: FunnelsQueryResponseApi
+    /**
+     * Sampling rate
+     * @nullable
+     */
+    samplingFactor?: number | null
+    /** Events and actions to include */
+    series: FunnelsQueryApiSeriesItem[]
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi
+    /**
+     * version of the node, used for schema migrations
+     * @nullable
+     */
+    version?: number | null
+}
+
+export interface RetentionValueApi {
+    count: number
+    /** @nullable */
+    label?: string | null
+}
+
+/**
+ * Optional breakdown value for retention cohorts
+ */
+export type RetentionResultApiBreakdownValue = string | number
+
+export interface RetentionResultApi {
+    /** Optional breakdown value for retention cohorts */
     breakdown_value?: RetentionResultApiBreakdownValue
     date: string
     label: string
     values: RetentionValueApi[]
 }
 
-/**
- * @nullable
- */
-export type RetentionEntityApiId = string | number | null
+export interface RetentionQueryResponseApi {
+    /**
+     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
+     * @nullable
+     */
+    error?: string | null
+    /**
+     * Generated HogQL query.
+     * @nullable
+     */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi
+    results: RetentionResultApi[]
+    /**
+     * Measured timings for different parts of the query generation process
+     * @nullable
+     */
+    timings?: QueryTimingApi[] | null
+}
+
+export type RetentionDashboardDisplayTypeApi =
+    (typeof RetentionDashboardDisplayTypeApi)[keyof typeof RetentionDashboardDisplayTypeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RetentionDashboardDisplayTypeApi = {
+    table_only: 'table_only',
+    graph_only: 'graph_only',
+    all: 'all',
+} as const
+
+export type MeanRetentionCalculationApi = (typeof MeanRetentionCalculationApi)[keyof typeof MeanRetentionCalculationApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const MeanRetentionCalculationApi = {
+    simple: 'simple',
+    weighted: 'weighted',
+    none: 'none',
+} as const
+
+export type RetentionPeriodApi = (typeof RetentionPeriodApi)[keyof typeof RetentionPeriodApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RetentionPeriodApi = {
+    Hour: 'Hour',
+    Day: 'Day',
+    Week: 'Week',
+    Month: 'Month',
+} as const
+
+export type RetentionReferenceApi = (typeof RetentionReferenceApi)[keyof typeof RetentionReferenceApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RetentionReferenceApi = {
+    total: 'total',
+    previous: 'previous',
+} as const
+
+export type RetentionTypeApi = (typeof RetentionTypeApi)[keyof typeof RetentionTypeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RetentionTypeApi = {
+    retention_recurring: 'retention_recurring',
+    retention_first_time: 'retention_first_time',
+    retention_first_ever_occurrence: 'retention_first_ever_occurrence',
+} as const
+
+export type RetentionEntityKindApi = (typeof RetentionEntityKindApi)[keyof typeof RetentionEntityKindApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RetentionEntityKindApi = {
+    ActionsNode: 'ActionsNode',
+    EventsNode: 'EventsNode',
+} as const
+
+export type EntityTypeApi = (typeof EntityTypeApi)[keyof typeof EntityTypeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EntityTypeApi = {
+    actions: 'actions',
+    events: 'events',
+    data_warehouse: 'data_warehouse',
+    new_entity: 'new_entity',
+    groups: 'groups',
+} as const
+
+export type RetentionEntityApiId = string | number
 
 export type RetentionEntityApiPropertiesItem =
     | EventPropertyFilterApi
@@ -3991,9 +2690,7 @@ export type RetentionEntityApiPropertiesItem =
 export interface RetentionEntityApi {
     /** @nullable */
     custom_name?: string | null
-    /** @nullable */
     id?: RetentionEntityApiId
-    /** @nullable */
     kind?: RetentionEntityKindApi
     /** @nullable */
     name?: string | null
@@ -4004,11 +2701,153 @@ export interface RetentionEntityApi {
      * @nullable
      */
     properties?: RetentionEntityApiPropertiesItem[] | null
-    /** @nullable */
     type?: EntityTypeApi
     /** @nullable */
     uuid?: string | null
 }
+
+export type TimeWindowModeApi = (typeof TimeWindowModeApi)[keyof typeof TimeWindowModeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const TimeWindowModeApi = {
+    strict_calendar_dates: 'strict_calendar_dates',
+    '24_hour_windows': '24_hour_windows',
+} as const
+
+export interface RetentionFilterApi {
+    /** @nullable */
+    cumulative?: boolean | null
+    dashboardDisplay?: RetentionDashboardDisplayTypeApi
+    /** controls the display of the retention graph */
+    display?: ChartDisplayTypeApi
+    /** @nullable */
+    goalLines?: GoalLineApi[] | null
+    meanRetentionCalculation?: MeanRetentionCalculationApi
+    /** @nullable */
+    minimumOccurrences?: number | null
+    period?: RetentionPeriodApi
+    /**
+     * Custom brackets for retention calculations
+     * @nullable
+     */
+    retentionCustomBrackets?: number[] | null
+    /** Whether retention is with regard to initial cohort size, or that of the previous period. */
+    retentionReference?: RetentionReferenceApi
+    retentionType?: RetentionTypeApi
+    returningEntity?: RetentionEntityApi
+    /**
+     * The selected interval to display across all cohorts (null = show all intervals for each cohort)
+     * @nullable
+     */
+    selectedInterval?: number | null
+    /** @nullable */
+    showTrendLines?: boolean | null
+    targetEntity?: RetentionEntityApi
+    /** The time window mode to use for retention calculations */
+    timeWindowMode?: TimeWindowModeApi
+    /** @nullable */
+    totalIntervals?: number | null
+}
+
+export type RetentionQueryApiKind = (typeof RetentionQueryApiKind)[keyof typeof RetentionQueryApiKind]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RetentionQueryApiKind = {
+    RetentionQuery: 'RetentionQuery',
+} as const
+
+export type RetentionQueryApiPropertiesAnyOfItem =
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | ElementPropertyFilterApi
+    | EventMetadataPropertyFilterApi
+    | SessionPropertyFilterApi
+    | CohortPropertyFilterApi
+    | RecordingPropertyFilterApi
+    | LogEntryPropertyFilterApi
+    | GroupPropertyFilterApi
+    | FeaturePropertyFilterApi
+    | FlagPropertyFilterApi
+    | HogQLPropertyFilterApi
+    | EmptyPropertyFilterApi
+    | DataWarehousePropertyFilterApi
+    | DataWarehousePersonPropertyFilterApi
+    | ErrorTrackingIssueFilterApi
+    | LogPropertyFilterApi
+    | RevenueAnalyticsPropertyFilterApi
+
+/**
+ * Property filters for all series
+ */
+export type RetentionQueryApiProperties = RetentionQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi
+
+export interface RetentionQueryApi {
+    /**
+     * Groups aggregation
+     * @nullable
+     */
+    aggregation_group_type_index?: number | null
+    /** Breakdown of the events and actions */
+    breakdownFilter?: BreakdownFilterApi
+    /**
+     * Colors used in the insight's visualization
+     * @nullable
+     */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi
+    /**
+     * Exclude internal and test users by applying the respective filters
+     * @nullable
+     */
+    filterTestAccounts?: boolean | null
+    kind?: RetentionQueryApiKind
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Property filters for all series */
+    properties?: RetentionQueryApiProperties
+    response?: RetentionQueryResponseApi
+    /** Properties specific to the retention insight */
+    retentionFilter: RetentionFilterApi
+    /**
+     * Sampling rate
+     * @nullable
+     */
+    samplingFactor?: number | null
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi
+    /**
+     * version of the node, used for schema migrations
+     * @nullable
+     */
+    version?: number | null
+}
+
+export type FunnelPathTypeApi = (typeof FunnelPathTypeApi)[keyof typeof FunnelPathTypeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const FunnelPathTypeApi = {
+    funnel_path_before_step: 'funnel_path_before_step',
+    funnel_path_between_steps: 'funnel_path_between_steps',
+    funnel_path_after_step: 'funnel_path_after_step',
+} as const
+
+export interface FunnelPathsFilterApi {
+    funnelPathType?: FunnelPathTypeApi
+    funnelSource: FunnelsQueryApi
+    /** @nullable */
+    funnelStep?: number | null
+}
+
+export type PathTypeApi = (typeof PathTypeApi)[keyof typeof PathTypeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PathTypeApi = {
+    $pageview: '$pageview',
+    $screen: '$screen',
+    custom_event: 'custom_event',
+    hogql: 'hogql',
+} as const
 
 export interface PathCleaningFilterApi {
     /** @nullable */
@@ -4019,6 +2858,50 @@ export interface PathCleaningFilterApi {
     regex?: string | null
 }
 
+export interface PathsFilterApi {
+    /** @nullable */
+    edgeLimit?: number | null
+    /** @nullable */
+    endPoint?: string | null
+    /** @nullable */
+    excludeEvents?: string[] | null
+    /** @nullable */
+    includeEventTypes?: PathTypeApi[] | null
+    /** @nullable */
+    localPathCleaningFilters?: PathCleaningFilterApi[] | null
+    /** @nullable */
+    maxEdgeWeight?: number | null
+    /** @nullable */
+    minEdgeWeight?: number | null
+    /**
+     * Relevant only within actors query
+     * @nullable
+     */
+    pathDropoffKey?: string | null
+    /**
+     * Relevant only within actors query
+     * @nullable
+     */
+    pathEndKey?: string | null
+    /** @nullable */
+    pathGroupings?: string[] | null
+    /** @nullable */
+    pathReplacements?: boolean | null
+    /**
+     * Relevant only within actors query
+     * @nullable
+     */
+    pathStartKey?: string | null
+    /** @nullable */
+    pathsHogQLExpression?: string | null
+    /** @nullable */
+    showFullUrls?: boolean | null
+    /** @nullable */
+    startPoint?: string | null
+    /** @nullable */
+    stepLimit?: number | null
+}
+
 export interface PathsLinkApi {
     average_conversion_time: number
     source: string
@@ -4026,16 +2909,584 @@ export interface PathsLinkApi {
     value: number
 }
 
+export interface PathsQueryResponseApi {
+    /**
+     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
+     * @nullable
+     */
+    error?: string | null
+    /**
+     * Generated HogQL query.
+     * @nullable
+     */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi
+    results: PathsLinkApi[]
+    /**
+     * Measured timings for different parts of the query generation process
+     * @nullable
+     */
+    timings?: QueryTimingApi[] | null
+}
+
+export type PathsQueryApiKind = (typeof PathsQueryApiKind)[keyof typeof PathsQueryApiKind]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PathsQueryApiKind = {
+    PathsQuery: 'PathsQuery',
+} as const
+
+export type PathsQueryApiPropertiesAnyOfItem =
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | ElementPropertyFilterApi
+    | EventMetadataPropertyFilterApi
+    | SessionPropertyFilterApi
+    | CohortPropertyFilterApi
+    | RecordingPropertyFilterApi
+    | LogEntryPropertyFilterApi
+    | GroupPropertyFilterApi
+    | FeaturePropertyFilterApi
+    | FlagPropertyFilterApi
+    | HogQLPropertyFilterApi
+    | EmptyPropertyFilterApi
+    | DataWarehousePropertyFilterApi
+    | DataWarehousePersonPropertyFilterApi
+    | ErrorTrackingIssueFilterApi
+    | LogPropertyFilterApi
+    | RevenueAnalyticsPropertyFilterApi
+
+/**
+ * Property filters for all series
+ */
+export type PathsQueryApiProperties = PathsQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi
+
+export interface PathsQueryApi {
+    /**
+     * Groups aggregation
+     * @nullable
+     */
+    aggregation_group_type_index?: number | null
+    /**
+     * Colors used in the insight's visualization
+     * @nullable
+     */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi
+    /**
+     * Exclude internal and test users by applying the respective filters
+     * @nullable
+     */
+    filterTestAccounts?: boolean | null
+    /** Used for displaying paths in relation to funnel steps. */
+    funnelPathsFilter?: FunnelPathsFilterApi
+    kind?: PathsQueryApiKind
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Properties specific to the paths insight */
+    pathsFilter: PathsFilterApi
+    /** Property filters for all series */
+    properties?: PathsQueryApiProperties
+    response?: PathsQueryResponseApi
+    /**
+     * Sampling rate
+     * @nullable
+     */
+    samplingFactor?: number | null
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi
+    /**
+     * version of the node, used for schema migrations
+     * @nullable
+     */
+    version?: number | null
+}
+
+export type StickinessQueryResponseApiResultsItem = { [key: string]: unknown }
+
+export interface StickinessQueryResponseApi {
+    /**
+     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
+     * @nullable
+     */
+    error?: string | null
+    /**
+     * Generated HogQL query.
+     * @nullable
+     */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi
+    results: StickinessQueryResponseApiResultsItem[]
+    /**
+     * Measured timings for different parts of the query generation process
+     * @nullable
+     */
+    timings?: QueryTimingApi[] | null
+}
+
+export type StickinessComputationModeApi =
+    (typeof StickinessComputationModeApi)[keyof typeof StickinessComputationModeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const StickinessComputationModeApi = {
+    non_cumulative: 'non_cumulative',
+    cumulative: 'cumulative',
+} as const
+
+export type StickinessOperatorApi = (typeof StickinessOperatorApi)[keyof typeof StickinessOperatorApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const StickinessOperatorApi = {
+    gte: 'gte',
+    lte: 'lte',
+    exact: 'exact',
+} as const
+
 export interface StickinessCriteriaApi {
     operator: StickinessOperatorApi
     value: number
 }
+
+export type StickinessFilterApiResultCustomizationsAnyOf = { [key: string]: ResultCustomizationByValueApi }
+
+export type StickinessFilterApiResultCustomizationsAnyOfTwo = { [key: string]: ResultCustomizationByPositionApi }
+
+/**
+ * Customizations for the appearance of result datasets.
+ */
+export type StickinessFilterApiResultCustomizations =
+    | StickinessFilterApiResultCustomizationsAnyOf
+    | StickinessFilterApiResultCustomizationsAnyOfTwo
+
+export interface StickinessFilterApi {
+    computedAs?: StickinessComputationModeApi
+    display?: ChartDisplayTypeApi
+    /** @nullable */
+    hiddenLegendIndexes?: number[] | null
+    /** Whether result datasets are associated by their values or by their order. */
+    resultCustomizationBy?: ResultCustomizationByApi
+    /** Customizations for the appearance of result datasets. */
+    resultCustomizations?: StickinessFilterApiResultCustomizations
+    /** @nullable */
+    showLegend?: boolean | null
+    /** @nullable */
+    showMultipleYAxes?: boolean | null
+    /** @nullable */
+    showValuesOnSeries?: boolean | null
+    stickinessCriteria?: StickinessCriteriaApi
+}
+
+export type StickinessQueryApiKind = (typeof StickinessQueryApiKind)[keyof typeof StickinessQueryApiKind]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const StickinessQueryApiKind = {
+    StickinessQuery: 'StickinessQuery',
+} as const
+
+export type StickinessQueryApiPropertiesAnyOfItem =
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | ElementPropertyFilterApi
+    | EventMetadataPropertyFilterApi
+    | SessionPropertyFilterApi
+    | CohortPropertyFilterApi
+    | RecordingPropertyFilterApi
+    | LogEntryPropertyFilterApi
+    | GroupPropertyFilterApi
+    | FeaturePropertyFilterApi
+    | FlagPropertyFilterApi
+    | HogQLPropertyFilterApi
+    | EmptyPropertyFilterApi
+    | DataWarehousePropertyFilterApi
+    | DataWarehousePersonPropertyFilterApi
+    | ErrorTrackingIssueFilterApi
+    | LogPropertyFilterApi
+    | RevenueAnalyticsPropertyFilterApi
+
+/**
+ * Property filters for all series
+ */
+export type StickinessQueryApiProperties = StickinessQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi
+
+export type StickinessQueryApiSeriesItem = EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi
+
+export interface StickinessQueryApi {
+    /** Compare to date range */
+    compareFilter?: CompareFilterApi
+    /**
+     * Colors used in the insight's visualization
+     * @nullable
+     */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi
+    /**
+     * Exclude internal and test users by applying the respective filters
+     * @nullable
+     */
+    filterTestAccounts?: boolean | null
+    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
+    interval?: IntervalTypeApi
+    /**
+     * How many intervals comprise a period. Only used for cohorts, otherwise default 1.
+     * @nullable
+     */
+    intervalCount?: number | null
+    kind?: StickinessQueryApiKind
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Property filters for all series */
+    properties?: StickinessQueryApiProperties
+    response?: StickinessQueryResponseApi
+    /**
+     * Sampling rate
+     * @nullable
+     */
+    samplingFactor?: number | null
+    /** Events and actions to include */
+    series: StickinessQueryApiSeriesItem[]
+    /** Properties specific to the stickiness insight */
+    stickinessFilter?: StickinessFilterApi
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi
+    /**
+     * version of the node, used for schema migrations
+     * @nullable
+     */
+    version?: number | null
+}
+
+export type LifecycleToggleApi = (typeof LifecycleToggleApi)[keyof typeof LifecycleToggleApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const LifecycleToggleApi = {
+    new: 'new',
+    resurrecting: 'resurrecting',
+    returning: 'returning',
+    dormant: 'dormant',
+} as const
+
+export interface LifecycleFilterApi {
+    /** @nullable */
+    showLegend?: boolean | null
+    /** @nullable */
+    showValuesOnSeries?: boolean | null
+    /** @nullable */
+    stacked?: boolean | null
+    /** @nullable */
+    toggledLifecycles?: LifecycleToggleApi[] | null
+}
+
+export type LifecycleQueryResponseApiResultsItem = { [key: string]: unknown }
+
+export interface LifecycleQueryResponseApi {
+    /**
+     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
+     * @nullable
+     */
+    error?: string | null
+    /**
+     * Generated HogQL query.
+     * @nullable
+     */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi
+    results: LifecycleQueryResponseApiResultsItem[]
+    /**
+     * Measured timings for different parts of the query generation process
+     * @nullable
+     */
+    timings?: QueryTimingApi[] | null
+}
+
+export type LifecycleQueryApiKind = (typeof LifecycleQueryApiKind)[keyof typeof LifecycleQueryApiKind]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const LifecycleQueryApiKind = {
+    LifecycleQuery: 'LifecycleQuery',
+} as const
+
+export type LifecycleQueryApiPropertiesAnyOfItem =
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | ElementPropertyFilterApi
+    | EventMetadataPropertyFilterApi
+    | SessionPropertyFilterApi
+    | CohortPropertyFilterApi
+    | RecordingPropertyFilterApi
+    | LogEntryPropertyFilterApi
+    | GroupPropertyFilterApi
+    | FeaturePropertyFilterApi
+    | FlagPropertyFilterApi
+    | HogQLPropertyFilterApi
+    | EmptyPropertyFilterApi
+    | DataWarehousePropertyFilterApi
+    | DataWarehousePersonPropertyFilterApi
+    | ErrorTrackingIssueFilterApi
+    | LogPropertyFilterApi
+    | RevenueAnalyticsPropertyFilterApi
+
+/**
+ * Property filters for all series
+ */
+export type LifecycleQueryApiProperties = LifecycleQueryApiPropertiesAnyOfItem[] | PropertyGroupFilterApi
+
+export type LifecycleQueryApiSeriesItem = EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi
+
+export interface LifecycleQueryApi {
+    /**
+     * Groups aggregation
+     * @nullable
+     */
+    aggregation_group_type_index?: number | null
+    /**
+     * Colors used in the insight's visualization
+     * @nullable
+     */
+    dataColorTheme?: number | null
+    /** Date range for the query */
+    dateRange?: DateRangeApi
+    /**
+     * Exclude internal and test users by applying the respective filters
+     * @nullable
+     */
+    filterTestAccounts?: boolean | null
+    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
+    interval?: IntervalTypeApi
+    kind?: LifecycleQueryApiKind
+    /** Properties specific to the lifecycle insight */
+    lifecycleFilter?: LifecycleFilterApi
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Property filters for all series */
+    properties?: LifecycleQueryApiProperties
+    response?: LifecycleQueryResponseApi
+    /**
+     * Sampling rate
+     * @nullable
+     */
+    samplingFactor?: number | null
+    /** Events and actions to include */
+    series: LifecycleQueryApiSeriesItem[]
+    /** Tags that will be added to the Query log comment */
+    tags?: QueryLogTagsApi
+    /**
+     * version of the node, used for schema migrations
+     * @nullable
+     */
+    version?: number | null
+}
+
+export type WebStatsBreakdownApi = (typeof WebStatsBreakdownApi)[keyof typeof WebStatsBreakdownApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WebStatsBreakdownApi = {
+    Page: 'Page',
+    InitialPage: 'InitialPage',
+    ExitPage: 'ExitPage',
+    ExitClick: 'ExitClick',
+    PreviousPage: 'PreviousPage',
+    ScreenName: 'ScreenName',
+    InitialChannelType: 'InitialChannelType',
+    InitialReferringDomain: 'InitialReferringDomain',
+    InitialUTMSource: 'InitialUTMSource',
+    InitialUTMCampaign: 'InitialUTMCampaign',
+    InitialUTMMedium: 'InitialUTMMedium',
+    InitialUTMTerm: 'InitialUTMTerm',
+    InitialUTMContent: 'InitialUTMContent',
+    InitialUTMSourceMediumCampaign: 'InitialUTMSourceMediumCampaign',
+    Browser: 'Browser',
+    OS: 'OS',
+    Viewport: 'Viewport',
+    DeviceType: 'DeviceType',
+    Country: 'Country',
+    Region: 'Region',
+    City: 'City',
+    Timezone: 'Timezone',
+    Language: 'Language',
+    FrustrationMetrics: 'FrustrationMetrics',
+} as const
+
+export type WebAnalyticsOrderByFieldsApi =
+    (typeof WebAnalyticsOrderByFieldsApi)[keyof typeof WebAnalyticsOrderByFieldsApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WebAnalyticsOrderByFieldsApi = {
+    Visitors: 'Visitors',
+    Views: 'Views',
+    AvgTimeOnPage: 'AvgTimeOnPage',
+    Clicks: 'Clicks',
+    BounceRate: 'BounceRate',
+    AverageScrollPercentage: 'AverageScrollPercentage',
+    ScrollGt80Percentage: 'ScrollGt80Percentage',
+    TotalConversions: 'TotalConversions',
+    UniqueConversions: 'UniqueConversions',
+    ConversionRate: 'ConversionRate',
+    ConvertingUsers: 'ConvertingUsers',
+    RageClicks: 'RageClicks',
+    DeadClicks: 'DeadClicks',
+    Errors: 'Errors',
+} as const
+
+export type WebAnalyticsOrderByDirectionApi =
+    (typeof WebAnalyticsOrderByDirectionApi)[keyof typeof WebAnalyticsOrderByDirectionApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WebAnalyticsOrderByDirectionApi = {
+    ASC: 'ASC',
+    DESC: 'DESC',
+} as const
 
 export interface SamplingRateApi {
     /** @nullable */
     denominator?: number | null
     numerator: number
 }
+
+export interface WebStatsTableQueryResponseApi {
+    /** @nullable */
+    columns?: unknown[] | null
+    /**
+     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
+     * @nullable
+     */
+    error?: string | null
+    /** @nullable */
+    hasMore?: boolean | null
+    /**
+     * Generated HogQL query.
+     * @nullable
+     */
+    hogql?: string | null
+    /** @nullable */
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** @nullable */
+    offset?: number | null
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi
+    results: unknown[]
+    samplingRate?: SamplingRateApi
+    /**
+     * Measured timings for different parts of the query generation process
+     * @nullable
+     */
+    timings?: QueryTimingApi[] | null
+    /** @nullable */
+    types?: unknown[] | null
+    /** @nullable */
+    usedPreAggregatedTables?: boolean | null
+}
+
+export interface WebAnalyticsSamplingApi {
+    /** @nullable */
+    enabled?: boolean | null
+    forceSamplingRate?: SamplingRateApi
+}
+
+export type WebStatsTableQueryApiConversionGoal = ActionConversionGoalApi | CustomEventConversionGoalApi
+
+export type WebStatsTableQueryApiKind = (typeof WebStatsTableQueryApiKind)[keyof typeof WebStatsTableQueryApiKind]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WebStatsTableQueryApiKind = {
+    WebStatsTableQuery: 'WebStatsTableQuery',
+} as const
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WebStatsTableQueryApiOrderByItem = {
+    ...WebAnalyticsOrderByFieldsApi,
+    ...WebAnalyticsOrderByDirectionApi,
+} as const
+export type WebStatsTableQueryApiPropertiesItem =
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | SessionPropertyFilterApi
+
+export interface WebStatsTableQueryApi {
+    /**
+     * Groups aggregation - not used in Web Analytics but required for type compatibility
+     * @nullable
+     */
+    aggregation_group_type_index?: number | null
+    breakdownBy: WebStatsBreakdownApi
+    compareFilter?: CompareFilterApi
+    conversionGoal?: WebStatsTableQueryApiConversionGoal
+    /**
+     * Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility
+     * @nullable
+     */
+    dataColorTheme?: number | null
+    dateRange?: DateRangeApi
+    /** @nullable */
+    doPathCleaning?: boolean | null
+    /** @nullable */
+    filterTestAccounts?: boolean | null
+    /** @nullable */
+    includeAvgTimeOnPage?: boolean | null
+    /** @nullable */
+    includeBounceRate?: boolean | null
+    /** @nullable */
+    includeRevenue?: boolean | null
+    /** @nullable */
+    includeScrollDepth?: boolean | null
+    /** For Product Analytics UI compatibility only - not used in Web Analytics query execution */
+    interval?: IntervalTypeApi
+    kind?: WebStatsTableQueryApiKind
+    /** @nullable */
+    limit?: number | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** @nullable */
+    offset?: number | null
+    /** @nullable */
+    orderBy?: (typeof WebStatsTableQueryApiOrderByItem)[keyof typeof WebStatsTableQueryApiOrderByItem][] | null
+    properties: WebStatsTableQueryApiPropertiesItem[]
+    response?: WebStatsTableQueryResponseApi
+    sampling?: WebAnalyticsSamplingApi
+    /**
+     * Sampling rate
+     * @nullable
+     */
+    samplingFactor?: number | null
+    tags?: QueryLogTagsApi
+    /** @nullable */
+    useSessionsTable?: boolean | null
+    /**
+     * version of the node, used for schema migrations
+     * @nullable
+     */
+    version?: number | null
+}
+
+export type WebAnalyticsItemKindApi = (typeof WebAnalyticsItemKindApi)[keyof typeof WebAnalyticsItemKindApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WebAnalyticsItemKindApi = {
+    unit: 'unit',
+    duration_s: 'duration_s',
+    percentage: 'percentage',
+    currency: 'currency',
+} as const
 
 export interface WebOverviewItemApi {
     /** @nullable */
@@ -4052,31 +3503,249 @@ export interface WebOverviewItemApi {
     value?: number | null
 }
 
+export interface WebOverviewQueryResponseApi {
+    /** @nullable */
+    dateFrom?: string | null
+    /** @nullable */
+    dateTo?: string | null
+    /**
+     * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
+     * @nullable
+     */
+    error?: string | null
+    /**
+     * Generated HogQL query.
+     * @nullable
+     */
+    hogql?: string | null
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** Query status indicates whether next to the provided data, a query is still running. */
+    query_status?: QueryStatusApi
+    /** The date range used for the query */
+    resolved_date_range?: ResolvedDateRangeResponseApi
+    results: WebOverviewItemApi[]
+    samplingRate?: SamplingRateApi
+    /**
+     * Measured timings for different parts of the query generation process
+     * @nullable
+     */
+    timings?: QueryTimingApi[] | null
+    /** @nullable */
+    usedPreAggregatedTables?: boolean | null
+}
+
+export type WebOverviewQueryApiConversionGoal = ActionConversionGoalApi | CustomEventConversionGoalApi
+
+export type WebOverviewQueryApiKind = (typeof WebOverviewQueryApiKind)[keyof typeof WebOverviewQueryApiKind]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WebOverviewQueryApiKind = {
+    WebOverviewQuery: 'WebOverviewQuery',
+} as const
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WebOverviewQueryApiOrderByItem = {
+    ...WebAnalyticsOrderByFieldsApi,
+    ...WebAnalyticsOrderByDirectionApi,
+} as const
+export type WebOverviewQueryApiPropertiesItem =
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | SessionPropertyFilterApi
+
+export interface WebOverviewQueryApi {
+    /**
+     * Groups aggregation - not used in Web Analytics but required for type compatibility
+     * @nullable
+     */
+    aggregation_group_type_index?: number | null
+    compareFilter?: CompareFilterApi
+    conversionGoal?: WebOverviewQueryApiConversionGoal
+    /**
+     * Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility
+     * @nullable
+     */
+    dataColorTheme?: number | null
+    dateRange?: DateRangeApi
+    /** @nullable */
+    doPathCleaning?: boolean | null
+    /** @nullable */
+    filterTestAccounts?: boolean | null
+    /** @nullable */
+    includeRevenue?: boolean | null
+    /** For Product Analytics UI compatibility only - not used in Web Analytics query execution */
+    interval?: IntervalTypeApi
+    kind?: WebOverviewQueryApiKind
+    /** Modifiers used when performing the query */
+    modifiers?: HogQLQueryModifiersApi
+    /** @nullable */
+    orderBy?: (typeof WebOverviewQueryApiOrderByItem)[keyof typeof WebOverviewQueryApiOrderByItem][] | null
+    properties: WebOverviewQueryApiPropertiesItem[]
+    response?: WebOverviewQueryResponseApi
+    sampling?: WebAnalyticsSamplingApi
+    /**
+     * Sampling rate
+     * @nullable
+     */
+    samplingFactor?: number | null
+    tags?: QueryLogTagsApi
+    /** @nullable */
+    useSessionsTable?: boolean | null
+    /**
+     * version of the node, used for schema migrations
+     * @nullable
+     */
+    version?: number | null
+}
+
+export type EndpointRequestApiQuery =
+    | HogQLQueryApi
+    | TrendsQueryApi
+    | FunnelsQueryApi
+    | RetentionQueryApi
+    | PathsQueryApi
+    | StickinessQueryApi
+    | LifecycleQueryApi
+    | WebStatsTableQueryApi
+    | WebOverviewQueryApi
+
+export type DataWarehouseSyncIntervalApi =
+    (typeof DataWarehouseSyncIntervalApi)[keyof typeof DataWarehouseSyncIntervalApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DataWarehouseSyncIntervalApi = {
+    '5min': '5min',
+    '30min': '30min',
+    '1hour': '1hour',
+    '6hour': '6hour',
+    '12hour': '12hour',
+    '24hour': '24hour',
+    '7day': '7day',
+    '30day': '30day',
+} as const
+
+export interface EndpointRequestApi {
+    /** @nullable */
+    cache_age_seconds?: number | null
+    /** @nullable */
+    derived_from_insight?: string | null
+    /** @nullable */
+    description?: string | null
+    /** @nullable */
+    is_active?: boolean | null
+    /**
+     * Whether this endpoint's query results are materialized to S3
+     * @nullable
+     */
+    is_materialized?: boolean | null
+    /** @nullable */
+    name?: string | null
+    query?: EndpointRequestApiQuery
+    /** How frequently should the underlying materialized view be updated */
+    sync_frequency?: DataWarehouseSyncIntervalApi
+}
+
 /**
+ * Map of Insight query keys to be overridden at execution time. For example:   Assuming query = {"kind": "TrendsQuery", "series": [{"kind": "EventsNode","name": "$pageview","event": "$pageview","math": "total"}]}   If query_override = {"series": [{"kind": "EventsNode","name": "$identify","event": "$identify","math": "total"}]}   The query executed will return the count of $identify events, instead of $pageview's
+ */
+export type EndpointRunRequestApiQueryOverrideAnyOf = { [key: string]: unknown }
+
+/**
+ * Map of Insight query keys to be overridden at execution time. For example:   Assuming query = {"kind": "TrendsQuery", "series": [{"kind": "EventsNode","name": "$pageview","event": "$pageview","math": "total"}]}   If query_override = {"series": [{"kind": "EventsNode","name": "$identify","event": "$identify","math": "total"}]}   The query executed will return the count of $identify events, instead of $pageview's
  * @nullable
  */
-export type CustomChannelConditionApiValue = string | string[] | null
+export type EndpointRunRequestApiQueryOverride = EndpointRunRequestApiQueryOverrideAnyOf | null | null
 
-export interface CustomChannelConditionApi {
-    id: string
-    key: CustomChannelFieldApi
-    op: CustomChannelOperatorApi
+/**
+ * A map for overriding HogQL query variables, where the key is the variable name and the value is the variable value. Variable must be set on the endpoint's query between curly braces (i.e. {variable.from_date}) For example: {"from_date": "1970-01-01"}
+ */
+export type EndpointRunRequestApiVariablesAnyOf = { [key: string]: unknown }
+
+/**
+ * A map for overriding HogQL query variables, where the key is the variable name and the value is the variable value. Variable must be set on the endpoint's query between curly braces (i.e. {variable.from_date}) For example: {"from_date": "1970-01-01"}
+ * @nullable
+ */
+export type EndpointRunRequestApiVariables = EndpointRunRequestApiVariablesAnyOf | null | null
+
+export type DashboardFilterApiPropertiesItem =
+    | EventPropertyFilterApi
+    | PersonPropertyFilterApi
+    | ElementPropertyFilterApi
+    | EventMetadataPropertyFilterApi
+    | SessionPropertyFilterApi
+    | CohortPropertyFilterApi
+    | RecordingPropertyFilterApi
+    | LogEntryPropertyFilterApi
+    | GroupPropertyFilterApi
+    | FeaturePropertyFilterApi
+    | FlagPropertyFilterApi
+    | HogQLPropertyFilterApi
+    | EmptyPropertyFilterApi
+    | DataWarehousePropertyFilterApi
+    | DataWarehousePersonPropertyFilterApi
+    | ErrorTrackingIssueFilterApi
+    | LogPropertyFilterApi
+    | RevenueAnalyticsPropertyFilterApi
+
+export interface DashboardFilterApi {
+    breakdown_filter?: BreakdownFilterApi
     /** @nullable */
-    value?: CustomChannelConditionApiValue
+    date_from?: string | null
+    /** @nullable */
+    date_to?: string | null
+    /** @nullable */
+    explicitDate?: boolean | null
+    /** @nullable */
+    properties?: DashboardFilterApiPropertiesItem[] | null
 }
 
-export interface HogQLNoticeApi {
-    /** @nullable */
-    end?: number | null
-    /** @nullable */
-    fix?: string | null
-    message: string
-    /** @nullable */
-    start?: number | null
+export type EndpointRefreshModeApi = (typeof EndpointRefreshModeApi)[keyof typeof EndpointRefreshModeApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EndpointRefreshModeApi = {
+    cache: 'cache',
+    force: 'force',
+    direct: 'direct',
+} as const
+
+export interface EndpointRunRequestApi {
+    /**
+     * Client provided query ID. Can be used to retrieve the status or cancel the query.
+     * @nullable
+     */
+    client_query_id?: string | null
+    /**
+     * Whether to include debug information (such as the executed HogQL) in the response.
+     * @nullable
+     */
+    debug?: boolean | null
+    /** A map for overriding insight query filters.
+
+Tip: Use to get data for a specific customer or user. */
+    filters_override?: DashboardFilterApi
+    /**
+     * Map of Insight query keys to be overridden at execution time. For example:   Assuming query = {"kind": "TrendsQuery", "series": [{"kind": "EventsNode","name": "$pageview","event": "$pageview","math": "total"}]}   If query_override = {"series": [{"kind": "EventsNode","name": "$identify","event": "$identify","math": "total"}]}   The query executed will return the count of $identify events, instead of $pageview's
+     * @nullable
+     */
+    query_override?: EndpointRunRequestApiQueryOverride
+    refresh?: EndpointRefreshModeApi
+    /**
+     * A map for overriding HogQL query variables, where the key is the variable name and the value is the variable value. Variable must be set on the endpoint's query between curly braces (i.e. {variable.from_date}) For example: {"from_date": "1970-01-01"}
+     * @nullable
+     */
+    variables?: EndpointRunRequestApiVariables
+    /**
+     * Specific endpoint version to execute. If not provided, the latest version is used.
+     * @nullable
+     */
+    version?: number | null
 }
 
-export interface RetentionValueApi {
-    count: number
-    /** @nullable */
-    label?: string | null
+export interface EndpointLastExecutionTimesRequestApi {
+    names: string[]
+}
+
+export interface QueryStatusResponseApi {
+    query_status: QueryStatusApi
 }

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -7,6 +7,20 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
+export interface ErrorTrackingFingerprintApi {
+    fingerprint: string
+    readonly issue_id: string
+    readonly created_at: string
+}
+
+export interface PaginatedErrorTrackingFingerprintListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ErrorTrackingFingerprintApi[]
+}
 
 /**
  * * `archived` - Archived
@@ -15,6 +29,8 @@
  * `pending_release` - Pending release
  * `suppressed` - Suppressed
  */
+export type ErrorTrackingIssueFullStatusEnumApi =
+    (typeof ErrorTrackingIssueFullStatusEnumApi)[keyof typeof ErrorTrackingIssueFullStatusEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ErrorTrackingIssueFullStatusEnumApi = {
@@ -24,6 +40,11 @@ export const ErrorTrackingIssueFullStatusEnumApi = {
     pending_release: 'pending_release',
     suppressed: 'suppressed',
 } as const
+
+export interface ErrorTrackingIssueAssignmentApi {
+    readonly id: string
+    readonly type: string
+}
 
 /**
  * * `slack` - Slack
@@ -77,31 +98,19 @@ export const KindEnumApi = {
     databricks: 'databricks',
 } as const
 
-export type ErrorTrackingIssueFullStatusEnumApi =
-    (typeof ErrorTrackingIssueFullStatusEnumApi)[keyof typeof ErrorTrackingIssueFullStatusEnumApi]
-
-export interface PaginatedErrorTrackingFingerprintListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ErrorTrackingFingerprintApi[]
+export interface ErrorTrackingExternalReferenceIntegrationApi {
+    readonly id: number
+    readonly kind: KindEnumApi
+    readonly display_name: string
 }
 
-export interface ErrorTrackingFingerprintApi {
-    fingerprint: string
-    readonly issue_id: string
-    readonly created_at: string
-}
-
-export interface PaginatedErrorTrackingIssueFullListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ErrorTrackingIssueFullApi[]
+export interface ErrorTrackingExternalReferenceApi {
+    readonly id: string
+    readonly integration: ErrorTrackingExternalReferenceIntegrationApi
+    integration_id: number
+    config: unknown
+    issue: string
+    readonly external_url: string
 }
 
 export interface ErrorTrackingIssueFullApi {
@@ -117,6 +126,15 @@ export interface ErrorTrackingIssueFullApi {
     readonly cohort: string
 }
 
+export interface PaginatedErrorTrackingIssueFullListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ErrorTrackingIssueFullApi[]
+}
+
 export interface PatchedErrorTrackingIssueFullApi {
     readonly id?: string
     status?: ErrorTrackingIssueFullStatusEnumApi
@@ -130,6 +148,16 @@ export interface PatchedErrorTrackingIssueFullApi {
     readonly cohort?: string
 }
 
+export interface ErrorTrackingReleaseApi {
+    readonly id: string
+    hash_id: string
+    readonly team_id: number
+    readonly created_at: string
+    metadata?: unknown
+    version: string
+    project: string
+}
+
 export interface PaginatedErrorTrackingReleaseListApi {
     count: number
     /** @nullable */
@@ -139,36 +167,25 @@ export interface PaginatedErrorTrackingReleaseListApi {
     results: ErrorTrackingReleaseApi[]
 }
 
-/**
- * @nullable
- */
-export type ErrorTrackingReleaseApiMetadata = unknown | null
-
-export interface ErrorTrackingReleaseApi {
-    readonly id: string
-    hash_id: string
-    readonly team_id: number
-    readonly created_at: string
-    /** @nullable */
-    metadata?: ErrorTrackingReleaseApiMetadata
-    version: string
-    project: string
-}
-
-/**
- * @nullable
- */
-export type PatchedErrorTrackingReleaseApiMetadata = unknown | null
-
 export interface PatchedErrorTrackingReleaseApi {
     readonly id?: string
     hash_id?: string
     readonly team_id?: number
     readonly created_at?: string
-    /** @nullable */
-    metadata?: PatchedErrorTrackingReleaseApiMetadata
+    metadata?: unknown
     version?: string
     project?: string
+}
+
+export interface ErrorTrackingStackFrameApi {
+    readonly id: string
+    readonly raw_id: string
+    readonly created_at: string
+    contents: unknown
+    resolved: boolean
+    context?: unknown
+    symbol_set_ref?: string
+    readonly release: ErrorTrackingReleaseApi
 }
 
 export interface PaginatedErrorTrackingStackFrameListApi {
@@ -178,32 +195,6 @@ export interface PaginatedErrorTrackingStackFrameListApi {
     /** @nullable */
     previous?: string | null
     results: ErrorTrackingStackFrameApi[]
-}
-
-/**
- * @nullable
- */
-export type ErrorTrackingStackFrameApiContext = unknown | null
-
-export interface ErrorTrackingStackFrameApi {
-    readonly id: string
-    readonly raw_id: string
-    readonly created_at: string
-    contents: unknown
-    resolved: boolean
-    /** @nullable */
-    context?: ErrorTrackingStackFrameApiContext
-    symbol_set_ref?: string
-    readonly release: ErrorTrackingReleaseApi
-}
-
-export interface PaginatedErrorTrackingSymbolSetListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ErrorTrackingSymbolSetApi[]
 }
 
 export interface ErrorTrackingSymbolSetApi {
@@ -220,6 +211,15 @@ export interface ErrorTrackingSymbolSetApi {
     readonly release: string
 }
 
+export interface PaginatedErrorTrackingSymbolSetListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ErrorTrackingSymbolSetApi[]
+}
+
 export interface PatchedErrorTrackingSymbolSetApi {
     readonly id?: string
     ref?: string
@@ -232,26 +232,6 @@ export interface PatchedErrorTrackingSymbolSetApi {
     /** @nullable */
     failure_reason?: string | null
     readonly release?: string
-}
-
-export interface ErrorTrackingIssueAssignmentApi {
-    readonly id: string
-    readonly type: string
-}
-
-export interface ErrorTrackingExternalReferenceApi {
-    readonly id: string
-    readonly integration: ErrorTrackingExternalReferenceIntegrationApi
-    integration_id: number
-    config: unknown
-    issue: string
-    readonly external_url: string
-}
-
-export interface ErrorTrackingExternalReferenceIntegrationApi {
-    readonly id: number
-    readonly kind: KindEnumApi
-    readonly display_name: string
 }
 
 export type EnvironmentsErrorTrackingFingerprintsListParams = {

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -7,49 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
-/**
- * * `web` - web
- * `product` - product
- */
-export type ExperimentTypeEnumApi = (typeof ExperimentTypeEnumApi)[keyof typeof ExperimentTypeEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ExperimentTypeEnumApi = {
-    web: 'web',
-    product: 'product',
-} as const
-
-export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const BlankEnumApi = {
-    '': '',
-} as const
-
-export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const NullEnumApi = {} as const
-
-/**
- * * `won` - Won
- * `lost` - Lost
- * `inconclusive` - Inconclusive
- * `stopped_early` - Stopped Early
- * `invalid` - Invalid
- */
-export type ConclusionEnumApi = (typeof ConclusionEnumApi)[keyof typeof ConclusionEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ConclusionEnumApi = {
-    won: 'won',
-    lost: 'lost',
-    inconclusive: 'inconclusive',
-    stopped_early: 'stopped_early',
-    invalid: 'invalid',
-} as const
-
 /**
  * * `engineering` - Engineering
  * `data` - Data
@@ -73,6 +30,87 @@ export const RoleAtOrganizationEnumApi = {
     sales: 'sales',
     other: 'other',
 } as const
+
+export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const BlankEnumApi = {
+    '': '',
+} as const
+
+export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const NullEnumApi = {} as const
+
+export type UserBasicApiHedgehogConfigAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type UserBasicApiHedgehogConfig = UserBasicApiHedgehogConfigAnyOf | null | null
+
+export type UserBasicApiRoleAtOrganization = RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
+    /** @nullable */
+    is_email_verified?: boolean | null
+    /** @nullable */
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: UserBasicApiRoleAtOrganization
+}
+
+export interface ExperimentHoldoutApi {
+    readonly id: number
+    /** @maxLength 400 */
+    name: string
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    description?: string | null
+    filters?: unknown
+    readonly created_by: UserBasicApi
+    readonly created_at: string
+    readonly updated_at: string
+}
+
+export interface PaginatedExperimentHoldoutListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ExperimentHoldoutApi[]
+}
+
+export interface PatchedExperimentHoldoutApi {
+    readonly id?: number
+    /** @maxLength 400 */
+    name?: string
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    description?: string | null
+    filters?: unknown
+    readonly created_by?: UserBasicApi
+    readonly created_at?: string
+    readonly updated_at?: string
+}
 
 /**
  * * `server` - Server
@@ -100,107 +138,101 @@ export const BucketingIdentifierEnumApi = {
     device_id: 'device_id',
 } as const
 
-export interface PaginatedExperimentHoldoutListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ExperimentHoldoutApi[]
-}
+export type MinimalFeatureFlagApiFilters = { [key: string]: unknown }
 
-export interface ExperimentHoldoutApi {
+/**
+ * Specifies where this feature flag should be evaluated
+
+* `server` - Server
+* `client` - Client
+* `all` - All
+ */
+export type MinimalFeatureFlagApiEvaluationRuntime = EvaluationRuntimeEnumApi | BlankEnumApi | NullEnumApi
+
+/**
+ * Identifier used for bucketing users into rollout and variants
+
+* `distinct_id` - User ID (default)
+* `device_id` - Device ID
+ */
+export type MinimalFeatureFlagApiBucketingIdentifier = BucketingIdentifierEnumApi | BlankEnumApi | NullEnumApi
+
+export interface MinimalFeatureFlagApi {
     readonly id: number
-    /** @maxLength 400 */
-    name: string
-    /**
-     * @maxLength 400
-     * @nullable
-     */
-    description?: string | null
-    filters?: unknown
-    readonly created_by: UserBasicApi
-    readonly created_at: string
-    readonly updated_at: string
-}
-
-export interface PatchedExperimentHoldoutApi {
-    readonly id?: number
-    /** @maxLength 400 */
+    readonly team_id: number
     name?: string
+    /** @maxLength 400 */
+    key: string
+    filters?: MinimalFeatureFlagApiFilters
+    deleted?: boolean
+    active?: boolean
+    /** @nullable */
+    ensure_experience_continuity?: boolean | null
+    /** @nullable */
+    has_encrypted_payloads?: boolean | null
     /**
-     * @maxLength 400
+     * @minimum -2147483648
+     * @maximum 2147483647
      * @nullable
      */
-    description?: string | null
-    filters?: unknown
-    readonly created_by?: UserBasicApi
-    readonly created_at?: string
-    readonly updated_at?: string
+    version?: number | null
+    /** Specifies where this feature flag should be evaluated
+
+* `server` - Server
+* `client` - Client
+* `all` - All */
+    evaluation_runtime?: MinimalFeatureFlagApiEvaluationRuntime
+    /** Identifier used for bucketing users into rollout and variants
+
+* `distinct_id` - User ID (default)
+* `device_id` - Device ID */
+    bucketing_identifier?: MinimalFeatureFlagApiBucketingIdentifier
+    readonly evaluation_tags: readonly string[]
 }
 
-export interface PaginatedExperimentListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ExperimentApi[]
+export interface ExperimentToSavedMetricApi {
+    readonly id: number
+    experiment: number
+    saved_metric: number
+    metadata?: unknown
+    readonly created_at: string
+    readonly query: unknown
+    readonly name: string
 }
 
 /**
- * @nullable
+ * * `web` - web
+ * `product` - product
  */
-export type ExperimentApiParameters = unknown | null
-
-/**
- * @nullable
- */
-export type ExperimentApiSecondaryMetrics = unknown | null
+export type ExperimentTypeEnumApi = (typeof ExperimentTypeEnumApi)[keyof typeof ExperimentTypeEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ExperimentApiType = { ...ExperimentTypeEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type ExperimentApiType = (typeof ExperimentApiType)[keyof typeof ExperimentApiType] | null
+export const ExperimentTypeEnumApi = {
+    web: 'web',
+    product: 'product',
+} as const
 
 /**
- * @nullable
+ * * `won` - Won
+ * `lost` - Lost
+ * `inconclusive` - Inconclusive
+ * `stopped_early` - Stopped Early
+ * `invalid` - Invalid
  */
-export type ExperimentApiExposureCriteria = unknown | null
-
-/**
- * @nullable
- */
-export type ExperimentApiMetrics = unknown | null
-
-/**
- * @nullable
- */
-export type ExperimentApiMetricsSecondary = unknown | null
-
-/**
- * @nullable
- */
-export type ExperimentApiStatsConfig = unknown | null
+export type ConclusionEnumApi = (typeof ConclusionEnumApi)[keyof typeof ConclusionEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ExperimentApiConclusion = { ...ConclusionEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type ExperimentApiConclusion = (typeof ExperimentApiConclusion)[keyof typeof ExperimentApiConclusion] | null
+export const ConclusionEnumApi = {
+    won: 'won',
+    lost: 'lost',
+    inconclusive: 'inconclusive',
+    stopped_early: 'stopped_early',
+    invalid: 'invalid',
+} as const
 
-/**
- * @nullable
- */
-export type ExperimentApiPrimaryMetricsOrderedUuids = unknown | null
+export type ExperimentApiType = ExperimentTypeEnumApi | BlankEnumApi | NullEnumApi
 
-/**
- * @nullable
- */
-export type ExperimentApiSecondaryMetricsOrderedUuids = unknown | null
+export type ExperimentApiConclusion = ConclusionEnumApi | BlankEnumApi | NullEnumApi
 
 /**
  * Mixin for serializers to add user access control fields
@@ -225,10 +257,8 @@ export interface ExperimentApi {
     holdout_id?: number | null
     /** @nullable */
     readonly exposure_cohort: number | null
-    /** @nullable */
-    parameters?: ExperimentApiParameters
-    /** @nullable */
-    secondary_metrics?: ExperimentApiSecondaryMetrics
+    parameters?: unknown
+    secondary_metrics?: unknown
     readonly saved_metrics: readonly ExperimentToSavedMetricApi[]
     /** @nullable */
     saved_metrics_ids?: unknown[] | null
@@ -239,25 +269,18 @@ export interface ExperimentApi {
     readonly created_by: UserBasicApi
     readonly created_at: string
     readonly updated_at: string
-    /** @nullable */
     type?: ExperimentApiType
-    /** @nullable */
-    exposure_criteria?: ExperimentApiExposureCriteria
-    /** @nullable */
-    metrics?: ExperimentApiMetrics
-    /** @nullable */
-    metrics_secondary?: ExperimentApiMetricsSecondary
-    /** @nullable */
-    stats_config?: ExperimentApiStatsConfig
+    exposure_criteria?: unknown
+    metrics?: unknown
+    metrics_secondary?: unknown
+    stats_config?: unknown
+    scheduling_config?: unknown
     _create_in_folder?: string
-    /** @nullable */
     conclusion?: ExperimentApiConclusion
     /** @nullable */
     conclusion_comment?: string | null
-    /** @nullable */
-    primary_metrics_ordered_uuids?: ExperimentApiPrimaryMetricsOrderedUuids
-    /** @nullable */
-    secondary_metrics_ordered_uuids?: ExperimentApiSecondaryMetricsOrderedUuids
+    primary_metrics_ordered_uuids?: unknown
+    secondary_metrics_ordered_uuids?: unknown
     /**
      * The effective access level the user has for this object
      * @nullable
@@ -265,61 +288,18 @@ export interface ExperimentApi {
     readonly user_access_level: string | null
 }
 
-/**
- * @nullable
- */
-export type PatchedExperimentApiParameters = unknown | null
+export interface PaginatedExperimentListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ExperimentApi[]
+}
 
-/**
- * @nullable
- */
-export type PatchedExperimentApiSecondaryMetrics = unknown | null
+export type PatchedExperimentApiType = ExperimentTypeEnumApi | BlankEnumApi | NullEnumApi
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedExperimentApiType = { ...ExperimentTypeEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type PatchedExperimentApiType = (typeof PatchedExperimentApiType)[keyof typeof PatchedExperimentApiType] | null
-
-/**
- * @nullable
- */
-export type PatchedExperimentApiExposureCriteria = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedExperimentApiMetrics = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedExperimentApiMetricsSecondary = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedExperimentApiStatsConfig = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedExperimentApiConclusion = { ...ConclusionEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type PatchedExperimentApiConclusion =
-    | (typeof PatchedExperimentApiConclusion)[keyof typeof PatchedExperimentApiConclusion]
-    | null
-
-/**
- * @nullable
- */
-export type PatchedExperimentApiPrimaryMetricsOrderedUuids = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedExperimentApiSecondaryMetricsOrderedUuids = unknown | null
+export type PatchedExperimentApiConclusion = ConclusionEnumApi | BlankEnumApi | NullEnumApi
 
 /**
  * Mixin for serializers to add user access control fields
@@ -344,10 +324,8 @@ export interface PatchedExperimentApi {
     holdout_id?: number | null
     /** @nullable */
     readonly exposure_cohort?: number | null
-    /** @nullable */
-    parameters?: PatchedExperimentApiParameters
-    /** @nullable */
-    secondary_metrics?: PatchedExperimentApiSecondaryMetrics
+    parameters?: unknown
+    secondary_metrics?: unknown
     readonly saved_metrics?: readonly ExperimentToSavedMetricApi[]
     /** @nullable */
     saved_metrics_ids?: unknown[] | null
@@ -358,152 +336,23 @@ export interface PatchedExperimentApi {
     readonly created_by?: UserBasicApi
     readonly created_at?: string
     readonly updated_at?: string
-    /** @nullable */
     type?: PatchedExperimentApiType
-    /** @nullable */
-    exposure_criteria?: PatchedExperimentApiExposureCriteria
-    /** @nullable */
-    metrics?: PatchedExperimentApiMetrics
-    /** @nullable */
-    metrics_secondary?: PatchedExperimentApiMetricsSecondary
-    /** @nullable */
-    stats_config?: PatchedExperimentApiStatsConfig
+    exposure_criteria?: unknown
+    metrics?: unknown
+    metrics_secondary?: unknown
+    stats_config?: unknown
+    scheduling_config?: unknown
     _create_in_folder?: string
-    /** @nullable */
     conclusion?: PatchedExperimentApiConclusion
     /** @nullable */
     conclusion_comment?: string | null
-    /** @nullable */
-    primary_metrics_ordered_uuids?: PatchedExperimentApiPrimaryMetricsOrderedUuids
-    /** @nullable */
-    secondary_metrics_ordered_uuids?: PatchedExperimentApiSecondaryMetricsOrderedUuids
+    primary_metrics_ordered_uuids?: unknown
+    secondary_metrics_ordered_uuids?: unknown
     /**
      * The effective access level the user has for this object
      * @nullable
      */
     readonly user_access_level?: string | null
-}
-
-/**
- * @nullable
- */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserBasicApiRoleAtOrganization = { ...RoleAtOrganizationEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserBasicApiRoleAtOrganization =
-    | (typeof UserBasicApiRoleAtOrganization)[keyof typeof UserBasicApiRoleAtOrganization]
-    | null
-
-export interface UserBasicApi {
-    readonly id: number
-    readonly uuid: string
-    /**
-     * @maxLength 200
-     * @nullable
-     */
-    distinct_id?: string | null
-    /** @maxLength 150 */
-    first_name?: string
-    /** @maxLength 150 */
-    last_name?: string
-    /** @maxLength 254 */
-    email: string
-    /** @nullable */
-    is_email_verified?: boolean | null
-    /** @nullable */
-    readonly hedgehog_config: UserBasicApiHedgehogConfig
-    /** @nullable */
-    role_at_organization?: UserBasicApiRoleAtOrganization
-}
-
-export type MinimalFeatureFlagApiFilters = { [key: string]: unknown }
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MinimalFeatureFlagApiEvaluationRuntime = {
-    ...EvaluationRuntimeEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * Specifies where this feature flag should be evaluated
-
-* `server` - Server
-* `client` - Client
-* `all` - All
- * @nullable
- */
-export type MinimalFeatureFlagApiEvaluationRuntime =
-    | (typeof MinimalFeatureFlagApiEvaluationRuntime)[keyof typeof MinimalFeatureFlagApiEvaluationRuntime]
-    | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MinimalFeatureFlagApiBucketingIdentifier = {
-    ...BucketingIdentifierEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * Identifier used for bucketing users into rollout and variants
-
-* `distinct_id` - User ID (default)
-* `device_id` - Device ID
- * @nullable
- */
-export type MinimalFeatureFlagApiBucketingIdentifier =
-    | (typeof MinimalFeatureFlagApiBucketingIdentifier)[keyof typeof MinimalFeatureFlagApiBucketingIdentifier]
-    | null
-
-export interface MinimalFeatureFlagApi {
-    readonly id: number
-    readonly team_id: number
-    name?: string
-    /** @maxLength 400 */
-    key: string
-    filters?: MinimalFeatureFlagApiFilters
-    deleted?: boolean
-    active?: boolean
-    /** @nullable */
-    ensure_experience_continuity?: boolean | null
-    /** @nullable */
-    has_encrypted_payloads?: boolean | null
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     * @nullable
-     */
-    version?: number | null
-    /**
-   * Specifies where this feature flag should be evaluated
-
-* `server` - Server
-* `client` - Client
-* `all` - All
-   * @nullable
-   */
-    evaluation_runtime?: MinimalFeatureFlagApiEvaluationRuntime
-    /**
-   * Identifier used for bucketing users into rollout and variants
-
-* `distinct_id` - User ID (default)
-* `device_id` - Device ID
-   * @nullable
-   */
-    bucketing_identifier?: MinimalFeatureFlagApiBucketingIdentifier
-    readonly evaluation_tags: readonly string[]
-}
-
-export interface ExperimentToSavedMetricApi {
-    readonly id: number
-    experiment: number
-    saved_metric: number
-    metadata?: unknown
-    readonly created_at: string
-    readonly query: unknown
-    readonly name: string
 }
 
 export type ExperimentHoldoutsListParams = {

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -7,6 +7,71 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
+/**
+ * * `engineering` - Engineering
+ * `data` - Data
+ * `product` - Product Management
+ * `founder` - Founder
+ * `leadership` - Leadership
+ * `marketing` - Marketing
+ * `sales` - Sales / Success
+ * `other` - Other
+ */
+export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RoleAtOrganizationEnumApi = {
+    engineering: 'engineering',
+    data: 'data',
+    product: 'product',
+    founder: 'founder',
+    leadership: 'leadership',
+    marketing: 'marketing',
+    sales: 'sales',
+    other: 'other',
+} as const
+
+export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const BlankEnumApi = {
+    '': '',
+} as const
+
+export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const NullEnumApi = {} as const
+
+export type UserBasicApiHedgehogConfigAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type UserBasicApiHedgehogConfig = UserBasicApiHedgehogConfigAnyOf | null | null
+
+export type UserBasicApiRoleAtOrganization = RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
+    /** @nullable */
+    is_email_verified?: boolean | null
+    /** @nullable */
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: UserBasicApiRoleAtOrganization
+}
 
 /**
  * * `feature_flags` - feature_flags
@@ -42,18 +107,6 @@ export const EvaluationRuntimeEnumApi = {
     all: 'all',
 } as const
 
-export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const BlankEnumApi = {
-    '': '',
-} as const
-
-export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const NullEnumApi = {} as const
-
 /**
  * * `distinct_id` - User ID (default)
  * `device_id` - Device ID
@@ -66,39 +119,6 @@ export const BucketingIdentifierEnumApi = {
     device_id: 'device_id',
 } as const
 
-/**
- * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
- */
-export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const RoleAtOrganizationEnumApi = {
-    engineering: 'engineering',
-    data: 'data',
-    product: 'product',
-    founder: 'founder',
-    leadership: 'leadership',
-    marketing: 'marketing',
-    sales: 'sales',
-    other: 'other',
-} as const
-
-export interface PaginatedFeatureFlagListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: FeatureFlagApi[]
-}
-
 export type FeatureFlagApiFilters = { [key: string]: unknown }
 
 export type FeatureFlagApiSurveys = { [key: string]: unknown }
@@ -106,40 +126,21 @@ export type FeatureFlagApiSurveys = { [key: string]: unknown }
 export type FeatureFlagApiFeatures = { [key: string]: unknown }
 
 /**
- * @nullable
- */
-export type FeatureFlagApiRollbackConditions = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FeatureFlagApiEvaluationRuntime = { ...EvaluationRuntimeEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
  * Specifies where this feature flag should be evaluated
 
 * `server` - Server
 * `client` - Client
 * `all` - All
- * @nullable
  */
-export type FeatureFlagApiEvaluationRuntime =
-    | (typeof FeatureFlagApiEvaluationRuntime)[keyof typeof FeatureFlagApiEvaluationRuntime]
-    | null
+export type FeatureFlagApiEvaluationRuntime = EvaluationRuntimeEnumApi | BlankEnumApi | NullEnumApi
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const FeatureFlagApiBucketingIdentifier = {
-    ...BucketingIdentifierEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
 /**
  * Identifier used for bucketing users into rollout and variants
 
 * `distinct_id` - User ID (default)
 * `device_id` - Device ID
- * @nullable
  */
-export type FeatureFlagApiBucketingIdentifier =
-    | (typeof FeatureFlagApiBucketingIdentifier)[keyof typeof FeatureFlagApiBucketingIdentifier]
-    | null
+export type FeatureFlagApiBucketingIdentifier = BucketingIdentifierEnumApi | BlankEnumApi | NullEnumApi
 
 /**
  * Serializer mixin that resolves appropriate response for tags depending on license.
@@ -167,8 +168,7 @@ export interface FeatureFlagApi {
     readonly experiment_set: string
     readonly surveys: FeatureFlagApiSurveys
     readonly features: FeatureFlagApiFeatures
-    /** @nullable */
-    rollback_conditions?: FeatureFlagApiRollbackConditions
+    rollback_conditions?: unknown
     /** @nullable */
     performed_rollback?: boolean | null
     readonly can_edit: boolean
@@ -197,22 +197,16 @@ export interface FeatureFlagApi {
     /** @nullable */
     has_encrypted_payloads?: boolean | null
     readonly status: string
-    /**
-   * Specifies where this feature flag should be evaluated
+    /** Specifies where this feature flag should be evaluated
 
 * `server` - Server
 * `client` - Client
-* `all` - All
-   * @nullable
-   */
+* `all` - All */
     evaluation_runtime?: FeatureFlagApiEvaluationRuntime
-    /**
-   * Identifier used for bucketing users into rollout and variants
+    /** Identifier used for bucketing users into rollout and variants
 
 * `distinct_id` - User ID (default)
-* `device_id` - Device ID
-   * @nullable
-   */
+* `device_id` - Device ID */
     bucketing_identifier?: FeatureFlagApiBucketingIdentifier
     /**
      * Last time this feature flag was called (from $feature_flag_called events)
@@ -223,6 +217,15 @@ export interface FeatureFlagApi {
     _should_create_usage_dashboard?: boolean
 }
 
+export interface PaginatedFeatureFlagListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: FeatureFlagApi[]
+}
+
 export type PatchedFeatureFlagApiFilters = { [key: string]: unknown }
 
 export type PatchedFeatureFlagApiSurveys = { [key: string]: unknown }
@@ -230,44 +233,21 @@ export type PatchedFeatureFlagApiSurveys = { [key: string]: unknown }
 export type PatchedFeatureFlagApiFeatures = { [key: string]: unknown }
 
 /**
- * @nullable
- */
-export type PatchedFeatureFlagApiRollbackConditions = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedFeatureFlagApiEvaluationRuntime = {
-    ...EvaluationRuntimeEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
  * Specifies where this feature flag should be evaluated
 
 * `server` - Server
 * `client` - Client
 * `all` - All
- * @nullable
  */
-export type PatchedFeatureFlagApiEvaluationRuntime =
-    | (typeof PatchedFeatureFlagApiEvaluationRuntime)[keyof typeof PatchedFeatureFlagApiEvaluationRuntime]
-    | null
+export type PatchedFeatureFlagApiEvaluationRuntime = EvaluationRuntimeEnumApi | BlankEnumApi | NullEnumApi
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedFeatureFlagApiBucketingIdentifier = {
-    ...BucketingIdentifierEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
 /**
  * Identifier used for bucketing users into rollout and variants
 
 * `distinct_id` - User ID (default)
 * `device_id` - Device ID
- * @nullable
  */
-export type PatchedFeatureFlagApiBucketingIdentifier =
-    | (typeof PatchedFeatureFlagApiBucketingIdentifier)[keyof typeof PatchedFeatureFlagApiBucketingIdentifier]
-    | null
+export type PatchedFeatureFlagApiBucketingIdentifier = BucketingIdentifierEnumApi | BlankEnumApi | NullEnumApi
 
 /**
  * Serializer mixin that resolves appropriate response for tags depending on license.
@@ -295,8 +275,7 @@ export interface PatchedFeatureFlagApi {
     readonly experiment_set?: string
     readonly surveys?: PatchedFeatureFlagApiSurveys
     readonly features?: PatchedFeatureFlagApiFeatures
-    /** @nullable */
-    rollback_conditions?: PatchedFeatureFlagApiRollbackConditions
+    rollback_conditions?: unknown
     /** @nullable */
     performed_rollback?: boolean | null
     readonly can_edit?: boolean
@@ -325,22 +304,16 @@ export interface PatchedFeatureFlagApi {
     /** @nullable */
     has_encrypted_payloads?: boolean | null
     readonly status?: string
-    /**
-   * Specifies where this feature flag should be evaluated
+    /** Specifies where this feature flag should be evaluated
 
 * `server` - Server
 * `client` - Client
-* `all` - All
-   * @nullable
-   */
+* `all` - All */
     evaluation_runtime?: PatchedFeatureFlagApiEvaluationRuntime
-    /**
-   * Identifier used for bucketing users into rollout and variants
+    /** Identifier used for bucketing users into rollout and variants
 
 * `distinct_id` - User ID (default)
-* `device_id` - Device ID
-   * @nullable
-   */
+* `device_id` - Device ID */
     bucketing_identifier?: PatchedFeatureFlagApiBucketingIdentifier
     /**
      * Last time this feature flag was called (from $feature_flag_called events)
@@ -349,6 +322,45 @@ export interface PatchedFeatureFlagApi {
     last_called_at?: string | null
     _create_in_folder?: string
     _should_create_usage_dashboard?: boolean
+}
+
+export interface ChangeApi {
+    readonly type: string
+    readonly action: string
+    readonly field: string
+    readonly before: unknown
+    readonly after: unknown
+}
+
+export interface MergeApi {
+    readonly type: string
+    readonly source: unknown
+    readonly target: unknown
+}
+
+export interface TriggerApi {
+    readonly job_type: string
+    readonly job_id: string
+    readonly payload: unknown
+}
+
+export interface DetailApi {
+    readonly id: string
+    changes?: ChangeApi[]
+    merge?: MergeApi
+    trigger?: TriggerApi
+    readonly name: string
+    readonly short_id: string
+    readonly type: string
+}
+
+export interface ActivityLogEntryApi {
+    readonly user: string
+    readonly activity: string
+    readonly scope: string
+    readonly item_id: string
+    detail?: DetailApi
+    readonly created_at: string
 }
 
 /**
@@ -370,99 +382,24 @@ export type LocalEvaluationResponseApiGroupTypeMapping = { [key: string]: string
  */
 export type LocalEvaluationResponseApiCohorts = { [key: string]: unknown }
 
-export interface LocalEvaluationResponseApi {
-    flags: MinimalFeatureFlagApi[]
-    group_type_mapping: LocalEvaluationResponseApiGroupTypeMapping
-    /** Cohort definitions keyed by cohort ID. Each value is a property group structure with 'type' (OR/AND) and 'values' (array of property groups or property filters). */
-    cohorts: LocalEvaluationResponseApiCohorts
-}
-
-export interface MyFlagsResponseApi {
-    feature_flag: MinimalFeatureFlagApi
-    value: unknown
-}
-
-/**
- * @nullable
- */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserBasicApiRoleAtOrganization = { ...RoleAtOrganizationEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserBasicApiRoleAtOrganization =
-    | (typeof UserBasicApiRoleAtOrganization)[keyof typeof UserBasicApiRoleAtOrganization]
-    | null
-
-export interface UserBasicApi {
-    readonly id: number
-    readonly uuid: string
-    /**
-     * @maxLength 200
-     * @nullable
-     */
-    distinct_id?: string | null
-    /** @maxLength 150 */
-    first_name?: string
-    /** @maxLength 150 */
-    last_name?: string
-    /** @maxLength 254 */
-    email: string
-    /** @nullable */
-    is_email_verified?: boolean | null
-    /** @nullable */
-    readonly hedgehog_config: UserBasicApiHedgehogConfig
-    /** @nullable */
-    role_at_organization?: UserBasicApiRoleAtOrganization
-}
-
-export interface ActivityLogEntryApi {
-    readonly user: string
-    readonly activity: string
-    readonly scope: string
-    readonly item_id: string
-    detail?: DetailApi
-    readonly created_at: string
-}
-
 export type MinimalFeatureFlagApiFilters = { [key: string]: unknown }
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MinimalFeatureFlagApiEvaluationRuntime = {
-    ...EvaluationRuntimeEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
 /**
  * Specifies where this feature flag should be evaluated
 
 * `server` - Server
 * `client` - Client
 * `all` - All
- * @nullable
  */
-export type MinimalFeatureFlagApiEvaluationRuntime =
-    | (typeof MinimalFeatureFlagApiEvaluationRuntime)[keyof typeof MinimalFeatureFlagApiEvaluationRuntime]
-    | null
+export type MinimalFeatureFlagApiEvaluationRuntime = EvaluationRuntimeEnumApi | BlankEnumApi | NullEnumApi
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MinimalFeatureFlagApiBucketingIdentifier = {
-    ...BucketingIdentifierEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
 /**
  * Identifier used for bucketing users into rollout and variants
 
 * `distinct_id` - User ID (default)
 * `device_id` - Device ID
- * @nullable
  */
-export type MinimalFeatureFlagApiBucketingIdentifier =
-    | (typeof MinimalFeatureFlagApiBucketingIdentifier)[keyof typeof MinimalFeatureFlagApiBucketingIdentifier]
-    | null
+export type MinimalFeatureFlagApiBucketingIdentifier = BucketingIdentifierEnumApi | BlankEnumApi | NullEnumApi
 
 export interface MinimalFeatureFlagApi {
     readonly id: number
@@ -483,54 +420,30 @@ export interface MinimalFeatureFlagApi {
      * @nullable
      */
     version?: number | null
-    /**
-   * Specifies where this feature flag should be evaluated
+    /** Specifies where this feature flag should be evaluated
 
 * `server` - Server
 * `client` - Client
-* `all` - All
-   * @nullable
-   */
+* `all` - All */
     evaluation_runtime?: MinimalFeatureFlagApiEvaluationRuntime
-    /**
-   * Identifier used for bucketing users into rollout and variants
+    /** Identifier used for bucketing users into rollout and variants
 
 * `distinct_id` - User ID (default)
-* `device_id` - Device ID
-   * @nullable
-   */
+* `device_id` - Device ID */
     bucketing_identifier?: MinimalFeatureFlagApiBucketingIdentifier
     readonly evaluation_tags: readonly string[]
 }
 
-export interface DetailApi {
-    readonly id: string
-    changes?: ChangeApi[]
-    merge?: MergeApi
-    trigger?: TriggerApi
-    readonly name: string
-    readonly short_id: string
-    readonly type: string
+export interface LocalEvaluationResponseApi {
+    flags: MinimalFeatureFlagApi[]
+    group_type_mapping: LocalEvaluationResponseApiGroupTypeMapping
+    /** Cohort definitions keyed by cohort ID. Each value is a property group structure with 'type' (OR/AND) and 'values' (array of property groups or property filters). */
+    cohorts: LocalEvaluationResponseApiCohorts
 }
 
-export interface ChangeApi {
-    readonly type: string
-    readonly action: string
-    readonly field: string
-    readonly before: unknown
-    readonly after: unknown
-}
-
-export interface MergeApi {
-    readonly type: string
-    readonly source: unknown
-    readonly target: unknown
-}
-
-export interface TriggerApi {
-    readonly job_type: string
-    readonly job_id: string
-    readonly payload: unknown
+export interface MyFlagsResponseApi {
+    feature_flag: MinimalFeatureFlagApi
+    value: unknown
 }
 
 export type FeatureFlagsListParams = {

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -7,7 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
 /**
  * * `engineering` - Engineering
  * `data` - Data
@@ -44,171 +43,14 @@ export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const NullEnumApi = {} as const
 
-export interface PaginatedDatasetItemListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: DatasetItemApi[]
-}
+export type UserBasicApiHedgehogConfigAnyOf = { [key: string]: unknown }
 
 /**
  * @nullable
  */
-export type DatasetItemApiInput = unknown | null
+export type UserBasicApiHedgehogConfig = UserBasicApiHedgehogConfigAnyOf | null | null
 
-/**
- * @nullable
- */
-export type DatasetItemApiOutput = unknown | null
-
-/**
- * @nullable
- */
-export type DatasetItemApiMetadata = unknown | null
-
-export interface DatasetItemApi {
-    readonly id: string
-    dataset: string
-    /** @nullable */
-    input?: DatasetItemApiInput
-    /** @nullable */
-    output?: DatasetItemApiOutput
-    /** @nullable */
-    metadata?: DatasetItemApiMetadata
-    /**
-     * @maxLength 255
-     * @nullable
-     */
-    ref_trace_id?: string | null
-    /** @nullable */
-    ref_timestamp?: string | null
-    /**
-     * @maxLength 255
-     * @nullable
-     */
-    ref_source_id?: string | null
-    /** @nullable */
-    deleted?: boolean | null
-    readonly created_at: string
-    /** @nullable */
-    readonly updated_at: string | null
-    readonly created_by: UserBasicApi
-    readonly team: number
-}
-
-/**
- * @nullable
- */
-export type PatchedDatasetItemApiInput = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedDatasetItemApiOutput = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedDatasetItemApiMetadata = unknown | null
-
-export interface PatchedDatasetItemApi {
-    readonly id?: string
-    dataset?: string
-    /** @nullable */
-    input?: PatchedDatasetItemApiInput
-    /** @nullable */
-    output?: PatchedDatasetItemApiOutput
-    /** @nullable */
-    metadata?: PatchedDatasetItemApiMetadata
-    /**
-     * @maxLength 255
-     * @nullable
-     */
-    ref_trace_id?: string | null
-    /** @nullable */
-    ref_timestamp?: string | null
-    /**
-     * @maxLength 255
-     * @nullable
-     */
-    ref_source_id?: string | null
-    /** @nullable */
-    deleted?: boolean | null
-    readonly created_at?: string
-    /** @nullable */
-    readonly updated_at?: string | null
-    readonly created_by?: UserBasicApi
-    readonly team?: number
-}
-
-export interface PaginatedDatasetListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: DatasetApi[]
-}
-
-/**
- * @nullable
- */
-export type DatasetApiMetadata = unknown | null
-
-export interface DatasetApi {
-    readonly id: string
-    /** @maxLength 400 */
-    name: string
-    /** @nullable */
-    description?: string | null
-    /** @nullable */
-    metadata?: DatasetApiMetadata
-    readonly created_at: string
-    /** @nullable */
-    readonly updated_at: string | null
-    /** @nullable */
-    deleted?: boolean | null
-    readonly created_by: UserBasicApi
-    readonly team: number
-}
-
-/**
- * @nullable
- */
-export type PatchedDatasetApiMetadata = unknown | null
-
-export interface PatchedDatasetApi {
-    readonly id?: string
-    /** @maxLength 400 */
-    name?: string
-    /** @nullable */
-    description?: string | null
-    /** @nullable */
-    metadata?: PatchedDatasetApiMetadata
-    readonly created_at?: string
-    /** @nullable */
-    readonly updated_at?: string | null
-    /** @nullable */
-    deleted?: boolean | null
-    readonly created_by?: UserBasicApi
-    readonly team?: number
-}
-
-/**
- * @nullable
- */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserBasicApiRoleAtOrganization = { ...RoleAtOrganizationEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserBasicApiRoleAtOrganization =
-    | (typeof UserBasicApiRoleAtOrganization)[keyof typeof UserBasicApiRoleAtOrganization]
-    | null
+export type UserBasicApiRoleAtOrganization = RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi
 
 export interface UserBasicApi {
     readonly id: number
@@ -228,8 +70,111 @@ export interface UserBasicApi {
     is_email_verified?: boolean | null
     /** @nullable */
     readonly hedgehog_config: UserBasicApiHedgehogConfig
-    /** @nullable */
     role_at_organization?: UserBasicApiRoleAtOrganization
+}
+
+export interface DatasetItemApi {
+    readonly id: string
+    dataset: string
+    input?: unknown
+    output?: unknown
+    metadata?: unknown
+    /**
+     * @maxLength 255
+     * @nullable
+     */
+    ref_trace_id?: string | null
+    /** @nullable */
+    ref_timestamp?: string | null
+    /**
+     * @maxLength 255
+     * @nullable
+     */
+    ref_source_id?: string | null
+    /** @nullable */
+    deleted?: boolean | null
+    readonly created_at: string
+    /** @nullable */
+    readonly updated_at: string | null
+    readonly created_by: UserBasicApi
+    readonly team: number
+}
+
+export interface PaginatedDatasetItemListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: DatasetItemApi[]
+}
+
+export interface PatchedDatasetItemApi {
+    readonly id?: string
+    dataset?: string
+    input?: unknown
+    output?: unknown
+    metadata?: unknown
+    /**
+     * @maxLength 255
+     * @nullable
+     */
+    ref_trace_id?: string | null
+    /** @nullable */
+    ref_timestamp?: string | null
+    /**
+     * @maxLength 255
+     * @nullable
+     */
+    ref_source_id?: string | null
+    /** @nullable */
+    deleted?: boolean | null
+    readonly created_at?: string
+    /** @nullable */
+    readonly updated_at?: string | null
+    readonly created_by?: UserBasicApi
+    readonly team?: number
+}
+
+export interface DatasetApi {
+    readonly id: string
+    /** @maxLength 400 */
+    name: string
+    /** @nullable */
+    description?: string | null
+    metadata?: unknown
+    readonly created_at: string
+    /** @nullable */
+    readonly updated_at: string | null
+    /** @nullable */
+    deleted?: boolean | null
+    readonly created_by: UserBasicApi
+    readonly team: number
+}
+
+export interface PaginatedDatasetListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: DatasetApi[]
+}
+
+export interface PatchedDatasetApi {
+    readonly id?: string
+    /** @maxLength 400 */
+    name?: string
+    /** @nullable */
+    description?: string | null
+    metadata?: unknown
+    readonly created_at?: string
+    /** @nullable */
+    readonly updated_at?: string | null
+    /** @nullable */
+    deleted?: boolean | null
+    readonly created_by?: UserBasicApi
+    readonly team?: number
 }
 
 export type EnvironmentsDatasetItemsListParams = {

--- a/products/llm_analytics/frontend/generated/api.ts
+++ b/products/llm_analytics/frontend/generated/api.ts
@@ -228,15 +228,6 @@ export const getEnvironmentsDatasetsListUrl = (projectId: string, params?: Envir
     const normalizedParams = new URLSearchParams()
 
     Object.entries(params || {}).forEach(([key, value]) => {
-        const explodeParameters = ['id__in', 'order_by']
-
-        if (Array.isArray(value) && explodeParameters.includes(key)) {
-            value.forEach((v) => {
-                normalizedParams.append(key, v === null ? 'null' : v.toString())
-            })
-            return
-        }
-
         if (value !== undefined) {
             normalizedParams.append(key, value === null ? 'null' : value.toString())
         }
@@ -586,15 +577,6 @@ export const getDatasetsListUrl = (projectId: string, params?: DatasetsListParam
     const normalizedParams = new URLSearchParams()
 
     Object.entries(params || {}).forEach(([key, value]) => {
-        const explodeParameters = ['id__in', 'order_by']
-
-        if (Array.isArray(value) && explodeParameters.includes(key)) {
-            value.forEach((v) => {
-                normalizedParams.append(key, v === null ? 'null' : v.toString())
-            })
-            return
-        }
-
         if (value !== undefined) {
             normalizedParams.append(key, value === null ? 'null' : value.toString())
         }

--- a/products/persons/frontend/generated/api.schemas.ts
+++ b/products/persons/frontend/generated/api.schemas.ts
@@ -7,7 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
 /**
  * * `AND` - AND
  * `OR` - OR
@@ -130,6 +129,19 @@ export const PropertyItemTypeEnumApi = {
     workflow_variable: 'workflow_variable',
 } as const
 
+export type PropertyItemApiOperator = OperatorEnumApi | BlankEnumApi | NullEnumApi
+
+export type PropertyItemApiType = PropertyItemTypeEnumApi | BlankEnumApi
+
+export interface PropertyItemApi {
+    /** Key of the property you're filtering on. For example `email` or `$current_url` */
+    key: string
+    /** Value of your filter. For example `test@example.com` or `https://example.com/test/`. Can be an array for an OR query, like `["test@example.com","ok@example.com"]` */
+    value: string
+    operator?: PropertyItemApiOperator
+    type?: PropertyItemApiType
+}
+
 export interface PropertyApi {
     /** 
  You can use a simplified version:
@@ -171,19 +183,11 @@ Or you can create more complicated queries with AND and OR:
 }
 ```
 
+
 * `AND` - AND
 * `OR` - OR */
     type?: PropertyTypeEnumApi
     values: PropertyItemApi[]
-}
-
-export interface PaginatedPersonListApi {
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    count?: number
-    results?: PersonApi[]
 }
 
 export interface PersonApi {
@@ -195,6 +199,15 @@ export interface PersonApi {
     readonly uuid: string
 }
 
+export interface PaginatedPersonListApi {
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    count?: number
+    results?: PersonApi[]
+}
+
 export interface PatchedPersonApi {
     readonly id?: number
     readonly name?: string
@@ -202,25 +215,6 @@ export interface PatchedPersonApi {
     properties?: unknown
     readonly created_at?: string
     readonly uuid?: string
-}
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PropertyItemApiOperator = { ...OperatorEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type PropertyItemApiOperator = (typeof PropertyItemApiOperator)[keyof typeof PropertyItemApiOperator] | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PropertyItemApiType = { ...PropertyItemTypeEnumApi, ...BlankEnumApi } as const
-export interface PropertyItemApi {
-    /** Key of the property you're filtering on. For example `email` or `$current_url` */
-    key: string
-    /** Value of your filter. For example `test@example.com` or `https://example.com/test/`. Can be an array for an OR query, like `["test@example.com","ok@example.com"]` */
-    value: string
-    /** @nullable */
-    operator?: PropertyItemApiOperator
-    type?: (typeof PropertyItemApiType)[keyof typeof PropertyItemApiType]
 }
 
 export type EnvironmentsPersonsListParams = {
@@ -299,23 +293,6 @@ export const EnvironmentsPersonsPartialUpdateFormat = {
     json: 'json',
 } as const
 
-export type EnvironmentsPersonsDestroyParams = {
-    /**
-     * If true, a task to delete all events associated with this person will be created and queued. The task does not run immediately and instead is batched together and at 5AM UTC every Sunday
-     */
-    delete_events?: boolean
-    format?: EnvironmentsPersonsDestroyFormat
-}
-
-export type EnvironmentsPersonsDestroyFormat =
-    (typeof EnvironmentsPersonsDestroyFormat)[keyof typeof EnvironmentsPersonsDestroyFormat]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EnvironmentsPersonsDestroyFormat = {
-    csv: 'csv',
-    json: 'json',
-} as const
-
 export type EnvironmentsPersonsActivityRetrieve2Params = {
     format?: EnvironmentsPersonsActivityRetrieve2Format
 }
@@ -325,19 +302,6 @@ export type EnvironmentsPersonsActivityRetrieve2Format =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EnvironmentsPersonsActivityRetrieve2Format = {
-    csv: 'csv',
-    json: 'json',
-} as const
-
-export type EnvironmentsPersonsDeleteEventsCreateParams = {
-    format?: EnvironmentsPersonsDeleteEventsCreateFormat
-}
-
-export type EnvironmentsPersonsDeleteEventsCreateFormat =
-    (typeof EnvironmentsPersonsDeleteEventsCreateFormat)[keyof typeof EnvironmentsPersonsDeleteEventsCreateFormat]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EnvironmentsPersonsDeleteEventsCreateFormat = {
     csv: 'csv',
     json: 'json',
 } as const
@@ -355,19 +319,6 @@ export type EnvironmentsPersonsDeletePropertyCreateFormat =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EnvironmentsPersonsDeletePropertyCreateFormat = {
-    csv: 'csv',
-    json: 'json',
-} as const
-
-export type EnvironmentsPersonsDeleteRecordingsCreateParams = {
-    format?: EnvironmentsPersonsDeleteRecordingsCreateFormat
-}
-
-export type EnvironmentsPersonsDeleteRecordingsCreateFormat =
-    (typeof EnvironmentsPersonsDeleteRecordingsCreateFormat)[keyof typeof EnvironmentsPersonsDeleteRecordingsCreateFormat]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EnvironmentsPersonsDeleteRecordingsCreateFormat = {
     csv: 'csv',
     json: 'json',
 } as const
@@ -438,6 +389,10 @@ export type EnvironmentsPersonsBulkDeleteCreateParams = {
      */
     delete_events?: boolean
     /**
+     * If true, a task to delete all recordings associated with this person will be created and queued. The task does not run immediately and instead is batched together and at 5AM UTC every Sunday
+     */
+    delete_recordings?: boolean
+    /**
      * A list of distinct IDs, up to 1000 of them. We'll delete all persons associated with those distinct IDs.
      */
     distinct_ids?: { [key: string]: unknown }
@@ -446,6 +401,10 @@ export type EnvironmentsPersonsBulkDeleteCreateParams = {
      * A list of PostHog person IDs, up to 1000 of them. We'll delete all the persons listed.
      */
     ids?: { [key: string]: unknown }
+    /**
+     * If true, the person record itself will not be deleted. This is useful if you want to keep the person record for auditing purposes but remove events and recordings associated with them
+     */
+    keep_person?: boolean
 }
 
 export type EnvironmentsPersonsBulkDeleteCreateFormat =
@@ -659,22 +618,6 @@ export const PersonsPartialUpdateFormat = {
     json: 'json',
 } as const
 
-export type PersonsDestroyParams = {
-    /**
-     * If true, a task to delete all events associated with this person will be created and queued. The task does not run immediately and instead is batched together and at 5AM UTC every Sunday
-     */
-    delete_events?: boolean
-    format?: PersonsDestroyFormat
-}
-
-export type PersonsDestroyFormat = (typeof PersonsDestroyFormat)[keyof typeof PersonsDestroyFormat]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PersonsDestroyFormat = {
-    csv: 'csv',
-    json: 'json',
-} as const
-
 export type PersonsActivityRetrieve2Params = {
     format?: PersonsActivityRetrieve2Format
 }
@@ -684,19 +627,6 @@ export type PersonsActivityRetrieve2Format =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const PersonsActivityRetrieve2Format = {
-    csv: 'csv',
-    json: 'json',
-} as const
-
-export type PersonsDeleteEventsCreateParams = {
-    format?: PersonsDeleteEventsCreateFormat
-}
-
-export type PersonsDeleteEventsCreateFormat =
-    (typeof PersonsDeleteEventsCreateFormat)[keyof typeof PersonsDeleteEventsCreateFormat]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PersonsDeleteEventsCreateFormat = {
     csv: 'csv',
     json: 'json',
 } as const
@@ -714,19 +644,6 @@ export type PersonsDeletePropertyCreateFormat =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const PersonsDeletePropertyCreateFormat = {
-    csv: 'csv',
-    json: 'json',
-} as const
-
-export type PersonsDeleteRecordingsCreateParams = {
-    format?: PersonsDeleteRecordingsCreateFormat
-}
-
-export type PersonsDeleteRecordingsCreateFormat =
-    (typeof PersonsDeleteRecordingsCreateFormat)[keyof typeof PersonsDeleteRecordingsCreateFormat]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PersonsDeleteRecordingsCreateFormat = {
     csv: 'csv',
     json: 'json',
 } as const
@@ -796,6 +713,10 @@ export type PersonsBulkDeleteCreateParams = {
      */
     delete_events?: boolean
     /**
+     * If true, a task to delete all recordings associated with this person will be created and queued. The task does not run immediately and instead is batched together and at 5AM UTC every Sunday
+     */
+    delete_recordings?: boolean
+    /**
      * A list of distinct IDs, up to 1000 of them. We'll delete all persons associated with those distinct IDs.
      */
     distinct_ids?: { [key: string]: unknown }
@@ -804,6 +725,10 @@ export type PersonsBulkDeleteCreateParams = {
      * A list of PostHog person IDs, up to 1000 of them. We'll delete all the persons listed.
      */
     ids?: { [key: string]: unknown }
+    /**
+     * If true, the person record itself will not be deleted. This is useful if you want to keep the person record for auditing purposes but remove events and recordings associated with them
+     */
+    keep_person?: boolean
 }
 
 export type PersonsBulkDeleteCreateFormat =

--- a/products/persons/frontend/generated/api.ts
+++ b/products/persons/frontend/generated/api.ts
@@ -13,10 +13,7 @@ import type {
     EnvironmentsPersonsActivityRetrieveParams,
     EnvironmentsPersonsBulkDeleteCreateParams,
     EnvironmentsPersonsCohortsRetrieveParams,
-    EnvironmentsPersonsDeleteEventsCreateParams,
     EnvironmentsPersonsDeletePropertyCreateParams,
-    EnvironmentsPersonsDeleteRecordingsCreateParams,
-    EnvironmentsPersonsDestroyParams,
     EnvironmentsPersonsFunnelCorrelationCreateParams,
     EnvironmentsPersonsFunnelCorrelationRetrieveParams,
     EnvironmentsPersonsFunnelCreateParams,
@@ -40,10 +37,7 @@ import type {
     PersonsActivityRetrieveParams,
     PersonsBulkDeleteCreateParams,
     PersonsCohortsRetrieveParams,
-    PersonsDeleteEventsCreateParams,
     PersonsDeletePropertyCreateParams,
-    PersonsDeleteRecordingsCreateParams,
-    PersonsDestroyParams,
     PersonsFunnelCorrelationCreateParams,
     PersonsFunnelCorrelationRetrieveParams,
     PersonsFunnelCreateParams,
@@ -96,15 +90,6 @@ export const getEnvironmentsPersonsListUrl = (projectId: string, params?: Enviro
     const normalizedParams = new URLSearchParams()
 
     Object.entries(params || {}).forEach(([key, value]) => {
-        const explodeParameters = ['properties']
-
-        if (Array.isArray(value) && explodeParameters.includes(key)) {
-            value.forEach((v) => {
-                normalizedParams.append(key, v === null ? 'null' : v.toString())
-            })
-            return
-        }
-
         if (value !== undefined) {
             normalizedParams.append(key, value === null ? 'null' : value.toString())
         }
@@ -275,51 +260,6 @@ export const environmentsPersonsPartialUpdate = async (
 }
 
 /**
- * Use this endpoint to delete individual persons. For bulk deletion, use the bulk_delete endpoint instead.
- */
-export type environmentsPersonsDestroyResponse204 = {
-    data: void
-    status: 204
-}
-
-export type environmentsPersonsDestroyResponseSuccess = environmentsPersonsDestroyResponse204 & {
-    headers: Headers
-}
-export type environmentsPersonsDestroyResponse = environmentsPersonsDestroyResponseSuccess
-
-export const getEnvironmentsPersonsDestroyUrl = (
-    projectId: string,
-    id: number,
-    params?: EnvironmentsPersonsDestroyParams
-) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/environments/${projectId}/persons/${id}/?${stringifiedParams}`
-        : `/api/environments/${projectId}/persons/${id}/`
-}
-
-export const environmentsPersonsDestroy = async (
-    projectId: string,
-    id: number,
-    params?: EnvironmentsPersonsDestroyParams,
-    options?: RequestInit
-): Promise<environmentsPersonsDestroyResponse> => {
-    return apiMutator<environmentsPersonsDestroyResponse>(getEnvironmentsPersonsDestroyUrl(projectId, id, params), {
-        ...options,
-        method: 'DELETE',
-    })
-}
-
-/**
  * This endpoint is meant for reading and deleting persons. To create or update persons, we recommend using the [capture API](https://posthog.com/docs/api/capture), the `$set` and `$unset` [properties](https://posthog.com/docs/product-analytics/user-properties), or one of our SDKs.
  */
 export type environmentsPersonsActivityRetrieve2Response200 = {
@@ -368,57 +308,6 @@ export const environmentsPersonsActivityRetrieve2 = async (
 }
 
 /**
- * Queue deletion of all events associated with this person. The task runs during non-peak hours.
- */
-export type environmentsPersonsDeleteEventsCreateResponse200 = {
-    data: void
-    status: 200
-}
-
-export type environmentsPersonsDeleteEventsCreateResponseSuccess = environmentsPersonsDeleteEventsCreateResponse200 & {
-    headers: Headers
-}
-export type environmentsPersonsDeleteEventsCreateResponse = environmentsPersonsDeleteEventsCreateResponseSuccess
-
-export const getEnvironmentsPersonsDeleteEventsCreateUrl = (
-    projectId: string,
-    id: number,
-    params?: EnvironmentsPersonsDeleteEventsCreateParams
-) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/environments/${projectId}/persons/${id}/delete_events/?${stringifiedParams}`
-        : `/api/environments/${projectId}/persons/${id}/delete_events/`
-}
-
-export const environmentsPersonsDeleteEventsCreate = async (
-    projectId: string,
-    id: number,
-    personApi: NonReadonly<PersonApi>,
-    params?: EnvironmentsPersonsDeleteEventsCreateParams,
-    options?: RequestInit
-): Promise<environmentsPersonsDeleteEventsCreateResponse> => {
-    return apiMutator<environmentsPersonsDeleteEventsCreateResponse>(
-        getEnvironmentsPersonsDeleteEventsCreateUrl(projectId, id, params),
-        {
-            ...options,
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...options?.headers },
-            body: JSON.stringify(personApi),
-        }
-    )
-}
-
-/**
  * This endpoint is meant for reading and deleting persons. To create or update persons, we recommend using the [capture API](https://posthog.com/docs/api/capture), the `$set` and `$unset` [properties](https://posthog.com/docs/product-analytics/user-properties), or one of our SDKs.
  */
 export type environmentsPersonsDeletePropertyCreateResponse200 = {
@@ -461,58 +350,6 @@ export const environmentsPersonsDeletePropertyCreate = async (
 ): Promise<environmentsPersonsDeletePropertyCreateResponse> => {
     return apiMutator<environmentsPersonsDeletePropertyCreateResponse>(
         getEnvironmentsPersonsDeletePropertyCreateUrl(projectId, id, params),
-        {
-            ...options,
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...options?.headers },
-            body: JSON.stringify(personApi),
-        }
-    )
-}
-
-/**
- * Queue deletion of all recordings associated with this person.
- */
-export type environmentsPersonsDeleteRecordingsCreateResponse200 = {
-    data: void
-    status: 200
-}
-
-export type environmentsPersonsDeleteRecordingsCreateResponseSuccess =
-    environmentsPersonsDeleteRecordingsCreateResponse200 & {
-        headers: Headers
-    }
-export type environmentsPersonsDeleteRecordingsCreateResponse = environmentsPersonsDeleteRecordingsCreateResponseSuccess
-
-export const getEnvironmentsPersonsDeleteRecordingsCreateUrl = (
-    projectId: string,
-    id: number,
-    params?: EnvironmentsPersonsDeleteRecordingsCreateParams
-) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/environments/${projectId}/persons/${id}/delete_recordings/?${stringifiedParams}`
-        : `/api/environments/${projectId}/persons/${id}/delete_recordings/`
-}
-
-export const environmentsPersonsDeleteRecordingsCreate = async (
-    projectId: string,
-    id: number,
-    personApi: NonReadonly<PersonApi>,
-    params?: EnvironmentsPersonsDeleteRecordingsCreateParams,
-    options?: RequestInit
-): Promise<environmentsPersonsDeleteRecordingsCreateResponse> => {
-    return apiMutator<environmentsPersonsDeleteRecordingsCreateResponse>(
-        getEnvironmentsPersonsDeleteRecordingsCreateUrl(projectId, id, params),
         {
             ...options,
             method: 'POST',
@@ -1262,15 +1099,6 @@ export const getPersonsListUrl = (projectId: string, params?: PersonsListParams)
     const normalizedParams = new URLSearchParams()
 
     Object.entries(params || {}).forEach(([key, value]) => {
-        const explodeParameters = ['properties']
-
-        if (Array.isArray(value) && explodeParameters.includes(key)) {
-            value.forEach((v) => {
-                normalizedParams.append(key, v === null ? 'null' : v.toString())
-            })
-            return
-        }
-
         if (value !== undefined) {
             normalizedParams.append(key, value === null ? 'null' : value.toString())
         }
@@ -1426,47 +1254,6 @@ export const personsPartialUpdate = async (
 }
 
 /**
- * Use this endpoint to delete individual persons. For bulk deletion, use the bulk_delete endpoint instead.
- */
-export type personsDestroyResponse204 = {
-    data: void
-    status: 204
-}
-
-export type personsDestroyResponseSuccess = personsDestroyResponse204 & {
-    headers: Headers
-}
-export type personsDestroyResponse = personsDestroyResponseSuccess
-
-export const getPersonsDestroyUrl = (projectId: string, id: number, params?: PersonsDestroyParams) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/projects/${projectId}/persons/${id}/?${stringifiedParams}`
-        : `/api/projects/${projectId}/persons/${id}/`
-}
-
-export const personsDestroy = async (
-    projectId: string,
-    id: number,
-    params?: PersonsDestroyParams,
-    options?: RequestInit
-): Promise<personsDestroyResponse> => {
-    return apiMutator<personsDestroyResponse>(getPersonsDestroyUrl(projectId, id, params), {
-        ...options,
-        method: 'DELETE',
-    })
-}
-
-/**
  * This endpoint is meant for reading and deleting persons. To create or update persons, we recommend using the [capture API](https://posthog.com/docs/api/capture), the `$set` and `$unset` [properties](https://posthog.com/docs/product-analytics/user-properties), or one of our SDKs.
  */
 export type personsActivityRetrieve2Response200 = {
@@ -1508,54 +1295,6 @@ export const personsActivityRetrieve2 = async (
     return apiMutator<personsActivityRetrieve2Response>(getPersonsActivityRetrieve2Url(projectId, id, params), {
         ...options,
         method: 'GET',
-    })
-}
-
-/**
- * Queue deletion of all events associated with this person. The task runs during non-peak hours.
- */
-export type personsDeleteEventsCreateResponse200 = {
-    data: void
-    status: 200
-}
-
-export type personsDeleteEventsCreateResponseSuccess = personsDeleteEventsCreateResponse200 & {
-    headers: Headers
-}
-export type personsDeleteEventsCreateResponse = personsDeleteEventsCreateResponseSuccess
-
-export const getPersonsDeleteEventsCreateUrl = (
-    projectId: string,
-    id: number,
-    params?: PersonsDeleteEventsCreateParams
-) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/projects/${projectId}/persons/${id}/delete_events/?${stringifiedParams}`
-        : `/api/projects/${projectId}/persons/${id}/delete_events/`
-}
-
-export const personsDeleteEventsCreate = async (
-    projectId: string,
-    id: number,
-    personApi: NonReadonly<PersonApi>,
-    params?: PersonsDeleteEventsCreateParams,
-    options?: RequestInit
-): Promise<personsDeleteEventsCreateResponse> => {
-    return apiMutator<personsDeleteEventsCreateResponse>(getPersonsDeleteEventsCreateUrl(projectId, id, params), {
-        ...options,
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(personApi),
     })
 }
 
@@ -1605,57 +1344,6 @@ export const personsDeletePropertyCreate = async (
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(personApi),
     })
-}
-
-/**
- * Queue deletion of all recordings associated with this person.
- */
-export type personsDeleteRecordingsCreateResponse200 = {
-    data: void
-    status: 200
-}
-
-export type personsDeleteRecordingsCreateResponseSuccess = personsDeleteRecordingsCreateResponse200 & {
-    headers: Headers
-}
-export type personsDeleteRecordingsCreateResponse = personsDeleteRecordingsCreateResponseSuccess
-
-export const getPersonsDeleteRecordingsCreateUrl = (
-    projectId: string,
-    id: number,
-    params?: PersonsDeleteRecordingsCreateParams
-) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/projects/${projectId}/persons/${id}/delete_recordings/?${stringifiedParams}`
-        : `/api/projects/${projectId}/persons/${id}/delete_recordings/`
-}
-
-export const personsDeleteRecordingsCreate = async (
-    projectId: string,
-    id: number,
-    personApi: NonReadonly<PersonApi>,
-    params?: PersonsDeleteRecordingsCreateParams,
-    options?: RequestInit
-): Promise<personsDeleteRecordingsCreateResponse> => {
-    return apiMutator<personsDeleteRecordingsCreateResponse>(
-        getPersonsDeleteRecordingsCreateUrl(projectId, id, params),
-        {
-            ...options,
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...options?.headers },
-            body: JSON.stringify(personApi),
-        }
-    )
 }
 
 /**

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -7,15 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-export interface PaginatedColumnConfigurationListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ColumnConfigurationApi[]
-}
-
 export interface ColumnConfigurationApi {
     readonly id: string
     /** @maxLength 255 */
@@ -25,6 +16,15 @@ export interface ColumnConfigurationApi {
     readonly updated_at: string
 }
 
+export interface PaginatedColumnConfigurationListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ColumnConfigurationApi[]
+}
+
 export interface PatchedColumnConfigurationApi {
     readonly id?: string
     /** @maxLength 255 */
@@ -32,15 +32,6 @@ export interface PatchedColumnConfigurationApi {
     columns?: string[]
     readonly created_at?: string
     readonly updated_at?: string
-}
-
-export interface PaginatedElementListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ElementApi[]
 }
 
 export interface ElementApi {
@@ -85,6 +76,15 @@ export interface ElementApi {
      * @nullable
      */
     order?: number | null
+}
+
+export interface PaginatedElementListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ElementApi[]
 }
 
 export interface PatchedElementApi {

--- a/products/replay/frontend/generated/api.schemas.ts
+++ b/products/replay/frontend/generated/api.schemas.ts
@@ -7,23 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
-/**
- * * `collection` - Collection
- * `filters` - Filters
- */
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const SessionRecordingPlaylistTypeEnumApi = {
-    collection: 'collection',
-    filters: 'filters',
-} as const
-
-export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const NullEnumApi = {} as const
-
 /**
  * * `engineering` - Engineering
  * `data` - Data
@@ -55,28 +38,57 @@ export const BlankEnumApi = {
     '': '',
 } as const
 
-export type SessionRecordingPlaylistTypeEnumApi =
-    (typeof SessionRecordingPlaylistTypeEnumApi)[keyof typeof SessionRecordingPlaylistTypeEnumApi]
-
-export interface PaginatedSessionRecordingPlaylistListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: SessionRecordingPlaylistApi[]
-}
-
-export type SessionRecordingPlaylistApiRecordingsCounts = { [key: string]: { [key: string]: number | boolean | null } }
+export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const SessionRecordingPlaylistApiType = { ...SessionRecordingPlaylistTypeEnumApi, ...NullEnumApi } as const
+export const NullEnumApi = {} as const
+
+export type UserBasicApiHedgehogConfigAnyOf = { [key: string]: unknown }
+
 /**
  * @nullable
  */
-export type SessionRecordingPlaylistApiType =
-    | (typeof SessionRecordingPlaylistApiType)[keyof typeof SessionRecordingPlaylistApiType]
-    | null
+export type UserBasicApiHedgehogConfig = UserBasicApiHedgehogConfigAnyOf | null | null
+
+export type UserBasicApiRoleAtOrganization = RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
+    /** @nullable */
+    is_email_verified?: boolean | null
+    /** @nullable */
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: UserBasicApiRoleAtOrganization
+}
+
+/**
+ * * `collection` - Collection
+ * `filters` - Filters
+ */
+export type SessionRecordingPlaylistTypeEnumApi =
+    (typeof SessionRecordingPlaylistTypeEnumApi)[keyof typeof SessionRecordingPlaylistTypeEnumApi]
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const SessionRecordingPlaylistTypeEnumApi = {
+    collection: 'collection',
+    filters: 'filters',
+} as const
+
+export type SessionRecordingPlaylistApiRecordingsCounts = { [key: string]: { [key: string]: number | boolean } }
+
+export type SessionRecordingPlaylistApiType = SessionRecordingPlaylistTypeEnumApi | NullEnumApi
 
 export interface SessionRecordingPlaylistApi {
     readonly id: number
@@ -100,28 +112,24 @@ export interface SessionRecordingPlaylistApi {
     readonly last_modified_at: string
     readonly last_modified_by: UserBasicApi
     readonly recordings_counts: SessionRecordingPlaylistApiRecordingsCounts
-    /** @nullable */
     readonly type: SessionRecordingPlaylistApiType
     /** Return whether this is a synthetic playlist */
     readonly is_synthetic: boolean
     _create_in_folder?: string
 }
 
-export type PatchedSessionRecordingPlaylistApiRecordingsCounts = {
-    [key: string]: { [key: string]: number | boolean | null }
+export interface PaginatedSessionRecordingPlaylistListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: SessionRecordingPlaylistApi[]
 }
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedSessionRecordingPlaylistApiType = {
-    ...SessionRecordingPlaylistTypeEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * @nullable
- */
-export type PatchedSessionRecordingPlaylistApiType =
-    | (typeof PatchedSessionRecordingPlaylistApiType)[keyof typeof PatchedSessionRecordingPlaylistApiType]
-    | null
+export type PatchedSessionRecordingPlaylistApiRecordingsCounts = { [key: string]: { [key: string]: number | boolean } }
+
+export type PatchedSessionRecordingPlaylistApiType = SessionRecordingPlaylistTypeEnumApi | NullEnumApi
 
 export interface PatchedSessionRecordingPlaylistApi {
     readonly id?: number
@@ -145,21 +153,22 @@ export interface PatchedSessionRecordingPlaylistApi {
     readonly last_modified_at?: string
     readonly last_modified_by?: UserBasicApi
     readonly recordings_counts?: PatchedSessionRecordingPlaylistApiRecordingsCounts
-    /** @nullable */
     readonly type?: PatchedSessionRecordingPlaylistApiType
     /** Return whether this is a synthetic playlist */
     readonly is_synthetic?: boolean
     _create_in_folder?: string
 }
 
-export interface PaginatedSessionRecordingListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: SessionRecordingApi[]
+export interface MinimalPersonApi {
+    readonly id: number
+    readonly name: string
+    readonly distinct_ids: string
+    properties?: unknown
+    readonly created_at: string
+    readonly uuid: string
 }
+
+export type SessionRecordingApiExternalReferencesItem = { [key: string]: unknown }
 
 export interface SessionRecordingApi {
     readonly id: string
@@ -200,7 +209,20 @@ export interface SessionRecordingApi {
     readonly ongoing: boolean
     /** @nullable */
     readonly activity_score: number | null
+    /** Load external references (linked issues) for this recording */
+    readonly external_references: readonly SessionRecordingApiExternalReferencesItem[]
 }
+
+export interface PaginatedSessionRecordingListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: SessionRecordingApi[]
+}
+
+export type PatchedSessionRecordingApiExternalReferencesItem = { [key: string]: unknown }
 
 export interface PatchedSessionRecordingApi {
     readonly id?: string
@@ -241,51 +263,8 @@ export interface PatchedSessionRecordingApi {
     readonly ongoing?: boolean
     /** @nullable */
     readonly activity_score?: number | null
-}
-
-/**
- * @nullable
- */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserBasicApiRoleAtOrganization = { ...RoleAtOrganizationEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserBasicApiRoleAtOrganization =
-    | (typeof UserBasicApiRoleAtOrganization)[keyof typeof UserBasicApiRoleAtOrganization]
-    | null
-
-export interface UserBasicApi {
-    readonly id: number
-    readonly uuid: string
-    /**
-     * @maxLength 200
-     * @nullable
-     */
-    distinct_id?: string | null
-    /** @maxLength 150 */
-    first_name?: string
-    /** @maxLength 150 */
-    last_name?: string
-    /** @maxLength 254 */
-    email: string
-    /** @nullable */
-    is_email_verified?: boolean | null
-    /** @nullable */
-    readonly hedgehog_config: UserBasicApiHedgehogConfig
-    /** @nullable */
-    role_at_organization?: UserBasicApiRoleAtOrganization
-}
-
-export interface MinimalPersonApi {
-    readonly id: number
-    readonly name: string
-    readonly distinct_ids: string
-    properties?: unknown
-    readonly created_at: string
-    readonly uuid: string
+    /** Load external references (linked issues) for this recording */
+    readonly external_references?: readonly PatchedSessionRecordingApiExternalReferencesItem[]
 }
 
 export type EnvironmentsSessionRecordingPlaylistsListParams = {

--- a/products/surveys/frontend/generated/api.schemas.ts
+++ b/products/surveys/frontend/generated/api.schemas.ts
@@ -7,7 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
 /**
  * * `popover` - popover
  * `widget` - widget
@@ -24,11 +23,18 @@ export const SurveyTypeApi = {
     api: 'api',
 } as const
 
+/**
+ * * `server` - Server
+ * `client` - Client
+ * `all` - All
+ */
+export type EvaluationRuntimeEnumApi = (typeof EvaluationRuntimeEnumApi)[keyof typeof EvaluationRuntimeEnumApi]
+
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const ResponseSamplingIntervalTypeEnumApi = {
-    day: 'day',
-    week: 'week',
-    month: 'month',
+export const EvaluationRuntimeEnumApi = {
+    server: 'server',
+    client: 'client',
+    all: 'all',
 } as const
 
 export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
@@ -44,20 +50,6 @@ export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
 export const NullEnumApi = {} as const
 
 /**
- * * `server` - Server
- * `client` - Client
- * `all` - All
- */
-export type EvaluationRuntimeEnumApi = (typeof EvaluationRuntimeEnumApi)[keyof typeof EvaluationRuntimeEnumApi]
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const EvaluationRuntimeEnumApi = {
-    server: 'server',
-    client: 'client',
-    all: 'all',
-} as const
-
-/**
  * * `distinct_id` - User ID (default)
  * `device_id` - Device ID
  */
@@ -68,6 +60,58 @@ export const BucketingIdentifierEnumApi = {
     distinct_id: 'distinct_id',
     device_id: 'device_id',
 } as const
+
+export type MinimalFeatureFlagApiFilters = { [key: string]: unknown }
+
+/**
+ * Specifies where this feature flag should be evaluated
+
+* `server` - Server
+* `client` - Client
+* `all` - All
+ */
+export type MinimalFeatureFlagApiEvaluationRuntime = EvaluationRuntimeEnumApi | BlankEnumApi | NullEnumApi
+
+/**
+ * Identifier used for bucketing users into rollout and variants
+
+* `distinct_id` - User ID (default)
+* `device_id` - Device ID
+ */
+export type MinimalFeatureFlagApiBucketingIdentifier = BucketingIdentifierEnumApi | BlankEnumApi | NullEnumApi
+
+export interface MinimalFeatureFlagApi {
+    readonly id: number
+    readonly team_id: number
+    name?: string
+    /** @maxLength 400 */
+    key: string
+    filters?: MinimalFeatureFlagApiFilters
+    deleted?: boolean
+    active?: boolean
+    /** @nullable */
+    ensure_experience_continuity?: boolean | null
+    /** @nullable */
+    has_encrypted_payloads?: boolean | null
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     * @nullable
+     */
+    version?: number | null
+    /** Specifies where this feature flag should be evaluated
+
+* `server` - Server
+* `client` - Client
+* `all` - All */
+    evaluation_runtime?: MinimalFeatureFlagApiEvaluationRuntime
+    /** Identifier used for bucketing users into rollout and variants
+
+* `distinct_id` - User ID (default)
+* `device_id` - Device ID */
+    bucketing_identifier?: MinimalFeatureFlagApiBucketingIdentifier
+    readonly evaluation_tags: readonly string[]
+}
 
 /**
  * * `engineering` - Engineering
@@ -93,6 +137,36 @@ export const RoleAtOrganizationEnumApi = {
     other: 'other',
 } as const
 
+export type UserBasicApiHedgehogConfigAnyOf = { [key: string]: unknown }
+
+/**
+ * @nullable
+ */
+export type UserBasicApiHedgehogConfig = UserBasicApiHedgehogConfigAnyOf | null | null
+
+export type UserBasicApiRoleAtOrganization = RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
+    /** @nullable */
+    is_email_verified?: boolean | null
+    /** @nullable */
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: UserBasicApiRoleAtOrganization
+}
+
 /**
  * * `day` - day
  * `week` - week
@@ -101,424 +175,14 @@ export const RoleAtOrganizationEnumApi = {
 export type ResponseSamplingIntervalTypeEnumApi =
     (typeof ResponseSamplingIntervalTypeEnumApi)[keyof typeof ResponseSamplingIntervalTypeEnumApi]
 
-export interface PaginatedSurveyListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: SurveyApi[]
-}
-
-/**
- * @nullable
- */
-export type SurveySerializerCreateUpdateOnlyApiTargetingFlagFilters = unknown | null
-
-/**
- * 
-        The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-        Basic (open-ended question)
-        - `id`: The question ID
-        - `type`: `open`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Link (a question with a link)
-        - `id`: The question ID
-        - `type`: `link`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `link`: The URL associated with the question.
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Rating (a question with a rating scale)
-        - `id`: The question ID
-        - `type`: `rating`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `display`: Display style of the rating (`number` or `emoji`).
-        - `scale`: The scale of the rating (`number`).
-        - `lowerBoundLabel`: Label for the lower bound of the scale.
-        - `upperBoundLabel`: Label for the upper bound of the scale.
-        - `isNpsQuestion`: Whether the question is an NPS rating.
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Multiple choice
-        - `id`: The question ID
-        - `type`: `single_choice` or `multiple_choice`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `choices`: An array of choices for the question.
-        - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-        - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Branching logic can be one of the following types:
-
-        Next question: Proceeds to the next question
-        ```json
-        {
-            "type": "next_question"
-        }
-        ```
-
-        End: Ends the survey, optionally displaying a confirmation message.
-        ```json
-        {
-            "type": "end"
-        }
-        ```
-
-        Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-        ```json
-        {
-            "type": "response_based",
-            "responseValues": {
-                "responseKey": "value"
-            }
-        }
-        ```
-
-        Specific question: Proceeds to a specific question by index.
-        ```json
-        {
-            "type": "specific_question",
-            "index": 2
-        }
-        ```
-        
- * @nullable
- */
-export type SurveySerializerCreateUpdateOnlyApiQuestions = unknown | null
-
-/**
- * @nullable
- */
-export type SurveySerializerCreateUpdateOnlyApiConditions = unknown | null
-
-/**
- * @nullable
- */
-export type SurveySerializerCreateUpdateOnlyApiAppearance = unknown | null
-
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const SurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType = {
-    ...ResponseSamplingIntervalTypeEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
+export const ResponseSamplingIntervalTypeEnumApi = {
+    day: 'day',
+    week: 'week',
+    month: 'month',
 } as const
-/**
- * @nullable
- */
-export type SurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType =
-    | (typeof SurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType)[keyof typeof SurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType]
-    | null
 
-/**
- * @nullable
- */
-export type SurveySerializerCreateUpdateOnlyApiResponseSamplingDailyLimits = unknown | null
-
-export interface SurveySerializerCreateUpdateOnlyApi {
-    readonly id: string
-    /** @maxLength 400 */
-    name: string
-    description?: string
-    type: SurveyTypeApi
-    /** @nullable */
-    schedule?: string | null
-    readonly linked_flag: MinimalFeatureFlagApi
-    /** @nullable */
-    linked_flag_id?: number | null
-    /** @nullable */
-    linked_insight_id?: number | null
-    targeting_flag_id?: number
-    readonly targeting_flag: MinimalFeatureFlagApi
-    readonly internal_targeting_flag: MinimalFeatureFlagApi
-    /** @nullable */
-    targeting_flag_filters?: SurveySerializerCreateUpdateOnlyApiTargetingFlagFilters
-    /** @nullable */
-    remove_targeting_flag?: boolean | null
-    /**
-   * 
-        The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-        Basic (open-ended question)
-        - `id`: The question ID
-        - `type`: `open`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Link (a question with a link)
-        - `id`: The question ID
-        - `type`: `link`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `link`: The URL associated with the question.
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Rating (a question with a rating scale)
-        - `id`: The question ID
-        - `type`: `rating`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `display`: Display style of the rating (`number` or `emoji`).
-        - `scale`: The scale of the rating (`number`).
-        - `lowerBoundLabel`: Label for the lower bound of the scale.
-        - `upperBoundLabel`: Label for the upper bound of the scale.
-        - `isNpsQuestion`: Whether the question is an NPS rating.
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Multiple choice
-        - `id`: The question ID
-        - `type`: `single_choice` or `multiple_choice`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `choices`: An array of choices for the question.
-        - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-        - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Branching logic can be one of the following types:
-
-        Next question: Proceeds to the next question
-        ```json
-        {
-            "type": "next_question"
-        }
-        ```
-
-        End: Ends the survey, optionally displaying a confirmation message.
-        ```json
-        {
-            "type": "end"
-        }
-        ```
-
-        Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-        ```json
-        {
-            "type": "response_based",
-            "responseValues": {
-                "responseKey": "value"
-            }
-        }
-        ```
-
-        Specific question: Proceeds to a specific question by index.
-        ```json
-        {
-            "type": "specific_question",
-            "index": 2
-        }
-        ```
-        
-   * @nullable
-   */
-    questions?: SurveySerializerCreateUpdateOnlyApiQuestions
-    /** @nullable */
-    conditions?: SurveySerializerCreateUpdateOnlyApiConditions
-    /** @nullable */
-    appearance?: SurveySerializerCreateUpdateOnlyApiAppearance
-    readonly created_at: string
-    readonly created_by: UserBasicApi
-    /** @nullable */
-    start_date?: string | null
-    /** @nullable */
-    end_date?: string | null
-    archived?: boolean
-    /**
-     * @minimum 0
-     * @maximum 2147483647
-     * @nullable
-     */
-    responses_limit?: number | null
-    /**
-     * @minimum 0
-     * @maximum 500
-     * @nullable
-     */
-    iteration_count?: number | null
-    /**
-     * @minimum 0
-     * @maximum 2147483647
-     * @nullable
-     */
-    iteration_frequency_days?: number | null
-    /** @nullable */
-    iteration_start_dates?: (string | null)[] | null
-    /**
-     * @minimum 0
-     * @maximum 2147483647
-     * @nullable
-     */
-    current_iteration?: number | null
-    /** @nullable */
-    current_iteration_start_date?: string | null
-    /** @nullable */
-    response_sampling_start_date?: string | null
-    /** @nullable */
-    response_sampling_interval_type?: SurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType
-    /**
-     * @minimum 0
-     * @maximum 2147483647
-     * @nullable
-     */
-    response_sampling_interval?: number | null
-    /**
-     * @minimum 0
-     * @maximum 2147483647
-     * @nullable
-     */
-    response_sampling_limit?: number | null
-    /** @nullable */
-    response_sampling_daily_limits?: SurveySerializerCreateUpdateOnlyApiResponseSamplingDailyLimits
-    /** @nullable */
-    enable_partial_responses?: boolean | null
-    _create_in_folder?: string
-}
-
-/**
- * 
-        The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-        Basic (open-ended question)
-        - `id`: The question ID
-        - `type`: `open`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Link (a question with a link)
-        - `id`: The question ID
-        - `type`: `link`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `link`: The URL associated with the question.
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Rating (a question with a rating scale)
-        - `id`: The question ID
-        - `type`: `rating`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `display`: Display style of the rating (`number` or `emoji`).
-        - `scale`: The scale of the rating (`number`).
-        - `lowerBoundLabel`: Label for the lower bound of the scale.
-        - `upperBoundLabel`: Label for the upper bound of the scale.
-        - `isNpsQuestion`: Whether the question is an NPS rating.
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Multiple choice
-        - `id`: The question ID
-        - `type`: `single_choice` or `multiple_choice`
-        - `question`: The text of the question.
-        - `description`: Optional description of the question.
-        - `descriptionContentType`: Content type of the description (`html` or `text`).
-        - `optional`: Whether the question is optional (`boolean`).
-        - `buttonText`: Text displayed on the submit button.
-        - `choices`: An array of choices for the question.
-        - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-        - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-        - `branching`: Branching logic for the question. See branching types below for details.
-
-        Branching logic can be one of the following types:
-
-        Next question: Proceeds to the next question
-        ```json
-        {
-            "type": "next_question"
-        }
-        ```
-
-        End: Ends the survey, optionally displaying a confirmation message.
-        ```json
-        {
-            "type": "end"
-        }
-        ```
-
-        Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-        ```json
-        {
-            "type": "response_based",
-            "responseValues": {
-                "responseKey": "value"
-            }
-        }
-        ```
-
-        Specific question: Proceeds to a specific question by index.
-        ```json
-        {
-            "type": "specific_question",
-            "index": 2
-        }
-        ```
-        
- * @nullable
- */
-export type SurveyApiQuestions = unknown | null
-
-/**
- * @nullable
- */
-export type SurveyApiAppearance = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const SurveyApiResponseSamplingIntervalType = {
-    ...ResponseSamplingIntervalTypeEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * @nullable
- */
-export type SurveyApiResponseSamplingIntervalType =
-    | (typeof SurveyApiResponseSamplingIntervalType)[keyof typeof SurveyApiResponseSamplingIntervalType]
-    | null
-
-/**
- * @nullable
- */
-export type SurveyApiResponseSamplingDailyLimits = unknown | null
+export type SurveyApiResponseSamplingIntervalType = ResponseSamplingIntervalTypeEnumApi | BlankEnumApi | NullEnumApi
 
 /**
  * Mixin for serializers to add user access control fields
@@ -538,8 +202,7 @@ export interface SurveyApi {
     linked_insight_id?: number | null
     readonly targeting_flag: MinimalFeatureFlagApi
     readonly internal_targeting_flag: MinimalFeatureFlagApi
-    /**
-   * 
+    /** 
         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
 
         Basic (open-ended question)
@@ -624,13 +287,10 @@ export interface SurveyApi {
             "index": 2
         }
         ```
-        
-   * @nullable
-   */
-    questions?: SurveyApiQuestions
+         */
+    questions?: unknown
     readonly conditions: string
-    /** @nullable */
-    appearance?: SurveyApiAppearance
+    appearance?: unknown
     readonly created_at: string
     readonly created_by: UserBasicApi
     /** @nullable */
@@ -669,7 +329,6 @@ export interface SurveyApi {
     current_iteration_start_date?: string | null
     /** @nullable */
     response_sampling_start_date?: string | null
-    /** @nullable */
     response_sampling_interval_type?: SurveyApiResponseSamplingIntervalType
     /**
      * @minimum 0
@@ -683,8 +342,7 @@ export interface SurveyApi {
      * @nullable
      */
     response_sampling_limit?: number | null
-    /** @nullable */
-    response_sampling_daily_limits?: SurveyApiResponseSamplingDailyLimits
+    response_sampling_daily_limits?: unknown
     /** @nullable */
     enable_partial_responses?: boolean | null
     /**
@@ -694,13 +352,40 @@ export interface SurveyApi {
     readonly user_access_level: string | null
 }
 
-/**
- * @nullable
- */
-export type PatchedSurveySerializerCreateUpdateOnlyApiTargetingFlagFilters = unknown | null
+export interface PaginatedSurveyListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: SurveyApi[]
+}
 
-/**
- * 
+export type SurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType =
+    | ResponseSamplingIntervalTypeEnumApi
+    | BlankEnumApi
+    | NullEnumApi
+
+export interface SurveySerializerCreateUpdateOnlyApi {
+    readonly id: string
+    /** @maxLength 400 */
+    name: string
+    description?: string
+    type: SurveyTypeApi
+    /** @nullable */
+    schedule?: string | null
+    readonly linked_flag: MinimalFeatureFlagApi
+    /** @nullable */
+    linked_flag_id?: number | null
+    /** @nullable */
+    linked_insight_id?: number | null
+    targeting_flag_id?: number
+    readonly targeting_flag: MinimalFeatureFlagApi
+    readonly internal_targeting_flag: MinimalFeatureFlagApi
+    targeting_flag_filters?: unknown
+    /** @nullable */
+    remove_targeting_flag?: boolean | null
+    /** 
         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
 
         Basic (open-ended question)
@@ -785,38 +470,70 @@ export type PatchedSurveySerializerCreateUpdateOnlyApiTargetingFlagFilters = unk
             "index": 2
         }
         ```
-        
- * @nullable
- */
-export type PatchedSurveySerializerCreateUpdateOnlyApiQuestions = unknown | null
+         */
+    questions?: unknown
+    conditions?: unknown
+    appearance?: unknown
+    readonly created_at: string
+    readonly created_by: UserBasicApi
+    /** @nullable */
+    start_date?: string | null
+    /** @nullable */
+    end_date?: string | null
+    archived?: boolean
+    /**
+     * @minimum 0
+     * @maximum 2147483647
+     * @nullable
+     */
+    responses_limit?: number | null
+    /**
+     * @minimum 0
+     * @maximum 500
+     * @nullable
+     */
+    iteration_count?: number | null
+    /**
+     * @minimum 0
+     * @maximum 2147483647
+     * @nullable
+     */
+    iteration_frequency_days?: number | null
+    /** @nullable */
+    iteration_start_dates?: (string | null)[] | null
+    /**
+     * @minimum 0
+     * @maximum 2147483647
+     * @nullable
+     */
+    current_iteration?: number | null
+    /** @nullable */
+    current_iteration_start_date?: string | null
+    /** @nullable */
+    response_sampling_start_date?: string | null
+    response_sampling_interval_type?: SurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType
+    /**
+     * @minimum 0
+     * @maximum 2147483647
+     * @nullable
+     */
+    response_sampling_interval?: number | null
+    /**
+     * @minimum 0
+     * @maximum 2147483647
+     * @nullable
+     */
+    response_sampling_limit?: number | null
+    response_sampling_daily_limits?: unknown
+    /** @nullable */
+    enable_partial_responses?: boolean | null
+    _create_in_folder?: string
+}
 
-/**
- * @nullable
- */
-export type PatchedSurveySerializerCreateUpdateOnlyApiConditions = unknown | null
-
-/**
- * @nullable
- */
-export type PatchedSurveySerializerCreateUpdateOnlyApiAppearance = unknown | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PatchedSurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType = {
-    ...ResponseSamplingIntervalTypeEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * @nullable
- */
 export type PatchedSurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType =
-    | (typeof PatchedSurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType)[keyof typeof PatchedSurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType]
-    | null
-
-/**
- * @nullable
- */
-export type PatchedSurveySerializerCreateUpdateOnlyApiResponseSamplingDailyLimits = unknown | null
+    | ResponseSamplingIntervalTypeEnumApi
+    | BlankEnumApi
+    | NullEnumApi
 
 export interface PatchedSurveySerializerCreateUpdateOnlyApi {
     readonly id?: string
@@ -834,12 +551,10 @@ export interface PatchedSurveySerializerCreateUpdateOnlyApi {
     targeting_flag_id?: number
     readonly targeting_flag?: MinimalFeatureFlagApi
     readonly internal_targeting_flag?: MinimalFeatureFlagApi
-    /** @nullable */
-    targeting_flag_filters?: PatchedSurveySerializerCreateUpdateOnlyApiTargetingFlagFilters
+    targeting_flag_filters?: unknown
     /** @nullable */
     remove_targeting_flag?: boolean | null
-    /**
-   * 
+    /** 
         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
 
         Basic (open-ended question)
@@ -924,14 +639,10 @@ export interface PatchedSurveySerializerCreateUpdateOnlyApi {
             "index": 2
         }
         ```
-        
-   * @nullable
-   */
-    questions?: PatchedSurveySerializerCreateUpdateOnlyApiQuestions
-    /** @nullable */
-    conditions?: PatchedSurveySerializerCreateUpdateOnlyApiConditions
-    /** @nullable */
-    appearance?: PatchedSurveySerializerCreateUpdateOnlyApiAppearance
+         */
+    questions?: unknown
+    conditions?: unknown
+    appearance?: unknown
     readonly created_at?: string
     readonly created_by?: UserBasicApi
     /** @nullable */
@@ -969,7 +680,6 @@ export interface PatchedSurveySerializerCreateUpdateOnlyApi {
     current_iteration_start_date?: string | null
     /** @nullable */
     response_sampling_start_date?: string | null
-    /** @nullable */
     response_sampling_interval_type?: PatchedSurveySerializerCreateUpdateOnlyApiResponseSamplingIntervalType
     /**
      * @minimum 0
@@ -983,123 +693,10 @@ export interface PatchedSurveySerializerCreateUpdateOnlyApi {
      * @nullable
      */
     response_sampling_limit?: number | null
-    /** @nullable */
-    response_sampling_daily_limits?: PatchedSurveySerializerCreateUpdateOnlyApiResponseSamplingDailyLimits
+    response_sampling_daily_limits?: unknown
     /** @nullable */
     enable_partial_responses?: boolean | null
     _create_in_folder?: string
-}
-
-export type MinimalFeatureFlagApiFilters = { [key: string]: unknown }
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MinimalFeatureFlagApiEvaluationRuntime = {
-    ...EvaluationRuntimeEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * Specifies where this feature flag should be evaluated
-
-* `server` - Server
-* `client` - Client
-* `all` - All
- * @nullable
- */
-export type MinimalFeatureFlagApiEvaluationRuntime =
-    | (typeof MinimalFeatureFlagApiEvaluationRuntime)[keyof typeof MinimalFeatureFlagApiEvaluationRuntime]
-    | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const MinimalFeatureFlagApiBucketingIdentifier = {
-    ...BucketingIdentifierEnumApi,
-    ...BlankEnumApi,
-    ...NullEnumApi,
-} as const
-/**
- * Identifier used for bucketing users into rollout and variants
-
-* `distinct_id` - User ID (default)
-* `device_id` - Device ID
- * @nullable
- */
-export type MinimalFeatureFlagApiBucketingIdentifier =
-    | (typeof MinimalFeatureFlagApiBucketingIdentifier)[keyof typeof MinimalFeatureFlagApiBucketingIdentifier]
-    | null
-
-export interface MinimalFeatureFlagApi {
-    readonly id: number
-    readonly team_id: number
-    name?: string
-    /** @maxLength 400 */
-    key: string
-    filters?: MinimalFeatureFlagApiFilters
-    deleted?: boolean
-    active?: boolean
-    /** @nullable */
-    ensure_experience_continuity?: boolean | null
-    /** @nullable */
-    has_encrypted_payloads?: boolean | null
-    /**
-     * @minimum -2147483648
-     * @maximum 2147483647
-     * @nullable
-     */
-    version?: number | null
-    /**
-   * Specifies where this feature flag should be evaluated
-
-* `server` - Server
-* `client` - Client
-* `all` - All
-   * @nullable
-   */
-    evaluation_runtime?: MinimalFeatureFlagApiEvaluationRuntime
-    /**
-   * Identifier used for bucketing users into rollout and variants
-
-* `distinct_id` - User ID (default)
-* `device_id` - Device ID
-   * @nullable
-   */
-    bucketing_identifier?: MinimalFeatureFlagApiBucketingIdentifier
-    readonly evaluation_tags: readonly string[]
-}
-
-/**
- * @nullable
- */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserBasicApiRoleAtOrganization = { ...RoleAtOrganizationEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserBasicApiRoleAtOrganization =
-    | (typeof UserBasicApiRoleAtOrganization)[keyof typeof UserBasicApiRoleAtOrganization]
-    | null
-
-export interface UserBasicApi {
-    readonly id: number
-    readonly uuid: string
-    /**
-     * @maxLength 200
-     * @nullable
-     */
-    distinct_id?: string | null
-    /** @maxLength 150 */
-    first_name?: string
-    /** @maxLength 150 */
-    last_name?: string
-    /** @maxLength 254 */
-    email: string
-    /** @nullable */
-    is_email_verified?: boolean | null
-    /** @nullable */
-    readonly hedgehog_config: UserBasicApiHedgehogConfig
-    /** @nullable */
-    role_at_organization?: UserBasicApiRoleAtOrganization
 }
 
 export type SurveysListParams = {

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -7,6 +7,24 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
+/**
+ * Serializer for extracted tasks
+ */
+export interface TaskApi {
+    title: string
+    description?: string
+    /** @nullable */
+    assignee?: string | null
+}
+
+export interface PaginatedTaskListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: TaskApi[]
+}
 
 /**
  * * `error_tracking` - Error Tracking
@@ -62,30 +80,35 @@ export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const NullEnumApi = {} as const
 
-export interface PaginatedTaskListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: TaskApi[]
-}
+export type UserBasicApiHedgehogConfigAnyOf = { [key: string]: unknown }
 
 /**
- * Serializer for extracted tasks
- */
-export interface TaskApi {
-    title: string
-    description?: string
-    /** @nullable */
-    assignee?: string | null
-}
-
-/**
- * JSON schema for the task. This is used to validate the output of the task.
  * @nullable
  */
-export type PatchedTaskApiJsonSchema = unknown | null
+export type UserBasicApiHedgehogConfig = UserBasicApiHedgehogConfigAnyOf | null | null
+
+export type UserBasicApiRoleAtOrganization = RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
+    /** @nullable */
+    is_email_verified?: boolean | null
+    /** @nullable */
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: UserBasicApiRoleAtOrganization
+}
 
 export interface PatchedTaskApi {
     readonly id?: string
@@ -106,54 +129,19 @@ export interface PatchedTaskApi {
      * @nullable
      */
     github_integration?: number | null
-    /**
-     * JSON schema for the task. This is used to validate the output of the task.
-     * @nullable
-     */
-    json_schema?: PatchedTaskApiJsonSchema
+    /** JSON schema for the task. This is used to validate the output of the task. */
+    json_schema?: unknown
     readonly latest_run?: string
     readonly created_at?: string
     readonly updated_at?: string
     readonly created_by?: UserBasicApi
 }
 
-/**
- * @nullable
- */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserBasicApiRoleAtOrganization = { ...RoleAtOrganizationEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserBasicApiRoleAtOrganization =
-    | (typeof UserBasicApiRoleAtOrganization)[keyof typeof UserBasicApiRoleAtOrganization]
-    | null
-
-export interface UserBasicApi {
-    readonly id: number
-    readonly uuid: string
-    /**
-     * @maxLength 200
-     * @nullable
-     */
-    distinct_id?: string | null
-    /** @maxLength 150 */
-    first_name?: string
-    /** @maxLength 150 */
-    last_name?: string
-    /** @maxLength 254 */
-    email: string
-    /** @nullable */
-    is_email_verified?: boolean | null
-    /** @nullable */
-    readonly hedgehog_config: UserBasicApiHedgehogConfig
-    /** @nullable */
-    role_at_organization?: UserBasicApiRoleAtOrganization
-}
-
 export type TasksListParams = {
+    /**
+     * Filter by creator user ID
+     */
+    created_by?: number
     /**
      * Number of results to return per page.
      */

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -28,7 +28,7 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
     : DistributeReadOnlyOverUnions<T>
 
 /**
- * Get a list of tasks for the current project, with optional filtering by origin product, stage, organization, and repository.
+ * Get a list of tasks for the current project, with optional filtering by origin product, stage, organization, repository, and created_by.
  * @summary List tasks
  */
 export type tasksListResponse200 = {

--- a/products/user_interviews/frontend/generated/api.schemas.ts
+++ b/products/user_interviews/frontend/generated/api.schemas.ts
@@ -7,7 +7,6 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-
 /**
  * * `engineering` - Engineering
  * `data` - Data
@@ -44,48 +43,14 @@ export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const NullEnumApi = {} as const
 
-export interface PaginatedUserInterviewListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: UserInterviewApi[]
-}
-
-export interface UserInterviewApi {
-    readonly id: string
-    readonly created_by: UserBasicApi
-    readonly created_at: string
-    interviewee_emails?: string[]
-    readonly transcript: string
-    summary?: string
-    audio: string
-}
-
-export interface PatchedUserInterviewApi {
-    readonly id?: string
-    readonly created_by?: UserBasicApi
-    readonly created_at?: string
-    interviewee_emails?: string[]
-    readonly transcript?: string
-    summary?: string
-    audio?: string
-}
+export type UserBasicApiHedgehogConfigAnyOf = { [key: string]: unknown }
 
 /**
  * @nullable
  */
-export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null
+export type UserBasicApiHedgehogConfig = UserBasicApiHedgehogConfigAnyOf | null | null
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const UserBasicApiRoleAtOrganization = { ...RoleAtOrganizationEnumApi, ...BlankEnumApi, ...NullEnumApi } as const
-/**
- * @nullable
- */
-export type UserBasicApiRoleAtOrganization =
-    | (typeof UserBasicApiRoleAtOrganization)[keyof typeof UserBasicApiRoleAtOrganization]
-    | null
+export type UserBasicApiRoleAtOrganization = RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi
 
 export interface UserBasicApi {
     readonly id: number
@@ -105,8 +70,36 @@ export interface UserBasicApi {
     is_email_verified?: boolean | null
     /** @nullable */
     readonly hedgehog_config: UserBasicApiHedgehogConfig
-    /** @nullable */
     role_at_organization?: UserBasicApiRoleAtOrganization
+}
+
+export interface UserInterviewApi {
+    readonly id: string
+    readonly created_by: UserBasicApi
+    readonly created_at: string
+    interviewee_emails?: string[]
+    readonly transcript: string
+    summary?: string
+    audio: string
+}
+
+export interface PaginatedUserInterviewListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: UserInterviewApi[]
+}
+
+export interface PatchedUserInterviewApi {
+    readonly id?: string
+    readonly created_by?: UserBasicApi
+    readonly created_at?: string
+    interviewee_emails?: string[]
+    readonly transcript?: string
+    summary?: string
+    audio?: string
 }
 
 export type EnvironmentsUserInterviewsListParams = {


### PR DESCRIPTION
**Problem**

Orval v8 uses esbuild internally to bundle mutator files for static analysis (parsing function signatures). When the mutator imports `lib/api`, esbuild follows the entire import chain and fails on ~400 scss files it can't handle. This causes orval to silently generate no output files.

**Fix**

Added a stub file (`api-stub-for-orval.ts`) that provides the same interface as `lib/api` but without the scss dependency chain. The orval config uses the `alias` option to redirect `lib/api` to this stub during code generation.

The stub is never executed at runtime - it's only used during orval's esbuild bundling step for signature parsing.

**Root cause**

Identified via git bisect: orval's "Convert to ESM" commit ([orval-labs/orval#2460](https://github.com/orval-labs/orval/pull/2460)) introduced esbuild for mutator validation.