### PR TITLE
chore: Drop fully rolled out feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -217,7 +217,6 @@ export const FEATURE_FLAGS = {
     // Temporary feature flags, still WIP, should be removed eventually
     AA_TEST_BAYESIAN_LEGACY: 'aa-test-bayesian-legacy', // owner: #team-experiments
     AA_TEST_BAYESIAN_NEW: 'aa-test-bayesian-new', // owner: #team-experiments
-    ACTIVITY_EVENT_BANNER_WORDING: 'activity-event-banner-wording', // owner: @arthurdedeus #team-customer-analytics
     ADVANCE_MARKETING_ANALYTICS_SETTINGS: 'advance-marketing-analytics-settings', // owner: @jabahamondes  #team-web-analytics
     APPROVALS: 'approvals', // owner: @yasen-posthog #team-platform-features
     AI_ONLY_MODE: 'ai-only-mode', // owner: #team-posthog-ai

--- a/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
+++ b/products/customer_analytics/frontend/components/Insights/ActiveUsersInsights.tsx
@@ -2,7 +2,6 @@ import { useValues } from 'kea'
 
 import { LemonBanner, LemonButton, Tooltip } from '@posthog/lemon-ui'
 
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { urls } from 'scenes/urls'
 
 import { Query } from '~/queries/Query/Query'
@@ -16,9 +15,6 @@ import { CustomerAnalyticsQueryCard } from '../CustomerAnalyticsQueryCard'
 
 export function ActiveUsersInsights(): JSX.Element {
     const { activityEvent, activeUsersInsights, customerLabel, tabId } = useValues(customerAnalyticsSceneLogic)
-    const activityEventBannerCopy = useFeatureFlag('ACTIVITY_EVENT_BANNER_WORDING', 'test')
-        ? 'What makes a user active in your product? Choose an event that signals real engagement, like completing a core action, rather than generic pageviews.'
-        : 'You are currently using the pageview event to define user activity. Consider using a more specific event or action to track activity accurately.'
 
     // Check if using pageview as default, with no properties filter
     const isOnlyPageview = isPageviewWithoutFilters(activityEvent)
@@ -27,7 +23,8 @@ export function ActiveUsersInsights(): JSX.Element {
         <div className="space-y-2">
             {isOnlyPageview && (
                 <LemonBanner type="warning">
-                    {activityEventBannerCopy}
+                    What makes a user active in your product? Choose an event that signals real engagement, like
+                    completing a core action, rather than generic pageviews.
                     <div className="flex flex-row items-center gap-4 mt-2 max-w-160">
                         <LemonButton
                             data-attr="customer-analytics-configure-activity-event"


### PR DESCRIPTION
## Problem

The current implementation uses a feature flag to A/B test different wording for the activity event banner in the Customer Analytics section. Now that testing is complete, we need to standardize on the final copy.

## Changes

- Removed the stale feature flag

## How did you test this code?

👁️ 

## Publish to changelog?

No