### PR TITLE
fix(logs-events): fix log details opened event not firing

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic.ts
@@ -1,4 +1,5 @@
 import { actions, kea, listeners, path, reducers } from 'kea'
+import { subscriptions } from 'kea-subscriptions'
 import posthog from 'posthog-js'
 
 import { ParsedLogMessage } from 'products/logs/frontend/types'
@@ -17,14 +18,17 @@ export const logDetailsModalLogic = kea<logDetailsModalLogicType>([
         setActiveTab: (tab: LogDetailsTab) => ({ tab }),
     }),
 
-    listeners(({ values }) => ({
-        openLogDetails: () => {
-            if (!values.isOpen) {
-                posthog.capture('logs details opened')
-            }
-        },
+    listeners(() => ({
         setActiveTab: ({ tab }) => {
             posthog.capture('logs details tab changed', { tab })
+        },
+    })),
+
+    subscriptions(() => ({
+        isOpen: (isOpen: boolean, previousIsOpen: boolean) => {
+            if (isOpen && !previousIsOpen) {
+                posthog.capture('logs details opened')
+            }
         },
     })),
 


### PR DESCRIPTION
## Problem

The `openLogDetails` listener was checking `!values.isOpen` before capturing the analytics event, but in Kea, listeners run *after* reducers. By the time the listener executed, `isOpen` was already `true`, so the event never fired.

## Changes

- Replaced the listener with a `kea-subscriptions` subscription on `isOpen`
- Subscription receives `(newValue, previousValue)`, allowing proper detection of `false → true` transitions
- Analytics event now correctly fires when the modal opens

## How did you test this code?

Verified the analytics event fires on modal open and does not fire on subsequent actions while modal remains open.

## Publish to changelog?

No