### PR TITLE
chore(experiments): add AA test to signup form to test device_id bucketing

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -333,6 +333,7 @@ export const FEATURE_FLAGS = {
     SHOPIFY_DWH: 'shopify-dwh', // owner: @andrew #team-data-stack
     SHOW_REFERRER_FAVICON: 'show-referrer-favicon', // owner: @jordanm-posthog #team-web-analytics
     SHOW_REPLAY_FILTERS_FEEDBACK_BUTTON: 'show-replay-filters-feedback-button', // owner: @ksvat #team-replay
+    SIGNUP_AA_TEST: 'signup-aa-test', // owner: @andehen #team-experiments multivariate=control,test
     SSE_DASHBOARDS: 'sse-dashboards', // owner: @aspicer #team-analytics-platform
     SURVEY_ANALYSIS_MAX_TOOL: 'survey-analysis-max-tool', // owner: #team-surveys
     SURVEY_RESULTS_V2: 'survey-results-v2', // owner: #team-surveys

--- a/frontend/src/scenes/authentication/signup/SignupContainer.tsx
+++ b/frontend/src/scenes/authentication/signup/SignupContainer.tsx
@@ -4,8 +4,9 @@ import { router } from 'kea-router'
 import { IconCheckCircle } from '@posthog/icons'
 
 import { BridgePage } from 'lib/components/BridgePage/BridgePage'
-import { CLOUD_HOSTNAMES } from 'lib/constants'
+import { CLOUD_HOSTNAMES, FEATURE_FLAGS } from 'lib/constants'
 import { Link } from 'lib/lemon-ui/Link'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
@@ -21,6 +22,9 @@ export const scene: SceneExport = {
 export function SignupContainer(): JSX.Element | null {
     const { preflight } = useValues(preflightLogic)
     const { user } = useValues(userLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const isAATestVariant = featureFlags[FEATURE_FLAGS.SIGNUP_AA_TEST] === 'test'
 
     const footerHighlights = {
         cloud: ['Hosted & managed by PostHog', 'Pay per event, cancel anytime', 'Fast and reliable support'],
@@ -42,6 +46,7 @@ export function SignupContainer(): JSX.Element | null {
             sideLogo
             leftContainerContent={<SignupLeftContainer />}
         >
+            {isAATestVariant && <div data-attr="signup-aa-test-variant" className="hidden" />}
             <SignupForm />
         </BridgePage>
     ) : null


### PR DESCRIPTION
## Changes

We are rolling out support for using `$device_id` as bucketing identifier (the id we use to assign users variants) in feature flags. This should be stable per _device_ and thus be good fit for "anonymous -> logged in" experiments.

To test it, I want to run an A/A test (no visual changes) on our signup form. I want to verify that the behavior is as intended (stable assignments across devices), and that assignments does not change when logging in due to the `$distinct_id` changes (which is an issue when using that as the bucketing identifier).

## How did you test this code?

Tested locally

## Publish to changelog?
