### PR TITLE
fix: fix flox activate

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -37,7 +37,7 @@ cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }
 sqlx-cli = { pkg-path = "sqlx-cli", version = "0.8.3" } # sqlx
 postgresql = { pkg-path = "postgresql_14" } # psql
 ffmpeg.pkg-path = "ffmpeg"
-gh = { pkg-path = "gh", version = "2.83.2" }
+gh = { pkg-path = "gh" }
 
 # Set environment variables in the `[vars]` section. These variables may not
 # reference one another, and are added to the environment without first


### PR DESCRIPTION
I believe that this PR https://github.com/PostHog/posthog/pull/44610 broke `flox activate`.

I am getting
```
❌ ERROR: resolution failed: constraints for group 'toplevel' are too tight
```

Either removing the version pin or adding `gh` to a separate `pkg-group` worked to fix it. I think we don't need a version pin because we are using a very basic `gh` functionality (`gh run download`) so I'm removing the pin.

It works just fine locally without the pin