### PR TITLE
refactor: Use proper prefix for `linux`

### DIFF
--- a/.github/workflows/build-hobby-installer.yml
+++ b/.github/workflows/build-hobby-installer.yml
@@ -45,7 +45,7 @@ jobs:
 
                   # Versioned release for history
                   gh release create "$VERSION" \
-                      bin/hobby-installer \
+                      bin/hobby-installer-linux \
                       --title "Hobby Installer $VERSION" \
                       --notes "Build from commit ${{ github.sha }}" \
                       --latest=false
@@ -54,7 +54,7 @@ jobs:
                   gh release delete hobby-latest --yes || true
                   git push origin :refs/tags/hobby-latest || true
                   gh release create hobby-latest \
-                      bin/hobby-installer \
+                      bin/hobby-installer-linux \
                       --title "Hobby Installer (Latest)" \
                       --notes "Latest hobby installer build - same as $VERSION
 

--- a/.github/workflows/build-hobby-installer.yml
+++ b/.github/workflows/build-hobby-installer.yml
@@ -44,6 +44,8 @@ jobs:
                   VERSION="hobby-$(date +%Y%m%d-%H%M%S)"
 
                   # Rename the binary to a more neutral name
+                  # This is the same name as the folder so we'll remove it first
+                  rm -rf bin/hobby-installer
                   mv bin/hobby-installer-linux bin/hobby-installer
 
                   # Versioned release for history

--- a/.github/workflows/build-hobby-installer.yml
+++ b/.github/workflows/build-hobby-installer.yml
@@ -43,9 +43,12 @@ jobs:
               run: |
                   VERSION="hobby-$(date +%Y%m%d-%H%M%S)"
 
+                  # Rename the binary to a more neutral name
+                  mv bin/hobby-installer-linux bin/hobby-installer
+
                   # Versioned release for history
                   gh release create "$VERSION" \
-                      bin/hobby-installer-linux \
+                      bin/hobby-installer \
                       --title "Hobby Installer $VERSION" \
                       --notes "Build from commit ${{ github.sha }}" \
                       --latest=false
@@ -54,7 +57,7 @@ jobs:
                   gh release delete hobby-latest --yes || true
                   git push origin :refs/tags/hobby-latest || true
                   gh release create hobby-latest \
-                      bin/hobby-installer-linux \
+                      bin/hobby-installer \
                       --title "Hobby Installer (Latest)" \
                       --notes "Latest hobby installer build - same as $VERSION
 

--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,6 @@ bin/*.lock
 
 # Avoid commiting built binaries, they can be built locally easily
 # We deploy them to releases via the `build-hobby-installer.yml` workflow
-bin/hobby-installer
 bin/hobby-installer-*
 bin/hobby-installer/hobby-installer
 bin/hobby-installer/hobby-installer.log

--- a/bin/hobby-installer/Makefile
+++ b/bin/hobby-installer/Makefile
@@ -15,13 +15,9 @@ GOMOD=$(GOCMD) mod
 # Build flags for smaller binary
 LDFLAGS=-ldflags "-s -w"
 
-# Default target builds the final binary for production
-all: build-linux
-
-# Install dependencies
-deps:
-	$(GOMOD) download
-	$(GOMOD) tidy
+# Run development version
+run: build
+	$(OUTPUT_DIR)/$(BINARY_NAME)-development
 
 # Build for current platform (development)
 build: deps
@@ -29,7 +25,7 @@ build: deps
 
 # Build for Linux (production - hobby deployments are on Ubuntu)
 build-linux: deps
-	GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(OUTPUT_DIR)/$(BINARY_NAME) .
+	GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(OUTPUT_DIR)/$(BINARY_NAME)-linux .
 
 # Build for macOS (for local testing)
 build-darwin: deps
@@ -39,12 +35,8 @@ build-darwin: deps
 build-demo: deps
 	$(GOBUILD) $(LDFLAGS) -o $(OUTPUT_DIR)/$(BINARY_NAME)-demo ./demo
 
-# Build all possible binaries
+# Build Linux and macOS binaries
 build-all: build build-linux build-darwin
-
-# Run development version
-run: build
-	$(OUTPUT_DIR)/$(BINARY_NAME)-development
 
 # Run a demo (usage: make demo DEMO=checks)
 demo: build-demo
@@ -53,11 +45,16 @@ demo: build-demo
 # Clean build artifacts
 clean:
 	$(GOCLEAN)
-	rm -f $(OUTPUT_DIR)/$(BINARY_NAME)
+	rm -f $(OUTPUT_DIR)/$(BINARY_NAME)-linux
 	rm -f $(OUTPUT_DIR)/$(BINARY_NAME)-darwin
 	rm -f $(OUTPUT_DIR)/$(BINARY_NAME)-development
 	rm -f $(OUTPUT_DIR)/$(BINARY_NAME)-demo
 	rm -f hobby-installer
+
+# Install dependencies
+deps:
+	$(GOMOD) download
+	$(GOMOD) tidy
 
 # Run tests
 test:

--- a/bin/hobby-installer/README.md
+++ b/bin/hobby-installer/README.md
@@ -53,11 +53,12 @@ CI mode is automatically enabled when common CI environment variables are detect
 ```bash
 cd bin/hobby-installer
 
-# Build for Linux (production - hobby deployments run on Ubuntu)
+# Build for development (current arch) and run
 make
 
-# Build for macOS (local testing)
+# Build for specific architecture
 make build-darwin
+make build-linux
 
 # Build all (development, linux, darwin)
 make build-all
@@ -65,7 +66,7 @@ make build-all
 
 Output binaries:
 
-- `bin/hobby-installer` - Linux binary (production)
+- `bin/hobby-installer-linux` - Linux binary
 - `bin/hobby-installer-darwin` - macOS binary (gitignored, local testing only)
 - `bin/hobby-installer-development` - Development binary for current platform
 - `bin/hobby-installer-demo` - Demo binary for testing UI components

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -535,8 +535,8 @@ tools:
         bin_script: posthog-node
         description: Start the posthog-node service (old plugin-server)
         hidden: true
-    posthog:hobby-installer:
-        bin_script: hobby-installer
+    posthog:hobby-installer-linux:
+        bin_script: hobby-installer-linux
         description: Run the hobby-installer installation script for Linux, don't use
             it on your MacOS development environment
         hidden: true


### PR DESCRIPTION
We were storing it with the same name as the folder which wasn't working well
