### PR TITLE
refactor: Switch to async queue.get in consumer

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/consumer.py
+++ b/products/batch_exports/backend/temporal/pipeline/consumer.py
@@ -125,7 +125,8 @@ class Consumer:
             get_task = asyncio.create_task(queue.get())
             _ = await asyncio.wait((get_task, producer_task), return_when=asyncio.FIRST_COMPLETED)
 
-            match _WaitResult((get_task.done(), producer_task.done())):
+            wait_result = _WaitResult((get_task.done(), producer_task.done()))
+            match wait_result:
                 case _WaitResult.FIRST_DONE | _WaitResult.BOTH_DONE:
                     record_batch = get_task.result()
 
@@ -140,7 +141,7 @@ class Consumer:
                         record_batch = await get_task
 
                 case _:
-                    typing.assert_never(_WaitResult)
+                    typing.assert_never(wait_result)
 
             self.logger.debug(f"Consuming batch number {self.total_record_batches_count}")
 

--- a/products/batch_exports/backend/temporal/pipeline/consumer.py
+++ b/products/batch_exports/backend/temporal/pipeline/consumer.py
@@ -134,6 +134,7 @@ class Consumer:
                         self.logger.debug(
                             "Empty queue with no more events being produced, closing writer loop and flushing"
                         )
+                        get_task.cancel()
                         break
                     else:
                         record_batch = await get_task


### PR DESCRIPTION
## Problem

The current implementation of `generate_record_batches_from_queue` uses a loop that calls `get_nowait` and continuously yields values until the queue is empty.

It bothers me a bit that this doesn't yield back control to the event loop if the queue is full or partially full. Only when the queue is empty do we yield back to the event loop by calling `await asyncio.sleep(0)`.

This means we could get stuck in a loop in which we don't yield back control for a long time, if the queue happens to be full of small record batches that take long to process downstream.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

I think ultimately we should be using the async method `queue.get` here. The challenge is that we need to detect when `queue.get` is waiting forever. As once the `producer_task` is done, and the queue is empty, then we can be confident nothing more is coming on the queue and `queue.get` would wait forever. Maybe the queue needs to be refactored to allow interrupting `get` once `producer_task` is done, but that seemed a bit more involved.

Instead, I went for a change in which we wait for `producer_task` and `queue.get` concurrently. If `queue.get` is done, then we can _get_ its result and yield it, like normal.

If only `producer_task` is done, then this means we may be waiting forever if the queue is empty. So, we check if the queue is empty and break the loop. This is fundamentally the same as the previous strategy which expected a `QueueEmpty` exception, which is raised when `queue.empty()` is `True`, only that now we do the check ourselves instead of waiting for an exception from `get_nowait`.

If the queue it's not empty, then we await the `get` to get its result, and continue the loop.

An enum is used (`_WaitResult`) together with `typing.assert_never` to tell the type checker that the case in which none of the two tasks finish is impossible to reach. This is because `asyncio.wait` does not return until one of the two tasks is done. So, none of them finishing would indicate a pretty serious bug in `asyncio.wait`. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran batch export tests and all are passing. For tests with both single and multiple consumers, this results in better performance, although the sample size is small. 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
