### PR TITLE
fix(batch-exports): Check for invalid S3 credentials

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -119,6 +119,8 @@ NON_RETRYABLE_ERROR_TYPES = (
     "NoSuchBucket",
     # S3 parameter validation failed.
     "ParamValidationError",
+    # Invalid S3 credentials when using `copy_into_redshift_activity_from_stage`.
+    "InvalidCredentialsError",
 )
 
 

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -476,8 +476,7 @@ class ConcurrentS3Consumer(Consumer):
         part_size: int = 50 * 1024 * 1024,
         max_concurrent_uploads: int = 5,
     ):
-        if not s3_inputs.aws_access_key_id or not s3_inputs.aws_secret_access_key:
-            raise InvalidCredentialsError("AWS access key ID and secret access key are required")
+        if not (s3_inputs.aws_access_key_id or "").strip() or not (s3_inputs.aws_secret_access_key or "").strip():
 
         return cls(
             bucket=s3_inputs.bucket_name,

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -426,8 +426,10 @@ class ConcurrentS3Consumer(Consumer):
     ):
         super().__init__()
 
-        if not (aws_access_key_id or "").strip() or not (aws_secret_access_key or "").strip():
-            raise InvalidCredentialsError("AWS access key ID and secret access key are required")
+        if (isinstance(aws_access_key_id, str) and aws_access_key_id.strip() == "") or (
+            isinstance(aws_secret_access_key, str) and aws_secret_access_key.strip() == ""
+        ):
+            raise InvalidCredentialsError("AWS access key ID and secret access key cannot be empty")
 
         self.bucket = bucket
         self.region_name = region_name

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -67,6 +67,8 @@ NON_RETRYABLE_ERROR_TYPES = (
     "UnsupportedFileFormatError",
     # Invalid compression input
     "UnsupportedCompressionError",
+    # Invalid S3 credentials
+    "InvalidCredentialsError",
 )
 
 FILE_FORMAT_EXTENSIONS = {
@@ -178,6 +180,13 @@ class InvalidS3EndpointError(Exception):
     """Exception raised when an S3 endpoint is invalid."""
 
     def __init__(self, message: str = "Endpoint URL is invalid."):
+        super().__init__(message)
+
+
+class InvalidCredentialsError(Exception):
+    """Exception raised when the S3 credentials are invalid."""
+
+    def __init__(self, message: str = "Credentials are invalid."):
         super().__init__(message)
 
 
@@ -467,6 +476,9 @@ class ConcurrentS3Consumer(Consumer):
         part_size: int = 50 * 1024 * 1024,
         max_concurrent_uploads: int = 5,
     ):
+        if not s3_inputs.aws_access_key_id or not s3_inputs.aws_secret_access_key:
+            raise InvalidCredentialsError("AWS access key ID and secret access key are required")
+
         return cls(
             bucket=s3_inputs.bucket_name,
             region_name=s3_inputs.region,

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -426,6 +426,9 @@ class ConcurrentS3Consumer(Consumer):
     ):
         super().__init__()
 
+        if not (aws_access_key_id or "").strip() or not (aws_secret_access_key or "").strip():
+            raise InvalidCredentialsError("AWS access key ID and secret access key are required")
+
         self.bucket = bucket
         self.region_name = region_name
         self.prefix = prefix
@@ -476,8 +479,6 @@ class ConcurrentS3Consumer(Consumer):
         part_size: int = 50 * 1024 * 1024,
         max_concurrent_uploads: int = 5,
     ):
-        if not (s3_inputs.aws_access_key_id or "").strip() or not (s3_inputs.aws_secret_access_key or "").strip():
-
         return cls(
             bucket=s3_inputs.bucket_name,
             region_name=s3_inputs.region,


### PR DESCRIPTION
## Problem

At the moment, in our S3 batch export we don't check to ensure the `aws_access_key_id` and `aws_secret_access_key` are non-empty.

## Changes

Check if these are empty and if so, raise a non-retryable error.

## How did you test this code?

Local testing

