### PR TITLE
fix: evals run list scroll

### DIFF
--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -287,9 +287,10 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
     }),
 
     urlToAction(({ actions, props }) => ({
-        '/llm-analytics/evaluations/:id': (_, __, ___, { method }) => {
-            // Only reload when user clicked link, not on browser back/forward
-            if (method === 'PUSH') {
+        '/llm-analytics/evaluations/:id': ({ id }, _, __, { method }) => {
+            // Only reload when navigating to a different evaluation, not on search param changes (e.g., pagination)
+            const newEvaluationId = id && id !== 'new' ? id : 'new'
+            if (method === 'PUSH' && newEvaluationId !== props.evaluationId) {
                 actions.loadEvaluation()
                 if (props.evaluationId !== 'new') {
                     actions.loadEvaluationRuns()


### PR DESCRIPTION
Fixes an issue that would cause the eval view page to reload and lose scroll position when paginating the eval run list.