### PR TITLE
fix(llma): lazy import umap to avoid numba caching error at startup

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/clustering.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/clustering.py
@@ -1,15 +1,17 @@
 """Clustering utilities: HDBSCAN and k-means implementations."""
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from sklearn.cluster import HDBSCAN, KMeans
 from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
 from sklearn.metrics import silhouette_score
-from umap import UMAP
 
 from posthog.temporal.llm_analytics.trace_clustering.models import HDBSCANResult, KMeansResult
+
+if TYPE_CHECKING:
+    from umap import UMAP
 
 
 def perform_kmeans_with_optimal_k(
@@ -143,6 +145,9 @@ def compute_2d_coordinates(
             centroid_coords = combined_coords[n_samples:]
 
     else:  # default to umap
+        # Lazy import to avoid numba JIT compilation at Django startup
+        from umap import UMAP
+
         # Adjust n_neighbors if we have fewer samples
         effective_n_neighbors = min(n_neighbors, n_samples - 1)
 
@@ -170,7 +175,7 @@ def reduce_dimensions_for_clustering(
     n_neighbors: int = 15,
     min_dist: float = 0.0,
     random_state: int = 42,
-) -> tuple[np.ndarray, UMAP]:
+) -> tuple[np.ndarray, "UMAP | None"]:
     """
     Reduce high-dimensional embeddings using UMAP for clustering.
 
@@ -187,6 +192,9 @@ def reduce_dimensions_for_clustering(
     Returns:
         Tuple of (reduced_embeddings, fitted_reducer)
     """
+    # Lazy import to avoid numba JIT compilation at Django startup
+    from umap import UMAP
+
     n_samples = len(embeddings)
 
     if n_samples < 2:


### PR DESCRIPTION
## Problem

Production pods are crash-looping due to a numba caching error when importing `umap` at Django startup:

```
RuntimeError: cannot cache function 'rdist': no locator available for file '/python-runtime/lib/python3.12/site-packages/umap/layouts.py'
```

The nginx unit environment has a read-only filesystem, and numba tries to cache JIT-compiled functions on import.

Introduced in #43488.

## Changes

- Move `from umap import UMAP` from top-level import to lazy imports inside the two functions that use it (`compute_2d_coordinates` and `reduce_dimensions_for_clustering`)
- Add `TYPE_CHECKING` guard for type hint usage
- Update return type annotation to use string literal

This ensures umap is only imported when clustering actually runs in the Temporal worker, not during Django startup for web servers.

## How did you test this code?

- Ran existing clustering test suite: all 21 tests pass
- Verified with ruff linter

## Publish to changelog?

No