### PR TITLE
fix(data-warehouse): Take into account the first 7-days of free rows during row tracking f…

### DIFF
--- a/posthog/temporal/data_imports/row_tracking.py
+++ b/posthog/temporal/data_imports/row_tracking.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.db.models import Sum
+from django.db.models import F, Q, Sum
 
 from dateutil import parser
 from structlog.types import FilteringBoundLogger
@@ -183,6 +183,7 @@ def will_hit_billing_limit(team_id: int, source: "ExternalDataSource", logger: F
 
         # Get all completed rows for all teams in org
         rows_synced_in_billing_period_dict = ExternalDataJob.objects.filter(
+            Q(finished_at__gte=F("pipeline__created_at") + timedelta(days=7)),
             team_id__in=all_teams_in_org,
             finished_at__gte=current_billing_cycle_start_dt,
             billable=True,

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -2549,7 +2549,9 @@ async def test_billing_limits_too_many_rows_previously(team, postgres_config, po
         mock.patch("ee.api.billing.requests.get") as mock_billing_request,
         mock.patch("posthog.cloud_utils.is_instance_licensed_cached", None),
     ):
-        source = await sync_to_async(ExternalDataSource.objects.create)(team=team)
+        with freeze_time("2023-01-01"):
+            source = await sync_to_async(ExternalDataSource.objects.create)(team=team)
+
         # A previous job that reached the billing limit
         await sync_to_async(ExternalDataJob.objects.create)(
             team=team,


### PR DESCRIPTION
## Problem
- We weren't taking into account free rows when calculating the "whether a sync will go over the billing limits" logic 

## Changes
- Check the create date of the source and exclude any jobs in the first 7 days of the source creation

## How did you test this code?
Added a unit test