### PR TITLE
feat: switch /deactivate to post

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -252,11 +252,12 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     class DeactivateSerializer(serializers.Serializer):
         products = serializers.CharField()
 
-    @action(methods=["GET"], detail=False)
+    @action(methods=["GET", "POST"], detail=False)
     def deactivate(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         organization = self._get_org_required()
 
-        serializer = self.DeactivateSerializer(data=request.GET)
+        data = request.GET if request.method == "GET" else request.data
+        serializer = self.DeactivateSerializer(data=data)
         serializer.is_valid(raise_exception=True)
 
         products = serializer.validated_data.get("products")

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -252,12 +252,11 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     class DeactivateSerializer(serializers.Serializer):
         products = serializers.CharField()
 
-    @action(methods=["GET", "POST"], detail=False)
+    @action(methods=["POST"], detail=False)
     def deactivate(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         organization = self._get_org_required()
 
-        data = request.GET if request.method == "GET" else request.data
-        serializer = self.DeactivateSerializer(data=data)
+        serializer = self.DeactivateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         products = serializer.validated_data.get("products")

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -957,7 +957,7 @@ class TestActivateBillingAPI(APILicensedTest):
         url = "/api/billing/deactivate"
         data = {"products": "product_1"}
 
-        response = self.client.get(url, data)
+        response = self.client.post(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_deactivate_products.assert_called_once_with(self.organization, "product_1")
@@ -967,7 +967,7 @@ class TestActivateBillingAPI(APILicensedTest):
         url = "/api/billing/deactivate"
         data = {"none": "nothing"}
 
-        response = self.client.get(url, data)
+        response = self.client.post(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -262,9 +262,10 @@ class BillingManager:
             capture_exception(e, {"organization_id": organization.id})
 
     def deactivate_products(self, organization: Organization, products: str) -> None:
-        res = requests.get(
-            f"{BILLING_SERVICE_URL}/api/billing/deactivate?products={products}",
+        res = requests.post(
+            f"{BILLING_SERVICE_URL}/api/billing/deactivate",
             headers=self.get_auth_headers(organization),
+            json={"products": products},
         )
 
         handle_billing_service_error(res)

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -336,7 +336,7 @@ export const billingLogic = kea<billingLogicType>([
 
                     actions.resetUnsubscribeError()
                     try {
-                        const response = await api.getResponse('api/billing/deactivate?products=' + key)
+                        const response = await api.createResponse('api/billing/deactivate', { products: key })
                         const jsonRes = await getJSONOrNull(response)
 
                         lemonToast.success(


### PR DESCRIPTION
## Changes

Switching to POST requests on `/deactivate` endpoint - for more context see `billing` PR: https://github.com/PostHog/billing/pull/1727

## How did you test this code?

- Manually (subscribed and deactivated before and after these changes)
- Updated existing tests
