### PR TITLE
feat(product tours): add more button actions: next/prev tour step, tour trigger

### DIFF
--- a/frontend/src/scenes/product-tours/components/TourSelector.tsx
+++ b/frontend/src/scenes/product-tours/components/TourSelector.tsx
@@ -1,0 +1,59 @@
+import { useValues } from 'kea'
+
+import { LemonSelect } from '@posthog/lemon-ui'
+
+import { ProductTour, ProgressStatus } from '~/types'
+
+import { productTourLogic } from '../productTourLogic'
+import { getProductTourStatus, productToursLogic } from '../productToursLogic'
+
+function TourStatusDot({ tour }: { tour: ProductTour }): JSX.Element {
+    const status = getProductTourStatus(tour)
+    const colorClass =
+        status === ProgressStatus.Running ? 'bg-success' : status === ProgressStatus.Draft ? 'bg-muted-alt' : 'bg-muted'
+
+    return <span className={`inline-block w-2 h-2 rounded-full ${colorClass}`} />
+}
+
+export interface TourSelectorProps {
+    value: string | undefined
+    onChange: (tourId: string) => void
+    size?: 'small' | 'medium'
+    fullWidth?: boolean
+    className?: string
+}
+
+export function TourSelector({
+    value,
+    onChange,
+    size = 'small',
+    fullWidth,
+    className,
+}: TourSelectorProps): JSX.Element {
+    const { productTours } = useValues(productToursLogic)
+    const { productTour } = useValues(productTourLogic)
+
+    const options = productTours
+        .filter((tour) => !tour.archived && tour.id !== productTour?.id)
+        .map((tour) => ({
+            value: tour.id,
+            label: (
+                <span className="flex items-center gap-2">
+                    <TourStatusDot tour={tour} />
+                    {tour.name}
+                </span>
+            ),
+        }))
+
+    return (
+        <LemonSelect
+            value={value}
+            onChange={onChange}
+            options={options}
+            placeholder="Select a tour..."
+            size={size}
+            fullWidth={fullWidth}
+            className={className}
+        />
+    )
+}

--- a/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.scss
+++ b/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.scss
@@ -120,12 +120,6 @@
         border-radius: 8px;
     }
 
-    &__step-settings {
-        padding: 1rem;
-        background: var(--bg-fill-primary);
-        border-radius: 8px;
-    }
-
     &__survey-layout {
         display: flex;
         gap: 2rem;

--- a/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/ProductTourStepsEditor.tsx
@@ -12,7 +12,7 @@ import {
     IconQuestion,
     IconTrash,
 } from '@posthog/icons'
-import { LemonBadge, LemonButton, LemonDivider, LemonModal } from '@posthog/lemon-ui'
+import { LemonBadge, LemonButton, LemonModal } from '@posthog/lemon-ui'
 
 import { PositionSelector } from 'scenes/surveys/survey-appearance/SurveyAppearancePositionSelector'
 
@@ -27,6 +27,7 @@ import {
 } from '~/types'
 
 import { ProductTourPreview } from '../components/ProductTourPreview'
+import { StepButtonsEditor } from './StepButtonsEditor'
 import { StepContentEditor } from './StepContentEditor'
 import { StepLayoutSettings } from './StepLayoutSettings'
 import { StepScreenshotThumbnail } from './StepScreenshotThumbnail'
@@ -263,17 +264,27 @@ export function ProductTourStepsEditor({ steps, appearance, onChange }: ProductT
                                     placeholder={`Type '/' for commands, or start writing your step ${selectedStepIndex + 1} content...`}
                                 />
 
-                                {/* Step settings */}
-                                <LemonDivider className="my-4" />
-
-                                <div className="ProductTourStepsEditor__step-settings">
-                                    <h4 className="font-semibold mb-3">Step settings</h4>
-
-                                    <StepLayoutSettings
-                                        step={selectedStep}
-                                        onChange={(updates) => updateStep(selectedStepIndex, updates)}
-                                        showPosition={selectedStep.type === 'modal'}
+                                {/* Step configuration */}
+                                <div className="mt-4 p-4 bg-fill-primary rounded-lg space-y-6">
+                                    <StepButtonsEditor
+                                        buttons={selectedStep.buttons}
+                                        onChange={(buttons) => updateStep(selectedStepIndex, { buttons })}
+                                        isTourContext={true}
+                                        stepIndex={selectedStepIndex}
+                                        totalSteps={steps.length}
+                                        layout="horizontal"
                                     />
+
+                                    <div>
+                                        <div className="text-xs font-semibold text-muted uppercase tracking-wide mb-3">
+                                            Layout
+                                        </div>
+                                        <StepLayoutSettings
+                                            step={selectedStep}
+                                            onChange={(updates) => updateStep(selectedStepIndex, updates)}
+                                            showPosition={selectedStep.type === 'modal'}
+                                        />
+                                    </div>
                                 </div>
                             </>
                         )}

