### PR TITLE
feat(experiments): Rename parts in the metrics bar for more clarity

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentVelocityStats.tsx
+++ b/frontend/src/scenes/experiments/ExperimentVelocityStats.tsx
@@ -28,7 +28,7 @@ export function ExperimentVelocityStats(): JSX.Element | null {
     return (
         <div className="px-3 py-2 border rounded bg-bg-light flex items-center gap-3">
             <div className="metric-cell-header font-semibold flex items-center gap-1">
-                Velocity (last 30d)
+                Velocity
                 <Tooltip title="Shows your team's experimentation velocity: how many experiments you're launching, running, and completing. Launched count is compared to the previous 30 days to track growth.">
                     <IconInfo className="text-muted-alt" fontSize="16" />
                 </Tooltip>
@@ -36,7 +36,7 @@ export function ExperimentVelocityStats(): JSX.Element | null {
             <div className="h-4 w-px bg-border" />
             <div className="flex items-baseline gap-1">
                 <span className="text-base font-semibold ">{launched_last_30d}</span>
-                <span>launched</span>
+                <span>launched (30d)</span>
                 {percent_change !== 0 && (
                     <span className={`metric-cell font-bold ${changeColor}`}>
                         {arrow} {Math.abs(percent_change)}%
@@ -46,7 +46,7 @@ export function ExperimentVelocityStats(): JSX.Element | null {
             <div>•</div>
             <div className="flex items-baseline gap-1">
                 <span className="text-base font-semibold">{active_experiments}</span>
-                <span className="">active</span>
+                <span className="">running</span>
             </div>
             <div>•</div>
             <div className="flex items-baseline gap-1">


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

The wording "active" was inconsistent and it was unclear what the difference to "launched" is

## Changes

- The 30d label has been moved to "launched"
- "active" has been renamed to "running"

<img width="1253" height="374" alt="experiments-velocity-bar-wording" src="https://github.com/user-attachments/assets/82a034e1-fd4b-4c7c-aa81-44050e5c9394" />

## How did you test this code?

Manually

## Publish to changelog?

no