### PR TITLE
chore(flags): Add flags_cache_source to canonical log line

### DIFF
--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::time::timeout;
-use tracing::{debug, info, warn};
+use tracing::debug;
 
 /// Metric name for tracking hypercache operations in Prometheus (same one used in Django's HyperCache)
 const HYPERCACHE_COUNTER_NAME: &str = "posthog_hypercache_get_from_cache";
@@ -318,14 +318,14 @@ impl HyperCacheReader {
                 return Ok((data, CacheSource::Redis));
             }
             Ok(Err(e)) => {
-                info!(
+                debug!(
                     cache_key = %redis_cache_key,
                     error = %e,
                     "HyperCache Redis miss, trying S3"
                 );
             }
             Err(_) => {
-                info!(
+                debug!(
                     cache_key = %redis_cache_key,
                     "HyperCache Redis timeout, trying S3"
                 );
@@ -353,21 +353,21 @@ impl HyperCacheReader {
                 return Ok((data, CacheSource::S3));
             }
             Ok(Err(e)) => {
-                info!(
+                debug!(
                     cache_key = %s3_cache_key,
                     error = %e,
                     "HyperCache S3 miss"
                 );
             }
             Err(_) => {
-                info!(
+                debug!(
                     cache_key = %s3_cache_key,
                     "HyperCache S3 timeout"
                 );
             }
         }
 
-        warn!(
+        debug!(
             redis_key = %redis_cache_key,
             s3_key = %s3_cache_key,
             namespace = %self.config.namespace,

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -92,6 +92,8 @@ pub struct FlagsCanonicalLogLine {
     pub flags_experience_continuity: usize,
     pub flags_disabled: bool,
     pub quota_limited: bool,
+    /// Source of the flags data: "Redis", "S3", or "Fallback" (PostgreSQL).
+    pub flags_cache_source: Option<&'static str>,
 
     // Deep evaluation metrics (populated via task_local from flag_matching.rs)
     /// Total number of database property fetch operations (aggregate counter).
@@ -146,6 +148,7 @@ impl Default for FlagsCanonicalLogLine {
             flags_experience_continuity: 0,
             flags_disabled: false,
             quota_limited: false,
+            flags_cache_source: None,
             db_property_fetches: 0,
             person_queries: 0,
             group_queries: 0,
@@ -199,6 +202,7 @@ impl FlagsCanonicalLogLine {
             flags_experience_continuity = self.flags_experience_continuity,
             flags_disabled = self.flags_disabled,
             quota_limited = self.quota_limited,
+            flags_cache_source = ?self.flags_cache_source,
             db_property_fetches = self.db_property_fetches,
             person_queries = self.person_queries,
             group_queries = self.group_queries,
@@ -255,6 +259,7 @@ mod tests {
         assert_eq!(log.flags_experience_continuity, 0);
         assert!(!log.flags_disabled);
         assert!(!log.quota_limited);
+        assert!(log.flags_cache_source.is_none());
         assert_eq!(log.db_property_fetches, 0);
         assert_eq!(log.person_queries, 0);
         assert_eq!(log.group_queries, 0);
@@ -293,6 +298,7 @@ mod tests {
         log.flags_experience_continuity = 2;
         log.flags_disabled = false;
         log.quota_limited = true;
+        log.flags_cache_source = Some("Redis");
         log.db_property_fetches = 3;
         log.property_cache_hits = 5;
         log.property_cache_misses = 2;

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -17,8 +17,9 @@ use serde_json::Value;
 use std::collections::HashMap;
 use uuid::Uuid;
 
-use super::{evaluation, types::FeatureFlagEvaluationContext};
+use super::{evaluation, types::FeatureFlagEvaluationContext, with_canonical_log};
 use crate::router;
+use common_hypercache::CacheSource;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -151,6 +152,14 @@ pub async fn fetch_and_filter(
     environment_tags: Option<&Vec<String>>,
 ) -> Result<FeatureFlagList, FlagError> {
     let flag_result = flag_service.get_flags_from_cache_or_pg(team_id).await?;
+
+    // Record cache source in canonical log for observability
+    let source_name = match flag_result.cache_source {
+        CacheSource::Redis => "Redis",
+        CacheSource::S3 => "S3",
+        CacheSource::Fallback => "Fallback",
+    };
+    with_canonical_log(|log| log.flags_cache_source = Some(source_name));
 
     // First filter by survey flags if requested
     let flags_after_survey_filter = filter_survey_flags(


### PR DESCRIPTION
## Problem

When looking at the logs to ensure we're hitting the cache properly, we have to correlate multiple log entries to see what the final source for the flags data ended up being.

## Changes

Add a `flags_cache_source` field to the canonical log to track where feature flags data was loaded from (Redis, S3, or Fallback/PostgreSQL).

Also change Hypercache library logs from info/warn to debug level since the canonical log now provides the summary information needed for analytics.

## How did you test this code?

Unit Test
Manual testing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No