--- a/frontend/src/scenes/product-tours/editor/StepButtonsEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/StepButtonsEditor.tsx
@@ -2,19 +2,49 @@ import { LemonInput, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { ProductTourButtonAction, ProductTourStepButton, ProductTourStepButtons } from '~/types'
 
-import { BUTTON_ACTION_OPTIONS, DEFAULT_PRIMARY_BUTTON, DEFAULT_SECONDARY_BUTTON } from '../productToursLogic'
+import { TourSelector } from '../components/TourSelector'
+import {
+    BUTTON_ACTION_OPTIONS,
+    DEFAULT_PRIMARY_BUTTON,
+    DEFAULT_SECONDARY_BUTTON,
+    TOUR_BUTTON_ACTION_OPTIONS,
+    getDefaultTourStepButtons,
+} from '../productToursLogic'
 
 interface ButtonEditorProps {
     button: ProductTourStepButton
     onChange: (button: ProductTourStepButton) => void
     label: string
+    isTourContext?: boolean
+    stepIndex?: number
+    totalSteps?: number
 }
 
-function ButtonEditor({ button, onChange, label }: ButtonEditorProps): JSX.Element {
+function ButtonEditor({
+    button,
+    onChange,
+    label,
+    isTourContext = false,
+    stepIndex = 0,
+    totalSteps = 1,
+}: ButtonEditorProps): JSX.Element {
+    const actionOptions = isTourContext ? TOUR_BUTTON_ACTION_OPTIONS : BUTTON_ACTION_OPTIONS
+
+    const actionDisabledReason = (action: ProductTourButtonAction): string | undefined => {
+        if (action === 'next_step' && stepIndex === totalSteps - 1) {
+            return 'No further tour steps'
+        }
+        if (action === 'previous_step' && stepIndex === 0) {
+            return 'No previous tour steps'
+        }
+    }
+
     return (
         <div className="space-y-2">
             <div className="flex items-center gap-3">
-                <span className="text-xs font-medium text-muted w-16 shrink-0">{label}</span>
+                <span className={`text-xs font-medium text-muted w-16 shrink-0 ${!label ? 'hidden' : ''}`}>
+                    {label}
+                </span>
                 <LemonInput
                     value={button.text}
                     onChange={(text) => onChange({ ...button, text })}
@@ -24,19 +54,40 @@ function ButtonEditor({ button, onChange, label }: ButtonEditorProps): JSX.Eleme
                 />
                 <LemonSelect
                     value={button.action}
-                    onChange={(action) => onChange({ ...button, action: action as ProductTourButtonAction })}
-                    options={BUTTON_ACTION_OPTIONS}
+                    onChange={(action) => {
+                        const newAction = action as ProductTourButtonAction
+                        onChange({
+                            ...button,
+                            action: newAction,
+                            link: newAction === 'link' ? button.link : undefined,
+                            tourId: newAction === 'trigger_tour' ? button.tourId : undefined,
+                        })
+                    }}
+                    options={actionOptions.map((opt) => ({
+                        ...opt,
+                        disabledReason: actionDisabledReason(opt.value),
+                    }))}
                     size="small"
                 />
             </div>
             {button.action === 'link' && (
                 <div className="flex items-center gap-3">
-                    <span className="w-16 shrink-0" />
+                    <span className={`w-16 shrink-0 ${!label ? 'hidden' : ''}`} />
                     <LemonInput
                         value={button.link ?? ''}
                         onChange={(link) => onChange({ ...button, link })}
                         placeholder="https://example.com"
                         size="small"
+                        className="flex-1"
+                    />
+                </div>
+            )}
+            {button.action === 'trigger_tour' && (
+                <div className="flex items-center gap-3">
+                    <span className={`w-16 shrink-0 ${!label ? 'hidden' : ''}`} />
+                    <TourSelector
+                        value={button.tourId}
+                        onChange={(tourId) => onChange({ ...button, tourId })}
                         className="flex-1"
                     />
                 </div>
@@ -47,12 +98,34 @@ function ButtonEditor({ button, onChange, label }: ButtonEditorProps): JSX.Eleme
 
 export interface StepButtonsEditorProps {
     buttons: ProductTourStepButtons | undefined
-    onChange: (buttons: ProductTourStepButtons) => void
+    onChange: (buttons: ProductTourStepButtons | undefined) => void
+    isTourContext?: boolean
+    stepIndex?: number
+    totalSteps?: number
+    layout?: 'stacked' | 'horizontal'
 }
 
-export function StepButtonsEditor({ buttons, onChange }: StepButtonsEditorProps): JSX.Element {
+export function StepButtonsEditor({
+    buttons,
+    onChange,
+    isTourContext = false,
+    stepIndex = 0,
+    totalSteps = 1,
+    layout = 'stacked',
+}: StepButtonsEditorProps): JSX.Element {
+    const customButtonsEnabled = !!buttons
     const primaryButton = buttons?.primary ?? DEFAULT_PRIMARY_BUTTON
     const secondaryButton = buttons?.secondary
+
+    const toggleCustomButtons = (enabled: boolean): void => {
+        if (enabled) {
+            onChange(
+                isTourContext ? getDefaultTourStepButtons(stepIndex, totalSteps) : { primary: DEFAULT_PRIMARY_BUTTON }
+            )
+        } else {
+            onChange(undefined)
+        }
+    }
 
     const updatePrimaryButton = (button: ProductTourStepButton): void => {
         onChange({
@@ -75,21 +148,89 @@ export function StepButtonsEditor({ buttons, onChange }: StepButtonsEditorProps)
         })
     }
 
+    if (layout === 'horizontal') {
+        return (
+            <div className="space-y-3">
+                {isTourContext && (
+                    <LemonSwitch checked={customButtonsEnabled} onChange={toggleCustomButtons} label="Custom buttons" />
+                )}
+                {(customButtonsEnabled || !isTourContext) && (
+                    <div className="flex gap-4">
+                        <div className="flex-1 space-y-2">
+                            <div className="text-xs font-medium text-muted">Primary</div>
+                            <ButtonEditor
+                                label=""
+                                button={primaryButton}
+                                onChange={updatePrimaryButton}
+                                isTourContext={isTourContext}
+                                stepIndex={stepIndex}
+                                totalSteps={totalSteps}
+                            />
+                        </div>
+                        <div className="flex-1 space-y-2">
+                            <div className="flex items-center justify-between">
+                                <span className="text-xs font-medium text-muted">Secondary</span>
+                                <LemonSwitch
+                                    checked={!!secondaryButton}
+                                    onChange={toggleSecondaryButton}
+                                    size="small"
+                                />
+                            </div>
+                            {secondaryButton ? (
+                                <ButtonEditor
+                                    label=""
+                                    button={secondaryButton}
+                                    onChange={updateSecondaryButton}
+                                    isTourContext={isTourContext}
+                                    stepIndex={stepIndex}
+                                    totalSteps={totalSteps}
+                                />
+                            ) : (
+                                <div className="text-muted text-sm py-2">No secondary button</div>
+                            )}
+                        </div>
+                    </div>
+                )}
+            </div>
+        )
+    }
+
     return (
         <div className="space-y-3">
-            <ButtonEditor label="Primary" button={primaryButton} onChange={updatePrimaryButton} />
-            {secondaryButton && (
-                <ButtonEditor label="Secondary" button={secondaryButton} onChange={updateSecondaryButton} />
+            {isTourContext && (
+                <LemonSwitch checked={customButtonsEnabled} onChange={toggleCustomButtons} label="Custom buttons" />
             )}
-            <div className="flex items-center gap-3">
-                <span className="w-16 shrink-0" />
-                <LemonSwitch
-                    checked={!!secondaryButton}
-                    onChange={toggleSecondaryButton}
-                    label="Secondary button"
-                    size="small"
-                />
-            </div>
+            {(customButtonsEnabled || !isTourContext) && (
+                <>
+                    <ButtonEditor
+                        label="Primary"
+                        button={primaryButton}
+                        onChange={updatePrimaryButton}
+                        isTourContext={isTourContext}
+                        stepIndex={stepIndex}
+                        totalSteps={totalSteps}
+                    />
+                    {secondaryButton && (
+                        <ButtonEditor
+                            label="Secondary"
+                            button={secondaryButton}
+                            onChange={updateSecondaryButton}
+                            isTourContext={isTourContext}
+                            stepIndex={stepIndex}
+                            totalSteps={totalSteps}
+                        />
+                    )}
+                    <div className="flex items-center gap-3">
+                        <span className="w-16 shrink-0" />
+                        <LemonSwitch
+                            checked={!!secondaryButton}
+                            onChange={toggleSecondaryButton}
+                            label="Secondary button"
+                            size="small"
+                        />
+                    </div>
+                </>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/product-tours/productToursLogic.ts
+++ b/frontend/src/scenes/product-tours/productToursLogic.ts
@@ -18,6 +18,7 @@ import {
     ProductTourButtonAction,
     ProductTourContent,
     ProductTourStepButton,
+    ProductTourStepButtons,
     ProgressStatus,
     SurveyPosition,
 } from '~/types'
@@ -27,6 +28,13 @@ import type { productToursLogicType } from './productToursLogicType'
 export const BUTTON_ACTION_OPTIONS: { value: ProductTourButtonAction; label: string }[] = [
     { value: 'dismiss', label: 'Dismiss' },
     { value: 'link', label: 'Open link' },
+    { value: 'trigger_tour', label: 'Start tour' },
+]
+
+export const TOUR_BUTTON_ACTION_OPTIONS: { value: ProductTourButtonAction; label: string }[] = [
+    { value: 'next_step', label: 'Next step' },
+    { value: 'previous_step', label: 'Previous step' },
+    ...BUTTON_ACTION_OPTIONS,
 ]
 
 export const DEFAULT_PRIMARY_BUTTON: ProductTourStepButton = {
@@ -38,6 +46,26 @@ export const DEFAULT_SECONDARY_BUTTON: ProductTourStepButton = {
     text: 'Learn more',
     action: 'link',
     link: '',
+}
+
+export function getDefaultTourStepButtons(stepIndex: number, totalSteps: number): ProductTourStepButtons {
+    const isFirstStep = stepIndex === 0
+    const isLastStep = stepIndex === totalSteps - 1
+
+    return {
+        primary: {
+            text: isLastStep ? 'Done' : 'Next',
+            action: isLastStep ? 'dismiss' : 'next_step',
+        },
+        ...(isFirstStep
+            ? {}
+            : {
+                  secondary: {
+                      text: 'Back',
+                      action: 'previous_step',
+                  },
+              }),
+    }
 }
 
 function createDefaultAnnouncementContent(): ProductTourContent {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3320,13 +3320,15 @@ export type ProductTourProgressionTriggerType = 'button' | 'click'
 
 export type ProductTourStepType = 'element' | 'modal' | 'survey'
 
-export type ProductTourButtonAction = 'dismiss' | 'link'
+export type ProductTourButtonAction = 'dismiss' | 'link' | 'next_step' | 'previous_step' | 'trigger_tour'
 
 export interface ProductTourStepButton {
     text: string
     action: ProductTourButtonAction
     /** URL to open when action is 'link' */
     link?: string
+    /** Tour ID to trigger when action is 'trigger_tour' */
+    tourId?: string
 }
 
 export interface ProductTourStepButtons {


### PR DESCRIPTION
## Problem

product tour custom buttons only support actions "link" and "dismiss"

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- adds support for "next step" "prev step" and "trigger tour"
- adds new horizontal layout to button editor + enables for all modal steps (incl within tours)

related sdk pr: https://github.com/PostHog/posthog-js/pull/2863

| horizontal layout (tour context) | stacked layout (announcement context) |
| --- | --- |
| ![Screenshot 2026-01-10 at 1.02.23 PM.png](https://app.graphite.com/user-attachments/assets/6fc14a45-ea51-4af9-aa20-d045d886ac51.png)<br> | ![Screenshot 2026-01-10 at 1.10.50 PM.png](https://app.graphite.com/user-attachments/assets/3ca8aa24-8e4f-4de5-9aae-cdec3b6941ab.png)<br> |

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->