### PR TITLE
chore(workflows): add progress logs to batch workflow consumer

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
@@ -201,16 +201,7 @@ export class CdpBatchHogFlowRequestsConsumer extends CdpConsumerBase {
         return {
             // This is all IO so we can set them off in the background and start processing the next batch
             backgroundTask: Promise.all([
-                this.cyclotronJobQueue.queueInvocations(invocationsToBeQueued).catch((err) => {
-                    captureException(err)
-                    logger.error('🔴', 'Error queuing hogflow invocations', {
-                        err,
-                        invocationCount: invocationsToBeQueued.length,
-                        teamIds: [...new Set(invocationsToBeQueued.map((i) => i.teamId))],
-                        functionIds: [...new Set(invocationsToBeQueued.map((i) => i.functionId))],
-                    })
-                    throw err
-                }),
+                this.cyclotronJobQueue.queueInvocations(invocationsToBeQueued),
                 this.hogFunctionMonitoringService.flush().catch((err) => {
                     captureException(err)
                     logger.error('🔴', 'Error producing queued messages for monitoring', { err })


### PR DESCRIPTION
## Problem

Context: https://posthog.slack.com/archives/C06GG249PR6/p1767913466133669?thread_ts=1767893465.342589&cid=C06GG249PR6

## Changes

Just adds logs and fixes a typo with rate limited invocation metric

## How did you test this code?

Existing typechecking + test coverage should keep this safe