### PR TITLE
fix(ci): update Slack when pending workflow completes resolution

### DIFF
--- a/.github/workflows/ci-master-status.yml
+++ b/.github/workflows/ci-master-status.yml
@@ -180,7 +180,7 @@ jobs:
                       text: ":white_check_mark: Resolved: *${{ steps.process.outputs.recovered_workflow }}* (${{ steps.commit.outputs.short_sha }})"
 
             - name: Calculate duration
-              if: steps.process.outputs.action == 'resolve' && steps.process.outputs.resolved == 'true'
+              if: steps.process.outputs.resolved == 'true'
               id: duration
               run: |
                   since="${{ steps.process.outputs.since }}"
@@ -190,7 +190,7 @@ jobs:
                   echo "mins=$mins" >> $GITHUB_OUTPUT
 
             - name: Update Slack to resolved
-              if: steps.process.outputs.action == 'resolve' && steps.process.outputs.resolved == 'true'
+              if: steps.process.outputs.resolved == 'true'
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: chat.update
@@ -217,7 +217,7 @@ jobs:
                             text: "*Commit*\n<${{ steps.commit.outputs.url }}|${{ steps.commit.outputs.short_sha }}> ${{ steps.commit.outputs.message }}"
 
             - name: Thread reply with resolution
-              if: steps.process.outputs.action == 'resolve' && steps.process.outputs.resolved == 'true'
+              if: steps.process.outputs.resolved == 'true'
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: chat.postMessage


### PR DESCRIPTION
**Problem**

When a pending (non-failing) required workflow passes and causes full incident resolution, Slack wasn't being updated. The incident would be marked as resolved in state, but the Slack message stayed showing it as unresolved.

**Root cause**

The Slack resolution steps checked `action == 'resolve' && resolved == 'true'`. But `action` is only `'resolve'` when a previously-failing workflow recovers. When a pending workflow (like Security) passes:
- `action = 'none'` (because it wasn't failing before)
- `resolved = 'true'` (all required workflows have now passed)

This combination didn't trigger the Slack update.

**Fix**

Change conditions from `action == 'resolve' && resolved == 'true'` to just `resolved == 'true'`.