### PR TITLE
feat: make the event_list limited to 2 concurrent running queries

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -186,64 +186,61 @@ def sync_execute(
 
     if tags.product == Product.MAX_AI or tags.service_name == "temporal-worker-max-ai":
         ch_user = ClickHouseUser.MAX_AI
-
-    if tags.product == Product.ENDPOINTS:
+    elif tags.product == Product.ENDPOINTS:
         ch_user = ClickHouseUser.ENDPOINTS
 
-    while True:
-        settings = {
-            **core_settings,
-            "log_comment": tags.to_json(),
-        }
-        if workload == Workload.OFFLINE:
-            # disabling hedged requests for offline queries reduces the likelihood of these queries bleeding over into the
-            # online resource pool when the offline resource pool is under heavy load. this comes at the cost of higher and
-            # more variable latency and a higher likelihood of query failures - but offline workloads should be tolerant to
-            # these disruptions
-            settings["use_hedged_requests"] = "0"
-        start_time = perf_counter()
-        try:
-            QUERY_STARTED_COUNTER.labels(
-                team_id=str(team_id or ""),
-                access_method=tags.access_method or "other",
-                chargeable=str(tags.chargeable or "0"),
-            ).inc()
-            with sync_client or get_client_from_pool(workload, team_id, readonly, ch_user) as client:
-                result = client.execute(
-                    prepared_sql,
-                    params=prepared_args,
-                    settings=settings,
-                    with_column_types=with_column_types,
-                    query_id=query_id,
-                )
-                if "INSERT INTO" in prepared_sql and client.last_query.progress.written_rows > 0:
-                    result = client.last_query.progress.written_rows
-        except Exception as e:
-            exception_type = ch_error_type(e)
-            QUERY_ERROR_COUNTER.labels(
-                exception_type=exception_type,
-                query_type=query_type,
-                workload=workload.value if workload else "None",
-                chargeable=str(tags.chargeable or "0"),
-            ).inc()
-            err = wrap_query_error(e)
-            raise err from e
-        finally:
-            execution_time = perf_counter() - start_time
+    settings = {
+        **core_settings,
+        "log_comment": tags.to_json(),
+    }
+    if workload == Workload.OFFLINE:
+        # disabling hedged requests for offline queries reduces the likelihood of these queries bleeding over into the
+        # online resource pool when the offline resource pool is under heavy load. this comes at the cost of higher and
+        # more variable latency and a higher likelihood of query failures - but offline workloads should be tolerant to
+        # these disruptions
+        settings["use_hedged_requests"] = "0"
+    start_time = perf_counter()
 
-            QUERY_FINISHED_COUNTER.labels(
-                team_id=str(team_id or ""),
-                access_method=tags.access_method or "other",
-                chargeable=str(tags.chargeable or "0"),
-            ).inc()
+    try:
+        QUERY_STARTED_COUNTER.labels(
+            team_id=str(team_id or ""),
+            access_method=tags.access_method or "other",
+            chargeable=str(tags.chargeable or "0"),
+        ).inc()
+        with sync_client or get_client_from_pool(workload, team_id, readonly, ch_user) as client:
+            result = client.execute(
+                prepared_sql,
+                params=prepared_args,
+                settings=settings,
+                with_column_types=with_column_types,
+                query_id=query_id,
+            )
+            if "INSERT INTO" in prepared_sql and client.last_query.progress.written_rows > 0:
+                result = client.last_query.progress.written_rows
+    except Exception as e:
+        exception_type = ch_error_type(e)
+        QUERY_ERROR_COUNTER.labels(
+            exception_type=exception_type,
+            query_type=query_type,
+            workload=workload.value if workload else "None",
+            chargeable=str(tags.chargeable or "0"),
+        ).inc()
+        err = wrap_query_error(e)
+        raise err from e
+    finally:
+        execution_time = perf_counter() - start_time
 
-            if query_counter := getattr(thread_local_storage, "query_counter", None):
-                query_counter.total_query_time += execution_time
+        QUERY_FINISHED_COUNTER.labels(
+            team_id=str(team_id or ""),
+            access_method=tags.access_method or "other",
+            chargeable=str(tags.chargeable or "0"),
+        ).inc()
 
-            if app_settings.SHELL_PLUS_PRINT_SQL:
-                print("Execution time: %.6fs" % (execution_time,))  # noqa T201
+        if query_counter := getattr(thread_local_storage, "query_counter", None):
+            query_counter.total_query_time += execution_time
 
-        break
+        if app_settings.SHELL_PLUS_PRINT_SQL:
+            print("Execution time: %.6fs" % (execution_time,))  # noqa T201
 
     return result
 

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -188,6 +188,7 @@ __APP_CONCURRENT_QUERY_PER_ORG: Optional[RateLimit] = None
 __APP_CONCURRENT_DASHBOARD_QUERIES_PER_ORG: Optional[RateLimit] = None
 __WEB_ANALYTICS_API_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
 __MATERIALIZED_ENDPOINTS_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
+__EVENTS_LIST_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
 
 
 def get_api_team_rate_limiter():
@@ -348,6 +349,36 @@ def get_materialized_endpoints_rate_limiter():
             retry_timeout=30.0,
         )
     return __MATERIALIZED_ENDPOINTS_CONCURRENT_QUERY_PER_TEAM
+
+
+def get_events_list_rate_limiter():
+    """
+    Limits the number of concurrent events_list queries per team.
+    events_list queries scan large amounts of event data and run on OFFLINE workload.
+    """
+    global __EVENTS_LIST_CONCURRENT_QUERY_PER_TEAM
+
+    def __applicable(
+        *args,
+        team_id: Optional[int] = None,
+        **kwargs,
+    ) -> bool:
+        return bool(not TEST and team_id)
+
+    if __EVENTS_LIST_CONCURRENT_QUERY_PER_TEAM is None:
+        __EVENTS_LIST_CONCURRENT_QUERY_PER_TEAM = RateLimit(
+            max_concurrency=2,
+            applicable=__applicable,
+            limit_name="events_list_per_team",
+            get_task_name=lambda *args, **kwargs: f"events_list:query:per-team:{kwargs.get('team_id')}",
+            get_task_id=lambda *args, **kwargs: (
+                current_task.request.id if current_task else (kwargs.get("task_id") or generate_short_id())
+            ),
+            ttl=600,
+            retry=0.134,
+            retry_timeout=30.0,
+        )
+    return __EVENTS_LIST_CONCURRENT_QUERY_PER_TEAM
 
 
 class ConcurrencyLimitExceeded(Exception):

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -196,6 +196,7 @@ class ExperimentQueryRunner(QueryRunner):
                 allow_experimental_analyzer=True,
                 max_bytes_before_external_group_by=MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
             ),
+            workload=self.workload,
         )
 
         # Remove the $multiple variant only when using exclude handling


### PR DESCRIPTION
## Problem

event_list queries must scan through a lot of data

## Changes

Keep events_list under control and allow only 2 concurrent queries per team.
if query is fast -> this is not an issue, if it's slow - it will save the cluster
