### PR TITLE
chore(flags): add device_id to canonical logs

### DIFF
--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -298,6 +298,7 @@ mod tests {
         log.api_version = Some("3".to_string());
         log.team_id = Some(123);
         log.distinct_id = Some("user_abc".to_string());
+        log.device_id = Some("device_123".to_string());
         log.flags_evaluated = 10;
         log.flags_experience_continuity = 2;
         log.flags_disabled = false;

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -86,6 +86,7 @@ pub struct FlagsCanonicalLogLine {
     // Populated during authentication
     pub team_id: Option<i32>,
     pub distinct_id: Option<String>,
+    pub device_id: Option<String>,
 
     // Populated during flag evaluation
     pub flags_evaluated: usize,
@@ -144,6 +145,7 @@ impl Default for FlagsCanonicalLogLine {
             api_version: None,
             team_id: None,
             distinct_id: None,
+            device_id: None,
             flags_evaluated: 0,
             flags_experience_continuity: 0,
             flags_disabled: false,
@@ -191,6 +193,7 @@ impl FlagsCanonicalLogLine {
             request_id = %self.request_id,
             team_id = self.team_id,
             distinct_id = self.distinct_id.as_deref(),
+            device_id = self.device_id.as_deref(),
             ip = %self.ip,
             user_agent = user_agent,
             lib = self.lib,
@@ -255,6 +258,7 @@ mod tests {
         assert!(log.api_version.is_none());
         assert!(log.team_id.is_none());
         assert!(log.distinct_id.is_none());
+        assert!(log.device_id.is_none());
         assert_eq!(log.flags_evaluated, 0);
         assert_eq!(log.flags_experience_continuity, 0);
         assert!(!log.flags_disabled);

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -113,8 +113,11 @@ async fn process_request_inner(
             .clone()
             .unwrap_or_else(|| "disabled".to_string());
 
-        // Populate canonical log with distinct_id
-        with_canonical_log(|log| log.distinct_id = Some(distinct_id_for_logging.clone()));
+        // Populate canonical log with distinct_id and device_id
+        with_canonical_log(|log| {
+            log.distinct_id = Some(distinct_id_for_logging.clone());
+            log.device_id = request.device_id.clone();
+        });
 
         tracing::debug!(
             "Authentication completed for distinct_id: {}",


### PR DESCRIPTION
## Problem

It's currently hard to debug the "bucket on device_id" feature, as we are not logging what value the requests actually contains.

## Changes
Log `device_id` as part of the canonical log lines. This will greatly improve the debug situation for the "bucket on device_id" feature.

## How did you test this code?

- Tests pass