### PR TITLE
fix(customers): Memoize customerProfileLogic attrs prop to avoid render loop

### DIFF
--- a/frontend/src/scenes/persons/PersonProfileCanvas.tsx
+++ b/frontend/src/scenes/persons/PersonProfileCanvas.tsx
@@ -1,4 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
+import { useMemo } from 'react'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -20,11 +21,16 @@ const PersonProfileCanvas = ({ person }: PersonProfileCanvasProps): JSX.Element 
     const shortId = `canvas-${id}`
     const mode = 'canvas'
     const { reportPersonProfileViewed } = useActions(eventUsageLogic)
-    const customerProfileLogicProps = {
-        attrs: {
+
+    const attrs = useMemo(
+        () => ({
             personId: id,
             distinctId,
-        },
+        }),
+        [id, distinctId]
+    )
+    const customerProfileLogicProps = {
+        attrs,
         scope: CustomerProfileScope.PERSON,
         key: `person-${id}`,
         canvasShortId: shortId,

--- a/products/customer_analytics/frontend/components/GroupProfileCanvas.tsx
+++ b/products/customer_analytics/frontend/components/GroupProfileCanvas.tsx
@@ -1,4 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
+import { useMemo } from 'react'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -25,11 +26,15 @@ export const GroupProfileCanvas = ({ group, tabId }: GroupProfileCanvasProps): J
     const groupTypeIndex = group.group_type_index
     const mode = 'canvas'
     const shortId = `${mode}-${groupKey}-${tabId}`
-    const customerProfileLogicProps = {
-        attrs: {
+    const attrs = useMemo(
+        () => ({
             groupKey,
             groupTypeIndex,
-        },
+        }),
+        [groupKey, groupTypeIndex]
+    )
+    const customerProfileLogicProps = {
+        attrs,
         scope: CustomerProfileScope[`GROUP_${groupTypeIndex}`],
         key: `customer-profile-${groupKey}-${tabId}`,
         canvasShortId: shortId,


### PR DESCRIPTION
## Problem

Users trying to add usage metrics from person or group Canvas were hitting a React error: "maximum update depth exceeded". Whenever they clicked the add metric button, the form would get into a infinite rerender loop that prevented them from creating the metrics.

The root cause was `props.attrs` in the dependency array of the notebook's content calculation (not directly, but from parent dependencies). This prop was creating reference changes on every scroll event, triggering continuous recalculation of the canvas content and causing the rerender cascade through the component tree.

<!-- Closes #ISSUE_ID -->
Solves:
- https://posthoghelp.zendesk.com/agent/tickets/46652 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/48890)
- https://posthoghelp.zendesk.com/agent/tickets/46650 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/48889)
## Changes

- Memoized  `attrs` before passing them into `customerProfileLogic` props

## How did you test this code?

1. Opened person Canvas
2. Clicked "add metric" button - confirmed no React error appears
3. Opened group Canvas  
4. Clicked "add metric" button - confirmed no error appears
5. Scrolled through both canvases - confirmed "content recalculated" only logs when dependencies actually change, not on every scroll
6. Verified metrics can be successfully added to notebooks from both person and group Canvas

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No