### PR TITLE
fix(flags): show the tag filter in the feature flags editing list

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagFilters.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagFilters.tsx
@@ -151,7 +151,7 @@ export function FeatureFlagFiltersSection({
                             />
                         </>
                     )}
-                    {config.tags && enabledFeaturesLogic.values.featureFlags?.[FEATURE_FLAGS.FLAG_EVALUATION_TAGS] && (
+                    {config.tags && (
                         <>
                             <span className="ml-1">
                                 <b>Tags</b>

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -455,7 +455,7 @@ export function OverViewTab({
                 type: true,
                 status: true,
                 createdBy: true,
-                tags: true,
+                tags: hasAvailableFeature(AvailableFeature.TAGGING),
                 runtime: true,
             }}
         />


### PR DESCRIPTION
## Problem

The tags filter dropdown on the feature flags overview page was hidden behind the `FLAG_EVALUATION_TAGS` feature flag in addition to the plan-based `TAGGING` feature check. This meant that users who had access to tagging through their plan couldn't use the filter unless they also had the feature flag enabled.

The `FLAG_EVALUATION_TAGS` feature flag is specifically for the enhanced "FeatureFlagEvaluationTags" component, not for basic tag filtering functionality. Users with tagging access should be able to filter feature flags by tags without requiring an additional feature flag.

## Changes

- Removed the `FLAG_EVALUATION_TAGS` feature flag check from the tags filter in `FeatureFlagFilters.tsx`
- Updated the filter configuration in `FeatureFlags.tsx` to conditionally show the tags filter based on the `TAGGING` available
feature
- The tags filter now follows the same access pattern as the tags column in the feature flags table

## How did you test this code?

Manual testing:

- Verified the tags filter appears for users with the `TAGGING` available feature
- Confirmed filtering by tags works correctly


## Publish to changelog?

No