### PR TITLE
fix(llma): use consistent llma-trace- prefix for clustering workflow names

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/README.md
+++ b/posthog/temporal/llm_analytics/trace_clustering/README.md
@@ -314,7 +314,7 @@ if results:
 
 ### Scheduled Execution
 
-The coordinator workflow (`trace-clustering-coordinator`) runs on a schedule and:
+The coordinator workflow (`llma-trace-clustering-coordinator`) runs on a schedule and:
 
 1. Processes teams from the `ALLOWED_TEAM_IDS` allowlist
 2. Spawns clustering workflow for each team in parallel
@@ -336,26 +336,27 @@ To add new teams, simply add their IDs to this list.
 
 Key constants in `constants.py`:
 
-| Constant                            | Default                    | Description                                   |
-| ----------------------------------- | -------------------------- | --------------------------------------------- |
-| `WORKFLOW_NAME`                     | llma-trace-clustering      | Temporal workflow name                        |
-| `DEFAULT_LOOKBACK_DAYS`             | 7                          | Days of trace history to analyze              |
-| `DEFAULT_MAX_SAMPLES`               | 1000                       | Maximum traces to sample                      |
-| `MIN_TRACES_FOR_CLUSTERING`         | 20                         | Minimum traces required for workflow          |
-| `COMPUTE_ACTIVITY_TIMEOUT`          | 120s                       | Clustering compute timeout                    |
-| `EMIT_ACTIVITY_TIMEOUT`             | 60s                        | Event emission timeout                        |
-| `LABELING_AGENT_MODEL`              | claude-sonnet-4-20250514   | Claude model for labeling agent               |
-| `LABELING_AGENT_MAX_ITERATIONS`     | 50                         | Max agent iterations before finalization      |
-| `LABELING_AGENT_RECURSION_LIMIT`    | 150                        | LangGraph recursion limit                     |
-| `LABELING_AGENT_TIMEOUT`            | 600.0                      | Full agent run timeout (seconds)              |
-| `DEFAULT_HDBSCAN_MIN_SAMPLES`       | 5                          | Min samples for HDBSCAN core points           |
-| `DEFAULT_MIN_CLUSTER_SIZE_FRACTION` | 0.01                       | Min cluster size as fraction of total samples |
-| `DEFAULT_UMAP_N_COMPONENTS`         | 100                        | UMAP dimensions for clustering                |
-| `DEFAULT_UMAP_N_NEIGHBORS`          | 15                         | UMAP neighborhood size                        |
-| `DEFAULT_UMAP_MIN_DIST`             | 0.0                        | UMAP min distance (tighter for clustering)    |
-| `NOISE_CLUSTER_ID`                  | -1                         | HDBSCAN noise/outlier cluster ID              |
-| `LLMA_TRACE_DOCUMENT_TYPE`          | llm-trace-summary-detailed | Document type filter for embeddings           |
-| `ALLOWED_TEAM_IDS`                  | [1, 2, 112495]             | Teams to process (allowlist approach)         |
+| Constant                            | Default                           | Description                                   |
+| ----------------------------------- | --------------------------------- | --------------------------------------------- |
+| `WORKFLOW_NAME`                     | llma-trace-clustering             | Temporal workflow name                        |
+| `COORDINATOR_WORKFLOW_NAME`         | llma-trace-clustering-coordinator | Temporal coordinator workflow name            |
+| `DEFAULT_LOOKBACK_DAYS`             | 7                                 | Days of trace history to analyze              |
+| `DEFAULT_MAX_SAMPLES`               | 1000                              | Maximum traces to sample                      |
+| `MIN_TRACES_FOR_CLUSTERING`         | 20                                | Minimum traces required for workflow          |
+| `COMPUTE_ACTIVITY_TIMEOUT`          | 120s                              | Clustering compute timeout                    |
+| `EMIT_ACTIVITY_TIMEOUT`             | 60s                               | Event emission timeout                        |
+| `LABELING_AGENT_MODEL`              | claude-sonnet-4-20250514          | Claude model for labeling agent               |
+| `LABELING_AGENT_MAX_ITERATIONS`     | 50                                | Max agent iterations before finalization      |
+| `LABELING_AGENT_RECURSION_LIMIT`    | 150                               | LangGraph recursion limit                     |
+| `LABELING_AGENT_TIMEOUT`            | 600.0                             | Full agent run timeout (seconds)              |
+| `DEFAULT_HDBSCAN_MIN_SAMPLES`       | 5                                 | Min samples for HDBSCAN core points           |
+| `DEFAULT_MIN_CLUSTER_SIZE_FRACTION` | 0.01                              | Min cluster size as fraction of total samples |
+| `DEFAULT_UMAP_N_COMPONENTS`         | 100                               | UMAP dimensions for clustering                |
+| `DEFAULT_UMAP_N_NEIGHBORS`          | 15                                | UMAP neighborhood size                        |
+| `DEFAULT_UMAP_MIN_DIST`             | 0.0                               | UMAP min distance (tighter for clustering)    |
+| `NOISE_CLUSTER_ID`                  | -1                                | HDBSCAN noise/outlier cluster ID              |
+| `LLMA_TRACE_DOCUMENT_TYPE`          | llm-trace-summary-detailed        | Document type filter for embeddings           |
+| `ALLOWED_TEAM_IDS`                  | [1, 2, 112495]                    | Teams to process (allowlist approach)         |
 
 ## Processing Flow
 

