### PR TITLE
fix(logs): use HogQL for fetch_log_by_uuid to resolve table correctly

### DIFF
--- a/products/logs/backend/explain.py
+++ b/products/logs/backend/explain.py
@@ -23,8 +23,11 @@ from rest_framework import exceptions, serializers, status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.clickhouse.client import sync_execute
+from posthog.models import Team
 from posthog.rate_limit import (
     LLMAnalyticsSummarizationBurstThrottle,
     LLMAnalyticsSummarizationDailyThrottle,
@@ -153,7 +156,7 @@ def load_prompt_template(template_name: str, context: dict) -> str:
     return template.render(Context(context, autoescape=False))
 
 
-def fetch_log_by_uuid(team_id: int, uuid: str, timestamp: str) -> dict | None:
+def fetch_log_by_uuid(team: Team, uuid: str, timestamp: str) -> dict | None:
     """Fetch a single log entry from ClickHouse by UUID.
 
     The timestamp parameter is required for efficient lookup - it allows ClickHouse
@@ -172,22 +175,28 @@ def fetch_log_by_uuid(team_id: int, uuid: str, timestamp: str) -> dict | None:
             hex(span_id) as span_id,
             event_name
         FROM logs
-        WHERE team_id = %(team_id)s
-          AND uuid = %(uuid)s
-          AND timestamp >= %(timestamp)s - INTERVAL 1 SECOND
-          AND timestamp <= %(timestamp)s + INTERVAL 1 SECOND
+        WHERE uuid = {uuid}
+          AND timestamp >= {timestamp} - INTERVAL 1 SECOND
+          AND timestamp <= {timestamp} + INTERVAL 1 SECOND
         LIMIT 1
     """
-    results = sync_execute(query, {"team_id": team_id, "uuid": uuid, "timestamp": timestamp})
-    if not results:
+    response = execute_hogql_query(
+        query=query,
+        team=team,
+        placeholders={
+            "uuid": ast.Constant(value=uuid),
+            "timestamp": ast.Constant(value=timestamp),
+        },
+    )
+    if not response.results:
         return None
 
-    row = results[0]
+    row = response.results[0]
     return {
         "uuid": row[0],
         "timestamp": row[1].replace(tzinfo=ZoneInfo("UTC")) if row[1] else None,
         "body": row[2],
-        "attributes": row[3],  # filtered_attributes from query
+        "attributes": row[3],
         "severity_text": row[4],
         "service_name": row[5],
         "resource_attributes": row[6],
@@ -297,7 +306,7 @@ class LogExplainViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                     )
                     return Response(cached_result, status=status.HTTP_200_OK)
 
-            log_data = fetch_log_by_uuid(self.team_id, uuid, timestamp)
+            log_data = fetch_log_by_uuid(self.team, uuid, timestamp)
             if not log_data:
                 return Response({"error": "Log not found"}, status=status.HTTP_404_NOT_FOUND)
 

--- a/products/logs/backend/test/test_explain.py
+++ b/products/logs/backend/test/test_explain.py
@@ -173,7 +173,7 @@ class TestFetchLogByUuid(ClickhouseTestMixin, APIBaseTest):
             sync_execute(sql)
 
     def test_returns_none_for_nonexistent_uuid(self):
-        result = fetch_log_by_uuid(self.team.id, "nonexistent-uuid", "2025-12-16T09:01:22")
+        result = fetch_log_by_uuid(self.team, "nonexistent-uuid", "2025-12-16T09:01:22")
         assert result is None
 
     def test_returns_log_data_for_existing_uuid(self):
@@ -187,7 +187,7 @@ class TestFetchLogByUuid(ClickhouseTestMixin, APIBaseTest):
                 {json.dumps(log_item)}
             """)
 
-        result = fetch_log_by_uuid(self.team.id, log_item["uuid"], log_item["timestamp"])
+        result = fetch_log_by_uuid(self.team, log_item["uuid"], log_item["timestamp"])
         assert result is not None
         assert result["uuid"] == log_item["uuid"]
         assert result["service_name"] == log_item["service_name"]
@@ -206,7 +206,7 @@ class TestFetchLogByUuid(ClickhouseTestMixin, APIBaseTest):
                 {json.dumps(log_item)}
             """)
 
-        result = fetch_log_by_uuid(self.team.id, log_item["uuid"], log_item["timestamp"])
+        result = fetch_log_by_uuid(self.team, log_item["uuid"], log_item["timestamp"])
         assert result is None
 
 


### PR DESCRIPTION
## Problem

The current implementation of log fetching in the explain.py module wasn't resolving the correct logs table.

## Changes

- Replaced direct SQL execution with HogQL query execution for fetching logs by UUID
- Changed `fetch_log_by_uuid` to accept a Team object instead of team_id
- Added proper parameter handling using HogQL AST constants
- Removed unnecessary filtering by team_id in the query as this is handled by the HogQL execution context
- Updated imports to include necessary HogQL components

## How did you test this code?

Updated unit tests & tested generation locally

## Publish to changelog?

No