### PR TITLE
chore: Add system annotation for wrong person properties

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
@@ -237,7 +237,7 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
                             // Only include if date is within the date range
                             if (dateInTimezone >= dateRange[0] && dateInTimezone < dateRange[1]) {
                                 return {
-                                    id: -(index + 1), // -1 for Jan 7, -2 for Jan 6
+                                    id: -(index + 1), // -1 for Jan 6, -2 for Jan 7
                                     scope: AnnotationScope.Project,
                                     content:
                                         'Some person properties on this date may have been set incorrectly. See https://status.posthog.com/ for more information.',

--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
@@ -1,15 +1,21 @@
 import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 
 import { Tick } from 'lib/Chart'
-import { Dayjs, dayjsLocalToTimezone } from 'lib/dayjs'
+import { isPersonPropertyFilter, parseProperties } from 'lib/components/PropertyFilters/utils'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { Dayjs, dayjs, dayjsLocalToTimezone } from 'lib/dayjs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { groupBy } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { AnnotationDataWithoutInsight, annotationsModel } from '~/models/annotationsModel'
+import { BreakdownFilter } from '~/queries/schema/schema-general'
 import {
     AnnotationScope,
+    AnnotationType,
+    AnyPropertyFilter,
     DashboardType,
     DatedAnnotationType,
     InsightLogicProps,
@@ -42,6 +48,31 @@ export function determineAnnotationsDateGroup(
     return adjustedDate.format('YYYY-MM-DD HH:mm:ssZZ')
 }
 
+function hasPersonPropertyFiltersOrBreakdown(
+    properties: AnyPropertyFilter[] | null | undefined,
+    breakdownFilter: BreakdownFilter | null | undefined
+): boolean {
+    // Check if there are person property filters
+    if (properties) {
+        const parsedProperties = parseProperties(properties)
+        if (parsedProperties.some((prop) => isPersonPropertyFilter(prop))) {
+            return true
+        }
+    }
+
+    // Check if breakdown is by person property
+    if (breakdownFilter) {
+        if (breakdownFilter.breakdown_type === 'person') {
+            return true
+        }
+        if (breakdownFilter.breakdowns?.some((breakdown) => breakdown.type === 'person')) {
+            return true
+        }
+    }
+
+    return false
+}
+
 export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
     path((key) => ['lib', 'components', 'Annotations', 'annotationsOverlayLogic', key]),
     props({ dashboardId: undefined } as AnnotationsOverlayLogicProps),
@@ -51,11 +82,13 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
             insightLogic,
             ['insightId', 'savedInsight'],
             insightVizDataLogic,
-            ['interval'],
+            ['interval', 'properties', 'breakdownFilter'],
             annotationsModel,
             ['annotations', 'annotationsLoading'],
             teamLogic,
             ['timezone'],
+            featureFlagLogic,
+            ['featureFlags'],
         ],
         actions: [annotationsModel, ['createAnnotationGenerically', 'updateAnnotation', 'deleteAnnotation']],
     })),
