### PR TITLE
feat(heatmaps): persist heatmap filters across page reloads

### DIFF
--- a/frontend/src/lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic.ts
+++ b/frontend/src/lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic.ts
@@ -97,7 +97,7 @@ export const iframedToolbarBrowserLogic = kea<iframedToolbarBrowserLogicType>([
         heatmapColorPalette: [
             'default' as string | null,
             {
-                setHeatmapColorPalette: (_, { Palette }) => Palette,
+                setHeatmapColorPalette: (_, { palette }) => palette,
             },
         ],
         heatmapFilters: [

--- a/frontend/src/lib/components/IframedToolbarBrowser/utils.ts
+++ b/frontend/src/lib/components/IframedToolbarBrowser/utils.ts
@@ -18,6 +18,9 @@ export const DEFAULT_HEATMAP_FILTERS: HeatmapFilters = {
     viewportAccuracy: 0.9,
     aggregation: 'total_count',
 }
+
+export const DEFAULT_HEATMAP_WIDTH = 1024
+
 export const calculateViewportRange = (
     heatmapFilters: HeatmapFilters,
     windowWidth: number

--- a/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
+++ b/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
@@ -45,7 +45,7 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
         setHeatmapFilters: (filters: HeatmapFilters) => ({ filters }),
         patchHeatmapFilters: (filters: Partial<HeatmapFilters>) => ({ filters }),
         setHeatmapFixedPositionMode: (mode: HeatmapFixedPositionMode) => ({ mode }),
-        setHeatmapColorPalette: (Palette: string | null) => ({ Palette }),
+        setHeatmapColorPalette: (palette: string | null) => ({ palette }),
         setHref: (href: string) => ({ href }),
         setHrefMatchType: (matchType: HrefMatchType) => ({ matchType }),
         setHeatmapScrollY: (scrollY: number) => ({ scrollY }),
@@ -65,6 +65,7 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
         ],
         commonFilters: [
             { date_from: '-7d' } as CommonFilters,
+            { persist: true },
             {
                 setCommonFilters: (_, { filters }) => filters,
             },
@@ -79,6 +80,7 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
         ],
         heatmapFixedPositionMode: [
             'fixed' as HeatmapFixedPositionMode,
+            { persist: true },
             {
                 setHeatmapFixedPositionMode: (_, { mode }) => mode,
             },
@@ -87,7 +89,7 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
             'default' as string | null,
             { persist: true },
             {
-                setHeatmapColorPalette: (_, { Palette }) => Palette,
+                setHeatmapColorPalette: (_, { palette }) => palette,
             },
         ],
         href: [
@@ -106,6 +108,7 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
         ],
         windowWidthOverride: [
             null as number | null,
+            { persist: true },
             {
                 setWindowWidthOverride: (_, { widthOverride }) => widthOverride,
             },

--- a/frontend/src/scenes/heatmaps/components/FilterPanel.tsx
+++ b/frontend/src/scenes/heatmaps/components/FilterPanel.tsx
@@ -31,7 +31,7 @@ const useDebounceLoading = (loading: boolean, delay = 200): boolean => {
 
 export function ViewportChooser(): JSX.Element {
     const { widthOverride } = useValues(heatmapLogic)
-    const { setIframeWidth } = useActions(heatmapLogic)
+    const { setWindowWidthOverride } = useActions(heatmapLogic)
 
     const options = [
         {
@@ -78,8 +78,8 @@ export function ViewportChooser(): JSX.Element {
             <span>Screen width:</span>
             <LemonSelect
                 size="small"
-                onChange={setIframeWidth}
-                value={widthOverride ? widthOverride : undefined}
+                onChange={setWindowWidthOverride}
+                value={widthOverride}
                 data-attr="viewport-chooser"
                 options={allOptions.map(({ value, icon }) => ({
                     value,

--- a/frontend/src/scenes/heatmaps/components/FixedReplayHeatmapBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/components/FixedReplayHeatmapBrowser.tsx
@@ -1,9 +1,7 @@
 import { useActions, useValues } from 'kea'
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import { HeatmapCanvas } from 'lib/components/heatmaps/HeatmapCanvas'
-import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
-import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 import { heatmapsBrowserLogic } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
 
 export function FixedReplayHeatmapBrowser({
@@ -14,17 +12,7 @@ export function FixedReplayHeatmapBrowser({
     const logic = heatmapsBrowserLogic()
 
     const { replayIframeData, hasValidReplayIframeData, widthOverride } = useValues(logic)
-    const { onIframeLoad, setIframeWidth } = useActions(logic)
-
-    const { setWindowWidthOverride } = useActions(heatmapDataLogic({ context: 'in-app' }))
-
-    const { width: iframeWidth } = useResizeObserver<HTMLIFrameElement>({ ref: iframeRef })
-    useEffect(() => {
-        if (widthOverride === null) {
-            setIframeWidth(iframeWidth ?? null)
-        }
-        setWindowWidthOverride(widthOverride)
-    }, [iframeWidth, setIframeWidth, widthOverride, setWindowWidthOverride])
+    const { onIframeLoad } = useActions(logic)
 
     return hasValidReplayIframeData ? (
         <div className="flex flex-row gap-x-2 w-full">
@@ -33,7 +21,7 @@ export function FixedReplayHeatmapBrowser({
                     <div
                         className="relative h-full overflow-scroll"
                         // eslint-disable-next-line react/forbid-dom-props
-                        style={{ width: widthOverride ?? '100%' }}
+                        style={{ width: widthOverride }}
                     >
                         <HeatmapCanvas positioning="absolute" widthOverride={widthOverride} context="in-app" />
                         <iframe

--- a/frontend/src/scenes/heatmaps/components/IframeHeatmapBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/components/IframeHeatmapBrowser.tsx
@@ -1,9 +1,7 @@
 import { useActions, useValues } from 'kea'
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import { HeatmapCanvas } from 'lib/components/heatmaps/HeatmapCanvas'
-import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
-import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 import { heatmapsBrowserLogic } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
 
 export function IframeHeatmapBrowser({
@@ -14,18 +12,7 @@ export function IframeHeatmapBrowser({
     const logic = heatmapsBrowserLogic()
 
     const { widthOverride, dataUrl, displayUrl } = useValues(logic)
-    const { onIframeLoad, setIframeWidth } = useActions(logic)
-
-    const { setWindowWidthOverride } = useActions(heatmapDataLogic({ context: 'in-app' }))
-
-    const { width: iframeWidth } = useResizeObserver<HTMLIFrameElement>({ ref: iframeRef })
-
-    useEffect(() => {
-        if (widthOverride === null) {
-            setIframeWidth(iframeWidth ?? null)
-        }
-        setWindowWidthOverride(widthOverride)
-    }, [iframeWidth, setIframeWidth, widthOverride, setWindowWidthOverride])
+    const { onIframeLoad } = useActions(logic)
 
     return (
         <div className="flex flex-row gap-x-2 w-full min-h-full">
@@ -33,7 +20,7 @@ export function IframeHeatmapBrowser({
                 <div
                     className="relative h-full overflow-scroll"
                     // eslint-disable-next-line react/forbid-dom-props
-                    style={{ width: widthOverride ?? '100%' }}
+                    style={{ width: widthOverride }}
                 >
                     <HeatmapCanvas positioning="absolute" widthOverride={widthOverride} context="in-app" />
                     <iframe
@@ -41,7 +28,7 @@ export function IframeHeatmapBrowser({
                         ref={iframeRef}
                         className="h-full bg-white"
                         // eslint-disable-next-line react/forbid-dom-props
-                        style={{ width: widthOverride ?? '100%' }}
+                        style={{ width: widthOverride }}
                         src={displayUrl || dataUrl || ''}
                         onLoad={onIframeLoad}
                         // these two sandbox values are necessary so that the site and toolbar can run

--- a/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
@@ -11,12 +11,12 @@ import {
     defaultAuthorizedUrlProperties,
 } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
 import {
-    DEFAULT_HEATMAP_FILTERS,
+    DEFAULT_HEATMAP_WIDTH,
     PostHogAppToolbarEvent,
     calculateViewportRange,
 } from 'lib/components/IframedToolbarBrowser/utils'
 import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
-import { CommonFilters, HeatmapFilters, HeatmapFixedPositionMode } from 'lib/components/heatmaps/types'
+import { CommonFilters, HeatmapFixedPositionMode } from 'lib/components/heatmaps/types'
 import { LemonBannerProps } from 'lib/lemon-ui/LemonBanner'
 import { objectsEqual } from 'lib/utils'
 import { removeReplayIframeDataFromLocalStorage } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
@@ -66,9 +66,29 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
             }),
             ['urlsKeyed', 'checkUrlIsAuthorized'],
             heatmapDataLogic({ context: 'in-app' }),
-            ['heatmapEmpty', 'hrefMatchType'],
+            [
+                'heatmapEmpty',
+                'hrefMatchType',
+                'windowWidthOverride',
+                'commonFilters',
+                'heatmapFilters',
+                'heatmapFixedPositionMode',
+                'heatmapColorPalette',
+            ],
         ],
-        actions: [heatmapDataLogic({ context: 'in-app' }), ['loadHeatmap', 'setHref', 'setHrefMatchType']],
+        actions: [
+            heatmapDataLogic({ context: 'in-app' }),
+            [
+                'loadHeatmap',
+                'setHref',
+                'setHrefMatchType',
+                'setWindowWidthOverride',
+                'setCommonFilters',
+                'patchHeatmapFilters',
+                'setHeatmapFixedPositionMode',
+                'setHeatmapColorPalette',
+            ],
+        ],
     })),
 
     actions({
@@ -83,13 +103,6 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
         loadTopUrls: true,
         maybeLoadTopUrls: true,
         loadBrowserSearchResults: true,
-        // TRICKY: duplicated with the heatmapLogic so that we can share the settings picker
-        patchHeatmapFilters: (filters: Partial<HeatmapFilters>) => ({ filters }),
-        setHeatmapColorPalette: (Palette: string | null) => ({ Palette }),
-        setHeatmapFixedPositionMode: (mode: HeatmapFixedPositionMode) => ({ mode }),
-        setCommonFilters: (filters: CommonFilters) => ({ filters }),
-        // TRICKY: duplication ends
-        setIframeWidth: (width: number | null) => ({ width }),
         toggleFilterPanelCollapsed: true,
         setIframeBanner: (banner: IFrameBanner | null) => ({ banner }),
         startTrackingLoading: true,
@@ -172,38 +185,6 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
                 toggleFilterPanelCollapsed: (state) => !state,
             },
         ],
-        // they're called common filters in the toolbar because they're shared between heatmaps and clickmaps
-        // the name is continued here since they're passed down into the embedded iframe
-        commonFilters: [
-            { date_from: '-7d' } as CommonFilters,
-            {
-                setCommonFilters: (_, { filters }) => filters,
-            },
-        ],
-        heatmapColorPalette: [
-            'default' as string | null,
-            {
-                setHeatmapColorPalette: (_, { Palette }) => Palette,
-            },
-        ],
-        heatmapFilters: [
-            DEFAULT_HEATMAP_FILTERS,
-            {
-                patchHeatmapFilters: (state, { filters }) => ({ ...state, ...filters }),
-            },
-        ],
-        heatmapFixedPositionMode: [
-            'fixed' as HeatmapFixedPositionMode,
-            {
-                setHeatmapFixedPositionMode: (_, { mode }) => mode,
-            },
-        ],
-        iframeWidth: [
-            null as number | null,
-            {
-                setIframeWidth: (_, { width }) => width,
-            },
-        ],
         browserSearchTerm: [
             '',
             {
@@ -232,12 +213,6 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
                 setIframeBanner: (_, { banner }) => banner,
             },
         ],
-        widthOverride: [
-            1024 as number | null,
-            {
-                setIframeWidth: (_, { width }) => width,
-            },
-        ],
         displayUrl: [
             null as string | null,
             {
@@ -247,6 +222,12 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
     }),
 
     selectors({
+        // Derived width with default applied - use this in components
+        widthOverride: [
+            (s) => [s.windowWidthOverride],
+            (windowWidthOverride: number | null) => windowWidthOverride ?? DEFAULT_HEATMAP_WIDTH,
+        ],
+
         browserUrlSearchOptions: [
             (s) => [s.browserSearchResults, s.topUrls, s.browserSearchTerm],
             (browserSearchResults, topUrls, browserSearchTerm) => {
@@ -286,9 +267,9 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
         ],
 
         viewportRange: [
-            (s) => [s.heatmapFilters, s.iframeWidth],
-            (heatmapFilters, iframeWidth) => {
-                return iframeWidth ? calculateViewportRange(heatmapFilters, iframeWidth) : { min: 0, max: 1800 }
+            (s) => [s.heatmapFilters, s.widthOverride],
+            (heatmapFilters, widthOverride) => {
+                return calculateViewportRange(heatmapFilters, widthOverride)
             },
         ],
 
@@ -481,8 +462,8 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
             const searchParams = { ...router.values.searchParams, heatmapFilters: values.heatmapFilters }
             return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: true }]
         },
-        setHeatmapColorPalette: ({ Palette }) => {
-            const searchParams = { ...router.values.searchParams, heatmapPalette: Palette }
+        setHeatmapColorPalette: ({ palette }) => {
+            const searchParams = { ...router.values.searchParams, heatmapPalette: palette }
             return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: true }]
         },
         setHeatmapFixedPositionMode: ({ mode }) => {

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
@@ -1,9 +1,9 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
-import { subscriptions } from 'kea-subscriptions'
 
 import api from 'lib/api'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
+import { DEFAULT_HEATMAP_WIDTH } from 'lib/components/IframedToolbarBrowser/utils'
 import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -21,13 +21,19 @@ export const heatmapLogic = kea<heatmapLogicType>([
     connect(() => ({
         values: [
             heatmapsBrowserLogic,
-            ['dataUrl', 'displayUrl', 'isBrowserUrlAuthorized', 'widthOverride'],
+            ['dataUrl', 'displayUrl', 'isBrowserUrlAuthorized'],
             heatmapDataLogic({ context: 'in-app' }),
-            ['heatmapFilters', 'heatmapColorPalette', 'heatmapFixedPositionMode', 'commonFilters'],
+            [
+                'heatmapFilters',
+                'heatmapColorPalette',
+                'heatmapFixedPositionMode',
+                'commonFilters',
+                'windowWidthOverride',
+            ],
         ],
         actions: [
             heatmapsBrowserLogic,
-            ['setDataUrl', 'setDisplayUrl', 'onIframeLoad', 'setIframeWidth'],
+            ['setDataUrl', 'setDisplayUrl', 'onIframeLoad'],
             heatmapsSceneLogic,
             ['loadSavedHeatmaps'],
             heatmapDataLogic({ context: 'in-app' }),
@@ -55,7 +61,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
     }),
     reducers({
         type: ['screenshot' as HeatmapType, { setType: (_, { type }) => type }],
-        width: [1024 as number | null, { setWidth: (_, { width }) => width }],
+        width: [DEFAULT_HEATMAP_WIDTH as number | null, { setWidth: (_, { width }) => width }],
         name: ['New heatmap', { setName: (_, { name }) => name }],
         loading: [false, { setLoading: (_, { loading }) => loading }],
         status: ['processing' as HeatmapStatus, { setStatus: (_, { status }) => status }],
@@ -82,7 +88,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
                 actions.setDataUrl(item.data_url)
                 actions.setType(item.type)
                 if (item.type === 'screenshot') {
-                    const desiredWidth = values.widthOverride ?? 1024
+                    const desiredWidth = values.widthOverride
                     if (item.status === 'completed' && item.has_content) {
                         actions.setScreenshotUrl(
                             `/api/environments/${window.POSTHOG_APP_CONTEXT?.current_team?.id}/heatmap_screenshots/${item.id}/content/?width=${desiredWidth}`
@@ -101,16 +107,15 @@ export const heatmapLogic = kea<heatmapLogicType>([
             }
         },
         // React to viewport width changes by updating the image URL directly
-        setIframeWidth: async ({ width }) => {
+        setWindowWidthOverride: async ({ widthOverride }) => {
             if (values.type !== 'screenshot' || !values.heatmapId) {
                 return
             }
-            const w = width ?? values.widthOverride ?? 1024
+            const w = widthOverride ?? DEFAULT_HEATMAP_WIDTH
             actions.setScreenshotError(null)
             actions.setScreenshotUrl(
                 `/api/environments/${window.POSTHOG_APP_CONTEXT?.current_team?.id}/heatmap_screenshots/${values.heatmapId}/content/?width=${w}`
             )
-            actions.setWindowWidthOverride(w)
         },
         pollScreenshotStatus: async ({ id, width }, breakpoint) => {
             let attempts = 0
@@ -121,7 +126,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
                 try {
                     const contentResponse = await api.heatmapScreenshots.getContent(id)
                     if (contentResponse.success) {
-                        const w = width ?? 1024
+                        const w = width ?? DEFAULT_HEATMAP_WIDTH
                         actions.setScreenshotUrl(
                             `/api/environments/${window.POSTHOG_APP_CONTEXT?.current_team?.id}/heatmap_screenshots/${id}/content/?width=${w}`
                         )
@@ -131,7 +136,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
                     } else {
                         const screenshot = contentResponse.data
                         if (screenshot.status === 'completed' && screenshot.has_content) {
-                            const w = width ?? 1024
+                            const w = width ?? DEFAULT_HEATMAP_WIDTH
                             actions.setScreenshotUrl(
                                 `/api/environments/${window.POSTHOG_APP_CONTEXT?.current_team?.id}/heatmap_screenshots/${screenshot.id}/content/?width=${w}`
                             )
@@ -201,7 +206,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
                 heatmap_url: values.type === 'screenshot' ? (values.screenshotUrl ?? '') : (values.displayUrl ?? ''),
                 heatmap_data_url: values.dataUrl ?? '',
                 heatmap_type: values.type,
-                width: values.widthOverride ?? 1024,
+                width: values.widthOverride,
                 heatmap_color_palette: values.heatmapColorPalette,
                 heatmap_fixed_position_mode: values.heatmapFixedPositionMode,
                 common_filters: values.commonFilters,
@@ -211,6 +216,11 @@ export const heatmapLogic = kea<heatmapLogicType>([
         },
     })),
     selectors({
+        // Single source of truth for width: windowWidthOverride from heatmapDataLogic (persisted)
+        widthOverride: [
+            (s) => [s.windowWidthOverride],
+            (windowWidthOverride: number | null) => windowWidthOverride ?? DEFAULT_HEATMAP_WIDTH,
+        ],
         isDisplayUrlValid: [
             (s) => [s.displayUrl],
             (displayUrl: string | null) => {
@@ -234,31 +244,19 @@ export const heatmapLogic = kea<heatmapLogicType>([
         ],
         desiredNumericWidth: [
             (s) => [s.widthOverride, s.containerWidth],
-            (widthOverride: number | null | undefined, containerWidth: number | null) => {
-                const requestedWidth = typeof widthOverride === 'number' ? widthOverride : null
-                return requestedWidth && containerWidth
-                    ? Math.min(requestedWidth, containerWidth)
-                    : (requestedWidth ?? null)
+            (widthOverride: number, containerWidth: number | null) => {
+                return containerWidth ? Math.min(widthOverride, containerWidth) : widthOverride
             },
         ],
-        effectiveWidth: [
-            (s) => [s.desiredNumericWidth],
-            (desiredNumericWidth: number | null) => desiredNumericWidth ?? undefined,
-        ],
+        effectiveWidth: [(s) => [s.desiredNumericWidth], (desiredNumericWidth: number) => desiredNumericWidth],
         scalePercent: [
             (s) => [s.widthOverride, s.containerWidth],
-            (widthOverride: number | null | undefined, containerWidth: number | null) => {
-                const requestedWidth = typeof widthOverride === 'number' ? widthOverride : null
-                const scale = requestedWidth && containerWidth ? Math.min(1, containerWidth / requestedWidth) : 1
+            (widthOverride: number, containerWidth: number | null) => {
+                const scale = containerWidth ? Math.min(1, containerWidth / widthOverride) : 1
                 return Math.round(scale * 100)
             },
         ],
     }),
-    subscriptions(({ actions }) => ({
-        widthOverride: (widthOverride) => {
-            actions.setWindowWidthOverride(widthOverride)
-        },
-    })),
     afterMount(({ actions }) => {
         actions.load()
     }),


### PR DESCRIPTION
## Problem

State wasn't being persisted after refreshing the page for some filters (date range, screen width, internal/test user filter and the positioning calculation)

## Changes

Persisting state and also removing duplicated logic for window override and iframewidth:
  - Add localStorage persistence for date range, screen width, color palette, heatmap filters, and fixed position mode via Kea's persist option
  - Establish single source of truth for width in heatmapDataLogic.windowWidthOverride
  - Connect filter values from heatmapDataLogic to heatmapsBrowserLogic instead of maintaining duplicate state
  - Add DEFAULT_HEATMAP_WIDTH constant to shared utils
  - Fix viewportRange selector to use widthOverride instead of iframeWidth
  - Fix naming convention: Palette -> palette (camelCase)
  - Remove unused setIframeWidth action and iframeWidth reducer


## How did you test this code?
Manually

https://github.com/user-attachments/assets/dc6dc0a3-3f8e-4d28-8414-f2f09e032f27


**My main concern is if you see any problem by not using the iframe logic and just relying on windowWidthOverride everywhere** . Do you guys see any warning here or a missing case I could test?  cc: @pauldambra @veryayskiy 
