### PR TITLE
fix: we should have sandboxes on iframes, even where we control the content

### DIFF
--- a/frontend/src/scenes/heatmaps/components/FixedReplayHeatmapBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/components/FixedReplayHeatmapBrowser.tsx
@@ -41,6 +41,7 @@ export function FixedReplayHeatmapBrowser({
                             ref={iframeRef}
                             className="w-full h-full bg-white"
                             srcDoc={replayIframeData?.html}
+                            sandbox=""
                             onLoad={onIframeLoad}
                             allow=""
                         />

--- a/frontend/src/scenes/session-recordings/player/view-explorer/SessionRecordingPlayerExplorer.tsx
+++ b/frontend/src/scenes/session-recordings/player/view-explorer/SessionRecordingPlayerExplorer.tsx
@@ -60,6 +60,7 @@ export function SessionRecordingPlayerExplorer({
                 <iframe
                     key={iframeKey}
                     srcDoc={html}
+                    sandbox=""
                     width={width}
                     height={height}
                     className="origin-top-left ph-no-capture"


### PR DESCRIPTION
we control the HTML content going in to heatmap and inspection iframes so they don't have sandbox on them

but we do rely on rrweb sanitization to make that safe

and we should have the sandbox _anyway_