### PR TITLE
fix(docker): Add missing common/migration_utils to Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 !bin
 !common/hogvm
 !common/esbuilder
+!common/migration_utils
 !common/plugin_transpiler/*.*
 !common/plugin_transpiler/src
 !common/tailwind

--- a/Dockerfile
+++ b/Dockerfile
@@ -188,6 +188,7 @@ ENV PATH=/python-runtime/bin:$PATH \
 COPY manage.py manage.py
 COPY common/esbuilder common/esbuilder
 COPY common/hogvm common/hogvm/
+COPY common/migration_utils common/migration_utils/
 COPY posthog posthog/
 COPY products/ products/
 COPY ee ee/
@@ -376,6 +377,7 @@ COPY --chown=posthog:posthog manage.py manage.py
 COPY --chown=posthog:posthog posthog posthog/
 COPY --chown=posthog:posthog ee ee/
 COPY --chown=posthog:posthog common/hogvm common/hogvm/
+COPY --chown=posthog:posthog common/migration_utils common/migration_utils/
 COPY --chown=posthog:posthog products products/
 
 # Setup ENV.


### PR DESCRIPTION
## Problem

PR #43946 added `common/migration_utils/` but didn't include it in the Dockerfile. This breaks all deployments with:

```
ModuleNotFoundError: No module named 'migration_utils'
```

The `wait-for-migrations` init container imports this module, so pods get stuck indefinitely.

## Changes

Add `COPY common/migration_utils common/migration_utils/` to both the `posthog-build` stage and the final stage in the Dockerfile.

## How did you test this code?

Verified the module exists locally and only contains standard library imports (no additional dependencies needed).

## Publish to changelog?

no
