### PR TITLE
refactor: use a CTE for properties to reconcile

### DIFF
--- a/posthog/dags/person_property_reconciliation.py
+++ b/posthog/dags/person_property_reconciliation.py
@@ -245,6 +245,7 @@ def get_person_property_updates_from_clickhouse(
                     GROUP BY person_id, kv_tuple.2, kv_tuple.1
                 )
                 GROUP BY person_id
+                HAVING length(grouped_props) > 0
             )
         ) AS merged
         INNER JOIN person_props AS p ON p.id = merged.person_id


### PR DESCRIPTION
## Problem

CH query for the reconciliation job was timing out

## Changes

- Refactored the query to use a CTE
- Added a list of ignored properties to lower the amount of data processed by the query

## How did you test this code?

- Existing regression tests