### PR TITLE
fix(customers): Move usage metrics creation to modal

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -45,14 +45,14 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
     const { response, responseLoading, responseError } = useValues(logic)
     const { loadData } = useActions(logic)
     const usageMetricsConfigLogicProps = { logicKey: attributes.nodeId }
-    const { toggleIsModalOpen } = useActions(usageMetricsConfigLogic(usageMetricsConfigLogicProps))
+    const { openModal } = useActions(usageMetricsConfigLogic(usageMetricsConfigLogicProps))
 
     useEffect(() => {
         setActions([
             {
                 text: 'Add metric',
                 icon: <IconPlusSmall />,
-                onClick: toggleIsModalOpen,
+                onClick: openModal,
             },
             {
                 text: 'Refresh',

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -102,7 +102,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
 }
 
 function UsageMetricsEmptyState(): JSX.Element {
-    const { toggleIsModalOpen } = useActions(usageMetricsConfigLogic)
+    const { openModal } = useActions(usageMetricsConfigLogic)
     return (
         <ProductIntroduction
             productName="Customer analytics"
@@ -111,7 +111,7 @@ function UsageMetricsEmptyState(): JSX.Element {
             isEmpty={true}
             productKey={ProductKey.CUSTOMER_ANALYTICS}
             className="border-none"
-            action={() => toggleIsModalOpen()}
+            action={() => openModal()}
         />
     )
 }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeUsageMetrics.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react'
 import { IconPlusSmall, IconRefresh } from '@posthog/icons'
 
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
-import { UsageMetricsConfig } from 'scenes/settings/environment/UsageMetricsConfig'
+import { UsageMetricsConfig, UsageMetricsModal } from 'scenes/settings/environment/UsageMetricsConfig'
 import { usageMetricsConfigLogic } from 'scenes/settings/environment/usageMetricsConfigLogic'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
@@ -44,13 +44,15 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
     const logic = dataNodeLogic(dataNodeLogicProps)
     const { response, responseLoading, responseError } = useValues(logic)
     const { loadData } = useActions(logic)
+    const usageMetricsConfigLogicProps = { logicKey: attributes.nodeId }
+    const { toggleIsModalOpen } = useActions(usageMetricsConfigLogic(usageMetricsConfigLogicProps))
 
     useEffect(() => {
         setActions([
             {
                 text: 'Add metric',
                 icon: <IconPlusSmall />,
-                onClick: () => toggleEditing(true),
+                onClick: toggleIsModalOpen,
             },
             {
                 text: 'Refresh',
@@ -77,22 +79,30 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeUsageMetricsAtt
     const hasResults = results.length > 0
 
     if (!hasResults) {
-        return <UsageMetricsEmptyState />
+        return (
+            <BindLogic logic={usageMetricsConfigLogic} props={usageMetricsConfigLogicProps}>
+                <UsageMetricsEmptyState />
+                <UsageMetricsModal />
+            </BindLogic>
+        )
     }
 
     return (
-        <div className="@container">
-            <div className="grid grid-cols-1 @md:grid-cols-2 @xl:grid-cols-4 gap-4 p-4">
-                {results.map((metric) => (
-                    <UsageMetricCard key={metric.id} metric={metric} />
-                ))}
+        <BindLogic logic={usageMetricsConfigLogic} props={usageMetricsConfigLogicProps}>
+            <div className="@container">
+                <div className="grid grid-cols-1 @md:grid-cols-2 @xl:grid-cols-4 gap-4 p-4">
+                    {results.map((metric) => (
+                        <UsageMetricCard key={metric.id} metric={metric} />
+                    ))}
+                </div>
+                <UsageMetricsModal />
             </div>
-        </div>
+        </BindLogic>
     )
 }
 
 function UsageMetricsEmptyState(): JSX.Element {
-    const { toggleEditing } = useActions(notebookNodeLogic)
+    const { toggleIsModalOpen } = useActions(usageMetricsConfigLogic)
     return (
         <ProductIntroduction
             productName="Customer analytics"
@@ -101,7 +111,7 @@ function UsageMetricsEmptyState(): JSX.Element {
             isEmpty={true}
             productKey={ProductKey.CUSTOMER_ANALYTICS}
             className="border-none"
-            action={() => toggleEditing(true)}
+            action={() => toggleIsModalOpen()}
         />
     )
 }

--- a/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
@@ -8,6 +8,7 @@ import {
     LemonInput,
     LemonLabel,
     LemonMenu,
+    LemonModal,
     LemonSelect,
     LemonTable,
     LemonTableColumns,
@@ -22,9 +23,7 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
-import { teamLogic } from 'scenes/teamLogic'
 
-import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import { AnyPropertyFilter, EntityTypes, FilterType } from '~/types'
 
 import { UsageMetric, usageMetricsConfigLogic } from './usageMetricsConfigLogic'
@@ -50,9 +49,8 @@ function sanitizeFilters(filters?: FilterType): FilterType {
 
 function UsageMetricsTable(): JSX.Element {
     const { usageMetrics, usageMetricsLoading } = useValues(usageMetricsConfigLogic)
-    const { removeUsageMetric } = useActions(usageMetricsConfigLogic)
-    const { reportUsageMetricDeleted, reportUsageMetricsUpdateButtonClicked, reportUsageMetricUpdated } =
-        useActions(eventUsageLogic)
+    const { removeUsageMetric, toggleIsModalOpen, setUsageMetricValues } = useActions(usageMetricsConfigLogic)
+    const { reportUsageMetricsUpdateButtonClicked } = useActions(eventUsageLogic)
 
     const columns: LemonTableColumns<UsageMetric> = [
         {
@@ -86,26 +84,8 @@ function UsageMetricsTable(): JSX.Element {
                             {
                                 label: 'Edit',
                                 onClick: () => {
-                                    LemonDialog.open({
-                                        title: 'Edit usage metric',
-                                        description: (
-                                            <div>
-                                                <UsageMetricsForm metric={metric} />
-                                            </div>
-                                        ),
-                                        primaryButton: {
-                                            htmlType: 'submit',
-                                            children: 'Save',
-                                            'data-attr': 'update-usage-metric',
-                                            form: 'usageMetric',
-                                            onClick: () => reportUsageMetricUpdated(),
-                                        },
-                                        secondaryButton: {
-                                            htmlType: 'button',
-                                            children: 'Cancel',
-                                            'data-attr': 'cancel-update-usage-metric',
-                                        },
-                                    })
+                                    toggleIsModalOpen()
+                                    setUsageMetricValues(metric)
                                     reportUsageMetricsUpdateButtonClicked()
                                 },
                             },
@@ -121,7 +101,6 @@ function UsageMetricsTable(): JSX.Element {
                                             status: 'danger',
                                             onClick: () => {
                                                 removeUsageMetric(metric.id)
-                                                reportUsageMetricDeleted()
                                             },
                                         },
                                         secondaryButton: {
@@ -142,24 +121,7 @@ function UsageMetricsTable(): JSX.Element {
     return <LemonTable columns={columns} dataSource={usageMetrics} loading={usageMetricsLoading} />
 }
 
-interface UsageMetricsFormProps {
-    metric?: UsageMetric
-}
-
-function UsageMetricsForm({ metric }: UsageMetricsFormProps): JSX.Element {
-    const { resetUsageMetric, setIsEditing, setUsageMetricValues } = useActions(usageMetricsConfigLogic)
-    const { reportUsageMetricCreated } = useActions(eventUsageLogic)
-    const { addProductIntent } = useActions(teamLogic)
-
-    if (metric) {
-        setUsageMetricValues(metric)
-    }
-
-    const handleCancelForm = (): void => {
-        resetUsageMetric()
-        setIsEditing(false)
-    }
-
+function UsageMetricsForm(): JSX.Element {
     const taxonomicGroupTypes = [
         TaxonomicFilterGroupType.EventProperties,
         TaxonomicFilterGroupType.EventMetadata,
@@ -266,46 +228,15 @@ function UsageMetricsForm({ metric }: UsageMetricsFormProps): JSX.Element {
                         }}
                     </LemonField>
                 </div>
-                <div>
-                    {!metric && (
-                        <div className="flex gap-2 mt-2">
-                            <LemonButton
-                                type="primary"
-                                data-attr="save-usage-metric"
-                                htmlType="submit"
-                                form="usageMetric"
-                                onClick={() => {
-                                    reportUsageMetricCreated()
-                                    addProductIntent({
-                                        product_type: ProductKey.CUSTOMER_ANALYTICS,
-                                        intent_context: ProductIntentContext.CUSTOMER_ANALYTICS_USAGE_METRIC_CREATED,
-                                    })
-                                }}
-                            >
-                                Save
-                            </LemonButton>
-                            <LemonButton type="secondary" data-attr="cancel-usage-metric" onClick={handleCancelForm}>
-                                Cancel
-                            </LemonButton>
-                        </div>
-                    )}
-                </div>
             </div>
         </Form>
     )
 }
 
 export function UsageMetricsConfig(): JSX.Element {
-    const { isEditing } = useValues(usageMetricsConfigLogic)
-    const { setIsEditing, resetUsageMetric } = useActions(usageMetricsConfigLogic)
+    const { toggleIsModalOpen } = useActions(usageMetricsConfigLogic)
     const { groupsEnabled } = useValues(groupsAccessLogic)
-    const { reportUsageMetricsCreateButtonClicked, reportUsageMetricsSettingsViewed } = useActions(eventUsageLogic)
-
-    const handleAddMetric = (): void => {
-        resetUsageMetric()
-        setIsEditing(true)
-        reportUsageMetricsCreateButtonClicked()
-    }
+    const { reportUsageMetricsSettingsViewed } = useActions(eventUsageLogic)
 
     useOnMountEffect(() => {
         reportUsageMetricsSettingsViewed()
@@ -319,13 +250,43 @@ export function UsageMetricsConfig(): JSX.Element {
                 Usage metrics are displayed in the person {groupsEnabled ? 'and group profiles' : 'profile'}.
             </p>
             <div className="flex flex-col gap-2 items-start">
-                {!isEditing && (
-                    <LemonButton type="primary" size="small" onClick={handleAddMetric} icon={<IconPlusSmall />}>
-                        Add metric
-                    </LemonButton>
-                )}
-                {isEditing ? <UsageMetricsForm /> : <UsageMetricsTable />}
+                <LemonButton type="primary" size="small" onClick={toggleIsModalOpen} icon={<IconPlusSmall />}>
+                    Add metric
+                </LemonButton>
+                <UsageMetricsTable />
+                <UsageMetricsModal />
             </div>
         </>
+    )
+}
+
+export function UsageMetricsModal(): JSX.Element {
+    const { isModalOpen } = useValues(usageMetricsConfigLogic)
+    const { toggleIsModalOpen, resetUsageMetric } = useActions(usageMetricsConfigLogic)
+
+    const handleClose = (): void => {
+        toggleIsModalOpen()
+        resetUsageMetric()
+    }
+
+    return (
+        <LemonModal
+            title="Add usage metric"
+            isOpen={isModalOpen}
+            onClose={handleClose}
+            description={<UsageMetricsForm />}
+            footer={
+                <>
+                    <LemonButton
+                        htmlType="submit"
+                        form="usageMetric"
+                        type="primary"
+                        children="Save"
+                        data-attr="create-usage-metric"
+                    />
+                    <LemonButton children="Cancel" onClick={handleClose} data-attr="cancel-create-usage-metric" />
+                </>
+            }
+        />
     )
 }

--- a/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
@@ -49,7 +49,7 @@ function sanitizeFilters(filters?: FilterType): FilterType {
 
 function UsageMetricsTable(): JSX.Element {
     const { usageMetrics, usageMetricsLoading } = useValues(usageMetricsConfigLogic)
-    const { removeUsageMetric, toggleIsModalOpen, setUsageMetricValues } = useActions(usageMetricsConfigLogic)
+    const { removeUsageMetric, openModal, setUsageMetricValues } = useActions(usageMetricsConfigLogic)
     const { reportUsageMetricsUpdateButtonClicked } = useActions(eventUsageLogic)
 
     const columns: LemonTableColumns<UsageMetric> = [
@@ -84,7 +84,7 @@ function UsageMetricsTable(): JSX.Element {
                             {
                                 label: 'Edit',
                                 onClick: () => {
-                                    toggleIsModalOpen()
+                                    openModal()
                                     setUsageMetricValues(metric)
                                     reportUsageMetricsUpdateButtonClicked()
                                 },
@@ -234,7 +234,7 @@ function UsageMetricsForm(): JSX.Element {
 }
 
 export function UsageMetricsConfig(): JSX.Element {
-    const { toggleIsModalOpen } = useActions(usageMetricsConfigLogic)
+    const { openModal } = useActions(usageMetricsConfigLogic)
     const { groupsEnabled } = useValues(groupsAccessLogic)
     const { reportUsageMetricsSettingsViewed } = useActions(eventUsageLogic)
 
@@ -250,7 +250,7 @@ export function UsageMetricsConfig(): JSX.Element {
                 Usage metrics are displayed in the person {groupsEnabled ? 'and group profiles' : 'profile'}.
             </p>
             <div className="flex flex-col gap-2 items-start">
-                <LemonButton type="primary" size="small" onClick={toggleIsModalOpen} icon={<IconPlusSmall />}>
+                <LemonButton type="primary" size="small" onClick={openModal} icon={<IconPlusSmall />}>
                     Add metric
                 </LemonButton>
                 <UsageMetricsTable />
@@ -262,18 +262,13 @@ export function UsageMetricsConfig(): JSX.Element {
 
 export function UsageMetricsModal(): JSX.Element {
     const { isModalOpen } = useValues(usageMetricsConfigLogic)
-    const { toggleIsModalOpen, resetUsageMetric } = useActions(usageMetricsConfigLogic)
-
-    const handleClose = (): void => {
-        toggleIsModalOpen()
-        resetUsageMetric()
-    }
+    const { closeModal } = useActions(usageMetricsConfigLogic)
 
     return (
         <LemonModal
             title="Add usage metric"
             isOpen={isModalOpen}
-            onClose={handleClose}
+            onClose={closeModal}
             description={<UsageMetricsForm />}
             footer={
                 <>
@@ -284,7 +279,7 @@ export function UsageMetricsModal(): JSX.Element {
                         children="Save"
                         data-attr="create-usage-metric"
                     />
-                    <LemonButton children="Cancel" onClick={handleClose} data-attr="cancel-create-usage-metric" />
+                    <LemonButton children="Cancel" onClick={closeModal} data-attr="cancel-create-usage-metric" />
                 </>
             }
         />

--- a/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
+++ b/frontend/src/scenes/settings/environment/UsageMetricsConfig.tsx
@@ -269,7 +269,7 @@ export function UsageMetricsModal(): JSX.Element {
             title="Add usage metric"
             isOpen={isModalOpen}
             onClose={closeModal}
-            description={<UsageMetricsForm />}
+            children={<UsageMetricsForm />}
             footer={
                 <>
                     <LemonButton

--- a/frontend/src/scenes/settings/environment/usageMetricsConfigLogic.ts
+++ b/frontend/src/scenes/settings/environment/usageMetricsConfigLogic.ts
@@ -58,14 +58,16 @@ export const usageMetricsConfigLogic = kea<usageMetricsConfigLogicType>([
         addUsageMetric: (metric: UsageMetricFormData) => ({ metric }),
         updateUsageMetric: (metric: UsageMetricFormData) => ({ metric }),
         removeUsageMetric: (id: string) => ({ id }),
-        toggleIsModalOpen: true,
+        openModal: true,
+        closeModal: true,
     })),
 
     reducers({
         isModalOpen: [
             false,
             {
-                toggleIsModalOpen: (state) => !state,
+                openModal: () => true,
+                closeModal: () => false,
             },
         ],
     }),
@@ -119,10 +121,12 @@ export const usageMetricsConfigLogic = kea<usageMetricsConfigLogicType>([
     })),
 
     listeners(({ actions }) => ({
-        submitUsageMetricSuccess: () => {
+        closeModal: () => {
             actions.resetUsageMetric()
+        },
+        submitUsageMetricSuccess: () => {
             actions.loadUsageMetrics()
-            actions.toggleIsModalOpen()
+            actions.closeModal()
         },
         addUsageMetricSuccess: () => {
             actions.loadUsageMetrics()

--- a/frontend/src/scenes/settings/environment/usageMetricsConfigLogic.ts
+++ b/frontend/src/scenes/settings/environment/usageMetricsConfigLogic.ts
@@ -3,7 +3,11 @@ import { forms } from 'kea-forms'
 import { lazyLoaders } from 'kea-loaders'
 
 import api from 'lib/api'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { projectLogic } from 'scenes/projectLogic'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 
 import type { usageMetricsConfigLogicType } from './usageMetricsConfigLogicType'
 
@@ -38,22 +42,33 @@ export interface UsageMetricsConfigLogicProps {
 
 export const usageMetricsConfigLogic = kea<usageMetricsConfigLogicType>([
     path(['scenes', 'settings', 'environment', 'usageMetricsConfigLogic']),
-    connect(() => ({
-        values: [projectLogic, ['currentProjectId']],
-    })),
     props({} as UsageMetricsConfigLogicProps),
     key(({ logicKey }) => logicKey || 'defaultKey'),
+    connect(() => ({
+        values: [projectLogic, ['currentProjectId']],
+        actions: [
+            eventUsageLogic,
+            ['reportUsageMetricCreated', 'reportUsageMetricUpdated', 'reportUsageMetricDeleted'],
+            teamLogic,
+            ['addProductIntent'],
+        ],
+    })),
 
     actions(() => ({
-        setIsEditing: (isEditing: boolean) => ({ isEditing }),
         addUsageMetric: (metric: UsageMetricFormData) => ({ metric }),
         updateUsageMetric: (metric: UsageMetricFormData) => ({ metric }),
         removeUsageMetric: (id: string) => ({ id }),
+        toggleIsModalOpen: true,
     })),
 
-    reducers(() => ({
-        isEditing: [false, { setIsEditing: (_, { isEditing }) => isEditing }],
-    })),
+    reducers({
+        isModalOpen: [
+            false,
+            {
+                toggleIsModalOpen: (state) => !state,
+            },
+        ],
+    }),
 
     lazyLoaders(({ values }) => ({
         usageMetrics: [
@@ -63,13 +78,16 @@ export const usageMetricsConfigLogic = kea<usageMetricsConfigLogicType>([
                     return await api.get(values.metricsUrl).then((response) => response.results)
                 },
                 addUsageMetric: async ({ metric }) => {
-                    return await api.create(values.metricsUrl, metric)
+                    const newMetric = await api.create(values.metricsUrl, metric)
+                    return [...values.usageMetrics, newMetric]
                 },
                 updateUsageMetric: async ({ metric }) => {
-                    return await api.update(`${values.metricsUrl}/${metric.id}`, metric)
+                    const updatedMetric = await api.update(`${values.metricsUrl}/${metric.id}`, metric)
+                    return [...values.usageMetrics.filter((m) => m.id !== metric.id), updatedMetric]
                 },
                 removeUsageMetric: async ({ id }) => {
-                    return await api.delete(`${values.metricsUrl}/${id}`)
+                    const deletedMetric = await api.delete(`${values.metricsUrl}/${id}`)
+                    return [...values.usageMetrics.filter((m) => m.id !== id), deletedMetric]
                 },
             },
         ],
@@ -102,17 +120,25 @@ export const usageMetricsConfigLogic = kea<usageMetricsConfigLogicType>([
 
     listeners(({ actions }) => ({
         submitUsageMetricSuccess: () => {
-            actions.setIsEditing(false)
             actions.resetUsageMetric()
+            actions.loadUsageMetrics()
+            actions.toggleIsModalOpen()
         },
         addUsageMetricSuccess: () => {
             actions.loadUsageMetrics()
+            actions.reportUsageMetricCreated()
+            actions.addProductIntent({
+                product_type: ProductKey.CUSTOMER_ANALYTICS,
+                intent_context: ProductIntentContext.CUSTOMER_ANALYTICS_USAGE_METRIC_CREATED,
+            })
         },
         updateUsageMetricSuccess: () => {
             actions.loadUsageMetrics()
+            actions.reportUsageMetricUpdated()
         },
         removeUsageMetricSuccess: () => {
             actions.loadUsageMetrics()
+            actions.reportUsageMetricDeleted()
         },
     })),
 ])


### PR DESCRIPTION
## Problem

Recent changes caused a bug where adding usage metrics from customer profiles triggers a render loop (potentially because we're trying to sync state between TipTap editor and kea).

~To buy us time to find a proper fix, let's move the form to a modal and refactor usages.~
Root cause was fixed [here](https://github.com/PostHog/posthog/pull/44673/changes). Keeping this as improves the UX.

## Changes

- Replaced inline editing of usage metrics with a modal-based approach for consistency
- Added `UsageMetricsCreateEditModal` component that can be reused across the application
- Updated the notebook node to use the same modal component as the settings page

## How did you test this code?

I tested this change by:
- Adding new usage metrics from both the notebook node and settings page
- Editing existing metrics from both locations
- Deleting metrics and verifying the UI updates correctly
- Confirming that event tracking works as expected for all operations
- Verifying that the modal opens and closes properly with the correct state

## Publish to changelog?

No