--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -20,6 +20,7 @@ DEFAULT_MAX_CONCURRENT_TEAMS = 3  # Max teams to process in parallel
 WORKFLOW_EXECUTION_TIMEOUT = timedelta(minutes=30)
 # Temporal configuration
 WORKFLOW_NAME = "llma-trace-clustering"
+COORDINATOR_WORKFLOW_NAME = "llma-trace-clustering-coordinator"
 
 # Activity timeouts (per activity type)
 COMPUTE_ACTIVITY_TIMEOUT = timedelta(seconds=120)  # Fetch + k-means + distances

--- a/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/coordinator.py
@@ -18,7 +18,7 @@ from temporalio.workflow import ChildWorkflowHandle
 
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.llm_analytics.trace_clustering import constants
-from posthog.temporal.llm_analytics.trace_clustering.constants import ALLOWED_TEAM_IDS
+from posthog.temporal.llm_analytics.trace_clustering.constants import ALLOWED_TEAM_IDS, COORDINATOR_WORKFLOW_NAME
 from posthog.temporal.llm_analytics.trace_clustering.models import ClusteringResult, ClusteringWorkflowInputs
 from posthog.temporal.llm_analytics.trace_clustering.workflow import DailyTraceClusteringWorkflow
 
@@ -49,7 +49,7 @@ def get_allowed_team_ids() -> list[int]:
     return ALLOWED_TEAM_IDS.copy()
 
 
-@temporalio.workflow.defn(name="trace-clustering-coordinator")
+@temporalio.workflow.defn(name=COORDINATOR_WORKFLOW_NAME)
 class TraceClusteringCoordinatorWorkflow(PostHogWorkflow):
     """
     Coordinator workflow that processes traces for teams in ALLOWED_TEAM_IDS.

--- a/posthog/temporal/llm_analytics/trace_clustering/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/schedule.py
@@ -8,6 +8,7 @@ from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, Sch
 
 from posthog.temporal.common.schedule import a_create_schedule, a_delete_schedule, a_schedule_exists, a_update_schedule
 from posthog.temporal.llm_analytics.trace_clustering.constants import (
+    COORDINATOR_WORKFLOW_NAME,
     DEFAULT_LOOKBACK_DAYS,
     DEFAULT_MAX_K,
     DEFAULT_MAX_SAMPLES,
@@ -26,7 +27,7 @@ async def create_trace_clustering_coordinator_schedule(client: Client):
     """
     coordinator_schedule = Schedule(
         action=ScheduleActionStartWorkflow(
-            "llma-trace-clustering-coordinator",
+            COORDINATOR_WORKFLOW_NAME,
             TraceClusteringCoordinatorInputs(
                 lookback_days=DEFAULT_LOOKBACK_DAYS,
                 max_samples=DEFAULT_MAX_SAMPLES,


### PR DESCRIPTION
## Problem

The coordinator workflow name was inconsistent:
- `coordinator.py` defined: `trace-clustering-coordinator`
- `schedule.py` expected: `llma-trace-clustering-coordinator`

This caused the schedule to fail with "workflow not found" error in Temporal Cloud.

## Changes

- Add `COORDINATOR_WORKFLOW_NAME` constant to `constants.py`
- Update `coordinator.py` to use the constant
- Update `schedule.py` to use the constant  
- Update `README.md` with correct workflow name

## How did you test this code?

Will verify after merge by re-running `schedule_temporal_workflows` in US/EU clusters and confirming schedule works in Temporal Cloud.

## Publish to changelog?

No