### PR TITLE
fix(sdk-doctor): add 30-day grace period for single-version cases

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSdkDoctorLogic.tsx
@@ -363,7 +363,7 @@ function computeAugmentedInfoRelease(
         // but no new events with the new version exist yet, causing confusing "Outdated" warnings
         const SINGLE_VERSION_GRACE_PERIOD_DAYS = 30
 
-        if (isSingleVersion && diff) {
+        if (isSingleVersion && diff && diff.kind !== 'patch') {
             isOutdated = daysSinceRelease !== undefined && daysSinceRelease > SINGLE_VERSION_GRACE_PERIOD_DAYS
         } else if (isRecentRelease) {
             // Apply grace period - don't flag anything <7 days old


### PR DESCRIPTION
## Problem

This was supposed to be fixed on https://github.com/PostHog/posthog/pull/40937 but I got sick at the time and it was auto-closed.

Fixes #44528

Extra context here: https://posthog.slack.com/archives/C04MZFDA5KK/p1767879691605179?thread_ts=1767878049.997409&cid=C04MZFDA5KK

To be fair, this will only happen until the dagster job runs again, so 30 days might seem too much, but we will soon have more work done on "sdk health" detection so we will probably have smarter detections.
