### PR TITLE
feat: removing the option to hide the feedback message

### DIFF
--- a/frontend/src/scenes/marketing-analytics/MarketingAnalyticsScene.tsx
+++ b/frontend/src/scenes/marketing-analytics/MarketingAnalyticsScene.tsx
@@ -72,12 +72,7 @@ const MarketingAnalyticsDashboard = (): JSX.Element => {
     const { tiles: marketingTiles } = useValues(marketingAnalyticsTilesLogic)
 
     const feedbackBanner = (
-        <LemonBanner
-            type="info"
-            dismissKey="marketing-analytics-beta-banner"
-            className="mb-2 mt-4"
-            action={{ children: 'Send feedback', id: 'marketing-analytics-feedback-button' }}
-        >
+        <LemonBanner type="info" action={{ children: 'Send feedback', id: 'marketing-analytics-feedback-button' }}>
             Marketing analytics is in beta. Please let us know what you'd like to see here and/or report any issues
             directly to us!
         </LemonBanner>


### PR DESCRIPTION
## Problem

Once the user dismiss the feedback banner we cannot longer obtain feedback from that user. Looking other implementations I see we can maintain it always. 

## Changes

 Removing dismiss key and some extra margin

## How did you test this code?
Manually:
<img width="1227" height="206" alt="image" src="https://github.com/user-attachments/assets/21ae98ab-16a1-4dd3-8ae9-3fe8cb45e8aa" />
