### PR TITLE
feat(experiments): automatic reload.

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -258,6 +258,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENTS_NEW_CALCULATOR: 'experiments-new-calculator', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_EXPOSURE_CRITERIA_COLLAPSABLE: 'experiments-exposure-criteria-collapsable', // owner: #team-experiments
+    EXPERIMENTS_RELOAD_ACTION: 'experiments-reload-action', // owner: @rodrigoi #team-experiments
     EXTERNAL_SURVEYS: 'external-surveys', // owner: #team-surveys
     FEATURE_FLAG_COHORT_CREATION: 'feature-flag-cohort-creation', // owner: #team-feature-flags
     FLAG_BUCKETING_IDENTIFIER: 'flag-bucketing-identifier', // owner: @andehen #team-experiments

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -437,6 +437,24 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportExperimentCreated: (experiment: Experiment) => ({ experiment }),
         reportExperimentUpdated: (experiment: Experiment) => ({ experiment }),
         reportExperimentViewed: (experiment: Experiment, duration: number | null) => ({ experiment, duration }),
+        reportExperimentMetricsRefreshed: (
+            experiment: Experiment,
+            forceRefresh: boolean,
+            context?: {
+                triggered_by: 'manual' | 'auto-refresh'
+                auto_refresh_enabled?: boolean
+                auto_refresh_interval?: number
+            }
+        ) => ({
+            experiment,
+            forceRefresh,
+            context,
+        }),
+        reportExperimentAutoRefreshToggled: (experiment: Experiment, enabled: boolean, interval: number) => ({
+            experiment,
+            enabled,
+            interval,
+        }),
         reportExperimentLaunched: (experiment: Experiment, launchDate: Dayjs) => ({ experiment, launchDate }),
         reportExperimentStartDateChange: (experiment: Experiment, newStartDate: string) => ({
             experiment,
@@ -1134,6 +1152,22 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             posthog.capture('experiment viewed', {
                 ...getEventPropertiesForExperiment(experiment),
                 duration,
+            })
+        },
+        reportExperimentMetricsRefreshed: ({ experiment, forceRefresh, context }) => {
+            posthog.capture('experiment metrics refreshed', {
+                ...getEventPropertiesForExperiment(experiment),
+                force_refresh: forceRefresh,
+                triggered_by: context?.triggered_by || 'manual',
+                auto_refresh_enabled: context?.auto_refresh_enabled,
+                auto_refresh_interval: context?.auto_refresh_interval,
+            })
+        },
+        reportExperimentAutoRefreshToggled: ({ experiment, enabled, interval }) => {
+            posthog.capture('experiment auto refresh toggled', {
+                ...getEventPropertiesForExperiment(experiment),
+                enabled,
+                interval,
             })
         },
         reportExperimentLaunched: ({ experiment, launchDate }) => {

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
@@ -1,0 +1,160 @@
+import clsx from 'clsx'
+import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
+
+import { IconCheck, IconRefresh } from '@posthog/icons'
+import { LemonBadge, LemonButton, LemonSwitch } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { dayjs } from 'lib/dayjs'
+import { usePageVisibilityCb } from 'lib/hooks/usePageVisibility'
+import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
+import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+import { humanFriendlyDuration } from 'lib/utils'
+
+import { EXPERIMENT_REFRESH_INTERVAL_SECONDS } from '../constants'
+import { experimentLogic } from '../experimentLogic'
+
+export const ExperimentLastRefreshText = (): JSX.Element => {
+    const { effectiveLastRefresh } = useValues(experimentLogic)
+    return (
+        <div className="flex items-center gap-1">
+            {effectiveLastRefresh && dayjs().diff(dayjs(effectiveLastRefresh), 'hour') < 24 ? (
+                <div className="flex items-center gap-1">
+                    <span>Last refreshed</span>
+                    <TZLabel time={effectiveLastRefresh} />
+                </div>
+            ) : (
+                'Refresh'
+            )}
+        </div>
+    )
+}
+
+const INTERVAL_OPTIONS = Array.from(EXPERIMENT_REFRESH_INTERVAL_SECONDS, (value) => ({
+    label: humanFriendlyDuration(value),
+    value: value,
+}))
+
+export function ExperimentReloadAction(): JSX.Element {
+    const {
+        primaryMetricsResultsLoading,
+        secondaryMetricsResultsLoading,
+        autoRefresh,
+        blockRefresh,
+        nextAllowedExperimentRefresh,
+    } = useValues(experimentLogic)
+    const { refreshExperimentResults, setAutoRefresh, setPageVisibility } = useActions(experimentLogic)
+
+    const isRefreshing = primaryMetricsResultsLoading || secondaryMetricsResultsLoading
+
+    usePageVisibilityCb((pageIsVisible) => {
+        setPageVisibility(pageIsVisible)
+    })
+
+    // Force re-render when cooldown expires
+    const [, setRenderTrigger] = useState(0)
+    useEffect(() => {
+        if (nextAllowedExperimentRefresh) {
+            const msUntilRefreshAllowed = dayjs(nextAllowedExperimentRefresh).diff(dayjs())
+            if (msUntilRefreshAllowed > 0) {
+                const timeoutId = setTimeout(() => setRenderTrigger((n) => n + 1), msUntilRefreshAllowed + 100)
+                return () => clearTimeout(timeoutId)
+            }
+        }
+    }, [nextAllowedExperimentRefresh])
+
+    const options = INTERVAL_OPTIONS.map((option) => ({
+        ...option,
+        disabledReason: !autoRefresh.enabled ? 'Enable auto refresh to set the interval' : undefined,
+    }))
+
+    return (
+        <div className="relative">
+            <LemonButton
+                onClick={() => refreshExperimentResults(true)}
+                type="secondary"
+                size="xsmall"
+                icon={
+                    isRefreshing ? (
+                        <Spinner textColored />
+                    ) : blockRefresh &&
+                      nextAllowedExperimentRefresh &&
+                      dayjs(nextAllowedExperimentRefresh).isAfter(dayjs()) ? (
+                        <IconCheck />
+                    ) : (
+                        <IconRefresh />
+                    )
+                }
+                data-attr="refresh-experiment"
+                tooltip="Refresh experiment results"
+                disabledReason={
+                    blockRefresh &&
+                    nextAllowedExperimentRefresh &&
+                    dayjs(nextAllowedExperimentRefresh).isAfter(dayjs())
+                        ? `Next refresh possible ${dayjs(nextAllowedExperimentRefresh).fromNow()}`
+                        : isRefreshing
+                          ? 'Loading...'
+                          : ''
+                }
+                sideAction={{
+                    'data-attr': 'refresh-experiment-dropdown',
+                    dropdown: {
+                        closeOnClickInside: false,
+                        placement: 'bottom-end',
+                        overlay: (
+                            <LemonMenuOverlay
+                                items={[
+                                    {
+                                        label: () => (
+                                            <LemonSwitch
+                                                onChange={(checked) => setAutoRefresh(checked, autoRefresh.interval)}
+                                                label="Auto refresh while on page"
+                                                checked={autoRefresh.enabled}
+                                                fullWidth
+                                                className="mt-1 mb-2"
+                                            />
+                                        ),
+                                    },
+                                    {
+                                        title: 'Refresh interval',
+                                        items: [
+                                            {
+                                                label: () => (
+                                                    <LemonRadio
+                                                        value={autoRefresh.interval}
+                                                        options={options}
+                                                        onChange={(value: number) => {
+                                                            setAutoRefresh(true, value)
+                                                        }}
+                                                        className="mx-2 mb-1"
+                                                    />
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ]}
+                            />
+                        ),
+                    },
+                }}
+            >
+                <span className={clsx('refresh-experiment-text')}>
+                    {isRefreshing ? 'Loading...' : <ExperimentLastRefreshText />}
+                </span>
+            </LemonButton>
+            <LemonBadge
+                size="small"
+                content={
+                    <>
+                        <IconRefresh className="mr-0" /> {humanFriendlyDuration(autoRefresh.interval)}
+                    </>
+                }
+                visible={autoRefresh.enabled}
+                position="top-right"
+                status="muted"
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
@@ -1,8 +1,7 @@
-import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
-import { IconCheck, IconRefresh } from '@posthog/icons'
+import { IconRefresh } from '@posthog/icons'
 import { LemonBadge, LemonButton, LemonSwitch } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
@@ -11,25 +10,22 @@ import { usePageVisibilityCb } from 'lib/hooks/usePageVisibility'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { Spinner } from 'lib/lemon-ui/Spinner'
+import { Label } from 'lib/ui/Label/Label'
 import { humanFriendlyDuration } from 'lib/utils'
 
 import { EXPERIMENT_REFRESH_INTERVAL_SECONDS } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 
-export const ExperimentLastRefreshText = (): JSX.Element => {
-    const { effectiveLastRefresh } = useValues(experimentLogic)
-    return (
-        <div className="flex items-center gap-1">
-            {effectiveLastRefresh && dayjs().diff(dayjs(effectiveLastRefresh), 'hour') < 24 ? (
-                <div className="flex items-center gap-1">
-                    <span>Last refreshed</span>
-                    <TZLabel time={effectiveLastRefresh} />
-                </div>
-            ) : (
-                'Refresh'
-            )}
-        </div>
-    )
+export const ExperimentLastRefreshText = ({ lastRefresh }: { lastRefresh: string }): JSX.Element => {
+    const colorClass = lastRefresh
+        ? dayjs().diff(dayjs(lastRefresh), 'hours') > 12
+            ? 'text-danger'
+            : dayjs().diff(dayjs(lastRefresh), 'hours') > 6
+              ? 'text-warning'
+              : ''
+        : ''
+
+    return <span className={colorClass}>{lastRefresh ? <TZLabel time={lastRefresh} /> : 'a while ago'}</span>
 }
 
 const INTERVAL_OPTIONS = Array.from(EXPERIMENT_REFRESH_INTERVAL_SECONDS, (value) => ({
@@ -37,33 +33,28 @@ const INTERVAL_OPTIONS = Array.from(EXPERIMENT_REFRESH_INTERVAL_SECONDS, (value)
     value: value,
 }))
 
-export function ExperimentReloadAction(): JSX.Element {
-    const {
-        primaryMetricsResultsLoading,
-        secondaryMetricsResultsLoading,
-        autoRefresh,
-        blockRefresh,
-        nextAllowedExperimentRefresh,
-    } = useValues(experimentLogic)
-    const { refreshExperimentResults, setAutoRefresh, setPageVisibility } = useActions(experimentLogic)
-
-    const isRefreshing = primaryMetricsResultsLoading || secondaryMetricsResultsLoading
+export const ExperimentReloadAction = ({
+    isRefreshing,
+    lastRefresh,
+    onClick,
+}: {
+    isRefreshing: boolean
+    lastRefresh: string
+    onClick: () => void
+}): JSX.Element => {
+    const { autoRefresh } = useValues(experimentLogic)
+    const { setAutoRefresh, setPageVisibility, stopAutoRefreshInterval } = useActions(experimentLogic)
 
     usePageVisibilityCb((pageIsVisible) => {
         setPageVisibility(pageIsVisible)
     })
 
-    // Force re-render when cooldown expires
-    const [, setRenderTrigger] = useState(0)
+    // Stop auto-refresh interval when component unmounts (e.g., navigating away)
     useEffect(() => {
-        if (nextAllowedExperimentRefresh) {
-            const msUntilRefreshAllowed = dayjs(nextAllowedExperimentRefresh).diff(dayjs())
-            if (msUntilRefreshAllowed > 0) {
-                const timeoutId = setTimeout(() => setRenderTrigger((n) => n + 1), msUntilRefreshAllowed + 100)
-                return () => clearTimeout(timeoutId)
-            }
+        return () => {
+            stopAutoRefreshInterval()
         }
-    }, [nextAllowedExperimentRefresh])
+    }, [stopAutoRefreshInterval])
 
     const options = INTERVAL_OPTIONS.map((option) => ({
         ...option,
@@ -71,90 +62,74 @@ export function ExperimentReloadAction(): JSX.Element {
     }))
 
     return (
-        <div className="relative">
-            <LemonButton
-                onClick={() => refreshExperimentResults(true)}
-                type="secondary"
-                size="xsmall"
-                icon={
-                    isRefreshing ? (
-                        <Spinner textColored />
-                    ) : blockRefresh &&
-                      nextAllowedExperimentRefresh &&
-                      dayjs(nextAllowedExperimentRefresh).isAfter(dayjs()) ? (
-                        <IconCheck />
-                    ) : (
-                        <IconRefresh />
-                    )
-                }
-                data-attr="refresh-experiment"
-                tooltip="Refresh experiment results"
-                disabledReason={
-                    blockRefresh &&
-                    nextAllowedExperimentRefresh &&
-                    dayjs(nextAllowedExperimentRefresh).isAfter(dayjs())
-                        ? `Next refresh possible ${dayjs(nextAllowedExperimentRefresh).fromNow()}`
-                        : isRefreshing
-                          ? 'Loading...'
-                          : ''
-                }
-                sideAction={{
-                    'data-attr': 'refresh-experiment-dropdown',
-                    dropdown: {
-                        closeOnClickInside: false,
-                        placement: 'bottom-end',
-                        overlay: (
-                            <LemonMenuOverlay
-                                items={[
-                                    {
-                                        label: () => (
-                                            <LemonSwitch
-                                                onChange={(checked) => setAutoRefresh(checked, autoRefresh.interval)}
-                                                label="Auto refresh while on page"
-                                                checked={autoRefresh.enabled}
-                                                fullWidth
-                                                className="mt-1 mb-2"
-                                            />
-                                        ),
-                                    },
-                                    {
-                                        title: 'Refresh interval',
-                                        items: [
-                                            {
-                                                label: () => (
-                                                    <LemonRadio
-                                                        value={autoRefresh.interval}
-                                                        options={options}
-                                                        onChange={(value: number) => {
-                                                            setAutoRefresh(true, value)
-                                                        }}
-                                                        className="mx-2 mb-1"
-                                                    />
-                                                ),
-                                            },
-                                        ],
-                                    },
-                                ]}
-                            />
-                        ),
-                    },
-                }}
-            >
-                <span className={clsx('refresh-experiment-text')}>
-                    {isRefreshing ? 'Loading...' : <ExperimentLastRefreshText />}
-                </span>
-            </LemonButton>
-            <LemonBadge
-                size="small"
-                content={
-                    <>
-                        <IconRefresh className="mr-0" /> {humanFriendlyDuration(autoRefresh.interval)}
-                    </>
-                }
-                visible={autoRefresh.enabled}
-                position="top-right"
-                status="muted"
-            />
+        <div className="flex flex-col">
+            <Label intent="menu">Last refreshed</Label>
+            <div className="relative">
+                <LemonButton
+                    onClick={onClick}
+                    type="secondary"
+                    size="xsmall"
+                    icon={isRefreshing ? <Spinner textColored /> : <IconRefresh />}
+                    data-attr="refresh-experiment"
+                    disabledReason={isRefreshing ? 'Loading...' : null}
+                    sideAction={{
+                        'data-attr': 'refresh-experiment-dropdown',
+                        dropdown: {
+                            closeOnClickInside: false,
+                            placement: 'bottom-end',
+                            overlay: (
+                                <LemonMenuOverlay
+                                    items={[
+                                        {
+                                            label: () => (
+                                                <LemonSwitch
+                                                    onChange={(checked) =>
+                                                        setAutoRefresh(checked, autoRefresh.interval)
+                                                    }
+                                                    label="Auto refresh while on page"
+                                                    checked={autoRefresh.enabled}
+                                                    fullWidth
+                                                    className="mt-1 mb-2"
+                                                />
+                                            ),
+                                        },
+                                        {
+                                            title: 'Refresh interval',
+                                            items: [
+                                                {
+                                                    label: () => (
+                                                        <LemonRadio
+                                                            value={autoRefresh.interval}
+                                                            options={options}
+                                                            onChange={(value: number) => {
+                                                                setAutoRefresh(true, value)
+                                                            }}
+                                                            className="mx-2 mb-1"
+                                                        />
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ]}
+                                />
+                            ),
+                        },
+                    }}
+                >
+                    {isRefreshing ? 'Loading…' : <ExperimentLastRefreshText lastRefresh={lastRefresh} />}
+                </LemonButton>
+                <LemonBadge
+                    size="small"
+                    content={
+                        <>
+                            <IconRefresh className="mr-0" /> {humanFriendlyDuration(autoRefresh.interval)}
+                        </>
+                    }
+                    visible={autoRefresh.enabled}
+                    position="top-right"
+                    status="muted"
+                />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
@@ -13,7 +13,6 @@ import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Label } from 'lib/ui/Label/Label'
 import { humanFriendlyDuration } from 'lib/utils'
 
-import { EXPERIMENT_REFRESH_INTERVAL_SECONDS } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 
 /**
@@ -78,7 +77,14 @@ export const ExperimentLastRefreshText = ({ lastRefresh }: { lastRefresh: string
     return <span className={colorClass}>{lastRefresh ? <TZLabel time={lastRefresh} /> : 'a while ago'}</span>
 }
 
-const INTERVAL_OPTIONS = Array.from(EXPERIMENT_REFRESH_INTERVAL_SECONDS, (value) => ({
+const getExperimentRefreshIntervalSeconds = (): number[] => {
+    if (process.env.NODE_ENV === 'development') {
+        return [10, 300, 900, 1800] // 10s, 5min, 15min, 30min
+    }
+    return [300, 900, 1800] // 5min, 15min, 30min
+}
+
+const INTERVAL_OPTIONS = Array.from(getExperimentRefreshIntervalSeconds(), (value) => ({
     label: humanFriendlyDuration(value),
     value: value,
 }))

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -16,7 +16,6 @@ import { cn } from 'lib/utils/css-classes'
 import { urls } from 'scenes/urls'
 
 import { ExperimentStatsMethod, ProgressStatus } from '~/types'
-import { MultivariateFlagVariant } from '~/types'
 
 import { CONCLUSION_DISPLAY_CONFIG } from '../constants'
 import { experimentLogic } from '../experimentLogic'

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -23,6 +23,7 @@ import type { ExperimentSceneLogicProps } from '../experimentSceneLogic'
 import { getExperimentStatus } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
 import { ExperimentDuration } from './ExperimentDuration'
+import { ExperimentReloadAction } from './ExperimentReloadAction'
 import { RunningTimeNew } from './RunningTimeNew'
 import { StatsMethodModal } from './StatsMethodModal'
 import { StatusTag } from './components'
@@ -95,6 +96,7 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
     const { isDescriptionModalOpen } = useValues(modalsLogic)
 
     const useNewCalculator = featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_CALCULATOR] === 'test'
+    const useNewReloadAction = featureFlags[FEATURE_FLAGS.EXPERIMENTS_RELOAD_ACTION] === 'test'
     const [tempDescription, setTempDescription] = useState(experiment.description || '')
 
     useEffect(() => {
@@ -270,11 +272,17 @@ export function Info({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId'>): JSX.E
                                             onClick={openRunningTimeConfigModal}
                                         />
                                     )}
-                                    <ExperimentLastRefresh
-                                        isRefreshing={primaryMetricsResultsLoading || secondaryMetricsResultsLoading}
-                                        lastRefresh={lastRefresh}
-                                        onClick={() => refreshExperimentResults(true)}
-                                    />
+                                    {useNewReloadAction ? (
+                                        <ExperimentReloadAction />
+                                    ) : (
+                                        <ExperimentLastRefresh
+                                            isRefreshing={
+                                                primaryMetricsResultsLoading || secondaryMetricsResultsLoading
+                                            }
+                                            lastRefresh={lastRefresh}
+                                            onClick={() => refreshExperimentResults(true)}
+                                        />
+                                    )}
                                 </>
                             )}
                             <div className="flex flex-col">

--- a/frontend/src/scenes/experiments/constants.ts
+++ b/frontend/src/scenes/experiments/constants.ts
@@ -32,6 +32,16 @@ export const EXPERIMENT_VARIANT_MULTIPLE = '$multiple'
 
 export const EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS = 50
 export const EXPERIMENT_MIN_METRIC_VALUE_FOR_RESULTS = 10
+
+// Autorefresh constants
+export const EXPERIMENT_MIN_REFRESH_INTERVAL_MINUTES = 5
+export const EXPERIMENT_AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 1800 // 30 min
+
+// Autorefresh interval options (in seconds)
+export const EXPERIMENT_REFRESH_INTERVAL_SECONDS = [300, 900, 1800] // 5min, 15min, 30min
+if (process.env.NODE_ENV === 'development') {
+    EXPERIMENT_REFRESH_INTERVAL_SECONDS.unshift(10) // 10s for dev
+}
 export const CONCLUSION_DISPLAY_CONFIG: Record<
     ExperimentConclusion,
     { title: string; description: string; color: string }

--- a/frontend/src/scenes/experiments/constants.ts
+++ b/frontend/src/scenes/experiments/constants.ts
@@ -37,11 +37,6 @@ export const EXPERIMENT_MIN_METRIC_VALUE_FOR_RESULTS = 10
 export const EXPERIMENT_MIN_REFRESH_INTERVAL_MINUTES = 5
 export const EXPERIMENT_AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 1800 // 30 min
 
-// Autorefresh interval options (in seconds)
-export const EXPERIMENT_REFRESH_INTERVAL_SECONDS = [300, 900, 1800] // 5min, 15min, 30min
-if (process.env.NODE_ENV === 'development') {
-    EXPERIMENT_REFRESH_INTERVAL_SECONDS.unshift(30) // 30s for dev
-}
 export const CONCLUSION_DISPLAY_CONFIG: Record<
     ExperimentConclusion,
     { title: string; description: string; color: string }

--- a/frontend/src/scenes/experiments/constants.ts
+++ b/frontend/src/scenes/experiments/constants.ts
@@ -40,7 +40,7 @@ export const EXPERIMENT_AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 1800 // 30 min
 // Autorefresh interval options (in seconds)
 export const EXPERIMENT_REFRESH_INTERVAL_SECONDS = [300, 900, 1800] // 5min, 15min, 30min
 if (process.env.NODE_ENV === 'development') {
-    EXPERIMENT_REFRESH_INTERVAL_SECONDS.unshift(10) // 10s for dev
+    EXPERIMENT_REFRESH_INTERVAL_SECONDS.unshift(30) // 30s for dev
 }
 export const CONCLUSION_DISPLAY_CONFIG: Record<
     ExperimentConclusion,

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1111,15 +1111,18 @@ export const experimentLogic = kea<experimentLogicType>([
         refreshExperimentResults: async ({ forceRefresh }) => {
             // Note: This listener is called both for manual and auto-refresh triggers
             // The context parameter is not available here, so we'll track from the calling locations
-            await Promise.all([
-                actions.loadPrimaryMetricsResults(forceRefresh),
-                actions.loadSecondaryMetricsResults(forceRefresh),
-                actions.loadExposures(forceRefresh),
-            ])
-
-            // After metrics load, set up auto-refresh if enabled
-            if (values.autoRefresh.enabled && values.experiment?.start_date) {
-                actions.resetAutoRefreshInterval()
+            try {
+                await Promise.all([
+                    actions.loadPrimaryMetricsResults(forceRefresh),
+                    actions.loadSecondaryMetricsResults(forceRefresh),
+                    actions.loadExposures(forceRefresh),
+                ])
+            } finally {
+                // Always set up auto-refresh if enabled, even if metrics fail to load
+                // This ensures the interval keeps trying to refresh
+                if (values.autoRefresh.enabled && values.experiment?.start_date) {
+                    actions.resetAutoRefreshInterval()
+                }
             }
         },
         updateExperimentMetrics: async () => {


### PR DESCRIPTION
## Problem

The experiments UI has no automatic or timed means of refreshing the metric results. Users must manually refresh metrics, except when they are older than the 24-hour caching period.
This sometimes causes undesirable behaviour from our users, such as repeatedly clicking the refresh button every few seconds. Those refreshes are not cached, and most of the time, changes to the results are minimal and cause strain on our server resources.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

> [!IMPORTANT]
> For this version, we are keeping the logic that defines when an experiment was last refreshed based on the earliest timestamp of the experiment metric queries. Because of the timing when this information becomes available to the client, we need are forced to duplicate some logic and use component level effects. All that would go away if we start storing the last refresh date on the `Experiment` model. **Most of the AI Code Reviews are about this**.

We are aligning the UI more closely with other parts of the app, like dashboards, to provide the user with automatic refresh options.

| control variant | test variant |
| - | - |
| <img width="426" height="251" alt="image" src="https://github.com/user-attachments/assets/f3827676-2f1a-46d7-b844-cb409a53f2fa" /> | <img width="398" height="253" alt="image" src="https://github.com/user-attachments/assets/ec4d26e6-5e5e-4b57-9e0e-e895fb8bfd97" /> |

**This does not change the default refresh behaviour.** There's no default automatic update, except for the 24-hour updates handled by the backend, and the user can refresh at any time.

If the user selects a time period, we'll automatically update the UI while it's open and, when loading the experiment, if the results have become stale.

The goal is to answer some questions about the user's refresh behaviour:

- Do users click less with auto-refresh?
- Are users still "trigger happy" with auto-refresh enabled?
- How often does auto-refresh fire vs manual?
- What intervals do users prefer?
- Adoption rate of the auto-refresh feature

Other changes include using the `TZLabel` component to show the same timezone information we show on every other date.

| `TZLabel` in action |
| - |
| <img width="393" height="204" alt="image" src="https://github.com/user-attachments/assets/8a9ee67c-2529-4ca4-bfed-3779e1da9365" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/d1bf370c-5142-4510-9710-f3087cefb90f)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. --> 