### PR TITLE
feat(dx): ship pre-migrated schema from CI for faster local setup

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -37,6 +37,7 @@ cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }
 sqlx-cli = { pkg-path = "sqlx-cli", version = "0.8.3" } # sqlx
 postgresql = { pkg-path = "postgresql_14" } # psql
 ffmpeg.pkg-path = "ffmpeg"
+gh = { pkg-path = "gh", version = "2.83.2" }
 
 # Set environment variables in the `[vars]` section. These variables may not
 # reference one another, and are added to the environment without first

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -408,6 +408,21 @@ jobs:
                   DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons" \
                     sqlx migrate run --source rust/persons_migrations/
 
+            - name: Dump migrated schema
+              if: github.event_name == 'push'
+              run: |
+                  # Dump schema + django_migrations data so Django knows which migrations are applied
+                  (pg_dump --schema-only --clean -h localhost -U posthog posthog && \
+                   pg_dump --data-only --table=django_migrations -h localhost -U posthog posthog) | gzip > schema.sql.gz
+
+            - name: Upload migrated schema artifact
+              if: github.event_name == 'push'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: migrated-schema
+                  path: schema.sql.gz
+                  retention-days: 90
+
             - name: Check migrations
               # Skip migration safety check on master push (no migration_files from path filter)
               if: github.event_name != 'push'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -417,7 +417,7 @@ jobs:
 
             - name: Upload migrated schema artifact
               if: github.event_name == 'push'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
                   name: migrated-schema
                   path: schema.sql.gz

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -432,19 +432,20 @@ db:
             rm -rf /tmp/migrated-schema-dl
             echo "✅ Downloaded to .postgres-backups/schema-latest.sql.gz"
         description: Download pre-migrated schema artifact from CI (requires gh CLI)
-        services:
-            - docker
     db:restore-schema:
         steps:
             - db:download-schema
             - db:dump
             - name: restore-schema
               cmd: |
+                  set -e
+                  set -o pipefail
                   echo "Restoring schema to database..."
                   gunzip -c .postgres-backups/schema-latest.sql.gz | docker compose exec -T db psql -q -U posthog posthog
                   echo "✅ Schema restored"
             - db:migrate
         description: Fetch pre-migrated schema from CI, restore it, and run any pending migrations (creates backup first)
+        destructive: true
         services:
             - postgresql
             - docker

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -422,6 +422,32 @@ db:
         services:
             - postgresql
             - docker
+    db:download-schema:
+        cmd: |
+            set -e
+            mkdir -p .postgres-backups
+            echo "Downloading pre-migrated schema from CI..."
+            gh run download --name migrated-schema -R PostHog/posthog -D /tmp/migrated-schema-dl
+            mv /tmp/migrated-schema-dl/schema.sql.gz .postgres-backups/schema-latest.sql.gz
+            rm -rf /tmp/migrated-schema-dl
+            echo "✅ Downloaded to .postgres-backups/schema-latest.sql.gz"
+        description: Download pre-migrated schema artifact from CI (requires gh CLI)
+        services:
+            - docker
+    db:restore-schema:
+        steps:
+            - db:download-schema
+            - db:dump
+            - name: restore-schema
+              cmd: |
+                  echo "Restoring schema to database..."
+                  gunzip -c .postgres-backups/schema-latest.sql.gz | docker compose exec -T db psql -q -U posthog posthog
+                  echo "✅ Schema restored"
+            - db:migrate
+        description: Fetch pre-migrated schema from CI, restore it, and run any pending migrations (creates backup first)
+        services:
+            - postgresql
+            - docker
 tests:
     test:python:
         cmd: pytest


### PR DESCRIPTION
**Problem**
Fresh dev setup waits ~4 minutes for Django migrations to run.

**Solution**
CI uploads a pre-migrated Postgres schema (including `django_migrations` table data) as an artifact on every master push. Devs can restore it locally to skip the migration wait.

**New hogli commands**
- `db:download-schema` - fetch artifact from latest master CI run
- `db:restore-schema` - orchestrates: download → backup local db → restore schema → run pending migrations

**Changes**
- CI: dump schema + django_migrations data, upload as 90-day artifact
- hogli: two new commands for restore flow
- flox: add `gh` CLI for artifact download

**Usage**
```bash
hogli db:restore-schema
```

Note: artifact won't exist until this merges and runs on master. After that, devs on fresh clones can use this to skip migrations.