### PR TITLE
feat(logs): click log row to open details modal

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
@@ -75,7 +75,7 @@ export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element
             isOpen={isOpen}
             onClose={closeLogDetails}
             simple
-            overlayClassName="backdrop-blur-none flex items-stretch justify-end pr-16 py-4 pointer-events-none h-screen"
+            overlayClassName="backdrop-blur-none bg-transparent flex items-stretch justify-end pr-16 py-4 pointer-events-none h-screen"
             className="m-0! max-w-3xl w-[50vw] pointer-events-auto min-h-full"
         >
             <div className="flex flex-col h-full">

--- a/products/logs/frontend/components/LogsViewer/LogRowFAB/LogRowFAB.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogRowFAB/LogRowFAB.tsx
@@ -52,6 +52,7 @@ export function LogRowFAB({
                 'opacity-0 group-hover:opacity-100 transition-opacity'
             )}
             onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
         >
             <FABGroup>
                 <LemonButton

--- a/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
@@ -44,7 +44,7 @@ export interface LogRowProps {
     tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime' | 'displayTimezone'>
     onTogglePin: (log: ParsedLogMessage) => void
     onToggleExpand: () => void
-    onSetCursor?: () => void
+    onClick?: () => void
     rowWidth?: number
     attributeColumns?: string[]
     attributeColumnWidths?: Record<string, number>
@@ -70,7 +70,7 @@ export function LogRow({
     tzLabelFormat,
     onTogglePin,
     onToggleExpand,
-    onSetCursor,
+    onClick,
     rowWidth,
     attributeColumns = [],
     attributeColumnWidths = {},
@@ -91,11 +91,21 @@ export function LogRow({
     const severityColor = SEVERITY_BAR_COLORS[log.severity_text] ?? 'bg-muted-3000'
 
     const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>): void => {
+        // Only handle shift+click here to prevent text selection during range select
         if (e.shiftKey && onShiftClick) {
             e.preventDefault()
             onShiftClick(logIndex)
-        } else {
-            onSetCursor?.()
+        }
+    }
+
+    const handleClick = (e: React.MouseEvent<HTMLDivElement>): void => {
+        // Don't trigger if user selected text
+        const selection = window.getSelection()
+        if (selection && selection.toString().length > 0) {
+            return
+        }
+        if (!e.shiftKey) {
+            onClick?.()
         }
     }
 
@@ -113,6 +123,7 @@ export function LogRow({
                     pinned && showPinnedWithOpacity && 'bg-warning-highlight opacity-50'
                 )}
                 onMouseDown={handleMouseDown}
+                onClick={handleClick}
             >
                 <div className="flex items-center self-stretch">
                     <Tooltip title={log.severity_text.toUpperCase()}>
@@ -144,6 +155,7 @@ export function LogRow({
                                 e.stopPropagation()
                                 onToggleExpand()
                             }}
+                            onClick={(e) => e.stopPropagation()}
                         />
                     </div>
                 </div>

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -8,6 +8,7 @@ import { List, ListRowProps } from 'react-virtualized/dist/es/List'
 
 import { TZLabelProps } from 'lib/components/TZLabel'
 
+import { logDetailsModalLogic } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic'
 import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
 import { LogRow } from 'products/logs/frontend/components/VirtualizedLogsList/LogRow'
 import { LogRowHeader } from 'products/logs/frontend/components/VirtualizedLogsList/LogRowHeader'
@@ -76,6 +77,7 @@ export function VirtualizedLogsList({
         setFocused,
         setCursorToLogId,
     } = useActions(logsViewerLogic)
+    const { openLogDetails } = useActions(logDetailsModalLogic)
 
     const containerRef = useRef<HTMLDivElement>(null)
 
@@ -163,6 +165,13 @@ export function VirtualizedLogsList({
         }
     }
 
+    const handleLogRowClick = (log: ParsedLogMessage, index: number): void => {
+        openLogDetails(log)
+        if (!disableCursor) {
+            userSetCursorIndex(index)
+        }
+    }
+
     const createRowRenderer = useCallback(
         (rowWidth?: number) =>
             ({ index, key, style, parent }: ListRowProps): JSX.Element => {
@@ -189,7 +198,7 @@ export function VirtualizedLogsList({
                                     tzLabelFormat={tzLabelFormat}
                                     onTogglePin={togglePinLog}
                                     onToggleExpand={() => toggleExpandLog(log.uuid)}
-                                    onSetCursor={disableCursor ? undefined : () => userSetCursorIndex(index)}
+                                    onClick={() => handleLogRowClick(log, index)}
                                     rowWidth={rowWidth}
                                     attributeColumns={attributeColumns}
                                     attributeColumnWidths={attributeColumnWidths}
@@ -221,6 +230,7 @@ export function VirtualizedLogsList({
             tzLabelFormat,
             togglePinLog,
             toggleExpandLog,
+            openLogDetails,
             userSetCursorIndex,
             attributeColumns,
             attributeColumnWidths,


### PR DESCRIPTION
## Problem

Opening log details required hovering to reveal the FAB, then clicking the "View details" button. This felt clunky compared to the intuitive pattern of clicking a row to see details.

## Changes

![2026-01-09 10.05.26.gif](https://app.graphite.com/user-attachments/assets/a5b666fb-13fd-40b0-98ea-d5617aed0354.gif)

- **Click to open details**: Clicking a log row now opens the details modal directly
- **Cursor remains independent**: Keyboard navigation (j/k) moves the cursor without opening the modal - Enter opens modal for the cursor position
- **Text selection preserved**: Checks `window.getSelection()` to avoid triggering modal when user is selecting text
- **Transparent modal overlay**: Allows clicking other log rows while modal is open to switch between logs
- **Proper event propagation**: FAB buttons and expand chevron don't bubble clicks to the row handler
- **Modal Overlay**: Also makes the modal overlay transparent as an affordance, to show that the user can still interact with the other logs.

## How did you test this code?

- Clicked log rows to verify modal opens
- Selected text to verify modal doesn't open during selection
- Used j/k navigation to verify cursor moves without opening modal
- Pressed Enter to verify modal opens for cursor position
- Clicked other rows while modal open to verify it switches logs
- Shift+clicked to verify range selection still works
- Clicked FAB buttons to verify they don't trigger row click