### PR TITLE
fix(phai): clarify that generated visualizations are transient

### DIFF
--- a/ee/hogai/tools/create_insight.py
+++ b/ee/hogai/tools/create_insight.py
@@ -16,9 +16,11 @@ from ee.hogai.utils.prompt import format_prompt_string
 from ee.hogai.utils.types.base import AssistantNodeName, AssistantState, NodePath
 
 INSIGHT_TOOL_PROMPT = """
-Use this tool to generate an insight from a structured plan. It will return a visualization that the user can analyze and a textual representation for your analysis. This tool can be used to create new insights or to edit existing insights. To edit an existing insight, you need to generate a new plan based on the schema of the existing insight.
+Use this tool to generate an insight from a structured plan. It will return a visualization that the user can analyze and a textual representation for your analysis. These visualizations are transient and only exist within the current conversation—they are not saved to the project. To save an insight permanently, users should click the open insight button in the conversation.
 
-The tool only generates a single insight per a call. If the user asks for multiple insights, you need to decompose a query into multiple subqueries and call the tool for each subquery.
+This tool can also be used to edit the visualization the user is currently viewing on the insight page. In that case, you need to generate a new plan based on the schema of the existing insight.
+
+The tool only generates a single visualization per call. If the user asks for multiple visualizations, you need to decompose a query into multiple subqueries and call the tool for each subquery.
 
 Follow these guidelines when retrieving data:
 


### PR DESCRIPTION
## Problem

The agent doesn't know that insights are transient.

## Changes

Update the create_insight tool prompt to make it clear that visualizations generated by the agent are transient and only exist within the conversation. They are not saved to the project. To save permanently, users should add them to a dashboard.

## How did you test this code?

Manual testing
