### PR TITLE
feat(product tours): set up foundation for announcement mode

### DIFF
--- a/frontend/src/scenes/product-tours/AnnouncementContentEditor.tsx
+++ b/frontend/src/scenes/product-tours/AnnouncementContentEditor.tsx
@@ -1,0 +1,64 @@
+import { JSONContent } from '@tiptap/core'
+import { renderProductTourPreview } from 'posthog-js/dist/product-tours-preview'
+import { useEffect, useRef } from 'react'
+
+import { ProductTourAppearance, ProductTourStep } from '~/types'
+
+import { StepContentEditor } from './editor/StepContentEditor'
+import { StepLayoutSettings } from './editor/StepLayoutSettings'
+import { prepareStepForRender } from './editor/generateStepHtml'
+
+export interface AnnouncementContentEditorProps {
+    step: ProductTourStep | undefined
+    appearance: ProductTourAppearance | undefined
+    onChange: (step: ProductTourStep) => void
+}
+
+export function AnnouncementContentEditor({ step, appearance, onChange }: AnnouncementContentEditorProps): JSX.Element {
+    const previewRef = useRef<HTMLDivElement>(null)
+
+    const updateStep = (updates: Partial<ProductTourStep>): void => {
+        if (step) {
+            onChange({ ...step, ...updates })
+        }
+    }
+
+    useEffect(() => {
+        if (previewRef.current && step) {
+            renderProductTourPreview({
+                step: prepareStepForRender(step) as any,
+                appearance: appearance as any,
+                parentElement: previewRef.current,
+                stepIndex: 0,
+                totalSteps: 1,
+            })
+        }
+    }, [step, step?.maxWidth, appearance])
+
+    if (!step) {
+        return <div>No content</div>
+    }
+
+    return (
+        <div className="flex gap-8 items-start">
+            <div className="flex-1 min-w-0">
+                <StepContentEditor
+                    content={step.content as JSONContent | null}
+                    onChange={(content) => updateStep({ content })}
+                    placeholder="Type '/' for commands, or start writing your announcement..."
+                />
+
+                <div className="mt-6 pt-6 border-t">
+                    <StepLayoutSettings step={step} onChange={updateStep} />
+                </div>
+            </div>
+
+            <div className="flex-1 min-w-0 sticky top-4">
+                <div className="text-xs text-muted uppercase tracking-wide mb-3">Preview</div>
+                <div className="flex justify-center items-center p-8 bg-[#f0f0f0] rounded min-h-[300px]">
+                    <div ref={previewRef} />
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -16,11 +16,13 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductTourStep } from '~/types'
 
+import { AnnouncementContentEditor } from './AnnouncementContentEditor'
 import { AutoShowSection } from './components/AutoShowSection'
 import { EditInToolbarButton } from './components/EditInToolbarButton'
 import { ProductTourCustomization } from './components/ProductTourCustomization'
 import { ProductTourStepsEditor } from './editor'
 import { ProductTourEditTab, productTourLogic } from './productTourLogic'
+import { isAnnouncement } from './productToursLogic'
 
 export function ProductTourEdit({ id }: { id: string }): JSX.Element {
     const {
@@ -49,12 +51,12 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
             <SceneContent>
                 <SceneTitleSection
                     name={productTour.name}
-                    description="Edit product tour settings"
+                    description={isAnnouncement(productTour) ? 'Edit announcement' : 'Edit product tour settings'}
                     resourceType={{ type: 'product_tour' }}
                     isLoading={productTourLoading}
                     actions={
                         <>
-                            <EditInToolbarButton tourId={id} />
+                            {!isAnnouncement(productTour) && <EditInToolbarButton tourId={id} />}
                             <LemonButton type="secondary" size="small" onClick={() => editingProductTour(false)}>
                                 Cancel
                             </LemonButton>
@@ -75,7 +77,14 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                     onChange={(newTab) => setEditTab(newTab as ProductTourEditTab)}
                     tabs={[
                         { key: ProductTourEditTab.Configuration, label: 'Configuration' },
-                        ...(showStepsEditor ? [{ key: ProductTourEditTab.Steps, label: 'Steps' }] : []),
+                        ...(showStepsEditor
+                            ? [
+                                  {
+                                      key: ProductTourEditTab.Steps,
+                                      label: isAnnouncement(productTour) ? 'Content' : 'Steps',
+                                  },
+                              ]
+                            : []),
                         { key: ProductTourEditTab.Customization, label: 'Customization' },
                     ]}
                 />
@@ -87,14 +96,6 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                                 placeholder="Tour name"
                                 value={productTourForm.name}
                                 onChange={(value) => setProductTourFormValue('name', value)}
-                            />
-                        </LemonField>
-
-                        <LemonField name="description" label="Description">
-                            <LemonInput
-                                placeholder="Optional description"
-                                value={productTourForm.description}
-                                onChange={(value) => setProductTourFormValue('description', value)}
                             />
                         </LemonField>
 
@@ -201,18 +202,30 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                     </div>
                 )}
 
-                {editTab === ProductTourEditTab.Steps && (
-                    <ProductTourStepsEditor
-                        steps={productTourForm.content?.steps ?? []}
-                        appearance={productTourForm.content?.appearance}
-                        onChange={(steps: ProductTourStep[]) => {
-                            setProductTourFormValue('content', {
-                                ...productTourForm.content,
-                                steps,
-                            })
-                        }}
-                    />
-                )}
+                {editTab === ProductTourEditTab.Steps &&
+                    (isAnnouncement(productTour) ? (
+                        <AnnouncementContentEditor
+                            step={productTourForm.content?.steps?.[0]}
+                            appearance={productTourForm.content?.appearance}
+                            onChange={(step: ProductTourStep) => {
+                                setProductTourFormValue('content', {
+                                    ...productTourForm.content,
+                                    steps: [step],
+                                })
+                            }}
+                        />
+                    ) : (
+                        <ProductTourStepsEditor
+                            steps={productTourForm.content?.steps ?? []}
+                            appearance={productTourForm.content?.appearance}
+                            onChange={(steps: ProductTourStep[]) => {
+                                setProductTourFormValue('content', {
+                                    ...productTourForm.content,
+                                    steps,
+                                })
+                            }}
+                        />
+                    ))}
 
                 {editTab === ProductTourEditTab.Customization && (
                     <ProductTourCustomization

--- a/frontend/src/scenes/product-tours/ProductTourView.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourView.tsx
@@ -40,7 +40,7 @@ import {
 import { EditInToolbarButton } from './components/EditInToolbarButton'
 import { ProductTourStatsSummary } from './components/ProductTourStatsSummary'
 import { productTourLogic } from './productTourLogic'
-import { getProductTourStatus, isProductTourRunning, productToursLogic } from './productToursLogic'
+import { getProductTourStatus, isAnnouncement, isProductTourRunning, productToursLogic } from './productToursLogic'
 
 export function ProductTourView({ id }: { id: string }): JSX.Element {
     const { productTour, productTourLoading, tourStats, tourStatsLoading, dateRange, targetingFlagFilters } = useValues(
@@ -59,7 +59,6 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
 
     const status = getProductTourStatus(productTour)
     const isRunning = isProductTourRunning(productTour)
-    const hasUrlCondition = !!productTour.content?.conditions?.url
 
     return (
         <SceneContent>
@@ -115,7 +114,6 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
                             <LemonButton
                                 type="primary"
                                 size="small"
-                                disabledReason={!hasUrlCondition ? 'Set a URL pattern before launching' : undefined}
                                 onClick={() => {
                                     LemonDialog.open({
                                         title: 'Launch this product tour?',
@@ -229,8 +227,12 @@ export function ProductTourView({ id }: { id: string }): JSX.Element {
                                     }
                                 />
                                 <LemonDivider />
-                                <StepsFunnel tour={productTour} dateRange={dateRange} />
-                                <LemonDivider />
+                                {!isAnnouncement(productTour) && (
+                                    <>
+                                        <StepsFunnel tour={productTour} dateRange={dateRange} />
+                                        <LemonDivider />
+                                    </>
+                                )}
                                 <TargetingSummary tour={productTour} targetingFlagFilters={targetingFlagFilters} />
                             </div>
                         ),

--- a/frontend/src/scenes/product-tours/ProductTours.tsx
+++ b/frontend/src/scenes/product-tours/ProductTours.tsx
@@ -1,10 +1,8 @@
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
-import { LemonButton, LemonModal } from '@posthog/lemon-ui'
+import { LemonButton } from '@posthog/lemon-ui'
 
-import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
-import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -15,6 +13,7 @@ import { Error404 } from '~/layout/Error404'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
+import { NewProductTourModal } from './components/NewProductTourModal'
 import { ProductToursTable } from './components/ProductToursTable'
 import { ProductToursTabs, productToursLogic } from './productToursLogic'
 
@@ -24,28 +23,19 @@ export const scene: SceneExport = {
 }
 
 function NewTourButton(): JSX.Element {
+    const { createAnnouncement } = useActions(productToursLogic)
     const [isModalOpen, setIsModalOpen] = useState(false)
 
     return (
         <>
             <LemonButton size="small" type="primary" onClick={() => setIsModalOpen(true)} data-attr="new-product-tour">
-                New tour
+                New
             </LemonButton>
-            <LemonModal
-                title="Create a new product tour"
-                description="Select a URL to launch the toolbar and create your product tour"
+            <NewProductTourModal
                 isOpen={isModalOpen}
                 onClose={() => setIsModalOpen(false)}
-                width={600}
-            >
-                <div className="mt-4">
-                    <AuthorizedUrlList
-                        type={AuthorizedUrlListType.TOOLBAR_URLS}
-                        addText="Add authorized URL"
-                        productTourId="new"
-                    />
-                </div>
-            </LemonModal>
+                onCreateAnnouncement={createAnnouncement}
+            />
         </>
     )
 }

--- a/frontend/src/scenes/product-tours/components/NewProductTourModal.tsx
+++ b/frontend/src/scenes/product-tours/components/NewProductTourModal.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react'
+
+import { IconCursorClick, IconMegaphone } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonLabel, LemonModal } from '@posthog/lemon-ui'
+
+import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
+import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
+
+import { ProductTourType } from '~/types'
+
+type ModalStep = 'type-selection' | 'url-selection' | 'announcement-name'
+
+const MODAL_TITLES: Record<ModalStep, string> = {
+    'type-selection': 'What would you like to create?',
+    'url-selection': 'Create a new product tour',
+    'announcement-name': 'Create a new announcement',
+}
+
+const MODAL_DESCRIPTIONS: Partial<Record<ModalStep, string>> = {
+    'url-selection': 'Select a URL to launch the toolbar and create your product tour',
+}
+
+export interface NewProductTourModalProps {
+    isOpen: boolean
+    onClose: () => void
+    onCreateAnnouncement: (name: string) => void
+}
+
+export function NewProductTourModal({ isOpen, onClose, onCreateAnnouncement }: NewProductTourModalProps): JSX.Element {
+    const [modalStep, setModalStep] = useState<ModalStep>('type-selection')
+    const [announcementName, setAnnouncementName] = useState('')
+
+    const resetModal = (): void => {
+        setModalStep('type-selection')
+        setAnnouncementName('')
+    }
+
+    const handleClose = (): void => {
+        onClose()
+        resetModal()
+    }
+
+    const handleTypeSelect = (type: ProductTourType): void => {
+        if (type === 'tour') {
+            setModalStep('url-selection')
+        } else {
+            setModalStep('announcement-name')
+        }
+    }
+
+    const handleCreateAnnouncement = (): void => {
+        if (announcementName.trim()) {
+            onCreateAnnouncement(announcementName.trim())
+            handleClose()
+        }
+    }
+
+    return (
+        <LemonModal
+            title={MODAL_TITLES[modalStep]}
+            description={MODAL_DESCRIPTIONS[modalStep]}
+            isOpen={isOpen}
+            onClose={handleClose}
+            width={600}
+        >
+            {modalStep === 'type-selection' ? (
+                <TypeSelectionStep onSelect={handleTypeSelect} />
+            ) : modalStep === 'announcement-name' ? (
+                <AnnouncementNameStep
+                    name={announcementName}
+                    onChange={setAnnouncementName}
+                    onBack={resetModal}
+                    onCreate={handleCreateAnnouncement}
+                />
+            ) : (
+                <UrlSelectionStep onBack={resetModal} />
+            )}
+        </LemonModal>
+    )
+}
+
+function TypeSelectionStep({ onSelect }: { onSelect: (type: ProductTourType) => void }): JSX.Element {
+    return (
+        <div className="flex gap-3 mt-2">
+            <button
+                type="button"
+                onClick={() => onSelect('tour')}
+                className="flex-1 flex flex-col items-center gap-3 p-6 rounded-lg border border-border hover:border-primary hover:bg-fill-button-tertiary-hover cursor-pointer transition-colors text-left"
+            >
+                <IconCursorClick className="text-3xl text-muted" />
+                <div>
+                    <div className="font-semibold mb-1">Product tour</div>
+                    <div className="text-muted text-sm">
+                        Multi-step walkthrough that guides users through your product
+                    </div>
+                </div>
+            </button>
+            <button
+                type="button"
+                onClick={() => onSelect('announcement')}
+                className="flex-1 flex flex-col items-center gap-3 p-6 rounded-lg border border-border hover:border-primary hover:bg-fill-button-tertiary-hover cursor-pointer transition-colors text-left"
+            >
+                <IconMegaphone className="text-3xl text-muted" />
+                <div>
+                    <div className="font-semibold mb-1">Announcement</div>
+                    <div className="text-muted text-sm">
+                        Single popup to announce a feature, share news, or display a message
+                    </div>
+                </div>
+            </button>
+        </div>
+    )
+}
+
+function AnnouncementNameStep({
+    name,
+    onChange,
+    onBack,
+    onCreate,
+}: {
+    name: string
+    onChange: (name: string) => void
+    onBack: () => void
+    onCreate: () => void
+}): JSX.Element {
+    return (
+        <div className="space-y-4">
+            <LemonLabel className="mb-2">Announcement title</LemonLabel>
+            <LemonInput
+                placeholder="e.g. New feature launch, Welcome message"
+                value={name}
+                onChange={onChange}
+                autoFocus
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                        onCreate()
+                    }
+                }}
+            />
+            <div className="flex justify-end gap-2">
+                <LemonButton type="secondary" onClick={onBack}>
+                    Back
+                </LemonButton>
+                <LemonButton
+                    type="primary"
+                    onClick={onCreate}
+                    disabledReason={!name.trim() ? 'Enter a name' : undefined}
+                >
+                    Create
+                </LemonButton>
+            </div>
+        </div>
+    )
+}
+
+function UrlSelectionStep({ onBack }: { onBack: () => void }): JSX.Element {
+    return (
+        <div className="mt-4 flex flex-col space-y-4">
+            <AuthorizedUrlList
+                type={AuthorizedUrlListType.TOOLBAR_URLS}
+                addText="Add authorized URL"
+                productTourId="new"
+            />
+            <div>
+                <LemonButton type="secondary" onClick={onBack}>
+                    &larr; Back
+                </LemonButton>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductToursTable.tsx
@@ -1,6 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
+import { IconCursorClick, IconMegaphone } from '@posthog/icons'
 import { LemonButton, LemonDialog, LemonDivider, LemonInput, LemonTable, LemonTag } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
@@ -14,7 +15,13 @@ import { urls } from 'scenes/urls'
 
 import { ProductTour, ProgressStatus } from '~/types'
 
-import { ProductToursTabs, getProductTourStatus, isProductTourRunning, productToursLogic } from '../productToursLogic'
+import {
+    ProductToursTabs,
+    getProductTourStatus,
+    isAnnouncement,
+    isProductTourRunning,
+    productToursLogic,
+} from '../productToursLogic'
 
 function ProductTourStatusTag({ tour }: { tour: ProductTour }): JSX.Element {
     const status = getProductTourStatus(tour)
@@ -67,14 +74,25 @@ export function ProductToursTable(): JSX.Element {
                         title: 'Name',
                         render: function RenderName(_, tour) {
                             return (
-                                <LemonTableLink to={urls.productTour(tour.id)} title={stringWithWBR(tour.name, 17)} />
+                                <div className="flex gap-2 items-center justify-start">
+                                    <LemonTag
+                                        type="option"
+                                        icon={isAnnouncement(tour) ? <IconMegaphone /> : <IconCursorClick />}
+                                    >
+                                        {isAnnouncement(tour) ? 'Announcement' : 'Tour'}
+                                    </LemonTag>
+                                    <LemonTableLink
+                                        to={urls.productTour(tour.id)}
+                                        title={stringWithWBR(tour.name, 17)}
+                                    />
+                                </div>
                             )
                         },
                     },
                     {
                         title: 'Steps',
                         render: function RenderSteps(_, tour) {
-                            return tour.content?.steps?.length ?? 0
+                            return isAnnouncement(tour) ? '-' : (tour.content?.steps?.length ?? 0)
                         },
                     },
                     ...(tab === ProductToursTabs.Active
@@ -108,11 +126,6 @@ export function ProductToursTable(): JSX.Element {
                                             {!tour.start_date && (
                                                 <LemonButton
                                                     fullWidth
-                                                    disabledReason={
-                                                        !tour.content?.conditions?.url
-                                                            ? 'Set a URL pattern before launching'
-                                                            : undefined
-                                                    }
                                                     onClick={() => {
                                                         LemonDialog.open({
                                                             title: 'Launch this product tour?',

--- a/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
@@ -2,7 +2,7 @@ import './ProductTourStepsEditor.scss'
 
 import { JSONContent } from '@tiptap/core'
 import { renderProductTourPreview } from 'posthog-js/dist/product-tours-preview'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import {
     IconChevronLeft,
@@ -13,9 +13,8 @@ import {
     IconQuestion,
     IconTrash,
 } from '@posthog/icons'
-import { LemonBadge, LemonButton, LemonDivider, LemonModal, LemonSegmentedButton } from '@posthog/lemon-ui'
+import { LemonBadge, LemonButton, LemonDivider, LemonModal } from '@posthog/lemon-ui'
 
-import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
 import { PositionSelector } from 'scenes/surveys/survey-appearance/SurveyAppearancePositionSelector'
 
 import {
@@ -29,6 +28,7 @@ import {
 } from '~/types'
 
 import { StepContentEditor } from './StepContentEditor'
+import { StepLayoutSettings } from './StepLayoutSettings'
 import { StepScreenshotThumbnail } from './StepScreenshotThumbnail'
 import { SurveyStepEditor } from './SurveyStepEditor'
 import { prepareStepForRender } from './generateStepHtml'
@@ -63,7 +63,7 @@ function getStepTitle(step: ProductTourStep, index: number): string {
     return `Step ${index + 1}`
 }
 
-function getWidthValue(maxWidth: ProductTourStep['maxWidth']): number {
+export function getWidthValue(maxWidth: ProductTourStep['maxWidth']): number {
     if (typeof maxWidth === 'number') {
         return maxWidth
     }
@@ -73,11 +73,11 @@ function getWidthValue(maxWidth: ProductTourStep['maxWidth']): number {
     return PRODUCT_TOUR_STEP_WIDTHS.default
 }
 
-function isPresetWidth(width: number): boolean {
+export function isPresetWidth(width: number): boolean {
     return Object.values(PRODUCT_TOUR_STEP_WIDTHS).includes(width)
 }
 
-const WIDTH_PRESET_OPTIONS = [
+export const TOUR_WIDTH_PRESET_OPTIONS = [
     { value: PRODUCT_TOUR_STEP_WIDTHS.compact, label: 'Compact' },
     { value: PRODUCT_TOUR_STEP_WIDTHS.default, label: 'Default' },
     { value: PRODUCT_TOUR_STEP_WIDTHS.wide, label: 'Wide' },
@@ -92,8 +92,8 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
     const [stepToDelete, setStepToDelete] = useState<number | null>(null)
     const [showPreviewModal, setShowPreviewModal] = useState(false)
     const [showScreenshotModal, setShowScreenshotModal] = useState(false)
-    const [previewElement, setPreviewElement] = useState<HTMLDivElement | null>(null)
-    const [surveyPreviewElement, setSurveyPreviewElement] = useState<HTMLDivElement | null>(null)
+    const previewRef = useRef<HTMLDivElement>(null)
+    const surveyPreviewRef = useRef<HTMLDivElement>(null)
 
     const selectedStep = steps[selectedStepIndex]
 
@@ -128,29 +128,29 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
     }
 
     useEffect(() => {
-        if (previewElement && selectedStep) {
+        if (showPreviewModal && previewRef.current && selectedStep) {
             renderProductTourPreview({
                 step: prepareStepForRender(selectedStep) as any,
                 appearance: appearance as any,
-                parentElement: previewElement,
+                parentElement: previewRef.current,
                 stepIndex: selectedStepIndex,
                 totalSteps: steps.length,
             })
         }
-    }, [previewElement, selectedStep, appearance, selectedStepIndex, steps.length])
+    }, [showPreviewModal, selectedStep, appearance, selectedStepIndex, steps.length])
 
     // Render inline survey preview
     useEffect(() => {
-        if (surveyPreviewElement && selectedStep?.type === 'survey') {
+        if (surveyPreviewRef.current && selectedStep?.type === 'survey') {
             renderProductTourPreview({
                 step: prepareStepForRender(selectedStep) as any,
                 appearance: appearance as any,
-                parentElement: surveyPreviewElement,
+                parentElement: surveyPreviewRef.current,
                 stepIndex: selectedStepIndex,
                 totalSteps: steps.length,
             })
         }
-    }, [surveyPreviewElement, selectedStep, appearance, selectedStepIndex, steps.length])
+    }, [selectedStep, appearance, selectedStepIndex, steps.length])
 
     if (steps.length === 0) {
         return (
@@ -273,7 +273,7 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
                                 <div className="ProductTourStepsEditor__survey-preview">
                                     <div className="text-xs text-muted uppercase tracking-wide mb-3">Preview</div>
                                     <div className="flex justify-center p-6 bg-[#f0f0f0] rounded min-h-[200px]">
-                                        <div ref={setSurveyPreviewElement} />
+                                        <div ref={surveyPreviewRef} />
                                     </div>
                                 </div>
                             </div>
@@ -292,48 +292,11 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
                                 <div className="ProductTourStepsEditor__step-settings">
                                     <h4 className="font-semibold mb-3">Step settings</h4>
 
-                                    <div className="flex gap-12 items-start">
-                                        <div className="w-80">
-                                            <label className="text-sm font-medium block mb-2">Width</label>
-                                            <div className="flex items-center gap-3 mb-2">
-                                                <LemonSlider
-                                                    value={getWidthValue(selectedStep.maxWidth)}
-                                                    onChange={(value) =>
-                                                        updateStep(selectedStepIndex, { maxWidth: value })
-                                                    }
-                                                    min={TOUR_STEP_MIN_WIDTH}
-                                                    max={TOUR_STEP_MAX_WIDTH}
-                                                    step={10}
-                                                    className="flex-1"
-                                                />
-                                                <span className="text-sm text-muted w-12 text-right">
-                                                    {getWidthValue(selectedStep.maxWidth)}px
-                                                </span>
-                                            </div>
-                                            <LemonSegmentedButton
-                                                size="small"
-                                                value={
-                                                    isPresetWidth(getWidthValue(selectedStep.maxWidth))
-                                                        ? getWidthValue(selectedStep.maxWidth)
-                                                        : undefined
-                                                }
-                                                onChange={(value) => updateStep(selectedStepIndex, { maxWidth: value })}
-                                                options={WIDTH_PRESET_OPTIONS}
-                                            />
-                                        </div>
-
-                                        {selectedStep.type === 'modal' && (
-                                            <div>
-                                                <label className="text-sm font-medium block mb-2">Position</label>
-                                                <PositionSelector
-                                                    value={selectedStep.modalPosition ?? SurveyPosition.MiddleCenter}
-                                                    onChange={(position: ScreenPosition) =>
-                                                        updateStep(selectedStepIndex, { modalPosition: position })
-                                                    }
-                                                />
-                                            </div>
-                                        )}
-                                    </div>
+                                    <StepLayoutSettings
+                                        step={selectedStep}
+                                        onChange={(updates) => updateStep(selectedStepIndex, updates)}
+                                        showPosition={selectedStep.type === 'modal'}
+                                    />
                                 </div>
                             </>
                         )}
@@ -367,15 +330,12 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
             {/* Preview modal */}
             <LemonModal
                 isOpen={showPreviewModal}
-                onClose={() => {
-                    setShowPreviewModal(false)
-                    setPreviewElement(null)
-                }}
+                onClose={() => setShowPreviewModal(false)}
                 title={`Preview: ${getStepTitle(selectedStep, selectedStepIndex)}`}
-                width="auto"
+                width={800}
             >
-                <div className="flex justify-center p-8 bg-[#f0f0f0] rounded min-h-[200px]">
-                    <div ref={setPreviewElement} />
+                <div className="flex justify-center items-center p-8 bg-[#f0f0f0] rounded min-h-[300px]">
+                    <div ref={previewRef} />
                 </div>
             </LemonModal>
 

--- a/frontend/src/scenes/product-tours/editor/StepLayoutSettings.tsx
+++ b/frontend/src/scenes/product-tours/editor/StepLayoutSettings.tsx
@@ -1,0 +1,57 @@
+import { LemonSegmentedButton } from '@posthog/lemon-ui'
+
+import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
+import { PositionSelector } from 'scenes/surveys/survey-appearance/SurveyAppearancePositionSelector'
+
+import { ProductTourStep, ScreenPosition, SurveyPosition } from '~/types'
+
+import {
+    TOUR_STEP_MAX_WIDTH,
+    TOUR_STEP_MIN_WIDTH,
+    TOUR_WIDTH_PRESET_OPTIONS,
+    getWidthValue,
+    isPresetWidth,
+} from './ProductTourStepsEditor'
+
+export interface StepLayoutSettingsProps {
+    step: ProductTourStep
+    onChange: (updates: Partial<ProductTourStep>) => void
+    showPosition?: boolean
+}
+
+export function StepLayoutSettings({ step, onChange, showPosition = true }: StepLayoutSettingsProps): JSX.Element {
+    return (
+        <div className="flex gap-12 items-start">
+            <div className="w-80">
+                <label className="text-sm font-medium block mb-2">Width</label>
+                <div className="flex items-center gap-3 mb-2">
+                    <LemonSlider
+                        value={getWidthValue(step.maxWidth)}
+                        onChange={(value) => onChange({ maxWidth: value })}
+                        min={TOUR_STEP_MIN_WIDTH}
+                        max={TOUR_STEP_MAX_WIDTH}
+                        step={10}
+                        className="flex-1"
+                    />
+                    <span className="text-sm text-muted w-12 text-right">{getWidthValue(step.maxWidth)}px</span>
+                </div>
+                <LemonSegmentedButton
+                    size="small"
+                    value={isPresetWidth(getWidthValue(step.maxWidth)) ? getWidthValue(step.maxWidth) : undefined}
+                    onChange={(value) => onChange({ maxWidth: value })}
+                    options={TOUR_WIDTH_PRESET_OPTIONS}
+                />
+            </div>
+
+            {showPosition && (
+                <div>
+                    <label className="text-sm font-medium block mb-2">Position</label>
+                    <PositionSelector
+                        value={step.modalPosition ?? SurveyPosition.MiddleCenter}
+                        onChange={(position: ScreenPosition) => onChange({ modalPosition: position })}
+                    />
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/product-tours/productToursLogic.ts
+++ b/frontend/src/scenes/product-tours/productToursLogic.ts
@@ -6,14 +6,51 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api, { PaginatedResponse } from 'lib/api'
+import { uuid } from 'lib/utils'
 import { Scene } from 'scenes/sceneTypes'
 import { sceneConfigurations } from 'scenes/scenes'
 import { urls } from 'scenes/urls'
 
 import { deleteFromTree } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
-import { Breadcrumb, ProductTour, ProgressStatus } from '~/types'
+import { Breadcrumb, ProductTour, ProductTourContent, ProgressStatus, SurveyPosition } from '~/types'
 
 import type { productToursLogicType } from './productToursLogicType'
+
+function createDefaultAnnouncementContent(): ProductTourContent {
+    return {
+        type: 'announcement',
+        steps: [
+            {
+                id: uuid(),
+                type: 'modal',
+                content: {
+                    type: 'doc',
+                    content: [
+                        {
+                            type: 'heading',
+                            attrs: { level: 2 },
+                            content: [{ type: 'text', text: 'Your announcement title' }],
+                        },
+                        {
+                            type: 'paragraph',
+                            content: [
+                                {
+                                    type: 'text',
+                                    text: 'Add your message here. You can use rich text formatting, images, and more.',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                modalPosition: SurveyPosition.MiddleCenter,
+            },
+        ],
+        appearance: {
+            showOverlay: false,
+            dismissOnClickOutside: false,
+        },
+    }
+}
 
 export enum ProductToursTabs {
     Active = 'active',
@@ -33,6 +70,10 @@ export function isProductTourRunning(tour: Pick<ProductTour, 'start_date' | 'end
     return getProductTourStatus(tour) === ProgressStatus.Running
 }
 
+export function isAnnouncement(tour: Pick<ProductTour, 'content'>): boolean {
+    return tour.content?.type === 'announcement'
+}
+
 export interface ProductToursFilters {
     archived: boolean
 }
@@ -44,6 +85,7 @@ export const productToursLogic = kea<productToursLogicType>([
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
         setFilters: (filters: Partial<ProductToursFilters>) => ({ filters }),
         setTab: (tab: ProductToursTabs) => ({ tab }),
+        createAnnouncement: (name: string) => ({ name }),
     }),
     loaders(({ values }) => ({
         productTours: {
@@ -91,6 +133,18 @@ export const productToursLogic = kea<productToursLogicType>([
         },
         deleteProductTourSuccess: () => {
             router.actions.push(urls.productTours())
+        },
+        createAnnouncement: async ({ name }) => {
+            try {
+                const announcement = await api.productTours.create({
+                    name,
+                    content: createDefaultAnnouncementContent(),
+                })
+                actions.loadProductTours()
+                router.actions.push(urls.productTour(announcement.id))
+            } catch {
+                lemonToast.error('Failed to create announcement')
+            }
         },
     })),
     selectors({

--- a/frontend/src/toolbar/product-tours/StepEditor.tsx
+++ b/frontend/src/toolbar/product-tours/StepEditor.tsx
@@ -8,7 +8,11 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
-import { TOUR_STEP_MAX_WIDTH, TOUR_STEP_MIN_WIDTH } from 'scenes/product-tours/editor/ProductTourStepsEditor'
+import {
+    TOUR_STEP_MAX_WIDTH,
+    TOUR_STEP_MIN_WIDTH,
+    getWidthValue,
+} from 'scenes/product-tours/editor/ProductTourStepsEditor'
 import { StepContentEditor } from 'scenes/product-tours/editor/StepContentEditor'
 import { SurveyStepEditor } from 'scenes/product-tours/editor/SurveyStepEditor'
 import { PositionSelector } from 'scenes/surveys/survey-appearance/SurveyAppearancePositionSelector'
@@ -16,14 +20,7 @@ import { PositionSelector } from 'scenes/surveys/survey-appearance/SurveyAppeara
 import { toolbarUploadMedia } from '~/toolbar/toolbarConfigLogic'
 import { ElementRect } from '~/toolbar/types'
 import { elementToActionStep } from '~/toolbar/utils'
-import {
-    PRODUCT_TOUR_STEP_WIDTHS,
-    ProductTourProgressionTriggerType,
-    ProductTourStepWidth,
-    ProductTourSurveyQuestion,
-    ScreenPosition,
-    SurveyPosition,
-} from '~/types'
+import { ProductTourProgressionTriggerType, ProductTourSurveyQuestion, ScreenPosition, SurveyPosition } from '~/types'
 
 import { productToursLogic } from './productToursLogic'
 
@@ -131,16 +128,7 @@ export function StepEditor({ rect, elementNotFound }: { rect?: ElementRect; elem
     // Survey step state - managed by SurveyStepEditor
     const [surveyConfig, setSurveyConfig] = useState<ProductTourSurveyQuestion | undefined>(editingStep?.survey)
 
-    const [editorWidth, setEditorWidth] = useState(() => {
-        const existingWidth = editingStep?.maxWidth
-        if (typeof existingWidth === 'number') {
-            return existingWidth
-        }
-        if (existingWidth && existingWidth in PRODUCT_TOUR_STEP_WIDTHS) {
-            return PRODUCT_TOUR_STEP_WIDTHS[existingWidth as ProductTourStepWidth]
-        }
-        return PRODUCT_TOUR_STEP_WIDTHS.default
-    })
+    const [editorWidth, setEditorWidth] = useState(() => getWidthValue(editingStep?.maxWidth))
     const [isResizing, setIsResizing] = useState(false)
 
     const isElementStep = editingStepType === 'element'
@@ -175,14 +163,7 @@ export function StepEditor({ rect, elementNotFound }: { rect?: ElementRect; elem
 
     useEffect(() => {
         if (editingStep) {
-            const existingWidth = editingStep.maxWidth
-            if (typeof existingWidth === 'number') {
-                setEditorWidth(existingWidth)
-            } else if (existingWidth && existingWidth in PRODUCT_TOUR_STEP_WIDTHS) {
-                setEditorWidth(PRODUCT_TOUR_STEP_WIDTHS[existingWidth as ProductTourStepWidth])
-            } else {
-                setEditorWidth(PRODUCT_TOUR_STEP_WIDTHS.default)
-            }
+            setEditorWidth(getWidthValue(editingStep.maxWidth))
         }
     }, [editingStep?.id, editingStep?.maxWidth])
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3382,9 +3382,14 @@ export interface ProductTourAppearance {
     boxShadow?: string
     showOverlay?: boolean
     whiteLabel?: boolean
+    /** defaults to true, auto-set to false for announcements/banners */
+    dismissOnClickOutside?: boolean
 }
 
+export type ProductTourType = 'tour' | 'announcement'
+
 export interface ProductTourContent {
+    type?: ProductTourType
     steps: ProductTourStep[]
     appearance?: ProductTourAppearance
     conditions?: ProductTourDisplayConditions


### PR DESCRIPTION
## Problem

many users who want product tours also want "announcements" -- which can be thought of as single-step tours

these can be created in a much simpler workflow than real step-by-step tours

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

lays the foundation for "announcement"-type tours. not perfect by any means, but sets things up to build upon:

- new creation modal: choose tour or announcement
- announcements do not open the toolbar. instead, you start editing content directly in the main app

things that will come in the next few PRs:

- the announcement steps need to be handled differently. they should not show "step N of M", or have the normal next button
- buttons on announcmenets should be customizable, e.g. button for dismiss, for opening a link, for launching a product tour, and so forth

|  |  |
| --- | --- |
| ![Screenshot 2026-01-09 at 1.35.19 PM.png](https://app.graphite.com/user-attachments/assets/09457c9c-8da4-4f30-834c-853d4181068b.png)<br> | ![Screenshot 2026-01-09 at 1.35.31 PM.png](https://app.graphite.com/user-attachments/assets/3d27e419-df75-4b6f-b88f-ae8fca3abd9c.png)<br> |

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no