### PR TITLE
fix: Remove early return for heatmap data processing in extractH…

### DIFF
--- a/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.test.ts
@@ -56,8 +56,8 @@ describe('createExtractHeatmapDataStep', () => {
         })
     })
 
-    describe('early return optimization', () => {
-        it('returns early when no $heatmap_data is present', async () => {
+    describe('no heatmap or scroll depth data', () => {
+        it('returns OK with no side effects when no $heatmap_data or scroll depth data is present', async () => {
             const event = createTestEvent()
             delete event.properties.$heatmap_data
 
@@ -65,7 +65,7 @@ describe('createExtractHeatmapDataStep', () => {
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
-                expect(result.value.preparedEvent).toBe(event)
+                expect(result.value.preparedEvent).toEqual(event)
                 expect(result.sideEffects).toEqual([])
                 expect(result.warnings).toEqual([])
             }

--- a/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
+++ b/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
@@ -23,12 +23,6 @@ export function createExtractHeatmapDataStep<TInput extends ExtractHeatmapDataSt
         input: TInput
     ): Promise<PipelineResult<ExtractHeatmapDataStepResult<TInput>>> {
         const { preparedEvent } = input
-
-        // Early return if there's no heatmap data to process
-        if (!preparedEvent.properties?.['$heatmap_data']) {
-            return Promise.resolve(ok({ ...input, preparedEvent }))
-        }
-
         const { eventUuid } = preparedEvent
         const acks: Promise<void>[] = []
         const warnings: PipelineWarning[] = []


### PR DESCRIPTION
## Problem

We are having problems with the scrolldepth heatmap: https://posthoghelp.zendesk.com/agent/tickets/45258. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49075) After investigating with Claude we realized that the ingestion could be the problem and the date of the start of the issue and this PR matches: https://github.com/PostHog/posthog/pull/43078/files#diff-f59241b59089b25f6bbd294b9271f489701d8c517ff8959d1b11cae68687c307R27

<img width="825" height="335" alt="image" src="https://github.com/user-attachments/assets/9b087868-39d1-46d3-9c80-25c48c654f54" />


## Changes

Based on that, I removed the early return.

## How did you test this code?
Added new test. Tested it locally:
<img width="1220" height="718" alt="image" src="https://github.com/user-attachments/assets/be9f01bf-c345-4a24-ae25-7a2f3202dd84" />




