### PR TITLE
feat(persons): add persons DB migration for reconciliation job restore table

### DIFF
--- a/rust/persons_migrations/20260108000001_add_person_reconciliation_backup.sql
+++ b/rust/persons_migrations/20260108000001_add_person_reconciliation_backup.sql
@@ -1,0 +1,30 @@
+-- Backup table for person property reconciliation job
+-- Stores original person state before updates for audit/rollback
+
+CREATE TABLE IF NOT EXISTS posthog_person_reconciliation_backup (
+    job_id TEXT NOT NULL,
+    team_id INTEGER NOT NULL,
+    person_id BIGINT NOT NULL,
+    -- Full row backup of posthog_person columns (BEFORE state)
+    uuid UUID NOT NULL,
+    properties JSONB NOT NULL,
+    properties_last_updated_at JSONB,
+    properties_last_operation JSONB,
+    version BIGINT,
+    is_identified BOOLEAN NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    is_user_id INTEGER,
+    -- Operations to be applied (from ClickHouse query)
+    pending_operations JSONB NOT NULL,
+    -- AFTER state (computed before update)
+    properties_after JSONB,
+    properties_last_updated_at_after JSONB,
+    properties_last_operation_after JSONB,
+    version_after BIGINT,
+    -- Metadata
+    backed_up_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (job_id, team_id, person_id)
+);
+
+CREATE INDEX IF NOT EXISTS person_reconciliation_backup_team_person
+    ON posthog_person_reconciliation_backup (team_id, person_id);


### PR DESCRIPTION
## Problem
We need a place to store before and after updates we can reverse from the persons reconiliation job in case it has unexpected side effects on source-of-truth user data in the `posthog_person` shards.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Adds migration file

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
