### PR TITLE
feat: add person reconciliation script backup

### DIFF
--- a/posthog/dags/person_property_reconciliation_query_explanation.md
+++ b/posthog/dags/person_property_reconciliation_query_explanation.md
@@ -303,11 +303,13 @@ The reconciliation logic in `reconcile_person_properties()` does compare timesta
 
 ---
 
-## Future: Adding $unset Support
+## $unset Support (Implemented)
+
+The reconciliation job now supports `$unset` operations. Here's how it works:
 
 ### Query changes
 
-Add `$unset` extraction to the ARRAY JOIN (note: `$unset` is an array of keys, not key-value pairs):
+`$unset` extraction in the ARRAY JOIN (note: `$unset` is an array of keys, not key-value pairs):
 
 ```sql
 -- In ARRAY JOIN arrayConcat:

--- a/posthog/dags/person_property_reconciliation_restore.py
+++ b/posthog/dags/person_property_reconciliation_restore.py
@@ -318,6 +318,7 @@ def restore_person_with_version_check(
 
     for attempt in range(max_retries):
         # Use prefetched person on first attempt, fetch fresh on retries
+        person: dict | None
         if attempt == 0 and prefetched_person is not None:
             person = prefetched_person
         else:

--- a/posthog/dags/person_property_reconciliation_restore.py
+++ b/posthog/dags/person_property_reconciliation_restore.py
@@ -1,0 +1,510 @@
+"""Dagster job for restoring person properties from backup table.
+
+This job reads backup entries created by the reconciliation job and restores
+person properties with configurable conflict resolution strategies.
+"""
+
+import json
+import time
+from typing import Any
+
+from django.conf import settings
+
+import dagster
+import psycopg2
+from dagster_k8s import k8s_job_executor
+
+from posthog.clickhouse.cluster import ClickhouseCluster
+from posthog.clickhouse.custom_metrics import MetricsClient
+from posthog.dags.common import JobOwners
+from posthog.dags.person_property_reconciliation import publish_person_to_kafka
+from posthog.kafka_client.client import _KafkaProducer
+
+executor_def = dagster.in_process_executor if settings.DEBUG else k8s_job_executor
+
+
+def ensure_dict(value: Any) -> dict:
+    """Ensure a value is a dict, parsing from JSON string if needed."""
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        return json.loads(value)
+    return {}
+
+
+class PersonPropertyRestoreConfig(dagster.Config):
+    """Configuration for the person property restore job."""
+
+    job_id: str  # Which backup job to restore from
+    team_ids: list[int] | None = None  # Optional: filter to specific teams
+    person_ids: list[int] | None = None  # Optional: filter to specific persons
+    conflict_resolution: str = "keep_newer"  # "keep_newer", "restore_wins", "full_overwrite"
+    dry_run: bool = False  # Log without applying
+
+
+def fetch_backup_entries(
+    cursor,
+    job_id: str,
+    team_ids: list[int] | None = None,
+    person_ids: list[int] | None = None,
+) -> list[dict]:
+    """Fetch backup entries for restore, grouped by team."""
+    query = """
+        SELECT
+            job_id, team_id, person_id, uuid::text,
+            properties, properties_last_updated_at, properties_last_operation, version,
+            is_identified, created_at, is_user_id,
+            properties_after, properties_last_updated_at_after, properties_last_operation_after, version_after
+        FROM posthog_person_reconciliation_backup
+        WHERE job_id = %s
+    """
+    params: list[Any] = [job_id]
+
+    if team_ids:
+        query += " AND team_id = ANY(%s)"
+        params.append(team_ids)
+
+    if person_ids:
+        query += " AND person_id = ANY(%s)"
+        params.append(person_ids)
+
+    query += " ORDER BY team_id, person_id"
+
+    cursor.execute(query, params)
+    columns = [desc[0] for desc in cursor.description]
+    return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+
+def fetch_person_by_id(cursor, team_id: int, person_id: int) -> dict | None:
+    """Fetch current person state by id."""
+    cursor.execute(
+        """
+        SELECT
+            id,
+            uuid::text,
+            properties,
+            properties_last_updated_at,
+            properties_last_operation,
+            version,
+            is_identified,
+            created_at,
+            is_user_id
+        FROM posthog_person
+        WHERE team_id = %s AND id = %s
+        """,
+        (team_id, person_id),
+    )
+    row = cursor.fetchone()
+    if not row:
+        return None
+    columns = [desc[0] for desc in cursor.description]
+    result = dict(zip(columns, row))
+    # Ensure JSONB fields are parsed (handles both RealDictCursor and regular cursors)
+    result["properties"] = ensure_dict(result.get("properties"))
+    result["properties_last_updated_at"] = ensure_dict(result.get("properties_last_updated_at"))
+    result["properties_last_operation"] = ensure_dict(result.get("properties_last_operation"))
+    return result
+
+
+def compute_restore_diff(
+    current_person: dict,
+    backup_before: dict,
+    backup_after: dict,
+    conflict_resolution: str,
+) -> dict | None:
+    """
+    Compute what properties to restore.
+
+    Args:
+        current_person: Current state from posthog_person table
+        backup_before: "Before" state from backup (what we want to restore TO)
+        backup_after: "After" state from backup (what reconciliation changed it TO)
+        conflict_resolution: How to handle conflicts
+            - "full_overwrite": Complete replacement with backup's before state
+            - "restore_wins": Restore all backed-up properties, preserve new properties added after backup
+            - "keep_newer": Only restore properties unchanged since backup
+
+    Returns:
+        Dict with updated properties, or None if no changes needed.
+    """
+    current_props = current_person.get("properties") or {}
+    backup_before_props = backup_before.get("properties") or {}
+    backup_after_props = backup_after.get("properties") or {}
+
+    if conflict_resolution == "full_overwrite":
+        if current_props == backup_before_props:
+            return None
+        return {
+            "properties": dict(backup_before_props),
+            "properties_last_updated_at": dict(backup_before.get("properties_last_updated_at") or {}),
+            "properties_last_operation": dict(backup_before.get("properties_last_operation") or {}),
+        }
+
+    result_properties = dict(current_props)
+    result_last_updated_at = dict(current_person.get("properties_last_updated_at") or {})
+    result_last_operation = dict(current_person.get("properties_last_operation") or {})
+    changes_made = False
+
+    backup_before_last_updated_at = backup_before.get("properties_last_updated_at") or {}
+    backup_before_last_operation = backup_before.get("properties_last_operation") or {}
+
+    for key, before_value in backup_before_props.items():
+        current_value = current_props.get(key)
+        after_value = backup_after_props.get(key)
+
+        if conflict_resolution == "restore_wins":
+            if current_value != before_value:
+                result_properties[key] = before_value
+                # Restore metadata to backup state (set if present, remove if not)
+                if key in backup_before_last_updated_at:
+                    result_last_updated_at[key] = backup_before_last_updated_at[key]
+                else:
+                    result_last_updated_at.pop(key, None)
+                if key in backup_before_last_operation:
+                    result_last_operation[key] = backup_before_last_operation[key]
+                else:
+                    result_last_operation.pop(key, None)
+                changes_made = True
+
+        elif conflict_resolution == "keep_newer":
+            if current_value == after_value and current_value != before_value:
+                result_properties[key] = before_value
+                # Restore metadata to backup state (set if present, remove if not)
+                if key in backup_before_last_updated_at:
+                    result_last_updated_at[key] = backup_before_last_updated_at[key]
+                else:
+                    result_last_updated_at.pop(key, None)
+                if key in backup_before_last_operation:
+                    result_last_operation[key] = backup_before_last_operation[key]
+                else:
+                    result_last_operation.pop(key, None)
+                changes_made = True
+
+    if not changes_made:
+        return None
+
+    return {
+        "properties": result_properties,
+        "properties_last_updated_at": result_last_updated_at,
+        "properties_last_operation": result_last_operation,
+    }
+
+
+def restore_person_with_version_check(
+    cursor,
+    team_id: int,
+    person_id: int,
+    person_uuid: str,
+    backup_entry: dict,
+    conflict_resolution: str,
+    dry_run: bool = False,
+    max_retries: int = 3,
+) -> tuple[bool, dict | None]:
+    """
+    Restore a person's properties with optimistic locking.
+
+    Args:
+        cursor: Database cursor
+        team_id: Team ID
+        person_id: Person ID (from backup)
+        person_uuid: Person UUID
+        backup_entry: Backup entry with before/after state
+        conflict_resolution: "keep_newer", "restore_wins", or "full_overwrite"
+        dry_run: If True, don't actually write the UPDATE
+        max_retries: Maximum retry attempts on version mismatch
+
+    Returns:
+        Tuple of (success: bool, updated_person_data: dict | None)
+        updated_person_data contains the final state for Kafka publishing
+    """
+    backup_before = {
+        "properties": ensure_dict(backup_entry.get("properties")),
+        "properties_last_updated_at": ensure_dict(backup_entry.get("properties_last_updated_at")),
+        "properties_last_operation": ensure_dict(backup_entry.get("properties_last_operation")),
+    }
+    backup_after = {
+        "properties": ensure_dict(backup_entry.get("properties_after")),
+        "properties_last_updated_at": ensure_dict(backup_entry.get("properties_last_updated_at_after")),
+        "properties_last_operation": ensure_dict(backup_entry.get("properties_last_operation_after")),
+    }
+
+    for _attempt in range(max_retries):
+        person = fetch_person_by_id(cursor, team_id, person_id)
+        if not person:
+            return False, None
+
+        current_version = person.get("version") or 0
+
+        update = compute_restore_diff(person, backup_before, backup_after, conflict_resolution)
+        if not update:
+            return True, None
+
+        if dry_run:
+            return True, None
+
+        cursor.execute(
+            """
+            UPDATE posthog_person SET
+                properties = %s,
+                properties_last_updated_at = %s,
+                properties_last_operation = %s,
+                version = %s
+            WHERE team_id = %s AND id = %s AND version = %s
+            RETURNING uuid
+            """,
+            (
+                json.dumps(update["properties"]),
+                json.dumps(update["properties_last_updated_at"]),
+                json.dumps(update["properties_last_operation"]),
+                current_version + 1,
+                team_id,
+                person_id,
+                current_version,
+            ),
+        )
+
+        if cursor.rowcount > 0:
+            return (
+                True,
+                {
+                    "id": person_uuid,
+                    "team_id": team_id,
+                    "properties": update["properties"],
+                    "is_identified": person.get("is_identified", False),
+                    "is_deleted": 0,
+                    "created_at": person.get("created_at"),
+                    "version": current_version + 1,
+                },
+            )
+
+    return False, None
+
+
+@dagster.op
+def get_backup_entries(
+    context: dagster.OpExecutionContext,
+    config: PersonPropertyRestoreConfig,
+    persons_database: dagster.ResourceParam[psycopg2.extensions.connection],
+) -> list[dict]:
+    """Query backup table for entries to restore."""
+    context.log.info(f"Fetching backup entries for job_id: {config.job_id}")
+
+    with persons_database.cursor() as cursor:
+        entries = fetch_backup_entries(cursor, config.job_id, config.team_ids, config.person_ids)
+
+    if not entries:
+        context.log.info("No backup entries found")
+        return []
+
+    team_ids = {e["team_id"] for e in entries}
+    context.log.info(f"Found {len(entries)} backup entries across {len(team_ids)} teams")
+    context.add_output_metadata(
+        {
+            "entry_count": dagster.MetadataValue.int(len(entries)),
+            "team_count": dagster.MetadataValue.int(len(team_ids)),
+        }
+    )
+
+    return entries
+
+
+@dagster.op(out=dagster.DynamicOut(list))
+def create_restore_chunks(
+    context: dagster.OpExecutionContext,
+    backup_entries: list[dict],
+):
+    """Group backup entries by team for parallel processing."""
+    if not backup_entries:
+        context.log.info("No entries to process")
+        return
+
+    teams: dict[int, list[dict]] = {}
+    for entry in backup_entries:
+        team_id = entry["team_id"]
+        if team_id not in teams:
+            teams[team_id] = []
+        teams[team_id].append(entry)
+
+    context.log.info(f"Creating {len(teams)} team chunks")
+
+    for team_id, entries in teams.items():
+        chunk_key = f"team_{team_id}"
+        yield dagster.DynamicOutput(
+            value=entries,
+            mapping_key=chunk_key,
+        )
+
+
+@dagster.op
+def restore_team_chunk(
+    context: dagster.OpExecutionContext,
+    config: PersonPropertyRestoreConfig,
+    chunk: list[dict],
+    persons_database: dagster.ResourceParam[psycopg2.extensions.connection],
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+    kafka_producer: dagster.ResourceParam[_KafkaProducer],
+) -> dict[str, Any]:
+    """Restore person properties for all backup entries in a team chunk."""
+    if not chunk:
+        return {"team_id": 0, "persons_processed": 0, "persons_restored": 0, "persons_skipped": 0}
+
+    team_id = chunk[0]["team_id"]
+    job_name = context.run.job_name
+    chunk_id = f"team_{team_id}"
+    metrics_client = MetricsClient(cluster)
+
+    context.log.info(
+        f"Starting restore for team_id={team_id}, entries={len(chunk)}, "
+        f"conflict_resolution={config.conflict_resolution}"
+    )
+
+    total_processed = 0
+    total_restored = 0
+    total_skipped = 0
+
+    try:
+        start_time = time.time()
+
+        with persons_database.cursor() as cursor:
+            cursor.execute("SET application_name = 'person_property_restore'")
+            cursor.execute("SET lock_timeout = '5s'")
+            cursor.execute("SET statement_timeout = '30min'")
+            cursor.execute("SET synchronous_commit = off")
+
+            persons_to_publish = []
+
+            for backup_entry in chunk:
+                person_id = backup_entry["person_id"]
+                person_uuid = backup_entry["uuid"]
+
+                success, person_data = restore_person_with_version_check(
+                    cursor=cursor,
+                    team_id=team_id,
+                    person_id=person_id,
+                    person_uuid=person_uuid,
+                    backup_entry=backup_entry,
+                    conflict_resolution=config.conflict_resolution,
+                    dry_run=config.dry_run,
+                )
+
+                if not success:
+                    context.log.warning(f"Failed to restore person after retries: {person_id}")
+                    total_skipped += 1
+                elif person_data:
+                    persons_to_publish.append(person_data)
+                    total_restored += 1
+                else:
+                    total_skipped += 1
+
+                total_processed += 1
+
+            if persons_to_publish and not config.dry_run:
+                persons_database.commit()
+
+                for person_data in persons_to_publish:
+                    try:
+                        publish_person_to_kafka(person_data, kafka_producer)
+                    except Exception as kafka_error:
+                        context.log.warning(
+                            f"Failed to publish person to Kafka: {person_data['id']}, error: {kafka_error}"
+                        )
+                try:
+                    kafka_producer.flush()
+                except Exception as flush_error:
+                    context.log.warning(f"Failed to flush Kafka producer: {flush_error}")
+
+                context.log.info(f"Restored {len(persons_to_publish)} persons for team_id={team_id}")
+            elif persons_to_publish and config.dry_run:
+                context.log.info(f"[DRY RUN] Would restore {len(persons_to_publish)} persons for team_id={team_id}")
+
+        duration = time.time() - start_time
+        try:
+            metrics_client.increment(
+                "person_property_restore_persons_processed_total",
+                labels={"job_name": job_name, "chunk_id": chunk_id},
+                value=float(total_processed),
+            ).result()
+            metrics_client.increment(
+                "person_property_restore_duration_seconds_total",
+                labels={"job_name": job_name, "chunk_id": chunk_id},
+                value=duration,
+            ).result()
+        except Exception:
+            pass
+
+    except Exception as e:
+        error_msg = f"Error for team_id={team_id}: {e}"
+        context.log.exception(error_msg)
+
+        try:
+            metrics_client.increment(
+                "person_property_restore_error",
+                labels={"job_name": job_name, "chunk_id": chunk_id, "reason": "error"},
+                value=1.0,
+            ).result()
+        except Exception:
+            pass
+
+        raise dagster.Failure(
+            description=error_msg,
+            metadata={
+                "team_id": dagster.MetadataValue.int(team_id),
+                "error_message": dagster.MetadataValue.text(str(e)),
+                "persons_processed_before_failure": dagster.MetadataValue.int(total_processed),
+            },
+        ) from e
+
+    context.log.info(
+        f"Completed team_id={team_id}: processed={total_processed}, restored={total_restored}, skipped={total_skipped}"
+    )
+
+    try:
+        metrics_client.increment(
+            "person_property_restore_persons_restored_total",
+            labels={"job_name": job_name, "chunk_id": chunk_id},
+            value=float(total_restored),
+        ).result()
+        metrics_client.increment(
+            "person_property_restore_persons_skipped_total",
+            labels={"job_name": job_name, "chunk_id": chunk_id},
+            value=float(total_skipped),
+        ).result()
+    except Exception:
+        pass
+
+    context.add_output_metadata(
+        {
+            "team_id": dagster.MetadataValue.int(team_id),
+            "persons_processed": dagster.MetadataValue.int(total_processed),
+            "persons_restored": dagster.MetadataValue.int(total_restored),
+            "persons_skipped": dagster.MetadataValue.int(total_skipped),
+        }
+    )
+
+    return {
+        "team_id": team_id,
+        "persons_processed": total_processed,
+        "persons_restored": total_restored,
+        "persons_skipped": total_skipped,
+    }
+
+
+@dagster.job(
+    tags={"owner": JobOwners.TEAM_INGESTION.value},
+    executor_def=executor_def,
+)
+def person_property_reconciliation_restore_from_backup():
+    """
+    Job to restore person properties from backup table.
+
+    This job reads backup entries created by the reconciliation job and
+    restores person properties. Conflict resolution options:
+    - full_overwrite: Complete overwrite with backup's "before" state
+    - restore_wins: Restore all backed-up properties, preserve new ones added after backup
+    - keep_newer: Only restore properties unchanged since backup
+    """
+    backup_entries = get_backup_entries()
+    chunks = create_restore_chunks(backup_entries)
+    chunks.map(restore_team_chunk)

--- a/posthog/dags/tests/test_person_property_reconciliation_restore.py
+++ b/posthog/dags/tests/test_person_property_reconciliation_restore.py
@@ -1,0 +1,1708 @@
+"""Integration tests for the person property restore job.
+
+These tests use real database connections, not mocks.
+"""
+
+import json
+import uuid as uuid_module
+from datetime import UTC, datetime
+
+import pytest
+
+from django.db import connections
+
+from posthog.dags.person_property_reconciliation_restore import (
+    compute_restore_diff,
+    fetch_backup_entries,
+    fetch_person_by_id,
+    restore_person_with_version_check,
+)
+from posthog.models import Organization, Person, Team
+from posthog.person_db_router import PERSONS_DB_FOR_WRITE
+
+
+def create_backup_entry(
+    cursor,
+    job_id: str,
+    team_id: int,
+    person_id: int,
+    person_uuid: str,
+    properties_before: dict,
+    properties_after: dict,
+    version_before: int = 1,
+    version_after: int = 2,
+    properties_last_updated_at_before: dict | None = None,
+    properties_last_operation_before: dict | None = None,
+    properties_last_updated_at_after: dict | None = None,
+    properties_last_operation_after: dict | None = None,
+) -> None:
+    """Helper to insert a backup entry directly into the backup table."""
+    cursor.execute(
+        """
+        INSERT INTO posthog_person_reconciliation_backup (
+            job_id, team_id, person_id, uuid,
+            properties, properties_last_updated_at, properties_last_operation,
+            version, is_identified, created_at, is_user_id,
+            pending_operations,
+            properties_after, properties_last_updated_at_after,
+            properties_last_operation_after, version_after
+        ) VALUES (
+            %s, %s, %s, %s::uuid,
+            %s, %s, %s,
+            %s, %s, %s, %s,
+            %s,
+            %s, %s, %s, %s
+        )
+        """,
+        (
+            job_id,
+            team_id,
+            person_id,
+            person_uuid,
+            json.dumps(properties_before),
+            json.dumps(properties_last_updated_at_before or {}),
+            json.dumps(properties_last_operation_before or {}),
+            version_before,
+            False,
+            datetime.now(UTC),
+            None,
+            json.dumps([]),  # pending_operations
+            json.dumps(properties_after),
+            json.dumps(properties_last_updated_at_after or {}),
+            json.dumps(properties_last_operation_after or {}),
+            version_after,
+        ),
+    )
+
+
+class TestComputeRestoreDiff:
+    """Unit tests for compute_restore_diff function."""
+
+    def test_full_overwrite_returns_backup_state(self):
+        """Test that full_overwrite completely replaces current with backup."""
+        current_person = {
+            "properties": {"email": "current@example.com", "new_prop": "added_after"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        backup_before = {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-01T00:00:00"},
+            "properties_last_operation": {"email": "set"},
+        }
+        backup_after = {
+            "properties": {"email": "reconciled@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="full_overwrite")
+
+        assert result == {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-01T00:00:00"},
+            "properties_last_operation": {"email": "set"},
+        }
+
+    def test_full_overwrite_returns_none_when_already_matches(self):
+        """Test that full_overwrite returns None when current already matches backup."""
+        current_person = {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        backup_before = {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        backup_after = {
+            "properties": {"email": "reconciled@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="full_overwrite")
+
+        assert result is None
+
+    def test_restore_wins_restores_backed_up_and_preserves_new(self):
+        """Test that restore_wins restores backed-up properties and preserves new ones."""
+        current_person = {
+            "properties": {"email": "current@example.com", "new_prop": "added_after"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        backup_before = {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-01T00:00:00"},
+            "properties_last_operation": {"email": "set"},
+        }
+        backup_after = {
+            "properties": {"email": "reconciled@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="restore_wins")
+
+        assert result == {
+            "properties": {"email": "original@example.com", "new_prop": "added_after"},
+            "properties_last_updated_at": {"email": "2024-01-01T00:00:00"},
+            "properties_last_operation": {"email": "set"},
+        }
+
+    def test_keep_newer_only_restores_unchanged_properties(self):
+        """Test that keep_newer only restores properties that haven't changed since backup."""
+        current_person = {
+            "properties": {
+                "email": "reconciled@example.com",  # unchanged since backup
+                "name": "Updated Name",  # changed after backup
+            },
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        backup_before = {
+            "properties": {"email": "original@example.com", "name": "Original Name"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        backup_after = {
+            "properties": {"email": "reconciled@example.com", "name": "Reconciled Name"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="keep_newer")
+
+        # email unchanged since backup (current == after), so restore to before
+        # name was changed after backup (current != after), so keep current
+        assert result == {
+            "properties": {"email": "original@example.com", "name": "Updated Name"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+    def test_keep_newer_returns_none_when_all_changed(self):
+        """Test keep_newer returns None when all properties changed after backup."""
+        current_person = {
+            "properties": {"email": "latest@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        backup_before = {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        backup_after = {
+            "properties": {"email": "reconciled@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="keep_newer")
+
+        # current != after, so property was changed after backup, keep it
+        assert result is None
+
+    def test_restore_wins_restores_metadata_when_present_in_backup(self):
+        """Test that metadata is restored when it exists in the backup."""
+        current_person = {
+            "properties": {"email": "current@example.com"},
+            "properties_last_updated_at": {"email": "2024-06-01T00:00:00"},
+            "properties_last_operation": {"email": "set"},
+        }
+        backup_before = {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-01T00:00:00"},
+            "properties_last_operation": {"email": "set_once"},
+        }
+        backup_after = {
+            "properties": {"email": "reconciled@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="restore_wins")
+
+        assert result == {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-01T00:00:00"},
+            "properties_last_operation": {"email": "set_once"},
+        }
+
+    def test_restore_wins_removes_metadata_when_absent_from_backup(self):
+        """Test that metadata is removed when it doesn't exist in the backup."""
+        current_person = {
+            "properties": {"email": "current@example.com"},
+            "properties_last_updated_at": {"email": "2024-06-01T00:00:00"},
+            "properties_last_operation": {"email": "set"},
+        }
+        backup_before = {
+            "properties": {"email": "original@example.com"},
+            # No metadata for email in backup
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+        backup_after = {
+            "properties": {"email": "reconciled@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="restore_wins")
+
+        assert result == {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+    def test_keep_newer_restores_metadata_correctly(self):
+        """Test that keep_newer also restores metadata correctly."""
+        current_person = {
+            "properties": {"email": "reconciled@example.com"},
+            "properties_last_updated_at": {"email": "2024-06-01T00:00:00"},
+            "properties_last_operation": {"email": "set"},
+        }
+        backup_before = {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-01T00:00:00"},
+            "properties_last_operation": {"email": "set_once"},
+        }
+        backup_after = {
+            "properties": {"email": "reconciled@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="keep_newer")
+
+        # Property restored since current == after, metadata also restored
+        assert result == {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-01T00:00:00"},
+            "properties_last_operation": {"email": "set_once"},
+        }
+
+    def test_metadata_preserved_for_unchanged_properties(self):
+        """Test that metadata for properties not being restored stays unchanged."""
+        current_person = {
+            "properties": {"email": "current@example.com", "name": "Current Name"},
+            "properties_last_updated_at": {"email": "2024-06-01T00:00:00", "name": "2024-06-01T00:00:00"},
+            "properties_last_operation": {"email": "set", "name": "set"},
+        }
+        backup_before = {
+            "properties": {"email": "original@example.com"},
+            "properties_last_updated_at": {"email": "2024-01-01T00:00:00"},
+            "properties_last_operation": {"email": "set_once"},
+        }
+        backup_after = {
+            "properties": {"email": "reconciled@example.com"},
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="restore_wins")
+
+        # Email restored with metadata, name preserved as-is (not in backup)
+        assert result == {
+            "properties": {"email": "original@example.com", "name": "Current Name"},
+            "properties_last_updated_at": {"email": "2024-01-01T00:00:00", "name": "2024-06-01T00:00:00"},
+            "properties_last_operation": {"email": "set_once", "name": "set"},
+        }
+
+    def test_full_overwrite_many_properties(self):
+        """Test full_overwrite with many properties - complete replacement."""
+        current_person = {
+            "properties": {
+                "email": "current@example.com",
+                "name": "Current Name",
+                "phone": "+1234567890",
+                "new_prop_1": "added_after_backup",
+                "new_prop_2": "also_added_after",
+                "new_prop_3": "third_new_one",
+            },
+            "properties_last_updated_at": {
+                "email": "2024-06-01T00:00:00",
+                "name": "2024-06-01T00:00:00",
+                "phone": "2024-06-01T00:00:00",
+            },
+            "properties_last_operation": {
+                "email": "set",
+                "name": "set",
+                "phone": "set",
+            },
+        }
+        backup_before = {
+            "properties": {
+                "email": "original@example.com",
+                "name": "Original Name",
+                "phone": "+0987654321",
+            },
+            "properties_last_updated_at": {
+                "email": "2024-01-01T00:00:00",
+                "name": "2024-01-01T00:00:00",
+            },
+            "properties_last_operation": {
+                "email": "set_once",
+                "name": "set",
+            },
+        }
+        backup_after = {
+            "properties": {
+                "email": "reconciled@example.com",
+                "name": "Reconciled Name",
+                "phone": "+1111111111",
+            },
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="full_overwrite")
+
+        # Complete replacement - all current properties replaced with backup_before
+        assert result == {
+            "properties": {
+                "email": "original@example.com",
+                "name": "Original Name",
+                "phone": "+0987654321",
+            },
+            "properties_last_updated_at": {
+                "email": "2024-01-01T00:00:00",
+                "name": "2024-01-01T00:00:00",
+            },
+            "properties_last_operation": {
+                "email": "set_once",
+                "name": "set",
+            },
+        }
+
+    def test_restore_wins_many_properties(self):
+        """Test restore_wins with many properties - restore backed-up, preserve new."""
+        current_person = {
+            "properties": {
+                "email": "current@example.com",
+                "name": "Current Name",
+                "phone": "+1234567890",
+                "new_prop_1": "added_after_backup",
+                "new_prop_2": "also_added_after",
+                "new_prop_3": "third_new_one",
+            },
+            "properties_last_updated_at": {
+                "email": "2024-06-01T00:00:00",
+                "name": "2024-06-01T00:00:00",
+                "new_prop_1": "2024-06-01T00:00:00",
+            },
+            "properties_last_operation": {
+                "email": "set",
+                "name": "set",
+                "new_prop_1": "set",
+            },
+        }
+        backup_before = {
+            "properties": {
+                "email": "original@example.com",
+                "name": "Original Name",
+                "phone": "+0987654321",
+            },
+            "properties_last_updated_at": {
+                "email": "2024-01-01T00:00:00",
+                "name": "2024-01-01T00:00:00",
+            },
+            "properties_last_operation": {
+                "email": "set_once",
+                "name": "set",
+            },
+        }
+        backup_after = {
+            "properties": {
+                "email": "reconciled@example.com",
+                "name": "Reconciled Name",
+                "phone": "+1111111111",
+            },
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="restore_wins")
+
+        # Backed-up properties restored, new properties preserved
+        assert result == {
+            "properties": {
+                "email": "original@example.com",
+                "name": "Original Name",
+                "phone": "+0987654321",
+                "new_prop_1": "added_after_backup",
+                "new_prop_2": "also_added_after",
+                "new_prop_3": "third_new_one",
+            },
+            "properties_last_updated_at": {
+                "email": "2024-01-01T00:00:00",
+                "name": "2024-01-01T00:00:00",
+                "new_prop_1": "2024-06-01T00:00:00",
+            },
+            "properties_last_operation": {
+                "email": "set_once",
+                "name": "set",
+                "new_prop_1": "set",
+            },
+        }
+
+    def test_keep_newer_many_properties(self):
+        """Test keep_newer with many properties - restore unchanged, keep changed."""
+        current_person = {
+            "properties": {
+                # Unchanged since backup (current == after) - should restore
+                "prop_unchanged_1": "reconciled_value_1",
+                "prop_unchanged_2": "reconciled_value_2",
+                "prop_unchanged_3": "reconciled_value_3",
+                # Changed after backup (current != after) - should keep
+                "prop_changed_1": "user_changed_1",
+                "prop_changed_2": "user_changed_2",
+                "prop_changed_3": "user_changed_3",
+                # New properties not in backup - should keep
+                "new_prop_1": "brand_new_1",
+                "new_prop_2": "brand_new_2",
+                "new_prop_3": "brand_new_3",
+            },
+            "properties_last_updated_at": {
+                "prop_unchanged_1": "2024-06-01T00:00:00",
+                "prop_changed_1": "2024-06-01T00:00:00",
+            },
+            "properties_last_operation": {
+                "prop_unchanged_1": "set",
+                "prop_changed_1": "set",
+            },
+        }
+        backup_before = {
+            "properties": {
+                "prop_unchanged_1": "original_value_1",
+                "prop_unchanged_2": "original_value_2",
+                "prop_unchanged_3": "original_value_3",
+                "prop_changed_1": "original_changed_1",
+                "prop_changed_2": "original_changed_2",
+                "prop_changed_3": "original_changed_3",
+            },
+            "properties_last_updated_at": {
+                "prop_unchanged_1": "2024-01-01T00:00:00",
+                "prop_changed_1": "2024-01-01T00:00:00",
+            },
+            "properties_last_operation": {
+                "prop_unchanged_1": "set_once",
+                "prop_changed_1": "set_once",
+            },
+        }
+        backup_after = {
+            "properties": {
+                "prop_unchanged_1": "reconciled_value_1",
+                "prop_unchanged_2": "reconciled_value_2",
+                "prop_unchanged_3": "reconciled_value_3",
+                "prop_changed_1": "reconciled_changed_1",
+                "prop_changed_2": "reconciled_changed_2",
+                "prop_changed_3": "reconciled_changed_3",
+            },
+            "properties_last_updated_at": {},
+            "properties_last_operation": {},
+        }
+
+        result = compute_restore_diff(current_person, backup_before, backup_after, conflict_resolution="keep_newer")
+
+        # Only unchanged properties restored; changed and new properties kept
+        assert result == {
+            "properties": {
+                # Restored (current == after)
+                "prop_unchanged_1": "original_value_1",
+                "prop_unchanged_2": "original_value_2",
+                "prop_unchanged_3": "original_value_3",
+                # Kept (current != after)
+                "prop_changed_1": "user_changed_1",
+                "prop_changed_2": "user_changed_2",
+                "prop_changed_3": "user_changed_3",
+                # Kept (not in backup)
+                "new_prop_1": "brand_new_1",
+                "new_prop_2": "brand_new_2",
+                "new_prop_3": "brand_new_3",
+            },
+            "properties_last_updated_at": {
+                "prop_unchanged_1": "2024-01-01T00:00:00",
+                "prop_changed_1": "2024-06-01T00:00:00",
+            },
+            "properties_last_operation": {
+                "prop_unchanged_1": "set_once",
+                "prop_changed_1": "set",
+            },
+        }
+
+
+def get_persons_db_connection():
+    """Get the correct database connection for person-related tables."""
+    return connections[PERSONS_DB_FOR_WRITE]
+
+
+@pytest.mark.django_db(transaction=True)
+class TestRestoreIntegration:
+    """Integration tests for restore functionality using real database."""
+
+    @pytest.fixture(autouse=True)
+    def setup_backup_table(self):
+        """Create the backup table if it doesn't exist."""
+        # Use persons database connection for backup table (since it references person_id)
+        persons_conn = get_persons_db_connection()
+        with persons_conn.cursor() as cursor:
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS posthog_person_reconciliation_backup (
+                    job_id TEXT NOT NULL,
+                    team_id INTEGER NOT NULL,
+                    person_id BIGINT NOT NULL,
+                    uuid UUID NOT NULL,
+                    properties JSONB NOT NULL,
+                    properties_last_updated_at JSONB,
+                    properties_last_operation JSONB,
+                    version BIGINT,
+                    is_identified BOOLEAN NOT NULL,
+                    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                    is_user_id INTEGER,
+                    pending_operations JSONB NOT NULL,
+                    properties_after JSONB,
+                    properties_last_updated_at_after JSONB,
+                    properties_last_operation_after JSONB,
+                    version_after BIGINT,
+                    backed_up_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                    PRIMARY KEY (job_id, team_id, person_id)
+                )
+            """)
+
+    @pytest.fixture
+    def organization(self):
+        """Create a test organization."""
+        return Organization.objects.create(name="Test Organization")
+
+    @pytest.fixture
+    def team(self, organization):
+        """Create a test team."""
+        return Team.objects.create(organization=organization, name="Test Team")
+
+    @pytest.fixture
+    def person(self, team):
+        """Create a test person."""
+        return Person.objects.create(
+            team_id=team.id,
+            uuid=uuid_module.uuid4(),
+            properties={"email": "current@example.com"},
+            version=5,
+        )
+
+    def test_fetch_backup_entries(self, team, person):
+        """Test fetching backup entries from database."""
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        with get_persons_db_connection().cursor() as cursor:
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                properties_before={"email": "original@example.com"},
+                properties_after={"email": "current@example.com"},
+            )
+
+            entries = fetch_backup_entries(cursor, job_id)
+
+        assert len(entries) == 1
+        assert entries[0]["team_id"] == team.id
+        assert entries[0]["person_id"] == person.id
+        # JSONB may be string or dict depending on cursor type
+        props = entries[0]["properties"]
+        if isinstance(props, str):
+            props = json.loads(props)
+        assert props == {"email": "original@example.com"}
+
+    def test_fetch_backup_entries_with_person_filter(self, team, person):
+        """Test fetching backup entries filtered by person_ids."""
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        person2 = Person.objects.create(
+            team_id=team.id,
+            uuid=uuid_module.uuid4(),
+            properties={"email": "other@example.com"},
+            version=1,
+        )
+
+        with get_persons_db_connection().cursor() as cursor:
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                properties_before={"email": "original1@example.com"},
+                properties_after={"email": "current1@example.com"},
+            )
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person2.id,
+                person_uuid=str(person2.uuid),
+                properties_before={"email": "original2@example.com"},
+                properties_after={"email": "current2@example.com"},
+            )
+
+            # Only fetch first person
+            entries = fetch_backup_entries(cursor, job_id, team_ids=None, person_ids=[person.id])
+
+        assert len(entries) == 1
+        assert entries[0]["person_id"] == person.id
+
+    def test_fetch_backup_entries_with_team_filter(self, organization, team, person):
+        """Test fetching backup entries filtered by team_ids."""
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        # Create a second team with a person
+        team2 = Team.objects.create(organization=organization, name="Test Team 2")
+        person2 = Person.objects.create(
+            team_id=team2.id,
+            uuid=uuid_module.uuid4(),
+            properties={"email": "other@example.com"},
+            version=1,
+        )
+
+        with get_persons_db_connection().cursor() as cursor:
+            # Create backup entries for both teams
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                properties_before={"email": "original1@example.com"},
+                properties_after={"email": "current1@example.com"},
+            )
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team2.id,
+                person_id=person2.id,
+                person_uuid=str(person2.uuid),
+                properties_before={"email": "original2@example.com"},
+                properties_after={"email": "current2@example.com"},
+            )
+
+            # Only fetch first team
+            entries = fetch_backup_entries(cursor, job_id, team_ids=[team.id])
+
+        assert len(entries) == 1
+        assert entries[0]["team_id"] == team.id
+        assert entries[0]["person_id"] == person.id
+
+    def test_fetch_person_by_id(self, team, person):
+        """Test fetching person by id."""
+        with get_persons_db_connection().cursor() as cursor:
+            fetched = fetch_person_by_id(cursor, team.id, person.id)
+
+        assert fetched is not None
+        assert fetched["id"] == person.id
+        assert fetched["uuid"] == str(person.uuid)
+        assert fetched["properties"] == {"email": "current@example.com"}
+
+    def test_restore_full_overwrite(self, team, person):
+        """Test full_overwrite restore overwrites current state."""
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        with get_persons_db_connection().cursor() as cursor:
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                properties_before={"email": "original@example.com", "name": "Original"},
+                properties_after={"email": "current@example.com"},
+                version_before=4,
+                version_after=5,
+            )
+
+            backup_entry = fetch_backup_entries(cursor, job_id)[0]
+
+            success, person_data = restore_person_with_version_check(
+                cursor=cursor,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                backup_entry=backup_entry,
+                conflict_resolution="full_overwrite",
+                dry_run=False,
+            )
+
+        assert success is True
+        assert person_data is not None
+
+        person.refresh_from_db()
+        assert person.properties == {"email": "original@example.com", "name": "Original"}
+        assert person.version == 6
+
+    def test_restore_keep_newer(self, team, person):
+        """Test keep_newer restore preserves changed properties."""
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        # Set current state to match backup's "after" state for one property
+        person.properties = {"email": "reconciled@example.com", "name": "User Changed This"}
+        person.save()
+
+        with get_persons_db_connection().cursor() as cursor:
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                properties_before={"email": "original@example.com", "name": "Original Name"},
+                properties_after={"email": "reconciled@example.com", "name": "Reconciled Name"},
+                version_before=4,
+                version_after=5,
+            )
+
+            backup_entry = fetch_backup_entries(cursor, job_id)[0]
+
+            success, person_data = restore_person_with_version_check(
+                cursor=cursor,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                backup_entry=backup_entry,
+                conflict_resolution="keep_newer",
+                dry_run=False,
+            )
+
+        assert success is True
+        assert person_data is not None
+
+        person.refresh_from_db()
+        # email: current == after, so restore to before
+        assert person.properties["email"] == "original@example.com"
+        # name: current != after (user changed it), so keep current
+        assert person.properties["name"] == "User Changed This"
+
+    def test_restore_restore_wins(self, team, person):
+        """Test restore_wins restores all backed-up properties."""
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        person.properties = {"email": "current@example.com", "brand_new": "added_later"}
+        person.save()
+
+        with get_persons_db_connection().cursor() as cursor:
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                properties_before={"email": "original@example.com"},
+                properties_after={"email": "reconciled@example.com"},
+                version_before=4,
+                version_after=5,
+            )
+
+            backup_entry = fetch_backup_entries(cursor, job_id)[0]
+
+            success, person_data = restore_person_with_version_check(
+                cursor=cursor,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                backup_entry=backup_entry,
+                conflict_resolution="restore_wins",
+                dry_run=False,
+            )
+
+        assert success is True
+        assert person_data is not None
+
+        person.refresh_from_db()
+        # email should be restored to original
+        assert person.properties["email"] == "original@example.com"
+        # brand_new property added after backup should be preserved
+        assert person.properties["brand_new"] == "added_later"
+
+    def test_restore_dry_run_does_not_modify(self, team, person):
+        """Test dry run mode doesn't modify the person."""
+        job_id = f"test-job-{uuid_module.uuid4()}"
+        original_properties = dict(person.properties)
+        original_version = person.version
+
+        with get_persons_db_connection().cursor() as cursor:
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                properties_before={"email": "original@example.com"},
+                properties_after={"email": "current@example.com"},
+            )
+
+            backup_entry = fetch_backup_entries(cursor, job_id)[0]
+
+            success, person_data = restore_person_with_version_check(
+                cursor=cursor,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                backup_entry=backup_entry,
+                conflict_resolution="full_overwrite",
+                dry_run=True,
+            )
+
+        assert success is True
+        assert person_data is None  # No data for Kafka in dry run
+
+        person.refresh_from_db()
+        assert person.properties == original_properties
+        assert person.version == original_version
+
+    def test_restore_skips_when_no_changes_needed(self, team, person):
+        """Test restore returns success with no data when current matches backup."""
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        # Set current to match backup's before state
+        person.properties = {"email": "original@example.com"}
+        person.save()
+
+        with get_persons_db_connection().cursor() as cursor:
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                properties_before={"email": "original@example.com"},
+                properties_after={"email": "reconciled@example.com"},
+            )
+
+            backup_entry = fetch_backup_entries(cursor, job_id)[0]
+
+            success, person_data = restore_person_with_version_check(
+                cursor=cursor,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                backup_entry=backup_entry,
+                conflict_resolution="full_overwrite",
+                dry_run=False,
+            )
+
+        assert success is True
+        assert person_data is None  # No changes needed
+
+
+@pytest.mark.django_db(transaction=True)
+class TestRestoreJobEndToEnd:
+    """End-to-end tests for the full Dagster job execution."""
+
+    @pytest.fixture(autouse=True)
+    def setup_backup_table(self):
+        """Create the backup table if it doesn't exist."""
+        persons_conn = get_persons_db_connection()
+        with persons_conn.cursor() as cursor:
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS posthog_person_reconciliation_backup (
+                    job_id TEXT NOT NULL,
+                    team_id INTEGER NOT NULL,
+                    person_id BIGINT NOT NULL,
+                    uuid UUID NOT NULL,
+                    properties JSONB NOT NULL,
+                    properties_last_updated_at JSONB,
+                    properties_last_operation JSONB,
+                    version BIGINT,
+                    is_identified BOOLEAN NOT NULL,
+                    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                    is_user_id INTEGER,
+                    pending_operations JSONB NOT NULL,
+                    properties_after JSONB,
+                    properties_last_updated_at_after JSONB,
+                    properties_last_operation_after JSONB,
+                    version_after BIGINT,
+                    backed_up_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                    PRIMARY KEY (job_id, team_id, person_id)
+                )
+            """)
+
+    @pytest.fixture
+    def organization(self):
+        """Create a test organization."""
+        return Organization.objects.create(name="Test Organization")
+
+    @pytest.fixture
+    def team(self, organization):
+        """Create a test team."""
+        return Team.objects.create(organization=organization, name="Test Team")
+
+    @pytest.fixture
+    def mock_kafka_producer(self):
+        """Create a mock Kafka producer."""
+        from unittest.mock import MagicMock
+
+        producer = MagicMock()
+        producer.flush = MagicMock()
+        return producer
+
+    def test_full_job_restores_persons(self, team, mock_kafka_producer, cluster):
+        """Test that the full Dagster job restores persons correctly."""
+        from posthog.dags.person_property_reconciliation_restore import (
+            person_property_reconciliation_restore_from_backup,
+        )
+
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        # Create test persons
+        person1 = Person.objects.create(
+            team_id=team.id,
+            uuid=uuid_module.uuid4(),
+            properties={"email": "current1@example.com", "name": "Current Name"},
+            version=5,
+        )
+        person2 = Person.objects.create(
+            team_id=team.id,
+            uuid=uuid_module.uuid4(),
+            properties={"email": "current2@example.com"},
+            version=3,
+        )
+
+        # Create backup entries
+        with get_persons_db_connection().cursor() as cursor:
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person1.id,
+                person_uuid=str(person1.uuid),
+                properties_before={"email": "original1@example.com", "name": "Original Name"},
+                properties_after={"email": "current1@example.com", "name": "Current Name"},
+                version_before=4,
+                version_after=5,
+            )
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person2.id,
+                person_uuid=str(person2.uuid),
+                properties_before={"email": "original2@example.com", "extra": "prop"},
+                properties_after={"email": "current2@example.com"},
+                version_before=2,
+                version_after=3,
+            )
+
+        # Create a Postgres resource that returns our connection
+        persons_conn = get_persons_db_connection()
+
+        # Run the job
+        result = person_property_reconciliation_restore_from_backup.execute_in_process(
+            run_config={
+                "ops": {
+                    "get_backup_entries": {
+                        "config": {
+                            "job_id": job_id,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                    "restore_team_chunk": {
+                        "config": {
+                            "job_id": job_id,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                }
+            },
+            resources={
+                "cluster": cluster,
+                "persons_database": persons_conn,
+                "kafka_producer": mock_kafka_producer,
+            },
+        )
+
+        assert result.success
+
+        # Verify persons were restored
+        person1.refresh_from_db()
+        person2.refresh_from_db()
+
+        assert person1.properties == {"email": "original1@example.com", "name": "Original Name"}
+        assert person1.version == 6
+
+        assert person2.properties == {"email": "original2@example.com", "extra": "prop"}
+        assert person2.version == 4
+
+        # Verify Kafka was called for each restored person
+        assert mock_kafka_producer.produce.call_count == 2
+        mock_kafka_producer.flush.assert_called()
+
+    def test_full_job_with_team_filter(self, organization, team, mock_kafka_producer, cluster):
+        """Test that team_ids filter works in the full job."""
+        from posthog.dags.person_property_reconciliation_restore import (
+            person_property_reconciliation_restore_from_backup,
+        )
+
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        # Create a second team
+        team2 = Team.objects.create(organization=organization, name="Test Team 2")
+
+        # Create persons in both teams
+        person1 = Person.objects.create(
+            team_id=team.id,
+            uuid=uuid_module.uuid4(),
+            properties={"email": "team1@example.com"},
+            version=2,
+        )
+        person2 = Person.objects.create(
+            team_id=team2.id,
+            uuid=uuid_module.uuid4(),
+            properties={"email": "team2@example.com"},
+            version=2,
+        )
+
+        # Create backup entries for both
+        with get_persons_db_connection().cursor() as cursor:
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person1.id,
+                person_uuid=str(person1.uuid),
+                properties_before={"email": "original1@example.com"},
+                properties_after={"email": "team1@example.com"},
+            )
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team2.id,
+                person_id=person2.id,
+                person_uuid=str(person2.uuid),
+                properties_before={"email": "original2@example.com"},
+                properties_after={"email": "team2@example.com"},
+            )
+
+        persons_conn = get_persons_db_connection()
+
+        # Run the job with team_ids filter - only restore team 1
+        result = person_property_reconciliation_restore_from_backup.execute_in_process(
+            run_config={
+                "ops": {
+                    "get_backup_entries": {
+                        "config": {
+                            "job_id": job_id,
+                            "team_ids": [team.id],
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                    "restore_team_chunk": {
+                        "config": {
+                            "job_id": job_id,
+                            "team_ids": [team.id],
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                }
+            },
+            resources={
+                "cluster": cluster,
+                "persons_database": persons_conn,
+                "kafka_producer": mock_kafka_producer,
+            },
+        )
+
+        assert result.success
+
+        # Verify only team 1 person was restored
+        person1.refresh_from_db()
+        person2.refresh_from_db()
+
+        assert person1.properties == {"email": "original1@example.com"}
+        assert person2.properties == {"email": "team2@example.com"}  # Unchanged
+
+    def test_full_job_dry_run(self, team, mock_kafka_producer, cluster):
+        """Test that dry_run mode doesn't modify data."""
+        from posthog.dags.person_property_reconciliation_restore import (
+            person_property_reconciliation_restore_from_backup,
+        )
+
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        person = Person.objects.create(
+            team_id=team.id,
+            uuid=uuid_module.uuid4(),
+            properties={"email": "current@example.com"},
+            version=5,
+        )
+        original_properties = dict(person.properties)
+        original_version = person.version
+
+        with get_persons_db_connection().cursor() as cursor:
+            create_backup_entry(
+                cursor,
+                job_id=job_id,
+                team_id=team.id,
+                person_id=person.id,
+                person_uuid=str(person.uuid),
+                properties_before={"email": "original@example.com"},
+                properties_after={"email": "current@example.com"},
+            )
+
+        persons_conn = get_persons_db_connection()
+
+        result = person_property_reconciliation_restore_from_backup.execute_in_process(
+            run_config={
+                "ops": {
+                    "get_backup_entries": {
+                        "config": {
+                            "job_id": job_id,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": True,
+                        }
+                    },
+                    "restore_team_chunk": {
+                        "config": {
+                            "job_id": job_id,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": True,
+                        }
+                    },
+                }
+            },
+            resources={
+                "cluster": cluster,
+                "persons_database": persons_conn,
+                "kafka_producer": mock_kafka_producer,
+            },
+        )
+
+        assert result.success
+
+        # Verify person was NOT modified
+        person.refresh_from_db()
+        assert person.properties == original_properties
+        assert person.version == original_version
+
+        # Verify Kafka was NOT called
+        mock_kafka_producer.produce.assert_not_called()
+
+    def test_full_job_many_teams_and_persons_restore_all(self, organization, mock_kafka_producer, cluster):
+        """Test restoring all persons across many teams - verify data isolation."""
+        from posthog.dags.person_property_reconciliation_restore import (
+            person_property_reconciliation_restore_from_backup,
+        )
+
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        # Create 5 teams with 4 persons each = 20 persons total
+        teams = []
+        persons = {}  # {team_id: [person1, person2, ...]}
+
+        for t in range(5):
+            team = Team.objects.create(organization=organization, name=f"Team {t}")
+            teams.append(team)
+            persons[team.id] = []
+
+            for p in range(4):
+                person = Person.objects.create(
+                    team_id=team.id,
+                    uuid=uuid_module.uuid4(),
+                    properties={
+                        "email": f"current_t{t}_p{p}@example.com",
+                        "team_marker": f"team_{t}",
+                        "person_marker": f"person_{p}",
+                    },
+                    version=10 + p,
+                )
+                persons[team.id].append(person)
+
+        # Create backup entries with distinct "before" data
+        with get_persons_db_connection().cursor() as cursor:
+            for team in teams:
+                t = teams.index(team)
+                for p, person in enumerate(persons[team.id]):
+                    create_backup_entry(
+                        cursor,
+                        job_id=job_id,
+                        team_id=team.id,
+                        person_id=person.id,
+                        person_uuid=str(person.uuid),
+                        properties_before={
+                            "email": f"original_t{t}_p{p}@example.com",
+                            "team_marker": f"team_{t}",
+                            "person_marker": f"person_{p}",
+                            "restored": True,
+                        },
+                        properties_after={
+                            "email": f"current_t{t}_p{p}@example.com",
+                            "team_marker": f"team_{t}",
+                            "person_marker": f"person_{p}",
+                        },
+                        version_before=9 + p,
+                        version_after=10 + p,
+                    )
+
+        persons_conn = get_persons_db_connection()
+
+        result = person_property_reconciliation_restore_from_backup.execute_in_process(
+            run_config={
+                "ops": {
+                    "get_backup_entries": {
+                        "config": {
+                            "job_id": job_id,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                    "restore_team_chunk": {
+                        "config": {
+                            "job_id": job_id,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                }
+            },
+            resources={
+                "cluster": cluster,
+                "persons_database": persons_conn,
+                "kafka_producer": mock_kafka_producer,
+            },
+        )
+
+        assert result.success
+
+        # Verify ALL 20 persons were restored with correct data
+        for team in teams:
+            t = teams.index(team)
+            for p, person in enumerate(persons[team.id]):
+                person.refresh_from_db()
+                assert person.properties == {
+                    "email": f"original_t{t}_p{p}@example.com",
+                    "team_marker": f"team_{t}",
+                    "person_marker": f"person_{p}",
+                    "restored": True,
+                }, f"Person t{t}_p{p} has wrong properties: {person.properties}"
+                assert person.version == 11 + p, f"Person t{t}_p{p} has wrong version: {person.version}"
+
+        # Verify Kafka was called for all 20 persons
+        assert mock_kafka_producer.produce.call_count == 20
+
+    def test_full_job_many_teams_filter_some_teams(self, organization, mock_kafka_producer, cluster):
+        """Test filtering to specific teams - only those teams should be restored."""
+        from posthog.dags.person_property_reconciliation_restore import (
+            person_property_reconciliation_restore_from_backup,
+        )
+
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        # Create 5 teams with 3 persons each
+        teams = []
+        persons = {}
+
+        for t in range(5):
+            team = Team.objects.create(organization=organization, name=f"Team {t}")
+            teams.append(team)
+            persons[team.id] = []
+
+            for p in range(3):
+                person = Person.objects.create(
+                    team_id=team.id,
+                    uuid=uuid_module.uuid4(),
+                    properties={"email": f"current_t{t}_p{p}@example.com", "status": "current"},
+                    version=5,
+                )
+                persons[team.id].append(person)
+
+        # Create backup entries for all
+        with get_persons_db_connection().cursor() as cursor:
+            for team in teams:
+                t = teams.index(team)
+                for p, person in enumerate(persons[team.id]):
+                    create_backup_entry(
+                        cursor,
+                        job_id=job_id,
+                        team_id=team.id,
+                        person_id=person.id,
+                        person_uuid=str(person.uuid),
+                        properties_before={"email": f"original_t{t}_p{p}@example.com", "status": "restored"},
+                        properties_after={"email": f"current_t{t}_p{p}@example.com", "status": "current"},
+                    )
+
+        persons_conn = get_persons_db_connection()
+
+        # Only restore teams 1 and 3 (indices)
+        teams_to_restore = [teams[1].id, teams[3].id]
+
+        result = person_property_reconciliation_restore_from_backup.execute_in_process(
+            run_config={
+                "ops": {
+                    "get_backup_entries": {
+                        "config": {
+                            "job_id": job_id,
+                            "team_ids": teams_to_restore,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                    "restore_team_chunk": {
+                        "config": {
+                            "job_id": job_id,
+                            "team_ids": teams_to_restore,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                }
+            },
+            resources={
+                "cluster": cluster,
+                "persons_database": persons_conn,
+                "kafka_producer": mock_kafka_producer,
+            },
+        )
+
+        assert result.success
+
+        # Verify teams 1 and 3 were restored
+        for t_idx in [1, 3]:
+            team = teams[t_idx]
+            for p, person in enumerate(persons[team.id]):
+                person.refresh_from_db()
+                assert person.properties["status"] == "restored", f"Team {t_idx} person {p} should be restored"
+                assert person.properties["email"] == f"original_t{t_idx}_p{p}@example.com"
+
+        # Verify teams 0, 2, 4 were NOT restored
+        for t_idx in [0, 2, 4]:
+            team = teams[t_idx]
+            for p, person in enumerate(persons[team.id]):
+                person.refresh_from_db()
+                assert person.properties["status"] == "current", f"Team {t_idx} person {p} should NOT be restored"
+                assert person.properties["email"] == f"current_t{t_idx}_p{p}@example.com"
+
+        # Verify Kafka was called for 6 persons (2 teams * 3 persons)
+        assert mock_kafka_producer.produce.call_count == 6
+
+    def test_full_job_filter_some_persons(self, organization, mock_kafka_producer, cluster):
+        """Test filtering to specific person_ids - only those persons should be restored."""
+        from posthog.dags.person_property_reconciliation_restore import (
+            person_property_reconciliation_restore_from_backup,
+        )
+
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        # Create 3 teams with 5 persons each
+        teams = []
+        persons = {}
+        all_persons = []
+
+        for t in range(3):
+            team = Team.objects.create(organization=organization, name=f"Team {t}")
+            teams.append(team)
+            persons[team.id] = []
+
+            for p in range(5):
+                person = Person.objects.create(
+                    team_id=team.id,
+                    uuid=uuid_module.uuid4(),
+                    properties={"email": f"current_t{t}_p{p}@example.com", "restored": False},
+                    version=5,
+                )
+                persons[team.id].append(person)
+                all_persons.append(person)
+
+        # Create backup entries for all
+        with get_persons_db_connection().cursor() as cursor:
+            for team in teams:
+                t = teams.index(team)
+                for p, person in enumerate(persons[team.id]):
+                    create_backup_entry(
+                        cursor,
+                        job_id=job_id,
+                        team_id=team.id,
+                        person_id=person.id,
+                        person_uuid=str(person.uuid),
+                        properties_before={"email": f"original_t{t}_p{p}@example.com", "restored": True},
+                        properties_after={"email": f"current_t{t}_p{p}@example.com", "restored": False},
+                    )
+
+        persons_conn = get_persons_db_connection()
+
+        # Only restore specific persons: first person from each team + last person from team 0
+        persons_to_restore = [
+            persons[teams[0].id][0].id,  # team 0, person 0
+            persons[teams[0].id][4].id,  # team 0, person 4
+            persons[teams[1].id][0].id,  # team 1, person 0
+            persons[teams[2].id][0].id,  # team 2, person 0
+        ]
+
+        result = person_property_reconciliation_restore_from_backup.execute_in_process(
+            run_config={
+                "ops": {
+                    "get_backup_entries": {
+                        "config": {
+                            "job_id": job_id,
+                            "person_ids": persons_to_restore,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                    "restore_team_chunk": {
+                        "config": {
+                            "job_id": job_id,
+                            "person_ids": persons_to_restore,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                }
+            },
+            resources={
+                "cluster": cluster,
+                "persons_database": persons_conn,
+                "kafka_producer": mock_kafka_producer,
+            },
+        )
+
+        assert result.success
+
+        # Verify only the selected persons were restored
+        for person in all_persons:
+            person.refresh_from_db()
+            if person.id in persons_to_restore:
+                assert person.properties["restored"] is True, f"Person {person.id} should be restored"
+            else:
+                assert person.properties["restored"] is False, f"Person {person.id} should NOT be restored"
+
+        # Verify Kafka was called for 4 persons
+        assert mock_kafka_producer.produce.call_count == 4
+
+    def test_full_job_filter_teams_and_persons(self, organization, mock_kafka_producer, cluster):
+        """Test filtering by both team_ids AND person_ids simultaneously."""
+        from posthog.dags.person_property_reconciliation_restore import (
+            person_property_reconciliation_restore_from_backup,
+        )
+
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        # Create 4 teams with 4 persons each = 16 persons
+        teams = []
+        persons = {}
+
+        for t in range(4):
+            team = Team.objects.create(organization=organization, name=f"Team {t}")
+            teams.append(team)
+            persons[team.id] = []
+
+            for p in range(4):
+                person = Person.objects.create(
+                    team_id=team.id,
+                    uuid=uuid_module.uuid4(),
+                    properties={
+                        "email": f"current_t{t}_p{p}@example.com",
+                        "team_id": t,
+                        "person_id": p,
+                        "restored": False,
+                    },
+                    version=5,
+                )
+                persons[team.id].append(person)
+
+        # Create backup entries for all
+        with get_persons_db_connection().cursor() as cursor:
+            for team in teams:
+                t = teams.index(team)
+                for p, person in enumerate(persons[team.id]):
+                    create_backup_entry(
+                        cursor,
+                        job_id=job_id,
+                        team_id=team.id,
+                        person_id=person.id,
+                        person_uuid=str(person.uuid),
+                        properties_before={
+                            "email": f"original_t{t}_p{p}@example.com",
+                            "team_id": t,
+                            "person_id": p,
+                            "restored": True,
+                        },
+                        properties_after={
+                            "email": f"current_t{t}_p{p}@example.com",
+                            "team_id": t,
+                            "person_id": p,
+                            "restored": False,
+                        },
+                    )
+
+        persons_conn = get_persons_db_connection()
+
+        # Filter to teams 0 and 2, AND persons 1 and 3 within those teams
+        # This should restore: team0/person1, team0/person3, team2/person1, team2/person3
+        teams_to_restore = [teams[0].id, teams[2].id]
+        persons_to_restore = [
+            persons[teams[0].id][1].id,
+            persons[teams[0].id][3].id,
+            persons[teams[2].id][1].id,
+            persons[teams[2].id][3].id,
+        ]
+
+        result = person_property_reconciliation_restore_from_backup.execute_in_process(
+            run_config={
+                "ops": {
+                    "get_backup_entries": {
+                        "config": {
+                            "job_id": job_id,
+                            "team_ids": teams_to_restore,
+                            "person_ids": persons_to_restore,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                    "restore_team_chunk": {
+                        "config": {
+                            "job_id": job_id,
+                            "team_ids": teams_to_restore,
+                            "person_ids": persons_to_restore,
+                            "conflict_resolution": "full_overwrite",
+                            "dry_run": False,
+                        }
+                    },
+                }
+            },
+            resources={
+                "cluster": cluster,
+                "persons_database": persons_conn,
+                "kafka_producer": mock_kafka_producer,
+            },
+        )
+
+        assert result.success
+
+        # Verify exactly the right persons were restored
+        expected_restored = {
+            (0, 1): True,
+            (0, 3): True,
+            (2, 1): True,
+            (2, 3): True,
+        }
+
+        for team in teams:
+            t = teams.index(team)
+            for p, person in enumerate(persons[team.id]):
+                person.refresh_from_db()
+                should_restore = expected_restored.get((t, p), False)
+
+                if should_restore:
+                    assert person.properties["restored"] is True, f"t{t}_p{p} should be restored"
+                    assert person.properties["email"] == f"original_t{t}_p{p}@example.com"
+                else:
+                    assert person.properties["restored"] is False, f"t{t}_p{p} should NOT be restored"
+                    assert person.properties["email"] == f"current_t{t}_p{p}@example.com"
+
+        # Verify Kafka was called for 4 persons
+        assert mock_kafka_producer.produce.call_count == 4
+
+    def test_full_job_restore_wins_preserves_new_properties(self, organization, mock_kafka_producer, cluster):
+        """Test restore_wins mode with many persons - new properties should be preserved."""
+        from posthog.dags.person_property_reconciliation_restore import (
+            person_property_reconciliation_restore_from_backup,
+        )
+
+        job_id = f"test-job-{uuid_module.uuid4()}"
+
+        # Create 3 teams with 3 persons each
+        teams = []
+        persons = {}
+
+        for t in range(3):
+            team = Team.objects.create(organization=organization, name=f"Team {t}")
+            teams.append(team)
+            persons[team.id] = []
+
+            for p in range(3):
+                # Current state has properties added after backup
+                person = Person.objects.create(
+                    team_id=team.id,
+                    uuid=uuid_module.uuid4(),
+                    properties={
+                        "email": f"current_t{t}_p{p}@example.com",
+                        "name": f"Current Name {t}_{p}",
+                        "new_after_backup": f"new_value_t{t}_p{p}",  # Added after backup
+                    },
+                    version=5,
+                )
+                persons[team.id].append(person)
+
+        # Create backup entries - "before" doesn't have new_after_backup
+        with get_persons_db_connection().cursor() as cursor:
+            for team in teams:
+                t = teams.index(team)
+                for p, person in enumerate(persons[team.id]):
+                    create_backup_entry(
+                        cursor,
+                        job_id=job_id,
+                        team_id=team.id,
+                        person_id=person.id,
+                        person_uuid=str(person.uuid),
+                        properties_before={
+                            "email": f"original_t{t}_p{p}@example.com",
+                            "name": f"Original Name {t}_{p}",
+                        },
+                        properties_after={
+                            "email": f"current_t{t}_p{p}@example.com",
+                            "name": f"Current Name {t}_{p}",
+                        },
+                    )
+
+        persons_conn = get_persons_db_connection()
+
+        result = person_property_reconciliation_restore_from_backup.execute_in_process(
+            run_config={
+                "ops": {
+                    "get_backup_entries": {
+                        "config": {
+                            "job_id": job_id,
+                            "conflict_resolution": "restore_wins",
+                            "dry_run": False,
+                        }
+                    },
+                    "restore_team_chunk": {
+                        "config": {
+                            "job_id": job_id,
+                            "conflict_resolution": "restore_wins",
+                            "dry_run": False,
+                        }
+                    },
+                }
+            },
+            resources={
+                "cluster": cluster,
+                "persons_database": persons_conn,
+                "kafka_producer": mock_kafka_producer,
+            },
+        )
+
+        assert result.success
+
+        # Verify all persons have:
+        # - email and name restored to original
+        # - new_after_backup preserved
+        for team in teams:
+            t = teams.index(team)
+            for p, person in enumerate(persons[team.id]):
+                person.refresh_from_db()
+                assert person.properties == {
+                    "email": f"original_t{t}_p{p}@example.com",
+                    "name": f"Original Name {t}_{p}",
+                    "new_after_backup": f"new_value_t{t}_p{p}",  # Preserved!
+                }, f"Person t{t}_p{p} has wrong properties: {person.properties}"
+
+        # All 9 persons restored
+        assert mock_kafka_producer.produce.call_count == 9

--- a/posthog/dags/tests/test_person_property_reconciliation_restore.py
+++ b/posthog/dags/tests/test_person_property_reconciliation_restore.py
@@ -758,7 +758,7 @@ class TestRestoreIntegration:
         team1 = Team.objects.create(organization=organization, name="Team 1")
         team2 = Team.objects.create(organization=organization, name="Team 2")
 
-        persons = {}
+        persons: dict[int, list[Person]] = {}
         for team in [team1, team2]:
             persons[team.id] = []
             for i in range(3):
@@ -1347,7 +1347,7 @@ class TestRestoreJobEndToEnd:
 
         # Create 5 teams with 4 persons each = 20 persons total
         teams = []
-        persons = {}  # {team_id: [person1, person2, ...]}
+        persons: dict[int, list[Person]] = {}
 
         for t in range(5):
             team = Team.objects.create(organization=organization, name=f"Team {t}")
@@ -1449,7 +1449,7 @@ class TestRestoreJobEndToEnd:
 
         # Create 5 teams with 3 persons each
         teams = []
-        persons = {}
+        persons: dict[int, list[Person]] = {}
 
         for t in range(5):
             team = Team.objects.create(organization=organization, name=f"Team {t}")
@@ -1544,8 +1544,8 @@ class TestRestoreJobEndToEnd:
 
         # Create 3 teams with 5 persons each
         teams = []
-        persons = {}
-        all_persons = []
+        persons: dict[int, list[Person]] = {}
+        all_persons: list[Person] = []
 
         for t in range(3):
             team = Team.objects.create(organization=organization, name=f"Team {t}")
@@ -1638,7 +1638,7 @@ class TestRestoreJobEndToEnd:
 
         # Create 4 teams with 4 persons each = 16 persons
         teams = []
-        persons = {}
+        persons: dict[int, list[Person]] = {}
 
         for t in range(4):
             team = Team.objects.create(organization=organization, name=f"Team {t}")
@@ -1762,7 +1762,7 @@ class TestRestoreJobEndToEnd:
 
         # Create 3 teams with 3 persons each
         teams = []
-        persons = {}
+        persons: dict[int, list[Person]] = {}
 
         for t in range(3):
             team = Team.objects.create(organization=organization, name=f"Team {t}")
@@ -1861,7 +1861,7 @@ class TestRestoreJobEndToEnd:
         # Create 3 teams with 2, 2, 1 persons = 5 total
         # With batch_size=2, this gives 3 batches (2, 2, 1) - last batch not full
         teams = []
-        persons = {}
+        persons: dict[int, list[Person]] = {}
         persons_per_team = [2, 2, 1]
 
         for t in range(3):

--- a/rust/persons_migrations/20260108000001_add_person_reconciliation_backup.sql
+++ b/rust/persons_migrations/20260108000001_add_person_reconciliation_backup.sql
@@ -1,0 +1,30 @@
+-- Backup table for person property reconciliation job
+-- Stores original person state before updates for audit/rollback
+
+CREATE TABLE IF NOT EXISTS posthog_person_reconciliation_backup (
+    job_id TEXT NOT NULL,
+    team_id INTEGER NOT NULL,
+    person_id BIGINT NOT NULL,
+    -- Full row backup of posthog_person columns (BEFORE state)
+    uuid UUID NOT NULL,
+    properties JSONB NOT NULL,
+    properties_last_updated_at JSONB,
+    properties_last_operation JSONB,
+    version BIGINT,
+    is_identified BOOLEAN NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    is_user_id INTEGER,
+    -- Operations to be applied (from ClickHouse query)
+    pending_operations JSONB NOT NULL,
+    -- AFTER state (computed before update)
+    properties_after JSONB,
+    properties_last_updated_at_after JSONB,
+    properties_last_operation_after JSONB,
+    version_after BIGINT,
+    -- Metadata
+    backed_up_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (job_id, team_id, person_id)
+);
+
+CREATE INDEX IF NOT EXISTS person_reconciliation_backup_team_person
+    ON posthog_person_reconciliation_backup (team_id, person_id);


### PR DESCRIPTION
## Problem

In case the person reconciliation goes wrong, we'd like to be able to restore the state.

## Changes

- Adds a backup table where the reconciliation script stores data from before and after the reconciliation for each person
- Adds a script to restore the data from the backup table

## How did you test this code?

- Added unit and integration tests