### PR TITLE
chore(mcp): add mcp server to mprocs

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -97,6 +97,10 @@ procs:
         shell: 'bin/check_postgres_up && bin/start-llm-gateway'
         autostart: true
 
+    mcp:
+        shell: 'bin/start-mcp-server'
+        autostart: false
+
     # This takes ~10 s
     migrate-postgres:
         shell: 'bin/check_postgres_up && bin/check_ducklake_up && bin/migrate --scope=postgres'

--- a/bin/start-mcp-server
+++ b/bin/start-mcp-server
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../services/mcp/typescript"
+
+pnpm install --frozen-lockfile
+
+export POSTHOG_BASE_URL="${POSTHOG_BASE_URL:-http://localhost:8000}"
+
+exec pnpm run dev

--- a/bin/start-mcp-server
+++ b/bin/start-mcp-server
@@ -3,8 +3,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../services/mcp/typescript"
 
-pnpm install --frozen-lockfile
+if [ ! -f .dev.vars ]; then
+    cp .dev.vars.example .dev.vars
+fi
 
-export POSTHOG_BASE_URL="${POSTHOG_BASE_URL:-http://localhost:8000}"
+pnpm install --frozen-lockfile
 
 exec pnpm run dev

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -277,9 +277,13 @@ build:
             - build:schema-latest-versions
         description: Generate all schema definitions (frontend JSON, Python, latest versions)
     build:openapi-schema:
-        cmd: |
-            mkdir -p frontend/tmp && DEBUG=1 OPENAPI_INCLUDE_INTERNAL=1 python manage.py spectacular --file frontend/tmp/openapi.json --format openapi-json && echo "OpenAPI schema written to frontend/tmp/openapi.json"
-        description: Generate OpenAPI schema from Django backend (writes to gitignored temp location)
+        cmd: 'mkdir -p frontend/tmp && DEBUG=1 OPENAPI_INCLUDE_INTERNAL=1 python manage.py
+            spectacular --file frontend/tmp/openapi.json --format openapi-json && echo "OpenAPI
+            schema written to frontend/tmp/openapi.json"
+
+            '
+        description: Generate OpenAPI schema from Django backend (writes to gitignored
+            temp location)
         services:
             - postgresql
             - clickhouse
@@ -462,7 +466,8 @@ quality:
         cmd: ./bin/ruff.sh check --fix
         description: Fix Python code quality issues
     format:markdown:
-        cmd: pnpm exec markdownlint-cli2 --config .config/.markdownlint-cli2.jsonc --fix "$@" && pnpm exec prettier --write "$@"
+        cmd: pnpm exec markdownlint-cli2 --config .config/.markdownlint-cli2.jsonc --fix
+            "$@" && pnpm exec prettier --write "$@"
         description: Format Markdown files
 tools:
     tool:temporal-django-worker:
@@ -529,6 +534,10 @@ tools:
     posthog:node:
         bin_script: posthog-node
         description: 'TODO: add description for posthog-node'
+        hidden: true
+    start:mcp:server:
+        bin_script: start-mcp-server
+        description: 'TODO: add description for start-mcp-server'
         hidden: true
 utilities:
     nuke:

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -529,7 +529,7 @@ tools:
         hidden: true
     start:llm:gateway:
         bin_script: start-llm-gateway
-        description: 'TODO: add description for start-llm-gateway'
+        description: 'Start the LLM gateway service'
         hidden: true
     posthog:node:
         bin_script: posthog-node
@@ -537,7 +537,7 @@ tools:
         hidden: true
     start:mcp:server:
         bin_script: start-mcp-server
-        description: 'TODO: add description for start-mcp-server'
+        description: 'Start the MCP server'
         hidden: true
 utilities:
     nuke:

--- a/services/mcp/.gitignore
+++ b/services/mcp/.gitignore
@@ -2,7 +2,8 @@ node_modules
 
 # wrangler files
 .wrangler
-.dev.vars*
+.dev.vars
+!.dev.vars.example
 .mcp.json
 .env.test
 

--- a/services/mcp/typescript/.dev.vars.example
+++ b/services/mcp/typescript/.dev.vars.example
@@ -1,0 +1,1 @@
+POSTHOG_BASE_URL=http://localhost:8000


### PR DESCRIPTION
it’s currently a bit awkard to run the mcp server, as it doesn’t live in mprocs like everything else does, this adds it there.