### PR TITLE
fix: update heartbeat details more frequently in realtime cohort workflow

### DIFF
--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow.py
@@ -123,9 +123,9 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
             return current_members_sql, hogql_context.values
 
         for idx, cohort in enumerate(cohorts, 1):
-            if idx % 100 == 0 or idx == len(cohorts):
-                heartbeater.details = (f"Processing cohort {idx}/{len(cohorts)}",)
-                logger.info(f"Processed {idx}/{len(cohorts)} cohorts so far")
+            heartbeater.details = (f"Processing cohort {idx}/{len(cohorts)} (cohort_id={cohort.id})",)
+            logger.info(f"Processing cohort {idx}/{len(cohorts)}", cohort_id=cohort.id)
+
             try:
                 current_members_sql, query_params = await build_query(cohort)
                 query_params = {
@@ -160,6 +160,8 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                     SETTINGS join_use_nulls = 1
                     FORMAT JSONEachRow
                 """
+
+                heartbeater.details = (f"Executing query for cohort {idx}/{len(cohorts)} (cohort_id={cohort.id})",)
 
                 with tags_context(
                     team_id=cohort.team_id,
@@ -226,6 +228,10 @@ async def process_realtime_cohort_calculation_activity(inputs: RealtimeCohortCal
                         f"Query completed for cohort {cohort.id}. Total messages to flush: {len(pending_kafka_messages)}",
                         cohort_id=cohort.id,
                         message_count=len(pending_kafka_messages),
+                    )
+
+                    heartbeater.details = (
+                        f"Flushing {len(pending_kafka_messages)} messages for cohort {idx}/{len(cohorts)} (cohort_id={cohort.id})",
                     )
                     await asyncio.to_thread(kafka_producer.flush)
 


### PR DESCRIPTION
### Problem

Heartbeat timeout issues in the realtime cohort calculation workflow. Previously, heartbeat details were only updated every 100 cohorts. When individual cohorts took longer than 5 minutes to process (due to slow ClickHouse queries or large Kafka flushes), Temporal would see the same heartbeat details repeatedly and consider the activity stuck, resulting in `TIMEOUT_TYPE_HEARTBEAT` errors.

```
{
  "type": "workflowExecutionFailedEventAttributes",
  "failure": {
    "message": "Activity task timed out",
    "cause": {
      "message": "activity Heartbeat timeout",
      "source": "Server",
      "cause": {
        "message": "activity Heartbeat timeout",
        "source": "Server",
        "timeoutFailureInfo": {
          "timeoutType": "TIMEOUT_TYPE_HEARTBEAT"
        }
      },
      "timeoutFailureInfo": {
        "timeoutType": "TIMEOUT_TYPE_HEARTBEAT",
        "lastHeartbeatDetails": {
          "payloads": [
            {
              "metadata": {
                "encoding": "YmluYXJ5L2VuY3J5cHRlZA=="
              },
              "data": "Z0FBQUFBQnBYX1BXWmg1cXBHNXRqVUdha2ZfcklKZHl6aWdrNjdoV25XQVNUdkxXVnVWUGhPYmN5VU9jUTJJUFRER0RRcDN4Q1c5UFd2VkgwU1FSaXh2d1c5UVVOOTBIYmtQamxISVIzMDh4REZJTW1qcy0tRzhsajhNbm1EcjZrQk1INFhwVHVGTFBKSVhJdGdreEJIQzZsczE4a09RbUw2SUdjZURZZWlNOUN5MkxSLXJ6bjZZPQ=="
            }
          ]
        }
      }
    },
    "activityFailureInfo": {
      "scheduledEventId": "5",
      "startedEventId": "6",
      "activityType": {
        "name": "process_realtime_cohort_calculation_activity"
      },
      "activityId": "1",
      "retryState": "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED"
    }
  },
  "retryState": "RETRY_STATE_RETRY_POLICY_NOT_SET",
  "workflowTaskCompletedEventId": "10"
}
```

### Changes

Updated the heartbeat details at three strategic points in the cohort processing loop:
1. **Before processing each cohort** - Shows which cohort is being worked on
2. **Before executing the ClickHouse query** - Indicates query execution is in progress
3. **Before flushing Kafka messages** - Shows Kafka flush operation with message count

This ensures Temporal sees continuous progress even when individual cohorts take a long time to process. Each heartbeat now includes the cohort index, total count, and cohort ID for better observability.