### PR TITLE
fix(product tours): fix preview modal

### DIFF
--- a/frontend/src/scenes/product-tours/AnnouncementContentEditor.tsx
+++ b/frontend/src/scenes/product-tours/AnnouncementContentEditor.tsx
@@ -1,13 +1,11 @@
 import { JSONContent } from '@tiptap/core'
-import { renderProductTourPreview } from 'posthog-js/dist/product-tours-preview'
-import { useEffect, useRef } from 'react'
 
 import { ProductTourAppearance, ProductTourStep } from '~/types'
 
+import { ProductTourPreview } from './components/ProductTourPreview'
 import { StepButtonsEditor } from './editor/StepButtonsEditor'
 import { StepContentEditor } from './editor/StepContentEditor'
 import { StepLayoutSettings } from './editor/StepLayoutSettings'
-import { prepareStepForRender } from './editor/generateStepHtml'
 
 export interface AnnouncementContentEditorProps {
     step: ProductTourStep | undefined
@@ -16,25 +14,11 @@ export interface AnnouncementContentEditorProps {
 }
 
 export function AnnouncementContentEditor({ step, appearance, onChange }: AnnouncementContentEditorProps): JSX.Element {
-    const previewRef = useRef<HTMLDivElement>(null)
-
     const updateStep = (updates: Partial<ProductTourStep>): void => {
         if (step) {
             onChange({ ...step, ...updates })
         }
     }
-
-    useEffect(() => {
-        if (previewRef.current && step) {
-            renderProductTourPreview({
-                step: prepareStepForRender(step) as any,
-                appearance: appearance as any,
-                parentElement: previewRef.current,
-                stepIndex: 0,
-                totalSteps: 1,
-            })
-        }
-    }, [step, appearance])
 
     if (!step) {
         return <div>No content</div>
@@ -62,7 +46,7 @@ export function AnnouncementContentEditor({ step, appearance, onChange }: Announ
             <div className="flex-1 min-w-0 sticky top-4">
                 <div className="text-xs text-muted uppercase tracking-wide mb-3">Preview</div>
                 <div className="flex justify-center items-center p-8 bg-[#f0f0f0] rounded min-h-[300px]">
-                    <div ref={previewRef} />
+                    <ProductTourPreview step={step} appearance={appearance} />
                 </div>
             </div>
         </div>

--- a/frontend/src/scenes/product-tours/components/ProductTourCustomization.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductTourCustomization.tsx
@@ -1,15 +1,15 @@
-import { renderProductTourPreview } from 'posthog-js/dist/product-tours-preview'
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 
 import { LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { LemonColorPicker } from 'lib/lemon-ui/LemonColor/LemonColorPicker'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider/LemonSlider'
-import { prepareStepForRender } from 'scenes/product-tours/editor/generateStepHtml'
 import { WEB_SAFE_FONTS } from 'scenes/surveys/constants'
 
 import { ProductTourAppearance, ProductTourStep } from '~/types'
+
+import { ProductTourPreview } from './ProductTourPreview'
 
 const DEFAULT_APPEARANCE: ProductTourAppearance = {
     backgroundColor: '#ffffff',
@@ -86,20 +86,7 @@ function TourStepPreview({
     selectedStepIndex: number
     onStepChange: (index: number) => void
 }): JSX.Element {
-    const previewRef = useRef<HTMLDivElement>(null)
     const step = steps[selectedStepIndex]
-
-    useEffect(() => {
-        if (previewRef.current && step) {
-            renderProductTourPreview({
-                step: prepareStepForRender(step) as any,
-                appearance: appearance as any,
-                parentElement: previewRef.current,
-                stepIndex: selectedStepIndex,
-                totalSteps: steps.length,
-            })
-        }
-    }, [step, appearance, selectedStepIndex, steps.length])
 
     const stepOptions = steps.map((_, index) => ({
         label: `Step ${index + 1}`,
@@ -120,7 +107,14 @@ function TourStepPreview({
                 )}
             </div>
             <div className="flex justify-center p-8 bg-[#f0f0f0] rounded min-h-[200px]">
-                <div ref={previewRef} />
+                {step && (
+                    <ProductTourPreview
+                        step={step}
+                        appearance={appearance}
+                        stepIndex={selectedStepIndex}
+                        totalSteps={steps.length}
+                    />
+                )}
             </div>
         </div>
     )

--- a/frontend/src/scenes/product-tours/components/ProductTourPreview.tsx
+++ b/frontend/src/scenes/product-tours/components/ProductTourPreview.tsx
@@ -1,0 +1,38 @@
+import { renderProductTourPreview } from 'posthog-js/dist/product-tours-preview'
+import { useEffect, useRef } from 'react'
+
+import { ProductTourAppearance, ProductTourStep } from '~/types'
+
+import { prepareStepForRender } from '../editor/generateStepHtml'
+
+export interface ProductTourPreviewProps {
+    step: ProductTourStep
+    appearance?: ProductTourAppearance
+    stepIndex?: number
+    totalSteps?: number
+    prepareStep?: boolean
+}
+
+export function ProductTourPreview({
+    step,
+    appearance,
+    stepIndex = 0,
+    totalSteps = 1,
+    prepareStep = true,
+}: ProductTourPreviewProps): JSX.Element {
+    const ref = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (ref.current) {
+            renderProductTourPreview({
+                step: (prepareStep ? prepareStepForRender(step) : step) as any,
+                appearance: appearance as any,
+                parentElement: ref.current,
+                stepIndex,
+                totalSteps,
+            })
+        }
+    }, [step, appearance, stepIndex, totalSteps, prepareStep])
+
+    return <div ref={ref} />
+}

--- a/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
@@ -1,8 +1,7 @@
 import './ProductTourStepsEditor.scss'
 
 import { JSONContent } from '@tiptap/core'
-import { renderProductTourPreview } from 'posthog-js/dist/product-tours-preview'
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 
 import {
     IconChevronLeft,
@@ -27,11 +26,11 @@ import {
     SurveyPosition,
 } from '~/types'
 
+import { ProductTourPreview } from '../components/ProductTourPreview'
 import { StepContentEditor } from './StepContentEditor'
 import { StepLayoutSettings } from './StepLayoutSettings'
 import { StepScreenshotThumbnail } from './StepScreenshotThumbnail'
 import { SurveyStepEditor } from './SurveyStepEditor'
-import { prepareStepForRender } from './generateStepHtml'
 
 export interface ProductTourStepsEditorProps {
     steps: ProductTourStep[]
@@ -92,8 +91,6 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
     const [stepToDelete, setStepToDelete] = useState<number | null>(null)
     const [showPreviewModal, setShowPreviewModal] = useState(false)
     const [showScreenshotModal, setShowScreenshotModal] = useState(false)
-    const previewRef = useRef<HTMLDivElement>(null)
-    const surveyPreviewRef = useRef<HTMLDivElement>(null)
 
     const selectedStep = steps[selectedStepIndex]
 
@@ -126,31 +123,6 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
         onChange(newSteps)
         setSelectedStepIndex(toIndex)
     }
-
-    useEffect(() => {
-        if (showPreviewModal && previewRef.current && selectedStep) {
-            renderProductTourPreview({
-                step: prepareStepForRender(selectedStep) as any,
-                appearance: appearance as any,
-                parentElement: previewRef.current,
-                stepIndex: selectedStepIndex,
-                totalSteps: steps.length,
-            })
-        }
-    }, [showPreviewModal, selectedStep, appearance, selectedStepIndex, steps.length])
-
-    // Render inline survey preview
-    useEffect(() => {
-        if (surveyPreviewRef.current && selectedStep?.type === 'survey') {
-            renderProductTourPreview({
-                step: prepareStepForRender(selectedStep) as any,
-                appearance: appearance as any,
-                parentElement: surveyPreviewRef.current,
-                stepIndex: selectedStepIndex,
-                totalSteps: steps.length,
-            })
-        }
-    }, [selectedStep, appearance, selectedStepIndex, steps.length])
 
     if (steps.length === 0) {
         return (
@@ -273,7 +245,12 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
                                 <div className="ProductTourStepsEditor__survey-preview">
                                     <div className="text-xs text-muted uppercase tracking-wide mb-3">Preview</div>
                                     <div className="flex justify-center p-6 bg-[#f0f0f0] rounded min-h-[200px]">
-                                        <div ref={surveyPreviewRef} />
+                                        <ProductTourPreview
+                                            step={selectedStep}
+                                            appearance={appearance}
+                                            stepIndex={selectedStepIndex}
+                                            totalSteps={steps.length}
+                                        />
                                     </div>
                                 </div>
                             </div>
@@ -335,7 +312,14 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
                 width={800}
             >
                 <div className="flex justify-center items-center p-8 bg-[#f0f0f0] rounded min-h-[300px]">
-                    <div ref={previewRef} />
+                    {selectedStep && (
+                        <ProductTourPreview
+                            step={selectedStep}
+                            appearance={appearance}
+                            stepIndex={selectedStepIndex}
+                            totalSteps={steps.length}
+                        />
+                    )}
                 </div>
             </LemonModal>
 

--- a/frontend/src/toolbar/product-tours/StepEditor.tsx
+++ b/frontend/src/toolbar/product-tours/StepEditor.tsx
@@ -1,6 +1,5 @@
 import { JSONContent } from '@tiptap/core'
 import { useActions, useValues } from 'kea'
-import { renderProductTourPreview } from 'posthog-js/dist/product-tours-preview'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import { IconChevronRight, IconCursorClick, IconTrash } from '@posthog/icons'
@@ -8,6 +7,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
+import { ProductTourPreview } from 'scenes/product-tours/components/ProductTourPreview'
 import {
     TOUR_STEP_MAX_WIDTH,
     TOUR_STEP_MIN_WIDTH,
@@ -112,7 +112,6 @@ export function StepEditor({ rect, elementNotFound }: { rect?: ElementRect; elem
 
     const [stepContent, setStepContent] = useState<JSONContent | null>(editingStep?.content ?? DEFAULT_STEP_CONTENT)
     const editorRef = useRef<HTMLDivElement>(null)
-    const surveyPreviewRef = useRef<HTMLDivElement>(null)
     const [position, setPosition] = useState<{ left: number; top: number } | null>(null)
     const [selector, setSelector] = useState('')
     const [showAdvanced, setShowAdvanced] = useState(false)
@@ -191,24 +190,6 @@ export function StepEditor({ rect, elementNotFound }: { rect?: ElementRect; elem
         setSurveyConfig(editingStep?.survey)
         setModalPosition(editingStep?.modalPosition ?? SurveyPosition.MiddleCenter)
     }, [editingStep?.id])
-
-    // Render survey preview using product tour's native survey rendering
-    useEffect(() => {
-        if (isSurveyStep && surveyPreviewRef.current && surveyConfig) {
-            renderProductTourPreview({
-                step: {
-                    id: 'preview',
-                    type: 'survey',
-                    content: null,
-                    survey: surveyConfig,
-                    progressionTrigger: 'button',
-                },
-                parentElement: surveyPreviewRef.current,
-                stepIndex: 0,
-                totalSteps: 1,
-            })
-        }
-    }, [isSurveyStep, surveyConfig])
 
     // Position element steps near target (when element is visible)
     useLayoutEffect(() => {
@@ -346,11 +327,18 @@ export function StepEditor({ rect, elementNotFound }: { rect?: ElementRect; elem
                         {/* Survey preview */}
                         <div className="pt-2">
                             <div className="text-[10px] text-muted uppercase tracking-wide mb-2">Preview</div>
-                            <div
-                                ref={surveyPreviewRef}
-                                // eslint-disable-next-line react/forbid-dom-props
-                                style={{ minHeight: 100 }}
-                            />
+                            {surveyConfig && (
+                                <ProductTourPreview
+                                    step={{
+                                        id: 'preview',
+                                        type: 'survey',
+                                        content: null,
+                                        survey: surveyConfig,
+                                        progressionTrigger: 'button',
+                                    }}
+                                    prepareStep={false}
+                                />
+                            )}
                         </div>
                     </div>
                 )}


### PR DESCRIPTION
## Problem

preview modal is not working for tour steps, and overall previews are sometimes causing errors:

> NotFoundError: Failed to execute 'removeChild' on 'Node':

fixing all the issues by extracting the preview to its own component, this also gets rid of the 1000 places we were doing the same thing

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

fixes it :)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manual testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no