### PR TITLE
fix(logs): remove log attributes from resource attribute filters

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -155,7 +155,7 @@ class LogsQueryRunnerMixin(QueryRunner):
                     [
                         f
                         for f in property_group.values
-                        if f.type in [LogPropertyFilterType.LOG_ATTRIBUTE, LogPropertyFilterType.LOG_RESOURCE_ATTRIBUTE]
+                        if f.type == LogPropertyFilterType.LOG_RESOURCE_ATTRIBUTE
                         and not operator_is_negative(f.operator)
                     ],
                 )
@@ -164,8 +164,7 @@ class LogsQueryRunnerMixin(QueryRunner):
                     [
                         f
                         for f in property_group.values
-                        if f.type in [LogPropertyFilterType.LOG_ATTRIBUTE, LogPropertyFilterType.LOG_RESOURCE_ATTRIBUTE]
-                        and operator_is_negative(f.operator)
+                        if f.type == LogPropertyFilterType.LOG_RESOURCE_ATTRIBUTE and operator_is_negative(f.operator)
                     ],
                 )
                 self.log_filters = cast(

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -462,7 +462,7 @@ class TestLogsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                             },
                             {
                                 "key": "log.file.record_number",
-                                "value": [34542],
+                                "value": ["34542"],
                                 "operator": "is_not",
                                 "type": "log_attribute",
                             },

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -461,9 +461,9 @@ class TestLogsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                                 "type": "log_resource_attribute",
                             },
                             {
-                                "key": "log.file.record_number",
-                                "value": ["34542"],
-                                "operator": "is_not",
+                                "key": "message",
+                                "value": ["time=2025-12-16T09:04:40.952Z"],
+                                "operator": "not_icontains",
                                 "type": "log_attribute",
                             },
                         ],

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -77,8 +77,9 @@ class TestAttributeFilters(APIBaseTest):
         # Verify that log attribute filters are included in the query
         self.assertIn("service.name", query_str)
         self.assertIn("http.method", query_str)
-        # Log attributes use resource_fingerprint filtering for optimization
-        self.assertIn("(in(resource_fingerprint", query_str)
+        # Log attributes DO NOT use resource_fingerprint filtering for optimization
+        # this optimization was premature and needs more thought, and probably has very little benefit anyway
+        self.assertNotIn("(in(resource_fingerprint", query_str)
 
     def test_resource_attribute_filters(self):
         """Test that resource attribute filters are properly handled"""

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -446,7 +446,7 @@ class TestLogsQueryRunner(ClickhouseTestMixin, APIBaseTest):
     @freeze_time("2025-12-16T10:33:00Z")
     def test_resource_negative_attribute_filters(self):
         query_params = {
-            "dateRange": {"date_from": "2025-12-16 09:32:36.178572Z", "date_to": None},
+            "dateRange": {"date_from": "2025-12-16 09:00:36.178572Z", "date_to": None},
             "limit": 100,
             "filterGroup": {
                 "type": "AND",


### PR DESCRIPTION
## Problem

resource attribute filters had log attributes included in them.

while technically we _can_ include them for the positive filters - it's a little more complicated because we strip attributes that are too large from the log attributes table (we _don't_ do this for resource attributes). So there's actually not a 100% guarantee the attribute is in the log_attributes table (there _is_ a guarantee for resource attributes)

For negative filters this should never have been there. This means if you e.g. exclude foo=bar, you exclude all resources that have ever sent a foo=bar log line, even if not 100% of a resources log lines include foo=bar

## Changes

simplify the resource attribute filters so they only operate on resource_attributes

## How did you test this code?
WIP

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no