### PR TITLE
fix(flags): Missing flag deps cause flags to fail closed

### DIFF
--- a/rust/feature-flags/src/api/types.rs
+++ b/rust/feature-flags/src/api/types.rs
@@ -481,6 +481,9 @@ impl FromFeatureAndMatch for FlagDetails {
                 Some("Holdout condition value".to_string())
             }
             FeatureFlagMatchReason::FlagDisabled => Some("Feature flag is disabled".to_string()),
+            FeatureFlagMatchReason::MissingDependency => {
+                Some("Flag cannot be evaluated due to missing dependency".to_string())
+            }
         }
     }
 }
@@ -677,6 +680,26 @@ mod tests {
             payload: None,
         },
         Some("Holdout condition value".to_string())
+    )]
+    #[case::flag_disabled(
+        FeatureFlagMatch {
+            matches: false,
+            variant: None,
+            reason: FeatureFlagMatchReason::FlagDisabled,
+            condition_index: None,
+            payload: None,
+        },
+        Some("Feature flag is disabled".to_string())
+    )]
+    #[case::missing_dependency(
+        FeatureFlagMatch {
+            matches: false,
+            variant: None,
+            reason: FeatureFlagMatchReason::MissingDependency,
+            condition_index: None,
+            payload: None,
+        },
+        Some("Flag cannot be evaluated due to missing dependency".to_string())
     )]
     fn test_get_reason_description(
         #[case] flag_match: FeatureFlagMatch,

--- a/rust/feature-flags/src/flags/flag_match_reason.rs
+++ b/rust/feature-flags/src/flags/flag_match_reason.rs
@@ -17,6 +17,8 @@ pub enum FeatureFlagMatchReason {
     HoldoutConditionValue,
     #[strum(serialize = "flag_disabled")]
     FlagDisabled,
+    #[strum(serialize = "missing_dependency")]
+    MissingDependency,
 }
 
 impl FeatureFlagMatchReason {
@@ -29,6 +31,7 @@ impl FeatureFlagMatchReason {
             FeatureFlagMatchReason::OutOfRolloutBound => 2,
             FeatureFlagMatchReason::NoConditionMatch => 1,
             FeatureFlagMatchReason::FlagDisabled => 0,
+            FeatureFlagMatchReason::MissingDependency => -1,
         }
     }
 }
@@ -58,6 +61,7 @@ impl std::fmt::Display for FeatureFlagMatchReason {
                 FeatureFlagMatchReason::NoGroupType => "no_group_type",
                 FeatureFlagMatchReason::HoldoutConditionValue => "holdout_condition_value",
                 FeatureFlagMatchReason::FlagDisabled => "flag_disabled",
+                FeatureFlagMatchReason::MissingDependency => "missing_dependency",
             }
         )
     }
@@ -70,12 +74,14 @@ mod tests {
     #[test]
     fn test_ordering() {
         let reasons = vec![
-            FeatureFlagMatchReason::FlagDisabled,
-            FeatureFlagMatchReason::NoConditionMatch,
-            FeatureFlagMatchReason::OutOfRolloutBound,
-            FeatureFlagMatchReason::NoGroupType,
-            FeatureFlagMatchReason::ConditionMatch,
-            FeatureFlagMatchReason::SuperConditionValue,
+            FeatureFlagMatchReason::MissingDependency,     // -1
+            FeatureFlagMatchReason::FlagDisabled,          // 0
+            FeatureFlagMatchReason::NoConditionMatch,      // 1
+            FeatureFlagMatchReason::OutOfRolloutBound,     // 2
+            FeatureFlagMatchReason::NoGroupType,           // 3
+            FeatureFlagMatchReason::ConditionMatch,        // 4
+            FeatureFlagMatchReason::HoldoutConditionValue, // 5
+            FeatureFlagMatchReason::SuperConditionValue,   // 6
         ];
 
         let mut sorted_reasons = reasons.clone();
@@ -109,6 +115,14 @@ mod tests {
         assert_eq!(
             FeatureFlagMatchReason::FlagDisabled.to_string(),
             "flag_disabled"
+        );
+        assert_eq!(
+            FeatureFlagMatchReason::HoldoutConditionValue.to_string(),
+            "holdout_condition_value"
+        );
+        assert_eq!(
+            FeatureFlagMatchReason::MissingDependency.to_string(),
+            "missing_dependency"
         );
     }
 }

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -27,7 +27,7 @@ use crate::metrics::utils::parse_exception_for_prometheus_label;
 use crate::properties::property_models::PropertyFilter;
 use crate::utils::graph_utils::{
     build_dependency_graph, filter_graph_by_keys, log_dependency_graph_operation_error,
-    DependencyGraph,
+    DependencyGraph, DependencyGraphResult, FilteredGraphResult,
 };
 use anyhow::Result;
 use common_metrics::{inc, timing_guard};
@@ -70,6 +70,18 @@ impl FeatureFlagMatch {
             (true, Some(variant)) => FlagValue::String(variant.clone()),
             (true, None) => FlagValue::Boolean(true),
             (false, _) => FlagValue::Boolean(false),
+        }
+    }
+
+    /// Creates a match result for flags with missing dependencies.
+    /// These flags evaluate to `false` (fail closed) with the `MissingDependency` reason.
+    pub fn missing_dependency() -> Self {
+        Self {
+            matches: false,
+            variant: None,
+            reason: FeatureFlagMatchReason::MissingDependency,
+            condition_index: None,
+            payload: None,
         }
     }
 }
