### PR TITLE
fix(workflows): improve person batching for batch workflows

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.test.ts
@@ -210,9 +210,11 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
 
             // Mock the personsManager to return some persons
             const mockCountMany = jest.fn().mockResolvedValue(2)
-            const mockStreamMany = jest.fn().mockImplementation(async ({ onPerson }: any) => {
-                await onPerson({ personId: 'person-1', distinctId: 'distinct-1' })
-                await onPerson({ personId: 'person-2', distinctId: 'distinct-2' })
+            const mockStreamMany = jest.fn().mockImplementation(async ({ onPersonBatch }: any) => {
+                await onPersonBatch([
+                    { personId: 'person-1', distinctId: 'distinct-1' },
+                    { personId: 'person-2', distinctId: 'distinct-2' },
+                ])
             })
 
             processor['personsManager'].countMany = mockCountMany
@@ -283,7 +285,7 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
                     teamId: team.id,
                     properties: batchRequest.filters.properties,
                 },
-                onPerson: expect.any(Function),
+                onPersonBatch: expect.any(Function),
             })
         })
 
@@ -390,8 +392,8 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
             ]
 
             // Mock the personsManager
-            const mockStreamMany = jest.fn().mockImplementation(async ({ onPerson }: any) => {
-                await onPerson({ personId: 'person-1', distinctId: 'distinct-1' })
+            const mockStreamMany = jest.fn().mockImplementation(async ({ onPersonBatch }: any) => {
+                await onPersonBatch([{ personId: 'person-1', distinctId: 'distinct-1' }])
             })
             jest.spyOn(processor['personsManager'], 'countMany').mockResolvedValue(1)
             processor['personsManager'].streamMany = mockStreamMany
@@ -440,8 +442,8 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
             )
 
             // Mock the personsManager
-            const mockStreamMany = jest.fn().mockImplementation(async ({ onPerson }: any) => {
-                await onPerson({ personId: 'person-1', distinctId: 'distinct-1' })
+            const mockStreamMany = jest.fn().mockImplementation(async ({ onPersonBatch }: any) => {
+                await onPersonBatch([{ personId: 'person-1', distinctId: 'distinct-1' }])
             })
             jest.spyOn(processor['personsManager'], 'countMany').mockResolvedValue(1)
             processor['personsManager'].streamMany = mockStreamMany
@@ -512,8 +514,8 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
             )
 
             // Mock the personsManager
-            const mockStreamMany = jest.fn().mockImplementation(async ({ onPerson }: any) => {
-                await onPerson({ personId: 'person-1', distinctId: 'distinct-1' })
+            const mockStreamMany = jest.fn().mockImplementation(async ({ onPersonBatch }: any) => {
+                await onPersonBatch([{ personId: 'person-1', distinctId: 'distinct-1' }])
             })
             jest.spyOn(processor['personsManager'], 'countMany').mockResolvedValue(1)
             processor['personsManager'].streamMany = mockStreamMany
@@ -573,9 +575,11 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
             )
 
             // Mock the personsManager
-            const mockStreamMany = jest.fn().mockImplementation(async ({ onPerson }: any) => {
-                await onPerson({ personId: 'person-1', distinctId: 'distinct-1' })
-                await onPerson({ personId: 'person-2', distinctId: 'distinct-2' })
+            const mockStreamMany = jest.fn().mockImplementation(async ({ onPersonBatch }: any) => {
+                await onPersonBatch([
+                    { personId: 'person-1', distinctId: 'distinct-1' },
+                    { personId: 'person-2', distinctId: 'distinct-2' },
+                ])
             })
             jest.spyOn(processor['personsManager'], 'countMany').mockResolvedValue(2)
             processor['personsManager'].streamMany = mockStreamMany

--- a/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
@@ -153,16 +153,19 @@ export class CdpBatchHogFlowRequestsConsumer extends CdpConsumerBase {
                     teamId: team.id,
                     properties: (filters.properties as PersonPropertyFilter[]) || [],
                 },
-                onPerson: ({ personId, distinctId }) => {
-                    const invocation = this.createHogFlowInvocation({
-                        hogFlow,
-                        team,
-                        personId,
-                        distinctId,
-                        defaultVariables,
-                    })
+                onPersonBatch: (persons: { personId: string; distinctId: string }[]) => {
+                    const batchInvocations = persons.map(({ personId, distinctId }) =>
+                        this.createHogFlowInvocation({
+                            hogFlow,
+                            team,
+                            personId,
+                            distinctId,
+                            defaultVariables,
+                        })
+                    )
 
-                    invocations.push(invocation)
+                    invocations.push(...batchInvocations)
+                    return Promise.resolve()
                 },
             })
         })

--- a/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.ts
@@ -153,7 +153,7 @@ export class CdpBatchHogFlowRequestsConsumer extends CdpConsumerBase {
                     teamId: team.id,
                     properties: (filters.properties as PersonPropertyFilter[]) || [],
                 },
-                onPersonBatch: (persons: { personId: string; distinctId: string }[]) => {
+                onPersonBatch: async (persons: { personId: string; distinctId: string }[]) => {
                     const batchInvocations = persons.map(({ personId, distinctId }) =>
                         this.createHogFlowInvocation({
                             hogFlow,

--- a/nodejs/src/cdp/services/managers/persons-manager.service.test.ts
+++ b/nodejs/src/cdp/services/managers/persons-manager.service.test.ts
@@ -205,7 +205,7 @@ describe('PersonsManager', () => {
 
             jest.spyOn(hub.personRepository, 'fetchPersonsByProperties').mockResolvedValueOnce(mockPersons)
 
-            const onPerson = jest.fn()
+            const onPersonBatch = jest.fn()
             await manager.streamMany({
                 filters: {
                     teamId: team.id,
@@ -218,13 +218,15 @@ describe('PersonsManager', () => {
                         },
                     ],
                 },
-                onPerson,
+                onPersonBatch,
             })
 
-            expect(onPerson).toHaveBeenCalledTimes(3)
-            expect(onPerson).toHaveBeenNthCalledWith(1, { personId: 'person-1', distinctId: 'distinct-1' })
-            expect(onPerson).toHaveBeenNthCalledWith(2, { personId: 'person-2', distinctId: 'distinct-2' })
-            expect(onPerson).toHaveBeenNthCalledWith(3, { personId: 'person-3', distinctId: 'distinct-3' })
+            expect(onPersonBatch).toHaveBeenCalledTimes(1)
+            expect(onPersonBatch).toHaveBeenCalledWith([
+                { personId: 'person-1', distinctId: 'distinct-1' },
+                { personId: 'person-2', distinctId: 'distinct-2' },
+                { personId: 'person-3', distinctId: 'distinct-3' },
+            ])
         })
 
         it('handles pagination correctly with multiple batches', async () => {
@@ -266,10 +268,10 @@ describe('PersonsManager', () => {
                     return callCount === 1 ? batch1 : batch2
                 })
 
-            const onPerson = jest.fn()
+            const onPersonBatch = jest.fn()
             await manager.streamMany({
                 filters: { teamId: team.id, properties: [] },
-                onPerson,
+                onPersonBatch,
             })
 
             expect(fetchSpy).toHaveBeenCalledTimes(2)
@@ -283,7 +285,7 @@ describe('PersonsManager', () => {
                 properties: [],
                 options: { limit: 500, cursor: '499' },
             })
-            expect(onPerson).toHaveBeenCalledTimes(800)
+            expect(onPersonBatch).toHaveBeenCalledTimes(2)
         })
 
         it('stops paginating when batch is not full', async () => {
@@ -304,26 +306,26 @@ describe('PersonsManager', () => {
 
             const fetchSpy = jest.spyOn(hub.personRepository, 'fetchPersonsByProperties').mockResolvedValueOnce(batch)
 
-            const onPerson = jest.fn()
+            const onPersonBatch = jest.fn()
             await manager.streamMany({
                 filters: { teamId: team.id, properties: [] },
-                onPerson,
+                onPersonBatch,
             })
 
             expect(fetchSpy).toHaveBeenCalledTimes(1)
-            expect(onPerson).toHaveBeenCalledTimes(200)
+            expect(onPersonBatch).toHaveBeenCalledTimes(1)
         })
 
         it('handles empty results', async () => {
             jest.spyOn(hub.personRepository, 'fetchPersonsByProperties').mockResolvedValueOnce([])
 
-            const onPerson = jest.fn()
+            const onPersonBatch = jest.fn()
             await manager.streamMany({
                 filters: { teamId: team.id, properties: [] },
-                onPerson,
+                onPersonBatch,
             })
 
-            expect(onPerson).not.toHaveBeenCalled()
+            expect(onPersonBatch).not.toHaveBeenCalled()
         })
 
         it('respects custom limit option', async () => {
@@ -364,11 +366,11 @@ describe('PersonsManager', () => {
                     return callCount === 1 ? batch1 : batch2
                 })
 
-            const onPerson = jest.fn()
+            const onPersonBatch = jest.fn()
             await manager.streamMany({
                 filters: { teamId: team.id, properties: [] },
                 options: { limit: 100 },
-                onPerson,
+                onPersonBatch,
             })
 
             expect(fetchSpy.mock.calls[0][0]).toEqual({
@@ -381,7 +383,7 @@ describe('PersonsManager', () => {
                 properties: [],
                 options: { limit: 100, cursor: '99' },
             })
-            expect(onPerson).toHaveBeenCalledTimes(150)
+            expect(onPersonBatch).toHaveBeenCalledTimes(2)
         })
     })
 })

--- a/nodejs/src/cdp/services/managers/persons-manager.service.ts
+++ b/nodejs/src/cdp/services/managers/persons-manager.service.ts
@@ -59,11 +59,11 @@ export class PersonsManagerService {
     public async streamMany({
         filters,
         options,
-        onPerson,
+        onPersonBatch,
     }: {
         filters: BatchPersonGetArgs
         options?: { limit?: number }
-        onPerson: ({ personId, distinctId }: { personId: string; distinctId: string }) => void
+        onPersonBatch: (personsBatch: { personId: string; distinctId: string }[]) => Promise<void>
     }): Promise<void> {
         const limit = options?.limit || 500
         let cursor: string | undefined = undefined
@@ -73,12 +73,12 @@ export class PersonsManagerService {
             options: { limit, cursor },
         })
         while (personBatch.length > 0) {
-            for (const personRow of personBatch) {
-                onPerson?.({
+            await onPersonBatch(
+                personBatch.map((personRow) => ({
                     personId: personRow.uuid,
                     distinctId: personRow.distinct_id,
-                })
-            }
+                }))
+            )
 
             // Skip another query if our page wasn't full
             if (personBatch.length < limit) {


### PR DESCRIPTION
## Problem

noticed this person batching code has two issues:
- It hammers call stack with these callback functions unecessarily
- The `streamMany` doesn't await the callback, so there could be execution flow issues especially on the last batch of persons.

## Changes

Fix the problems above

## How did you test this code?

Updated tests accordingly