### PR TITLE
fix(revenue-analytics): empty subscriptionProperty causes failed materialized views

### DIFF
--- a/posthog/models/team/team_revenue_analytics_config.py
+++ b/posthog/models/team/team_revenue_analytics_config.py
@@ -41,6 +41,11 @@ class TeamRevenueAnalyticsConfig(models.Model):
         value = value or []
         try:
             dumped_value = [RevenueAnalyticsEventItem.model_validate(event).model_dump() for event in value]
+            # Sanitize empty strings to None for optional property fields
+            for event in dumped_value:
+                for key in ("subscriptionProperty", "productProperty", "couponProperty"):
+                    if event.get(key) == "":
+                        event[key] = None
             self._events = dumped_value
         except Exception as e:
             raise ValidationError(f"Invalid events schema: {str(e)}")

--- a/products/revenue_analytics/backend/views/sources/events/subscription.py
+++ b/products/revenue_analytics/backend/views/sources/events/subscription.py
@@ -16,7 +16,7 @@ def build(handle: SourceHandle) -> BuiltQuery:
 
     prefix = view_prefix_for_event(event.eventName)
 
-    if event.subscriptionProperty is None:
+    if not event.subscriptionProperty:
         return BuiltQuery(
             key=event.eventName,
             prefix=prefix,

--- a/products/revenue_analytics/backend/views/sources/test/events/test_events_subscription.py
+++ b/products/revenue_analytics/backend/views/sources/test/events/test_events_subscription.py
@@ -165,11 +165,9 @@ class TestSubscriptionEventsBuilder(EventsSourceBaseTest):
         handle = SourceHandle(type="events", team=self.team, event=event_config)
         query = build(handle)
 
-        self.assertEqual(
-            query.test_comments,
-            "no_property",
-            "Empty string subscriptionProperty should be treated as no property configured",
-        )
+        assert (
+            query.test_comments == "no_property"
+        ), "Empty string subscriptionProperty should be treated as no property configured"
 
         query_sql = query.query.to_hogql()
-        self.assertNotIn("properties.``", query_sql, "Should not generate invalid HogQL with empty property name")
+        assert "properties.``" not in query_sql, "Should not generate invalid HogQL with empty property name"

--- a/products/revenue_analytics/backend/views/sources/test/events/test_events_subscription.py
+++ b/products/revenue_analytics/backend/views/sources/test/events/test_events_subscription.py
@@ -147,3 +147,29 @@ class TestSubscriptionEventsBuilder(EventsSourceBaseTest):
         renewed_sql = query.query.to_hogql()
         self.assertIn("properties.subscription_uuid AS subscription_id", renewed_sql)
         self.assertIn("min(properties.service_name) AS product_id", renewed_sql)
+
+    def test_empty_string_subscription_property_returns_empty_query(self):
+        """Regression test: Empty string subscriptionProperty should be treated same as None."""
+        [event_config] = self.configure_events(
+            [
+                {
+                    "eventName": "test_event",
+                    "revenueProperty": "price",
+                    "subscriptionProperty": "",  # Empty string, NOT None
+                    "currencyAwareDecimal": False,
+                    "revenueCurrencyProperty": {"static": "USD"},
+                }
+            ]
+        )
+
+        handle = SourceHandle(type="events", team=self.team, event=event_config)
+        query = build(handle)
+
+        self.assertEqual(
+            query.test_comments,
+            "no_property",
+            "Empty string subscriptionProperty should be treated as no property configured",
+        )
+
+        query_sql = query.query.to_hogql()
+        self.assertNotIn("properties.``", query_sql, "Should not generate invalid HogQL with empty property name")


### PR DESCRIPTION
## Problem

Setting an empty subscription property in revenue analytics generates SQL with `properties.''` failing the views and breaking revenue analytics. 

Context: https://posthoghelp.zendesk.com/agent/tickets/46621 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49588)

## Changes

- Swapped if `event.subscriptionProperty is None:` for `if not event.subscriptionProperty:` to handle empty strings
- Sanitized empty string property values (subscriptionProperty, productProperty, couponProperty) to None at the model layer
- Added regression test for empty string subscriptionProperty

## How did you test this code?

Wrote a failing test to confirm the bug, then confirmed it fails in dev creating fake sources with empty sub props, then it works with the fix applied.

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