@@ -238,25 +250,33 @@ impl FeatureFlagMatcher {
         let eval_timer = common_metrics::timing_guard(FLAG_EVALUATION_TIME, &[]);
 
         // Build dependency graph once - reused for both optimization check and evaluation
-        let (global_dependency_graph, graph_errors) =
-            match build_dependency_graph(&feature_flags, self.team_id) {
-                Some((graph, errors)) => (graph, errors),
-                None => return FlagsResponse::new(true, HashMap::new(), None, request_id),
-            };
+        let DependencyGraphResult {
+            graph: global_dependency_graph,
+            errors: graph_errors,
+            flags_with_missing_deps: global_flags_with_missing_deps,
+        } = match build_dependency_graph(&feature_flags, self.team_id) {
+            Some(result) => result,
+            None => return FlagsResponse::new(true, HashMap::new(), None, request_id),
+        };
 
         // Filter graph by flag_keys if specified (includes transitive dependencies)
-        let dependency_graph = if let Some(ref keys) = flag_keys {
-            match filter_graph_by_keys(&global_dependency_graph, keys) {
-                Some(filtered_graph) => filtered_graph,
+        let (dependency_graph, flags_with_missing_deps) = if let Some(ref keys) = flag_keys {
+            match filter_graph_by_keys(
+                &global_dependency_graph,
+                keys,
+                &global_flags_with_missing_deps,
+            ) {
+                Some(FilteredGraphResult {
+                    graph,
+                    flags_with_missing_deps,
+                }) => (graph, flags_with_missing_deps),
                 None => return FlagsResponse::new(true, HashMap::new(), None, request_id),
             }
         } else {
-            global_dependency_graph
+            (global_dependency_graph, global_flags_with_missing_deps)
         };
 
-        // Track graph construction errors for the response (errors already logged in build_dependency_graph)
-        let has_graph_errors = !graph_errors.is_empty();
-        if has_graph_errors {
+        if !graph_errors.is_empty() {
             with_canonical_log(|log| log.dependency_graph_errors = graph_errors.len());
         }
 
@@ -332,12 +352,18 @@ impl FeatureFlagMatcher {
 
         // Pass the pre-built graph to avoid redundant graph construction
         let flags_response = self
-            .evaluate_flags_with_overrides(overrides, request_id, dependency_graph)
+            .evaluate_flags_with_overrides(
+                overrides,
+                request_id,
+                dependency_graph,
+                flags_with_missing_deps,
+            )
             .await;
 
+        let has_cycle_errors = graph_errors.iter().any(|e| e.is_cycle());
         let has_errors = flag_hash_key_override_error
             || flags_response.errors_while_computing_flags
-            || has_graph_errors;
+            || has_cycle_errors;
 
         eval_timer
             .label("outcome", if has_errors { "error" } else { "success" })
@@ -507,6 +533,7 @@ impl FeatureFlagMatcher {
         overrides: FlagEvaluationOverrides,
         request_id: Uuid,
         dependency_graph: DependencyGraph<FeatureFlag>,
+        flags_with_missing_deps: HashSet<i32>,
     ) -> FlagsResponse {
         let mut errors_while_computing_flags = overrides.hash_key_override_error;
         let mut evaluated_flags_map = HashMap::new();
@@ -548,6 +575,7 @@ impl FeatureFlagMatcher {
                 &overrides.group_property_overrides,
                 &overrides.hash_key_overrides,
                 &mut evaluated_flags_map,
+                &flags_with_missing_deps,
             )
             .await;
         errors_while_computing_flags |= graph_evaluation_errors;
@@ -569,6 +597,7 @@ impl FeatureFlagMatcher {
         group_property_overrides: &Option<HashMap<String, HashMap<String, Value>>>,
         hash_key_overrides: &Option<HashMap<String, String>>,
         evaluated_flags_map: &mut HashMap<String, FlagDetails>,
+        flags_with_missing_deps: &HashSet<i32>,
     ) -> bool {
         // Get evaluation stages for the dependency graph
         let evaluation_stages = match flag_dependency_graph.evaluation_stages() {
@@ -589,6 +618,7 @@ impl FeatureFlagMatcher {
                     person_property_overrides,
                     group_property_overrides,
                     hash_key_overrides,
+                    flags_with_missing_deps,
                 )
                 .await;
             errors_while_computing_flags |= level_errors;
@@ -673,6 +703,7 @@ impl FeatureFlagMatcher {
         person_property_overrides: &Option<HashMap<String, Value>>,
         group_property_overrides: &Option<HashMap<String, HashMap<String, Value>>>,
         hash_key_overrides: &Option<HashMap<String, String>>,
+        flags_with_missing_deps: &HashSet<i32>,
     ) -> (HashMap<String, FlagDetails>, bool) {
         // initialize some state
         let mut errors_while_computing_flags = false;
@@ -722,6 +753,11 @@ impl FeatureFlagMatcher {
         let results: Vec<(String, Result<FeatureFlagMatch, FlagError>)> = flags_to_evaluate
             .par_iter()
             .map(|flag| {
+                // Flags with missing dependencies evaluate to false (fail closed)
+                if flags_with_missing_deps.contains(&flag.id) {
+                    return (flag.key.clone(), Ok(FeatureFlagMatch::missing_dependency()));
+                }
+
                 // If the overrides for this flag are not in the pre-computed map, assume no overrides
                 // this shouldn't happen, but it's here to avoid panics
                 let property_overrides = precomputed_property_overrides

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -18,6 +18,13 @@ pub enum GraphError<Id> {
     CycleDetected(Id),
 }
 
+impl<Id> GraphError<Id> {
+    /// Returns true if this error represents a cycle in the dependency graph.
+    pub fn is_cycle(&self) -> bool {
+        matches!(self, GraphError::CycleDetected(_))
+    }
+}
+
 /// Trait for types that can provide their dependencies
 pub trait DependencyProvider {
     type Id: Copy + Eq + std::hash::Hash + std::fmt::Display + Into<i64>;
@@ -120,9 +127,9 @@ where
             }
         }
 
-        let (graph, errors) = Self::from_nodes(&nodes_to_include)?;
+        let (graph, errors, _nodes_with_missing_deps) = Self::from_nodes(&nodes_to_include)?;
 
-        // If there are any errors (missing dependencies or cycles), fail
+        // Single-root constructor fails strictly on any error
         if !errors.is_empty() {
             // Return the first error as the failure reason
             match errors[0] {
@@ -141,18 +148,24 @@ where
     }
 
     /// Builds a full multi-root dependency graph from the provided set of nodes.
-    /// Returns a tuple of the graph and a vector of errors.
-    /// The errors are returned in the order they were encountered.
-    /// The graph is returned even if there are errors.
-    /// - Cycles are detected and removed from the graph.
-    /// - Missing dependencies are detected and removed from the graph.
+    /// Returns a tuple of:
+    /// - The graph
+    /// - A vector of errors encountered (missing dependencies, cycles)
+    /// - A set of node IDs that have missing dependencies
+    ///
+    /// Behavior:
+    /// - Cycles are detected and the cycle-starting node is removed from the graph.
+    /// - Missing dependencies are tracked but nodes with missing deps are KEPT in the graph.
+    /// - Nodes with missing dependencies should be evaluated as `false` (fail closed).
     /// - A partial-graph is returned even if there are errors.
     #[allow(clippy::type_complexity)]
-    pub fn from_nodes(nodes: &[T]) -> Result<(Self, Vec<GraphError<T::Id>>), T::Error> {
+    pub fn from_nodes(
+        nodes: &[T],
+    ) -> Result<(Self, Vec<GraphError<T::Id>>, HashSet<T::Id>), T::Error> {
         let mut graph = DiGraph::new();
         let mut id_map = HashMap::with_capacity(nodes.len());
         let mut errors = Vec::new();
-        let mut nodes_with_missing_deps = Vec::new();
+        let mut nodes_with_missing_deps: HashSet<T::Id> = HashSet::new();
 
         // Insert all nodes first
         for node in nodes {
@@ -160,7 +173,8 @@ where
             id_map.insert(node.get_id(), idx);
         }
 
-        // Insert edges and track nodes with missing dependencies
+        // Insert edges and track nodes with direct missing dependencies
+        let mut nodes_with_direct_missing_deps: HashSet<NodeIndex> = HashSet::new();
         for node in nodes {
             let source_idx = id_map[&node.get_id()];
             for dep_id in node.extract_dependencies()? {
@@ -168,21 +182,50 @@ where
                     graph.add_edge(source_idx, *target_idx, ());
                 } else {
                     errors.push(GraphError::MissingDependency(dep_id));
-                    nodes_with_missing_deps.push(source_idx);
+                    nodes_with_direct_missing_deps.insert(source_idx);
                 }
             }
         }
 
-        // Remove all nodes with missing dependencies and their dependents
-        nodes_with_missing_deps.sort_by(|a, b| b.cmp(a));
-        for node_idx in nodes_with_missing_deps {
-            Self::remove_node_and_dependents_from_graph(&mut graph, node_idx);
-        }
+        // Propagate missing dependency status transitively.
+        // Any node that depends (directly or transitively) on a node with a missing
+        // dependency should also be marked, so it evaluates to false (fail closed).
+        Self::propagate_missing_deps_transitively(
+            &graph,
+            &nodes_with_direct_missing_deps,
+            &mut nodes_with_missing_deps,
+        );
 
         // Remove all cycles from the graph
         Self::remove_all_cycles(&mut graph, &mut errors);
 
-        Ok((Self { graph }, errors))
+        Ok((Self { graph }, errors, nodes_with_missing_deps))
+    }
+
+    /// Propagates missing dependency status transitively through the graph.
+    /// Any node that depends (directly or transitively) on a node with a missing
+    /// dependency will be added to the output set.
+    fn propagate_missing_deps_transitively(
+        graph: &DiGraph<T, ()>,
+        nodes_with_direct_missing_deps: &HashSet<NodeIndex>,
+        output: &mut HashSet<T::Id>,
+    ) {
+        use petgraph::Direction::Incoming;
+        let mut visited: HashSet<NodeIndex> = HashSet::new();
+        let mut stack: Vec<NodeIndex> = nodes_with_direct_missing_deps.iter().copied().collect();
+
+        while let Some(idx) = stack.pop() {
+            if visited.insert(idx) {
+                // Add this node's ID to the output set
+                output.insert(graph[idx].get_id());
+                // Find all nodes that depend on this node (incoming edges = dependents)
+                for dependent_idx in graph.neighbors_directed(idx, Incoming) {
+                    if !visited.contains(&dependent_idx) {
+                        stack.push(dependent_idx);
+                    }
+                }
+            }
+        }
     }
 
     /// Removes all cycles from the graph, adding cycle errors to the errors vector.
@@ -353,39 +396,63 @@ where
     }
 }
 
+/// Result of building a dependency graph, including the graph, errors, and flags with missing dependencies.
+pub struct DependencyGraphResult {
+    /// The dependency graph (may include nodes with missing dependencies)
+    pub graph: DependencyGraph<FeatureFlag>,
+    /// Errors encountered during construction (missing dependencies, cycles)
+    pub errors: Vec<GraphError<i32>>,
+    /// Set of flag IDs that have missing dependencies and should evaluate to false
+    pub flags_with_missing_deps: HashSet<i32>,
+}
+
 /// Builds a dependency graph for flag evaluation.
-/// Returns None only if there were fatal errors during graph construction.
-/// Partial errors (cycles, missing dependencies) are returned in the errors vector
-/// and the graph contains only the valid nodes.
+/// Returns None only for fatal errors. Partial errors (cycles, missing dependencies)
+/// are returned in the result and nodes with missing dependencies are kept in the graph.
 pub fn build_dependency_graph(
     feature_flags: &crate::flags::flag_models::FeatureFlagList,
     team_id: common_types::TeamId,
-) -> Option<(DependencyGraph<FeatureFlag>, Vec<GraphError<i32>>)> {
+) -> Option<DependencyGraphResult> {
     // Build the global dependency graph once, handling partial errors gracefully
-    let (global_graph, errors) = match DependencyGraph::from_nodes(&feature_flags.flags) {
-        Ok((graph, graph_errors)) => (graph, graph_errors),
-        Err(e) => {
-            log_dependency_graph_operation_error("build global dependency graph", &e, team_id);
-            return None; // Only return None for fatal errors
-        }
-    };
+    let (global_graph, errors, flags_with_missing_deps) =
+        match DependencyGraph::from_nodes(&feature_flags.flags) {
+            Ok((graph, graph_errors, missing_deps)) => (graph, graph_errors, missing_deps),
+            Err(e) => {
+                log_dependency_graph_operation_error("build global dependency graph", &e, team_id);
+                return None; // Only return None for fatal errors
+            }
+        };
 
     // Log any dependency errors but continue with the valid graph
     if !errors.is_empty() {
         log_dependency_graph_construction_errors(&errors, team_id);
     }
 
-    Some((global_graph, errors))
+    Some(DependencyGraphResult {
+        graph: global_graph,
+        errors,
+        flags_with_missing_deps,
+    })
+}
+
+/// Result of filtering a dependency graph.
+pub struct FilteredGraphResult {
+    /// The filtered dependency graph
+    pub graph: DependencyGraph<FeatureFlag>,
+    /// Subset of flags_with_missing_deps that are in the filtered graph
+    pub flags_with_missing_deps: HashSet<i32>,
 }
 
 /// Filters a dependency graph to include only the requested flags and their dependencies.
+/// Also filters the flags_with_missing_deps set to only include flags in the filtered graph.
 /// Returns None if:
 /// - There were errors during filtering
 /// - The global_graph's internal state is corrupted
 pub fn filter_graph_by_keys(
     global_graph: &DependencyGraph<FeatureFlag>,
     requested_keys: &[String],
-) -> Option<DependencyGraph<FeatureFlag>> {
+    flags_with_missing_deps: &HashSet<i32>,
+) -> Option<FilteredGraphResult> {
     let mut nodes_to_include = HashSet::new();
 
     // Build an index from flag keys to node indices for O(1) lookups
@@ -437,10 +504,13 @@ pub fn filter_graph_by_keys(
     // Create a new graph with only the filtered nodes
     let mut filtered_graph = DiGraph::new();
     let mut node_mapping = HashMap::new();
+    let mut filtered_missing_deps = HashSet::new();
 
-    // Add all the nodes we want to include
     for &node_idx in &nodes_to_include {
         let flag = global_graph.graph[node_idx].clone();
+        if flags_with_missing_deps.contains(&flag.id) {
+            filtered_missing_deps.insert(flag.id);
+        }
         let new_idx = filtered_graph.add_node(flag);
         node_mapping.insert(node_idx, new_idx);
     }
@@ -460,8 +530,11 @@ pub fn filter_graph_by_keys(
         }
     }
 
-    Some(DependencyGraph {
-        graph: filtered_graph,
+    Some(FilteredGraphResult {
+        graph: DependencyGraph {
+            graph: filtered_graph,
+        },
+        flags_with_missing_deps: filtered_missing_deps,
     })
 }
 

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -603,8 +603,7 @@ mod tests {
             assert_eq!(
                 nodes_with_missing_deps.len(),
                 2,
-                "Expected 2 nodes with missing deps, got: {:?}",
-                nodes_with_missing_deps
+                "Expected 2 nodes with missing deps, got: {nodes_with_missing_deps:?}"
             );
             assert!(nodes_with_missing_deps.contains(&1));
             assert!(nodes_with_missing_deps.contains(&2));

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -351,8 +351,13 @@ mod tests {
                 TestItem::new(3, HashSet::new()),
             ];
 
-            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            let (graph, errors, nodes_with_missing_deps) =
+                DependencyGraph::from_nodes(&items).unwrap();
             assert!(errors.is_empty(), "Expected no errors, found: {errors:?}");
+            assert!(
+                nodes_with_missing_deps.is_empty(),
+                "Expected no missing deps, found: {nodes_with_missing_deps:?}"
+            );
             assert_eq!(graph.node_count(), 3);
             assert_eq!(graph.edge_count(), 0);
         }
@@ -368,8 +373,13 @@ mod tests {
                 TestItem::new(6, HashSet::new()),
             ];
 
-            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            let (graph, errors, nodes_with_missing_deps) =
+                DependencyGraph::from_nodes(&items).unwrap();
             assert!(errors.is_empty(), "Expected no errors, found: {errors:?}");
+            assert!(
+                nodes_with_missing_deps.is_empty(),
+                "Expected no missing deps"
+            );
             assert_eq!(graph.node_count(), 6);
             assert_eq!(graph.edge_count(), 3);
         }
@@ -402,7 +412,7 @@ mod tests {
                 TestItem::new(16, HashSet::from([14])),
             ];
 
-            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            let (graph, errors, _) = DependencyGraph::from_nodes(&items).unwrap();
             assert_eq!(
                 errors.len(),
                 2,
@@ -450,30 +460,44 @@ mod tests {
 
         #[test]
         fn test_build_from_nodes_with_missing_dependencies() {
-            // 4 -> 3 -> 1 -> (999: missing)
-            // 2 -> 1 -> (999: missing)
+            // Test that nodes with missing dependencies (direct or transitive) are
+            // KEPT in the graph but tracked for fail-closed evaluation.
+            //
+            // Graph structure:
+            // 4 -> 2 -> 1 -> (999: missing)
+            // 3 -> 1 -> (999: missing)
             // 6 -> (1000: missing)
+            // 5 (no deps, valid)
+            //
+            // Expected: nodes 1, 2, 3, 4, 6 should be tracked (transitive propagation)
+            // Only node 5 should NOT be tracked.
             let items = vec![
-                TestItem::new(1, HashSet::from([999])),  // Missing dependency.
-                TestItem::new(2, HashSet::from([1])), // Depends on node that depends on a missing dependency.
-                TestItem::new(3, HashSet::from([1])), // Depends on node that depends on a missing dependency.
-                TestItem::new(4, HashSet::from([2])), // Depends on node that depends on a node that depends on a missing dependency.
-                TestItem::new(5, HashSet::new()),     // Should remain.
-                TestItem::new(6, HashSet::from([1000])), // Missing dependency.
+                TestItem::new(1, HashSet::from([999])), // Direct missing dependency
+                TestItem::new(2, HashSet::from([1])),   // Transitive (via 1)
+                TestItem::new(3, HashSet::from([1])),   // Transitive (via 1)
+                TestItem::new(4, HashSet::from([2])),   // Transitive (via 2 -> 1)
+                TestItem::new(5, HashSet::new()),       // No deps, valid
+                TestItem::new(6, HashSet::from([1000])), // Direct missing dependency
             ];
 
-            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            let (graph, errors, nodes_with_missing_deps) =
+                DependencyGraph::from_nodes(&items).unwrap();
+
+            // All nodes are kept in the graph (no removal of broken flags)
             assert_eq!(
                 graph.node_count(),
-                1,
-                "Expected only the valid subgraph (5)"
+                6,
+                "All nodes should be kept in the graph"
             );
+
+            // Errors only track the DIRECT missing dependencies (not transitive)
             assert_eq!(
                 errors.len(),
                 2,
-                "Expected two errors due to missing dependencies"
+                "Expected two errors due to direct missing dependencies"
             );
-            // Check that both missing dependencies are reported (order may vary)
+
+            // Check that both missing dependencies are reported
             let missing_ids: Vec<_> = errors
                 .iter()
                 .filter_map(|e| {
@@ -492,12 +516,101 @@ mod tests {
                 missing_ids.contains(&1000),
                 "Expected missing dependency 1000"
             );
+
+            // All nodes that transitively depend on missing deps are tracked
+            assert_eq!(
+                nodes_with_missing_deps.len(),
+                5,
+                "Expected 5 nodes with missing deps (1, 2, 3, 4, 6)"
+            );
+            assert!(nodes_with_missing_deps.contains(&1));
+            assert!(nodes_with_missing_deps.contains(&2));
+            assert!(nodes_with_missing_deps.contains(&3));
+            assert!(nodes_with_missing_deps.contains(&4));
+            assert!(nodes_with_missing_deps.contains(&6));
+            assert!(
+                !nodes_with_missing_deps.contains(&5),
+                "Node 5 should NOT be tracked (no missing deps)"
+            );
+
+            // All nodes are present in the graph
+            assert!(graph.contains_node(1));
+            assert!(graph.contains_node(2));
+            assert!(graph.contains_node(3));
+            assert!(graph.contains_node(4));
             assert!(graph.contains_node(5));
-            assert!(!graph.contains_node(1));
-            assert!(!graph.contains_node(2));
-            assert!(!graph.contains_node(3));
-            assert!(!graph.contains_node(4));
-            assert!(!graph.contains_node(6));
+            assert!(graph.contains_node(6));
+        }
+
+        #[test]
+        fn test_diamond_dependency_with_missing_dep() {
+            // Test diamond dependency where one branch has a missing dep.
+            //
+            // Graph structure:
+            //       1
+            //      / \
+            //     2   3
+            //      \ /
+            //       4 -> (999: missing)
+            //
+            // Expected: nodes 1, 2, 3, 4 should all be in nodes_with_missing_deps
+            let items = vec![
+                TestItem::new(1, HashSet::from([2, 3])), // Depends on both 2 and 3
+                TestItem::new(2, HashSet::from([4])),    // Depends on 4
+                TestItem::new(3, HashSet::from([4])),    // Depends on 4
+                TestItem::new(4, HashSet::from([999])),  // Missing dependency
+            ];
+
+            let (graph, errors, nodes_with_missing_deps) =
+                DependencyGraph::from_nodes(&items).unwrap();
+
+            assert_eq!(graph.node_count(), 4);
+            assert_eq!(errors.len(), 1);
+
+            // All nodes transitively depend on the missing dependency
+            assert_eq!(nodes_with_missing_deps.len(), 4);
+            assert!(nodes_with_missing_deps.contains(&1));
+            assert!(nodes_with_missing_deps.contains(&2));
+            assert!(nodes_with_missing_deps.contains(&3));
+            assert!(nodes_with_missing_deps.contains(&4));
+        }
+
+        #[test]
+        fn test_partial_missing_dependency_branch() {
+            // Test where only one branch of dependencies has a missing dep.
+            //
+            // Graph structure:
+            //   1 -> 2 -> (999: missing)
+            //   3 -> 4 (valid, no missing deps)
+            //   5 (no deps)
+            //
+            // Expected: only nodes 1, 2 should be in nodes_with_missing_deps
+            let items = vec![
+                TestItem::new(1, HashSet::from([2])), // Depends on 2 (transitive missing)
+                TestItem::new(2, HashSet::from([999])), // Missing dependency
+                TestItem::new(3, HashSet::from([4])), // Depends on 4 (valid)
+                TestItem::new(4, HashSet::new()),     // No deps, valid
+                TestItem::new(5, HashSet::new()),     // No deps, valid
+            ];
+
+            let (graph, errors, nodes_with_missing_deps) =
+                DependencyGraph::from_nodes(&items).unwrap();
+
+            assert_eq!(graph.node_count(), 5);
+            assert_eq!(errors.len(), 1);
+
+            // Only nodes 1 and 2 should be tracked (the broken branch)
+            assert_eq!(
+                nodes_with_missing_deps.len(),
+                2,
+                "Expected 2 nodes with missing deps, got: {:?}",
+                nodes_with_missing_deps
+            );
+            assert!(nodes_with_missing_deps.contains(&1));
+            assert!(nodes_with_missing_deps.contains(&2));
+            assert!(!nodes_with_missing_deps.contains(&3));
+            assert!(!nodes_with_missing_deps.contains(&4));
+            assert!(!nodes_with_missing_deps.contains(&5));
         }
     }
 
@@ -512,7 +625,7 @@ mod tests {
                 TestItem::new(3, HashSet::new()),
             ];
 
-            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            let (graph, errors, _) = DependencyGraph::from_nodes(&items).unwrap();
             assert!(errors.is_empty(), "Expected no errors, found: {errors:?}");
             let stages = graph.evaluation_stages().unwrap();
 
@@ -539,7 +652,7 @@ mod tests {
                 TestItem::new(3, HashSet::new()),
             ];
 
-            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            let (graph, errors, _) = DependencyGraph::from_nodes(&items).unwrap();
             assert!(errors.is_empty(), "Expected no errors, found: {errors:?}");
             let stages = graph.evaluation_stages().unwrap();
 
@@ -559,7 +672,7 @@ mod tests {
                 TestItem::new(6, HashSet::new()),
             ];
 
-            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            let (graph, errors, _) = DependencyGraph::from_nodes(&items).unwrap();
             assert!(errors.is_empty(), "Expected no errors, found: {errors:?}");
             let stages = graph.evaluation_stages().unwrap();
 
@@ -591,7 +704,7 @@ mod tests {
                 TestItem::new(4, HashSet::new()),
             ];
 
-            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            let (graph, errors, _) = DependencyGraph::from_nodes(&items).unwrap();
             assert!(errors.is_empty(), "Expected no errors, found: {errors:?}");
             let stages = graph.evaluation_stages().unwrap();
 
@@ -628,7 +741,7 @@ mod tests {
                 TestItem::new(9, HashSet::new()),
             ];
 
-            let (graph, errors) = DependencyGraph::from_nodes(&items).unwrap();
+            let (graph, errors, _) = DependencyGraph::from_nodes(&items).unwrap();
             assert!(errors.is_empty(), "Expected no errors, found: {errors:?}");
             let stages = graph.evaluation_stages().unwrap();
 
@@ -658,7 +771,9 @@ mod tests {
 #[cfg(test)]
 mod filter_graph_by_keys_tests {
     use crate::flags::flag_models::{FeatureFlag, FeatureFlagList, FlagFilters, FlagPropertyGroup};
-    use crate::utils::graph_utils::{build_dependency_graph, filter_graph_by_keys};
+    use crate::utils::graph_utils::{
+        build_dependency_graph, filter_graph_by_keys, DependencyGraphResult, FilteredGraphResult,
+    };
     use crate::utils::test_utils::create_test_flag;
     use std::collections::HashSet;
 
@@ -718,15 +833,19 @@ mod filter_graph_by_keys_tests {
         let feature_flags = FeatureFlagList { flags };
         let team_id = 1;
 
-        let (global_graph, _) = build_dependency_graph(&feature_flags, team_id).unwrap();
-        let result = filter_graph_by_keys(&global_graph, &[]);
+        let DependencyGraphResult {
+            graph: global_graph,
+            flags_with_missing_deps,
+            ..
+        } = build_dependency_graph(&feature_flags, team_id).unwrap();
+        let result = filter_graph_by_keys(&global_graph, &[], &flags_with_missing_deps);
 
         assert!(result.is_some());
-        let filtered_graph = result.unwrap();
-        assert_eq!(filtered_graph.node_count(), 0);
-        assert_eq!(filtered_graph.edge_count(), 0);
+        let FilteredGraphResult { graph, .. } = result.unwrap();
+        assert_eq!(graph.node_count(), 0);
+        assert_eq!(graph.edge_count(), 0);
         // Verify the actual flag content
-        let nodes = filtered_graph.get_all_nodes();
+        let nodes = graph.get_all_nodes();
         assert_eq!(nodes.len(), 0);
     }
 
@@ -741,17 +860,25 @@ mod filter_graph_by_keys_tests {
         let feature_flags = FeatureFlagList { flags };
         let team_id = 1;
 
-        let (global_graph, _) = build_dependency_graph(&feature_flags, team_id).unwrap();
-        let result = filter_graph_by_keys(&global_graph, &["flag1".to_string()]);
+        let DependencyGraphResult {
+            graph: global_graph,
+            flags_with_missing_deps,
+            ..
+        } = build_dependency_graph(&feature_flags, team_id).unwrap();
+        let result = filter_graph_by_keys(
+            &global_graph,
+            &["flag1".to_string()],
+            &flags_with_missing_deps,
+        );
 
         assert!(result.is_some());
-        let filtered_graph = result.unwrap();
-        assert_eq!(filtered_graph.node_count(), 1);
-        assert_eq!(filtered_graph.edge_count(), 0);
-        assert!(filtered_graph.contains_node(1));
+        let FilteredGraphResult { graph, .. } = result.unwrap();
+        assert_eq!(graph.node_count(), 1);
+        assert_eq!(graph.edge_count(), 0);
+        assert!(graph.contains_node(1));
 
         // Verify the actual flag content
-        let nodes = filtered_graph.get_all_nodes();
+        let nodes = graph.get_all_nodes();
         assert_eq!(nodes.len(), 1);
         assert_eq!(nodes[0].id, 1);
         assert_eq!(nodes[0].key, "flag1");
@@ -768,18 +895,26 @@ mod filter_graph_by_keys_tests {
         let feature_flags = FeatureFlagList { flags };
         let team_id = 1;
 
-        let (global_graph, _) = build_dependency_graph(&feature_flags, team_id).unwrap();
-        let result = filter_graph_by_keys(&global_graph, &["flag1".to_string()]);
+        let DependencyGraphResult {
+            graph: global_graph,
+            flags_with_missing_deps,
+            ..
+        } = build_dependency_graph(&feature_flags, team_id).unwrap();
+        let result = filter_graph_by_keys(
+            &global_graph,
+            &["flag1".to_string()],
+            &flags_with_missing_deps,
+        );
 
         assert!(result.is_some());
-        let filtered_graph = result.unwrap();
-        assert_eq!(filtered_graph.node_count(), 2);
-        assert_eq!(filtered_graph.edge_count(), 1);
-        assert!(filtered_graph.contains_node(1));
-        assert!(filtered_graph.contains_node(2));
+        let FilteredGraphResult { graph, .. } = result.unwrap();
+        assert_eq!(graph.node_count(), 2);
+        assert_eq!(graph.edge_count(), 1);
+        assert!(graph.contains_node(1));
+        assert!(graph.contains_node(2));
 
         // Verify the actual flag content
-        let nodes = filtered_graph.get_all_nodes();
+        let nodes = graph.get_all_nodes();
         assert_eq!(nodes.len(), 2);
         let flag_ids: Vec<i32> = nodes.iter().map(|f| f.id).collect();
         let flag_keys: Vec<&str> = nodes.iter().map(|f| f.key.as_str()).collect();
@@ -801,21 +936,27 @@ mod filter_graph_by_keys_tests {
         let feature_flags = FeatureFlagList { flags };
         let team_id = 1;
 
-        let (global_graph, _) =
-            crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
-        let result =
-            filter_graph_by_keys(&global_graph, &["flag1".to_string(), "flag2".to_string()]);
+        let DependencyGraphResult {
+            graph: global_graph,
+            flags_with_missing_deps,
+            ..
+        } = crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
+        let result = filter_graph_by_keys(
+            &global_graph,
+            &["flag1".to_string(), "flag2".to_string()],
+            &flags_with_missing_deps,
+        );
 
         assert!(result.is_some());
-        let filtered_graph = result.unwrap();
-        assert_eq!(filtered_graph.node_count(), 3);
-        assert_eq!(filtered_graph.edge_count(), 2);
-        assert!(filtered_graph.contains_node(1));
-        assert!(filtered_graph.contains_node(2));
-        assert!(filtered_graph.contains_node(3));
-        assert!(!filtered_graph.contains_node(4)); // flag4 should not be included
-                                                   // Verify the actual flag content
-        let nodes = filtered_graph.get_all_nodes();
+        let FilteredGraphResult { graph, .. } = result.unwrap();
+        assert_eq!(graph.node_count(), 3);
+        assert_eq!(graph.edge_count(), 2);
+        assert!(graph.contains_node(1));
+        assert!(graph.contains_node(2));
+        assert!(graph.contains_node(3));
+        assert!(!graph.contains_node(4)); // flag4 should not be included
+                                          // Verify the actual flag content
+        let nodes = graph.get_all_nodes();
         let flag_ids: std::collections::HashSet<i32> = nodes.iter().map(|f| f.id).collect();
         let flag_keys: std::collections::HashSet<&str> =
             nodes.iter().map(|f| f.key.as_str()).collect();
@@ -836,16 +977,23 @@ mod filter_graph_by_keys_tests {
         let feature_flags = FeatureFlagList { flags };
         let team_id = 1;
 
-        let (global_graph, _) =
-            crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
-        let result = filter_graph_by_keys(&global_graph, &["nonexistent_flag".to_string()]);
+        let DependencyGraphResult {
+            graph: global_graph,
+            flags_with_missing_deps,
+            ..
+        } = crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
+        let result = filter_graph_by_keys(
+            &global_graph,
+            &["nonexistent_flag".to_string()],
+            &flags_with_missing_deps,
+        );
 
         assert!(result.is_some());
-        let filtered_graph = result.unwrap();
-        assert_eq!(filtered_graph.node_count(), 0);
-        assert_eq!(filtered_graph.edge_count(), 0);
+        let FilteredGraphResult { graph, .. } = result.unwrap();
+        assert_eq!(graph.node_count(), 0);
+        assert_eq!(graph.edge_count(), 0);
         // Verify the actual flag content
-        let nodes = filtered_graph.get_all_nodes();
+        let nodes = graph.get_all_nodes();
         assert_eq!(nodes.len(), 0);
     }
 
@@ -859,21 +1007,25 @@ mod filter_graph_by_keys_tests {
         let feature_flags = FeatureFlagList { flags };
         let team_id = 1;
 
-        let (global_graph, _) =
-            crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
+        let DependencyGraphResult {
+            graph: global_graph,
+            flags_with_missing_deps,
+            ..
+        } = crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
         let result = filter_graph_by_keys(
             &global_graph,
             &["flag1".to_string(), "nonexistent_flag".to_string()],
+            &flags_with_missing_deps,
         );
 
         assert!(result.is_some());
-        let filtered_graph = result.unwrap();
-        assert_eq!(filtered_graph.node_count(), 1);
-        assert_eq!(filtered_graph.edge_count(), 0);
-        assert!(filtered_graph.contains_node(1));
+        let FilteredGraphResult { graph, .. } = result.unwrap();
+        assert_eq!(graph.node_count(), 1);
+        assert_eq!(graph.edge_count(), 0);
+        assert!(graph.contains_node(1));
 
         // Verify the actual flag content
-        let nodes = filtered_graph.get_all_nodes();
+        let nodes = graph.get_all_nodes();
         assert_eq!(nodes.len(), 1);
         assert_eq!(nodes[0].id, 1);
         assert_eq!(nodes[0].key, "flag1");
@@ -896,22 +1048,29 @@ mod filter_graph_by_keys_tests {
         let feature_flags = FeatureFlagList { flags };
         let team_id = 1;
 
-        let (global_graph, _) =
-            crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
-        let result = filter_graph_by_keys(&global_graph, &["flag1".to_string()]);
+        let DependencyGraphResult {
+            graph: global_graph,
+            flags_with_missing_deps,
+            ..
+        } = crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
+        let result = filter_graph_by_keys(
+            &global_graph,
+            &["flag1".to_string()],
+            &flags_with_missing_deps,
+        );
 
         assert!(result.is_some());
-        let filtered_graph = result.unwrap();
-        assert_eq!(filtered_graph.node_count(), 4);
-        assert_eq!(filtered_graph.edge_count(), 4);
-        assert!(filtered_graph.contains_node(1));
-        assert!(filtered_graph.contains_node(2));
-        assert!(filtered_graph.contains_node(3));
-        assert!(filtered_graph.contains_node(4));
-        assert!(!filtered_graph.contains_node(5)); // flag5 should not be included
-        assert!(!filtered_graph.contains_node(6)); // flag6 should not be included
-                                                   // Verify the actual flag content
-        let nodes = filtered_graph.get_all_nodes();
+        let FilteredGraphResult { graph, .. } = result.unwrap();
+        assert_eq!(graph.node_count(), 4);
+        assert_eq!(graph.edge_count(), 4);
+        assert!(graph.contains_node(1));
+        assert!(graph.contains_node(2));
+        assert!(graph.contains_node(3));
+        assert!(graph.contains_node(4));
+        assert!(!graph.contains_node(5)); // flag5 should not be included
+        assert!(!graph.contains_node(6)); // flag6 should not be included
+                                          // Verify the actual flag content
+        let nodes = graph.get_all_nodes();
         let flag_ids: std::collections::HashSet<i32> = nodes.iter().map(|f| f.id).collect();
         let flag_keys: std::collections::HashSet<&str> =
             nodes.iter().map(|f| f.key.as_str()).collect();
@@ -939,21 +1098,27 @@ mod filter_graph_by_keys_tests {
         let feature_flags = FeatureFlagList { flags };
         let team_id = 1;
 
-        let (global_graph, _) =
-            crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
-        let result =
-            filter_graph_by_keys(&global_graph, &["flag1".to_string(), "flag3".to_string()]);
+        let DependencyGraphResult {
+            graph: global_graph,
+            flags_with_missing_deps,
+            ..
+        } = crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
+        let result = filter_graph_by_keys(
+            &global_graph,
+            &["flag1".to_string(), "flag3".to_string()],
+            &flags_with_missing_deps,
+        );
 
         assert!(result.is_some());
-        let filtered_graph = result.unwrap();
-        assert_eq!(filtered_graph.node_count(), 4);
-        assert_eq!(filtered_graph.edge_count(), 2);
-        assert!(filtered_graph.contains_node(1));
-        assert!(filtered_graph.contains_node(2));
-        assert!(filtered_graph.contains_node(3));
-        assert!(filtered_graph.contains_node(4));
+        let FilteredGraphResult { graph, .. } = result.unwrap();
+        assert_eq!(graph.node_count(), 4);
+        assert_eq!(graph.edge_count(), 2);
+        assert!(graph.contains_node(1));
+        assert!(graph.contains_node(2));
+        assert!(graph.contains_node(3));
+        assert!(graph.contains_node(4));
         // Verify the actual flag content
-        let nodes = filtered_graph.get_all_nodes();
+        let nodes = graph.get_all_nodes();
         let flag_ids: std::collections::HashSet<i32> = nodes.iter().map(|f| f.id).collect();
         let flag_keys: std::collections::HashSet<&str> =
             nodes.iter().map(|f| f.key.as_str()).collect();
@@ -980,16 +1145,23 @@ mod filter_graph_by_keys_tests {
         let feature_flags = FeatureFlagList { flags };
         let team_id = 1;
 
-        let (global_graph, _) =
-            crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
-        let result = filter_graph_by_keys(&global_graph, &["flag1".to_string()]);
+        let DependencyGraphResult {
+            graph: global_graph,
+            flags_with_missing_deps,
+            ..
+        } = crate::utils::graph_utils::build_dependency_graph(&feature_flags, team_id).unwrap();
+        let result = filter_graph_by_keys(
+            &global_graph,
+            &["flag1".to_string()],
+            &flags_with_missing_deps,
+        );
 
         assert!(result.is_some());
-        let filtered_graph = result.unwrap();
-        assert_eq!(filtered_graph.node_count(), 3);
-        assert_eq!(filtered_graph.edge_count(), 3);
+        let FilteredGraphResult { graph, .. } = result.unwrap();
+        assert_eq!(graph.node_count(), 3);
+        assert_eq!(graph.edge_count(), 3);
         // Verify the actual flag content
-        let nodes = filtered_graph.get_all_nodes();
+        let nodes = graph.get_all_nodes();
         let flag_ids: std::collections::HashSet<i32> = nodes.iter().map(|f| f.id).collect();
         let flag_keys: std::collections::HashSet<&str> =
             nodes.iter().map(|f| f.key.as_str()).collect();
@@ -999,7 +1171,7 @@ mod filter_graph_by_keys_tests {
             ["flag1", "flag2", "flag3"].iter().cloned().collect()
         );
         // Verify the edge structure is preserved
-        let evaluation_stages = filtered_graph.evaluation_stages().unwrap();
+        let evaluation_stages = graph.evaluation_stages().unwrap();
         assert_eq!(evaluation_stages.len(), 3);
         assert_eq!(evaluation_stages[0].len(), 1); // flag3 (no dependencies)
         assert_eq!(evaluation_stages[1].len(), 1); // flag2 (depends on flag3)


### PR DESCRIPTION
## Problem

Scenario:
Flag A is depended on by flag B.
Flag A is disabled, and as a result, flag B can no longer be evaluated.

The current behavior of the service will omit flag A (it's disabled) and flag B (cannot be evaluated; missing a dependency) from the response, while setting `errorsComputingFlags: true`.

This has a downstream effect whereby clients will silently stop replacing cached flag values, instead merging them due to `errorsComputingFlags: true` in the response. If the end-user disabled a flag that they didn't realize was a dependency, this behavior can silently continue for some time, causing newly disabled flags to remain in client caches.

Related to https://posthoghelp.zendesk.com/agent/tickets/46332 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50769)

## Changes

This change considers missing dependencies as a configuration error instead of a transient error. When a flag has a direct or a transitive dependency on a missing flag, those flags will fail closed, returning `enabled: false` and citing `missing_dependency` as the evaluation reason.

I believe additional changes are necessary in the frontend to provide better feedback when this is about to occur, and to make dependent flags more visible.

## How did you test this code?

Updated existing tests, added a couple more, verified locally.