### PR TITLE
feat(logs): add copy log message and link buttons in LogDetailsModal

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
@@ -1,9 +1,12 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonCheckbox, LemonModal, LemonTabs } from '@posthog/lemon-ui'
+import { IconCopy, IconX } from '@posthog/icons'
+import { LemonButton, LemonCheckbox, LemonModal, LemonTabs } from '@posthog/lemon-ui'
 
 import { JSONViewer } from 'lib/components/JSONViewer'
 import { TZLabel } from 'lib/components/TZLabel'
+import { IconLink } from 'lib/lemon-ui/icons'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
@@ -53,7 +56,7 @@ interface LogDetailsModalProps {
 export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element | null {
     const { isLogDetailsOpen, selectedLog, jsonParseAllFields, activeTab } = useValues(logDetailsModalLogic)
     const { closeLogDetails, setJsonParseAllFields, setActiveTab } = useActions(logDetailsModalLogic)
-    const { addFilter } = useActions(logsViewerLogic)
+    const { addFilter, copyLinkToLog } = useActions(logsViewerLogic)
 
     const handleApplyFilter = (key: string, value: string, attributeType: 'log' | 'resource'): void => {
         const filterType =
@@ -79,10 +82,38 @@ export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element
             simple
             overlayClassName="backdrop-blur-none bg-transparent flex items-stretch justify-end pr-16 py-4 pointer-events-none h-screen"
             className="m-0! max-w-3xl w-[50vw] pointer-events-auto min-h-full"
+            hideCloseButton
         >
             <div className="flex flex-col h-full">
                 <LemonModal.Header className="flex flex-col gap-2">
-                    <h3>Log details</h3>
+                    <div className="flex items-center justify-between">
+                        <h3>Log details</h3>
+                        <div className="flex items-center gap-1">
+                            <LemonButton
+                                size="xsmall"
+                                icon={<IconCopy />}
+                                onClick={() => void copyToClipboard(selectedLog.body, 'log message')}
+                                tooltip="Copy log message"
+                                aria-label="Copy log message"
+                                data-attr="logs-viewer-copy-message"
+                            />
+                            <LemonButton
+                                size="xsmall"
+                                icon={<IconLink />}
+                                onClick={() => copyLinkToLog(selectedLog.uuid)}
+                                tooltip="Copy link to log"
+                                aria-label="Copy link to log"
+                                data-attr="logs-viewer-copy-link"
+                            />
+                            <LemonButton
+                                size="xsmall"
+                                icon={<IconX />}
+                                onClick={closeLogDetails}
+                                tooltip="Close"
+                                aria-label="Close"
+                            />
+                        </div>
+                    </div>
                     <div className="flex items-center gap-6">
                         <div className="flex items-center gap-2">
                             <span className="text-muted text-xs font-semibold uppercase">Timestamp</span>


### PR DESCRIPTION
## Problem

The log details modal lacks convenient options for users to copy log messages or share links to specific logs, making it harder to collaborate or reference logs in other contexts.

## Changes

![image.png](https://app.graphite.com/user-attachments/assets/8476f09e-d0d5-469a-93fd-82150480888a.png)

Enhanced the Log Details Modal with additional functionality:
- Added a copy button to easily copy the log message to clipboard
- Added a link button to copy a direct link to the specific log
- Replaced the default close button with a custom one in the header
- Improved the header layout with better organization of controls

## How did you test this code?

Manually tested the new buttons in the Log Details Modal:
- Verified the copy log message button correctly copies the log content to clipboard
- Confirmed the copy link button generates and copies a shareable link to the specific log
- Tested the close button functionality to ensure it properly dismisses the modal
- Checked that the UI layout remains responsive and visually consistent

## Publish to changelog?

No