### PR TITLE
feat(product tours): add button config to announcements

### DIFF
--- a/frontend/src/scenes/product-tours/AnnouncementContentEditor.tsx
+++ b/frontend/src/scenes/product-tours/AnnouncementContentEditor.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react'
 
 import { ProductTourAppearance, ProductTourStep } from '~/types'
 
+import { StepButtonsEditor } from './editor/StepButtonsEditor'
 import { StepContentEditor } from './editor/StepContentEditor'
 import { StepLayoutSettings } from './editor/StepLayoutSettings'
 import { prepareStepForRender } from './editor/generateStepHtml'
@@ -33,7 +34,7 @@ export function AnnouncementContentEditor({ step, appearance, onChange }: Announ
                 totalSteps: 1,
             })
         }
-    }, [step, step?.maxWidth, appearance])
+    }, [step, appearance])
 
     if (!step) {
         return <div>No content</div>
@@ -47,6 +48,11 @@ export function AnnouncementContentEditor({ step, appearance, onChange }: Announ
                     onChange={(content) => updateStep({ content })}
                     placeholder="Type '/' for commands, or start writing your announcement..."
                 />
+
+                <div className="mt-6 pt-6 border-t">
+                    <label className="text-sm font-medium block mb-3">Buttons</label>
+                    <StepButtonsEditor buttons={step.buttons} onChange={(buttons) => updateStep({ buttons })} />
+                </div>
 
                 <div className="mt-6 pt-6 border-t">
                     <StepLayoutSettings step={step} onChange={updateStep} />

--- a/frontend/src/scenes/product-tours/ProductTourEdit.tsx
+++ b/frontend/src/scenes/product-tours/ProductTourEdit.tsx
@@ -29,6 +29,7 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
         productTour,
         productTourLoading,
         productTourForm,
+        productTourFormAllErrors,
         targetingFlagFilters,
         isProductTourFormSubmitting,
         editTab,
@@ -45,13 +46,14 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
     }
 
     const conditions = productTourForm.content?.conditions || {}
+    const entityKeyword = isAnnouncement(productTour) ? 'announcement' : 'tour'
 
     return (
         <Form logic={productTourLogic} props={{ id }} formKey="productTourForm">
             <SceneContent>
                 <SceneTitleSection
                     name={productTour.name}
-                    description={isAnnouncement(productTour) ? 'Edit announcement' : 'Edit product tour settings'}
+                    description={`Edit ${entityKeyword} settings`}
                     resourceType={{ type: 'product_tour' }}
                     isLoading={productTourLoading}
                     actions={
@@ -104,7 +106,7 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                         <div>
                             <h3 className="font-semibold mb-2">Display conditions</h3>
                             <p className="text-secondary text-sm mb-4">
-                                Configure how and when this tour is shown to users.
+                                Configure how and when this {entityKeyword} is shown to users.
                             </p>
 
                             <div className="space-y-4">
@@ -113,7 +115,8 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                                         <div>
                                             <h4 className="font-semibold">Auto-show this tour</h4>
                                             <p className="text-secondary text-sm mb-0">
-                                                Automatically show this tour to users who match your conditions
+                                                Automatically show this {entityKeyword} to users who match your
+                                                conditions
                                             </p>
                                         </div>
                                         <LemonSwitch
@@ -127,7 +130,9 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                                             <div>
                                                 <h5 className="font-semibold mb-3">
                                                     Who to show&nbsp;
-                                                    <Tooltip title="Only auto-show the tour to users who match these conditions">
+                                                    <Tooltip
+                                                        title={`Only auto-show the ${entityKeyword} to users who match these conditions`}
+                                                    >
                                                         <IconInfo />
                                                     </Tooltip>
                                                 </h5>
@@ -180,7 +185,8 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
                                 <div className="border rounded p-4 bg-surface-primary">
                                     <h4 className="font-semibold mb-2">Manual trigger</h4>
                                     <p className="text-secondary text-sm mb-4">
-                                        Show this tour when users click an element matching this CSS selector.
+                                        Show this {entityKeyword} when users click an element matching this CSS
+                                        selector.
                                     </p>
                                     <LemonInput
                                         className="font-mono"
@@ -204,16 +210,23 @@ export function ProductTourEdit({ id }: { id: string }): JSX.Element {
 
                 {editTab === ProductTourEditTab.Steps &&
                     (isAnnouncement(productTour) ? (
-                        <AnnouncementContentEditor
-                            step={productTourForm.content?.steps?.[0]}
-                            appearance={productTourForm.content?.appearance}
-                            onChange={(step: ProductTourStep) => {
-                                setProductTourFormValue('content', {
-                                    ...productTourForm.content,
-                                    steps: [step],
-                                })
-                            }}
-                        />
+                        <>
+                            {productTourFormAllErrors._form && (
+                                <LemonField name="_form" className="mb-4">
+                                    <span />
+                                </LemonField>
+                            )}
+                            <AnnouncementContentEditor
+                                step={productTourForm.content?.steps?.[0]}
+                                appearance={productTourForm.content?.appearance}
+                                onChange={(step: ProductTourStep) => {
+                                    setProductTourFormValue('content', {
+                                        ...productTourForm.content,
+                                        steps: [step],
+                                    })
+                                }}
+                            />
+                        </>
                     ) : (
                         <ProductTourStepsEditor
                             steps={productTourForm.content?.steps ?? []}

--- a/frontend/src/scenes/product-tours/editor/StepButtonsEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/StepButtonsEditor.tsx
@@ -1,0 +1,95 @@
+import { LemonInput, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+
+import { ProductTourButtonAction, ProductTourStepButton, ProductTourStepButtons } from '~/types'
+
+import { BUTTON_ACTION_OPTIONS, DEFAULT_PRIMARY_BUTTON, DEFAULT_SECONDARY_BUTTON } from '../productToursLogic'
+
+interface ButtonEditorProps {
+    button: ProductTourStepButton
+    onChange: (button: ProductTourStepButton) => void
+    label: string
+}
+
+function ButtonEditor({ button, onChange, label }: ButtonEditorProps): JSX.Element {
+    return (
+        <div className="space-y-2">
+            <div className="flex items-center gap-3">
+                <span className="text-xs font-medium text-muted w-16 shrink-0">{label}</span>
+                <LemonInput
+                    value={button.text}
+                    onChange={(text) => onChange({ ...button, text })}
+                    placeholder="Button text"
+                    size="small"
+                    className="flex-1"
+                />
+                <LemonSelect
+                    value={button.action}
+                    onChange={(action) => onChange({ ...button, action: action as ProductTourButtonAction })}
+                    options={BUTTON_ACTION_OPTIONS}
+                    size="small"
+                />
+            </div>
+            {button.action === 'link' && (
+                <div className="flex items-center gap-3">
+                    <span className="w-16 shrink-0" />
+                    <LemonInput
+                        value={button.link ?? ''}
+                        onChange={(link) => onChange({ ...button, link })}
+                        placeholder="https://example.com"
+                        size="small"
+                        className="flex-1"
+                    />
+                </div>
+            )}
+        </div>
+    )
+}
+
+export interface StepButtonsEditorProps {
+    buttons: ProductTourStepButtons | undefined
+    onChange: (buttons: ProductTourStepButtons) => void
+}
+
+export function StepButtonsEditor({ buttons, onChange }: StepButtonsEditorProps): JSX.Element {
+    const primaryButton = buttons?.primary ?? DEFAULT_PRIMARY_BUTTON
+    const secondaryButton = buttons?.secondary
+
+    const updatePrimaryButton = (button: ProductTourStepButton): void => {
+        onChange({
+            ...buttons,
+            primary: button,
+        })
+    }
+
+    const updateSecondaryButton = (button: ProductTourStepButton): void => {
+        onChange({
+            ...buttons,
+            secondary: button,
+        })
+    }
+
+    const toggleSecondaryButton = (enabled: boolean): void => {
+        onChange({
+            ...buttons,
+            secondary: enabled ? DEFAULT_SECONDARY_BUTTON : undefined,
+        })
+    }
+
+    return (
+        <div className="space-y-3">
+            <ButtonEditor label="Primary" button={primaryButton} onChange={updatePrimaryButton} />
+            {secondaryButton && (
+                <ButtonEditor label="Secondary" button={secondaryButton} onChange={updateSecondaryButton} />
+            )}
+            <div className="flex items-center gap-3">
+                <span className="w-16 shrink-0" />
+                <LemonSwitch
+                    checked={!!secondaryButton}
+                    onChange={toggleSecondaryButton}
+                    label="Secondary button"
+                    size="small"
+                />
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/product-tours/productTourLogic.ts
+++ b/frontend/src/scenes/product-tours/productTourLogic.ts
@@ -269,9 +269,30 @@ export const productTourLogic = kea<productTourLogicType>([
     forms(({ actions, props }) => ({
         productTourForm: {
             defaults: NEW_PRODUCT_TOUR as ProductTourForm,
-            errors: ({ name }: ProductTourForm) => ({
-                name: !name ? 'Name is required' : undefined,
-            }),
+            alwaysShowErrors: true,
+            errors: ({ name, content }: ProductTourForm) => {
+                const errors: Record<string, string | undefined> = {
+                    name: !name ? 'Name is required' : undefined,
+                }
+
+                if (content.type === 'announcement') {
+                    for (const step of content.steps || []) {
+                        const primaryButton = step.buttons?.primary
+                        const secondaryButton = step.buttons?.secondary
+
+                        if (primaryButton?.action === 'link' && !primaryButton.link?.trim()) {
+                            errors._form = 'Primary button requires a URL'
+                            break
+                        }
+                        if (secondaryButton?.action === 'link' && !secondaryButton.link?.trim()) {
+                            errors._form = 'Secondary button requires a URL'
+                            break
+                        }
+                    }
+                }
+
+                return errors
+            },
             submit: async (formValues: ProductTourForm) => {
                 const processedContent: ProductTourContent = {
                     ...formValues.content,

--- a/frontend/src/scenes/product-tours/productToursLogic.ts
+++ b/frontend/src/scenes/product-tours/productToursLogic.ts
@@ -12,9 +12,33 @@ import { sceneConfigurations } from 'scenes/scenes'
 import { urls } from 'scenes/urls'
 
 import { deleteFromTree } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
-import { Breadcrumb, ProductTour, ProductTourContent, ProgressStatus, SurveyPosition } from '~/types'
+import {
+    Breadcrumb,
+    ProductTour,
+    ProductTourButtonAction,
+    ProductTourContent,
+    ProductTourStepButton,
+    ProgressStatus,
+    SurveyPosition,
+} from '~/types'
 
 import type { productToursLogicType } from './productToursLogicType'
+
+export const BUTTON_ACTION_OPTIONS: { value: ProductTourButtonAction; label: string }[] = [
+    { value: 'dismiss', label: 'Dismiss' },
+    { value: 'link', label: 'Open link' },
+]
+
+export const DEFAULT_PRIMARY_BUTTON: ProductTourStepButton = {
+    text: 'Got it',
+    action: 'dismiss',
+}
+
+export const DEFAULT_SECONDARY_BUTTON: ProductTourStepButton = {
+    text: 'Learn more',
+    action: 'link',
+    link: '',
+}
 
 function createDefaultAnnouncementContent(): ProductTourContent {
     return {
@@ -41,6 +65,9 @@ function createDefaultAnnouncementContent(): ProductTourContent {
                             ],
                         },
                     ],
+                },
+                buttons: {
+                    primary: DEFAULT_PRIMARY_BUTTON,
                 },
                 modalPosition: SurveyPosition.MiddleCenter,
             },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3314,6 +3314,20 @@ export type ProductTourProgressionTriggerType = 'button' | 'click'
 
 export type ProductTourStepType = 'element' | 'modal' | 'survey'
 
+export type ProductTourButtonAction = 'dismiss' | 'link'
+
+export interface ProductTourStepButton {
+    text: string
+    action: ProductTourButtonAction
+    /** URL to open when action is 'link' */
+    link?: string
+}
+
+export interface ProductTourStepButtons {
+    primary?: ProductTourStepButton
+    secondary?: ProductTourStepButton
+}
+
 /** Preset width options for product tour tooltips */
 export type ProductTourStepWidth = 'compact' | 'default' | 'wide' | 'extra-wide'
 
@@ -3350,6 +3364,8 @@ export interface ProductTourStep {
     screenshotMediaId?: string
     /** enhanced element data for more reliable lookup at runtime */
     inferenceData?: InferredSelector
+    /** Button configuration for tour steps (modals / announcements) */
+    buttons?: ProductTourStepButtons
 }
 
 /** Tracks a snapshot of steps at a point in time for funnel analysis */


### PR DESCRIPTION
## Problem

announcements need to be displayed slightly differently than normal tour steps.

specifically, they do not need "next"/"back" buttons - they need customizable buttons

depends on https://github.com/PostHog/posthog-js/pull/2863 to actually work

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds button config for announcements:

- primary and (optional) secondary buttons
- button actions: dismiss or open link

future: add a third option for launching a product tour 😎

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

|  |  |
| --- | --- |
| ![Screenshot 2026-01-09 at 1.36.36 PM.png](https://app.graphite.com/user-attachments/assets/44eff4f8-92b8-49e1-8a57-1489733a7af1.png)<br> | ![Screenshot 2026-01-09 at 1.36.45 PM.png](https://app.graphite.com/user-attachments/assets/d8db608f-8230-46b5-a35f-000811e5e95e.png)<br> |

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no