### PR TITLE
fix(llma): ensure `$ai_error_normalized` is always set for error events

### DIFF
--- a/nodejs/src/ingestion/ai/errors/index.ts
+++ b/nodejs/src/ingestion/ai/errors/index.ts
@@ -3,14 +3,16 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 import { aiErrorNormalizationCounter } from '../metrics'
 import { normalizeError } from './normalize-error'
 
+const UNKNOWN_ERROR = 'Unknown error'
+
 /**
  * Process error normalization for AI events.
  *
- * Only normalizes events that have $ai_is_error = true and $ai_error property.
- * Adds $ai_error_normalized property with the normalized error message.
+ * For all events with $ai_is_error = true, ensures $ai_error_normalized is set.
+ * This guarantees errors can be grouped in the LLM analytics errors tab.
  *
  * This is a non-blocking operation - if normalization fails for any reason,
- * the original event is returned unchanged.
+ * a fallback value is used.
  */
 export function processAiErrorNormalization<T extends PluginEvent>(event: T): T {
     if (!event.properties) {
@@ -31,6 +33,9 @@ export function processAiErrorNormalization<T extends PluginEvent>(event: T): T 
 
         const aiError = event.properties['$ai_error']
         if (aiError === undefined || aiError === null) {
+            // No error message provided, use fallback
+            event.properties['$ai_error_normalized'] = UNKNOWN_ERROR
+            aiErrorNormalizationCounter.labels({ status: 'fallback' }).inc()
             return event
         }
 
@@ -49,14 +54,14 @@ export function processAiErrorNormalization<T extends PluginEvent>(event: T): T 
         // Normalize the error message
         const normalizedError = normalizeError(errorString)
 
-        // Only set if we have a non-empty normalized error
-        if (normalizedError) {
-            event.properties['$ai_error_normalized'] = normalizedError
-            aiErrorNormalizationCounter.labels({ status: 'normalized' }).inc()
-        }
+        // Always set normalized error, use fallback if normalization produced empty result
+        event.properties['$ai_error_normalized'] = normalizedError || UNKNOWN_ERROR
+        aiErrorNormalizationCounter.labels({ status: normalizedError ? 'normalized' : 'fallback' }).inc()
 
         return event
     } catch {
+        // Ensure we still set a value even on error
+        event.properties['$ai_error_normalized'] = UNKNOWN_ERROR
         aiErrorNormalizationCounter.labels({ status: 'error' }).inc()
         return event
     }

--- a/nodejs/src/ingestion/ai/errors/normalize-error.test.ts
+++ b/nodejs/src/ingestion/ai/errors/normalize-error.test.ts
@@ -296,14 +296,36 @@ describe('processAiErrorNormalization', () => {
         expect(result.properties!['$ai_error_normalized']).toBeUndefined()
     })
 
-    it('does not add $ai_error_normalized when $ai_error is missing', () => {
+    it('sets fallback when $ai_error is missing', () => {
         const event = createEvent({
             $ai_is_error: true,
         })
 
         const result = processAiErrorNormalization(event)
 
-        expect(result.properties!['$ai_error_normalized']).toBeUndefined()
+        expect(result.properties!['$ai_error_normalized']).toBe('Unknown error')
+    })
+
+    it('sets fallback when $ai_error is null', () => {
+        const event = createEvent({
+            $ai_is_error: true,
+            $ai_error: null,
+        })
+
+        const result = processAiErrorNormalization(event)
+
+        expect(result.properties!['$ai_error_normalized']).toBe('Unknown error')
+    })
+
+    it('sets fallback when $ai_error normalizes to empty string', () => {
+        const event = createEvent({
+            $ai_is_error: true,
+            $ai_error: '   ',
+        })
+
+        const result = processAiErrorNormalization(event)
+
+        expect(result.properties!['$ai_error_normalized']).toBe('Unknown error')
     })
 
     it('handles events without properties', () => {

--- a/products/llm_analytics/backend/queries/errors.sql
+++ b/products/llm_analytics/backend/queries/errors.sql
@@ -1,37 +1,27 @@
 /*
--- Error normalization is now done at ingestion time.
+-- Error normalization is done at ingestion time.
 -- The $ai_error_normalized property contains the pre-computed normalized error message.
 -- See: nodejs/src/ingestion/ai/errors/normalize-error.ts
+--
+-- This query uses HogQL property syntax (properties.$prop) to leverage materialized columns
+-- for $ai_trace_id, $ai_session_id, and $ai_is_error for better performance.
 */
 
-WITH
-
-normalized_errors AS (
-    SELECT
-        distinct_id,
-        timestamp,
-        event,
-        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '') as ai_trace_id,
-        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$ai_session_id'), ''), 'null'), '^"|"$', '') as ai_session_id,
-        JSONExtractString(properties, '$ai_error_normalized') as normalized_error
-    FROM events
-    WHERE event IN ('$ai_generation', '$ai_span', '$ai_trace', '$ai_embedding')
-        AND properties.$ai_is_error = 'true'
-        AND {filters}
-)
-
 SELECT
-    normalized_error as error,
-    countDistinctIf(ai_trace_id, isNotNull(ai_trace_id) AND ai_trace_id != '') as traces,
+    properties.$ai_error_normalized as error,
+    countDistinctIf(properties.$ai_trace_id, properties.$ai_trace_id != '') as traces,
     countIf(event = '$ai_generation') as generations,
     countIf(event = '$ai_span') as spans,
     countIf(event = '$ai_embedding') as embeddings,
-    countDistinctIf(ai_session_id, isNotNull(ai_session_id) AND ai_session_id != '') as sessions,
+    countDistinctIf(properties.$ai_session_id, properties.$ai_session_id != '') as sessions,
     uniq(distinct_id) as users,
     uniq(toDate(timestamp)) as days_seen,
     min(timestamp) as first_seen,
     max(timestamp) as last_seen
-FROM normalized_errors
-GROUP BY normalized_error
+FROM events
+WHERE event IN ('$ai_generation', '$ai_span', '$ai_trace', '$ai_embedding')
+    AND properties.$ai_is_error = 'true'
+    AND {filters}
+GROUP BY error
 ORDER BY __ORDER_BY__ __ORDER_DIRECTION__
 LIMIT 100


### PR DESCRIPTION
## Problem

1. Users see "No error" rows in the LLM analytics errors tab. This happens when events have `$ai_is_error=true` but either:
   - The `$ai_error` property is missing/null
   - The error normalization produces an empty string

2. The errors.sql query was not using materialized columns for `$ai_trace_id` and `$ai_session_id`, resulting in slower JSON extraction.

## Changes

### Fix: Always set $ai_error_normalized
- Always set `$ai_error_normalized` to "Unknown error" as a fallback when `$ai_is_error=true` but no valid error message is available
- Added tests for the fallback behavior

### Perf: Optimize errors query
- Simplified query to use HogQL property syntax (`properties.$ai_trace_id`) which resolves to materialized columns
- Removed unnecessary CTE structure
- Now uses `mat_$ai_trace_id`, `mat_$ai_session_id`, and `mat_$ai_is_error` materialized columns

## How did you test this code?

- Added unit tests for missing `$ai_error`, null `$ai_error`, and empty normalization cases
- All 66 tests pass
- Benchmarked query performance locally: ~27% improvement with identical results

## Publish to changelog?

No