### PR TITLE
chore(llma): standardize temporal schedule IDs with llma-trace prefix

### DIFF
--- a/posthog/temporal/llm_analytics/trace_clustering/constants.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/constants.py
@@ -21,6 +21,7 @@ WORKFLOW_EXECUTION_TIMEOUT = timedelta(minutes=30)
 # Temporal configuration
 WORKFLOW_NAME = "llma-trace-clustering"
 COORDINATOR_WORKFLOW_NAME = "llma-trace-clustering-coordinator"
+COORDINATOR_SCHEDULE_ID = "llma-trace-clustering-coordinator-schedule"
 
 # Activity timeouts (per activity type)
 COMPUTE_ACTIVITY_TIMEOUT = timedelta(seconds=120)  # Fetch + k-means + distances

--- a/posthog/temporal/llm_analytics/trace_clustering/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/schedule.py
@@ -8,6 +8,7 @@ from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, Sch
 
 from posthog.temporal.common.schedule import a_create_schedule, a_delete_schedule, a_schedule_exists, a_update_schedule
 from posthog.temporal.llm_analytics.trace_clustering.constants import (
+    COORDINATOR_SCHEDULE_ID,
     COORDINATOR_WORKFLOW_NAME,
     DEFAULT_LOOKBACK_DAYS,
     DEFAULT_MAX_K,
@@ -34,19 +35,18 @@ async def create_trace_clustering_coordinator_schedule(client: Client):
                 min_k=DEFAULT_MIN_K,
                 max_k=DEFAULT_MAX_K,
             ),
-            id="llma-trace-clustering-coordinator-schedule",
+            id=COORDINATOR_SCHEDULE_ID,
             task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(days=1))]),
     )
 
-    schedule_id = "llma-trace-clustering-coordinator-schedule"
-    if await a_schedule_exists(client, schedule_id):
-        await a_update_schedule(client, schedule_id, coordinator_schedule)
+    if await a_schedule_exists(client, COORDINATOR_SCHEDULE_ID):
+        await a_update_schedule(client, COORDINATOR_SCHEDULE_ID, coordinator_schedule)
     else:
         await a_create_schedule(
             client,
-            schedule_id,
+            COORDINATOR_SCHEDULE_ID,
             coordinator_schedule,
             trigger_immediately=False,
         )
@@ -58,5 +58,4 @@ async def delete_trace_clustering_coordinator_schedule(client: Client):
     Args:
         client: Temporal client
     """
-    schedule_id = "llma-trace-clustering-coordinator-schedule"
-    await a_delete_schedule(client, schedule_id)
+    await a_delete_schedule(client, COORDINATOR_SCHEDULE_ID)

--- a/posthog/temporal/llm_analytics/trace_summarization/README.md
+++ b/posthog/temporal/llm_analytics/trace_summarization/README.md
@@ -97,7 +97,7 @@ temporal workflow start \
 
 ### Scheduled Execution
 
-The coordinator runs hourly via Temporal schedule (configured in `schedule.py`). Verify at http://localhost:8233 → schedule: `batch-trace-summarization-schedule`.
+The coordinator runs hourly via Temporal schedule (configured in `schedule.py`). Verify at http://localhost:8233 → schedule: `llma-trace-summarization-coordinator-schedule`.
 
 ### Team Allowlist
 

--- a/posthog/temporal/llm_analytics/trace_summarization/constants.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/constants.py
@@ -51,3 +51,4 @@ ALLOWED_TEAM_IDS: list[int] = [
 # Temporal configuration
 WORKFLOW_NAME = "llma-trace-summarization"
 COORDINATOR_WORKFLOW_NAME = "llma-trace-summarization-coordinator"
+COORDINATOR_SCHEDULE_ID = "llma-trace-summarization-coordinator-schedule"

--- a/posthog/temporal/llm_analytics/trace_summarization/schedule.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/schedule.py
@@ -8,6 +8,7 @@ from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, Sch
 
 from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
 from posthog.temporal.llm_analytics.trace_summarization.constants import (
+    COORDINATOR_SCHEDULE_ID,
     COORDINATOR_WORKFLOW_NAME,
     DEFAULT_BATCH_SIZE,
     DEFAULT_MAX_TRACES_PER_WINDOW,
@@ -33,18 +34,18 @@ async def create_batch_trace_summarization_schedule(client: Client):
                 mode=DEFAULT_MODE,
                 window_minutes=DEFAULT_WINDOW_MINUTES,
             ),
-            id="batch-trace-summarization-coordinator-schedule",
+            id=COORDINATOR_SCHEDULE_ID,
             task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(hours=SCHEDULE_INTERVAL_HOURS))]),
     )
 
-    if await a_schedule_exists(client, "batch-trace-summarization-schedule"):
-        await a_update_schedule(client, "batch-trace-summarization-schedule", batch_trace_summarization_schedule)
+    if await a_schedule_exists(client, COORDINATOR_SCHEDULE_ID):
+        await a_update_schedule(client, COORDINATOR_SCHEDULE_ID, batch_trace_summarization_schedule)
     else:
         await a_create_schedule(
             client,
-            "batch-trace-summarization-schedule",
+            COORDINATOR_SCHEDULE_ID,
             batch_trace_summarization_schedule,
             trigger_immediately=False,
         )


### PR DESCRIPTION
## Problem

Temporal schedule IDs for LLM analytics workflows were inconsistent. The trace summarization schedule used `batch-trace-summarization-schedule` while clustering used `llma-trace-clustering-coordinator-schedule`.

## Changes

- Add `COORDINATOR_SCHEDULE_ID` constants to both `trace_clustering` and `trace_summarization` modules
- Rename trace summarization schedule from `batch-trace-summarization-schedule` to `llma-trace-summarization-coordinator-schedule`
- Use constants instead of hardcoded schedule IDs throughout

## How did you test this code?

Linter passes. After merge, will run `python manage.py schedule_temporal_workflows` on US and EU pods, then delete the old `batch-trace-summarization-schedule` from both Temporal namespaces.

## Publish to changelog?

No