### PR TITLE
chore: Add event metadata section to funnel filters

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/FunnelsQuerySteps.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/FunnelsQuerySteps.tsx
@@ -76,6 +76,7 @@ export function FunnelsQuerySteps({ insightProps }: EditorFilterProps): JSX.Elem
                     TaxonomicFilterGroupType.EventProperties,
                     TaxonomicFilterGroupType.PersonProperties,
                     TaxonomicFilterGroupType.EventFeatureFlags,
+                    TaxonomicFilterGroupType.EventMetadata,
                     ...groupsTaxonomicTypes,
                     TaxonomicFilterGroupType.Cohorts,
                     TaxonomicFilterGroupType.Elements,


### PR DESCRIPTION
## Problem

The event metadata section doesn't appear for funnel filters

https://posthoghelp.zendesk.com/agent/tickets/44859 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49373)

## Changes

Added event metadata - I wasn't sure if we should be considering adding it to other places where it's missing, but don't have enough context to know if the sections there are chosen quite deliberately!

## How did you test this code?

Tested locally