@@ -142,34 +175,89 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
             },
         ],
         relevantAnnotations: [
-            (s, p) => [s.annotations, s.dateRange, p.insightNumericId, p.dashboardId, s.savedInsight],
-            (annotations, dateRange, insightNumericId, dashboardId, savedInsight) => {
+            (s, p) => [
+                s.annotations,
+                s.dateRange,
+                s.timezone,
+                s.featureFlags,
+                p.insightNumericId,
+                p.dashboardId,
+                s.savedInsight,
+                s.properties,
+                s.breakdownFilter,
+            ],
+            (
+                annotations,
+                dateRange,
+                timezone,
+                featureFlags,
+                insightNumericId,
+                dashboardId,
+                savedInsight,
+                properties,
+                breakdownFilter
+            ) => {
                 // This assumes that there are no more annotations in the project than AnnotationsViewSet
                 // pagination class's default_limit of 100. As of June 2023, this is not true on Cloud US,
                 // where 3 projects exceed this limit. To accommodate those, we should always make a request for the
                 // date range of the graph, and not rely on the annotations in the store.
 
-                return (
-                    dateRange
-                        ? annotations.filter(
-                              (annotation) =>
-                                  (annotation.scope !== AnnotationScope.Insight ||
-                                      annotation.dashboard_item === insightNumericId) &&
-                                  (annotation.scope !== AnnotationScope.Dashboard ||
-                                      annotation.dashboard_item === insightNumericId ||
-                                      (dashboardId
-                                          ? // on dashboard page, only show annotations if scoped to this dashboard
-                                            annotation.dashboard_id === dashboardId
-                                          : // on insight page, show annotation if insight is on any dashboard which this annotation is scoped to
-                                            savedInsight?.dashboard_tiles?.find(
-                                                ({ dashboard_id }) => dashboard_id === annotation.dashboard_id
-                                            ))) &&
-                                  annotation.date_marker &&
-                                  annotation.date_marker >= dateRange[0] &&
-                                  annotation.date_marker < dateRange[1]
-                          )
-                        : []
-                ) as DatedAnnotationType[]
+                const filteredAnnotations = dateRange
+                    ? annotations.filter(
+                          (annotation: AnnotationType) =>
+                              (annotation.scope !== AnnotationScope.Insight ||
+                                  annotation.dashboard_item === insightNumericId) &&
+                              (annotation.scope !== AnnotationScope.Dashboard ||
+                                  annotation.dashboard_item === insightNumericId ||
+                                  (dashboardId
+                                      ? // on dashboard page, only show annotations if scoped to this dashboard
+                                        annotation.dashboard_id === dashboardId
+                                      : // on insight page, show annotation if insight is on any dashboard which this annotation is scoped to
+                                        savedInsight?.dashboard_tiles?.find(
+                                            ({ dashboard_id }) => dashboard_id === annotation.dashboard_id
+                                        ))) &&
+                              annotation.date_marker &&
+                              annotation.date_marker >= dateRange[0] &&
+                              annotation.date_marker < dateRange[1]
+                      )
+                    : []
+
+                // Add special annotation for January 6th and 7th if person property filters or breakdown are present
+                // The incident period was Jan 6, 8:01pm UTC - Jan 7, 2:52pm UTC
+                if (
+                    dateRange &&
+                    hasPersonPropertyFiltersOrBreakdown(properties, breakdownFilter) &&
+                    featureFlags[FEATURE_FLAGS.PERSON_PROPERTY_INCIDENT_ANNOTATION_JAN_2026]
+                ) {
+                    const incidentDates = ['2026-01-06', '2026-01-07']
+                    const specialAnnotations: DatedAnnotationType[] = incidentDates
+                        .map((dateStr, index) => {
+                            const dateInTimezone = dayjsLocalToTimezone(dateStr, timezone).startOf('day')
+
+                            // Only include if date is within the date range
+                            if (dateInTimezone >= dateRange[0] && dateInTimezone < dateRange[1]) {
+                                return {
+                                    id: -(index + 1), // -1 for Jan 7, -2 for Jan 6
+                                    scope: AnnotationScope.Project,
+                                    content:
+                                        'Some person properties on this date may have been set incorrectly. See https://status.posthog.com/ for more information.',
+                                    date_marker: dateInTimezone,
+                                    created_at: dayjs(),
+                                    updated_at: dayjs().toISOString(),
+                                    dashboard_item: null,
+                                    deleted: false,
+                                } as DatedAnnotationType
+                            }
+                            return null
+                        })
+                        .filter((annotation): annotation is DatedAnnotationType => annotation !== null)
+
+                    if (specialAnnotations.length > 0) {
+                        return [...filteredAnnotations, ...specialAnnotations] as DatedAnnotationType[]
+                    }
+                }
+
+                return filteredAnnotations as DatedAnnotationType[]
             },
         ],
         groupedAnnotations: [

--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
@@ -20,6 +20,7 @@ import {
     DatedAnnotationType,
     InsightLogicProps,
     IntervalType,
+    PropertyGroupFilter,
     QueryBasedInsightModel,
 } from '~/types'
 
@@ -49,7 +50,7 @@ export function determineAnnotationsDateGroup(
 }
 
 function hasPersonPropertyFiltersOrBreakdown(
-    properties: AnyPropertyFilter[] | null | undefined,
+    properties: AnyPropertyFilter[] | PropertyGroupFilter | null | undefined,
     breakdownFilter: BreakdownFilter | null | undefined
 ): boolean {
     // Check if there are person property filters

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -171,6 +171,7 @@ export const FEATURE_FLAGS = {
     // Feature flags used to control opt-in for different behaviors, should not be removed
     AI_UX: 'ai-ux-improvements', // owner: #team-platform-ux, small improvements to the ai experience
     CONTROL_SUPPORT_LOGIN: 'control_support_login', // owner: #team-security, used to control whether users can opt out of support impersonation
+    PERSON_PROPERTY_INCIDENT_ANNOTATION_JAN_2026: 'person-property-incident-annotation-jan-2026', // owner: #team-platform-features, shows system annotation for Jan 6-7 2026 person property incident
     AUDIT_LOGS_ACCESS: 'audit-logs-access', // owner: #team-platform-features, used to control access to audit logs
     CUSTOM_CSS_THEMES: 'custom-css-themes', // owner: #team-growth, used to enable custom CSS for teams who want to have fun
     GAME_CENTER: 'game-center', // owner: everybody, this is just internal for now


### PR DESCRIPTION
## Problem

Add an annotation to any insights that filter on or breakdown by person property for the incident.

<img width="910" height="612" alt="image" src="https://github.com/user-attachments/assets/84dee434-0065-4acf-8975-4460fbebe2bc" />


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
